### PR TITLE
Bugfix webprofiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/request_panel.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/request_panel.php
@@ -42,7 +42,8 @@
         <th>Value</th>
     </tr>
 
-    <?php foreach ($data->getSessionAttributes()->getRawValue() as $key => $value): ?>
+    <?php if (count($sessionAttributes = $data->getSessionAttributes())):?>
+    <?php foreach ($sessionAttributes->getRawValue() as $key => $value): ?>
         <tr>
             <th><?php echo $key ?></th>
             <td>
@@ -58,4 +59,5 @@
             </td>
         </tr>
     <?php endforeach; ?>
+    <?php endif; ?>
 </table>


### PR DESCRIPTION
I caught an error in WebProfiler page like below.

Fatal error: Call to a member function getRawValue() on a non-object in /path-to-sandbox/src/vendor/symfony/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/request_panel.php on line 45

When the session attributes don't exist, $data->sessionAttributes->getRawValue() cannot be called as not being defined.
So I added the check whether the session attributes exist or not before calling getRawValue().
