### PR TITLE
status codes

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -123,6 +123,9 @@ class Application
         }
 
         if ($this->autoExit) {
+            if ($statusCode > 255) {
+                $statusCode = 255;
+            }
             // @codeCoverageIgnoreStart
             exit($statusCode);
             // @codeCoverageIgnoreEnd


### PR DESCRIPTION
if you return a status code bigger than 255, bash will see it as status code 0. Proof:
$ php -r "exit(255);" ; echo $?
255
$ php -r "exit(256);" ; echo $?
0

This is also in the bash manpage in the section "EXIT STATUS". This fix makes sure an error code stays an error code, so we can check for it. I noticed this because Doctrine 2.0 migrations threw a PDO exception and tried to exit with code 23000. This became an exit(0) and our buildsystem did a thumbs up. Obviously not ok :-)
