### PR TITLE
Fixed an error in EventDispatcher::disconnect, Added support for "global" event listeners with $name = null

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -51,6 +51,11 @@ class EventDispatcher
             return false;
         }
 
+        if (null === $listener) {
+        	unset($this->listeners[$name]);
+        	return;
+        }
+
         foreach ($this->listeners[$name] as $priority => $callables) {
             foreach ($callables as $i => $callable) {
                 if ($listener === $callable) {

--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -33,6 +33,7 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         
         $dispatcher->disconnect('bar');
         $this->assertEquals(array(), $dispatcher->getListeners('bar'), '->disconnect() without a listener disconnects all listeners of for an event name');
+        $this->assertEquals(array('listenToBarBar'), $dispatcher->getListeners('barbar'), '->disconnect() without a listener disconnects all listeners of for an event name');
     }
 
     public function testGetHasListeners()
@@ -103,7 +104,6 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $e = $dispatcher->filter($event = new Event(new \stdClass(), 'foo'), 'foo');
         $this->assertEquals('*-foo-*', $e->getReturnValue(), '->filter() filters a value');
     }
-
 }
 
 class Listener

--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -104,6 +104,22 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $e = $dispatcher->filter($event = new Event(new \stdClass(), 'foo'), 'foo');
         $this->assertEquals('*-foo-*', $e->getReturnValue(), '->filter() filters a value');
     }
+    
+    public function testGlobalConnectAndDisconnect()
+    {
+		$dispatcher = new EventDispatcher();
+		$dispatcher->connect('bar', 'listenToBar');
+		$dispatcher->connect('barbar', 'listenToBar');
+        $dispatcher->connect(null, 'listenToBarBar');
+        $this->assertEquals(array('listenToBar', 'listenToBarBar'), $dispatcher->getListeners('bar', true), '->connect() with event name null connects a global listener (1)');
+        $this->assertEquals(array('listenToBar', 'listenToBarBar'), $dispatcher->getListeners('barbar', true), '->connect() with event name null connects a global listener (2)');
+        $this->assertEquals(array('listenToBar'), $dispatcher->getListeners('bar', false), '->connect() with event name null connects a global listener (3)');
+        $this->assertEquals(array('listenToBar'), $dispatcher->getListeners('barbar', false), '->connect() with event name null connects a global listener (4)');
+        
+        $dispatcher->disconnect(null, 'listenToBarBar');
+        $this->assertEquals(array('listenToBar'), $dispatcher->getListeners('bar', true), '->disconnect() with event name null disconnects a global listener');
+    }
+    
 }
 
 class Listener

--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -30,6 +30,9 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('listenToBarBar'), $dispatcher->getListeners('barbar'), '->disconnect() disconnects a listener for an event name');
 
         $this->assertFalse($dispatcher->disconnect('foobar', 'listen'), '->disconnect() returns false if the listener does not exist');
+        
+        $dispatcher->disconnect('bar');
+        $this->assertEquals(array(), $dispatcher->getListeners('bar'), '->disconnect() without a listener disconnects all listeners of for an event name');
     }
 
     public function testGetHasListeners()
@@ -100,6 +103,7 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $e = $dispatcher->filter($event = new Event(new \stdClass(), 'foo'), 'foo');
         $this->assertEquals('*-foo-*', $e->getReturnValue(), '->filter() filters a value');
     }
+
 }
 
 class Listener


### PR DESCRIPTION
1. Fixed an error in EventDispatcher::disconnect
   The behaviour of disconnect() didn't match its description: If you pass NULL as the listener, no listener instead of all an event's listeners is disconnected.
   I added the missing check for null and a test for it.
2. Added support (like already described in DocCode) for listeners, which are notified on all events. They have to be connected to the event with the name NULL.
   I added some first tests. Probably some more tests to verify notify/filter/notifyAll/... should be added as well to guarantee correct behavior if those methods stop using getListeners().
