### PR TITLE
Fixes 2 errors in displaying a form

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Form/Field.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Form/Field.php
@@ -49,14 +49,14 @@ class Field extends BaseField
         }
 
         return $this->engine->render($template, array(
-            'field'      => $this,
+            'field'      => $this->field,
             'origin'     => $this->field,
             'attributes' => array_merge($this->field->getAttributes(), $attributes),
             'generator'  => $this->generator,
         ));
     }
 
-    public function label($label, $template = null)
+    public function label($label = false, $template = null)
     {
         if (null === $template) {
             $template = 'FrameworkBundle:Form:label.php';


### PR DESCRIPTION
Hello,

This commit fixes 2 errors when displaying a form.

Warning error : Missing argument 1 for Symfony\Bundle\FrameworkBundle\Templating\Form\Field::label()
Error fatal : 
Call to undefined method
Symfony\Bundle\FrameworkBundle\Templating\Form\Field::getDisplayedData() in file Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget/textarea_field.php
