### PR TITLE
Fixed broken call to Bundle\FrameworkBundle\Console\Application::addCommand()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_field.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_field.php
@@ -1,0 +1,8 @@
+<input type="password"
+	id="<?php echo $field->getId() ?>"
+	name="<?php echo $field->getName() ?>"
+	value="<?php echo $field->getDisplayedData() ?>"
+	<?php if ($field->isDisabled()): ?>disabled="disabled"<?php endif ?>
+	<?php // FIXME if (!isset($attr['maxlength']) && $field->getMaxLength() > 0) $attr['maxlength'] = $field->getMaxLength() ?>
+	<?php echo $view['form']->attributes($attr) ?>
+/>

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -152,7 +152,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
         foreach ($finder as $file) {
             $r = new \ReflectionClass($prefix.strtr($file->getPath(), array($dir => '', '/' => '\\')).'\\'.basename($file, '.php'));
             if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract()) {
-                $application->addCommand($r->newInstance());
+                $application->add($r->newInstance());
             }
         }
     }


### PR DESCRIPTION
Symfony\Bundle\FrameworkBundle\Console\Application::addCommand() was called from Component/HttpKernel/Bundle/Bundle.php line 155.

I changed this call to call the add() method instead as Fabien described in https://github.com/symfony/symfony/commit/944d91c1dfc68cf7f769ba7b60cb328fa06b786c
