### PR TITLE
Fix the "Call to a member function getDebugLogger() on a non-object" error in DoctrineMongoDbLogger.

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Logger/DoctrineMongoDBLogger.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Logger/DoctrineMongoDBLogger.php
@@ -39,6 +39,10 @@ class DoctrineMongoDBLogger
 
     public function getQueries()
     {
+        /*if (null === $this->logger) {
+            return false;
+        }*/
+        
         $logger = $this->logger->getDebugLogger();
 
         if (!$logger) {

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Logger/DoctrineMongoDBLogger.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Logger/DoctrineMongoDBLogger.php
@@ -39,9 +39,9 @@ class DoctrineMongoDBLogger
 
     public function getQueries()
     {
-        /*if (null === $this->logger) {
+        if (null === $this->logger) {
             return false;
-        }*/
+        }
         
         $logger = $this->logger->getDebugLogger();
 


### PR DESCRIPTION
The $logger property of the DoctrineMongoDbLogger class is used without checking that $this->logger is not null (and it is null by default) in the method getQueries().
