### PR TITLE
Form - Extra line in textareas

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/textarea_field.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/textarea_field.php
@@ -1,3 +1,3 @@
-<textarea id="<?php echo $field->getId() ?>" name="<?php echo $field->getName() ?>" <?php if ($field->isDisabled()): ?>disabled="disabled"<?php endif ?>>
-    <?php echo $view->escape($field->getDisplayedData()) ?>
-</textarea>
+<textarea id="<?php echo $field->getId() ?>" name="<?php echo $field->getName() ?>"<?php if ($field->isDisabled()): ?> disabled="disabled"<?php endif ?>><?php
+    echo $view->escape($field->getDisplayedData())
+?></textarea>


### PR DESCRIPTION
Hi,

Textarea fields are rendered with the value indented, which adds spaces before the content.
    <textarea>
      Value
    </textarea>
Is rendered as (by the browser) [  Value] instead of [Value]
