### PR TITLE
Password field template

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_field.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_field.php
@@ -1,0 +1,8 @@
+<input type="password"
+	id="<?php echo $field->getId() ?>"
+	name="<?php echo $field->getName() ?>"
+	value="<?php echo $field->getDisplayedData() ?>"
+	<?php if ($field->isDisabled()): ?>disabled="disabled"<?php endif ?>
+	<?php // FIXME if (!isset($attr['maxlength']) && $field->getMaxLength() > 0) $attr['maxlength'] = $field->getMaxLength() ?>
+	<?php echo $view['form']->attributes($attr) ?>
+/>


### PR DESCRIPTION
Added a template for PasswordField to Symfony/Bundle/FrameworkBundle/Resources/views/Form.

The template is a duplicate of the template for TextField except for the type of the input field.
