### PR TITLE
NotFoundHttpException 500 http status code

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
@@ -75,7 +75,7 @@ class ExceptionController extends ContainerAware
         switch ($exception->getClass()) {
             case 'Symfony\Component\Security\Exception\AccessDeniedException':
                 return 403;
-            case 'Symfony\Component\HttpKernel\Exception\HttpNotFoundException':
+            case 'Symfony\Component\HttpKernel\Exception\NotFoundHttpException':
                 return 404;
             default:
                 return 500;


### PR DESCRIPTION
Hi,
Since 55bed307f1e67eda91c5, the browser gets a 500 error code when NotFoundHttpException is thrown, because HttpNotFoundException is used instead of NotFoundHttpException. This commit fixes the typo.
