### PR TITLE
[Security] Fix the call method

### DIFF
--- a/src/Symfony/Component/HttpKernel/Security/Firewall/FormAuthenticationListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/FormAuthenticationListener.php
@@ -179,7 +179,7 @@ abstract class FormAuthenticationListener
             return $targetUrl;
         }
 
-        if ($this->options['use_referer'] && $targetUrl = $request->getHeader('Referer')) {
+        if ($this->options['use_referer'] && $targetUrl = $request->headers->get('Referer')) {
 
             return $targetUrl;
         }


### PR DESCRIPTION
The method getHeader($key) does not exist in the class /Symfony/Component/HttpFoundation/Request.

I replaced it with $request-> headers->get($key)
