### PR TITLE
Array session storage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -11,6 +11,8 @@
         <parameter key="session.storage.native.options" type="collection" />
         <parameter key="session.storage.pdo.class">Symfony\Component\HttpFoundation\SessionStorage\PdoSessionStorage</parameter>
         <parameter key="session.storage.pdo.options" type="collection" />
+        <parameter key="session.storage.array.class">Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage</parameter>
+        <parameter key="session.storage.array.options" type="collection" />
     </parameters>
 
     <services>
@@ -28,6 +30,10 @@
         <service id="session.storage.pdo" class="%session.storage.pdo.class%">
             <argument type="service" id="pdo_connection" />
             <argument>%session.storage.pdo.options%</argument>
+        </service>
+
+        <service id="session.storage.array" class="%session.storage.array.class%">
+            <argument>%session.storage.array.options%</argument>
         </service>
 
         <service id="session.storage" alias="session.storage.native" />

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/ArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/ArraySessionStorage.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation\SessionStorage;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * ArraySessionStorage.
+ *
+ * @author Fabien Potencier <fabien.potencier@symfony-project.com>
+ * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ */
+
+class ArraySessionStorage implements SessionStorageInterface
+{
+    private $data = array();
+
+    public function read($key, $default = null)
+    {
+        return array_key_exists($key, $this->data) ? $this->data[$key] : $default;
+    }
+
+    public function regenerate($destroy = false)
+    {
+        if ($destroy) {
+            $this->data = array();
+        }
+        return true;
+    }
+
+    public function remove($key)
+    {
+        unset($this->data[$key]);
+    }
+
+    public function start()
+    {
+    }
+
+    public function write($key, $data)
+    {
+        $this->data[$key] = $data;
+    }
+}


### PR DESCRIPTION
Fabien,
I added array session storage for use in tests.
When using regular WebTestCase and enabled session with autostart, it throws warnings, because headers cannot be sent after output to CLI already started.
My solution was to create this simple session interface implementation and add

```
services:
    session.storage: @session.storage.array
```

to my `config_test.yml`
