### PR TITLE
doctrine:mapping:import bugfix

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/ImportMappingDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/ImportMappingDoctrineCommand.php
@@ -93,7 +93,8 @@ EOT
         $databaseDriver = new DatabaseDriver($em->getConnection()->getSchemaManager());
         $em->getConfiguration()->setMetadataDriverImpl($databaseDriver);
 
-        $cmf = new DisconnectedClassMetadataFactory($em);
+        $cmf = new DisconnectedClassMetadataFactory();
+        $cmf->setEntityManager($em);
         $metadata = $cmf->getAllMetadata();
         if ($metadata) {
             $output->writeln(sprintf('Importing mapping information from "<info>%s</info>" entity manager', $emName));


### PR DESCRIPTION
I tried to create mapping from existing MySQL database. I got Fatal error:
PHP Fatal error:  Call to a member function getConfiguration() on a non-object in /home/chester/workspace/MyProject/src/vendor/doctrine/lib/Doctrine/ORM/Mapping/ClassMetadataFactory.php on line 135
with clue in stack trace:
(...)
PHP   7. Doctrine\ORM\Mapping\ClassMetadataFactory->getAllMetadata() /home/chester/workspace/lingus/src/vendor/symfony/src/Symfony/Bundle/DoctrineBundle/Command/ImportMappingDoctrineCommand.php:97
(...)
After googling I found this bug report at Doctrine:
http://www.doctrine-project.org/jira/browse/DDC-939?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel
So I fixed the code in symfony. 
It worked.

However - somebody should see, if this bugfix possibly should be applied in some other places in framework - my knowledge about symfony/doctrine is rather small.
