### PR TITLE
doctrine:generate:entities destination folder error on Windows

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -73,7 +73,7 @@ EOT
 
             // transform classname to a path and substract it to get the destination
             $path = dirname(str_replace('\\', '/', $class));
-            $destination = str_replace('/'.$path, "", $bundle->getPath());
+            $destination = str_replace('/'.$path, "", str_replace('\\', '/', $bundle->getPath()));
 
             if ($metadatas = $this->getBundleMetadatas($bundle)) {
                 $output->writeln(sprintf('Generating entities for "<info>%s</info>"', $class));


### PR DESCRIPTION
Right now, running the command from the root of a sandbox, would generate entities in /src/Application/MyBundle/Application/MyBundle/Entity.
The cause is a substring replace on string paths using distinct separators. 
