### PR TITLE
Fixed FileTest::testRename to work for windows file system.

### DIFF
--- a/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
@@ -96,10 +96,10 @@ class FileTest extends \PHPUnit_Framework_TestCase
     public function testRename()
     {
         $path = __DIR__.'/Fixtures/test.copy.gif';
-        $targetPath = __DIR__.'/Fixtures/test.target.gif';
+        $targetPath = realpath(__DIR__.'/Fixtures') . DIRECTORY_SEPARATOR . 'test.target.gif';
         @unlink($path);
         @unlink($targetPath);
-        copy(__DIR__.'/Fixtures/test.gif', $path);
+        copy(realpath(__DIR__.'/Fixtures/test.gif'), $path);
 
         $file = new File($path);
         $file->rename('test.target.gif');

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
@@ -96,10 +96,10 @@ class FileTest extends \PHPUnit_Framework_TestCase
     public function testRename()
     {
         $path = __DIR__.'/Fixtures/test.copy.gif';
-        $targetPath = realpath(__DIR__.'/Fixtures') . DIRECTORY_SEPARATOR . 'test.target.gif';
+        $targetPath = __DIR__.'/Fixtures/test.target.gif';
         @unlink($path);
         @unlink($targetPath);
-        copy(realpath(__DIR__.'/Fixtures/test.gif'), $path);
+        copy(__DIR__.'/Fixtures/test.gif', $path);
 
         $file = new File($path);
         $file->rename('test.target.gif');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+date_default_timezone_set('Europe/Paris');
+ 
 if (file_exists($file = __DIR__.'/../autoload.php')) {
     require_once $file;
 } elseif (file_exists($file = __DIR__.'/../autoload.php.dist')) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,8 +9,6 @@
  * file that was distributed with this source code.
  */
 
-date_default_timezone_set('Europe/Paris');
- 
 if (file_exists($file = __DIR__.'/../autoload.php')) {
     require_once $file;
 } elseif (file_exists($file = __DIR__.'/../autoload.php.dist')) {


### PR DESCRIPTION
Hi.

I'm coming from the Zend Framework world. And I must say - brilliant framework. I decided to commit some of my time looking at it.

First I tried to run tests, and there are some suggestions on how to make it play nice with windows.

When i first run test, I get a number of warnings rearding timezone settings:

"Warning: It is not safe to rely on the system's timezone settings. You are _required_ to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier."

So I added it to bootstrap.

After that, I got this:

PHPUnit 3.5.5 by Sebastian Bergmann.

.................E..........................................   60 / 1980
............................................................  120 / 1980
............................................................  180 / 1980
............................................................  240 / 1980
............................................................  300 / 1980
............................................................  360 / 1980
............................................................  420 / 1980
............................................................  480 / 1980
............................................................  540 / 1980
............................................................  600 / 1980
............................................................  660 / 1980
............................................................  720 / 1980
............................................................  780 / 1980
............................................................  840 / 1980
.......F....................................................  900 / 1980
............................................................  960 / 1980
.................E.......................................... 1020 / 1980
........................................S................... 1080 / 1980
............................................................ 1140 / 1980
............................................................ 1200 / 1980
............................................................ 1260 / 1980
............................................................ 1320 / 1980
............................................................ 1380 / 1980
............................................................ 1440 / 1980
............................................................ 1500 / 1980
............................................................ 1560 / 1980
............................................................ 1620 / 1980
............................................................ 1680 / 1980
............................................................ 1740 / 1980
............................................................ 1800 / 1980
............................................................ 1860 / 1980
............................................................ 1920 / 1980
............................................................ 1980 / 1980

Time: 7 seconds, Memory: 50.50Mb

There were 2 errors:

1) Symfony\Tests\Component\BrowserKit\ClientTest::testInsulatedRequests
RuntimeException: Unable to find the PHP executable.

G:\projects\PHP\symfony\src\Symfony\Component\Process\PhpProcess.php:88
G:\projects\PHP\symfony\src\Symfony\Component\Process\PhpProcess.php:58
G:\projects\PHP\symfony\src\Symfony\Component\BrowserKit\Client.php:236
G:\projects\PHP\symfony\src\Symfony\Component\BrowserKit\Client.php:206
G:\projects\PHP\symfony\tests\Symfony\Tests\Component\BrowserKit\ClientTest.php:289

2) Symfony\Tests\Component\HttpKernel\ClientTest::testGetScript
RuntimeException: Unable to find the PHP executable.

G:\projects\PHP\symfony\src\Symfony\Component\Process\PhpProcess.php:88
G:\projects\PHP\symfony\src\Symfony\Component\Process\PhpProcess.php:58
G:\projects\PHP\symfony\src\Symfony\Component\BrowserKit\Client.php:236
G:\projects\PHP\symfony\src\Symfony\Component\BrowserKit\Client.php:206
G:\projects\PHP\symfony\tests\Symfony\Tests\Component\HttpKernel\ClientTest.php:53
## 

There was 1 failure:

1) Symfony\Tests\Component\HttpFoundation\File\FileTest::testRename
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-G:\projects\PHP\symfony\tests\Symfony\Tests\Component\HttpFoundation\File/Fixtures/test.target.gif
+G:\projects\PHP\symfony\tests\Symfony\Tests\Component\HttpFoundation\File\Fixtures\test.target.gif

G:\projects\PHP\symfony\tests\Symfony\Tests\Component\HttpFoundation\File\FileTest.php:109

FAILURES!
Tests: 1980, Assertions: 5015, Failures: 1, Errors: 2, Skipped: 1.

I fixed FileTest::testRename, but RuntimeException: Unable to find the PHP executable.
left unresolved, probably there is hardcoded path to /usr/bin/env php

Regards,
Saša Stamenković.
