### PR TITLE
Untitled

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -121,7 +121,7 @@ abstract class DoctrineCommand extends Command
         $entityManagers = array();
         $ids = $this->container->getServiceIds();
         foreach ($ids as $id) {
-            preg_match('/doctrine.orm.(.*)_entity_manager/', $id, $matches);
+            preg_match('/^doctrine.orm.(.*)_entity_manager$/', $id, $matches);
             if ($matches) {
                 $name = $matches[1];
                 $entityManagers[$name] = $this->container->get($id);


### PR DESCRIPTION
Fix for the regular expression in the getEntityManager method. Only "entity_manager" services should be returned; "entity_manager.*" have to be excluded.
This was necessary in order to make "app/console doctrine:generate:entities" work again.
