### PR TITLE
Fix typo in framework bundle services definition

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
@@ -70,12 +70,12 @@
         <xsd:sequence>
             <xsd:element name="entity-managers" type="entity_managers" minOccurs="0" maxOccurs="1" />
             <xsd:element name="mappings" type="mappings" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="auto-generate-proxy-classes" type="xsd:string" minOccurs="0" maxOccurs="1" />
         </xsd:sequence>
 
         <xsd:attribute name="default-entity-manager" type="xsd:string" />
         <xsd:attribute name="metadata-driver" type="xsd:string" />
         <xsd:attribute name="cache-driver" type="xsd:string" />
-        <xsd:attribute name="auto-generate-proxy-classes" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="entity_managers">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -10,7 +10,7 @@
         <parameter key="response.class">Symfony\Component\HttpFoundation\Response</parameter>
         <parameter key="error_handler.class">Symfony\Component\HttpKernel\Debug\ErrorHandler</parameter>
         <parameter key="error_handler.level">null</parameter>
-        <parameter key="filesystem.class">Symfony\Bundle\FrameworkBundle\Util\FileSystem</parameter>
+        <parameter key="filesystem.class">Symfony\Bundle\FrameworkBundle\Util\Filesystem</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
It does not work in case sensitive filesystems as the class is named Filesystem and not FileSystem.
