### PR TITLE
Pull request for services.xml

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -10,7 +10,7 @@
         <parameter key="response.class">Symfony\Component\HttpFoundation\Response</parameter>
         <parameter key="error_handler.class">Symfony\Component\HttpKernel\Debug\ErrorHandler</parameter>
         <parameter key="error_handler.level">null</parameter>
-        <parameter key="filesystem.class">Symfony\Bundle\FrameworkBundle\Util\FileSystem</parameter>
+        <parameter key="filesystem.class">Symfony\Bundle\FrameworkBundle\Util\Filesystem</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
There's a small bug in a newly added line to the services.xml, introduced in commit 3a6f5561, where the Filesystem class is incorrectly referenced as FileSystem.  Please pull into trunk.  (Amongst other things, this prevents the assets:install console task from running.)
