### PR TITLE
Error when switching user

### DIFF
--- a/src/Symfony/Component/HttpKernel/Security/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/HttpKernel/Security/Firewall/SwitchUserListener.php
@@ -122,7 +122,7 @@ class SwitchUserListener implements ListenerInterface
             throw new \LogicException(sprintf('You are already switched to "%s" user.', (string) $token));
         }
 
-        $this->accessDecisionManager->decide($token, null, array($this->role));
+        $this->accessDecisionManager->decide($token, array(), array($this->role));
 
         $username = $request->get($this->usernameParameter);
 


### PR DESCRIPTION
When using the `_switch_user` listener I recieved the following error:

Catchable fatal error: Argument 2 passed to Symfony\Component\Security\Authorization\AccessDecisionManager::decide() must be an array, null given, called in /home/daniel/www/yProx/src/vendor/Symfony/src/Symfony/Component/HttpKernel/Security/Firewall/SwitchUserListener.php on line 125 and defined in /home/daniel/www/yProx/src/vendor/Symfony/src/Symfony/Component/Security/Authorization/AccessDecisionManager.php on line 48

This fix explicitly passes an `array()` instead
