### PR TITLE
fix bug in Symfony\Bundle\DoctrineMigrationsBundle\Command\DoctrineCommand

### DIFF
--- a/src/Symfony/Bundle/DoctrineMigrationsBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineMigrationsBundle/Command/DoctrineCommand.php
@@ -27,12 +27,12 @@ abstract class DoctrineCommand extends BaseCommand
     {
         $configuration->setMigrationsNamespace($bundle.'\DoctrineMigrations');
 
-        $bundle = $this->application->getKernel()->getBundle($input->getArgument('bundle'));
+        $bundle = $application->getKernel()->getBundle($bundle);
         $dir = $bundle->getPath().'/DoctrineMigrations';
 
         $configuration->setMigrationsDirectory($dir);
         $configuration->registerMigrationsFromDirectory($dir);
-        $configuration->setName($bundle.' Migrations');
+        $configuration->setName($bundle->getName().' Migrations');
         $configuration->setMigrationsTableName(Inflector::tableize($bundle->getName()).'_migration_versions');
     }
 }


### PR DESCRIPTION
Command "php app/console doctrine:migrations:status --bundle="PortfolioBundle"" don't working after last sandbox update:

PHP Fatal error: Using $this when not in object context in /var/www/test/symfony2/src/vendor/symfony/src/Symfony/Bundle/DoctrineMigrationsBundle/Command/DoctrineCommand.php on line 30

After this fix "doctrine:migrations:*" commands work fine
