### PR TITLE
fix bug in Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
 use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Form\FieldInterface;
 use Symfony\Component\Form\FieldGroupInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine;
+use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 
 /**
  * Form is a factory that wraps Form instances.
@@ -28,7 +28,7 @@ class FormHelper extends Helper
 
     protected $engine;
 
-    public function __construct(DelegatingEngine $engine)
+    public function __construct(EngineInterface $engine)
     {
         $this->engine = $engine;
     }


### PR DESCRIPTION
After last sandbox update I catch new error in my test project:

Catchable fatal error: Argument 1 passed to Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper::__construct() must be an instance of Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine, instance of Symfony\Bundle\FrameworkBundle\Templating\PhpEngine given, called in /var/www/test/symfony2/app/cache/dev/appDevDebugProjectContainer.php on line 394 and defined in /var/www/test/symfony2/src/vendor/symfony/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php on line 31

This argument instance of Symfony\Bundle\FrameworkBundle\Templating\PhpEngine. 
Symfony\Bundle\FrameworkBundle\Templating\PhpEngine and Symfony\Bundle\FrameworkBundle\Templating\DelegatingEngine implements EngineInterface. 
This fix resolve this problem.
