### PR TITLE
Doctrine proxy_* configuration ignored

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -241,6 +241,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
     protected function mergeOrmConfig(array $configs, $container)
     {
         $supportedEntityManagerOptions = array(
+            'proxy_dir'                         => 'proxy_dir',
+            'proxy_namespace'                   => 'proxy_namespace',
+            'auto_generate_proxy_classes'       => 'auto_generate_proxy_classes',
             'metadata_cache_driver'             => 'metadata_cache_driver',
             'query_cache_driver'                => 'query_cache_driver',
             'result_cache_driver'               => 'result_cache_driver',

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -70,6 +70,6 @@ class ApacheMatcherDumper extends MatcherDumper
             $regexes[] = sprintf("%sRewriteCond %%{PATH_INFO} %s\nRewriteRule .* %s [QSA,L,%s]", $conditions, $regex, $options['script_name'], $variables);
         }
 
-        return implode("\n\n", $regexes);
+        return implode("\n\n", $regexes)."\n";
     }
 }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -101,7 +101,7 @@ class Route
     public function setOptions(array $options)
     {
         $this->options = array_merge(array(
-            'segment_separators' => array('/', '.'),
+            'segment_separators' => array('/', '.', '-'),
             'text_regex'         => '.+?',
             'compiler_class'     => 'Symfony\\Component\\Routing\\RouteCompiler',
         ), $options);

--- a/tests/Symfony/Tests/Component/Routing/CompiledRouteTest.php
+++ b/tests/Symfony/Tests/Component/Routing/CompiledRouteTest.php
@@ -37,7 +37,7 @@ class CompiledRouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar'), $compiled->getDefaults(), '->getDefaults() returns the route defaults');
         $this->assertEquals(array('foo' => '\d+'), $compiled->getRequirements(), '->getRequirements() returns the route requirements');
         $this->assertEquals(array_merge(array(
-            'segment_separators' => array('/', '.'),
+            'segment_separators' => array('/', '.', '-'),
             'text_regex'         => '.+?',
             'compiler_class'     => 'Symfony\\Component\\Routing\\RouteCompiler',
         ), array('foo' => 'bar')), $compiled->getOptions(), '->getOptions() returns the route options');

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.apache
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.apache
@@ -2,5 +2,5 @@ RewriteCond %{PATH_INFO} ^/foo/(baz|symfony)$
 RewriteRule .* app.php [QSA,L,E=_ROUTING__route:foo,E=_ROUTING_bar:%1,E=_ROUTING_def:test]
 
 RewriteCond %{REQUEST_METHOD} ^(GET|head) [NC]
-RewriteCond %{PATH_INFO} ^/bar/([^/\.]+?)$
+RewriteCond %{PATH_INFO} ^/bar/([^/\.\-]+?)$
 RewriteRule .* app.php [QSA,L,E=_ROUTING__route:bar,E=_ROUTING_foo:%1]

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
@@ -25,7 +25,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array_merge($this->mergeDefaults($matches, array (  'def' => 'test',)), array('_route' => 'foo'));
         }
 
-        if (isset($this->context['method']) && preg_match('#^(GET|head)$#xi', $this->context['method']) && 0 === strpos($url, '/bar') && preg_match('#^/bar/(?P<foo>[^/\.]+?)$#x', $url, $matches)) {
+        if (isset($this->context['method']) && preg_match('#^(GET|head)$#xi', $this->context['method']) && 0 === strpos($url, '/bar') && preg_match('#^/bar/(?P<foo>[^/\.\-]+?)$#x', $url, $matches)) {
             return array_merge($this->mergeDefaults($matches, array ()), array('_route' => 'bar'));
         }
 

--- a/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
@@ -45,7 +45,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with a variable',
                 array('/foo/{bar}'),
-                '/foo', '#^/foo/(?P<bar>[^/\.]+?)$#x', array('bar' => '{bar}'), array(
+                '/foo', '#^/foo/(?P<bar>[^/\.\-]+?)$#x', array('bar' => '{bar}'), array(
                     array('variable', '/', '{bar}', 'bar'),
                     array('text', '/', 'foo', null),
                 )),
@@ -53,7 +53,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with a variable that has a default value',
                 array('/foo/{bar}', array('bar' => 'bar')),
-                '/foo', '#^/foo(?:/(?P<bar>[^/\.]+?))?$#x', array('bar' => '{bar}'), array(
+                '/foo', '#^/foo(?:/(?P<bar>[^/\.\-]+?))?$#x', array('bar' => '{bar}'), array(
                     array('variable', '/', '{bar}', 'bar'),
                     array('text', '/', 'foo', null),
                 )),
@@ -61,7 +61,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables',
                 array('/foo/{bar}/{foobar}'),
-                '/foo', '#^/foo/(?P<bar>[^/\.]+?)/(?P<foobar>[^/\.]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
+                '/foo', '#^/foo/(?P<bar>[^/\.\-]+?)/(?P<foobar>[^/\.\-]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
                     array('variable', '/', '{foobar}', 'foobar'),
                     array('variable', '/', '{bar}', 'bar'),
                     array('text', '/', 'foo', null),
@@ -70,7 +70,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables that have default values',
                 array('/foo/{bar}/{foobar}', array('bar' => 'bar', 'foobar' => 'foobar')),
-                '/foo', '#^/foo(?:/(?P<bar>[^/\.]+?) (?:/(?P<foobar>[^/\.]+?) )?)?$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
+                '/foo', '#^/foo(?:/(?P<bar>[^/\.\-]+?) (?:/(?P<foobar>[^/\.\-]+?) )?)?$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
                     array('variable', '/', '{foobar}', 'foobar'),
                     array('variable', '/', '{bar}', 'bar'),
                     array('text', '/', 'foo', null),
@@ -79,7 +79,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables but some of them have no default values',
                 array('/foo/{bar}/{foobar}', array('bar' => 'bar')),
-                '/foo', '#^/foo/(?P<bar>[^/\.]+?)/(?P<foobar>[^/\.]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
+                '/foo', '#^/foo/(?P<bar>[^/\.\-]+?)/(?P<foobar>[^/\.\-]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
                     array('variable', '/', '{foobar}', 'foobar'),
                     array('variable', '/', '{bar}', 'bar'),
                     array('text', '/', 'foo', null),
@@ -88,7 +88,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with a custom token',
                 array('/=foo', array(), array(), array('compiler_class' => 'Symfony\\Tests\\Component\\Routing\\RouteCompiler')),
-                '', '#^/foo/(?P<foo>[^/\.]+?)$#x', array('foo' => '=foo'), array(
+                '', '#^/foo/(?P<foo>[^/\.\-]+?)$#x', array('foo' => '=foo'), array(
                     array('label', '/', '=foo', 'foo'),
                 )),
         );

--- a/tests/Symfony/Tests/Component/Routing/RouteTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteTest.php
@@ -41,7 +41,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route = new Route('/{foo}');
         $route->setOptions(array('foo' => 'bar'));
         $this->assertEquals(array_merge(array(
-        'segment_separators' => array('/', '.'),
+        'segment_separators' => array('/', '.', '-'),
         'text_regex'         => '.+?',
         'compiler_class'     => 'Symfony\\Component\\Routing\\RouteCompiler',
         ), array('foo' => 'bar')), $route->getOptions(), '->setOptions() sets the options');


### PR DESCRIPTION
Three options were missing from the 'supportedEntityManagerOptions' array (the default values would get loaded regardless of user configuration).
