### PR TITLE
[DoctrineBundle] EntityUserProvider: call to loadUserByUsername from loadUserByAccount

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Security/EntityUserProvider.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Security/EntityUserProvider.php
@@ -65,6 +65,6 @@ class EntityUserProvider implements UserProviderInterface
             throw new UnsupportedAccountException(sprintf('Instances of "%s" are not supported.', get_class($account)));
         }
 
-        return $this->loadUserByUsername((string) $account);
+        return $this->loadUserByUsername($account->getUsername());
     }
 }


### PR DESCRIPTION
In EntityUserProvider class, the method loadUserByAccount() was calling loadUserByUsername method with param : "(string) $account". That was forcing the developper to return the username from __toString() method in his AccountInterface implementation.
