### PR TITLE
ControlerResolver moved to http_kernel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/InternalController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/InternalController.php
@@ -42,6 +42,6 @@ class InternalController extends ContainerAware
             $attributes->add($tmp);
         }
 
-        return $this->container->get('controller_resolver')->forward($controller, $attributes->all(), $request->query->all());
+        return $this->container->get('http_kernel')->forward($controller, $attributes->all(), $request->query->all());
     }
 }


### PR DESCRIPTION
As stated in the commit 73ab6875217d3d137f68 the controler_resolver service as been moved to http_kernel. My commit need review but it fixe an error when using the _internal route.
