### PR TITLE
[Fomr] Added label option to Form fields

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/FormExtension.php
@@ -181,7 +181,7 @@ class FormExtension extends \Twig_Extension
         return $this->render($field, 'label', array(
             'field'  => $field,
             'params' => $parameters,
-            'label'  => null !== $label ? $label : ucfirst(strtolower(str_replace('_', ' ', $field->getKey()))),
+            'label'  => null !== $label ? $label : $field->getLabel(),
         ));
     }
 

--- a/src/Symfony/Component/Form/Field.php
+++ b/src/Symfony/Component/Form/Field.php
@@ -63,6 +63,7 @@ class Field extends Configurable implements FieldInterface
 
     public function __construct($key = null, array $options = array())
     {
+        $this->addOption('label');
         $this->addOption('data');
         $this->addOption('trim', true);
         $this->addOption('required', true);
@@ -71,7 +72,7 @@ class Field extends Configurable implements FieldInterface
         $this->addOption('value_transformer');
         $this->addOption('normalization_transformer');
 
-        $this->key = (string)$key;
+        $this->key = $key;
 
         if (isset($options['data'])) {
             // Populate the field with fixed data
@@ -167,6 +168,14 @@ class Field extends Configurable implements FieldInterface
     public function getName()
     {
         return null === $this->parent ? $this->key : $this->parent->getName().'['.$this->key.']';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getLabel()
+    {
+        return $this->getOption('label') ?: $this->key;
     }
 
     /**

--- a/src/Symfony/Component/Form/Field.php
+++ b/src/Symfony/Component/Form/Field.php
@@ -175,7 +175,7 @@ class Field extends Configurable implements FieldInterface
      */
     public function getLabel()
     {
-        return $this->getOption('label') ?: $this->key;
+        return $this->getOption('label') ?: ucfirst(strtolower(str_replace('_', ' ', $this->key)));
     }
 
     /**

--- a/src/Symfony/Component/Form/FieldInterface.php
+++ b/src/Symfony/Component/Form/FieldInterface.php
@@ -81,6 +81,13 @@ interface FieldInterface
     function getName();
 
     /**
+     * Returns the label of the field.
+     *
+     * @return string  If no label is specified, the label is equal to its key.
+     */
+    function getLabel();
+
+    /**
      * Returns the ID of the field.
      *
      * @return string  The ID of a field is equal to its name, where all


### PR DESCRIPTION
The idea is that you can define a label key that does not have to match with your property name. In conjunction with translation keys this can be pretty useful.
