### PR TITLE
Core request fix

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -56,6 +56,11 @@ class Request
      */
     public $headers;
 
+    /**
+     * @var \Symfony\Component\HttpFoundation\ResponseHeaderBag
+     */
+    public $responseHeaders;
+
     protected $content;
     protected $languages;
     protected $charsets;
@@ -108,6 +113,7 @@ class Request
         $this->files = new FileBag($files);
         $this->server = new ServerBag($server);
         $this->headers = new HeaderBag($this->server->getHeaders());
+        $this->responseHeaders = new ResponseHeaderBag();
 
         $this->content = $content;
         $this->languages = null;

--- a/src/Symfony/Component/HttpKernel/ResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/ResponseListener.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel;
 
 use Symfony\Component\EventDispatcher\EventInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -38,6 +39,8 @@ class ResponseListener
      */
     public function filter(EventInterface $event, Response $response)
     {
+        $this->mergeHeadersFromRequest($event->get('request'), $response);
+
         if (HttpKernelInterface::MASTER_REQUEST !== $event->get('request_type')) {
             return $response;
         }
@@ -57,5 +60,16 @@ class ResponseListener
         }
 
         return $response;
+    }
+
+    protected function mergeHeadersFromRequest(Request $request, Response $response)
+    {
+        foreach ($request->responseHeaders->all() as $key => $value) {
+            $response->headers->set($key, $value, true);
+        }
+
+        foreach ($request->responseHeaders->getCookies() as $cookie) {
+            $response->setCookie($cookie);
+        }
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/ResponseListenerTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/ResponseListenerTest.php
@@ -22,7 +22,7 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
 {
     public function testFilterDoesNothingForSubRequests()
     {
-        $event = new Event(null, 'core.response', array('request_type' => HttpKernelInterface::SUB_REQUEST));
+        $event = new Event(null, 'core.response', array('request_type' => HttpKernelInterface::SUB_REQUEST, 'request' => new Request()));
         $this->getDispatcher()->filter($event, $response = new Response('foo'));
 
         $this->assertEquals('', $response->headers->get('content-type'));
@@ -30,7 +30,7 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testFilterDoesNothingIfContentTypeIsSet()
     {
-        $event = new Event(null, 'core.response', array('request_type' => HttpKernelInterface::MASTER_REQUEST));
+        $event = new Event(null, 'core.response', array('request_type' => HttpKernelInterface::MASTER_REQUEST, 'request' => new Request()));
         $response = new Response('foo');
         $response->headers->set('Content-Type', 'text/plain');
         $this->getDispatcher()->filter($event, $response);


### PR DESCRIPTION
This commit allows headers/cookies to be set from a core.request listener easily without having to worry about our multi-request architecture, they are always set on the correct response.
