### PR TITLE
[Security][SecurityBundle] Firewall subrequest reconnections

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -71,7 +71,7 @@
         </service>
 
         <service id="security.encoder_factory" alias="security.encoder_factory.generic"></service>
-        
+
         <service id="security.account_checker" class="%security.account_checker.class%" public="false" />
 
 
@@ -107,6 +107,7 @@
         <!-- Firewall related services -->
         <service id="security.firewall" class="%security.firewall.class%">
             <tag name="kernel.listener" event="core.request" method="handle" priority="-128" />
+            <tag name="kernel.listener" event="core.response" method="handleResponse" priority="128" />
             <argument type="service" id="security.firewall.map" />
             <argument type="service" id="event_dispatcher" />
         </service>

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -122,6 +122,13 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Handles form based authentication.
      *
      * @param Event $event An Event instance

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -65,6 +65,13 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Handles X509 authentication.
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -53,11 +53,18 @@ class AccessListener implements ListenerInterface
     {
         $dispatcher->connect('core.security', array($this, 'handle'), 0);
     }
-    
+
     /**
      * {@inheritDoc}
      */
     public function unregister(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
     {
     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -56,6 +56,13 @@ class AnonymousAuthenticationListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Handles anonymous authentication.
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -67,6 +67,13 @@ class BasicAuthenticationListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Handles basic authentication.
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -55,6 +55,13 @@ class ChannelListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Handles channel management.
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -70,6 +70,14 @@ class ContextListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+        $dispatcher->connect('core.response', array($this, 'write'), 0);
+    }
+
+    /**
      * Reads the SecurityContext from the session.
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -70,6 +70,13 @@ class DigestAuthenticationListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Handles digest authentication.
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -71,6 +71,14 @@ class ExceptionListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+        $dispatcher->connect('core.exception', array($this, 'handleException'), 0);
+    }
+
+    /**
      * Handles security related exceptions.
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/ListenerInterface.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ListenerInterface.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Interface that must be implemented by firewall listeners
- * 
+ *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 interface ListenerInterface
@@ -39,4 +39,15 @@ interface ListenerInterface
      * @param EventDispatcherInterface $dispatcher
      */
     function unregister(EventDispatcherInterface $dispatcher);
+
+    /**
+     * The implementation must reconnect this listener to all events it needs to
+     * handle after the core.security event.
+     *
+     * This method is called only if a sub request required the listeners to be
+     * unregistered.
+     *
+     * @param EventDispatcherInterface $dispatcher
+     */
+    function reconnect(EventDispatcherInterface $dispatcher);
 }

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -79,6 +79,13 @@ class LogoutListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Performs the logout if requested
      *
      * @param EventInterface $event An EventInterface instance

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -77,6 +77,14 @@ class RememberMeListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+        $dispatcher->connect('core.response', array($this, 'updateCookies'), 0);
+    }
+
+    /**
      * Handles remember-me cookie based authentication.
      *
      * @param Event $event An Event instance

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -86,6 +86,13 @@ class SwitchUserListener implements ListenerInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function reconnect(EventDispatcherInterface $dispatcher)
+    {
+    }
+
+    /**
      * Handles digest authentication.
      *
      * @param EventInterface $event An EventInterface instance


### PR DESCRIPTION
All firewall listeners are disconnected on core.request of the subrequest. The new listeners are then registered. As the last step of core.response of the subrequest all of the firewall listeners are unregistered and the firewall
listeners of the super request are reconnected to allow them to handle events occuring later in the request processing (e.g. their own matching core.response).

Attention: This is untested code, Johannes asked me to submit it anyway.
