### PR TITLE
Assetic: renamed some classes

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Factory/AssetManager.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/AssetManager.php
@@ -18,7 +18,7 @@ use Assetic\Factory\LazyAssetManager;
  *
  * @author Kris Wallsmith <kris.wallsmith@symfony-project.com>
  */
-class CachedAssetManager extends LazyAssetManager
+class AssetManager extends LazyAssetManager
 {
     protected $cacheFiles = array();
     protected $fresh = true;

--- a/src/Symfony/Bundle/AsseticBundle/FilterManager.php
+++ b/src/Symfony/Bundle/AsseticBundle/FilterManager.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\AsseticBundle;
 
-use Assetic\FilterManager;
+use Assetic\FilterManager as BaseFilterManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Kris Wallsmith <kris.wallsmith@symfony-project.com>
  */
-class LazyFilterManager extends FilterManager
+class FilterManager extends BaseFilterManager
 {
     protected $container;
     protected $mappings;

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -6,8 +6,8 @@
 
     <parameters>
         <parameter key="assetic.asset_factory.class">Symfony\Bundle\AsseticBundle\Factory\AssetFactory</parameter>
-        <parameter key="assetic.asset_manager.class">Symfony\Bundle\AsseticBundle\Factory\CachedAssetManager</parameter>
-        <parameter key="assetic.filter_manager.class">Symfony\Bundle\AsseticBundle\LazyFilterManager</parameter>
+        <parameter key="assetic.asset_manager.class">Symfony\Bundle\AsseticBundle\Factory\AssetManager</parameter>
+        <parameter key="assetic.filter_manager.class">Symfony\Bundle\AsseticBundle\FilterManager</parameter>
 
         <parameter key="assetic.filter.coffee.class">Assetic\Filter\CoffeeScriptFilter</parameter>
         <parameter key="assetic.filter.cssrewrite.class">Assetic\Filter\CssRewriteFilter</parameter>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetManagerTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetManagerTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Bundle\AsseticBundle\Tests\Factory;
 
-use Symfony\Bundle\AsseticBundle\Factory\CachedAssetManager;
+use Symfony\Bundle\AsseticBundle\Factory\AssetManager;
 
-class CachedAssetManagerTest extends \PHPUnit_Framework_TestCase
+class AssetManagerTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
@@ -31,7 +31,7 @@ class CachedAssetManagerTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $am = new CachedAssetManager($factory);
+        $am = new AssetManager($factory);
         $am->addCacheFile($file);
 
         $this->assertTrue($am->has('foo'), '->loadFormulae() loads formulae');

--- a/src/Symfony/Bundle/AsseticBundle/Tests/FilterManagerTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/FilterManagerTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Bundle\AsseticBundle\Tests;
 
-use Symfony\Bundle\AsseticBundle\LazyFilterManager;
+use Symfony\Bundle\AsseticBundle\FilterManager;
 
-class LazyFilterManagerTest extends \PHPUnit_Framework_TestCase
+class FilterManagerTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
@@ -32,7 +32,7 @@ class LazyFilterManagerTest extends \PHPUnit_Framework_TestCase
             ->with('assetic.filter.bar')
             ->will($this->returnValue($filter));
 
-        $fm = new LazyFilterManager($container, array('foo' => 'assetic.filter.bar'));
+        $fm = new FilterManager($container, array('foo' => 'assetic.filter.bar'));
 
         $this->assertSame($filter, $fm->get('foo'), '->get() loads the filter from the container');
         $this->assertSame($filter, $fm->get('foo'), '->get() loads the filter from the container');
@@ -42,7 +42,7 @@ class LazyFilterManagerTest extends \PHPUnit_Framework_TestCase
     {
         $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
 
-        $fm = new LazyFilterManager($container, array('foo' => 'assetic.filter.bar'));
+        $fm = new FilterManager($container, array('foo' => 'assetic.filter.bar'));
         $this->assertTrue($fm->has('foo'), '->has() returns true for lazily mapped filters');
     }
 
@@ -56,7 +56,7 @@ class LazyFilterManagerTest extends \PHPUnit_Framework_TestCase
             ->with('assetic.filter.bar')
             ->will($this->returnValue($filter));
 
-        $fm = new LazyFilterManager($container, array('foo' => 'assetic.filter.bar'));
+        $fm = new FilterManager($container, array('foo' => 'assetic.filter.bar'));
         $fm->set('bar', $filter);
         $all = $fm->all();
         $this->assertEquals(2, count($all), '->all() returns all lazy and normal filters');


### PR DESCRIPTION
The sub-classes use the same name as their parent now, consistent with the rest of the framework.
