### PR TITLE
Routing urlencode fix

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -98,7 +98,7 @@ class UrlGenerator implements UrlGeneratorInterface
                         throw new \InvalidArgumentException(sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given).', $token[3], $name, $requirements[$token[3]], $tparams[$token[3]]));
                     }
 
-                    $url = $token[1].urlencode($tparams[$token[3]]).$url;
+                    $url = $token[1].$tparams[$token[3]].$url;
                     $optional = false;
                 }
             } elseif ('text' === $token[0]) {


### PR DESCRIPTION
With the current way, if you have / for example in a route variable, it encodes it in %2F, and since this is not valid in URLs apache returns a 404 without even hitting app.php.

Edit: Of course, query parameters are still url encoded as they should be by http_build_query below in that same method.
