### PR TITLE
[FrameworkBundle] Routing: Use router instead of router.real

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -86,7 +86,7 @@
 
         <service id="router.cache_warmer" class="%router.cache_warmer.class%" public="false">
             <tag name="kernel.cache_warmer" />
-            <argument type="service" id="router.real" />
+            <argument type="service" id="router" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
In the definition of `router.cache_warmer service`, `router.real` is used.
I propose to use `router`.
