### PR TITLE
Assetic: Removed PHP_CodeSniffer dependency

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -52,7 +52,6 @@
         <!-- filters -->
         <service id="assetic.filter.cssrewrite" class="%assetic.filter.cssrewrite.class%">
             <tag name="assetic.filter" alias="cssrewrite" />
-            <argument type="service" id="assetic.css_tokenizer" />
         </service>
         <service id="assetic.filter.less" class="%assetic.filter.less.class%">
             <tag name="assetic.filter" alias="less" />
@@ -83,9 +82,6 @@
         </service>
 
         <!-- other -->
-        <service id="assetic.css_tokenizer" class="PHP_CodeSniffer_Tokenizers_CSS" public="false">
-            <file>PHP/CodeSniffer.php</file>
-        </service>
         <service id="assetic.config_cache" class="%assetic.config_cache.class%" public="false">
             <argument>%assetic.cache_dir%/config</argument>
         </service>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/DependencyInjection/AsseticExtensionTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/DependencyInjection/AsseticExtensionTest.php
@@ -43,10 +43,6 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Assetic is not available.');
         }
 
-        if (false === @include_once 'PHP/CodeSniffer.php') {
-            $this->markTestSkipped('PHP_CodeSniffer is not installed.');
-        }
-
         $this->kernel = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\Kernel')
             ->disableOriginalConstructor()
             ->getMock();


### PR DESCRIPTION
assetic/master use PCRE rather than a tokenizer to rewrite CSS urls
