### PR TITLE
[Security] Copy token attributes in PreAuthenticated and User AuthenticationProviders

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProvider.php
@@ -68,7 +68,10 @@ class PreAuthenticatedAuthenticationProvider implements AuthenticationProviderIn
 
         $this->accountChecker->checkPostAuth($user);
 
-        return new PreAuthenticatedToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles());
+        $authenticatedToken = new PreAuthenticatedToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles());
+        $authenticatedToken->setAttributes($token->getAttributes());
+
+        return $authenticatedToken;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -70,7 +70,10 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
             $this->checkAuthentication($user, $token);
             $this->accountChecker->checkPostAuth($user);
 
-            return new UsernamePasswordToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles());
+            $authenticatedToken = new UsernamePasswordToken($user, $token->getCredentials(), $this->providerKey, $user->getRoles());
+            $authenticatedToken->setAttributes($token->getAttributes());
+
+            return $authenticatedToken;
         } catch (UsernameNotFoundException $notFound) {
             if ($this->hideUserNotFoundExceptions) {
                 throw new BadCredentialsException('Bad credentials', 0, $notFound);

--- a/tests/Symfony/Tests/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/Authentication/Provider/PreAuthenticatedAuthenticationProviderTest.php
@@ -60,6 +60,7 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
         $this->assertEquals('pass', $token->getCredentials());
         $this->assertEquals('key', $token->getProviderKey());
         $this->assertEquals(array(), $token->getRoles());
+        $this->assertEquals(array('foo' => 'bar'), $token->getAttributes(), '->authenticate() copies token attributes');
         $this->assertSame($user, $token->getUser());
     }
 
@@ -102,6 +103,8 @@ class PreAuthenticatedAuthenticationProviderTest extends \PHPUnit_Framework_Test
             ->method('getProviderKey')
             ->will($this->returnValue('key'))
         ;
+
+        $token->setAttributes(array('foo' => 'bar'));
 
         return $token;
     }

--- a/tests/Symfony/Tests/Component/Security/Core/Authentication/Provider/UserAuthenticationProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/Authentication/Provider/UserAuthenticationProviderTest.php
@@ -157,6 +157,7 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($user, $authToken->getUser());
         $this->assertEquals(array(new Role('ROLE_FOO')), $authToken->getRoles());
         $this->assertEquals('foo', $authToken->getCredentials());
+        $this->assertEquals(array('foo' => 'bar'), $authToken->getAttributes(), '->authenticate() copies token attributes');
     }
 
     protected function getSupportedToken()
@@ -167,6 +168,8 @@ class UserAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
             ->method('getProviderKey')
             ->will($this->returnValue('key'))
         ;
+
+        $mock->setAttributes(array('foo' => 'bar'));
 
         return $mock;
     }


### PR DESCRIPTION
The use case for this PR is as follows:

I have a listener on the `security.interactive_login` event that sets a login time attribute on the UsernamePasswordToken after a successful login. I use this so that a custom `AuthenticationTrustResolver` implementation can consider users remembered instead of fully-authenticated if they logged in over 15 minutes ago, which allows for Amazon-like two-tiered authentication.

`UserAuthenticationProvider::authenticate()` likes to construct new UsernamePasswordToken objects after it performs pre/post auth checks and password validation. I noticed this happens on the request after a successful login, even if the incoming token argument is already authenticated.  My solution is to ensure the attributes get copied over into the newly-constructed token before `authenticate()` returns.
