### PR TITLE
[Kernel] Get rid of Kernel::registerRootDir()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Kernel.php
@@ -20,13 +20,13 @@ class Kernel extends BaseKernel
 {
     public function __construct()
     {
-        $this->tmpDir = sys_get_temp_dir().'/sf2_'.rand(1, 9999);
-        if (!is_dir($this->tmpDir)) {
-            if (false === @mkdir($this->tmpDir)) {
-                die(sprintf('Unable to create a temporary directory (%s)', $this->tmpDir));
+        $this->rootDir = sys_get_temp_dir().'/sf2_'.rand(1, 9999);
+        if (!is_dir($this->rootDir)) {
+            if (false === @mkdir($this->rootDir)) {
+                die(sprintf('Unable to create a temporary directory (%s)', $this->rootDir));
             }
-        } elseif (!is_writable($this->tmpDir)) {
-            die(sprintf('Unable to write in a temporary directory (%s)', $this->tmpDir));
+        } elseif (!is_writable($this->rootDir)) {
+            die(sprintf('Unable to write in a temporary directory (%s)', $this->rootDir));
         }
 
         parent::__construct('env', true);
@@ -42,12 +42,7 @@ class Kernel extends BaseKernel
     public function __destruct()
     {
         $fs = new Filesystem();
-        $fs->remove($this->tmpDir);
-    }
-
-    public function registerRootDir()
-    {
-        return $this->tmpDir;
+        $fs->remove($this->rootDir);
     }
 
     public function registerBundles()

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -41,7 +41,19 @@ class HttpKernel implements HttpKernelInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Handles a Request to convert it to a Response.
+     *
+     * When $catch is true, the implementation must catch all exceptions
+     * and do its best to convert them to a Response instance.
+     *
+     * @param  Request $request A Request instance
+     * @param  integer $type    The type of the request
+     *                          (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
+     * @param  Boolean $catch   Whether to catch exceptions or not
+     *
+     * @return Response A Response instance
+     *
+     * @throws \Exception When an Exception occurs during processing
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -26,15 +26,6 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 interface KernelInterface extends HttpKernelInterface, \Serializable
 {
     /**
-     * Returns the root directory of this application.
-     *
-     * Most of the time, this is just __DIR__.
-     *
-     * @return string A directory path
-     */
-    function registerRootDir();
-
-    /**
      * Returns an array of bundles to registers.
      *
      * @return array An array of bundle instances.
@@ -77,12 +68,12 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     function isClassInActiveBundle($class);
 
     /**
-     * Returns a bundle by its name.
+     * Returns a bundle and optionally its descendants by its name.
      *
      * @param string  $name  Bundle name
-     * @param Boolean $first Whether to return the first bundle or all bundles matching this name
+     * @param Boolean $first Whether to return the first bundle only or together with its descendants
      *
-     * @return BundleInterface A BundleInterface instance
+     * @return BundleInterface|Array A BundleInterface instance or an array of BundleInterface instances if $first is false
      *
      * @throws \InvalidArgumentException when the bundle is not enabled
      */
@@ -116,6 +107,11 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      */
     function locateResource($name, $dir = null, $first = true);
 
+    /**
+     * Gets the name of the kernel
+     *
+     * @return string The kernel name
+     */
     function getName();
 
     /**


### PR DESCRIPTION
The proposed implementation uses reflection in `Kernel::getRootDir()` instead.

If speed is really a concern, you still can override the default implementation of `getRootdir` to return `__DIR__`

Also add / fix some PHPDoc.
