### PR TITLE
appending web developer toolbar to page content

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
@@ -91,6 +91,8 @@ class WebDebugToolbarListener
 
         if (false !== $pos = $posrFunction($content, '</body>')) {
             $content = $substrFunction($content, 0, $pos).$toolbar.$substrFunction($content, $pos);
+        } else {
+            $content .= $toolbar;
         }
 
         $response->setContent($content);


### PR DESCRIPTION
I appended the toolbar content to the page content in the WebDebugToolbarBundle because for some reason it is not printed if there's no </body> tag in the content.
