### PR TITLE
[Security] SoC - Move authentication target url generation out of the authentication listener

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -69,9 +69,9 @@ class FormLoginFactory extends AbstractFactory
         return $provider;
     }
 
-    protected function createListener($container, $id, $config, $userProvider)
+    protected function createListener($container, $id, $config, $userProvider, $targetUrlGenerator)
     {
-        $listenerId = parent::createListener($container, $id, $config, $userProvider);
+        $listenerId = parent::createListener($container, $id, $config, $userProvider, $targetUrlGenerator);
 
         if (isset($config['csrf_provider'])) {
             $container

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -10,6 +10,7 @@
         <parameter key="security.channel_listener.class">Symfony\Component\Security\Http\Firewall\ChannelListener</parameter>
 
         <parameter key="security.authentication.form_entry_point.class">Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint</parameter>
+        <parameter key="security.authentication.target_url_generator.class">Symfony\Component\Security\Http\Authentication\TargetUrlGenerator</parameter>
         <parameter key="security.authentication.listener.form.class">Symfony\Component\Security\Http\Firewall\UsernamePasswordFormAuthenticationListener</parameter>
 
         <parameter key="security.authentication.listener.basic.class">Symfony\Component\Security\Http\Firewall\BasicAuthenticationListener</parameter>
@@ -26,7 +27,7 @@
         <parameter key="security.authentication.x509.credentials">SSL_CLIENT_S_DN</parameter>
 
         <parameter key="security.authentication.listener.anonymous.class">Symfony\Component\Security\Http\Firewall\AnonymousAuthenticationListener</parameter>
-        
+
         <parameter key="security.authentication.switchuser_listener.class">Symfony\Component\Security\Http\Firewall\SwitchUserListener</parameter>
 
         <parameter key="security.logout_listener.class">Symfony\Component\Security\Http\Firewall\LogoutListener</parameter>
@@ -44,7 +45,7 @@
         <parameter key="security.authentication.provider.anonymous">Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider</parameter>
         <parameter key="security.anonymous.key">SomeRandomValue</parameter>
     </parameters>
-    
+
     <services>
         <service id="security.authentication.listener.anonymous" class="%security.authentication.listener.anonymous.class%" public="false">
             <argument type="service" id="security.context" />
@@ -93,10 +94,13 @@
 
         <service id="security.authentication.form_entry_point" class="%security.authentication.form_entry_point.class%" public="false" abstract="true" />
 
+        <service id="security.authentication.target_url_generator" class="%security.authentication.target_url_generator.class%" public="false" abstract="true" />
+
         <service id="security.authentication.listener.abstract" abstract="true" public="false">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.manager" />
             <argument type="service" id="security.authentication.session_strategy" />
+            <argument type="service" id="security.authentication.target_url_generator" />
             <argument />
             <argument type="collection"></argument>
             <argument type="service" id="security.authentication.success_handler" on-invalid="null" />
@@ -104,8 +108,8 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 
-        <service id="security.authentication.listener.form" 
-                 class="%security.authentication.listener.form.class%" 
+        <service id="security.authentication.listener.form"
+                 class="%security.authentication.listener.form.class%"
                  parent="security.authentication.listener.abstract"
                  abstract="true">
         </service>
@@ -134,19 +138,19 @@
             <argument type="service" id="security.authentication.digest_entry_point" />
             <argument type="service" id="logger" on-invalid="null" />
         </service>
-        
+
         <service id="security.authentication.provider.dao" class="%security.authentication.provider.dao.class%" abstract="true" public="false">
             <argument /> <!-- User Provider -->
             <argument type="service" id="security.account_checker" />
             <argument /> <!-- Provider-shared Key -->
             <argument type="service" id="security.encoder_factory" />
         </service>
-        
+
         <service id="security.authentication.provider.pre_authenticated" class="%security.authentication.provider.pre_authenticated.class%" abstract="true" public="false">
             <argument /> <!-- User Provider -->
             <argument type="service" id="security.account_checker" />
         </service>
-        
+
         <service id="security.exception_listener" class="%security.exception_listener.class%" public="false" abstract="true">
             <argument type="service" id="security.context" />
             <argument type="service" id="security.authentication.trust_resolver" />

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -22,12 +22,13 @@ interface AuthenticationSuccessHandlerInterface
      * is called by authentication listeners inheriting from
      * AbstractAuthenticationListener.
      *
-     * @param EventInterface $event the "core.security" event, this event always
+     * @param EventInterface     $event the "core.security" event, this event always
      *                              has the kernel as target
-     * @param Request        $request
-     * @param TokenInterface $token
+     * @param Request            $request
+     * @param TokenInterface     $token
+     * @param TargetUrlGenerator $targetUrlGenerator - has a determineTargetUrl method
      *
      * @return Response the response to return
      */
-    function onAuthenticationSuccess(EventInterface $event, Request $request, TokenInterface $token);
+    function onAuthenticationSuccess(EventInterface $event, Request $request, TokenInterface $token, TargetUrlGenerator $targetUrlGenerator);
 }

--- a/src/Symfony/Component/Security/Http/Authentication/TargetUrlGenerator.php
+++ b/src/Symfony/Component/Security/Http/Authentication/TargetUrlGenerator.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * TargetUrlGenerator determines the authentication target url
+ *
+ * @author Fabien Potencier <fabien.potencier@symfony-project.com>
+ * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+ */
+class TargetUrlGenerator
+{
+    protected $options;
+
+    public function __construct($options)
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * Builds the target URL according to the defined options.
+     *
+     * @param Request $request
+     *
+     * @return string
+     */
+    public function determineTargetUrl(Request $request)
+    {
+        if ($this->options['always_use_default_target_path']) {
+            return $this->options['default_target_path'];
+        }
+
+        if ($targetUrl = $request->get($this->options['target_path_parameter'])) {
+            return $targetUrl;
+        }
+
+        $session = $request->getSession();
+        if ($targetUrl = $session->get('_security.target_path')) {
+            $session->remove('_security.target_path');
+
+            return $targetUrl;
+        }
+
+        if ($this->options['use_referer'] && $targetUrl = $request->headers->get('Referer')) {
+            return $targetUrl;
+        }
+
+        return $this->options['default_target_path'];
+    }
+}

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
+use Symfony\Component\Security\Http\Authentication\TargetUrlGenerator;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -35,9 +36,9 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     /**
      * {@inheritdoc}
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, $providerKey, array $options = array(), AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, LoggerInterface $logger = null, CsrfProviderInterface $csrfProvider = null)
+    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, TargetUrlGenerator $targetUrlGenerator, $providerKey, array $options = array(), AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, LoggerInterface $logger = null, CsrfProviderInterface $csrfProvider = null)
     {
-        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $providerKey, array_merge(array(
+        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $targetUrlGenerator, $providerKey, array_merge(array(
             'username_parameter' => '_username',
             'password_parameter' => '_password',
             'csrf_parameter'     => '_csrf_token',


### PR DESCRIPTION
This adds a new class `Symfony\Component\Security\Http\Authentication\TargetUrlGenerator`, responsible for generating the
target url after a successful authentication. This logic was previously
embedded in the abstract authentication listener.
By improving separation of concerns, this change allows to generate the
target url from a custom authentication success handler.
