### PR TITLE
Doctrine config

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -45,6 +45,10 @@ class Configuration
         $node
             ->arrayNode('dbal')
                 ->beforeNormalization()
+                    ->ifNull()
+                    ->then(function($v) { return array (); }) // Let use the default values with the subsequent closure.
+                ->end()
+                ->beforeNormalization()
                     ->ifTrue(function($v){ return is_array($v) && !array_key_exists('connections', $v) && !array_key_exists('connection', $v); })
                     ->then(function($v) {
                         $connection = array ();
@@ -61,7 +65,7 @@ class Configuration
                         return $v;
                     })
                 ->end()
-                ->scalarNode('default_connection')->cannotBeEmpty()->defaultValue('default')->end()
+                ->scalarNode('default_connection')->isRequired()->cannotBeEmpty()->end()
                 ->fixXmlConfig('type')
                 ->arrayNode('types')
                     ->useAttributeAsKey('name')
@@ -82,6 +86,7 @@ class Configuration
     {
         $node = new NodeBuilder('connections', 'array');
         $node
+            ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
             ->prototype('array')
                 ->scalarNode('dbname')->end()
@@ -132,8 +137,7 @@ class Configuration
                         return $v;
                     })
                 ->end()
-                ->scalarNode('default_entity_manager')->cannotBeEmpty()->defaultValue('default')->end()
-                ->scalarNode('default_connection')->cannotBeEmpty()->defaultValue('default')->end()
+                ->scalarNode('default_entity_manager')->isRequired()->cannotBeEmpty()->end()
                 ->booleanNode('auto_generate_proxy_classes')->defaultFalse()->end()
                 ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/orm/Proxies')->end()
                 ->scalarNode('proxy_namespace')->defaultValue('Proxies')->end()
@@ -147,6 +151,7 @@ class Configuration
     {
         $node = new NodeBuilder('entity_managers', 'array');
         $node
+            ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
             ->prototype('array')
                 ->addDefaultsIfNotSet()
@@ -157,6 +162,8 @@ class Configuration
                 ->scalarNode('class_metadata_factory_name')->defaultValue('%doctrine.orm.class_metadata_factory_name%')->end()
                 ->fixXmlConfig('mapping')
                 ->arrayNode('mappings')
+                    ->isRequired()
+                    ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->beforeNormalization()

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -24,13 +24,18 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class Configuration
 {
+    private $kernelDebug;
+
     /**
      * Generates the configuration tree.
      *
+     * @param Boolean $kernelDebug
      * @return \Symfony\Component\Config\Definition\NodeInterface
      */
-    public function getConfigTree()
+    public function getConfigTree($kernelDebug)
     {
+        $this->kernelDebug = (bool) $kernelDebug;
+
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('doctrine', 'array');
 
@@ -109,7 +114,7 @@ class Configuration
                 ->scalarNode('wrapper_class')->end()
                 ->scalarNode('platform_service')->end()
                 ->scalarNode('charset')->defaultValue('UTF-8')->end()
-                ->booleanNode('logging')->defaultFalse()->end()
+                ->booleanNode('logging')->defaultValue($this->kernelDebug)->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+/**
+ * This class contains the configuration information for the bundle
+ *
+ * This information is solely responsible for how the different configuration
+ * sections are normalized, and merged.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class Configuration
+{
+    /**
+     * Generates the configuration tree.
+     *
+     * @return \Symfony\Component\Config\Definition\NodeInterface
+     */
+    public function getConfigTree()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('doctrine', 'array');
+
+        $this->addDbalSection($rootNode);
+        $this->addOrmSection($rootNode);
+
+        return $treeBuilder->buildTree();
+    }
+
+    private function addDbalSection(NodeBuilder $node)
+    {
+        $node
+            ->arrayNode('dbal')
+                ->beforeNormalization()
+                    ->ifTrue(function($v){ return is_array($v) && !array_key_exists('connections', $v) && !array_key_exists('connection', $v); })
+                    ->then(function($v) {
+                        $connection = array ();
+                        $keys = array ('dbname', 'host', 'port', 'user', 'password', 'driver', 'driver_class', 'options', 'path', 'memory', 'unix_socket', 'wrapper_class', 'platform_service', 'charset', 'logging');
+                        foreach ($keys as $key) {
+                            if (array_key_exists($key, $v)) {
+                                $connection[$key] = $v[$key];
+                                unset($v[$key]);
+                            }
+                        }
+                        $defaultConnection = isset($v['default_connection']) ? (string) $v['default_connection'] : 'default';
+                        $v['connections'] = array ($defaultConnection => $connection);
+                        $v['default_connection'] = $defaultConnection;
+                        return $v;
+                    })
+                ->end()
+                ->scalarNode('default_connection')->isRequired()->cannotBeEmpty()->end()
+                ->fixXmlConfig('type')
+                ->arrayNode('types')
+                    ->useAttributeAsKey('name')
+                    ->prototype('scalar')
+                        ->beforeNormalization()
+                            ->ifTrue(function($v) { return is_array($v) && isset($v['class']); })
+                            ->then(function($v) { return $v['class']; })
+                        ->end()
+                    ->end()
+                ->end()
+                ->fixXmlConfig('connection')
+                ->builder($this->getDbalConnectionsNode())
+            ->end()
+        ;
+    }
+
+    private function getDbalConnectionsNode()
+    {
+        $node = new NodeBuilder('connections', 'array');
+        $node
+            ->useAttributeAsKey('name')
+            ->prototype('array')
+                ->scalarNode('dbname')->end()
+                ->scalarNode('host')->defaultValue('localhost')->end()
+                ->scalarNode('port')->defaultNull()->end()
+                ->scalarNode('user')->defaultValue('root')->end()
+                ->scalarNode('password')->defaultNull()->end()
+                ->scalarNode('driver')->defaultValue('pdo_mysql')->end()
+                ->scalarNode('driver_class')->end()
+                ->arrayNode('options')
+                    ->useAttributeAsKey('key')
+                    ->prototype('scalar')->end()
+                ->end()
+                ->scalarNode('path')->end()
+                ->booleanNode('memory')->end()
+                ->scalarNode('unix_socket')->end()
+                ->scalarNode('wrapper_class')->end()
+                ->scalarNode('platform_service')->end()
+                ->scalarNode('charset')->defaultValue('UTF-8')->end()
+                ->booleanNode('logging')->defaultFalse()->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function addOrmSection(NodeBuilder $node)
+    {
+        $node
+            ->arrayNode('orm')
+                ->beforeNormalization()
+                    ->ifTrue(function($v){ return is_array($v) && !array_key_exists('entity_managers', $v) && !array_key_exists('entity_manager', $v); })
+                    ->then(function($v) {
+                        $entityManager = array ();
+                        $keys = array ('result_cache_driver', 'metadata_cache_driver', 'query_cache_driver', 'mappings');
+                        foreach ($keys as $key) {
+                            if (array_key_exists($key, $v)) {
+                                $entityManagers[$key] = $v[$key];
+                                unset($v[$key]);
+                            }
+                        }
+                        if (!empty ($entityManager)) {
+                            $defaultEntityManager = isset($v['default_entity_manager']) ? (string) $v['default_entity_manager'] : 'default';
+                            $v['entity_managers'] = array ($defaultEntityManager => $entityManager);
+                            $v['default_entity_manager'] = $defaultEntityManager;
+                        }
+                        return $v;
+                    })
+                ->end()
+                ->scalarNode('default_entity_manager')->isRequired()->cannotBeEmpty()->end()
+                ->booleanNode('auto_generate_proxy_classes')->defaultFalse()->end()
+                ->fixXmlConfig('entity_manager')
+                ->builder($this->getOrmEntityManagersNode())
+            ->end()
+        ;
+    }
+
+    private function getOrmEntityManagersNode()
+    {
+        $node = new NodeBuilder('entity_managers', 'array');
+        $node
+            ->useAttributeAsKey('name')
+            ->prototype('array')
+                ->addDefaultsIfNotSet()
+                ->builder($this->getOrmCacheDriverNode('query_cache_driver'))
+                ->builder($this->getOrmCacheDriverNode('metadata_cache_driver'))
+                ->builder($this->getOrmCacheDriverNode('result_cache_driver'))
+                ->scalarNode('connection')->end()
+                ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/orm/Proxies')->end()
+                ->scalarNode('proxy_namespace')->defaultValue('Proxies')->end()
+                ->scalarNode('class_metadata_factory_name')->end()
+                ->fixXmlConfig('mapping')
+                ->arrayNode('mappings')
+                    ->useAttributeAsKey('name')
+                    ->treatNullLike(array ())
+                    ->prototype('array')
+                        ->beforeNormalization()
+                            ->ifString()
+                            ->then(function($v) { return array ('type' => $v); })
+                        ->end()
+                        ->scalarNode('type')->end()
+                        ->scalarNode('dir')->end()
+                        ->scalarNode('alias')->end()
+                        ->scalarNode('prefix')->end()
+                        ->booleanNode('is_bundle')->end()
+                        ->performNoDeepMerging()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function getOrmCacheDriverNode($name)
+    {
+        $node = new NodeBuilder($name, 'array');
+        $node
+            ->beforeNormalization()
+                ->ifString()
+                ->then(function($v) { return array ('type' => $v); })
+            ->end()
+            ->scalarNode('type')->defaultValue('array')->end()
+            ->scalarNode('host')->end()
+            ->scalarNode('port')->end()
+            ->scalarNode('instance_class')->end()
+        ;
+
+        return $node;
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\DoctrineBundle\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Alias;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -20,6 +19,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * DoctrineExtension is an extension for the Doctrine DBAL and ORM library.
@@ -32,23 +32,16 @@ class DoctrineExtension extends AbstractDoctrineExtension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
-        $dbal = $orm = array();
-        foreach ($configs as $config) {
-            if (isset($config['dbal'])) {
-                $dbal[] = $config['dbal'];
-            }
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $config = $processor->process($configuration->getConfigTree(), $configs);
 
-            if (isset($config['orm'])) {
-                $orm[] = $config['orm'];
-            }
+        if (!empty($config['dbal'])) {
+            $this->dbalLoad($config['dbal'], $container);
         }
 
-        if (!empty($dbal)) {
-            $this->dbalLoad($dbal, $container);
-        }
-
-        if (!empty($orm)) {
-            $this->ormLoad($orm, $container);
+        if (!empty($config['orm'])) {
+            $this->ormLoad($config['orm'], $container);
         }
     }
 
@@ -62,183 +55,74 @@ class DoctrineExtension extends AbstractDoctrineExtension
      * @param array $config An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    protected function dbalLoad(array $configs, ContainerBuilder $container)
+    protected function dbalLoad(array $config, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('dbal.xml');
 
-        $config = $this->mergeDbalConfig($configs, $container);
-
         $container->setAlias('database_connection', sprintf('doctrine.dbal.%s_connection', $config['default_connection']));
+        $container->setAlias('doctrine.dbal.event_manager', new Alias(sprintf('doctrine.dbal.%s_connection.event_manager', $config['default_connection']), false));
         $container->setParameter('doctrine.dbal.default_connection', $config['default_connection']);
         $container->setParameter('doctrine.dbal.types', $config['types']);
 
         foreach ($config['connections'] as $name => $connection) {
-            $this->loadDbalConnection($connection, $container);
+            $this->loadDbalConnection($name, $connection, $container);
         }
-    }
-
-    /**
-     * Merges a set of exclusive independent DBAL configurations into another.
-     *
-     * Beginning from the default settings this method acts as incremental merge
-     * of all the configurations that are passed through multiple environment
-     * and fallbacks for example config.yml + config_dev.yml
-     *
-     * @param array $configs
-     * @return array
-     */
-    protected function mergeDbalConfig(array $configs, $container)
-    {
-        $supportedConnectionParams = array(
-            'dbname'                => 'dbname',
-            'host'                  => 'host',
-            'port'                  => 'port',
-            'user'                  => 'user',
-            'password'              => 'password',
-            'driver'                => 'driver',
-            'driver-class'          => 'driverClass', // doctrine conv.
-            'options'               => 'driverOptions', // doctrine conv.
-            'path'                  => 'path',
-            'unix-socket'           => 'unix_socket',
-            'memory'                => 'memory',
-            'driver_class'          => 'driverClass', // doctrine conv.
-            'unix_socket'           => 'unix_socket',
-            'wrapper_class'         => 'wrapperClass', // doctrine conv.
-            'wrapper-class'         => 'wrapperClass', // doctrine conv.
-            'charset'               => 'charset',
-        );
-        $supportedContainerParams = array(
-            'platform-service'      => 'platform_service',
-            'platform_service'      => 'platform_service',
-            'logging'               => 'logging',
-        );
-        $mergedConfig = array(
-            'default_connection'  => 'default',
-            'types' => array(),
-        );
-        $connectionDefaults = array(
-            'driver' => array(
-                'host'                => 'localhost',
-                'driver'              => 'pdo_mysql',
-                'driverOptions'       => array(),
-                'user'                => 'root',
-                'password'            => null,
-                'port'                => null,
-            ),
-            'container' => array(
-                'logging'             => (bool)$container->getParameter('doctrine.dbal.logging')
-            ),
-        );
-
-        foreach ($configs as $config) {
-            if (isset($config['default-connection'])) {
-                $mergedConfig['default_connection'] = $config['default-connection'];
-            } else if (isset($config['default_connection'])) {
-                $mergedConfig['default_connection'] = $config['default_connection'];
-            }
-
-            // Handle DBAL Types
-            if (isset($config['types'])) {
-                if (isset($config['types']['type'][0])) {
-                    $config['types'] = $config['types']['type'];
-                }
-                foreach ($config['types'] AS $name => $type) {
-                    if (is_array($type) && isset($type['name']) && isset($type['class'])) { // xml case
-                        $mergedConfig['types'][$type['name']] = $type['class'];
-                    } else { // yml case
-                        $mergedConfig['types'][$name] = $type;
-                    }
-                }
-            }
-        }
-
-        foreach ($configs as $config) {
-            if (isset($config['connections'])) {
-                $configConnections = $config['connections'];
-                if (isset($config['connections']['connection']) && isset($config['connections']['connection'][0])) {
-                    $configConnections = $config['connections']['connection'];
-                }
-            } else {
-                $configConnections[$mergedConfig['default_connection']] = $config;
-            }
-            
-            foreach ($configConnections as $name => $connection) {
-                $connectionName = isset($connection['name']) ? $connection['name'] : $name;
-                if (!isset($mergedConfig['connections'][$connectionName])) {
-                    $mergedConfig['connections'][$connectionName] = $connectionDefaults;
-                }
-                $mergedConfig['connections'][$connectionName]['name'] = $connectionName;
-
-                foreach ($connection as $k => $v) {
-                    if (isset($supportedConnectionParams[$k])) {
-                        $mergedConfig['connections'][$connectionName]['driver'][$supportedConnectionParams[$k]] = $v;
-                    } else if (isset($supportedContainerParams[$k])) {
-                        $mergedConfig['connections'][$connectionName]['container'][$supportedContainerParams[$k]] = $v;
-                    }
-                }
-            }
-        }
-
-        return $mergedConfig;
     }
 
     /**
      * Loads a configured DBAL connection.
      *
+     * @param string $name The name of the connection
      * @param array $connection A dbal connection configuration.
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    protected function loadDbalConnection(array $connection, ContainerBuilder $container)
+    protected function loadDbalConnection($name, array $connection, ContainerBuilder $container)
     {
-        $containerDef = new Definition($container->getParameter('doctrine.dbal.configuration_class'));
+        $containerDef = new Definition('%doctrine.dbal.configuration_class%');
         $containerDef->setPublic(false);
-        if (isset($connection['container']['logging']) && $connection['container']['logging']) {
+        if (isset($connection['logging']) && $connection['logging']) {
             $containerDef->addMethodCall('setSQLLogger', array(new Reference('doctrine.dbal.logger')));
+            unset ($connection['logging']);
         }
-        $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $connection['name']), $containerDef);
-
-        $driverOptions = $connection['driver'];
+        $container->setDefinition(sprintf('doctrine.dbal.%s_connection.configuration', $name), $containerDef);
 
         $driverDef = new Definition('Doctrine\DBAL\Connection');
         $driverDef->setFactoryService('doctrine.dbal.connection_factory');
         $driverDef->setFactoryMethod('createConnection');
-        $container->setDefinition(sprintf('doctrine.dbal.%s_connection', $connection['name']), $driverDef);
+        $container->setDefinition(sprintf('doctrine.dbal.%s_connection', $name), $driverDef);
 
         // event manager
-        $eventManagerId = sprintf('doctrine.dbal.%s_connection.event_manager', $connection['name']);
+        $eventManagerId = sprintf('doctrine.dbal.%s_connection.event_manager', $name);
         $eventManagerDef = new Definition('%doctrine.dbal.event_manager_class%');
         $eventManagerDef->setPublic(false);
         $container->setDefinition($eventManagerId, $eventManagerDef);
 
-        if ($container->getParameter('doctrine.dbal.default_connection') == $connection['name']) {
-            $container->setAlias('doctrine.dbal.event_manager', new Alias(sprintf('doctrine.dbal.%s_connection.event_manager', $connection['name']), false));
-        }
-
-        if (isset($driverOptions['charset'])) {
-            if ( (isset($driverOptions['driver']) && stripos($driverOptions['driver'], 'mysql') !== false) ||
-                 (isset($driverOptions['driverClass']) && stripos($driverOptions['driverClass'], 'mysql') !== false)) {
+        if (isset($connection['charset'])) {
+            if ( (isset($connection['driver']) && stripos($connection['driver'], 'mysql') !== false) ||
+                 (isset($connection['driverClass']) && stripos($connection['driverClass'], 'mysql') !== false)) {
                 $mysqlSessionInit = new Definition('%doctrine.dbal.events.mysql_session_init.class%');
-                $mysqlSessionInit->setArguments(array($driverOptions['charset']));
+                $mysqlSessionInit->setArguments(array($connection['charset']));
                 $mysqlSessionInit->setPublic(false);
-                $mysqlSessionInit->addTag(sprintf('doctrine.dbal.%s_event_subscriber', $connection['name']));
+                $mysqlSessionInit->addTag(sprintf('doctrine.dbal.%s_event_subscriber', $name));
 
                 $container->setDefinition(
-                    sprintf('doctrine.dbal.%s_connection.events.mysqlsessioninit', $connection['name']),
+                    sprintf('doctrine.dbal.%s_connection.events.mysqlsessioninit', $name),
                     $mysqlSessionInit
                 );
-                unset($driverOptions['charset']);
+                unset($connection['charset']);
             }
         }
 
-        if (isset($connection['container']['platform_service'])) {
-            $driverOptions['platform'] = new Reference($connection['container']['platform_service']);
+        if (isset($connection['platform_service'])) {
+            $connection['platform'] = new Reference($connection['platform_service']);
+            unset ($connection['platform_service']);
         }
 
         $driverDef->setArguments(array(
-            $driverOptions,
-            new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $connection['name'])),
-            new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $connection['name']))
+            $connection,
+            new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name)),
+            new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $name))
         ));
     }
 
@@ -252,148 +136,28 @@ class DoctrineExtension extends AbstractDoctrineExtension
      * @param array $config An array of configuration settings
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    protected function ormLoad(array $configs, ContainerBuilder $container)
+    protected function ormLoad(array $config, ContainerBuilder $container)
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('orm.xml');
 
-        $config = $this->mergeOrmConfig($configs, $container);
-        
-        $options = array('default_entity_manager', 'default_connection', 'auto_generate_proxy_classes');
+        $options = array('default_entity_manager', 'default_connection', 'auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
         foreach ($options as $key) {
             $container->setParameter('doctrine.orm.'.$key, $config[$key]);
         }
 
-        foreach ($config['entity_managers'] as $entityManager) {
-            $this->loadOrmEntityManager($entityManager, $container);
+        $container->setAlias('doctrine.orm.entity_manager', sprintf('doctrine.orm.%s_entity_manager', $config['default_entity_manager']));
 
-            if ($entityManager['name'] == $config['default_entity_manager']) {
-                $container->setAlias(
-                    'doctrine.orm.entity_manager',
-                    sprintf('doctrine.orm.%s_entity_manager', $entityManager['name'])
-                );
-            }
+        foreach ($config['entity_managers'] as $name => $entityManager) {
+            $entityManager['name'] = $name;
+            $this->loadOrmEntityManager($entityManager, $container);
         }
 
         $container->setParameter('doctrine.orm.entity_managers', array_keys($config['entity_managers']));
     }
 
-    protected function mergeOrmConfig(array $configs, $container)
-    {
-        $supportedEntityManagerOptions = array(
-            'metadata_cache_driver'             => 'metadata_cache_driver',
-            'query_cache_driver'                => 'query_cache_driver',
-            'result_cache_driver'               => 'result_cache_driver',
-            'class_metadata_factory_name'       => 'class_metadata_factory_name',
-            'metadata-cache-driver'             => 'metadata_cache_driver',
-            'query-cache-driver'                => 'query_cache_driver',
-            'result-cache-driver'               => 'result_cache_driver',
-            'class-metadata-factory-name'       => 'class_metadata_factory_name',
-            'connection'                        => 'connection'
-        );
-
-        $mergedConfig = array(
-            'default_entity_manager' => 'default',
-            'default_connection' => 'default',
-            'auto_generate_proxy_classes' => false,
-            'entity_managers' => array(),
-        );
-
-        $defaultManagerOptions = array(
-            'proxy_dir'                     => $container->getParameter('doctrine.orm.proxy_dir'),
-            'proxy_namespace'               => $container->getParameter('doctrine.orm.proxy_namespace'),
-            'auto_generate_proxy_classes'   => false,
-            'metadata_cache_driver'         => $container->getParameter('doctrine.orm.metadata_cache_driver'),
-            'query_cache_driver'            => $container->getParameter('doctrine.orm.query_cache_driver'),
-            'result_cache_driver'           => $container->getParameter('doctrine.orm.result_cache_driver'),
-            'configuration_class'           => $container->getParameter('doctrine.orm.configuration_class'),
-            'entity_manager_class'          => $container->getParameter('doctrine.orm.entity_manager_class'),
-            'class_metadata_factory_name'   => $container->getParameter('doctrine.orm.class_metadata_factory_name'),
-        );
-        
-        foreach ($configs as $config) {
-            if (isset($config['default-entity-manager'])) {
-                $mergedConfig['default_entity_manager'] = $config['default-entity-manager'];
-            } else if (isset($config['default_entity_manager'])) {
-                $mergedConfig['default_entity_manager'] = $config['default_entity_manager'];
-            }
-            if (isset($config['default-connection'])) {
-                $mergedConfig['default_connection'] = $config['default-connection'];
-            } else if (isset($config['default_connection'])) {
-                $mergedConfig['default_connection'] = $config['default_connection'];
-            }
-            if (isset($config['auto_generate_proxy_classes'])) {
-                $defaultManagerOptions['auto_generate_proxy_classes'] = $config['auto_generate_proxy_classes'];
-            }
-            if (isset($config['auto-generate-proxy-classes'])) {
-                $defaultManagerOptions['auto_generate_proxy_classes'] = $config['auto-generate-proxy-classes'];
-            }
-        }
-        $defaultManagerOptions['connection'] = $mergedConfig['default_connection'];
-
-        foreach ($configs as $config) {
-            if (isset($config['entity-managers'])) {
-                $config['entity_managers'] = $config['entity-managers'];
-            }
-
-            $entityManagers = array();
-            if (isset($config['entity_managers'])) {
-                $configEntityManagers = $config['entity_managers'];
-                if (isset($config['entity_managers']['entity-manager'])) {
-                    $config['entity_managers']['entity_manager'] = $config['entity_managers']['entity-manager'];
-                }
-                if (isset($config['entity_managers']['entity_manager']) && isset($config['entity_managers']['entity_manager'][0])) {
-                    $configEntityManagers = $config['entity_managers']['entity_manager'];
-                }
-                
-                foreach ($configEntityManagers as $name => $entityManager) {
-                    $name = isset($entityManager['name']) ? $entityManager['name'] : $name;
-                    $entityManagers[$name] = $entityManager;
-                }
-            } else {
-                $entityManagers = array($mergedConfig['default_entity_manager'] => $config);
-            }
-
-            foreach ($entityManagers as $name => $managerConfig) {
-                if (!isset($mergedConfig['entity_managers'][$name])) {
-                    $mergedConfig['entity_managers'][$name] = $defaultManagerOptions;
-                }
-
-                foreach ($managerConfig as $k => $v) {
-                    if (isset($supportedEntityManagerOptions[$k])) {
-                        $k = $supportedEntityManagerOptions[$k];
-                        $mergedConfig['entity_managers'][$name][$k] = $v;
-                    }
-                }
-                $mergedConfig['entity_managers'][$name]['name'] = $name;
-
-                if (isset($managerConfig['mappings'])) {
-                    foreach ($managerConfig['mappings'] as $mappingName => $mappingConfig) {
-                        if (!isset($mergedConfig['entity_managers'][$name]['mappings'][$mappingName])) {
-                            $mergedConfig['entity_managers'][$name]['mappings'][$mappingName] = array();
-                        }
-
-                        if (is_array($mappingConfig)) {
-                            foreach ($mappingConfig as $k => $v) {
-                                $mergedConfig['entity_managers'][$name]['mappings'][$mappingName][$k] = $v;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        return $mergedConfig;
-    }
-
     /**
      * Loads a configured ORM entity manager.
-     *
-     * You need to be aware that ormLoad() can be called multiple times, which makes this method tricky to implement.
-     * There are two possible runtime scenarios:
-     *
-     * 1. If the EntityManager was defined before, override only the new calls to Doctrine\ORM\Configuration
-     * 2. If the EntityManager was not defined before, gather all the defaults for not specified options and set all the information.
      *
      * @param array $entityManager A configured ORM entity manager.
      * @param ContainerBuilder $container A ContainerBuilder instance
@@ -414,9 +178,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
             'setQueryCacheImpl'             => new Reference(sprintf('doctrine.orm.%s_query_cache', $entityManager['name'])),
             'setResultCacheImpl'            => new Reference(sprintf('doctrine.orm.%s_result_cache', $entityManager['name'])),
             'setMetadataDriverImpl'         => new Reference('doctrine.orm.'.$entityManager['name'].'_metadata_driver'),
-            'setProxyDir'                   => $entityManager['proxy_dir'],
-            'setProxyNamespace'             => $entityManager['proxy_namespace'],
-            'setAutoGenerateProxyClasses'   => $entityManager['auto_generate_proxy_classes'],
+            'setProxyDir'                   => '%doctrine.orm.proxy_dir%',
+            'setProxyNamespace'             => '%doctrine.orm.proxy_namespace%',
+            'setAutoGenerateProxyClasses'   => '%doctrine.orm.auto_generate_proxy_classes%',
             'setClassMetadataFactoryName'   => $entityManager['class_metadata_factory_name'],
         );
         foreach ($uniqueMethods as $method => $arg) {
@@ -482,7 +246,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $this->loadMappingInformation($entityManager, $container);
         $this->registerMappingDrivers($entityManager, $container);
-        
+
         $ormConfigDef->addMethodCall('setEntityNamespaces', array($this->aliasMap));
     }
 
@@ -534,14 +298,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
      * Gets an entity manager cache driver definition for metadata, query and result caches.
      *
      * @param array $entityManager The array configuring an entity manager.
-     * @param string|array $cacheDriver The cache driver configuration.
+     * @param array $cacheDriver The cache driver configuration.
      * @param ContainerBuilder $container
      * @return Definition $cacheDef
      */
     protected function getEntityManagerCacheDefinition(array $entityManager, $cacheDriver, ContainerBuilder $container)
     {
-        $type = is_array($cacheDriver) && isset($cacheDriver['type']) ? $cacheDriver['type'] : $cacheDriver;
-        if ('memcache' === $type) {
+        if ('memcache' === $cacheDriver['type']) {
             $cacheDef = new Definition('%doctrine.orm.cache.memcache_class%');
             $memcacheInstance = new Definition('%doctrine.orm.cache.memcache_instance_class%');
             $memcacheInstance->addMethodCall('connect', array(
@@ -549,8 +312,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
             ));
             $container->setDefinition(sprintf('doctrine.orm.%s_memcache_instance', $entityManager['name']), $memcacheInstance);
             $cacheDef->addMethodCall('setMemcache', array(new Reference(sprintf('doctrine.orm.%s_memcache_instance', $entityManager['name']))));
-        } else if (in_array($type, array('apc', 'array', 'xcache'))) {
-            $cacheDef = new Definition('%'.sprintf('doctrine.orm.cache.%s_class', $type).'%');
+        } else if (in_array($cacheDriver['type'], array('apc', 'array', 'xcache'))) {
+            $cacheDef = new Definition('%'.sprintf('doctrine.orm.cache.%s_class', $cacheDriver['type']).'%');
         }
         $cacheDef->setPublic(false);
         $cacheDef->addMethodCall('setNamespace', array('sf2orm_'.$entityManager['name']));

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -140,8 +140,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('orm.xml');
-
-        $options = array('default_entity_manager', 'default_connection', 'auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
+        $options = array('default_entity_manager', 'auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
         foreach ($options as $key) {
             $container->setParameter('doctrine.orm.'.$key, $config[$key]);
         }

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -34,7 +34,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
     {
         $configuration = new Configuration();
         $processor = new Processor();
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $processor->process($configuration->getConfigTree($container->getParameter('kernel.debug')), $configs);
 
         if (!empty($config['dbal'])) {
             $this->dbalLoad($config['dbal'], $container);

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
@@ -33,25 +33,13 @@
     </xsd:attributeGroup>
 
     <xsd:complexType name="dbal">
-        <xsd:all>
-            <xsd:element name="connections" type="connections" minOccurs="0" maxOccurs="1" />
-            <xsd:element name="types" type="types" minOccurs="0" maxOccurs="1" />
-        </xsd:all>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="connection" type="connection" />
+            <xsd:element name="type" type="type" />
+        </xsd:choice>
 
         <xsd:attribute name="default-connection" type="xsd:string" />
         <xsd:attributeGroup ref="connection-config" />
-    </xsd:complexType>
-
-    <xsd:complexType name="connections">
-        <xsd:choice minOccurs="1" maxOccurs="unbounded">
-            <xsd:element name="connection" type="connection" />
-        </xsd:choice>
-    </xsd:complexType>
-
-    <xsd:complexType name="types">
-        <xsd:choice minOccurs="1" maxOccurs="unbounded">
-            <xsd:element name="type" type="type" />
-        </xsd:choice>
     </xsd:complexType>
 
     <xsd:complexType name="type">
@@ -73,18 +61,12 @@
         <xsd:attribute name="is-bundle" type="xsd:boolean" />
     </xsd:complexType>
 
-    <xsd:complexType name="mappings">
-        <xsd:choice minOccurs="1" maxOccurs="unbounded">
-            <xsd:element name="mapping" type="mapping" />
-        </xsd:choice>
-    </xsd:complexType>
-
     <xsd:complexType name="orm">
-        <xsd:all>
-            <xsd:element name="entity-managers" type="entity_managers" minOccurs="0" maxOccurs="1" />
-            <xsd:element name="mappings" type="mappings" minOccurs="0" maxOccurs="1" />
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="entity-manager" type="entity_manager" />
+            <xsd:element name="mapping" type="mapping" />
             <xsd:element name="metadata-cache-driver" type="metadata_cache_driver" minOccurs="0" maxOccurs="1" />
-        </xsd:all>
+        </xsd:choice>
 
         <xsd:attribute name="default-entity-manager" type="xsd:string" />
         <xsd:attribute name="default-connection" type="xsd:string" />
@@ -106,17 +88,11 @@
         <xsd:attribute name="type" type="xsd:string" />
     </xsd:complexType>
 
-    <xsd:complexType name="entity_managers">
-        <xsd:choice minOccurs="1" maxOccurs="unbounded">
-            <xsd:element name="entity-manager" type="entity_manager" />
-        </xsd:choice>
-    </xsd:complexType>
-
     <xsd:complexType name="entity_manager">
-        <xsd:all>
-            <xsd:element name="mappings" type="mappings" minOccurs="0" maxOccurs="1" />
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="mapping" type="mapping" />
             <xsd:element name="metadata-cache-driver" type="metadata_cache_driver" minOccurs="0" maxOccurs="1" />
-        </xsd:all>
+        </xsd:choice>
 
         <xsd:attribute name="connection" type="xsd:string" />
         <xsd:attribute name="name" type="xsd:string" />

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -658,6 +658,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         }
 
         return new ContainerBuilder(new ParameterBag(array(
+            'kernel.debug'       => false,
             'kernel.bundles'     => $map,
             'kernel.cache_dir'   => sys_get_temp_dir(),
             'kernel.root_dir'    => __DIR__ . "/../../../../../" // src dir

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -160,7 +160,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $arguments = $definition->getArguments();
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
-        $this->assertEquals('doctrine.dbal.default_connection', (string) $arguments[0]);
+        $this->assertEquals('database_connection', (string) $arguments[0]);
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
         $this->assertEquals('doctrine.orm.default_configuration', (string) $arguments[1]);
 
@@ -198,7 +198,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine.orm.entity_manager', $definition->getTags());
 
         $this->assertDICConstructorArguments($definition, array(
-            new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration')
+            new Reference('database_connection'), new Reference('doctrine.orm.default_configuration')
         ));
     }
 
@@ -238,7 +238,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertArrayHasKey('doctrine.orm.entity_manager', $definition->getTags());
 
         $this->assertDICConstructorArguments($definition, array(
-            new Reference('doctrine.dbal.default_connection'), new Reference('doctrine.orm.default_configuration')
+            new Reference('database_connection'), new Reference('doctrine.orm.default_configuration')
         ));
     }
 
@@ -489,15 +489,15 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container->compile();
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_cache');
-        $this->assertDICDefinitionClass($definition, '%doctrine.orm.cache.memcache_class%');
+        $this->assertDICDefinitionClass($definition, 'Doctrine\Common\Cache\MemcacheCache');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setMemcache',
             array(new Reference('doctrine.orm.default_memcache_instance'))
         );
 
         $definition = $container->getDefinition('doctrine.orm.default_memcache_instance');
-        $this->assertDICDefinitionClass($definition, '%doctrine.orm.cache.memcache_instance_class%');
+        $this->assertDICDefinitionClass($definition, 'Memcache');
         $this->assertDICDefinitionMethodCallOnce($definition, 'connect', array(
-            '%doctrine.orm.cache.memcache_host%', '%doctrine.orm.cache.memcache_port%'
+            'localhost', '11211'
         ));
     }
 

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -186,7 +186,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('dbal' => array(), 'orm' => array())), $container);
+        $loader->load(array(array('dbal' => array(), 'orm' => array('mappings' => array('YamlBundle' => array())))), $container);
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
         $this->assertEquals('Doctrine\DBAL\Connection', $definition->getClass());
@@ -207,8 +207,6 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
         $container->registerExtension($loader);
-
-        $loader->load(array(array('dbal' => array(), 'orm' => array())), $container);
 
         $this->loadFromFile($container, 'orm_service_simple_single_entity_manager');
 
@@ -269,6 +267,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'password' => 'sqlite_s3cr3t',
                 'dbname' => 'sqlite_db',
                 'memory' => true,
+                'logging' => false,
+                'charset' => 'UTF-8'
             ),
             new Reference('doctrine.dbal.default_connection.configuration'),
             new Reference('doctrine.dbal.default_connection.event_manager')
@@ -307,9 +307,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('doctrine.dbal.conn1_connection.configuration', (string) $args[1]);
         $this->assertEquals('doctrine.dbal.conn1_connection.event_manager', (string) $args[2]);
 
-        $this->assertEquals('doctrine.orm.dm2_entity_manager', (string) $container->getAlias('doctrine.orm.entity_manager'));
+        $this->assertEquals('doctrine.orm.em2_entity_manager', (string) $container->getAlias('doctrine.orm.entity_manager'));
 
-        $definition = $container->getDefinition('doctrine.orm.dm1_entity_manager');
+        $definition = $container->getDefinition('doctrine.orm.em1_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager_class%', $definition->getClass());
         $this->assertEquals('%doctrine.orm.entity_manager_class%', $definition->getFactoryClass());
         $this->assertEquals('create', $definition->getFactoryMethod());
@@ -319,7 +319,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
         $this->assertEquals('doctrine.dbal.conn1_connection', (string) $arguments[0]);
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
-        $this->assertEquals('doctrine.orm.dm1_configuration', (string) $arguments[1]);
+        $this->assertEquals('doctrine.orm.em1_configuration', (string) $arguments[1]);
 
         $definition = $container->getDefinition('doctrine.dbal.conn2_connection');
         $this->assertEquals('Doctrine\DBAL\Connection', $definition->getClass());
@@ -331,7 +331,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('doctrine.dbal.conn2_connection.configuration', (string) $args[1]);
         $this->assertEquals('doctrine.dbal.conn2_connection.event_manager', (string) $args[2]);
 
-        $definition = $container->getDefinition('doctrine.orm.dm2_entity_manager');
+        $definition = $container->getDefinition('doctrine.orm.em2_entity_manager');
         $this->assertEquals('%doctrine.orm.entity_manager_class%', $definition->getClass());
         $this->assertEquals('%doctrine.orm.entity_manager_class%', $definition->getFactoryClass());
         $this->assertEquals('create', $definition->getFactoryMethod());
@@ -341,15 +341,15 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
         $this->assertEquals('doctrine.dbal.conn2_connection', (string) $arguments[0]);
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[1]);
-        $this->assertEquals('doctrine.orm.dm2_configuration', (string) $arguments[1]);
+        $this->assertEquals('doctrine.orm.em2_configuration', (string) $arguments[1]);
 
-        $definition = $container->getDefinition('doctrine.orm.dm1_metadata_cache');
+        $definition = $container->getDefinition('doctrine.orm.em1_metadata_cache');
         $this->assertEquals('%doctrine.orm.cache.xcache_class%', $definition->getClass());
 
-        $definition = $container->getDefinition('doctrine.orm.dm1_query_cache');
+        $definition = $container->getDefinition('doctrine.orm.em1_query_cache');
         $this->assertEquals('%doctrine.orm.cache.array_class%', $definition->getClass());
 
-        $definition = $container->getDefinition('doctrine.orm.dm1_result_cache');
+        $definition = $container->getDefinition('doctrine.orm.em1_result_cache');
         $this->assertEquals('%doctrine.orm.cache.array_class%', $definition->getClass());
     }
 
@@ -469,10 +469,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container->getCompilerPassConfig()->setRemovingPasses(array());
         $container->compile();
 
-        $definition = $container->getDefinition('doctrine.orm.dm1_metadata_cache');
+        $definition = $container->getDefinition('doctrine.orm.em1_metadata_cache');
         $this->assertDICDefinitionClass($definition, '%doctrine.orm.cache.xcache_class%');
 
-        $definition = $container->getDefinition('doctrine.orm.dm2_metadata_cache');
+        $definition = $container->getDefinition('doctrine.orm.em2_metadata_cache');
         $this->assertDICDefinitionClass($definition, '%doctrine.orm.cache.apc_class%');
     }
 

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal>
+        <dbal default-connection="mysql">
             <connection
                 name="mysql"
                 dbname="mysql_db"

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_multiple_connections.xml
@@ -8,28 +8,26 @@
 
     <config>
         <dbal>
-            <connections>
-                <connection
-                    name="mysql"
-                    dbname="mysql_db"
-                    user="mysql_user"
-                    password="mysql_s3cr3t"
-                    unix-socket="/path/to/mysqld.sock" /><!--  -->
-                <connection
-                    name="sqlite"
-                    driver="pdo_sqlite"
-                    dbname="sqlite_db"
-                    user="sqlite_user"
-                    password="sqlite_s3cr3t"
-                    memory="true" />
-                <connection
-                    name="oci"
-                    driver="oci8"
-                    dbname="oracle_db"
-                    user="oracle_user"
-                    password="oracle_s3cr3t"
-                    charset="utf8" />
-            </connections>
+            <connection
+                name="mysql"
+                dbname="mysql_db"
+                user="mysql_user"
+                password="mysql_s3cr3t"
+                unix-socket="/path/to/mysqld.sock" /><!--  -->
+            <connection
+                name="sqlite"
+                driver="pdo_sqlite"
+                dbname="sqlite_db"
+                user="sqlite_user"
+                password="sqlite_s3cr3t"
+                memory="true" />
+            <connection
+                name="oci"
+                driver="oci8"
+                dbname="oracle_db"
+                user="oracle_user"
+                password="oracle_s3cr3t"
+                charset="utf8" />
         </dbal>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_connection.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_connection.xml
@@ -8,14 +8,12 @@
 
     <config>
         <dbal>
-            <connections>
-                <connection
-                    name="mysql"
-                    dbname="mysql_db"
-                    user="mysql_user"
-                    password="mysql_s3cr3t"
-                    unix-socket="/path/to/mysqld.sock" /><!--  -->
-            </connections>
+            <connection
+                name="mysql"
+                dbname="mysql_db"
+                user="mysql_user"
+                password="mysql_s3cr3t"
+                unix-socket="/path/to/mysqld.sock" /><!--  -->
         </dbal>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_connection.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_service_single_connection.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal>
+        <dbal default-connection="mysql">
             <connection
                 name="mysql"
                 dbname="mysql_db"

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
@@ -7,8 +7,9 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal>
+        <dbal default-connection="default">
             <type name="test" class="Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType" />
+            <connection name="default" />
         </dbal>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/dbal_types.xml
@@ -8,9 +8,7 @@
 
     <config>
         <dbal>
-            <types>
-                <type name="test" class="Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType" />
-            </types>
+            <type name="test" class="Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType" />
         </dbal>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
@@ -10,6 +10,8 @@
         <orm
             auto-generate-proxy-classes="false"
             metadata-cache-driver="apc"
-        />
+        >
+            <mapping name="YamlBundle" />
+        </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <orm default-entity-manager="dm2" default-connection="conn1">
+        <orm default-entity-manager="em2">
             <entity-manager name="em1">
                 <mapping name="AnnotationsBundle" />
             </entity-manager>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
@@ -7,23 +7,17 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <orm>
-            <entity-managers>
-                <entity-manager name="em1">
-                    <mappings>
-                        <mapping name="AnnotationsBundle" />
-                    </mappings>
-                </entity-manager>
-                <entity-manager name="em2">
-                    <mappings>
-                        <mapping name="YamlBundle" dir="Resources/config/doctrine/metadata" alias="yml" />
-                        <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
-                            dir="%kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata"
-                            alias="TestAlias"
-                        />
-                    </mappings>
-                </entity-manager>
-            </entity-managers>
+        <orm default-entity-manager="dm2" default-connection="conn1">
+            <entity-manager name="em1">
+                <mapping name="AnnotationsBundle" />
+            </entity-manager>
+            <entity-manager name="em2">
+                <mapping name="YamlBundle" dir="Resources/config/doctrine/metadata" alias="yml" />
+                <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
+                    dir="%kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata"
+                    alias="TestAlias"
+                />
+            </entity-manager>
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
@@ -28,9 +28,13 @@
                 memory="true" />
         </dbal>
 
-        <orm default-entity-manager="dm2" default-connection="conn1" auto-generate-proxy-classes="true">
-            <entity-manager name="dm1" metadata-cache-driver="xcache" connection="conn1" />
-            <entity-manager name="dm2" connection="conn2" metadata-cache-driver="apc" />
+        <orm default-entity-manager="em2" auto-generate-proxy-classes="true">
+            <entity-manager name="em1" metadata-cache-driver="xcache" connection="conn1">
+                <mapping name="YamlBundle" />
+            </entity-manager>
+            <entity-manager name="em2" connection="conn2" metadata-cache-driver="apc">
+                <mapping name="YamlBundle" />
+            </entity-manager>
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_multiple_entity_managers.xml
@@ -11,30 +11,26 @@
     </srv:parameters>
 
     <config>
-        <dbal>
-            <connections>
-                <connection
-                    name="conn1"
-                    driver="pdo_sqlite"
-                    dbname="sqlite_db"
-                    user="sqlite_user"
-                    password="sqlite_s3cr3t"
-                    memory="true" />
-                <connection
-                    name="conn2"
-                    driver="pdo_sqlite"
-                    dbname="sqlite_db"
-                    user="sqlite_user"
-                    password="sqlite_s3cr3t"
-                    memory="true" />
-            </connections>
+        <dbal default-connection="conn1">
+            <connection
+                name="conn1"
+                driver="pdo_sqlite"
+                dbname="sqlite_db"
+                user="sqlite_user"
+                password="sqlite_s3cr3t"
+                memory="true" />
+            <connection
+                name="conn2"
+                driver="pdo_sqlite"
+                dbname="sqlite_db"
+                user="sqlite_user"
+                password="sqlite_s3cr3t"
+                memory="true" />
         </dbal>
 
         <orm default-entity-manager="dm2" default-connection="conn1" auto-generate-proxy-classes="true">
-            <entity-managers>
-                <entity-manager name="dm1" metadata-cache-driver="xcache" connection="conn1" />
-                <entity-manager name="dm2" connection="conn2" metadata-cache-driver="apc" />
-            </entity-managers>
+            <entity-manager name="dm1" metadata-cache-driver="xcache" connection="conn1" />
+            <entity-manager name="dm2" connection="conn2" metadata-cache-driver="apc" />
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager.xml
@@ -15,6 +15,7 @@
                 <port>11211</port>
                 <instance-class>Memcache</instance-class>
             </metadata-cache-driver>
+            <mapping name="YamlBundle" />
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
@@ -12,15 +12,13 @@
 
     <config>
         <dbal>
-            <connections>
-                <connection
-                    name="default"
-                    driver="pdo_sqlite"
-                    dbname="sqlite_db"
-                    user="sqlite_user"
-                    password="sqlite_s3cr3t"
-                    memory="true" />
-            </connections>
+            <connection
+                name="default"
+                driver="pdo_sqlite"
+                dbname="sqlite_db"
+                user="sqlite_user"
+                password="sqlite_s3cr3t"
+                memory="true" />
         </dbal>
 
         <orm
@@ -29,16 +27,14 @@
                 default-connection="conn1"
                 auto-generate-proxy-classes="true"
             >
-            <entity-managers>
-                <entity-manager name="default" connection="default">
-                    <metadata-cache-driver type="memcache">
-                        <class>Doctrine\Common\Cache\MemcacheCache</class>
-                        <host>localhost</host>
-                        <port>11211</port>
-                        <instance-class>Memcache</instance-class>
-                    </metadata-cache-driver>
-                </entity-manager>
-            </entity-managers>
+            <entity-manager name="default" connection="default">
+                <metadata-cache-driver type="memcache">
+                    <class>Doctrine\Common\Cache\MemcacheCache</class>
+                    <host>localhost</host>
+                    <port>11211</port>
+                    <instance-class>Memcache</instance-class>
+                </metadata-cache-driver>
+            </entity-manager>
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_single_entity_manager.xml
@@ -11,7 +11,7 @@
     </srv:parameters>
 
     <config>
-        <dbal>
+        <dbal default-connection="default">
             <connection
                 name="default"
                 driver="pdo_sqlite"
@@ -22,9 +22,7 @@
         </dbal>
 
         <orm
-                metadata-cache-driver="apc"
-                default-entity-manager="dm2"
-                default-connection="conn1"
+                default-entity-manager="default"
                 auto-generate-proxy-classes="true"
             >
             <entity-manager name="default" connection="default">
@@ -34,6 +32,7 @@
                     <port>11211</port>
                     <instance-class>Memcache</instance-class>
                 </metadata-cache-driver>
+                <mapping name="YamlBundle" />
             </entity-manager>
         </orm>
     </config>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
@@ -8,14 +8,12 @@
 
     <config>
         <orm>
-            <mappings>
-                <mapping name="AnnotationsBundle" />
-                <mapping name="YamlBundle" dir="Resources/config/doctrine/metadata" alias="yml" />
-                <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
-                    dir="%kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata"
-                    alias="TestAlias"
-                />
-            </mappings>
+            <mapping name="AnnotationsBundle" />
+            <mapping name="YamlBundle" dir="Resources/config/doctrine/metadata" alias="yml" />
+            <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
+                dir="%kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata"
+                alias="TestAlias"
+            />
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_multiple_connections.yml
@@ -1,5 +1,6 @@
 doctrine:
     dbal:
+        default_connection: mysql
         connections:
             mysql:
                 dbname: mysql_db

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_connection.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/dbal_service_single_connection.yml
@@ -1,5 +1,6 @@
 doctrine:
     dbal:
+        default_connection: mysql
         connections:
             mysql:
                 dbname: mysql_db

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/dbal_types.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/dbal_types.yml
@@ -1,4 +1,7 @@
 doctrine:
     dbal:
+        default_connection: default
         types:
             test: Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType
+        connections:
+            default: ~

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
@@ -2,3 +2,5 @@ doctrine:
     orm:
         auto_generate_proxy_classes: false
         metadata_cache_driver: apc
+        mappings:
+            YamlBundle: ~

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
@@ -1,8 +1,7 @@
 doctrine:
     orm:
+        default_entity_manager: em2
         entity_managers:
-            default_entity_manager: dm2
-            default_connection: conn1
             em1:
                 mappings:
                     AnnotationsBundle: ~

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
@@ -1,6 +1,8 @@
 doctrine:
     orm:
         entity_managers:
+            default_entity_manager: dm2
+            default_connection: conn1
             em1:
                 mappings:
                     AnnotationsBundle: ~

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_multiple_entity_managers.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_multiple_entity_managers.yml
@@ -3,6 +3,7 @@ parameters:
 
 doctrine:
     dbal:
+        default_connection: conn1
         connections:
             conn1:
                 driver: pdo_sqlite
@@ -18,13 +19,16 @@ doctrine:
                 memory: true
 
     orm:
-        default_entity_manager: dm2
-        default_connection: conn1
+        default_entity_manager: em2
         auto_generate_proxy_classes: true
         entity_managers:
-            dm1:
+            em1:
                 metadata_cache_driver: xcache
                 connection: conn1
-            dm2:
+                mappings:
+                    YamlBundle: ~
+            em2:
                 metadata_cache_driver: apc
                 connection: conn2
+                mappings:
+                    YamlBundle: ~

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager.yml
@@ -1,7 +1,8 @@
 doctrine:
     dbal: ~
-
     orm:
+        mappings:
+            YamlBundle: ~
         metadata_cache_driver:
             type: memcache
             class: Doctrine\Common\Cache\MemcacheCache

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_single_entity_manager.yml
@@ -1,5 +1,6 @@
 doctrine:
     dbal:
+        default_connection: default
         connections:
             default:
                 driver: pdo_sqlite
@@ -9,14 +10,14 @@ doctrine:
                 memory: true
 
     orm:
-        metadata_cache_driver: apc
         default_entity_manager: dm2
-        default_connection: conn1
         proxy_namespace: Proxies
         auto_generate_proxy_classes: true
         entity_managers:
             default:
                 connection: default
+                mappings:
+                    YamlBundle: ~
                 metadata_cache_driver:
                     type: memcache
                     class: Doctrine\Common\Cache\MemcacheCache

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/TestCase.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/TestCase.php
@@ -50,31 +50,33 @@ class TestCase extends \PHPUnit_Framework_TestCase
     public function createYamlBundleTestContainer()
     {
         $container = new ContainerBuilder(new ParameterBag(array(
+            'kernel.debug'       => false,
             'kernel.bundles'     => array('YamlBundle' => 'Fixtures\Bundles\YamlBundle\YamlBundle'),
             'kernel.cache_dir'   => sys_get_temp_dir(),
             'kernel.root_dir'    => __DIR__ . "/../../../../" // src dir
         )));
         $loader = new DoctrineExtension();
         $container->registerExtension($loader);
-        $loader->load(array(array('dbal' => array(
-            'connections' => array(
-                'default' => array(
-                    'driver' => 'pdo_mysql',
-                    'charset' => 'UTF-8',
-                    'platform-service' => 'my.platform',
-                )
-            ),
-            'types' => array(
-                'test' => 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType',
-            ),
-        ))), $container);
-        $loader->load(array(
-            array('orm' => array(
+        $loader->load(array(array(
+            'dbal' => array(
+                'connections' => array(
+                    'default' => array(
+                        'driver' => 'pdo_mysql',
+                        'charset' => 'UTF-8',
+                        'platform-service' => 'my.platform',
+                    )
+                ),
+                'default_connection' => 'default',
+                'types' => array(
+                    'test' => 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType',
+                ),
+            ), 'orm' => array(
                 'mappings' => array('YamlBundle' => array(
                     'type' => 'yml',
                     'dir' => __DIR__ . "/DependencyInjection/Fixtures/Bundles/YamlBundle/Resources/config/doctrine/metadata/orm",
                     'prefix' => 'Fixtures\Bundles\YamlBundle',
-            ))))), $container);
+            )))
+        )), $container);
 
         $container->setDefinition('my.platform', new \Symfony\Component\DependencyInjection\Definition('Doctrine\DBAL\Platforms\MySqlPlatform'));
 


### PR DESCRIPTION
This converts DoctrineBundle to use the configuration class.

BC breaks for XML users:
the `<connections>`, `<types>`, `<entity-managers>` and `<mappings>` wrapper tags have been removed (same choice than the MongoDBBundle PR).

Changes:
Defining an entity manager is now mandatory when using the ORM (which is logical) and defining an non-empty mapping for each entity manager is also mandatory (which is also logical as an entity manager without mapping is useless).

This also fixes the some bugs in the extension to use the parameters properly.
