### PR TITLE
[AsseticBundle] added ETags to the development controller

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Controller/AsseticController.php
+++ b/src/Symfony/Bundle/AsseticBundle/Controller/AsseticController.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\AsseticBundle\Controller;
 
 use Assetic\Asset\AssetCache;
-use Assetic\AssetManager;
+use Assetic\Factory\LazyAssetManager;
 use Assetic\Cache\CacheInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -29,7 +29,7 @@ class AsseticController
     protected $am;
     protected $cache;
 
-    public function __construct(Request $request, AssetManager $am, CacheInterface $cache)
+    public function __construct(Request $request, LazyAssetManager $am, CacheInterface $cache)
     {
         $this->request = $request;
         $this->am = $am;
@@ -43,23 +43,34 @@ class AsseticController
         }
 
         $asset = $this->getAsset($name);
+        $response = $this->createResponse();
 
-        $response = new Response();
-
-        // validate if-modified-since
+        // last-modified
         if (null !== $lastModified = $asset->getLastModified()) {
             $date = new \DateTime();
             $date->setTimestamp($lastModified);
             $response->setLastModified($date);
+        }
 
-            if ($response->isNotModified($this->request)) {
-                return $response;
-            }
+        // etag
+        if ($this->am->hasFormula($name)) {
+            $formula = $this->am->getFormula($name);
+            $formula['last_modified'] = $lastModified;
+            $response->setETag(md5(serialize($formula)));
+        }
+
+        if ($response->isNotModified($this->request)) {
+            return $response;
         }
 
         $response->setContent($asset->dump());
 
         return $response;
+    }
+
+    protected function createResponse()
+    {
+        return new Response();
     }
 
     protected function getAsset($name)


### PR DESCRIPTION
The controller will now invalidate a cached HTTP response if the contents of the asset has changed OR the configuration of the asset (i.e. filters).
