### PR TITLE
[AsseticBundle] distinct read and write paths

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/CacheWarmer/AssetWriterCacheWarmer.php
+++ b/src/Symfony/Bundle/AsseticBundle/CacheWarmer/AssetWriterCacheWarmer.php
@@ -14,25 +14,32 @@ namespace Symfony\Bundle\AsseticBundle\CacheWarmer;
 use Assetic\AssetManager;
 use Assetic\AssetWriter;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class AssetWriterCacheWarmer extends CacheWarmer
 {
     protected $am;
     protected $writer;
+    protected $dispatcher;
 
-    public function __construct(AssetManager $am, AssetWriter $writer)
+    public function __construct(AssetManager $am, AssetWriter $writer, EventDispatcher $dispatcher)
     {
         $this->am = $am;
         $this->writer = $writer;
+        $this->dispatcher = $dispatcher;
     }
 
     public function warmUp($cacheDir)
     {
+        // notify an event so custom stream wrappers can be registered lazily
+        $this->dispatcher->notify(new Event(null, 'assetic.write'));
+
         $this->writer->writeManagerAssets($this->am);
     }
 
     public function isOptional()
     {
-        return false;
+        return true;
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -37,7 +37,8 @@ class AsseticExtension extends Extension
      *     <assetic:config
      *         debug="true"
      *         use-controller="true"
-     *         document-root="/path/to/document/root"
+     *         read-from="/path/to/web"
+     *         write-to="s3://mybucket"
      *         closure="/path/to/google_closure/compiler.jar"
      *         yui="/path/to/yuicompressor.jar"
      *         default-javascripts-output="js/build/*.js"
@@ -49,7 +50,8 @@ class AsseticExtension extends Extension
      *     assetic:
      *         debug: true
      *         use_controller: true
-     *         document_root: /path/to/document/root
+     *         read_from: /path/to/web
+     *         write_to: s3://mybucket
      *         closure: /path/to/google_closure/compiler.jar
      *         yui: /path/to/yuicompressor.jar
      *         default_javascripts_output: js/build/*.js
@@ -71,7 +73,8 @@ class AsseticExtension extends Extension
 
         $container->setParameter('assetic.debug', $config['debug']);
         $container->setParameter('assetic.use_controller', $config['use_controller']);
-        $container->setParameter('assetic.document_root', $config['document_root']);
+        $container->setParameter('assetic.read_from', $config['read_from']);
+        $container->setParameter('assetic.write_to', $config['write_to']);
         $container->setParameter('assetic.default_javascripts_output', $config['default_javascripts_output']);
         $container->setParameter('assetic.default_stylesheets_output', $config['default_stylesheets_output']);
 

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Configuration.php
@@ -37,7 +37,8 @@ class Configuration
         $rootNode
             ->booleanNode('debug')->defaultValue($kernelDebug)->end()
             ->booleanNode('use_controller')->defaultValue($kernelDebug)->end()
-            ->scalarNode('document_root')->defaultValue('%kernel.root_dir%/../web')->end()
+            ->scalarNode('read_from')->defaultValue('%kernel.root_dir%/../web')->end()
+            ->scalarNode('write_to')->defaultValue('%assetic.read_from%')->end()
             ->scalarNode('closure')->end()
             ->scalarNode('yui')->end()
             ->scalarNode('default_javascripts_output')->defaultValue('js/*.js')->end()

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/asset_writer.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/asset_writer.xml
@@ -14,9 +14,10 @@
             <tag name="kernel.cache_warmer" />
             <argument type="service" id="assetic.asset_manager" />
             <argument type="service" id="assetic.asset_writer" />
+            <argument type="service" id="event_dispatcher" />
         </service>
         <service id="assetic.asset_writer" class="%assetic.asset_writer.class%" public="false">
-            <argument>%assetic.document_root%</argument>
+            <argument>%assetic.write_to%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -45,7 +45,7 @@
         </service>
         <service id="assetic.asset_factory" class="%assetic.asset_factory.class%" public="false">
             <argument type="service" id="kernel" />
-            <argument>%assetic.document_root%</argument>
+            <argument>%assetic.read_from%</argument>
             <argument>%assetic.debug%</argument>
             <call method="setFilterManager"><argument type="service" id="assetic.filter_manager" /></call>
         </service>
@@ -56,7 +56,7 @@
         </service>
         <service id="assetic.filter.less" class="%assetic.filter.less.class%">
             <tag name="assetic.filter" alias="less" />
-            <argument>%assetic.document_root%</argument>
+            <argument>%assetic.read_from%</argument>
             <argument>%assetic.node_bin%</argument>
             <argument>%assetic.node_paths%</argument>
         </service>
@@ -73,7 +73,7 @@
         </service>
         <service id="assetic.filter.sprockets" class="%assetic.filter.sprockets.class%">
             <tag name="assetic.filter" alias="sprockets" />
-            <argument>%assetic.document_root%</argument>
+            <argument>%assetic.read_from%</argument>
             <argument>%assetic.sprocketize_bin%</argument>
         </service>
         <service id="assetic.filter.coffee" class="%assetic.filter.coffee.class%">
@@ -83,7 +83,7 @@
         </service>
         <service id="assetic.filter.stylus" class="%assetic.filter.stylus.class%">
             <tag name="assetic.filter" alias="stylus" />
-            <argument>%assetic.document_root%</argument>
+            <argument>%assetic.read_from%</argument>
             <argument>%assetic.node_bin%</argument>
             <argument>%assetic.node_paths%</argument>
         </service>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/schema/assetic-1.0.xsd
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/schema/assetic-1.0.xsd
@@ -9,7 +9,8 @@
         <xsd:complexType name="config">
             <xsd:attribute name="debug" type="xsd:string" />
             <xsd:attribute name="use-controller" type="xsd:string" />
-            <xsd:attribute name="document-root" type="xsd:string" />
+            <xsd:attribute name="read-from" type="xsd:string" />
+            <xsd:attribute name="write-to" type="xsd:string" />
             <xsd:attribute name="closure" type="xsd:string" />
             <xsd:attribute name="yui" type="xsd:string" />
             <xsd:attribute name="default-javascripts-output" type="xsd:string" />

--- a/src/Symfony/Bundle/AsseticBundle/Tests/DependencyInjection/AsseticExtensionTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/DependencyInjection/AsseticExtensionTest.php
@@ -93,25 +93,6 @@ class AsseticExtensionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getDocumentRootKeys
-     */
-    public function testDocumentRoot($key)
-    {
-        $extension = new AsseticExtension();
-        $extension->load(array(array($key => '/path/to/web')), $this->container);
-
-        $this->assertEquals('/path/to/web', $this->container->getParameter('assetic.document_root'), '"'.$key.'" sets document root');
-    }
-
-    public function getDocumentRootKeys()
-    {
-        return array(
-            array('document_root'),
-            array('document-root'),
-        );
-    }
-
-    /**
      * @dataProvider getUseControllerKeys
      */
     public function testUseController($bool, $includes, $omits)

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Resources/config/config.yml
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Resources/config/config.yml
@@ -18,4 +18,4 @@ twig:
 
 assetic:
     use_controller: true
-    document_root:  "%kernel.root_dir%/web"
+    read_from:      "%kernel.root_dir%/web"

--- a/src/Symfony/Bundle/AsseticBundle/Twig/StaticNode.php
+++ b/src/Symfony/Bundle/AsseticBundle/Twig/StaticNode.php
@@ -28,7 +28,7 @@ class StaticNode extends AsseticNode
         return new \Twig_Node_Expression_Function(
             new \Twig_Node_Expression_Name('asset', $body->getLine()),
             new \Twig_Node(array(
-                new \Twig_Node_Expression_Constant($this->getAttribute('target_url')),
+                new \Twig_Node_Expression_Constant($this->getAttribute('target_url'), $body->getLine()),
             )),
             $body->getLine()
         );


### PR DESCRIPTION
I've decoupled configuration for where Assetic reads assets from and where it writes assets to. This is the foundation for writing dumped assets to your CDN via custom stream wrappers.
