### PR TITLE
fixed array input parsing in ArgvInput

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -164,7 +164,7 @@ class ArgvInput extends Input
 
         // unexpected argument
         } else {
-            throw new RuntimeException('Too many arguments.');
+            throw new \RuntimeException('Too many arguments.');
         }
     }
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -150,11 +150,22 @@ class ArgvInput extends Input
      */
     protected function parseArgument($token)
     {
-        if (!$this->definition->hasArgument(count($this->arguments))) {
-            throw new \RuntimeException('Too many arguments.');
-        }
+        $c = count($this->arguments);
 
-        $this->arguments[$this->definition->getArgument(count($this->arguments))->getName()] = $token;
+        // if input is expecting another argument, add it
+        if ($this->definition->hasArgument($c)) {
+            $arg = $this->definition->getArgument($c);
+            $this->arguments[$arg->getName()] = $arg->isArray()? array($token) : $token;
+
+        // if last argument isArray(), append token to last argument
+        } elseif ($this->definition->hasArgument($c - 1) && $this->definition->getArgument($c - 1)->isArray()) {
+            $arg = $this->definition->getArgument($c - 1);
+            $this->arguments[$arg->getName()][] = $token;
+
+        // unexpected argument
+        } else {
+            throw new RuntimeException('Too many arguments.');
+        }
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Console/Input/ArgvInputTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/ArgvInputTest.php
@@ -135,6 +135,14 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
         $input = new TestInput(array('cli.php', '-fbbar'));
         $input->bind(new InputDefinition(array(new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL), new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL))));
         $this->assertEquals(array('foo' => 'bbar', 'bar' => null), $input->getOptions(), '->parse() parses short options when they are aggregated as a single one and one of them takes a value');
+
+        try {
+            $input = new TestInput(array('cli.php', 'foo', 'bar', 'baz', 'bat'));
+            $input->bind(new InputDefinition(array(new InputArgument('name', InputArgument::IS_ARRAY))));
+            $this->assertEquals(array('name' => array('foo', 'bar', 'baz', 'bat')), $input->getArguments(), '->parse() parses array arguments');
+        } catch (\RuntimeException $e) {
+            $this->assertNotEquals('Too many arguments.', $e->getMessage(), '->parse() parses array arguments');
+        }
     }
 
     public function testGetFirstArgument()


### PR DESCRIPTION
ArgvInput would improperly throw RuntimeExceptions because it was trying to map arguments 1:1 with argument definitions without accounting for the argument mode IS_ARRAY.
