### PR TITLE
[Routing] Optional placeholders anywhere in the pattern

### DIFF
--- a/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
@@ -70,7 +70,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables that have default values',
                 array('/foo/{bar}/{foobar}', array('bar' => 'bar', 'foobar' => 'foobar')),
-                '/foo', '#^/foo(?:/(?P<bar>[^/\.]+?) (?:/(?P<foobar>[^/\.]+?) )?)?$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
+                '/foo', '#^/foo(?:/(?P<bar>[^/\.]+?))?(?:/(?P<foobar>[^/\.]+?))?$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
                     array('variable', '/', '{foobar}', 'foobar'),
                     array('variable', '/', '{bar}', 'bar'),
                     array('text', '/', 'foo', null),
@@ -79,10 +79,29 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables but some of them have no default values',
                 array('/foo/{bar}/{foobar}', array('bar' => 'bar')),
-                '/foo', '#^/foo/(?P<bar>[^/\.]+?)/(?P<foobar>[^/\.]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
+                '/foo', '#^/foo(?:/(?P<bar>[^/\.]+?))?/(?P<foobar>[^/\.]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
                     array('variable', '/', '{foobar}', 'foobar'),
                     array('variable', '/', '{bar}', 'bar'),
                     array('text', '/', 'foo', null),
+                )),
+
+            array(
+                'Route with several variables that some of them have no default values and some of them have empty defaults',
+                array('/foo/{bar}/{foobar}/{foofoobar}', array('bar' => 'bar', 'foobar' => '')),
+                '/foo', '#^/foo(?:/(?P<bar>[^/\.]+?))?(?:/(?P<foobar>[^/\.]+?))?/(?P<foofoobar>[^/\.]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}', 'foofoobar' => '{foofoobar}'), array(
+                    array('variable', '/', '{foofoobar}', 'foofoobar'),
+                    array('variable', '/', '{foobar}', 'foobar'),
+                    array('variable', '/', '{bar}', 'bar'),
+                    array('text', '/', 'foo', null),
+                )),
+
+            array(
+                'Route with several variables that some of them have no default values and one of them is first segment',
+                array('/{bar}/{foobar}/{foofoobar}', array('bar' => 'bar', 'foobar' => 'foobar')),
+                '', '#^/?(?:/(?P<bar>[^/\.]+?))?(?:/(?P<foobar>[^/\.]+?))?/(?P<foofoobar>[^/\.]+?)$#x', array('bar' => '{bar}', 'foobar' => '{foobar}', 'foofoobar' => '{foofoobar}'), array(
+                    array('variable', '/', '{foofoobar}', 'foofoobar'),
+                    array('variable', '/', '{foobar}', 'foobar'),
+                    array('variable', '/', '{bar}', 'bar')
                 )),
 
             array(


### PR DESCRIPTION
I encountered a limitation with optional placeholders. 
Currently they are available only in the end of the pattern, e.g.: 
/static/optional1/optional2/optional3/ or /optional1/optional2/

However this limits the usage of optional placeholders and is solvable only with multiple patterns which looks ugly if you have many of them. 
One of the use cases:
/products/{optional_culture}/{optional_category1}/{optional_category2}/{optional_category3}/{product_id}

This pull requests adds support for having as many optional placeholders in any order it is needed.

If you want to create an optional placeholder, it is needed to specify default value for it as it was before. However in these use cases you might want to have empty default value, so support for an empty default string value was added. Before it was not possible to assign empty string as a default placeholder value.

I don't know if this is a thing that has to be in the core, it could be separated as a custom route compiler, however I would like to get your comments on this one.
