### PR TITLE
[Translation] Fixed the addition of the fallbackLocale catalogue to the current locale catalogue.

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -112,15 +112,6 @@ class Translator implements TranslatorInterface
             $this->loadCatalogue($locale);
         }
 
-        if(!$this->catalogues[$locale]->has($id, $domain)) {
-            
-            $locale = $this->fallbackLocale;
-            
-            if (!isset($this->catalogues[$locale])) {
-                $this->loadCatalogue($locale);
-            }
-        } 
-
         return strtr($this->catalogues[$locale]->get($id, $domain), $parameters);
     }
 
@@ -143,15 +134,15 @@ class Translator implements TranslatorInterface
     protected function loadCatalogue($locale)
     {
         $this->catalogues[$locale] = new MessageCatalogue($locale);
-        if (!isset($this->resources[$locale])) {
-            return;
-        }
 
-        foreach ($this->resources[$locale] as $resource) {
-            if (!isset($this->loaders[$resource[0]])) {
-                throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $resource[0]));
+        if (isset($this->resources[$locale])) {
+
+            foreach ($this->resources[$locale] as $resource) {
+                if (!isset($this->loaders[$resource[0]])) {
+                    throw new \RuntimeException(sprintf('The "%s" translation loader is not registered.', $resource[0]));
+                }
+                $this->catalogues[$locale]->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
             }
-            $this->catalogues[$locale]->addCatalogue($this->loaders[$resource[0]]->load($resource[1], $locale, $resource[2]));
         }
 
         $this->optimizeCatalogue($locale);

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -112,6 +112,15 @@ class Translator implements TranslatorInterface
             $this->loadCatalogue($locale);
         }
 
+        if(!$this->catalogues[$locale]->has($id, $domain)) {
+            
+            $locale = $this->fallbackLocale;
+            
+            if (!isset($this->catalogues[$locale])) {
+                $this->loadCatalogue($locale);
+            }
+        } 
+
         return strtr($this->catalogues[$locale]->get($id, $domain), $parameters);
     }
 

--- a/tests/Symfony/Tests/Component/Translation/TranslatorTest.php
+++ b/tests/Symfony/Tests/Component/Translation/TranslatorTest.php
@@ -43,10 +43,12 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
 
     public function testTransWithFallbackLocale()
     {
-        $translator = new Translator('en_US', new MessageSelector());
+        $translator = new Translator('fr_FR', new MessageSelector());
         $translator->addLoader('array', new ArrayLoader());
         $translator->addResource('array', array('foo' => 'foofoo'), 'en_US');
         $translator->addResource('array', array('bar' => 'foobar'), 'en');
+
+        $translator->setFallbackLocale('en');
 
         $this->assertEquals('foobar', $translator->trans('bar'));
     }


### PR DESCRIPTION
When loading a catalogue the function "optimizeCatalogue" add the fallback catalogue to the current locale catalogue. This should be done by first adding the language catalogue and finally adding the fallbacklocale catalogue specified in the configuration. This subsequent additions are done by the "loadCatalogue" function.

The problem is that in the "loadCatalogue" function exists an if statement that checks if the resource of a given locale exists before loading it. If not, the function simply returns. This return implies that the subsequent addition of the fallbacklocale wouldn't be done.

This has been fixed by simply replacing the current if statement and adding a new one that, if the resource exists, then executes the process of resource loading. Finally, the function continue calling the "optimizeCatalogue" function.
