### PR TITLE
Fix Acl schema generator

### DIFF
--- a/src/Symfony/Component/Security/Acl/Resources/bin/generateSql.php
+++ b/src/Symfony/Component/Security/Acl/Resources/bin/generateSql.php
@@ -27,7 +27,7 @@ $schema = new Schema(array(
 
 $reflection = new ReflectionClass('Doctrine\\DBAL\\Platforms\\AbstractPlatform');
 $finder = new Finder();
-$finder->name('*.php')->in(dirname($reflection->getFileName()));
+$finder->name('*Platform.php')->in(dirname($reflection->getFileName()));
 foreach ($finder as $file) {
     require_once $file->getPathName();
     $className = 'Doctrine\\DBAL\\Platforms\\' . $file->getBasename('.php');


### PR DESCRIPTION
Change 3e818846 in doctrine/dbal introduced a number of new classes in the Doctrine\DBAL\Platforms\Keywords namespace, so we need to be more careful here when generating Acl schema, so as to only load platform classes and not any of the others in the same directory.
