### PR TITLE
[ZendBundle] compiled log classes (redeux)

### DIFF
--- a/src/Symfony/Bundle/ZendBundle/DependencyInjection/ZendExtension.php
+++ b/src/Symfony/Bundle/ZendBundle/DependencyInjection/ZendExtension.php
@@ -60,6 +60,21 @@ class ZendExtension extends Extension
                     $container->findDefinition('zend.logger')->removeMethodCall('registerErrorHandler');
                 }
             }
+
+            $this->addClassesToCompile(array(
+                'Zend\\Log\\Factory',
+                'Zend\\Log\\Filter',
+                'Zend\\Log\\Filter\\AbstractFilter',
+                'Zend\\Log\\Filter\\Priority',
+                'Zend\\Log\\Formatter',
+                'Zend\\Log\\Formatter\\Simple',
+                'Zend\\Log\\Logger',
+                'Zend\\Log\\Writer',
+                'Zend\\Log\\Writer\\AbstractWriter',
+                'Zend\\Log\\Writer\\Stream',
+                'Symfony\\Bundle\\ZendBundle\\Logger\\DebugLogger',
+                'Symfony\\Bundle\\ZendBundle\\Logger\\Logger',
+            ));
         }
     }
 


### PR DESCRIPTION
I've moved the Symfony classes that rely on Zend classes to the bottom of the list so classes aren't loaded twice.
