### PR TITLE
[DependencyInjection] Inline pass fix

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -37,7 +37,7 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
     /**
      * Processes the ContainerBuilder for inline service definitions.
      *
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
@@ -89,9 +89,9 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
     /**
      * Checks if the definition is inlineable.
      *
-     * @param ContainerBuilder $container 
-     * @param string $id 
-     * @param Definition $definition 
+     * @param ContainerBuilder $container
+     * @param string $id
+     * @param Definition $definition
      * @return boolean If the definition is inlineable
      */
     protected function isInlinableDefinition(ContainerBuilder $container, $id, Definition $definition)
@@ -113,6 +113,10 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             $ids[] = $edge->getSourceNode()->getId();
         }
 
-        return count(array_unique($ids)) <= 1;
+        if (count(array_unique($ids)) > 1) {
+            return false;
+        }
+
+        return $container->getDefinition(reset($ids))->getScope() === $definition->getScope();
     }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPassTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Tests\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Scope;
+
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Compiler\AnalyzeServiceReferencesPass;
 use Symfony\Component\DependencyInjection\Compiler\Compiler;
@@ -108,6 +110,20 @@ class InlineServiceDefinitionsPassTest extends \PHPUnit_Framework_TestCase
 
         $inlinedArguments = $arguments[1]->getArguments();
         $this->assertSame($a, $inlinedArguments[0]);
+    }
+
+    public function testProcessInlinesOnlyIfSameScope()
+    {
+        $container = new ContainerBuilder();
+
+        $container->addScope(new Scope('foo'));
+        $a = $container->register('a')->setPublic(false)->setScope('foo');
+        $b = $container->register('b')->addArgument(new Reference('a'));
+
+        $this->process($container);
+        $arguments = $b->getArguments();
+        $this->assertEquals(new Reference('a'), $arguments[0]);
+        $this->assertTrue($container->hasDefinition('a'));
     }
 
     protected function process(ContainerBuilder $container)


### PR DESCRIPTION
The introduction of scopes has created a bug in the inline definition pass where the service's scope was changed silently.

Although the unit tests pass, this bug fix might break things which have currently relied on this false behavior.
