### PR TITLE
Feature/mongodb session storage

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -105,13 +105,18 @@ class Configuration
         $rootNode
             ->arrayNode('session')
                 ->canBeUnset()
-                // Strip "pdo." prefix from option keys, since dots cannot appear in node names
+                // Strip "pdo." and "mongodb." prefix from option keys, since dots cannot appear in node names
                 ->beforeNormalization()
                     ->ifArray()
                     ->then(function($v){
                         foreach ($v as $key => $value) {
                             if (0 === strncmp('pdo.', $key, 4)) {
                                 $v[substr($key, 4)] = $value;
+                                unset($v[$key]);
+                            }
+
+                            if (0 === strncmp('mongodb.', $key, 8)) {
+                                $v[substr($key, 8)] = $value;
                                 unset($v[$key]);
                             }
                         }
@@ -134,6 +139,11 @@ class Configuration
                 ->scalarNode('db_id_col')->end()
                 ->scalarNode('db_data_col')->end()
                 ->scalarNode('db_time_col')->end()
+                // MongoDBSessionStorage options
+                ->scalarNode('collection')->end()
+                ->scalarNode('id_field')->end()
+                ->scalarNode('data_field')->end()
+                ->scalarNode('time_field')->end()
                 ->end()
         ;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -274,7 +274,7 @@ class FrameworkExtension extends Extension
         $container->setAlias('session.storage', 'session.storage.'.$config['storage_id']);
 
         $options = $container->getParameter('session.storage.'.$config['storage_id'].'.options');
-        foreach (array('name', 'lifetime', 'path', 'domain', 'secure', 'httponly', 'db_table', 'db_id_col', 'db_data_col', 'db_time_col') as $key) {
+        foreach (array('name', 'lifetime', 'path', 'domain', 'secure', 'httponly', 'db_table', 'db_id_col', 'db_data_col', 'db_time_col', 'collection', 'id_field', 'data_field', 'time_field') as $key) {
             if (isset($config[$key])) {
                 $options[$key] = $config[$key];
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -70,7 +70,7 @@
 
     <xsd:complexType name="session">
         <xsd:attribute name="class" type="xsd:string" />
-        <xsd:attribute name="storage-id" type="xsd:string" />
+        <xsd:attribute name="storage-id" type="storage_id" />
         <xsd:attribute name="default-locale" type="xsd:string" />
         <xsd:attribute name="name" type="xsd:string" />
         <xsd:attribute name="lifetime" type="xsd:integer" />
@@ -89,6 +89,14 @@
         <xsd:attribute name="mongodb.data-field" type="xsd:string" />
         <xsd:attribute name="mongodb.time-field" type="xsd:string" />
     </xsd:complexType>
+    
+    <xsd:simpleType name="storage_id">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="pdo" />
+            <xsd:enumeration value="mongodb" />
+            <xsd:enumeration value="native" />
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:complexType name="templating">
         <xsd:sequence>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -84,6 +84,10 @@
         <xsd:attribute name="pdo.db-id-col" type="xsd:string" />
         <xsd:attribute name="pdo.db-data-col" type="xsd:string" />
         <xsd:attribute name="pdo.db-time-col" type="xsd:string" />
+        <xsd:attribute name="mongodb.collection" type="xsd:string" />
+        <xsd:attribute name="mongodb.id-field" type="xsd:string" />
+        <xsd:attribute name="mongodb.data-field" type="xsd:string" />
+        <xsd:attribute name="mongodb.time-field" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="templating">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -11,6 +11,8 @@
         <parameter key="session.storage.native.options" type="collection" />
         <parameter key="session.storage.pdo.class">Symfony\Component\HttpFoundation\SessionStorage\PdoSessionStorage</parameter>
         <parameter key="session.storage.pdo.options" type="collection" />
+        <parameter key="session.storage.mongodb.class">Symfony\Component\HttpFoundation\SessionStorage\MongoDBSessionStorage</parameter>
+        <parameter key="session.storage.mongodb.options" type="collection" />
         <parameter key="session.storage.array.class">Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage</parameter>
         <parameter key="session.storage.array.options" type="collection" />
     </parameters>
@@ -30,6 +32,11 @@
         <service id="session.storage.pdo" class="%session.storage.pdo.class%" public="false">
             <argument type="service" id="pdo_connection" />
             <argument>%session.storage.pdo.options%</argument>
+        </service>
+
+        <service id="session.storage.mongodb" class="%session.storage.mongodb.class%" public="false">
+            <argument type="service" id="mongodb_database" />
+            <argument>%session.storage.mongodb.options%</argument>
         </service>
 
         <service id="session.storage.array" class="%session.storage.array.class%" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_mongodb.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/session_mongodb.php
@@ -1,0 +1,11 @@
+<?php
+
+$container->loadFromExtension('framework', array(
+    'session' => array(
+        'storage_id'         => 'mongodb',
+        'mongodb.collection' => 'collection',
+        'mongodb.id_field'   => 'id',
+        'mongodb.data_field' => 'data',
+        'mongodb.time_field' => 'time',
+    ),
+));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_mongodb.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/session_mongodb.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://www.symfony-project.org/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:app="http://www.symfony-project.org/schema/dic/symfony"
+    xsi:schemaLocation="http://www.symfony-project.org/schema/dic/services http://www.symfony-project.org/schema/dic/services/services-1.0.xsd
+                        http://www.symfony-project.org/schema/dic/symfony http://www.symfony-project.org/schema/dic/symfony/symfony-1.0.xsd">
+
+    <app:config>
+        <app:session storage-id="mongodb" mongodb.collection="collection" mongodb.id-field="id" mongodb.data-field="data" mongodb.time-field="time" />
+    </app:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_mongodb.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/session_mongodb.yml
@@ -1,0 +1,7 @@
+framework:
+    session:
+        storage_id:         mongodb
+        mongodb.collection: collection
+        mongodb.id_field:   id
+        mongodb.data_field: data
+        mongodb.time_field: time

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -75,7 +75,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->getDefinition('session')->hasMethodCall('start'));
         $this->assertEquals('Session', $container->getParameter('session.class'));
         $this->assertEquals('session.storage.native', (string) $container->getAlias('session.storage'));
-        
+
         $options = $container->getParameter('session.storage.native.options');
         $this->assertEquals('_SYMFONY', $options['name']);
         $this->assertEquals(86400, $options['lifetime']);
@@ -95,6 +95,18 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals('id', $options['db_id_col']);
         $this->assertEquals('data', $options['db_data_col']);
         $this->assertEquals('time', $options['db_time_col']);
+    }
+
+    public function testSessionMongoDB()
+    {
+        $container = $this->createContainerFromFile('session_mongodb');
+        $options = $container->getParameter('session.storage.mongodb.options');
+
+        $this->assertEquals('session.storage.mongodb', (string) $container->getAlias('session.storage'));
+        $this->assertEquals('collection', $options['collection']);
+        $this->assertEquals('id', $options['id_field']);
+        $this->assertEquals('data', $options['data_field']);
+        $this->assertEquals('time', $options['time_field']);
     }
 
     public function testTemplating()

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/MongoDBSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/MongoDBSessionStorage.php
@@ -22,7 +22,7 @@ class MongoDBSessionStorage extends NativeSessionStorage
     protected $db;
 
     /**
-     * @throws \InvalidArgumentException When "db_table" option is not provided
+     * @throws \InvalidArgumentException When "collection" option is not provided
      */
     public function __construct(\MongoDB $db, array $options = array())
     {

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/MongoDBSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/MongoDBSessionStorage.php
@@ -33,7 +33,7 @@ class MongoDBSessionStorage extends NativeSessionStorage
             'time_field' => 'sess_time',
         ), $options);
 
-        if (!array_key_exists('collection', $options)) {
+        if (!isset($options['collection'])) {
             throw new \InvalidArgumentException('You must provide the "collection" option for a MongoDBSessionStorage.');
         }
 

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/MongoDBSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/MongoDBSessionStorage.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\SessionStorage;
+
+/**
+ * MongoDBSessionStorage.
+ *
+ * @author Fabien Potencier <fabien.potencier@symfony-project.com>
+ * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ */
+class MongoDBSessionStorage extends NativeSessionStorage
+{
+    protected $db;
+
+    /**
+     * @throws \InvalidArgumentException When "db_table" option is not provided
+     */
+    public function __construct(\MongoDB $db, array $options = array())
+    {
+        $this->db = $db;
+        $options = array_merge(array(
+            'id_field'   => 'sess_id',
+            'data_field' => 'sess_data',
+            'time_field' => 'sess_time',
+        ), $options);
+
+        if (!array_key_exists('collection', $options)) {
+            throw new \InvalidArgumentException('You must provide the "collection" option for a MongoDBSessionStorage.');
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * Starts the session.
+     */
+    public function start()
+    {
+        if (self::$sessionStarted) {
+            return;
+        }
+
+        // use this object as the session handler
+        session_set_save_handler(
+            array($this, 'sessionOpen'),
+            array($this, 'sessionClose'),
+            array($this, 'sessionRead'),
+            array($this, 'sessionWrite'),
+            array($this, 'sessionDestroy'),
+            array($this, 'sessionGC')
+        );
+
+        parent::start();
+    }
+
+    /**
+     * Opens a session.
+     *
+     * @param  string $path  (ignored)
+     * @param  string $name  (ignored)
+     *
+     * @return Boolean true, if the session was opened, otherwise an exception is thrown
+     */
+    public function sessionOpen($path = null, $name = null)
+    {
+        return true;
+    }
+
+    /**
+     * Closes a session.
+     *
+     * @return Boolean true, if the session was closed, otherwise false
+     */
+    public function sessionClose()
+    {
+        // do nothing
+        return true;
+    }
+
+    /**
+     * Destroys a session.
+     *
+     * @param  string $id  A session ID
+     *
+     * @return Boolean   true, if the session was destroyed, otherwise an exception is thrown
+     */
+    public function sessionDestroy($id)
+    {
+        // get table/column
+        $collection  = $this->options['collection'];
+        $id_field = $this->options['id_field'];
+
+        // delete the record associated with this id
+        return $this->db->selectCollection($collection)->remove(array(
+            $id_field => $id
+        ));
+    }
+
+    /**
+     * Cleans up old sessions.
+     *
+     * @param  int $lifetime  The lifetime of a session
+     *
+     * @return Boolean true, if old sessions have been cleaned, otherwise an exception is thrown
+     */
+    public function sessionGC($lifetime)
+    {
+        // get table/column
+        $collection = $this->options['collection'];
+        $time_field = $this->options['time_field'];
+
+        // delete the record associated with this id
+        $this->db->selectCollection($collection)->remove(array(
+            $time_field => array('$lt' => new \MongoDate(time() - $lifetime))
+        ));
+
+        return true;
+    }
+
+    /**
+     * Reads a session.
+     *
+     * @param  string $id  A session ID
+     *
+     * @return string      The session data if the session was read or created
+     */
+    public function sessionRead($id)
+    {
+        // get collection/fields
+        $collection = $this->options['collection'];
+        $data_field = $this->options['data_field'];
+        $id_field   = $this->options['id_field'];
+        $time_field = $this->options['time_field'];
+        $collection = $this->db->selectCollection($collection);
+        $result     = $collection->findOne(array($id_field => $id));
+
+        if (null !== $result) {
+            return $result[$data_field];
+        }
+
+        // session does not exist, create it
+        $collection->insert(array(
+            $id_field   => $id,
+            $data_field => '',
+            $time_field => new \MongoDate(),
+        ));
+
+        return '';
+    }
+
+    /**
+     * Writes session data.
+     *
+     * @param  string $id    A session ID
+     * @param  string $data  A serialized chunk of session data
+     *
+     * @return Boolean true, if the session was written
+     */
+    public function sessionWrite($id, $data)
+    {
+        // get table/column
+        $collection = $this->options['collection'];
+        $data_field = $this->options['data_field'];
+        $id_field   = $this->options['id_field'];
+        $time_field = $this->options['time_field'];
+
+        $collection  = $this->db->selectCollection($collection);
+
+        return $collection->update(
+            array(
+                $id_field => $id
+            ),
+            array('$set' => array(
+                $data_field => $data,
+                $time_field => new \MongoDate()
+            ))
+        );
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
@@ -23,7 +23,7 @@ class PdoSessionStorage extends NativeSessionStorage
     /**
      * @throws \InvalidArgumentException When "db_table" option is not provided
      */
-    public function __construct(\PDO $db, $options = null)
+    public function __construct(\PDO $db, array $options = array())
     {
         $this->db = $db;
         $options = array_merge(array(

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
@@ -32,7 +32,7 @@ class PdoSessionStorage extends NativeSessionStorage
             'db_time_col' => 'sess_time',
         ), $options);
 
-        if (!array_key_exists('db_table', $options)) {
+        if (!isset($options['db_table'])) {
             throw new \InvalidArgumentException('You must provide the "db_table" option for a PdoSessionStorage.');
         }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/SessionStorage/MongoDBSessionStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/SessionStorage/MongoDBSessionStorageTest.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpFoundation\SessionStorage;
+
+use Symfony\Component\HttpFoundation\SessionStorage\MongoDBSessionStorage;
+
+/**
+ * MongoDBSessionStorage.
+ *
+ * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ */
+class MongoDBSessionStorageTest extends \PHPUnit_Framework_TestCase
+{
+    private $storage;
+    private $db;
+    private $collection = 'session';
+
+    protected function setUp()
+    {
+        if (!class_exists('Mongo')) {
+            $this->markTestSkipped('Mongo extension is disabled');
+        }
+
+        try {
+            $mongo  = new \Mongo();
+        } catch (\MongoConnectionException $e) {
+            $this->markTestSkipped($e->getMessage());
+        }
+
+        $this->db = $mongo->selectDB('test');
+        $this->storage = new MongoDBSessionStorage($this->db, array(
+            'collection' => $this->collection,
+        ));
+
+        $this->db->selectCollection($this->collection)->drop();
+    }
+
+    public function testOpen()
+    {
+        $this->assertTrue($this->storage->sessionOpen());
+    }
+
+    public function testClose()
+    {
+        $this->assertTrue($this->storage->sessionClose());
+    }
+
+    public function testDestroy()
+    {
+        $id         = '112';
+        $collection = $this->db->selectCollection($this->collection);
+
+        $collection->insert(array(
+            'sess_id' => $id
+        ));
+
+        $this->assertNotNull($collection->findOne(array(
+            'sess_id' => $id
+        )));
+
+        $this->storage->sessionDestroy($id);
+
+        $this->assertNull($collection->findOne(array(
+            'sess_id' => $id
+        )));
+    }
+
+    public function testGC()
+    {
+        $collection = $this->db->selectCollection($this->collection);
+        $lifetime   = 3600;
+        $sessions   = array();
+        $oldSessCnt = 0;
+
+        for ($i = 0; $i < 20; $i++) {
+            $session = array(
+                'sess_id'   => (string) $i,
+                'sess_data' => 'some data',
+                'sess_time' => new \MongoDate(time() - rand(0, $lifetime * 2)),
+            );
+
+            if ($session['sess_time']->sec < time() - $lifetime) {
+                $oldSessCnt++;
+            }
+
+            $sessions[] = $session;
+        }
+
+        $collection->batchInsert($sessions);
+
+        $this->assertEquals(20, $collection->find(array())->count());
+
+        $this->assertTrue($this->storage->sessionGC($lifetime));
+
+        $this->assertEquals(20 - $oldSessCnt, $collection->find(array())->count());
+    }
+
+    public function testReadNonExistentSession()
+    {
+        $id = '123';
+
+        $collection = $this->db->selectCollection($this->collection);
+
+        $this->assertEquals(null, $collection->findOne(array('sess_id' => $id)));
+
+        $this->assertEquals('', $this->storage->sessionRead($id));
+
+        $session = $collection->findOne(array('sess_id' => $id));
+        $this->assertNotNull($session);
+        $this->assertEquals($id, $session['sess_id']);
+        $this->assertEquals('', $session['sess_data']);
+        $this->assertInstanceOf('MongoDate', $session['sess_time']);
+        $this->assertEquals(0, round(time() - $session['sess_time']->sec));
+    }
+
+    public function testReadExistingSession()
+    {
+        $id = '123';
+        $data = 'some session data';
+
+        $this->db->selectCollection($this->collection)->insert(array(
+            'sess_id'   => $id,
+            'sess_data' => $data,
+            'sess_time' => new \MongoDate(time() - 300),
+        ));
+
+        $this->assertEquals($data, $this->storage->sessionRead($id));
+    }
+
+    public function testWrite()
+    {
+        $id         = '123';
+        $data       = 'some session data';
+        $collection = $this->db->selectCollection($this->collection);
+
+        $this->assertTrue($this->storage->sessionWrite($id, $data));
+
+        $this->assertNull($session = $collection->findOne(array('sess_id' => $id)));
+
+        $collection->insert(array(
+            'sess_id'   => $id,
+            'sess_data' => '',
+            'sess_time' => new \MongoDate(),
+        ));
+
+        $this->assertNotNull($collection->findOne(array('sess_id' => $id)));
+
+        $this->assertTrue($this->storage->sessionWrite($id, $data));
+
+        $session = $collection->findOne(array('sess_id' => $id));
+
+        $this->assertNotNull($session);
+        $this->assertEquals($data, $session['sess_data']);
+        $this->assertInstanceOf('MongoDate', $session['sess_time']);
+        $this->assertEquals(0, round(time() - $session['sess_time']->sec));
+    }
+}


### PR DESCRIPTION
implemented mongodb session storage, modified XSD in FrameworkBundle to allow new storage type and restricted storage_id to a ENUM with only three values for autocompletion
