### PR TITLE
[AsseticBundle] migrating functional to unit tests

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\AsseticBundle\Factory;
 
 use Assetic\Factory\AssetFactory as BaseAssetFactory;
-use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * Loads asset formulae from the filesystem.
@@ -23,7 +23,7 @@ class AssetFactory extends BaseAssetFactory
 {
     protected $kernel;
 
-    public function __construct(Kernel $kernel, $baseDir, $debug = false)
+    public function __construct(KernelInterface $kernel, $baseDir, $debug = false)
     {
         $this->kernel = $kernel;
 

--- a/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetManagerCacheWarmerTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetManagerCacheWarmerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\CacheWarmer;
+
+use Symfony\Bundle\AsseticBundle\CacheWarmer\AssetManagerCacheWarmer;
+
+class AssetManagerCacheWarmerTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Assetic\\AssetManager')) {
+            $this->markTestSkipped('Assetic is not available.');
+        }
+    }
+
+    public function testWarmUp()
+    {
+        $am = $this->getMockBuilder('Assetic\\Factory\\LazyAssetManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $am->expects($this->once())->method('load');
+
+        $warmer = new AssetManagerCacheWarmer($am);
+        $warmer->warmUp('/path/to/cache');
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetWriterCacheWarmerTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetWriterCacheWarmerTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\CacheWarmer;
+
+use Symfony\Bundle\AsseticBundle\CacheWarmer\AssetWriterCacheWarmer;
+use Symfony\Component\EventDispatcher\Event;
+
+class AssetWriterCacheWarmerTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Assetic\\AssetManager')) {
+            $this->markTestSkipped('Assetic is not available.');
+        }
+    }
+
+    public function testWarmUp()
+    {
+        $am = $this->getMock('Assetic\\AssetManager');
+        $writer = $this->getMockBuilder('Assetic\\AssetWriter')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $dispatcher = $this->getMock('Symfony\\Component\\EventDispatcher\\EventDispatcher');
+
+        $event = new Event(null, 'assetic.write');
+
+        $dispatcher->expects($this->once())
+            ->method('notify')
+            ->with($event);
+        $writer->expects($this->once())
+            ->method('writeManagerAssets')
+            ->with($am);
+
+        $warmer = new AssetWriterCacheWarmer($am, $writer, $dispatcher);
+        $warmer->warmUp('/path/to/cache');
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Controller/AsseticControllerTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Controller/AsseticControllerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Controller;
+
+use Symfony\Bundle\AsseticBundle\Controller\AsseticController;
+
+class AsseticControllerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $request;
+    protected $headers;
+    protected $am;
+    protected $cache;
+
+    protected $controller;
+
+    protected function setUp()
+    {
+        if (!class_exists('Assetic\\AssetManager')) {
+            $this->markTestSkipped('Assetic is not available.');
+        }
+
+        $this->request = $this->getMock('Symfony\\Component\\HttpFoundation\\Request');
+        $this->headers = $this->getMock('Symfony\\Component\\HttpFoundation\\ParameterBag');
+        $this->request->headers = $this->headers;
+        $this->am = $this->getMockBuilder('Assetic\\Factory\\LazyAssetManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->cache = $this->getMock('Assetic\\Cache\\CacheInterface');
+
+        $this->controller = new AsseticController($this->request, $this->am, $this->cache);
+    }
+
+    public function testRenderNotFound()
+    {
+        $this->setExpectedException('Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException');
+
+        $name = 'foo';
+
+        $this->am->expects($this->once())
+            ->method('has')
+            ->with($name)
+            ->will($this->returnValue(false));
+
+        $this->controller->render($name);
+    }
+
+    public function testRenderLastModifiedFresh()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $name = 'foo';
+        $lastModified = strtotime('2010-10-10 10:10:10');
+        $ifModifiedSince = gmdate('D, d M Y H:i:s', $lastModified).' GMT';
+
+        $asset->expects($this->any())->method('getFilters')->will($this->returnValue(array()));
+        $this->am->expects($this->once())->method('has')->with($name)->will($this->returnValue(true));
+        $this->am->expects($this->once())->method('get')->with($name)->will($this->returnValue($asset));
+        $asset->expects($this->once())->method('getLastModified')->will($this->returnValue($lastModified));
+        $this->headers->expects($this->once())->method('get')->with('If-Modified-Since')->will($this->returnValue($ifModifiedSince));
+
+        $asset->expects($this->never())
+            ->method('dump');
+
+        $response = $this->controller->render($name);
+        $this->assertEquals(304, $response->getStatusCode(), '->render() sends a Not Modified response when If-Modified-Since is fresh');
+    }
+
+    public function testRenderLastModifiedStale()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $name = 'foo';
+        $content = '==ASSET_CONTENT==';
+        $lastModified = strtotime('2010-10-10 10:10:10');
+        $ifModifiedSince = gmdate('D, d M Y H:i:s', $lastModified - 300).' GMT';
+
+        $asset->expects($this->any())->method('getFilters')->will($this->returnValue(array()));
+        $this->am->expects($this->once())->method('has')->with($name)->will($this->returnValue(true));
+        $this->am->expects($this->once())->method('get')->with($name)->will($this->returnValue($asset));
+        $asset->expects($this->exactly(2))->method('getLastModified')->will($this->returnValue($lastModified));
+        $this->headers->expects($this->once())->method('get')->with('If-Modified-Since')->will($this->returnValue($ifModifiedSince));
+
+        $this->cache->expects($this->once())
+            ->method('has')
+            ->with($this->isType('string'))
+            ->will($this->returnValue(false));
+        $asset->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue($content));
+
+        $response = $this->controller->render($name);
+        $this->assertEquals(200, $response->getStatusCode(), '->render() sends an OK response when If-Modified-Since is stale');
+        $this->assertEquals($content, $response->getContent(), '->render() sends the dumped asset as the response content');
+    }
+
+    public function testRenderETagFresh()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $name = 'foo';
+        $formula = array(array('js/core.js'), array(), array(''));
+        $etag = md5(serialize($formula + array('last_modified' => null)));
+
+        $asset->expects($this->any())->method('getFilters')->will($this->returnValue(array()));
+        $this->am->expects($this->once())->method('has')->with($name)->will($this->returnValue(true));
+        $this->am->expects($this->once())->method('get')->with($name)->will($this->returnValue($asset));
+
+        $this->am->expects($this->once())
+            ->method('hasFormula')
+            ->with($name)
+            ->will($this->returnValue(true));
+        $this->am->expects($this->once())
+            ->method('getFormula')
+            ->with($name)
+            ->will($this->returnValue($formula));
+        $this->request->expects($this->once())
+            ->method('getETags')
+            ->will($this->returnValue(array('"'.$etag.'"')));
+        $asset->expects($this->never())
+            ->method('dump');
+
+        $response = $this->controller->render($name);
+        $this->assertEquals(304, $response->getStatusCode(), '->render() sends a Not Modified response when If-None-Match is fresh');
+    }
+
+    public function testRenderETagStale()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $name = 'foo';
+        $content = '==ASSET_CONTENT==';
+        $formula = array(array('js/core.js'), array(), array(''));
+        $etag = md5(serialize($formula + array('last_modified' => null)));
+
+        $asset->expects($this->any())->method('getFilters')->will($this->returnValue(array()));
+        $this->am->expects($this->once())->method('has')->with($name)->will($this->returnValue(true));
+        $this->am->expects($this->once())->method('get')->with($name)->will($this->returnValue($asset));
+
+        $this->am->expects($this->once())
+            ->method('hasFormula')
+            ->with($name)
+            ->will($this->returnValue(true));
+        $this->am->expects($this->once())
+            ->method('getFormula')
+            ->with($name)
+            ->will($this->returnValue($formula));
+        $this->request->expects($this->once())
+            ->method('getETags')
+            ->will($this->returnValue(array('"123"')));
+        $asset->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue($content));
+
+        $response = $this->controller->render($name);
+        $this->assertEquals(200, $response->getStatusCode(), '->render() sends an OK response when If-None-Match is stale');
+        $this->assertEquals($content, $response->getContent(), '->render() sends the dumped asset as the response content');
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Factory;
+
+use Symfony\Bundle\AsseticBundle\Factory\AssetFactory;
+
+class AssetFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected $kernel;
+    protected $factory;
+
+    protected function setUp()
+    {
+        if (!class_exists('Assetic\\AssetManager')) {
+            $this->markTestSkipped('Assetic is not available.');
+        }
+
+        $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
+        $this->factory = new AssetFactory($this->kernel, '/path/to/web');
+    }
+
+    public function testBundleNotation()
+    {
+        $input = '@MyBundle/Resources/css/main.css';
+
+        $this->kernel->expects($this->once())
+            ->method('locateResource')
+            ->with($input)
+            ->will($this->returnValue('/path/to/bundle/Resources/css/main.css'));
+
+        $this->factory->createAsset($input);
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/FunctionalTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/FunctionalTest.php
@@ -14,6 +14,9 @@ namespace Symfony\Bundle\AsseticBundle\Tests;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Request;
 
+/**
+ * @group functional
+ */
 class FunctionalTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()


### PR DESCRIPTION
I'm working on migrating the AsseticBundle functional tests to unit tests. You can call `phpunit --exclude-group functional` to exclude them in the meantime.
