### PR TITLE
[CacheWarmer] TemplatePaths cache warmer generates bad templates file

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
@@ -91,7 +91,8 @@ class TemplatePathsCacheWarmer extends CacheWarmer
                     if (null !== $bundle) {
                       $template->set('bundle', $bundle);
                     }
-                    $templates[$template->getSignature()] = $file->getRealPath();
+                    $templatePath = sprintf('%s:%s:%s.%s.%s', $template->get('bundle'), $template->get('controller'), $template->get('name'), $template->get('format'), $template->get('engine'));
+                    $templates[$templatePath] = $file->getRealPath();
                 }
             }
         }


### PR DESCRIPTION
When template paths warmer is enabled, it generates templates.php file like this:
<?php return array('md5signature' => 'path');
And md5 string is used in twig bundle for warming cache templates. Though it only understands Bundle:Sesction:Template.format.engine format, so it throws errors like this:
Template name "a6425a46d30cbcf531a85c01282dda4a" is not valid (format is "bundle:section:template.format.engine").
This fixes the problem by setting valid format as key, instead of md5 signature.
