### PR TITLE
[Templating] Fix to support CachedRouter's in RouteHelper.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/CachedRouter.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/CachedRouter.php
@@ -86,4 +86,14 @@ class CachedRouter implements RouterInterface
     {
         return $this->matcher->match($url);
     }
+    
+    /**
+     * Gets the UrlGenerator instance associated with this Router.
+     *
+     * @return UrlGeneratorInterface A UrlGeneratorInterface instance
+     */
+    public function getGenerator()
+    {
+        return $this->generator;
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInstance;
 
 /**
  * RouterHelper manages links between pages in a template context.
@@ -26,9 +26,9 @@ class RouterHelper extends Helper
     /**
      * Constructor.
      *
-     * @param Router $router A Router instance
+     * @param RouterInstance $router A Router instance
      */
-    public function __construct(Router $router)
+    public function __construct(RouterInstance $router)
     {
         $this->generator = $router->getGenerator();
     }


### PR DESCRIPTION
Route helper required Router instance while cached routers are instances of CachedRouter. 
Changed type to RouterInstance.
Added method getGenerator to CachedRouter.
