### PR TITLE
[DependencyInjection] removed eager param replacement

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -150,7 +150,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             $this->extensionConfigs[$namespace] = array();
         }
 
-        $this->extensionConfigs[$namespace][] = $this->getParameterBag()->resolveValue($values);
+        $this->extensionConfigs[$namespace][] = $values;
 
         return $this;
     }

--- a/tests/Symfony/Tests/Component/DependencyInjection/CallableExtension.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/CallableExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+class CallableExtension implements ExtensionInterface
+{
+    private $callable;
+    private $alias;
+
+    public function __construct($callable, $alias)
+    {
+        $this->callable = $callable;
+        $this->alias = $alias;
+    }
+
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        call_user_func($this->callable, $configs, $container);
+    }
+
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+
+    public function getNamespace()
+    {
+        return false;
+    }
+
+    public function getXsdValidationBasePath()
+    {
+        return false;
+    }
+}

--- a/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
@@ -514,6 +514,25 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $container->setDefinition('a', new Definition());
     }
 
+    public function testParamTokensPassedToExtensionAreReplacedLazily()
+    {
+        $load = function($configs, $container)
+        {
+            $container->setParameter('actual', $configs[0]['foo']);
+        };
+
+        $container = new ContainerBuilder();
+        $container->registerExtension(new CallableExtension($load, 'my_extension'));
+
+        $container->setParameter('foo', 'not_this_one');
+        $container->loadFromExtension('my_extension', array('foo' => '%foo%'));
+        $container->setParameter('foo', 'this_one');
+
+        $container->compile();
+
+        $this->assertEquals('this_one', $container->getParameter('actual'));
+    }
+
     /**
      * @param string $class
      * @param int $methodCallsCount


### PR DESCRIPTION
Removed replacement of parameter placeholders at load time since they're now replaced at compile time. Extensions should be written to expect parameter placeholders.
