### PR TITLE
is_file check is not enough()

### DIFF
--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -60,7 +60,7 @@ class FilesystemLoader extends Loader
 
         $logs = array();
         foreach ($this->templatePathPatterns as $templatePathPattern) {
-            if (is_file($file = strtr($templatePathPattern, $replacements))) {
+            if (is_readable($file = strtr($templatePathPattern, $replacements))) {
                 if (null !== $this->debugger) {
                     $this->debugger->log(sprintf('Loaded template file "%s"', $file));
                 }

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -69,7 +69,7 @@ class Yaml
         $file = '';
 
         // if input is a file, process it
-        if (strpos($input, "\n") === false && is_file($input)) {
+        if (strpos($input, "\n") === false && is_readable($input)) {
             $file = $input;
 
             ob_start();


### PR DESCRIPTION
For example when loading config I got this error message:

```
There is no extension able to load the configuration for "Warning"
```

Very confusing. With this change, it will fail with:

  The service file "Foobundle/Resources/config/foo.yml" is not valid.

Which is much better.
