### PR TITLE
Js escape bug

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -412,7 +412,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
                 function ($value) use ($that)
                 {
                     if ('UTF-8' != $that->getCharset()) {
-                        $string = $that->convertEncoding($value, 'UTF-8', $that->getCharset());
+                        $value = $that->convertEncoding($value, 'UTF-8', $that->getCharset());
                     }
 
                     $callback = function ($matches) use ($that)
@@ -430,15 +430,15 @@ class PhpEngine implements EngineInterface, \ArrayAccess
                         return '\\u'.substr('0000'.bin2hex($char), -4);
                     };
 
-                    if (null === $string = preg_replace_callback('#[^\p{L}\p{N} ]#u', $callback, $string)) {
+                    if (null === $value = preg_replace_callback('#[^\p{L}\p{N} ]#u', $callback, $value)) {
                         throw new \InvalidArgumentException('The string to escape is not a valid UTF-8 string.');
                     }
 
                     if ('UTF-8' != $that->getCharset()) {
-                        $string = $that->convertEncoding($string, $that->getCharset(), 'UTF-8');
+                        $value = $that->convertEncoding($value, $that->getCharset(), 'UTF-8');
                     }
 
-                    return $string;
+                    return $value;
                 },
         );
     }


### PR DESCRIPTION
Fixed error in PhpEngine escapers that would cause an undefined variable error when attempting to escape a JS string when the charset is UTF-8.
