### PR TITLE
Fix overrided server

### DIFF
--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -507,10 +507,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
     public function testOverrideGlobals()
     {
-        $time = $_SERVER['REQUEST_TIME']; // fix for phpunit timer
-
         $request = new Request();
         $request->initialize(array('foo' => 'bar'));
+
+        // as the Request::overrideGlobals really work, it erase $_SERVER, so we must backup it
+        $server = $_SERVER;
+
         $request->overrideGlobals();
 
         $this->assertEquals(array('foo' => 'bar'), $_GET);
@@ -530,7 +532,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertArrayHasKey('HTTP_X_FORWARDED_PROTO', $_SERVER);
 
-        $_SERVER['REQUEST_TIME'] = $time; // fix for phpunit timer
+        // restore initial $_SERVER array
+        $_SERVER = $server;
     }
 
     public function testGetScriptName()


### PR DESCRIPTION
$_SERVER was overrided by RequestTest::testOverrideGlobals so it is now backuped and restored after test case execution.
