### PR TITLE
[DependencyInjection] Property Injection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -31,16 +31,16 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
     protected $currentId;
     protected $currentDefinition;
     protected $repeatedPass;
-    protected $ignoreMethodCalls;
+    protected $onlyConstructorArguments;
 
     /**
      * Constructor.
      *
      * @param boolean $ignoreMethodCalls Sets this Service Reference pass to ignore method calls
      */
-    public function __construct($ignoreMethodCalls = false)
+    public function __construct($onlyConstructorArguments = false)
     {
-        $this->ignoreMethodCalls = (Boolean) $ignoreMethodCalls;
+        $this->onlyConstructorArguments = (Boolean) $onlyConstructorArguments;
     }
 
     /**
@@ -53,7 +53,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
     /**
      * Processes a ContainerBuilder object to populate the service reference graph.
      *
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
@@ -70,8 +70,9 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
             $this->currentDefinition = $definition;
             $this->processArguments($definition->getArguments());
 
-            if (!$this->ignoreMethodCalls) {
+            if (!$this->onlyConstructorArguments) {
                 $this->processArguments($definition->getMethodCalls());
+                $this->processArguments($definition->getProperties());
             }
         }
 
@@ -101,6 +102,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
             } else if ($argument instanceof Definition) {
                 $this->processArguments($argument->getArguments());
                 $this->processArguments($argument->getMethodCalls());
+                $this->processArguments($argument->getProperties());
             }
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -29,7 +29,7 @@ class CheckReferenceValidityPass implements CompilerPassInterface
     /**
      * Processes the ContainerBuilder to validate References.
      *
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
@@ -66,6 +66,7 @@ class CheckReferenceValidityPass implements CompilerPassInterface
 
             $this->validateReferences($definition->getArguments());
             $this->validateReferences($definition->getMethodCalls());
+            $this->validateReferences($definition->getProperties());
         }
     }
 
@@ -100,8 +101,8 @@ class CheckReferenceValidityPass implements CompilerPassInterface
     /**
      * Validates the scope of a single Reference.
      *
-     * @param Reference $reference 
-     * @param Definition $definition 
+     * @param Reference $reference
+     * @param Definition $definition
      * @throws \RuntimeException when there is an issue with the Reference scope
      */
     protected function validateScope(Reference $reference, Definition $definition = null)

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -51,6 +51,10 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             $definition->setMethodCalls(
                 $this->inlineArguments($container, $definition->getMethodCalls())
             );
+
+            $definition->setProperties(
+                $this->inlineArguments($container, $definition->getProperties())
+            );
         }
     }
 
@@ -80,6 +84,7 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
             } else if ($argument instanceof Definition) {
                 $argument->setArguments($this->inlineArguments($container, $argument->getArguments()));
                 $argument->setMethodCalls($this->inlineArguments($container, $argument->getMethodCalls()));
+                $argument->setProperties($this->inlineArguments($container, $argument->getProperties()));
             }
         }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -19,7 +19,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
     /**
      * Process the ContainerBuilder to replace DefinitionDecorator instances with their real Definition instances.
      *
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
@@ -40,7 +40,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
      * Resolves the definition
      *
      * @param string $id The definition identifier
-     * @param DefinitionDecorator $definition 
+     * @param DefinitionDecorator $definition
      * @return Definition
      */
     protected function resolveDefinition($id, DefinitionDecorator $definition)
@@ -61,6 +61,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
         $def->setClass($parentDef->getClass());
         $def->setArguments($parentDef->getArguments());
         $def->setMethodCalls($parentDef->getMethodCalls());
+        $def->setProperties($parentDef->getProperties());
         $def->setFactoryClass($parentDef->getFactoryClass());
         $def->setFactoryMethod($parentDef->getFactoryMethod());
         $def->setFactoryService($parentDef->getFactoryService());
@@ -105,6 +106,11 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
 
             $index = (integer) substr($k, strlen('index_'));
             $def->setArgument($index, $v);
+        }
+
+        // merge properties
+        foreach ($definition->getProperties() as $k => $v) {
+            $def->setProperty($k, $v);
         }
 
         // append method calls

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -26,7 +26,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
     protected $container;
     protected $exceptions;
 
-    /** 
+    /**
      * Constructor.
      *
      * @param array $exceptions An array of exceptions
@@ -49,7 +49,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
     /**
      * Process the ContainerBuilder to resolve invalid references.
      *
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
@@ -72,6 +72,17 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
                 }
             }
             $definition->setMethodCalls($calls);
+
+            $properties = array();
+            foreach ($definition->getProperties() as $name => $value) {
+                try {
+                    $value = $this->processArguments(array($value), true);
+                    $properties[$name] = reset($value);
+                } catch (\RuntimeException $ignore) {
+                    // ignore property
+                }
+            }
+            $definition->setProperties($properties);
         }
     }
 
@@ -79,7 +90,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
      * Processes arguments to determine invalid references.
      *
      * @param array $arguments An array of Reference objects
-     * @param boolean $inMethodCall 
+     * @param boolean $inMethodCall
      */
     protected function processArguments(array $arguments, $inMethodCall = false)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -25,7 +25,7 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
     /**
      * Processes the ContainerBuilder to resolve parameter placeholders.
      *
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
@@ -41,6 +41,8 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
                 $calls[$this->resolveValue($name)] = $this->resolveValue($arguments);
             }
             $definition->setMethodCalls($calls);
+
+            $definition->setProperties($this->resolveValue($definition->getProperties()));
         }
 
         $aliases = array();

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveReferencesToAliasesPass.php
@@ -27,7 +27,7 @@ class ResolveReferencesToAliasesPass implements CompilerPassInterface
     /**
      * Processes the ContainerBuilder to replace references to aliases with actual service references.
      *
-     * @param ContainerBuilder $container 
+     * @param ContainerBuilder $container
      */
     public function process(ContainerBuilder $container)
     {
@@ -40,6 +40,7 @@ class ResolveReferencesToAliasesPass implements CompilerPassInterface
 
             $definition->setArguments($this->processArguments($definition->getArguments()));
             $definition->setMethodCalls($this->processArguments($definition->getMethodCalls()));
+            $definition->setProperties($this->processArguments($definition->getProperties()));
         }
 
         foreach ($container->getAliases() as $id => $alias) {

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -25,6 +25,7 @@ class Definition
     protected $factoryService;
     protected $scope;
     protected $arguments;
+    protected $properties;
     protected $calls;
     protected $configurator;
     protected $tags;
@@ -48,6 +49,7 @@ class Definition
         $this->public = true;
         $this->synthetic = false;
         $this->abstract = false;
+        $this->properties = array();
     }
 
     /**
@@ -157,6 +159,25 @@ class Definition
     public function setArguments(array $arguments)
     {
         $this->arguments = $arguments;
+
+        return $this;
+    }
+
+    public function setProperties(array $properties)
+    {
+        $this->properties = $properties;
+
+        return $this;
+    }
+
+    public function getProperties()
+    {
+        return $this->properties;
+    }
+
+    public function setProperty($name, $value)
+    {
+        $this->properties[$name] = $value;
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -68,7 +68,10 @@ class GraphvizDumper extends Dumper
 
         $this->edges = array();
         foreach ($this->container->getDefinitions() as $id => $definition) {
-            $this->edges[$id] = $this->findEdges($id, $definition->getArguments(), true, '');
+            $this->edges[$id] = array_merge(
+                $this->findEdges($id, $definition->getArguments(), true, ''),
+                $this->findEdges($id, $definition->getProperties(), false, '')
+            );
 
             foreach ($definition->getMethodCalls() as $call) {
                 $this->edges[$id] = array_merge(
@@ -120,8 +123,8 @@ class GraphvizDumper extends Dumper
      *
      * @param string $id The service id used to find edges
      * @param array $arguments An array of arguments
-     * @param boolean $required 
-     * @param string $name 
+     * @param boolean $required
+     * @param string $name
      * @return array An array of edges
      */
     protected function findEdges($id, $arguments, $required, $name)

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -60,7 +60,7 @@ class XmlDumper extends Dumper
     /**
      * Adds parameters.
      *
-     * @param DOMElement $parent 
+     * @param DOMElement $parent
      * @return void
      */
     protected function addParameters(\DOMElement $parent)
@@ -82,8 +82,8 @@ class XmlDumper extends Dumper
     /**
      * Adds method calls.
      *
-     * @param array $methodcalls 
-     * @param DOMElement $parent 
+     * @param array $methodcalls
+     * @param DOMElement $parent
      * @return void
      */
     protected function addMethodCalls(array $methodcalls, \DOMElement $parent)
@@ -101,8 +101,8 @@ class XmlDumper extends Dumper
     /**
      * Adds interface injector.
      *
-     * @param InterfaceInjector $injector 
-     * @param DOMElement $parent 
+     * @param InterfaceInjector $injector
+     * @param DOMElement $parent
      * @return void
      */
     protected function addInterfaceInjector(InterfaceInjector $injector, \DOMElement $parent)
@@ -116,7 +116,7 @@ class XmlDumper extends Dumper
     /**
      * Adds interface injectors.
      *
-     * @param DOMElement $parent 
+     * @param DOMElement $parent
      * @return void
      */
     protected function addInterfaceInjectors(\DOMElement $parent)
@@ -135,9 +135,9 @@ class XmlDumper extends Dumper
     /**
      * Adds a service.
      *
-     * @param Definition $definition 
-     * @param string $id 
-     * @param DOMElement $parent 
+     * @param Definition $definition
+     * @param string $id
+     * @param DOMElement $parent
      * @return void
      */
     protected function addService($definition, $id, \DOMElement $parent)
@@ -179,6 +179,10 @@ class XmlDumper extends Dumper
             $this->convertParameters($parameters, 'argument', $service);
         }
 
+        if ($parameters = $definition->getProperties()) {
+            $this->convertParameters($parameters, 'property', $service, 'name');
+        }
+
         $this->addMethodCalls($definition->getMethodCalls(), $service);
 
         if ($callable = $definition->getConfigurator()) {
@@ -198,9 +202,9 @@ class XmlDumper extends Dumper
     /**
      * Adds a service alias.
      *
-     * @param string $alias 
-     * @param string $id 
-     * @param DOMElement $parent 
+     * @param string $alias
+     * @param string $id
+     * @param DOMElement $parent
      * @return void
      */
     protected function addServiceAlias($alias, $id, \DOMElement $parent)
@@ -217,7 +221,7 @@ class XmlDumper extends Dumper
     /**
      * Adds services.
      *
-     * @param DOMElement $parent 
+     * @param DOMElement $parent
      * @return void
      */
     protected function addServices(\DOMElement $parent)
@@ -241,23 +245,23 @@ class XmlDumper extends Dumper
     /**
      * Converts parameters.
      *
-     * @param string $parameters 
-     * @param string $type 
-     * @param DOMElement $parent 
+     * @param string $parameters
+     * @param string $type
+     * @param DOMElement $parent
      * @return void
      */
-    protected function convertParameters($parameters, $type, \DOMElement $parent)
+    protected function convertParameters($parameters, $type, \DOMElement $parent, $keyAttribute = 'key')
     {
         $withKeys = array_keys($parameters) !== range(0, count($parameters) - 1);
         foreach ($parameters as $key => $value) {
             $element = $this->document->createElement($type);
             if ($withKeys) {
-                $element->setAttribute('key', $key);
+                $element->setAttribute($keyAttribute, $key);
             }
 
             if (is_array($value)) {
                 $element->setAttribute('type', 'collection');
-                $this->convertParameters($value, $type, $element);
+                $this->convertParameters($value, $type, $element, 'key');
             } else if (is_object($value) && $value instanceof Reference) {
                 $element->setAttribute('type', 'service');
                 $element->setAttribute('id', (string) $value);
@@ -284,7 +288,7 @@ class XmlDumper extends Dumper
     /**
      * Escapes arguments
      *
-     * @param array $arguments 
+     * @param array $arguments
      * @return array
      */
     protected function escape($arguments)

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -60,8 +60,8 @@ class YamlDumper extends Dumper
     /**
      * Adds a service
      *
-     * @param string $id 
-     * @param Definition $definition 
+     * @param string $id
+     * @param Definition $definition
      * @return string
      */
     protected function addService($id, $definition)
@@ -103,6 +103,10 @@ class YamlDumper extends Dumper
             $code .= sprintf("    arguments: %s\n", Yaml::dump($this->dumpValue($definition->getArguments()), 0));
         }
 
+        if ($definition->getProperties()) {
+            $code .= sprintf("    properties: %s\n", Yaml::dump($this->dumpValue($definition->getProperties()), 0));
+        }
+
         if ($definition->getMethodCalls()) {
             $code .= sprintf("    calls:\n      %s\n", str_replace("\n", "\n      ", Yaml::dump($this->dumpValue($definition->getMethodCalls()), 1)));
         }
@@ -129,8 +133,8 @@ class YamlDumper extends Dumper
     /**
      * Adds a service alias
      *
-     * @param string $alias 
-     * @param string $id 
+     * @param string $alias
+     * @param string $id
      * @return void
      */
     protected function addServiceAlias($alias, $id)
@@ -214,8 +218,8 @@ class YamlDumper extends Dumper
     /**
      * Gets the service call.
      *
-     * @param string $id 
-     * @param Reference $reference 
+     * @param string $id
+     * @param Reference $reference
      * @return string
      */
     protected function getServiceCall($id, Reference $reference = null)
@@ -230,7 +234,7 @@ class YamlDumper extends Dumper
     /**
      * Gets parameter call.
      *
-     * @param string $id 
+     * @param string $id
      * @return string
      */
     protected function getParameterCall($id)
@@ -241,8 +245,8 @@ class YamlDumper extends Dumper
     /**
      * Prepares parameters
      *
-     * @param string $parameters 
-     * @return array 
+     * @param string $parameters
+     * @return array
      */
     protected function prepareParameters($parameters)
     {
@@ -263,7 +267,7 @@ class YamlDumper extends Dumper
     /**
      * Escapes arguments
      *
-     * @param array $arguments 
+     * @param array $arguments
      * @return array
      */
     protected function escape($arguments)

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -79,8 +79,8 @@ class XmlFileLoader extends FileLoader
     /**
      * Parses parameters
      *
-     * @param SimpleXMLElement $xml 
-     * @param string $file 
+     * @param SimpleXMLElement $xml
+     * @param string $file
      * @return void
      */
     protected function parseParameters(SimpleXMLElement $xml, $file)
@@ -95,8 +95,8 @@ class XmlFileLoader extends FileLoader
     /**
      * Parses imports
      *
-     * @param SimpleXMLElement $xml 
-     * @param string $file 
+     * @param SimpleXMLElement $xml
+     * @param string $file
      * @return void
      */
     protected function parseImports(SimpleXMLElement $xml, $file)
@@ -114,8 +114,8 @@ class XmlFileLoader extends FileLoader
     /**
      * Parses interface injectors
      *
-     * @param SimpleXMLElement $xml 
-     * @param string $file 
+     * @param SimpleXMLElement $xml
+     * @param string $file
      * @return void
      */
     protected function parseInterfaceInjectors(SimpleXMLElement $xml, $file)
@@ -148,8 +148,8 @@ class XmlFileLoader extends FileLoader
     /**
      * Parses multiple definitions
      *
-     * @param SimpleXMLElement $xml 
-     * @param string $file 
+     * @param SimpleXMLElement $xml
+     * @param string $file
      * @return void
      */
     protected function parseDefinitions(SimpleXMLElement $xml, $file)
@@ -166,9 +166,9 @@ class XmlFileLoader extends FileLoader
     /**
      * Parses an individual Definition
      *
-     * @param string $id 
-     * @param SimpleXMLElement $service 
-     * @param string $file 
+     * @param string $id
+     * @param SimpleXMLElement $service
+     * @param string $file
      * @return void
      */
     protected function parseDefinition($id, $service, $file)
@@ -201,6 +201,7 @@ class XmlFileLoader extends FileLoader
         }
 
         $definition->setArguments($service->getArgumentsAsPhp('argument'));
+        $definition->setProperties($service->getArgumentsAsPhp('property'));
 
         if (isset($service->configurator)) {
             if (isset($service->configurator['function'])) {
@@ -260,8 +261,8 @@ class XmlFileLoader extends FileLoader
     /**
      * Processes anonymous services
      *
-     * @param SimpleXMLElement $xml 
-     * @param string $file 
+     * @param SimpleXMLElement $xml
+     * @param string $file
      * @return array An array of anonymous services
      */
     protected function processAnonymousServices(SimpleXMLElement $xml, $file)
@@ -314,8 +315,8 @@ class XmlFileLoader extends FileLoader
     /**
      * Validates an XML document.
      *
-     * @param DOMDocument $dom 
-     * @param string $file 
+     * @param DOMDocument $dom
+     * @param string $file
      */
     protected function validate(\DOMDocument $dom, $file)
     {
@@ -448,7 +449,7 @@ EOF
     /**
      * Loads from an extension.
      *
-     * @param SimpleXMLElement $xml 
+     * @param SimpleXMLElement $xml
      * @return void
      */
     protected function loadFromExtensions(SimpleXMLElement $xml)

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
-
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\InterfaceInjector;
@@ -86,8 +85,8 @@ class YamlFileLoader extends FileLoader
     /**
      * Parses all imports
      *
-     * @param array $content 
-     * @param string $file 
+     * @param array $content
+     * @param string $file
      * @return void
      */
     protected function parseImports($content, $file)
@@ -105,8 +104,8 @@ class YamlFileLoader extends FileLoader
     /**
      * Parses interface injectors.
      *
-     * @param array $content 
-     * @param string $file 
+     * @param array $content
+     * @param string $file
      * @return void
      */
     protected function parseInterfaceInjectors($content, $file)
@@ -142,8 +141,8 @@ class YamlFileLoader extends FileLoader
     /**
      * Parses definitions
      *
-     * @param array $content 
-     * @param string $file 
+     * @param array $content
+     * @param string $file
      * @return void
      */
     protected function parseDefinitions($content, $file)
@@ -160,9 +159,9 @@ class YamlFileLoader extends FileLoader
     /**
      * Parses a definition.
      *
-     * @param string $id 
-     * @param array $service 
-     * @param string $file 
+     * @param string $id
+     * @param array $service
+     * @param string $file
      * @return void
      */
     protected function parseDefinition($id, $service, $file)
@@ -224,6 +223,10 @@ class YamlFileLoader extends FileLoader
             $definition->setArguments($this->resolveServices($service['arguments']));
         }
 
+        if (isset($service['properties'])) {
+            $definition->setProperties($this->resolveServices($service['properties']));
+        }
+
         if (isset($service['configurator'])) {
             if (is_string($service['configurator'])) {
                 $definition->setConfigurator($service['configurator']);
@@ -261,7 +264,7 @@ class YamlFileLoader extends FileLoader
     /**
      * Loads a YAML file.
      *
-     * @param string $file 
+     * @param string $file
      * @return array The file content
      */
     protected function loadFile($file)
@@ -304,7 +307,7 @@ class YamlFileLoader extends FileLoader
     /**
      * Resolves services.
      *
-     * @param string $value 
+     * @param string $value
      * @return void
      */
     protected function resolveServices($value)
@@ -336,7 +339,7 @@ class YamlFileLoader extends FileLoader
     /**
      * Loads from Extensions
      *
-     * @param array $content 
+     * @param array $content
      * @return void
      */
     protected function loadFromExtensions($content)

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -98,6 +98,7 @@
       <xsd:element name="configurator" type="configurator" minOccurs="0" maxOccurs="1" />
       <xsd:element name="call" type="call" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="tag" type="tag" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
     </xsd:choice>
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="class" type="xsd:string" />
@@ -133,6 +134,14 @@
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="key" type="xsd:string" />
     <xsd:attribute name="on-invalid" type="invalid_sequence" />
+  </xsd:complexType>
+
+  <xsd:complexType name="property" mixed="true">
+    <xsd:attribute name="type" type="argument_type" />
+    <xsd:attribute name="id" type="xsd:string" />
+    <xsd:attribute name="name" type="xsd:string" />
+    <xsd:attribute name="on-invalid" type="xsd:string" />
+    <xsd:attribute name="strict" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="argument" mixed="true">

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -21,7 +21,7 @@ class SimpleXMLElement extends \SimpleXMLElement
     /**
      * Converts an attribute as a php type.
      *
-     * @param string $name 
+     * @param string $name
      * @return mixed
      */
     public function getAttributeAsPhp($name)
@@ -32,13 +32,16 @@ class SimpleXMLElement extends \SimpleXMLElement
     /**
      * Returns arguments as valid php types.
      *
-     * @param string $name 
+     * @param string $name
      * @return mixed
      */
     public function getArgumentsAsPhp($name)
     {
         $arguments = array();
         foreach ($this->$name as $arg) {
+            if (isset($arg['name'])) {
+                $arg['key'] = (string) $arg['name'];
+            }
             $key = isset($arg['key']) ? (string) $arg['key'] : (!$arguments ? 0 : max(array_keys($arguments)) + 1);
 
             // parameter keys are case insensitive
@@ -89,7 +92,7 @@ class SimpleXMLElement extends \SimpleXMLElement
     /**
      * Converts an xml value to a php type.
      *
-     * @param mixed $value 
+     * @param mixed $value
      * @return mixed
      */
     static public function phpize($value)

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPassTest.php
@@ -40,11 +40,17 @@ class AnalyzeServiceReferencesPassTest extends \PHPUnit_Framework_TestCase
             ->addArgument($ref4 = new Reference('b'))
         ;
 
+        $d = $container
+            ->register('d')
+            ->setProperty('foo', $ref5 = new Reference('b'))
+        ;
+
         $graph = $this->process($container);
 
-        $this->assertEquals(2, count($edges = $graph->getNode('b')->getInEdges()));
+        $this->assertEquals(3, count($edges = $graph->getNode('b')->getInEdges()));
         $this->assertSame($ref1, $edges[0]->getValue());
         $this->assertSame($ref4, $edges[1]->getValue());
+        $this->assertSame($ref5, $edges[2]->getValue());
     }
 
     public function testProcessDetectsReferencesFromInlinedDefinitions()

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -15,9 +15,10 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
     public function testProcess()
     {
         $container = new ContainerBuilder();
-        $container->register('parent', 'foo')->setArguments(array('moo', 'b'));
+        $container->register('parent', 'foo')->setArguments(array('moo', 'b'))->setProperty('foo', 'moo');
         $container->setDefinition('child', new DefinitionDecorator('parent'))
             ->setArgument(0, 'a')
+            ->setProperty('foo', 'bar')
             ->setClass('bar')
         ;
 
@@ -27,6 +28,7 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertNotInstanceOf('Symfony\Component\DependencyInjection\DefinitionDecorator', $def);
         $this->assertEquals('bar', $def->getClass());
         $this->assertEquals(array('a', 'b'), $def->getArguments());
+        $this->assertEquals(array('foo' => 'bar'), $def->getProperties());
     }
 
     public function testProcessAppendsMethodCallsAlways()

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPassTest.php
@@ -62,6 +62,19 @@ class ResolveInvalidReferencesPassTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', (string) $arguments[0]);
     }
 
+    public function testProcessRemovesPropertiesOnInvalid()
+    {
+        $container = new ContainerBuilder();
+        $def = $container
+            ->register('foo')
+            ->setProperty('foo', new Reference('bar', ContainerInterface::IGNORE_ON_INVALID_REFERENCE))
+        ;
+
+        $this->process($container);
+
+        $this->assertEquals(array(), $def->getProperties());
+    }
+
     protected function process(ContainerBuilder $container, array $exceptions = array())
     {
         $pass = new ResolveInvalidReferencesPass($exceptions);

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
@@ -220,4 +220,22 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         ;
         $this->assertSame(array('foo', 'bar'), $def->getArguments());
     }
+
+    public function testSetGetProperties()
+    {
+        $def = new Definition('stdClass');
+
+        $this->assertEquals(array(), $def->getProperties());
+        $this->assertSame($def, $def->setProperties(array('foo' => 'bar')));
+        $this->assertEquals(array('foo' => 'bar'), $def->getProperties());
+    }
+
+    public function testSetProperty()
+    {
+        $def = new Definition('stdClass');
+
+        $this->assertEquals(array(), $def->getProperties());
+        $this->assertSame($def, $def->setProperty('foo', 'bar'));
+        $this->assertEquals(array('foo' => 'bar'), $def->getProperties());
+    }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/containers/container9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/containers/container9.php
@@ -15,6 +15,7 @@ $container->
     setFactoryClass('FooClass')->
     setFactoryMethod('getInstance')->
     setArguments(array('foo', new Reference('foo.baz'), array('%foo%' => 'foo is %foo%', 'bar' => '%foo%'), true, new Reference('service_container')))->
+    setProperties(array('foo' => 'bar', 'moo' => new Reference('foo.baz')))->
     setScope('prototype')->
     addMethodCall('setBar', array(new Reference('bar')))->
     addMethodCall('initialize')->

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/graphviz/services9.dot
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/graphviz/services9.dot
@@ -15,6 +15,7 @@ digraph sc {
   node_foobaz [label="foobaz\n\n", shape=record, fillcolor="#ff9999", style="filled"];
   node_foo -> node_foo_baz [label="" style="filled"];
   node_foo -> node_service_container [label="" style="filled"];
+  node_foo -> node_foo_baz [label="" style="dashed"];
   node_foo -> node_bar [label="setBar()" style="dashed"];
   node_bar -> node_foo_baz [label="" style="filled"];
   node_method_call1 -> node_foo [label="setBar()" style="dashed"];

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/foo.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/foo.php
@@ -2,6 +2,8 @@
 
 class FooClass
 {
+    private $foo, $moo;
+
     public $bar = null, $initialized = false, $configured = false, $called = false, $arguments = array();
 
     public function __construct($arguments = array())

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
@@ -59,10 +59,18 @@ class ProjectServiceContainer extends Container
      */
     protected function getFooService()
     {
-        $instance = call_user_func(array('FooClass', 'getInstance'), 'foo', $this->get('foo.baz'), array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo'), 'bar' => $this->getParameter('foo')), true, $this);
+        $a = $this->get('foo.baz');
+
+        $instance = call_user_func(array('FooClass', 'getInstance'), 'foo', $a, array($this->getParameter('foo') => 'foo is '.$this->getParameter('foo'), 'bar' => $this->getParameter('foo')), true, $this);
 
         $instance->setBar($this->get('bar'));
         $instance->initialize();
+        $b = new \ReflectionProperty($instance, 'foo');
+        $b->setAccessible(true);
+        $b->setValue($instance, 'bar');
+        $c = new \ReflectionProperty($instance, 'moo');
+        $c->setAccessible(true);
+        $c->setValue($instance, $a);
         sc_configure($instance);
 
         return $instance;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services9.xml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services9.xml
@@ -17,6 +17,8 @@
       </argument>
       <argument>true</argument>
       <argument type="service" id="service_container"/>
+      <property name="foo">bar</property>
+      <property name="moo" type="service" id="foo.baz"/>
       <call method="setBar">
         <argument type="service" id="bar"/>
       </call>

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services9.yml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services9.yml
@@ -11,6 +11,7 @@ services:
       - { name: foo, bar: bar }
     factory_method: getInstance
     arguments: [foo, '@foo.baz', { '%foo%': 'foo is %foo%', bar: '%foo%' }, true, '@service_container']
+    properties: { foo: bar, moo: '@foo.baz' }
     calls:
       - [setBar, ['@bar']]
       - [initialize, {  }]


### PR DESCRIPTION
This adds support for injecting services directly into object properties (without setters, or constructor arguments) using the Reflection API. The performance impact is quite minimal if noticeable at all.

In a second step, we can allow people to add @Autowired annotations to service properties which will make it much easier for example to configure controllers.
