### PR TITLE
Code coverage on HttpFoundation/Response

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
                 <directory>./src/Symfony/Bundle/*/Resources</directory>
                 <directory>./src/Symfony/Bundle/*/Tests</directory>
                 <directory>./src/Symfony/Component/*/Resources</directory>
+                <directory>./src/Symfony/Component/*/*/Resources</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -217,7 +217,7 @@ class Response
     public function setStatusCode($code, $text = null)
     {
         $this->statusCode = (int) $code;
-        if ($this->statusCode < 100 || $this->statusCode > 599) {
+        if ($this->isInvalid()) {
             throw new \InvalidArgumentException(sprintf('The HTTP status code "%s" is not valid.', $code));
         }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -511,7 +511,7 @@ class Response
      */
     public function getLastModified()
     {
-        return $this->headers->getDate('LastModified');
+        return $this->headers->getDate('Last-Modified');
     }
 
     /**


### PR DESCRIPTION
Added tests on HttpFoundation/Response

Also fixes the code coverage generation crash when the resources folder are more than 1 folder deep.
