### PR TITLE
[Security] Ticket 9557 session issue when no session manager has been configured

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -160,7 +160,10 @@ class ExceptionListener implements ListenerInterface
             $this->logger->debug('Calling Authentication entry point');
         }
 
-        $request->getSession()->set('_security.target_path', $request->getUri());
+        // session isn't required when using http basic authentification mechanism for example
+        if ($request->hasSession()) {
+            $request->getSession()->set('_security.target_path', $request->getUri());
+        }
 
         return $this->authenticationEntryPoint->start($event, $request, $authException);
     }


### PR DESCRIPTION
TICKET #9557: session isn't required when using http basic authentification mecanism for example

http://trac.symfony-project.org/ticket/9557
