### PR TITLE
[Console] added possibilty to define keys of an array argument

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -155,12 +155,23 @@ class ArgvInput extends Input
         // if input is expecting another argument, add it
         if ($this->definition->hasArgument($c)) {
             $arg = $this->definition->getArgument($c);
-            $this->arguments[$arg->getName()] = $arg->isArray()? array($token) : $token;
+            if (false !== strpos($token, '=')) {
+                $parts = explode('=', $token);
+                $this->arguments[$arg->getName()][$parts[0]] = $parts[1];
+            } else {
+                $this->arguments[$arg->getName()] = $arg->isArray() ? array($token) : $token;
+            }
 
         // if last argument isArray(), append token to last argument
         } elseif ($this->definition->hasArgument($c - 1) && $this->definition->getArgument($c - 1)->isArray()) {
             $arg = $this->definition->getArgument($c - 1);
-            $this->arguments[$arg->getName()][] = $token;
+
+            if (false !== strpos($token, '=')) {
+                $parts = explode('=', $token);
+                $this->arguments[$arg->getName()][$parts[0]] = $parts[1];
+            } else {
+                $this->arguments[$arg->getName()][] = $token;
+            }
 
         // unexpected argument
         } else {

--- a/tests/Symfony/Tests/Component/Console/Input/ArgvInputTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/ArgvInputTest.php
@@ -34,6 +34,14 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
         $input->bind(new InputDefinition(array(new InputArgument('name'))));
         $this->assertEquals(array('name' => 'foo'), $input->getArguments(), '->parse() is stateless');
 
+        $input = new TestInput(array('cli.php', 'foo'));
+        $input->bind(new InputDefinition(array(new InputArgument('name', InputArgument::IS_ARRAY))));
+        $this->assertEquals(array('name' => array('foo')), $input->getArguments(), '->parse() parses array argument');
+
+        $input = new TestInput(array('cli.php', 'foo=bar'));
+        $input->bind(new InputDefinition(array(new InputArgument('name', InputArgument::IS_ARRAY))));
+        $this->assertEquals(array('name' => array('foo' => 'bar')), $input->getArguments(), '->parse() parses array argument with keys');
+
         $input = new TestInput(array('cli.php', '--foo'));
         $input->bind(new InputDefinition(array(new InputOption('foo'))));
         $this->assertEquals(array('foo' => true), $input->getOptions(), '->parse() parses long options without a value');


### PR DESCRIPTION
As far as i have understood things, i think we can't pass array arguments with keys in the console.

I have a command with one argument, an array argument <code>InputArgument::IS_ARRAY</code>.

Actually we can only define array values:

<pre>
php app/console my:command foo bar=baz
// array('foo', 'bar=baz')
</pre>


This patch allow to define keys and values, separated by <code>=</code>:

<pre>
php app/console my:command foo bar=baz
// array('foo', 'bar' => 'baz')
</pre>
