### PR TITLE
Use of is_callable over method_exists to ensure method can be called with current scope

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/TreeBuilder.php
@@ -72,7 +72,7 @@ class TreeBuilder
     protected function createConfigNode(NodeBuilder $node)
     {
         $method = 'create'.$node->type.'ConfigNode';
-        if (!method_exists($this, $method)) {
+        if (!is_callable(array($this, $method))) {
             throw new \RuntimeException(sprintf('Unknown node type: "%s"', $node->type));
         }
 

--- a/src/Symfony/Component/CssSelector/Node/FunctionNode.php
+++ b/src/Symfony/Component/CssSelector/Node/FunctionNode.php
@@ -37,7 +37,7 @@ class FunctionNode implements NodeInterface
      * @param NodeInterface $selector The XPath expression
      * @param string $type
      * @param string $name
-     * @param XPathExpr $expr 
+     * @param XPathExpr $expr
      */
     public function __construct($selector, $type, $name, $expr)
     {
@@ -66,7 +66,7 @@ class FunctionNode implements NodeInterface
             throw new SyntaxError(sprintf('The pseudo-class %s is not supported', $this->name));
         }
         $method = '_xpath_'.str_replace('-', '_', $this->name);
-        if (!method_exists($this, $method)) {
+        if (!is_callable(array($this, $method))) {
             throw new SyntaxError(sprintf('The pseudo-class %s is unknown', $this->name));
         }
 
@@ -76,10 +76,10 @@ class FunctionNode implements NodeInterface
     /**
      * undocumented function
      *
-     * @param XPathExpr $xpath 
-     * @param mixed $expr 
-     * @param string $last 
-     * @param string $addNameTest 
+     * @param XPathExpr $xpath
+     * @param mixed $expr
+     * @param string $last
+     * @param string $addNameTest
      * @return XPathExpr
      */
     protected function _xpath_nth_child($xpath, $expr, $last = false, $addNameTest = true)
@@ -148,8 +148,8 @@ class FunctionNode implements NodeInterface
     /**
      * undocumented function
      *
-     * @param XPathExpr $xpath 
-     * @param XPathExpr $expr 
+     * @param XPathExpr $xpath
+     * @param XPathExpr $expr
      * @return XPathExpr
      */
     protected function _xpath_nth_last_child($xpath, $expr)
@@ -160,8 +160,8 @@ class FunctionNode implements NodeInterface
     /**
      * undocumented function
      *
-     * @param XPathExpr $xpath 
-     * @param XPathExpr $expr 
+     * @param XPathExpr $xpath
+     * @param XPathExpr $expr
      * @return XPathExpr
      */
     protected function _xpath_nth_of_type($xpath, $expr)
@@ -176,8 +176,8 @@ class FunctionNode implements NodeInterface
     /**
      * undocumented function
      *
-     * @param XPathExpr $xpath 
-     * @param XPathExpr $expr 
+     * @param XPathExpr $xpath
+     * @param XPathExpr $expr
      * @return XPathExpr
      */
     protected function _xpath_nth_last_of_type($xpath, $expr)
@@ -188,8 +188,8 @@ class FunctionNode implements NodeInterface
     /**
      * undocumented function
      *
-     * @param XPathExpr $xpath 
-     * @param XPathExpr $expr 
+     * @param XPathExpr $xpath
+     * @param XPathExpr $expr
      * @return XPathExpr
      */
     protected function _xpath_contains($xpath, $expr)
@@ -211,8 +211,8 @@ class FunctionNode implements NodeInterface
     /**
      * undocumented function
      *
-     * @param XPathExpr $xpath 
-     * @param XPathExpr $expr 
+     * @param XPathExpr $xpath
+     * @param XPathExpr $expr
      * @return XPathExpr
      */
     protected function _xpath_not($xpath, $expr)
@@ -229,7 +229,7 @@ class FunctionNode implements NodeInterface
     /**
      * Parses things like '1n+2', or 'an+b' generally, returning (a, b)
      *
-     * @param mixed $s 
+     * @param mixed $s
      * @return array
      */
     protected function parseSeries($s)

--- a/src/Symfony/Component/CssSelector/Node/PseudoNode.php
+++ b/src/Symfony/Component/CssSelector/Node/PseudoNode.php
@@ -73,7 +73,7 @@ class PseudoNode implements NodeInterface
             throw new SyntaxError(sprintf('The pseudo-class %s is unsupported', $this->ident));
         }
         $method = 'xpath_'.str_replace('-', '_', $this->ident);
-        if (!method_exists($this, $method)) {
+        if (!is_callable(array($this, $method))) {
             throw new SyntaxError(sprintf('The pseudo-class %s is unknown', $this->ident));
         }
 
@@ -119,7 +119,7 @@ class PseudoNode implements NodeInterface
         return $xpath;
     }
 
-    /** 
+    /**
      * Sets the XPath  to be the last child.
      *
      * @param XPathExpr $xpath The XPath expression

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -190,7 +190,7 @@ class Container implements ContainerInterface
     {
         $id = strtolower($id);
 
-        return isset($this->services[$id]) || method_exists($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service');
+        return isset($this->services[$id]) || is_callable(array($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service'));
     }
 
     /**
@@ -220,7 +220,7 @@ class Container implements ContainerInterface
             throw new \LogicException(sprintf('Circular reference detected for service "%s" (services currently loading: %s).', $id, implode(', ', array_keys($this->loading))));
         }
 
-        if (method_exists($this, $method = 'get'.strtr($id, array('_' => '', '.' => '_')).'Service')) {
+        if (is_callable(array($this, $method = 'get'.strtr($id, array('_' => '', '.' => '_')).'Service'))) {
             $this->loading[$id] = true;
 
             $service = $this->$method();

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -66,7 +66,7 @@ class ControllerResolver implements ControllerResolverInterface
 
         list($controller, $method) = $this->createController($controller);
 
-        if (!method_exists($controller, $method)) {
+        if (!is_callable(array($controller, $method))) {
             throw new \InvalidArgumentException(sprintf('Method "%s::%s" does not exist.', get_class($controller), $method));
         }
 

--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -42,7 +42,7 @@ class Route
 
         foreach ($data as $key => $value) {
             $method = 'set'.$key;
-            if (!method_exists($this, $method)) {
+            if (!is_callable(array($this, $method))) {
                 throw new \BadMethodCallException(sprintf("Unknown property '%s' on annotation '%s'.", $key, get_class($this)));
             }
             $this->$method($value);

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -61,7 +61,7 @@ class ObjectIdentity implements ObjectIdentityInterface
         try {
             if ($domainObject instanceof DomainObjectInterface) {
                 return new self($domainObject->getObjectIdentifier(), get_class($domainObject));
-            } else if (method_exists($domainObject, 'getId')) {
+            } else if (is_callable(array($domainObject, 'getId'))) {
                 return new self($domainObject->getId(), get_class($domainObject));
             }
         } catch (\InvalidArgumentException $invalid) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/Token.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/Token.php
@@ -141,7 +141,7 @@ abstract class Token implements TokenInterface
 
         if (!is_string($user) && !is_object($user)) {
             throw new \InvalidArgumentException('$user must be an object, or a primitive string.');
-        } else if (is_object($user) && !$user instanceof AccountInterface && !method_exists($user, '__toString')) {
+        } else if (is_object($user) && !$user instanceof AccountInterface && !is_callable(array($user, '__toString'))) {
             throw new \InvalidArgumentException('If $user is an object, it must implement __toString().');
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -99,7 +99,7 @@ class GetSetMethodNormalizer extends AbstractNormalizer
 
         foreach ($data as $attribute => $value) {
             $setter = 'set' . $attribute;
-            if (method_exists($object, $setter)) {
+            if (is_callable(array($object, $setter))) {
                 $object->$setter($value);
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -28,7 +28,7 @@ class CountryValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -29,7 +29,7 @@ class DateTimeValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -25,7 +25,7 @@ class DateValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -25,7 +25,7 @@ class EmailValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/ExecuteValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ExecuteValidator.php
@@ -39,7 +39,7 @@ class ExecuteValidator extends ConstraintValidator
         $propertyPath = $context->getPropertyPath();
 
         foreach ($methods as $method) {
-            if (!method_exists($object, $method)) {
+            if (!is_callable(array($object, $method))) {
                 throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Execute constraint does not exist', $method));
             }
 

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -25,7 +25,7 @@ class FileValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !$value instanceof FileObject && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !$value instanceof FileObject && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -31,7 +31,7 @@ class IpValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -28,7 +28,7 @@ class LanguageValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -28,7 +28,7 @@ class LocaleValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
@@ -23,7 +23,7 @@ class MaxLengthValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
@@ -23,7 +23,7 @@ class MinLengthValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -23,7 +23,7 @@ class RegexValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -25,7 +25,7 @@ class TimeValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -34,7 +34,7 @@ class UrlValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && is_callable(array($value, '__toString()')))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 

--- a/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
@@ -26,9 +26,9 @@ class GetterMetadata extends MemberMetadata
         $getMethod = 'get'.ucfirst($property);
         $isMethod = 'is'.ucfirst($property);
 
-        if (method_exists($class, $getMethod)) {
+        if (is_callable(array($class, $getMethod))) {
             $method = $getMethod;
-        } else if (method_exists($class, $isMethod)) {
+        } else if (is_callable(array($class, $isMethod))) {
             $method = $isMethod;
         } else {
             throw new ValidatorException(sprintf('Neither method %s nor %s exists in class %s', $getMethod, $isMethod, $class));


### PR DESCRIPTION
Modified the use of method_exists to is_callable (safer). You could consider for each "method_exists()" also adding "is_callable()" for possible readability or move to "is_callable()" simply for readability.

Background: The true intent is to check whether the method exists on the object and is callable by the current scope. The "method_exists()" does not check for whether there will be any trouble calling the method (such as a private method scope).

This behaviour seems to have changed in 5.3.

Cheers
Cam
