### PR TITLE
Fix webprofiler flashes after a redirect

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
@@ -47,7 +47,11 @@ class WebDebugToolbarListener
             return $response;
         }
 
+        $request = $event->get('request');
+
         if ($response->headers->has('X-Debug-Token') && $response->isRedirect() && $this->interceptRedirects) {
+            $request->getSession()->persistFlashes();
+
             $response->setContent(
                 sprintf('<html><head></head><body><h1>This Request redirects to<br /><a href="%1$s">%1$s</a>.</h1><h4>The redirect was intercepted by the web debug toolbar to help debugging.<br/>For more information, see the "intercept-redirects" option of the Profiler.</h4></body></html>',
                 $response->headers->get('Location'))
@@ -56,7 +60,7 @@ class WebDebugToolbarListener
             $response->headers->remove('Location');
         }
 
-        $request = $event->get('request');
+
         if (!$response->headers->has('X-Debug-Token')
             || '3' === substr($response->getStatusCode(), 0, 1)
             || ($response->headers->has('Content-Type') && false === strpos($response->headers->get('Content-Type'), 'html'))

--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -62,7 +62,12 @@ class Session implements \Serializable
         }
 
         // flag current flash messages to be removed at shutdown
-        $this->oldFlashes = array_flip(array_keys($this->attributes['_flash']));
+        if (!isset($this->attributes['_persist_flashes'])) {
+            $this->oldFlashes = array_flip(array_keys($this->attributes['_flash']));
+        } else {
+            $this->oldFlashes = array();
+            unset($this->attributes['_persist_flashes']);
+        }
 
         $this->started = true;
     }
@@ -253,6 +258,11 @@ class Session implements \Serializable
     public function clearFlashes()
     {
         $this->attributes['_flash'] = array();
+    }
+
+    public function persistFlashes()
+    {
+        $this->attributes['_persist_flashes'] = true;
     }
 
     public function save()


### PR DESCRIPTION
This fixes the bug #[9537](http://trac.symfony-project.org/ticket/9537) which prevented seeing flashes after a redirect has been intercepted by the webprofiler.
This just add an "persist_flashes" flag to the session. Is it the best way to do it ?
