### PR TITLE
Profiler searchbox

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/profiler.css
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/profiler.css
@@ -376,6 +376,11 @@ td.main, td.menu {
     color:#565656;
 }
 
+.search input[type="search"]
+{
+    -webkit-appearance: textfield;
+}
+
 .search button
 {
     -webkit-appearance: button-bevel;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -18,7 +18,7 @@
                             <img src="{{ asset('bundles/webprofiler/images/profiler/grey_magnifier.png') }}" alt="Search on Symfony website"/>
                         </label>
 
-                        <input name="q" id="search_id" type="text" placeholder="Search on Symfony website"/>
+                        <input name="q" id="search_id" type="search" placeholder="Search on Symfony website"/>
 
                         <button type="submit">
                             <span class="border_l">


### PR DESCRIPTION
For the sake of added semantics (and some nifty inbuilt function in Webkit browsers), this pull request changes the search box in the Symfony profiler to using HTML5 type="search".
