### PR TITLE
Hotfix/test client

### DIFF
--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -95,12 +95,7 @@ EOF;
      */
     protected function filterRequest(DomRequest $request)
     {
-        $uri = $request->getUri();
-        if (preg_match('#^https?\://([^/]+)/(.*)$#', $uri, $matches)) {
-            $uri = '/'.$matches[2];
-        }
-
-        return Request::create($uri, $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
+        return Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpKernel/ClientTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/ClientTest.php
@@ -44,6 +44,9 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->request('GET', 'http://www.example.com/');
         $this->assertEquals('Request: /', $client->getResponse()->getContent(), '->doRequest() uses the request handler to make the request');
         $this->assertEquals('www.example.com', $client->getRequest()->getHost(), '->doRequest() uses the request handler to make the request');
+
+        $client->request('GET', 'http://www.example.com/?parameter=http://google.com');
+        $this->assertEquals('http://www.example.com/?parameter='.urlencode('http://google.com'), $client->getRequest()->getUri(), '->doRequest() uses the request handler to make the request');
     }
 
     public function testGetScript()


### PR DESCRIPTION
this makes it possible to use something like `$client->request('GET', '/kath/register/remote?forward=http://google.com');` in tests. Previously if you had get parameters in the query string, the pasre_url function would make `path` key `NULL`, which results in router not being able to find the controller and tests fail.
This function is not meant to parse relative urls - http://us.php.net/parse_url notes state so.
