### PR TITLE
[Security] Numeric passwords comparing bugfix

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -77,6 +77,9 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      */
     protected function comparePasswords($password1, $password2)
     {
+        settype($password1, 'string');
+        settype($password2, 'string');
+
         if (strlen($password1) !== strlen($password2)) {
             return false;
         }


### PR DESCRIPTION
Method comparePassword haven't been working for numeric (plaintype) passwords properly because inserted password was converted into integer type a and compared with stored password as a string type. Bugfix changes data type of passwords into string before comparing.
