### PR TITLE
[AsseticBundle] Throw an Exception if assetic:dump --watch is used without --debug

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
+++ b/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
@@ -33,7 +33,7 @@ class DumpCommand extends Command
             ->setName('assetic:dump')
             ->setDescription('Dumps all assets to the filesystem')
             ->addArgument('write_to', InputArgument::OPTIONAL, 'Override the configured asset root')
-            ->addOption('watch', null, InputOption::VALUE_NONE, 'Check for changes every second')
+            ->addOption('watch', null, InputOption::VALUE_NONE, 'Check for changes every second, debug mode only')
         ;
     }
 
@@ -70,6 +70,10 @@ class DumpCommand extends Command
      */
     protected function watch(LazyAssetManager $am, $basePath, OutputInterface $output, $debug = false)
     {
+        if (!$debug) {
+            throw new \RuntimeException('The --watch option is only available in debug mode.');
+        }
+
         $refl = new \ReflectionClass('Assetic\\AssetManager');
         $prop = $refl->getProperty('assets');
         $prop->setAccessible(true);
@@ -92,9 +96,7 @@ class DumpCommand extends Command
 
                 // reset the asset manager
                 $prop->setValue($am, array());
-                if ($debug) {
-                    $am->load();
-                }
+                $am->load();
 
                 file_put_contents($cache, serialize($previously));
                 $error = '';


### PR DESCRIPTION
The --watch option does not work without debug mode because the LazyAssetManager will use loaders reading from stale caches otherwise.
