### PR TITLE
[AsseticBundle] inotify support for --watch option in assetic:dump command

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
+++ b/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
@@ -33,7 +33,7 @@ class DumpCommand extends Command
             ->setName('assetic:dump')
             ->setDescription('Dumps all assets to the filesystem')
             ->addArgument('write_to', InputArgument::OPTIONAL, 'Override the configured asset root')
-            ->addOption('watch', null, InputOption::VALUE_NONE, 'Check for changes every second')
+            ->addOption('watch', null, InputOption::VALUE_NONE, 'Check for changes every second, debug mode only')
         ;
     }
 
@@ -70,6 +70,10 @@ class DumpCommand extends Command
      */
     protected function watch(LazyAssetManager $am, $basePath, OutputInterface $output, $debug = false)
     {
+        if (!$debug) {
+            throw new \RuntimeException('The --watch option is only available in debug mode.');
+        }
+
         $refl = new \ReflectionClass('Assetic\\AssetManager');
         $prop = $refl->getProperty('assets');
         $prop->setAccessible(true);
@@ -92,9 +96,7 @@ class DumpCommand extends Command
 
                 // reset the asset manager
                 $prop->setValue($am, array());
-                if ($debug) {
-                    $am->load();
-                }
+                $am->load();
 
                 file_put_contents($cache, serialize($previously));
                 $error = '';

--- a/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
+++ b/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
@@ -61,7 +61,7 @@ class DumpCommand extends Command
      * Watches a asset manager for changes.
      *
      * This method includes an infinite loop the continuously polls the asset
-     * manager for changes.
+     * manager for changes. If available, inotify is used to wait for changes.
      *
      * @param LazyAssetManager $am      The asset manager
      * @param string           $basePath The base directory to write to
@@ -85,23 +85,42 @@ class DumpCommand extends Command
             $previously = array();
         }
 
+        if (function_exists('inotify_init')) {
+            $inotify = inotify_init();
+        } else {
+            $inotify = false;
+        }
+
         $error = '';
         while (true) {
             try {
-                foreach ($am->getNames() as $name) {
+                file_put_contents($cache, serialize($previously));
+
+                if (false !== $inotify) {
+                    $reload = $this->inotifyWait($am, $output, $inotify);
+                } else {
+                    sleep(1);
+                    $reload = true;
+                }
+
+                $checkAssets = array();
+                if (true === $reload) {
+                    // reset the asset manager
+                    $prop->setValue($am, array());
+                    $am->load();
+
+                    $checkAssets = $am->getNames();
+                } else if (is_array($reload)) {
+                    $checkAssets = $reload;
+                }
+
+                foreach ($checkAssets as $name) {
                     if ($asset = $this->checkAsset($am, $name, $previously)) {
                         $this->dumpAsset($asset, $basePath, $output);
                     }
                 }
 
-                // reset the asset manager
-                $prop->setValue($am, array());
-                $am->load();
-
-                file_put_contents($cache, serialize($previously));
                 $error = '';
-
-                sleep(1);
             } catch (\Exception $e) {
                 if ($error != $msg = $e->getMessage()) {
                     $output->writeln('<error>[error]</error> '.$msg);
@@ -109,6 +128,66 @@ class DumpCommand extends Command
                 }
             }
         }
+
+        if (false !== $inotify) {
+            fclose($inotify);
+        }
+    }
+
+    /**
+     * Sets up watches for inotify to monitor all assetic resources and assets.
+     *
+     * After waiting on inotify to find file modifications it either returns an
+     * array of modified assets or true to indicate that a resource was modifed.
+     *
+     * @param LazyAssetManager $am      The asset manager
+     * @param OutputInterface  $output  The command output
+     * @param resource         $inotify File descriptor of the inotify handle
+     *
+     * @return Boolean|array True if a resource was modified or an array of
+     *                       modified assets.
+     */
+    protected function inotifyWait(LazyAssetManager $am, OutputInterface $output, $inotify)
+    {
+        $flags = IN_MODIFY | IN_ATTRIB | IN_MOVE | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF;
+
+        // add a watch for every resource (e.g. template file directory)
+        $resourceWatches = array();
+        foreach ($am->getResources() as $resource) {
+            $path = (string) $resource;
+            $watch = inotify_add_watch($inotify, $path, $flags);
+            $resourceWatches[$watch] = true;
+        }
+
+        // add watches for all files involved in any formulas
+        $assetsWatches = array();
+        foreach ($am->getNames() as $name) {
+            $asset = $am->get($name);
+            foreach ($asset->getPaths() as $path) {
+                $watch = inotify_add_watch($inotify, $path, $flags);
+                $assetWatches[$watch] = $name;
+            }
+        }
+
+        // blocks until an event occurs
+        $events = inotify_read($inotify);
+
+        $reloadAssets = array();
+        $reload = false;
+        foreach ($events as $event) {
+            if (isset($resourceWatches[$event['wd']])) {
+                $reload = true;
+            } else if (isset($assetWatches[$event['wd']])) {
+                $reloadAssets[$event['wd']] = $assetWatches[$event['wd']];
+            }
+        }
+
+        if ($reload) {
+            $output->writeln('<info>[reload]</info> all asset manager resources');
+            return true;
+        }
+
+        return $reloadAssets;
     }
 
     /**


### PR DESCRIPTION
Using inotify the command does not need to busy wait for changes in any of the files defining formulae or containing assets anymore. It configures a number of inotify watches and reacts only once a change has been performed.

Depends on this pull request in assetic: https://github.com/kriswallsmith/assetic/pull/13
