### PR TITLE
[FrameworkBundle] Fix notice in Translator

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -21,11 +21,11 @@ use Symfony\Component\Translation\Loader\LoaderInterface;
 class Translator implements TranslatorInterface
 {
     private $catalogues;
-    private $locale;
     private $fallbackLocale;
     private $loaders;
     private $resources;
     private $selector;
+    protected $locale;
 
     /**
      * Constructor.


### PR DESCRIPTION
Make Translator.locale property protected, because the translator class in FrameworkBundle uses it.

I feel somewhat anxious with all these private things. So many doors closed.
