### PR TITLE
Add DoctrineMongoDB Configuration

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
@@ -123,18 +123,19 @@ class Configuration
         $node
             ->useAttributeAsKey('name')
             ->prototype('array')
+                ->beforeNormalization()
+                    // if it's not an array, then the scalar is the type key
+                    ->ifString()
+                    ->then(function($v) { return array ('type' => $v); })
+                ->end()
                 // I believe that "null" should *not* set the type
                 // it's guessed in AbstractDoctrineExtension::detectMetadataDriver
                 ->treatNullLike(array())
-                ->beforeNormalization()
-                    // if it's not an array, then the scalar is the type key
-                    ->ifTrue(function($v) { return !is_array($v); })
-                    ->then(function($v){ return array('type' => $v); })
-                ->end()
                 ->scalarNode('type')->end()
                 ->scalarNode('dir')->end()
                 ->scalarNode('prefix')->end()
                 ->scalarNode('alias')->end()
+                ->booleanNode('is_bundle')->end()
                 ->performNoDeepMerging()
             ->end()
         ;

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
@@ -29,10 +29,10 @@ class Configuration
         $this->addConnectionsSection($rootNode);
 
         $rootNode
-            ->scalarNode('proxy_namespace')->defaultValue(null)->end()
-            ->scalarNode('auto_generate_proxy_classes')->defaultValue(null)->end()
-            ->scalarNode('hydrator_namespace')->defaultValue(null)->end()
-            ->scalarNode('auto_generate_hydrator_classes')->defaultValue(null)->end()
+            ->scalarNode('proxy_namespace')->defaultValue('Proxies')->end()
+            ->scalarNode('auto_generate_proxy_classes')->defaultValue(false)->end()
+            ->scalarNode('hydrator_namespace')->defaultValue('Hydrators')->end()
+            ->scalarNode('auto_generate_hydrator_classes')->defaultValue(false)->end()
         ;
 
         return $treeBuilder->buildTree();

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+/**
+ * FrameworkExtension configuration structure.
+ *
+ * @author Ryan Weaver <ryan@thatsquality.com>
+ */
+class Configuration
+{
+    /**
+     * Generates the configuration tree.
+     *
+     * @param boolean $kernelDebug The kernel.debug DIC parameter
+     * @return \Symfony\Component\DependencyInjection\Configuration\NodeInterface
+     */
+    public function getConfigTree()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('doctrinemongodb', 'array');
+
+        $this->addSingleDocumentManagerSection($rootNode);
+        $this->addDocumentManagersSection($rootNode);
+        $this->addSingleConnectionSection($rootNode);
+        $this->addConnectionsSection($rootNode);
+
+        $rootNode
+            ->scalarNode('proxy_namespace')->defaultValue(null)->end()
+            ->scalarNode('auto_generate_proxy_classes')->defaultValue(null)->end()
+            ->scalarNode('hydrator_namespace')->defaultValue(null)->end()
+            ->scalarNode('auto_generate_hydrator_classes')->defaultValue(null)->end()
+        ;
+
+        return $treeBuilder->buildTree();
+    }
+
+    /**
+     * Builds the nodes responsible for the config that supports the single
+     * document manager.
+     */
+    private function addSingleDocumentManagerSection(NodeBuilder $rootNode)
+    {
+        $rootNode
+            ->scalarNode('default_document_manager')->defaultValue('default')->end()
+            ->scalarNode('default_database')->defaultValue('default')->end()
+            ->builder($this->getMetadataCacheDriverNode())
+            ->fixXmlConfig('mapping')
+            ->builder($this->getMappingsNode())
+        ;
+    }
+
+    /**
+     * Configures the "document_managers" section
+     */
+    private function addDocumentManagersSection(NodeBuilder $rootNode)
+    {
+        $rootNode
+            ->fixXmlConfig('document_manager')
+            ->arrayNode('document_managers')
+                ->useAttributeAsKey('id')
+                ->prototype('array')
+                    ->performNoDeepMerging()
+                    ->treatNullLike(array())
+                    ->builder($this->getMetadataCacheDriverNode())
+                    ->scalarNode('default_database')->end()
+                    ->scalarNode('connection')->end()
+                    ->scalarNode('database')->end()
+                    ->fixXmlConfig('mapping')
+                    ->builder($this->getMappingsNode())
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Configures the single-connection section:
+     *   * default_connection
+     *   * server
+     *   * options
+     */
+    private function addSingleConnectionSection(NodeBuilder $rootNode)
+    {
+        $rootNode
+            ->scalarNode('default_connection')->defaultValue('default')->end()
+            ->builder($this->addConnectionServerNode())
+            ->builder($this->addConnectionOptionsNode())
+        ;
+    }
+
+    /**
+     * Adds the configuration for the "connections" key
+     */
+    private function addConnectionsSection(NodeBuilder $rootNode)
+    {
+        $rootNode
+            ->fixXmlConfig('connection')
+            ->arrayNode('connections')
+                ->useAttributeAsKey('id')
+                ->prototype('array')
+                    ->performNoDeepMerging()
+                    ->builder($this->addConnectionServerNode())
+                    ->builder($this->addConnectionOptionsNode())
+                ->end()
+            ->end()
+        ;
+    }
+
+    /**
+     * Returns the array node used for "mappings".
+     *
+     * This is used in two different parts of the tree.
+     *
+     * @param NodeBuilder $rootNode The parent node
+     * @return NodeBuilder
+     */
+    protected function getMappingsNode()
+    {
+        $node = new Nodebuilder('mappings', 'array');
+        $node
+            ->useAttributeAsKey('name')
+            ->prototype('array')
+                // I believe that "null" should *not* set the type
+                // it's guessed in AbstractDoctrineExtension::detectMetadataDriver
+                ->treatNullLike(array())
+                ->beforeNormalization()
+                    // if it's not an array, then the scalar is the type key
+                    ->ifTrue(function($v) { return !is_array($v); })
+                    ->then(function($v){ return array('type' => $v); })
+                ->end()
+                ->scalarNode('type')->end()
+                ->scalarNode('dir')->end()
+                ->scalarNode('prefix')->end()
+                ->scalarNode('alias')->end()
+                ->performNoDeepMerging()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    /**
+     * Adds the NodeBuilder for the "server" key of a connection.
+     */
+    private function addConnectionServerNode()
+    {
+        $node = new NodeBuilder('server', 'scalar');
+
+        $node
+            ->defaultValue(null)
+        ->end();
+
+        return $node;
+    }
+
+    /**
+     * Adds the NodeBuilder for the "options" key of a connection.
+     */
+    private function addConnectionOptionsNode()
+    {
+        $node = new NodeBuilder('options', 'array');
+
+        $node
+            ->performNoDeepMerging()
+            ->addDefaultsIfNotSet() // adds an empty array of omitted
+
+            // options go into the Mongo constructor
+            // http://www.php.net/manual/en/mongo.construct.php
+            ->booleanNode('connect')->end()
+            ->scalarNode('persist')->end()
+            ->scalarNode('timeout')->end()
+            ->booleanNode('replicaSet')->end()
+            ->scalarNode('username')->end()
+            ->scalarNode('password')->end()
+        ->end();
+
+        return $node;
+    }
+
+    private function getMetadataCacheDriverNode()
+    {
+        $node = new NodeBuilder('metadata_cache_driver', 'array');
+
+        $node
+            ->beforeNormalization()
+                // if scalar
+                ->ifTrue(function($v) { return !is_array($v); })
+                ->then(function($v) { return array('type' => $v); })
+            ->end()
+            ->scalarNode('type')->end()
+            ->scalarNode('class')->end()
+            ->scalarNode('host')->end()
+            ->scalarNode('port')->end()
+            ->scalarNode('instance_class')->end()
+        ->end();
+
+        return $node;
+    }
+}

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ class Configuration
     public function getConfigTree()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('doctrinemongodb', 'array');
+        $rootNode = $treeBuilder->root('doctrine_mongo_db', 'array');
 
         $this->addSingleDocumentManagerSection($rootNode);
         $this->addDocumentManagersSection($rootNode);

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -208,14 +208,6 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         if (count($config['document_managers'])) {
             $configDocumentManagers = $config['document_managers'];
 
-            if (isset($config['document_managers']['document-manager'])) {
-                $config['document_managers']['document_manager'] = $config['document_managers']['document-manager'];
-            }
-
-            if (isset($config['document_managers']['document_manager']) && isset($config['document_managers']['document_manager'][0])) {
-                // Multiple document managers
-                $configDocumentManagers = $config['document_managers']['document_manager'];
-            }
             foreach ($configDocumentManagers as $name => $documentManager) {
                 $documentManagers[isset($documentManager['id']) ? $documentManager['id'] : $name] = $documentManager;
             }
@@ -287,10 +279,6 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $connections = array();
         if (count($config['connections'])) {
             $configConnections = $config['connections'];
-            if (isset($config['connections']['connection']) && isset($config['connections']['connection'][0])) {
-                // Multiple connections
-                $configConnections = $config['connections']['connection'];
-            }
             foreach ($configConnections as $name => $connection) {
                 $connections[isset($connection['id']) ? $connection['id'] : $name] = $connection;
             }

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -30,6 +30,34 @@ use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineEx
  */
 class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 {
+    /**
+     * Responds to the doctrine_mongo_db configuration parameter.
+     *
+     * Available options:
+     *
+     *  * mappings                  An array of bundle names (as the key)
+     *                              and mapping configuration (as the value).
+     *  * default_document_manager  The name of the document manager that should be
+     *                              marked as the default. Default: default.
+     *  * default_connection        If using a single connection, the name to give
+     *                              to that connection. Default: default.
+     *  * metadata_cache_driver     Options: array (default), apc, memcache, xcache
+     *  * server                    The server if only specifying one connection
+     *                              (e.g. mongodb://localhost:27017)
+     *  * options                   The connections options if only specifying
+     *                              one connection.
+     *  * connections               An array of each connection and its configuration
+     *  * document_managers         An array of document manager names and
+     *                              configuration.
+     *  * default_database          The database for a document manager that didn't
+     *                              explicitly set a database. Default: default;
+     *  * proxy_namespace           Namespace of the generated proxies. Default: Proxies
+     *  * auto_generate_proxy_classes Whether to always regenerate the proxt classes.
+     *                              Default: false.
+     *  * hydrator_namespace        Namespace of the generated proxies. Default: Hydrators
+     *  * auto_generate_hydrator_classes Whether to always regenerate the proxt classes.
+     *                              Default: false.
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         foreach ($configs as $config) {

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -74,22 +74,24 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $config['metadata_cache_driver'] = array('type' => 'array');
         }
 
-        $this->loadDefaults($config, $container);
+        // set some options as parameters and unset them
+        $config = $this->overrideParameters($config, $container);
+
+       
         $this->loadConnections($config, $container);
         $this->loadDocumentManagers($config, $container);
         $this->loadConstraints($config, $container);
     }
 
     /**
-     * Loads the default configuration.
+     * Uses some of the extension options to override DI extension parameters.
      *
-     * @param array $config An array of configuration settings
+     * @param array $options The available configuration options
      * @param ContainerBuilder $container A ContainerBuilder instance
      */
-    protected function loadDefaults(array $config, ContainerBuilder $container)
+    protected function overrideParameters($options, ContainerBuilder $container)
     {
-        // Allow these application configuration options to override the defaults
-        $options = array(
+        $overrides = array(
             'default_document_manager',
             'default_connection',
             'proxy_namespace',
@@ -98,11 +100,17 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             'auto_generate_hydrator_classes',
             'default_database',
         );
-        foreach ($options as $key) {
-            if (isset($config[$key])) {
-                $container->setParameter('doctrine.odm.mongodb.'.$key, $config[$key]);
+
+        foreach ($overrides as $key) {
+            if (isset($options[$key])) {
+                $container->setParameter('doctrine.odm.mongodb.'.$key, $options[$key]);
+
+                // the option should not be used, the parameter should be referenced
+                unset($options[$key]);
             }
         }
+
+        return $options;
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -118,8 +118,6 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
     {
         $defaultDocumentManager = $container->getParameter('doctrine.odm.mongodb.default_document_manager');
         $defaultDatabase = isset($documentManager['default_database']) ? $documentManager['default_database'] : $container->getParameter('doctrine.odm.mongodb.default_database');
-        $proxyCacheDir = $container->getParameter('kernel.cache_dir').'/doctrine/odm/mongodb/Proxies';
-        $hydratorCacheDir = $container->getParameter('kernel.cache_dir').'/doctrine/odm/mongodb/Hydrators';
         $configServiceName = sprintf('doctrine.odm.mongodb.%s_configuration', $documentManager['name']);
 
         if ($container->hasDefinition($configServiceName)) {
@@ -135,12 +133,12 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $methods = array(
             'setMetadataCacheImpl' => new Reference(sprintf('doctrine.odm.mongodb.%s_metadata_cache', $documentManager['name'])),
             'setMetadataDriverImpl' => new Reference(sprintf('doctrine.odm.mongodb.%s_metadata_driver', $documentManager['name'])),
-            'setProxyDir' => $proxyCacheDir,
-            'setProxyNamespace' => $container->getParameter('doctrine.odm.mongodb.proxy_namespace'),
-            'setAutoGenerateProxyClasses' => $container->getParameter('doctrine.odm.mongodb.auto_generate_proxy_classes'),
-            'setHydratorDir' => $hydratorCacheDir,
-            'setHydratorNamespace' => $container->getParameter('doctrine.odm.mongodb.hydrator_namespace'),
-            'setAutoGenerateHydratorClasses' => $container->getParameter('doctrine.odm.mongodb.auto_generate_hydrator_classes'),
+            'setProxyDir' => '%kernel.cache_dir%'.'/doctrine/odm/mongodb/Proxies',
+            'setProxyNamespace' => '%doctrine.odm.mongodb.proxy_namespace%',
+            'setAutoGenerateProxyClasses' => '%doctrine.odm.mongodb.auto_generate_proxy_classes%',
+            'setHydratorDir' => '%kernel.cache_dir%'.'/doctrine/odm/mongodb/Hydrators',
+            'setHydratorNamespace' => '%doctrine.odm.mongodb.hydrator_namespace%',
+            'setAutoGenerateHydratorClasses' => '%doctrine.odm.mongodb.auto_generate_hydrator_classes%',
             'setDefaultDB' => $defaultDatabase,
             'setLoggerCallable' => array(new Reference('doctrine.odm.mongodb.logger'), 'logQuery'),
         );

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -106,7 +106,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $container
         );
 
-        $this->loadConstraints($config, $container);
+        $this->loadConstraints($container);
     }
 
     /**
@@ -339,7 +339,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         $odmConfigDef->addMethodCall('setDocumentNamespaces', array($this->aliasMap));
     }
 
-    protected function loadConstraints($config, ContainerBuilder $container)
+    protected function loadConstraints(ContainerBuilder $container)
     {
         if ($container->hasParameter('validator.annotations.namespaces')) {
             $container->setParameter('validator.annotations.namespaces', array_merge(

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
@@ -6,7 +6,6 @@
 
   <parameters>
     <parameter key="doctrine.odm.mongodb.default_document_manager">default</parameter>
-    <parameter key="doctrine.odm.mongodb.default_connection">default</parameter>
     <parameter key="doctrine.odm.mongodb.default_database">default</parameter>
     <parameter key="doctrine.odm.mongodb.connection_class">Doctrine\MongoDB\Connection</parameter>
     <parameter key="doctrine.odm.mongodb.configuration_class">Doctrine\ODM\MongoDB\Configuration</parameter>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
@@ -5,8 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
   <parameters>
-    <parameter key="doctrine.odm.mongodb.default_document_manager">default</parameter>
-    <parameter key="doctrine.odm.mongodb.default_database">default</parameter>
     <parameter key="doctrine.odm.mongodb.connection_class">Doctrine\MongoDB\Connection</parameter>
     <parameter key="doctrine.odm.mongodb.configuration_class">Doctrine\ODM\MongoDB\Configuration</parameter>
     <parameter key="doctrine.odm.mongodb.document_manager_class">Doctrine\ODM\MongoDB\DocumentManager</parameter>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
@@ -8,7 +8,6 @@
     <parameter key="doctrine.odm.mongodb.default_document_manager">default</parameter>
     <parameter key="doctrine.odm.mongodb.default_connection">default</parameter>
     <parameter key="doctrine.odm.mongodb.default_database">default</parameter>
-    <parameter key="doctrine.odm.mongodb.metadata_cache_driver">array</parameter>
     <parameter key="doctrine.odm.mongodb.connection_class">Doctrine\MongoDB\Connection</parameter>
     <parameter key="doctrine.odm.mongodb.configuration_class">Doctrine\ODM\MongoDB\Configuration</parameter>
     <parameter key="doctrine.odm.mongodb.document_manager_class">Doctrine\ODM\MongoDB\DocumentManager</parameter>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/ContainerTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/ContainerTest.php
@@ -28,7 +28,10 @@ class ContainerTest extends TestCase
         )));
         $loader = new DoctrineMongoDBExtension();
         $container->registerExtension($loader);
-        $loader->load(array('mappings' => array('YamlBundle' => array())), $container);
+
+        $configs = array();
+        $configs[] = array('mappings' => array('YamlBundle' => array()));
+        $loader->load($configs, $container);
 
         return $container;
     }

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -321,7 +321,6 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container->getCompilerPassConfig()->setRemovingPasses(array());
         $container->compile();
 
-        $this->assertEquals('apc', $container->getParameter('doctrine.odm.mongodb.metadata_cache_driver'));
         $this->assertTrue($container->getParameter('doctrine.odm.mongodb.auto_generate_proxy_classes'));
     }
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineMongoDBBundle\Tests\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Configuration;
+
+use Symfony\Component\Config\Definition\Processor;
+
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider optionProvider
+     * @param array $configs The source array of configuration arrays
+     * @param array $correctValues A key-value pair of end values to check
+     */
+    public function testMergeOptions(array $configs, array $correctValues)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $options = $processor->process($configuration->getConfigTree(), $configs);
+
+        foreach ($correctValues as $key => $correctVal)
+        {
+            $this->assertEquals($correctVal, $options[$key]);
+        }
+    }
+
+    public function optionProvider()
+    {
+        $cases = array();
+
+        // single config, testing normal option setting
+        $cases[] = array(
+            array(
+                array('default_document_manager' => 'foo'),
+            ),
+            array('default_document_manager' => 'foo')
+        );
+
+        // single config, testing normal option setting with dashes
+        $cases[] = array(
+            array(
+                array('default-document-manager' => 'bar'),
+            ),
+            array('default_document_manager' => 'bar')
+        );
+
+        // testing the normal override merging - the later config array wins
+        $cases[] = array(
+            array(
+                array('default_document_manager' => 'foo'),
+                array('default_document_manager' => 'baz'),
+            ),
+            array('default_document_manager' => 'baz')
+        );
+
+        // the "options" array is totally replaced
+        $cases[] = array(
+            array(
+                array('options' => array('timeout' => 2000)),
+                array('options' => array('username' => 'foo')),
+            ),
+            array('options' => array('username' => 'foo')),
+        );
+
+        // mappings are merged non-recursively.
+        $cases[] = array(
+            array(
+                array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('dir' => 'val2'))),
+                array('mappings' => array('barmap' => array('prefix' => 'val3'))),
+            ),
+            array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('prefix' => 'val3'))),
+        );
+
+        // connections are merged non-recursively.
+        $cases[] = array(
+            array(
+                array('connections' => array('foocon' => array('server' => 'val1'), 'barcon' => array('options' => array('username' => 'val2')))),
+                array('connections' => array('barcon' => array('server' => 'val3'))),
+            ),
+            array('connections' => array(
+                'foocon' => array('server' => 'val1', 'options' => array()),
+                'barcon' => array('server' => 'val3', 'options' => array())
+            )),
+        );
+
+        // managers are merged non-recursively.
+        $cases[] = array(
+            array(
+                array('document_managers' => array('foodm' => array('database' => 'val1'), 'bardm' => array('default_database' => 'val2'))),
+                array('document_managers' => array('bardm' => array('database' => 'val3'))),
+            ),
+            array('document_managers' => array(
+                'foodm' => array('database' => 'val1', 'mappings' => array()),
+                'bardm' => array('database' => 'val3', 'mappings' => array()),
+            )),
+        );
+
+        return $cases;
+    }
+
+    /**
+     * @dataProvider getNormalizationTests
+     */
+    public function testNormalizeOptions(array $config, $targetKey, array $normalized)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $options = $processor->process($configuration->getConfigTree(), array($config));
+        $this->assertSame($normalized, $options[$targetKey]);
+    }
+
+    public function getNormalizationTests()
+    {
+        return array(
+            // connection versus connections (id is the identifier)
+            array(
+                array('connection' => array(
+                    array('server' => 'mongodb://abc', 'id' => 'foo'),
+                    array('server' => 'mongodb://def', 'id' => 'bar'),
+                )),
+                'connections',
+                array(
+                    'foo' => array('server' => 'mongodb://abc', 'options' => array()),
+                    'bar' => array('server' => 'mongodb://def', 'options' => array()),
+                ),
+            ),
+            // document_manager versus document_managers (id is the identifier)
+            array(
+                array('document_manager' => array(
+                    array('connection' => 'conn1', 'id' => 'foo'),
+                    array('connection' => 'conn2', 'id' => 'bar'),
+                )),
+                'document_managers',
+                array(
+                    'foo' => array('connection' => 'conn1', 'mappings' => array()),
+                    'bar' => array('connection' => 'conn2', 'mappings' => array()),
+                ),
+            ),
+            // mapping versus mappings (name is the identifier)
+            array(
+                array('mapping' => array(
+                    array('type' => 'yml', 'name' => 'foo'),
+                    array('type' => 'xml', 'name' => 'bar'),
+                )),
+                'mappings',
+                array(
+                    'foo' => array('type' => 'yml'),
+                    'bar' => array('type' => 'xml'),
+                ),
+            ),
+            // mapping configuration that's beneath a specific document manager
+            array(
+                array('document_manager' => array(
+                    array('id' => 'foo', 'connection' => 'conn1', 'mapping' => array(
+                        'type' => 'xml', 'name' => 'foo-mapping'
+                    )),
+                )),
+                'document_managers',
+                array(
+                    'foo' => array('connection' => 'conn1', 'mappings' => array(
+                        'foo-mapping' => array('type' => 'xml'),
+                    )),
+                ),
+            ),
+        );
+    }
+}

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -18,6 +18,39 @@ use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
+    public function testDefaults()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $options = $processor->process($configuration->getConfigTree(), array());
+
+        $defaults = array(
+            'auto_generate_hydrator_classes'    => false,
+            'auto_generate_proxy_classes'       => false,
+            'default_document_manager'          => 'default',
+            'default_database'                  => 'default',
+            'mappings'                          => array(),
+            'document_managers'                 => array(),
+            'default_connection'                => 'default',
+            'server'                            => null,
+            'options'                           => array(),
+            'connections'                       => array(),
+            'proxy_namespace'                   => 'Proxies',
+            'hydrator_namespace'                => 'Hydrators',
+        );
+
+        foreach ($defaults as $key => $default) {
+            $this->assertTrue(array_key_exists($key, $options), sprintf('The default "%s" exists', $key));
+            $this->assertEquals($default, $options[$key]);
+
+            unset($options[$key]);
+        }
+
+        if (count($options)) {
+            $this->fail('Extra defaults were returned: '. print_r($options, true));
+        }
+    }
+
     /**
      * @dataProvider optionProvider
      * @param array $configs The source array of configuration arrays

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\DoctrineMongoDBBundle\Tests\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Configuration;
+use Symfony\Component\Yaml\Yaml;
 
 use Symfony\Component\Config\Definition\Processor;
 
@@ -49,6 +50,94 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         if (count($options)) {
             $this->fail('Extra defaults were returned: '. print_r($options, true));
         }
+    }
+
+    /**
+     * Tests a full configuration.
+     *
+     * @dataProvider fullConfigurationProvider
+     */
+    public function testFullConfiguration($config)
+    {
+        $processor = new Processor();
+        $configuration = new Configuration();
+        $options = $processor->process($configuration->getConfigTree(), array($config));
+
+        $expected = array(
+            'proxy_namespace'                   => 'Test_Proxies',
+            'auto_generate_proxy_classes'       => true,
+            'hydrator_namespace'                => 'Test_Hydrators',
+            'auto_generate_hydrator_classes'    => true,
+            'default_document_manager'          => 'default_dm_name',
+            'default_database'                  => 'default_db_name',
+            'metadata_cache_driver' => array(
+                'type'      => 'memcache',
+                'class'     => 'fooClass',
+                'host'      => 'host_val',
+                'port'      => 1234,
+                'instance_class' => 'instance_val',
+            ),
+            'default_connection'                => 'conn1',
+            'server'                            => 'http://server',
+            'options'       => array(
+                'connect'   => true,
+                'persist'   => 'persist_val',
+                'timeout'   => 500,
+                'replicaSet' => true,
+                'username'  => 'username_val',
+                'password'  => 'password_val',
+            ),
+            'connections'   => array(
+                'conn1'         => array(
+                    'server'    => null,
+                    'options'   => array(),
+                ),
+                'conn2'         => array(
+                    'server'    => 'http://server2',
+                    'options'   => array(),
+                ),
+            ),
+            'mappings'      => array(
+                'FooBundle'     => array(
+                    'type' => 'annotations',
+                ),
+            ),
+            'document_managers' => array(
+                'dm1' => array(
+                    'mappings' => array(),
+                ),
+                'dm2' => array(
+                    'default_database' => 'dm2_default_db',
+                    'connection' => 'dm2_connection',
+                    'database' => 'db1',
+                    'mappings' => array(
+                        'BarBundle' => array(
+                            'type'      => 'yml',
+                            'dir'       => '%kernel.cache_dir%',
+                            'prefix'    => 'prefix_val',
+                            'alias'     => 'alias_val',
+                        )
+                    ),
+                    'metadata_cache_driver' => array(
+                        'type' => 'apc',
+                    )
+                )
+            )
+        );
+
+        //var_dump($options);
+
+        $this->assertEquals($expected, $options);
+    }
+
+    public function fullConfigurationProvider()
+    {
+      $yaml = Yaml::load(__DIR__.'/Fixtures/config/yml/full.yml');
+      $yaml = $yaml['doctrine_mongo_db'];
+
+       return array(
+           array($yaml),
+       );
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -125,8 +125,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        //var_dump($options);
-
         $this->assertEquals($expected, $options);
     }
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -116,6 +116,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                             'dir'       => '%kernel.cache_dir%',
                             'prefix'    => 'prefix_val',
                             'alias'     => 'alias_val',
+                            'is_bundle' => false,
                         )
                     ),
                     'metadata_cache_driver' => array(

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineMongoDBBundle\Tests\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\DoctrineMongoDBExtension;
+
+use Symfony\Component\Config\Definition\Processor;
+
+class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider parameterProvider
+     */
+    public function testParameterOverride($option, $parameter, $value)
+    {
+        $container = new ContainerBuilder();
+        $loader = new DoctrineMongoDBExtension();
+        $loader->load(array(array($option => $value)), $container);
+
+        $this->assertEquals($value, $container->getParameter('doctrine.odm.mongodb.'.$parameter));
+    }
+
+    public function parameterProvider()
+    {
+        return array(
+            array('proxy_namespace', 'proxy_namespace', 'foo'),
+            array('proxy-namespace', 'proxy_namespace', 'bar'),
+        );
+    }
+}

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_multiple_connections.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_multiple_connections.xml
@@ -13,21 +13,18 @@
             proxy-namespace="Proxies"
             auto-generate-proxy-classes="true"
         >
-        <doctrine:connections>
-            <doctrine:connection id="conn1" server="mongodb://localhost:27017">
-                <options>
-                    <connect>true</connect>
-                </options>
-            </doctrine:connection>
-            <doctrine:connection id="conn2" server="mongodb://localhost:27017">
-                <options>
-                    <connect>true</connect>
-                </options>
-            </doctrine:connection>
-        </doctrine:connections>
-        <doctrine:document-managers>
-            <doctrine:document-manager id="dm1" metadata-cache-driver="xcache" connection="conn1" />
-            <doctrine:document-manager id="dm2" connection="conn2" />
-        </doctrine:document-managers>
+        <doctrine:connection id="conn1" server="mongodb://localhost:27017">
+            <options>
+                <connect>true</connect>
+            </options>
+        </doctrine:connection>
+        <doctrine:connection id="conn2" server="mongodb://localhost:27017">
+            <options>
+                <connect>true</connect>
+            </options>
+        </doctrine:connection>
+
+        <doctrine:document-manager id="dm1" metadata-cache-driver="xcache" connection="conn1" />
+        <doctrine:document-manager id="dm2" connection="conn2" />
     </doctrine:mongodb>
 </container>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection.xml
@@ -7,22 +7,21 @@
                         http://symfony.com/schema/dic/doctrine/odm/mongodb http://symfony.com/schema/dic/doctrine/odm/mongodb/mongodb-1.0.xsd">
 
     <doctrine:mongodb>
-        <doctrine:connections>
-            <doctrine:connection id="default" server="mongodb://localhost:27017">
-                <options>
-                    <connect>true</connect>
-                </options>
-            </doctrine:connection>
-        </doctrine:connections>
-        <doctrine:document-managers>
-            <doctrine:document-manager id="default" connection="default">
-                <metadata-cache-driver type="memcache">
-                    <class>Doctrine\Common\Cache\MemcacheCache</class>
-                    <host>localhost</host>
-                    <port>11211</port>
-                    <instance-class>Memcache</instance-class>
-                </metadata-cache-driver>
-            </doctrine:document-manager>
-        </doctrine:document-managers>
+
+        <doctrine:connection id="default" server="mongodb://localhost:27017">
+            <options>
+                <connect>true</connect>
+            </options>
+        </doctrine:connection>
+
+        <doctrine:document-manager id="default" connection="default">
+            <metadata-cache-driver type="memcache">
+                <class>Doctrine\Common\Cache\MemcacheCache</class>
+                <host>localhost</host>
+                <port>11211</port>
+                <instance-class>Memcache</instance-class>
+            </metadata-cache-driver>
+        </doctrine:document-manager>
+
     </doctrine:mongodb>
 </container>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/odm_imports_import.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/odm_imports_import.xml
@@ -8,7 +8,6 @@
 
     <doctrine:mongodb
         auto-generate-proxy-classes="false"
-        metadata-cache-driver="apc"
     >
     </doctrine:mongodb>
 </container>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -1,0 +1,48 @@
+doctrine_mongo_db:
+    proxy_namespace:    Test_Proxies
+    auto_generate_proxy_classes:    true
+
+    hydrator_namespace: Test_Hydrators
+    auto_generate_hydrator_classes: true
+
+    default_document_manager:  default_dm_name
+    default_database:          default_db_name
+    metadata_cache_driver:
+        type:                  memcache
+        class:                 fooClass
+        host:                  host_val
+        port:                  1234
+        instance_class:        instance_val
+
+    default_connection:        conn1
+    server:         http://server
+    options:
+        connect:    true
+        persist:    persist_val
+        timeout:    500
+        replicaSet: true
+        username:   username_val
+        password:   password_val
+
+    connections:
+        conn1:      ~
+        conn2:
+            server: http://server2
+
+    mappings:
+        FooBundle:   annotations
+
+    document_managers:
+        dm1:        ~
+        dm2:
+            default_database: dm2_default_db
+            connection:       dm2_connection
+            database:         db1
+            mappings:
+                BarBundle:
+                    type:   yml
+                    dir:    %kernel.cache_dir%
+                    prefix: prefix_val
+                    alias:  alias_val
+            metadata_cache_driver: apc
+        

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -44,5 +44,6 @@ doctrine_mongo_db:
                     dir:    %kernel.cache_dir%
                     prefix: prefix_val
                     alias:  alias_val
+                    is_bundle: false
             metadata_cache_driver: apc
         

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/odm_imports_import.yml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/odm_imports_import.yml
@@ -1,3 +1,2 @@
 doctrine_mongo_db:
   auto_generate_proxy_classes: false
-  metadata_cache_driver: apc


### PR DESCRIPTION
Hey guys-

This was brought over from https://github.com/fabpot/symfony/pull/740 and has been rebased to the latest. This is a sister pull request of https://github.com/symfony/symfony/pull/99/files. 
- New Configuration class for DoctrineMongoDBExtension
- The cleanup of the class, involving removal of getParameter() calls and the removal of some parameters
- The removal of the extra "connections" and "document_managers" node in XML. This was redundant and made normalization a huge pain. This breaks BC, but I believe is more correct. (https://github.com/weaverryan/symfony/commit/a1ecb9216cca5610b1846e7b03bc4beae386905f)

I think that the tests overall have decent coverage, but they're still a bit of a mess. Certain tests should test the Configuration merging+normalization, and others should feed raw config values (not loaded from an XML or YAML fixture file) into the actual Configuration Extension class and measure the container afterwards. This distinction is still not well-made, and I believe that's repeated for many DI extension classes. This can easily be solved later in a totally BC way.

Comments welcome - fwiw, jmikola from OpenSky had kicked the tires on this a little bit a couple of weeks ago for me.

Thanks!
