### PR TITLE
fix for ignoring abstract definition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -28,7 +28,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
             // yes, we are specifically fetching the definition from the
             // container to ensure we are not operating on stale data
             $definition = $container->getDefinition($id);
-            if (!$definition instanceof DefinitionDecorator) {
+            if (!$definition instanceof DefinitionDecorator || $definition->isAbstract()) {
                 continue;
             }
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -3,11 +3,8 @@
 namespace Symfony\Tests\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
-
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
-
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
@@ -133,6 +130,56 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $def = $container->getDefinition('child2');
         $this->assertEquals(array('a', 'b', 'c'), $def->getArguments());
         $this->assertEquals('foo', $def->getClass());
+    }
+
+    public function testProcessIgnoreAbstractDefinitions()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('parent')
+        ;
+
+        $container
+            ->setDefinition('child', new DefinitionDecorator('parent'))
+            ->setAbstract(true)
+        ;
+
+        $pass = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Compiler\\ResolveDefinitionTemplatesPass')
+            ->setMethods(array('resolveDefinition'))
+            ->getMock()
+        ;
+
+        $pass->expects($this->never())
+            ->method('resolveDefinition')
+        ;
+
+        $pass->process($container);
+    }
+
+    public function testProcessDontIgnoreNonAbstractDefinitions()
+    {
+        $container = new ContainerBuilder();
+
+        $container
+            ->register('parent')
+        ;
+
+        $container
+            ->setDefinition('child', new DefinitionDecorator('parent'))
+            ->setAbstract(false)
+        ;
+
+        $pass = $this->getMockBuilder('Symfony\\Component\\DependencyInjection\\Compiler\\ResolveDefinitionTemplatesPass')
+            ->setMethods(array('resolveDefinition'))
+            ->getMock()
+        ;
+
+        $pass->expects($this->once())
+            ->method('resolveDefinition')
+        ;
+
+        $pass->process($container);
     }
 
     protected function process(ContainerBuilder $container)


### PR DESCRIPTION
This is to stop exception from being thrown when the parent is not defined for an abstract definition.
