### PR TITLE
[DependencyInjection] false circular reference detection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -223,7 +223,12 @@ class Container implements ContainerInterface
         if (method_exists($this, $method = 'get'.strtr($id, array('_' => '', '.' => '_')).'Service')) {
             $this->loading[$id] = true;
 
-            $service = $this->$method();
+            try {
+                $service = $this->$method();
+            } catch (\Exception $e) {
+                unset($this->loading[$id]);
+                throw $e;
+            }
 
             unset($this->loading[$id]);
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/ContainerTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ContainerTest.php
@@ -98,7 +98,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('service_container', 'foo', 'bar'), $sc->getServiceIds(), '->getServiceIds() returns all defined service ids');
 
         $sc = new ProjectServiceContainer();
-        $this->assertEquals(array('scoped', 'scoped_foo', 'bar', 'foo_bar', 'foo.baz', 'circular', 'service_container'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods');
+        $this->assertEquals(array('scoped', 'scoped_foo', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'service_container'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods');
     }
 
     /**
@@ -337,6 +337,25 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($c->isScopeActive('foo'));
     }
 
+    public function testGetThrowsException()
+    {
+        $c = new ProjectServiceContainer();
+
+        try {
+            $c->get('throw_exception');
+            $this->fail();
+        } catch (\Exception $e) {
+            $this->assertEquals('Something went terribly wrong!', $e->getMessage());
+        }
+
+        try {
+            $c->get('throw_exception');
+            $this->fail();
+        } catch (\Exception $e) {
+            $this->assertEquals('Something went terribly wrong!', $e->getMessage());
+        }
+    }
+
     public function getInvalidParentScopes()
     {
         return array(
@@ -411,5 +430,10 @@ class ProjectServiceContainer extends Container
     protected function getCircularService()
     {
         return $this->get('circular');
+    }
+
+    protected function getThrowExceptionService()
+    {
+        throw new \Exception('Something went terribly wrong!');
     }
 }


### PR DESCRIPTION
If creating a service throws an exception that is caught upstream, attempting to create that service again will throw a false positive for circular reference detection.
