### PR TITLE
Doctrine charset

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -113,7 +113,7 @@ class Configuration
                 ->fixXmlConfig('wrapper_class', 'wrapperClass')
                 ->scalarNode('wrapper_class')->end()
                 ->scalarNode('platform_service')->end()
-                ->scalarNode('charset')->defaultValue('UTF-8')->end()
+                ->scalarNode('charset')->end()
                 ->booleanNode('logging')->defaultValue($this->kernelDebug)->end()
             ->end()
         ;


### PR DESCRIPTION
This removes the default value for the DBAL charset. `UTF8` has to be used explicitly when using a mysql database in utf-8.
