### PR TITLE
Show request method in "No route found found" log

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -96,7 +96,7 @@ class RequestListener
                 $request->getSession()->setLocale($locale);
             }
         } elseif (null !== $this->logger) {
-            $this->logger->err(sprintf('No route found for %s', $request->getPathInfo()));
+            $this->logger->err(sprintf('No route found for %s %s', $request->getMethod(), $request->getPathInfo()));
         }
     }
 }


### PR DESCRIPTION
It's useful to know the request method when a 404 error happens.
