### PR TITLE
[Security] Numeric passwords comparing bugfix 2

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -459,7 +459,7 @@ class SecurityExtension extends Extension
 
             $container
                 ->setDefinition($userId, new DefinitionDecorator('security.user.provider.in_memory.user'))
-                ->setArguments(array($username, $user['password'], $user['roles']))
+                ->setArguments(array($username, (string)$user['password'], $user['roles']))
             ;
 
             $definition->addMethodCall('createUser', array(new Reference($userId)));


### PR DESCRIPTION
Method BasePasswordEncoder::comparePassword haven't been working for numeric (plaintype) passwords properly because inserted password was converted into integer type a and compared with stored password as a string type. Bugfix changes data type of passwords into string before comparing.
This pull request replace [earlier pull request](https://github.com/symfony/symfony/pull/203)
