### PR TITLE
Simple Performance Improvement

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -69,16 +69,16 @@ class Router implements RouterInterface
         );
 
         // check option names and live merge, if errors are encountered Exception will be thrown
-        $invalid=array();
-        $is_invalid=false;
+        $invalid = array();
+        $is_invalid = false;
         // This allows to avoid innefficients array_diff, array_keys, and so on, we only walks one the overriden options
         // With array_keys, array_diff and array_merge there is 3 full walk of the $this->options array and 2 of $options.
-        foreach ($options as $key=>$value) {
+        foreach ($options as $key => $value) {
             if (!isset($this->options[$key])) {
-                $this->options[$key]=$value;
+                $this->options[$key] = $value;
             } else {
-                $is_invalid=true;
-                $invalid[]=$key;
+                $is_invalid = true;
+                $invalid[] = $key;
             }
         }
         if ($is_invalid) {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -74,7 +74,7 @@ class Router implements RouterInterface
         // This allows to avoid innefficients array_diff, array_keys, and so on, we only walks one the overriden options
         // With array_keys, array_diff and array_merge there is 3 full walk of the $this->options array and 2 of $options.
         foreach ($options as $key => $value) {
-            if (!isset($this->options[$key])) {
+            if (isset($this->options[$key])) {
                 $this->options[$key] = $value;
             } else {
                 $isInvalid = true;

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -68,12 +68,22 @@ class Router implements RouterInterface
             'resource_type'          => null,
         );
 
-        // check option names
-        if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
-            throw new \InvalidArgumentException(sprintf('The Router does not support the following options: \'%s\'.', implode('\', \'', $diff)));
+        // check option names and live merge, if errors are encountered Exception will be thrown
+        $invalid=array();
+        $is_invalid=false;
+        // This allows to avoid innefficients array_diff, array_keys, and so on, we only walks one the overriden options
+        // With array_keys, array_diff and array_merge there is 3 full walk of the $this->options array and 2 of $options.
+        foreach ($options as $key=>$value) {
+            if (!isset($this->options[$key])) {
+                $this->options[$key]=$value;
+            } else {
+                $is_invalid=true;
+                $invalid[]=$key;
+            }
         }
-
-        $this->options = array_merge($this->options, $options);
+	if ($is_invalid) {
+            throw new \InvalidArgumentException(sprintf('The Router does not support the following options: \'%s\'.', implode('\', \'', $invalid)));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -74,7 +74,7 @@ class Router implements RouterInterface
         // This allows to avoid innefficients array_diff, array_keys, and so on, we only walks one the overriden options
         // With array_keys, array_diff and array_merge there is 3 full walk of the $this->options array and 2 of $options.
         foreach ($options as $key => $value) {
-            if (isset($this->options[$key])) {
+            if (array_key_exists($this->options, $key))) {
                 $this->options[$key] = $value;
             } else {
                 $isInvalid = true;

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -70,18 +70,18 @@ class Router implements RouterInterface
 
         // check option names and live merge, if errors are encountered Exception will be thrown
         $invalid = array();
-        $is_invalid = false;
+        $isInvalid = false;
         // This allows to avoid innefficients array_diff, array_keys, and so on, we only walks one the overriden options
         // With array_keys, array_diff and array_merge there is 3 full walk of the $this->options array and 2 of $options.
         foreach ($options as $key => $value) {
             if (!isset($this->options[$key])) {
                 $this->options[$key] = $value;
             } else {
-                $is_invalid = true;
+                $isInvalid = true;
                 $invalid[] = $key;
             }
         }
-        if ($is_invalid) {
+        if ($isInvalid) {
             throw new \InvalidArgumentException(sprintf('The Router does not support the following options: \'%s\'.', implode('\', \'', $invalid)));
         }
     }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -81,7 +81,7 @@ class Router implements RouterInterface
                 $invalid[]=$key;
             }
         }
-	if ($is_invalid) {
+        if ($is_invalid) {
             throw new \InvalidArgumentException(sprintf('The Router does not support the following options: \'%s\'.', implode('\', \'', $invalid)));
         }
     }


### PR DESCRIPTION
Dropped the array_keys, array_diff, array_merge.

The current implementation does 3 full scan of $options, 2 of $this->options

My implementation only does one scan of $options, and as such will be faster.

Furthermore, this allow to simply drop 4 functions call and associated context switches (hash table creation, destruction, ...)
