### PR TITLE
Doctrine simplify

### DIFF
--- a/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
@@ -43,19 +43,7 @@ abstract class AbstractDoctrineExtension extends Extension
     protected function loadMappingInformation(array $objectManager, $container)
     {
         if (isset($objectManager['mappings'])) {
-            // fix inconsistency between yaml and xml naming
-            if (isset($objectManager['mappings']['mapping'])) {
-                if (isset($objectManager['mappings']['mapping'][0])) {
-                    $objectManager['mappings'] = $objectManager['mappings']['mapping'];
-                } else {
-                    $objectManager['mappings'] = array($objectManager['mappings']['mapping']);
-                }
-            }
-
             foreach ($objectManager['mappings'] as $mappingName => $mappingConfig) {
-                if (is_string($mappingConfig)) {
-                    $mappingConfig = array('type' => $mappingConfig);
-                }
                 if (!isset($mappingConfig['dir'])) {
                     $mappingConfig['dir'] = false;
                 }
@@ -73,12 +61,6 @@ abstract class AbstractDoctrineExtension extends Extension
                 }
                 if (!isset($mappingConfig['is_bundle'])) {
                     $mappingConfig['is_bundle'] = !file_exists($mappingConfig['dir']);
-                }
-
-                if (isset($mappingConfig['name'])) {
-                    $mappingName = $mappingConfig['name'];
-                } else if ($mappingConfig === null) {
-                    $mappingConfig = array();
                 }
 
                 if ($mappingConfig['is_bundle']) {

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -51,24 +51,8 @@ class Configuration
             ->arrayNode('dbal')
                 ->beforeNormalization()
                     ->ifNull()
-                    ->then(function($v) { return array (); }) // Let use the default values with the subsequent closure.
-                ->end()
-                ->beforeNormalization()
-                    ->ifTrue(function($v){ return is_array($v) && !array_key_exists('connections', $v) && !array_key_exists('connection', $v); })
-                    ->then(function($v) {
-                        $connection = array ();
-                        $keys = array ('dbname', 'host', 'port', 'user', 'password', 'driver', 'driver_class', 'options', 'path', 'memory', 'unix_socket', 'wrapper_class', 'platform_service', 'charset', 'logging');
-                        foreach ($keys as $key) {
-                            if (array_key_exists($key, $v)) {
-                                $connection[$key] = $v[$key];
-                                unset($v[$key]);
-                            }
-                        }
-                        $defaultConnection = isset($v['default_connection']) ? (string) $v['default_connection'] : 'default';
-                        $v['connections'] = array ($defaultConnection => $connection);
-                        $v['default_connection'] = $defaultConnection;
-                        return $v;
-                    })
+                    // Define a default connection using the default values
+                    ->then(function($v) { return array ('default_connection' => 'default', 'connections' => array('default' => array())); })
                 ->end()
                 ->scalarNode('default_connection')->isRequired()->cannotBeEmpty()->end()
                 ->fixXmlConfig('type')
@@ -125,23 +109,6 @@ class Configuration
     {
         $node
             ->arrayNode('orm')
-                ->beforeNormalization()
-                    ->ifTrue(function($v){ return is_array($v) && !array_key_exists('entity_managers', $v) && !array_key_exists('entity_manager', $v); })
-                    ->then(function($v) {
-                        $entityManager = array ();
-                        $keys = array ('result_cache_driver', 'result-cache-driver', 'metadata_cache_driver', 'metadata-cache-driver', 'query_cache_driver', 'query-cache-driver', 'mappings', 'mapping', 'connection');
-                        foreach ($keys as $key) {
-                            if (array_key_exists($key, $v)) {
-                                $entityManager[$key] = $v[$key];
-                                unset($v[$key]);
-                            }
-                        }
-                        $defaultEntityManager = isset($v['default_entity_manager']) ? (string) $v['default_entity_manager'] : 'default';
-                        $v['entity_managers'] = array ($defaultEntityManager => $entityManager);
-                        $v['default_entity_manager'] = $defaultEntityManager;
-                        return $v;
-                    })
-                ->end()
                 ->scalarNode('default_entity_manager')->isRequired()->cannotBeEmpty()->end()
                 ->booleanNode('auto_generate_proxy_classes')->defaultFalse()->end()
                 ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/orm/Proxies')->end()

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -40,7 +40,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('dbal' => array('password' => 'foo')), array(), array('dbal' => array('default_connection' => 'foo')), array()), $container);
+        $loader->load(array(array('dbal' => array('connections' => array('default'=> array('password' => 'foo')))), array(), array('dbal' => array('default_connection' => 'foo')), array()), $container);
 
         $arguments = $container->getDefinition('doctrine.dbal.default_connection')->getArguments();
         $config = $arguments[0];
@@ -112,7 +112,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('dbal' => array(), 'orm' => array('mappings' => array('YamlBundle' => array())))), $container);
+        $loader->load(array(array('dbal' => null, 'orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array())))))), $container);
 
         $this->assertFalse($container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
         $this->assertEquals('Doctrine\ORM\Configuration', $container->getParameter('doctrine.orm.configuration_class'));
@@ -134,11 +134,16 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $config = array(
             'proxy_namespace' => 'MyProxies',
             'auto_generate_proxy_classes' => true,
-            'mappings' => array('YamlBundle' => array()),
+            'default_entity_manager' => 'default',
+            'entity_managers' => array(
+                'default' => array(
+                    'mappings' => array('YamlBundle' => array()),
+                    )
+                )
         );
 
         $container = $this->getContainer();
-        $loader->load(array(array('dbal' => array(), 'orm' => $config)), $container);
+        $loader->load(array(array('dbal' => null, 'orm' => $config)), $container);
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
         $this->assertEquals('Doctrine\DBAL\Connection', $definition->getClass());
@@ -186,7 +191,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('dbal' => array(), 'orm' => array('mappings' => array('YamlBundle' => array())))), $container);
+        $loader->load(array(array('dbal' => null, 'orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array())))))), $container);
 
         $definition = $container->getDefinition('doctrine.dbal.default_connection');
         $this->assertEquals('Doctrine\DBAL\Connection', $definition->getClass());
@@ -357,7 +362,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('mappings' => array('YamlBundle' => array())))), $container);
+        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array())))))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
@@ -370,7 +375,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('mappings' => array('YamlBundle' => array('alias' => 'yml'))))), $container);
+        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array('alias' => 'yml'))))))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
@@ -383,7 +388,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('YamlBundle');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('mappings' => array('YamlBundle' => array())))), $container);
+        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array())))))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -397,7 +402,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('XmlBundle');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('mappings' => array('XmlBundle' => array())))), $container);
+        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('XmlBundle' => array())))))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -411,7 +416,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('mappings' => array('AnnotationsBundle' => array())))), $container);
+        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array())))))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -426,13 +431,17 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $loader = new DoctrineExtension();
 
         $loader->load(array(array('orm' => array(
-                'auto_generate_proxy_classes' => true,
-                'mappings' => array('AnnotationsBundle' => array())
-            )),
+            'auto_generate_proxy_classes' => true,
+            'default_entity_manager' => 'default',
+            'entity_managers' => array(
+                'default' => array('mappings' => array('AnnotationsBundle' => array()))
+            ))),
             array('orm' => array(
                 'auto_generate_proxy_classes' => false,
-                'mappings' => array('XmlBundle' => array())
-        ))), $container);
+                'default_entity_manager' => 'default',
+                'entity_managers' => array(
+                    'default' => array('mappings' => array('XmlBundle' => array()))
+        )))), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', array(
@@ -619,7 +628,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle', 'Vendor');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('mappings' => array('AnnotationsBundle' => array())))), $container);
+        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array())))))), $container);
 
         $calls = $container->getDefinition('doctrine.orm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.orm.default_annotation_metadata_driver', (string) $calls[0][1][0]);

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
@@ -9,9 +9,11 @@
     <config>
         <orm
             auto-generate-proxy-classes="false"
-            metadata-cache-driver="apc"
+            default-entity-manager="default"
         >
-            <mapping name="YamlBundle" />
+            <entity-manager name="default" metadata-cache-driver="apc">
+                <mapping name="YamlBundle" />
+            </entity-manager>
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_service_simple_single_entity_manager.xml
@@ -8,14 +8,16 @@
 
     <config>
         <dbal />
-        <orm>
-            <metadata-cache-driver type="memcache">
-                <class>Doctrine\Common\Cache\MemcacheCache</class>
-                <host>localhost</host>
-                <port>11211</port>
-                <instance-class>Memcache</instance-class>
-            </metadata-cache-driver>
-            <mapping name="YamlBundle" />
+        <orm default-entity-manager="default">
+            <entity-manager name="default">
+                <metadata-cache-driver type="memcache">
+                    <class>Doctrine\Common\Cache\MemcacheCache</class>
+                    <host>localhost</host>
+                    <port>11211</port>
+                    <instance-class>Memcache</instance-class>
+                </metadata-cache-driver>
+                <mapping name="YamlBundle" />
+            </entity-manager>
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_single_em_bundle_mappings.xml
@@ -7,13 +7,15 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <orm>
-            <mapping name="AnnotationsBundle" />
-            <mapping name="YamlBundle" dir="Resources/config/doctrine/metadata" alias="yml" />
-            <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
-                dir="%kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata"
-                alias="TestAlias"
-            />
+        <orm default-entity-manager="default">
+            <entity-manager name="default">
+                <mapping name="AnnotationsBundle" />
+                <mapping name="YamlBundle" dir="Resources/config/doctrine/metadata" alias="yml" />
+                <mapping name="manual" type="xml" prefix="Fixtures\Bundles\XmlBundle"
+                    dir="%kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata"
+                    alias="TestAlias"
+                />
+            </entity-manager>
         </orm>
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
@@ -1,6 +1,9 @@
 doctrine:
     orm:
         auto_generate_proxy_classes: false
-        metadata_cache_driver: apc
-        mappings:
-            YamlBundle: ~
+        default_entity_manager: default
+        entity_managers:
+            default:
+                metadata_cache_driver: apc
+                mappings:
+                    YamlBundle: ~

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_service_simple_single_entity_manager.yml
@@ -1,11 +1,14 @@
 doctrine:
     dbal: ~
     orm:
-        mappings:
-            YamlBundle: ~
-        metadata_cache_driver:
-            type: memcache
-            class: Doctrine\Common\Cache\MemcacheCache
-            host: localhost
-            port: 11211
-            instance_class: Memcache
+        default_entity_manager: default
+        entity_managers:
+            default:
+                mappings:
+                    YamlBundle: ~
+                metadata_cache_driver:
+                    type: memcache
+                    class: Doctrine\Common\Cache\MemcacheCache
+                    host: localhost
+                    port: 11211
+                    instance_class: Memcache

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_bundle_mappings.yml
@@ -1,12 +1,15 @@
 doctrine:
     orm:
-        mappings:
-            AnnotationsBundle: ~
-            YamlBundle:
-                dir: Resources/config/doctrine/metadata
-                alias: yml
-            manual:
-                type: xml
-                prefix: Fixtures\Bundles\XmlBundle
-                dir: %kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata
-                alias: TestAlias
+        default_entity_manager: default
+        entity_managers:
+            default:
+                mappings:
+                    AnnotationsBundle: ~
+                    YamlBundle:
+                        dir: Resources/config/doctrine/metadata
+                        alias: yml
+                    manual:
+                        type: xml
+                        prefix: Fixtures\Bundles\XmlBundle
+                        dir: %kernel.root_dir%/../src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/Bundles/XmlBundle/Resources/config/doctrine/metadata
+                        alias: TestAlias

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/TestCase.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/TestCase.php
@@ -62,7 +62,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
                 'connections' => array(
                     'default' => array(
                         'driver' => 'pdo_mysql',
-                        'charset' => 'UTF-8',
+                        'charset' => 'UTF8',
                         'platform-service' => 'my.platform',
                     )
                 ),
@@ -71,10 +71,15 @@ class TestCase extends \PHPUnit_Framework_TestCase
                     'test' => 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestType',
                 ),
             ), 'orm' => array(
-                'mappings' => array('YamlBundle' => array(
-                    'type' => 'yml',
-                    'dir' => __DIR__ . "/DependencyInjection/Fixtures/Bundles/YamlBundle/Resources/config/doctrine/metadata/orm",
-                    'prefix' => 'Fixtures\Bundles\YamlBundle',
+                'default_entity_manager' => 'default',
+                'entity_managers' => array (
+                    'default' => array(
+                    'mappings' => array('YamlBundle' => array(
+                        'type' => 'yml',
+                        'dir' => __DIR__ . "/DependencyInjection/Fixtures/Bundles/YamlBundle/Resources/config/doctrine/metadata/orm",
+                        'prefix' => 'Fixtures\Bundles\YamlBundle',
+                    )
+                )
             )))
         )), $container);
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
@@ -23,9 +23,7 @@ class Configuration
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('doctrine_mongo_db', 'array');
 
-        $this->addSingleDocumentManagerSection($rootNode);
         $this->addDocumentManagersSection($rootNode);
-        $this->addSingleConnectionSection($rootNode);
         $this->addConnectionsSection($rootNode);
 
         $rootNode
@@ -33,24 +31,12 @@ class Configuration
             ->scalarNode('auto_generate_proxy_classes')->defaultValue(false)->end()
             ->scalarNode('hydrator_namespace')->defaultValue('Hydrators')->end()
             ->scalarNode('auto_generate_hydrator_classes')->defaultValue(false)->end()
+            ->scalarNode('default_document_manager')->defaultValue('default')->end()
+            ->scalarNode('default_connection')->defaultValue('default')->end()
+            ->scalarNode('default_database')->defaultValue('default')->end()
         ;
 
         return $treeBuilder->buildTree();
-    }
-
-    /**
-     * Builds the nodes responsible for the config that supports the single
-     * document manager.
-     */
-    private function addSingleDocumentManagerSection(NodeBuilder $rootNode)
-    {
-        $rootNode
-            ->scalarNode('default_document_manager')->defaultValue('default')->end()
-            ->scalarNode('default_database')->defaultValue('default')->end()
-            ->builder($this->getMetadataCacheDriverNode())
-            ->fixXmlConfig('mapping')
-            ->builder($this->getMappingsNode())
-        ;
     }
 
     /**
@@ -63,31 +49,15 @@ class Configuration
             ->arrayNode('document_managers')
                 ->useAttributeAsKey('id')
                 ->prototype('array')
-                    ->performNoDeepMerging()
+                    //->performNoDeepMerging()
                     ->treatNullLike(array())
                     ->builder($this->getMetadataCacheDriverNode())
-                    ->scalarNode('default_database')->end()
                     ->scalarNode('connection')->end()
                     ->scalarNode('database')->end()
                     ->fixXmlConfig('mapping')
                     ->builder($this->getMappingsNode())
                 ->end()
             ->end()
-        ;
-    }
-
-    /**
-     * Configures the single-connection section:
-     *   * default_connection
-     *   * server
-     *   * options
-     */
-    private function addSingleConnectionSection(NodeBuilder $rootNode)
-    {
-        $rootNode
-            ->scalarNode('default_connection')->defaultValue('default')->end()
-            ->builder($this->addConnectionServerNode())
-            ->builder($this->addConnectionOptionsNode())
         ;
     }
 
@@ -102,7 +72,7 @@ class Configuration
                 ->useAttributeAsKey('id')
                 ->prototype('array')
                     ->performNoDeepMerging()
-                    ->builder($this->addConnectionServerNode())
+                    ->scalarNode('server')->defaultNull()->end()
                     ->builder($this->addConnectionOptionsNode())
                 ->end()
             ->end()
@@ -139,20 +109,6 @@ class Configuration
                 ->performNoDeepMerging()
             ->end()
         ;
-
-        return $node;
-    }
-
-    /**
-     * Adds the NodeBuilder for the "server" key of a connection.
-     */
-    private function addConnectionServerNode()
-    {
-        $node = new NodeBuilder('server', 'scalar');
-
-        $node
-            ->defaultValue(null)
-        ->end();
 
         return $node;
     }

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -77,26 +77,9 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
         // set some options as parameters and unset them
         $config = $this->overrideParameters($config, $container);
 
-        // if no "connections" were given, setup the default connection
-        if (!isset($config['connections']) || !$config['connections']) {
-            $defaultName = $config['default_connection'];
-            $config['connections'] = array($defaultName => array(
-                'server'    => $config['server'],
-                'options'   => $config['options'],
-            ));
-        }
         // load the connections
         $this->loadConnections($config['connections'], $container);
 
-        // if no "document_managers" were given, setup the default manager
-        if (!isset($config['document_managers']) || !$config['document_managers']) {
-            $defaultName = $config['default_document_manager'];
-            $config['document_managers'] = array($defaultName => array(
-                'mappings'          => $config['mappings'],
-                'default_database'  => $config['default_database'],
-                'metadata_cache_driver' => $config['metadata_cache_driver'],
-            ));
-        }
         // load the document managers
         $this->loadDocumentManagers(
             $config['document_managers'],

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/ContainerTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/ContainerTest.php
@@ -30,7 +30,7 @@ class ContainerTest extends TestCase
         $container->registerExtension($loader);
 
         $configs = array();
-        $configs[] = array('mappings' => array('YamlBundle' => array()));
+        $configs[] = array('connections' => array('default' => array()), 'document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))));
         $loader->load($configs, $container);
 
         return $container;

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -51,6 +51,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $config = array(
             'proxy_namespace' => 'MyProxies',
             'auto_generate_proxy_classes' => true,
+            'connections' => array('default' => array()),
+            'document_managers' => array('default' => array())
         );
         $loader->load(array($config), $container);
 
@@ -80,8 +82,13 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $loader = new DoctrineMongoDBExtension();
 
         $config = array(
-            'server' => 'mongodb://localhost:27017',
-            'options' => array('connect' => true)
+            'connections' => array(
+                'default' => array(
+                    'server' => 'mongodb://localhost:27017',
+                    'options' => array('connect' => true)
+                )
+            ),
+            'document_managers' => array('default' => array())
         );
         $loader->load(array($config), $container);
 
@@ -218,7 +225,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->load(array(array('mappings' => array('YamlBundle' => array()))), $container);
+        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))), $container);
 
         $definition = $container->getDefinition('doctrine.odm.mongodb.default_configuration');
         $calls = $definition->getMethodCalls();
@@ -231,7 +238,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineMongoDBExtension('YamlBundle');
 
-        $loader->load(array(array('mappings' => array('YamlBundle' => array()))), $container);
+        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))))), $container);
 
         $calls = $container->getDefinition('doctrine.odm.mongodb.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.odm.mongodb.default_yml_metadata_driver', (string) $calls[0][1][0]);
@@ -243,7 +250,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer('XmlBundle');
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->load(array(array('mappings' => array('XmlBundle' => array()))), $container);
+        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('XmlBundle' => array()))))), $container);
 
         $calls = $container->getDefinition('doctrine.odm.mongodb.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.odm.mongodb.default_xml_metadata_driver', (string) $calls[0][1][0]);
@@ -255,7 +262,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle');
         $loader = new DoctrineMongoDBExtension();
 
-        $loader->load(array(array('mappings' => array('AnnotationsBundle' => array()))), $container);
+        $loader->load(array(array('document_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array()))))), $container);
 
         $calls = $container->getDefinition('doctrine.odm.mongodb.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.odm.mongodb.default_annotation_metadata_driver', (string) $calls[0][1][0]);

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -30,11 +30,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'auto_generate_proxy_classes'       => false,
             'default_document_manager'          => 'default',
             'default_database'                  => 'default',
-            'mappings'                          => array(),
             'document_managers'                 => array(),
             'default_connection'                => 'default',
-            'server'                            => null,
-            'options'                           => array(),
             'connections'                       => array(),
             'proxy_namespace'                   => 'Proxies',
             'hydrator_namespace'                => 'Hydrators',
@@ -70,44 +67,40 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'auto_generate_hydrator_classes'    => true,
             'default_document_manager'          => 'default_dm_name',
             'default_database'                  => 'default_db_name',
-            'metadata_cache_driver' => array(
-                'type'      => 'memcache',
-                'class'     => 'fooClass',
-                'host'      => 'host_val',
-                'port'      => 1234,
-                'instance_class' => 'instance_val',
-            ),
             'default_connection'                => 'conn1',
-            'server'                            => 'http://server',
-            'options'       => array(
-                'connect'   => true,
-                'persist'   => 'persist_val',
-                'timeout'   => 500,
-                'replicaSet' => true,
-                'username'  => 'username_val',
-                'password'  => 'password_val',
-            ),
             'connections'   => array(
                 'conn1'         => array(
-                    'server'    => null,
-                    'options'   => array(),
+                    'server'    => 'http://server',
+                    'options'   => array(
+                        'connect'   => true,
+                        'persist'   => 'persist_val',
+                        'timeout'   => 500,
+                        'replicaSet' => true,
+                        'username'  => 'username_val',
+                        'password'  => 'password_val',
+                    ),
                 ),
                 'conn2'         => array(
                     'server'    => 'http://server2',
                     'options'   => array(),
                 ),
             ),
-            'mappings'      => array(
-                'FooBundle'     => array(
-                    'type' => 'annotations',
-                ),
-            ),
             'document_managers' => array(
                 'dm1' => array(
-                    'mappings' => array(),
+                    'mappings' => array(
+                        'FooBundle'     => array(
+                            'type' => 'annotations',
+                        ),
+                    ),
+                    'metadata_cache_driver' => array(
+                        'type'      => 'memcache',
+                        'class'     => 'fooClass',
+                        'host'      => 'host_val',
+                        'port'      => 1234,
+                        'instance_class' => 'instance_val',
+                    ),
                 ),
                 'dm2' => array(
-                    'default_database' => 'dm2_default_db',
                     'connection' => 'dm2_connection',
                     'database' => 'db1',
                     'mappings' => array(
@@ -188,19 +181,19 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         // the "options" array is totally replaced
         $cases[] = array(
             array(
-                array('options' => array('timeout' => 2000)),
-                array('options' => array('username' => 'foo')),
+                array('connections' => array('default' => array('options' => array('timeout' => 2000)))),
+                array('connections' => array('default' => array('options' => array('username' => 'foo')))),
             ),
-            array('options' => array('username' => 'foo')),
+            array('connections' => array('default' => array('options' => array('username' => 'foo'), 'server' => null))),
         );
 
         // mappings are merged non-recursively.
         $cases[] = array(
             array(
-                array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('dir' => 'val2'))),
-                array('mappings' => array('barmap' => array('prefix' => 'val3'))),
+                array('document_managers' => array('default' => array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('dir' => 'val2'))))),
+                array('document_managers' => array('default' => array('mappings' => array('barmap' => array('prefix' => 'val3'))))),
             ),
-            array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('prefix' => 'val3'))),
+            array('document_managers' => array('default' => array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('prefix' => 'val3'))))),
         );
 
         // connections are merged non-recursively.
@@ -218,7 +211,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         // managers are merged non-recursively.
         $cases[] = array(
             array(
-                array('document_managers' => array('foodm' => array('database' => 'val1'), 'bardm' => array('default_database' => 'val2'))),
+                array('document_managers' => array('foodm' => array('database' => 'val1'), 'bardm' => array('database' => 'val2'))),
                 array('document_managers' => array('bardm' => array('database' => 'val3'))),
             ),
             array('document_managers' => array(
@@ -266,18 +259,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 array(
                     'foo' => array('connection' => 'conn1', 'mappings' => array()),
                     'bar' => array('connection' => 'conn2', 'mappings' => array()),
-                ),
-            ),
-            // mapping versus mappings (name is the identifier)
-            array(
-                array('mapping' => array(
-                    array('type' => 'yml', 'name' => 'foo'),
-                    array('type' => 'xml', 'name' => 'bar'),
-                )),
-                'mappings',
-                array(
-                    'foo' => array('type' => 'yml'),
-                    'bar' => array('type' => 'xml'),
                 ),
             ),
             // mapping configuration that's beneath a specific document manager

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_multiple_connections.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_multiple_connections.xml
@@ -7,24 +7,23 @@
                         http://symfony.com/schema/dic/doctrine/odm/mongodb http://symfony.com/schema/dic/doctrine/odm/mongodb/mongodb-1.0.xsd">
 
     <doctrine:mongodb
-            metadata-cache-driver="apc"
             default-document-manager="dm2"
             default-connection="conn1"
             proxy-namespace="Proxies"
             auto-generate-proxy-classes="true"
         >
         <doctrine:connection id="conn1" server="mongodb://localhost:27017">
-            <options>
-                <connect>true</connect>
-            </options>
+            <doctrine:options>
+                <doctrine:connect>true</doctrine:connect>
+            </doctrine:options>
         </doctrine:connection>
         <doctrine:connection id="conn2" server="mongodb://localhost:27017">
-            <options>
-                <connect>true</connect>
-            </options>
+            <doctrine:options>
+                <doctrine:connect>true</doctrine:connect>
+            </doctrine:options>
         </doctrine:connection>
 
         <doctrine:document-manager id="dm1" metadata-cache-driver="xcache" connection="conn1" />
-        <doctrine:document-manager id="dm2" connection="conn2" />
+        <doctrine:document-manager id="dm2" connection="conn2" metadata-cache-driver="apc" />
     </doctrine:mongodb>
 </container>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_simple_single_connection.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_simple_single_connection.xml
@@ -6,15 +6,19 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/doctrine/odm/mongodb http://symfony.com/schema/dic/doctrine/odm/mongodb/mongodb-1.0.xsd">
 
-    <doctrine:mongodb server="mongodb://localhost:27017" default_database="mydb">
-        <metadata-cache-driver type="memcache">
-            <class>Doctrine\Common\Cache\MemcacheCache</class>
-            <host>localhost</host>
-            <port>11211</port>
-            <instance-class>Memcache</instance-class>
-        </metadata-cache-driver>
-        <options>
-            <connect>true</connect>
-        </options>
+    <doctrine:mongodb default_database="mydb">
+        <doctrine:connection server="mongodb://localhost:27017" id="default">
+            <doctrine:options>
+                <doctrine:connect>true</doctrine:connect>
+            </doctrine:options>
+        </doctrine:connection>
+        <doctrine:document-manager id="default" connection="default">
+            <doctrine:metadata-cache-driver type="memcache">
+                <doctrine:class>Doctrine\Common\Cache\MemcacheCache</doctrine:class>
+                <doctrine:host>localhost</doctrine:host>
+                <doctrine:port>11211</doctrine:port>
+                <doctrine:instance-class>Memcache</doctrine:instance-class>
+            </doctrine:metadata-cache-driver>
+        </doctrine:document-manager>
     </doctrine:mongodb>
 </container>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/xml/mongodb_service_single_connection.xml
@@ -9,18 +9,18 @@
     <doctrine:mongodb>
 
         <doctrine:connection id="default" server="mongodb://localhost:27017">
-            <options>
-                <connect>true</connect>
-            </options>
+            <doctrine:options>
+                <doctrine:connect>true</doctrine:connect>
+            </doctrine:options>
         </doctrine:connection>
 
         <doctrine:document-manager id="default" connection="default">
-            <metadata-cache-driver type="memcache">
-                <class>Doctrine\Common\Cache\MemcacheCache</class>
-                <host>localhost</host>
-                <port>11211</port>
-                <instance-class>Memcache</instance-class>
-            </metadata-cache-driver>
+            <doctrine:metadata-cache-driver type="memcache">
+                <doctrine:class>Doctrine\Common\Cache\MemcacheCache</doctrine:class>
+                <doctrine:host>localhost</doctrine:host>
+                <doctrine:port>11211</doctrine:port>
+                <doctrine:instance-class>Memcache</doctrine:instance-class>
+            </doctrine:metadata-cache-driver>
         </doctrine:document-manager>
 
     </doctrine:mongodb>

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -7,35 +7,33 @@ doctrine_mongo_db:
 
     default_document_manager:  default_dm_name
     default_database:          default_db_name
-    metadata_cache_driver:
-        type:                  memcache
-        class:                 fooClass
-        host:                  host_val
-        port:                  1234
-        instance_class:        instance_val
 
     default_connection:        conn1
-    server:         http://server
-    options:
-        connect:    true
-        persist:    persist_val
-        timeout:    500
-        replicaSet: true
-        username:   username_val
-        password:   password_val
 
     connections:
-        conn1:      ~
+        conn1:
+            server:         http://server
+            options:
+                connect:    true
+                persist:    persist_val
+                timeout:    500
+                replicaSet: true
+                username:   username_val
+                password:   password_val
         conn2:
             server: http://server2
 
-    mappings:
-        FooBundle:   annotations
-
     document_managers:
-        dm1:        ~
+        dm1:
+            mappings:
+                FooBundle:   annotations
+            metadata_cache_driver:
+                type:                  memcache
+                class:                 fooClass
+                host:                  host_val
+                port:                  1234
+                instance_class:        instance_val
         dm2:
-            default_database: dm2_default_db
             connection:       dm2_connection
             database:         db1
             mappings:
@@ -46,4 +44,3 @@ doctrine_mongo_db:
                     alias:  alias_val
                     is_bundle: false
             metadata_cache_driver: apc
-        

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_multiple_connections.yml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_multiple_connections.yml
@@ -1,7 +1,6 @@
 doctrine_mongo_db:
   default_document_manager: dm2
   default_connection: conn2
-  metadata_cache_driver: apc
   connections:
     conn1:
       server: mongodb://localhost:27017
@@ -17,3 +16,4 @@ doctrine_mongo_db:
       metadata_cache_driver: xcache
     dm2:
       connection: conn2
+      metadata_cache_driver: apc

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/mongodb_service_simple_single_connection.yml
@@ -1,10 +1,14 @@
 doctrine_mongo_db:
-  server: mongodb://localhost:27017
+  connections:
+    default:
+      server: mongodb://localhost:27017
+      options: { connect: true }
   default_database: mydb
-  options: { connect: true }
-  metadata_cache_driver:
-    type: memcache
-    class: Doctrine\Common\Cache\MemcacheCache
-    host: localhost
-    port: 11211
-    instance_class: Memcache
+  document_managers:
+    default:
+      metadata_cache_driver:
+        type: memcache
+        class: Doctrine\Common\Cache\MemcacheCache
+        host: localhost
+        port: 11211
+        instance_class: Memcache


### PR DESCRIPTION
This removes the short syntax for both DoctrineBundle and DoctrineMongoDBBundle as discussed in http://groups.google.com/group/symfony-devs/browse_thread/thread/c84bae4edba5a7ba
