### PR TITLE
Console output tags exception

### DIFF
--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -198,7 +198,7 @@ abstract class Output implements OutputInterface
         } else {
             // bg=blue;fg=red
             if (!preg_match_all('/([^=]+)=([^;]+)(;|$)/', strtolower($match[1]), $matches, PREG_SET_ORDER)) {
-                throw new \InvalidArgumentException(sprintf('Unknown style "%s".', $match[1]));
+                return $match[0];
             }
 
             $parameters = array();
@@ -235,6 +235,10 @@ abstract class Output implements OutputInterface
      */
     private function replaceEndStyle($match)
     {
+        if (!isset(self::$styles[strtolower($match[1])])) {
+            return $match[0];
+        }
+
         if (!$this->decorated) {
             return '';
         }

--- a/tests/Symfony/Tests/Component/Console/Output/OutputTest.php
+++ b/tests/Symfony/Tests/Component/Console/Output/OutputTest.php
@@ -84,13 +84,13 @@ class OutputTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('Unknown output type given (24)', $e->getMessage());
         }
 
-        try {
-            $output->writeln('<bar>foo</bar>');
-            $this->fail('->writeln() throws an \InvalidArgumentException when a style does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('\InvalidArgumentException', $e, '->writeln() throws an \InvalidArgumentException when a style does not exist');
-            $this->assertEquals('Unknown style "bar".', $e->getMessage());
-        }
+        $output->clear();
+        $output->write('<bar>foo</bar>');
+        $this->assertEquals('<bar>foo</bar>', $output->output, '->write() do nothing when a style does not exist');
+
+        $output->clear();
+        $output->writeln('<bar>foo</bar>');
+        $this->assertEquals("<bar>foo</bar>\n", $output->output, '->writeln() do nothing when a style does not exist');
     }
 }
 

--- a/tests/Symfony/Tests/Component/Console/Output/OutputTest.php
+++ b/tests/Symfony/Tests/Component/Console/Output/OutputTest.php
@@ -98,6 +98,11 @@ class TestOutput extends Output
 {
     public $output = '';
 
+    public function clear()
+    {
+        $this->output = '';
+    }
+
     public function doWrite($message, $newline)
     {
         $this->output .= $message.($newline ? "\n" : '');


### PR DESCRIPTION
As promised, tags in output fix.

Before this patch, every normal tag or something with "<" or ">" in it throwed Exception "undefined style", which is bad, cuz sometimes we just want to print simple tags.
After those commits, console output will do nothing if specified in tag style is not found (or not style).
