### PR TITLE
[Routing] Fixed compiling routes with empty string or 0 as default parameter value.

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -212,7 +212,7 @@ class RouteCompiler implements RouteCompilerInterface
         $this->segments[] = preg_quote($separator, '#').'(?P<'.$variable.'>'.$requirement.')';
         $this->variables[$variable] = $name;
 
-        if (!$this->route->getDefault($variable)) {
+        if (null === $this->route->getDefault($variable)) {
             $this->firstOptional = count($this->segments);
         }
     }

--- a/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
@@ -69,7 +69,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
 
             array(
                 'Route with several variables that have default values',
-                array('/foo/{bar}/{foobar}', array('bar' => 'bar', 'foobar' => 'foobar')),
+                array('/foo/{bar}/{foobar}', array('bar' => 'bar', 'foobar' => '')),
                 '/foo', '#^/foo(?:/(?P<bar>[^/\.]+?) (?:/(?P<foobar>[^/\.]+?) )?)?$#x', array('bar' => '{bar}', 'foobar' => '{foobar}'), array(
                     array('variable', '/', '{foobar}', 'foobar'),
                     array('variable', '/', '{bar}', 'bar'),


### PR DESCRIPTION
Fixed improper behavior of RouteCompiler - optional parameter with default value set to "" (empty string) or 0 was treated as required parameter.
