### PR TITLE
Doctrine config

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -52,9 +52,9 @@ class Configuration
                 ->beforeNormalization()
                     ->ifNull()
                     // Define a default connection using the default values
-                    ->then(function($v) { return array ('default_connection' => 'default', 'connections' => array('default' => array())); })
+                    ->then(function($v) { return array ('connections' => array('default' => array())); })
                 ->end()
-                ->scalarNode('default_connection')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('default_connection')->end()
                 ->fixXmlConfig('type')
                 ->arrayNode('types')
                     ->useAttributeAsKey('name')
@@ -109,7 +109,7 @@ class Configuration
     {
         $node
             ->arrayNode('orm')
-                ->scalarNode('default_entity_manager')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('default_entity_manager')->end()
                 ->booleanNode('auto_generate_proxy_classes')->defaultFalse()->end()
                 ->scalarNode('proxy_dir')->defaultValue('%kernel.cache_dir%/doctrine/orm/Proxies')->end()
                 ->scalarNode('proxy_namespace')->defaultValue('Proxies')->end()

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -60,6 +60,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('dbal.xml');
 
+        if (empty ($config['default_connection'])) {
+            $config['default_connection'] = reset(array_keys($config['connections']));
+        }
+
         $container->setAlias('database_connection', sprintf('doctrine.dbal.%s_connection', $config['default_connection']));
         $container->setAlias('doctrine.dbal.event_manager', new Alias(sprintf('doctrine.dbal.%s_connection.event_manager', $config['default_connection']), false));
         $container->setParameter('doctrine.dbal.default_connection', $config['default_connection']);
@@ -140,6 +144,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('orm.xml');
+
+        $entityManagers = array_keys($config['entity_managers']);
+
+        if (empty ($config['default_entity_manager'])) {
+            $config['default_entity_manager'] = reset($entityManagers);
+        }
+
         $options = array('default_entity_manager', 'auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
         foreach ($options as $key) {
             $container->setParameter('doctrine.orm.'.$key, $config[$key]);
@@ -152,7 +163,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $this->loadOrmEntityManager($entityManager, $container);
         }
 
-        $container->setParameter('doctrine.orm.entity_managers', array_keys($config['entity_managers']));
+        $container->setParameter('doctrine.orm.entity_managers', $entityManagers);
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
@@ -42,8 +42,8 @@ class Configuration
             ->scalarNode('auto_generate_proxy_classes')->defaultValue(false)->end()
             ->scalarNode('hydrator_namespace')->defaultValue('Hydrators')->end()
             ->scalarNode('auto_generate_hydrator_classes')->defaultValue(false)->end()
-            ->scalarNode('default_document_manager')->defaultValue('default')->end()
-            ->scalarNode('default_connection')->defaultValue('default')->end()
+            ->scalarNode('default_document_manager')->end()
+            ->scalarNode('default_connection')->end()
             ->scalarNode('default_database')->defaultValue('default')->end()
         ;
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -49,6 +49,13 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $config['metadata_cache_driver'] = array('type' => 'array');
         }
 
+        if (empty ($config['default_connection'])) {
+            $config['default_connection'] = reset(array_keys($config['connections']));
+        }
+        if (empty ($config['default_document_manager'])) {
+            $config['default_document_manager'] = reset(array_keys($config['document_managers']));
+        }
+
         // set some options as parameters and unset them
         $config = $this->overrideParameters($config, $container);
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/ContainerTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/ContainerTest.php
@@ -25,6 +25,7 @@ class ContainerTest extends TestCase
         $container = new ContainerBuilder(new ParameterBag(array(
             'kernel.bundles'     => array('YamlBundle' => 'DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\YamlBundle\YamlBundle'),
             'kernel.cache_dir'   => sys_get_temp_dir(),
+            'kernel.debug'       => false,
         )));
         $loader = new DoctrineMongoDBExtension();
         $container->registerExtension($loader);

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -356,6 +356,7 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
         return new ContainerBuilder(new ParameterBag(array(
             'kernel.bundles'     => array($bundle => 'DoctrineMongoDBBundle\\Tests\\DependencyInjection\\Fixtures\\Bundles\\'.$bundle.'\\'.$bundle),
             'kernel.cache_dir'   => sys_get_temp_dir(),
+            'kernel.debug'       => false,
         )));
     }
 }

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -22,16 +22,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testDefaults()
     {
         $processor = new Processor();
-        $configuration = new Configuration();
+        $configuration = new Configuration(false);
         $options = $processor->process($configuration->getConfigTree(), array());
 
         $defaults = array(
             'auto_generate_hydrator_classes'    => false,
             'auto_generate_proxy_classes'       => false,
-            'default_document_manager'          => 'default',
             'default_database'                  => 'default',
             'document_managers'                 => array(),
-            'default_connection'                => 'default',
             'connections'                       => array(),
             'proxy_namespace'                   => 'Proxies',
             'hydrator_namespace'                => 'Hydrators',
@@ -57,7 +55,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testFullConfiguration($config)
     {
         $processor = new Processor();
-        $configuration = new Configuration();
+        $configuration = new Configuration(false);
         $options = $processor->process($configuration->getConfigTree(), array($config));
 
         $expected = array(
@@ -99,6 +97,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'port'      => 1234,
                         'instance_class' => 'instance_val',
                     ),
+                    'logging' => false,
                 ),
                 'dm2' => array(
                     'connection' => 'dm2_connection',
@@ -114,7 +113,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     ),
                     'metadata_cache_driver' => array(
                         'type' => 'apc',
-                    )
+                    ),
+                    'logging' => true,
                 )
             )
         );
@@ -140,7 +140,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testMergeOptions(array $configs, array $correctValues)
     {
         $processor = new Processor();
-        $configuration = new Configuration();
+        $configuration = new Configuration(false);
         $options = $processor->process($configuration->getConfigTree(), $configs);
 
         foreach ($correctValues as $key => $correctVal)
@@ -193,7 +193,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 array('document_managers' => array('default' => array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('dir' => 'val2'))))),
                 array('document_managers' => array('default' => array('mappings' => array('barmap' => array('prefix' => 'val3'))))),
             ),
-            array('document_managers' => array('default' => array('mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('prefix' => 'val3'))))),
+            array('document_managers' => array('default' => array('logging' => false, 'mappings' => array('foomap' => array('type' => 'val1'), 'barmap' => array('prefix' => 'val3'))))),
         );
 
         // connections are merged non-recursively.
@@ -215,8 +215,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 array('document_managers' => array('bardm' => array('database' => 'val3'))),
             ),
             array('document_managers' => array(
-                'foodm' => array('database' => 'val1', 'mappings' => array()),
-                'bardm' => array('database' => 'val3', 'mappings' => array()),
+                'foodm' => array('database' => 'val1', 'logging' => false, 'mappings' => array()),
+                'bardm' => array('database' => 'val3', 'logging' => false, 'mappings' => array()),
             )),
         );
 
@@ -229,7 +229,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     public function testNormalizeOptions(array $config, $targetKey, array $normalized)
     {
         $processor = new Processor();
-        $configuration = new Configuration();
+        $configuration = new Configuration(false);
         $options = $processor->process($configuration->getConfigTree(), array($config));
         $this->assertSame($normalized, $options[$targetKey]);
     }
@@ -257,8 +257,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 )),
                 'document_managers',
                 array(
-                    'foo' => array('connection' => 'conn1', 'mappings' => array()),
-                    'bar' => array('connection' => 'conn2', 'mappings' => array()),
+                    'foo' => array('connection' => 'conn1', 'logging' => false, 'mappings' => array()),
+                    'bar' => array('connection' => 'conn2', 'logging' => false, 'mappings' => array()),
                 ),
             ),
             // mapping configuration that's beneath a specific document manager
@@ -272,7 +272,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 array(
                     'foo' => array('connection' => 'conn1', 'mappings' => array(
                         'foo-mapping' => array('type' => 'xml'),
-                    )),
+                    ), 'logging' => false),
                 ),
             ),
         );

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/DoctrineMongoDBExtensionTest.php
@@ -24,6 +24,7 @@ class DoctrineMongoDBExtensionTest extends \PHPUnit_Framework_TestCase
     public function testParameterOverride($option, $parameter, $value)
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
         $loader = new DoctrineMongoDBExtension();
         $loader->load(array(array($option => $value)), $container);
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/Fixtures/config/yml/full.yml
@@ -44,3 +44,4 @@ doctrine_mongo_db:
                     alias:  alias_val
                     is_bundle: false
             metadata_cache_driver: apc
+            logging: true


### PR DESCRIPTION
The default entity manager and connections are now the first defined in the config to avoid requiring to set the parameter when there is only one.

this commit also fixed the tests of DoctrineMongoDBBundle because I needed to run the testsuite so it makes https://github.com/symfony/symfony/pull/267 obsolete (I don't always use the same value for the boolean parameter so it would likely conflict if they are both merged)
