### PR TITLE
Use first authenticated token provided instead of last attempted

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -59,7 +59,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
 
             try {
                 $result = $provider->authenticate($token);
-                if (null != $result) {
+                if (null !== $result) {
                     break;
                 }
             } catch (AccountStatusException $e) {

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -59,7 +59,9 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
 
             try {
                 $result = $provider->authenticate($token);
-                break;
+                if (null != $result) {
+                    break;
+                }
             } catch (AccountStatusException $e) {
                 $e->setExtraInformation($token);
 

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -59,6 +59,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
 
             try {
                 $result = $provider->authenticate($token);
+                break;
             } catch (AccountStatusException $e) {
                 $e->setExtraInformation($token);
 


### PR DESCRIPTION
I found this using FacebookBundle where my apps configuration together with that of the bundle produced the following in app/cache/appDevDebugProjectContainer.php

```
protected function getSecurity_Authentication_ManagerService()
{
    $a = $this->get('fos_facebook.api');

    return $this->services['security.authentication.manager'] = new \Symfony\Component\Security\Core\Authentication\AuthenticationProviderManager(array(
        0 => new \FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider($a, $this->get('fos_facebook.user_provider'), new \Symfony\Component\Security\Core\User\UserChecker()),
        1 => new \Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider('SomeRandomValue'),
        2 => new \FOS\FacebookBundle\Security\Authentication\Provider\FacebookProvider($a)
    ));
}
```

You see that the first provider (configured on app level) is fully qualified while the default one from the bundle isn't. While this could be an error of the bundle itself the result was counter intuitive.

The first provider was able to create an authenticated token which was then overridden by the second provider with an empty token that was then used for further execution. The result was a constant 403 although the user was authenticated properly.

I think the first provider that is able to produce a token should be used. this also avoids execution of probably the same thing all over.
