### PR TITLE
[FrameworkBundle][Cache] Create cache directory if not exists.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
@@ -28,6 +28,7 @@ class ContainerBuilderDebugDumpPass implements CompilerPassInterface
     {
         $file = self::getBuilderCacheFilename($container);
 
+        @mkdir(dirname($file), 0777, true);
         if (false !== @file_put_contents($file, serialize($container))) {
             chmod($file, 0666);
         } else {


### PR DESCRIPTION
When the cache directory is empty, I get the following error :

```
PHP Fatal error:  Uncaught exception 'RuntimeException' with message 'Failed to write cache file ".../app/cache/dev/appDevProjectContainerBuilder.cache".' in .../vendor/symfony/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php:35
```

This commit fix it by creating the directory tree.

**Not sure about the chmod.**
