### PR TITLE
Added a more helpful message on the doctrine:database:drop command

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/DropDatabaseDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DropDatabaseDoctrineCommand.php
@@ -71,7 +71,9 @@ EOT
                 $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
             }
         } else {
+            $output->writeln('<error>ATTENTION:</error> This operation should not be executed in a production enviroment.' . PHP_EOL);
             $output->writeln(sprintf('<info>Would drop the database named <comment>%s</comment>.</info>', $name));
+            $output->writeln('Please run the operation with --force to execute');
             $output->writeln('<error>All data will be lost!</error>');
         }
     }


### PR DESCRIPTION
Added a hint to use --force to actually execute the doctrine:database:drop command, as it's not shown unless the user types --help to find out.

This message also keeps consistency with the other drop messages
- doctrine:schema:drop command, for example, extends this doctrine class:
  https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Tools/Console/Command/SchemaTool/DropCommand.php#L95
  
  which shows the "attention line" and the "use --force to execute" help messages as well
