### PR TITLE
Adjustment to allow for mixed case keys in parameter collections

### DIFF
--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -35,7 +35,7 @@ class SimpleXMLElement extends \SimpleXMLElement
      * @param string $name
      * @return mixed
      */
-    public function getArgumentsAsPhp($name)
+    public function getArgumentsAsPhp($name, $lowercase = true)
     {
         $arguments = array();
         foreach ($this->$name as $arg) {
@@ -45,7 +45,7 @@ class SimpleXMLElement extends \SimpleXMLElement
             $key = isset($arg['key']) ? (string) $arg['key'] : (!$arguments ? 0 : max(array_keys($arguments)) + 1);
 
             // parameter keys are case insensitive
-            if ('parameter' == $name) {
+            if ('parameter' == $name and $lowercase) {
                 $key = strtolower($key);
             }
 
@@ -73,7 +73,7 @@ class SimpleXMLElement extends \SimpleXMLElement
                     $arguments[$key] = new Reference((string) $arg['id'], $invalidBehavior, $strict);
                     break;
                 case 'collection':
-                    $arguments[$key] = $arg->getArgumentsAsPhp($name);
+                    $arguments[$key] = $arg->getArgumentsAsPhp($name, false);
                     break;
                 case 'string':
                     $arguments[$key] = (string) $arg;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services2.xml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services2.xml
@@ -24,5 +24,8 @@
       </parameter>
     </parameter>
     <parameter key="foo_bar" type="service" id="foo_bar" />
+    <parameter key="MixedCase" type="collection"> <!-- Shoud be lower cased -->
+      <parameter key="MixedCaseKey">value</parameter> <!-- Shoud stay mixed case -->
+    </parameter>
   </parameters>
 </container>

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
@@ -84,7 +84,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services2.xml');
 
         $actual = $container->getParameterBag()->all();
-        $expected = array('a string', 'foo' => 'bar', 'values' => array(0, 'integer' => 4, 100 => null, 'true', true, false, 'on', 'off', 'float' => 1.3, 1000.3, 'a string', array('foo', 'bar')), 'foo_bar' => new Reference('foo_bar'));
+        $expected = array('a string', 'foo' => 'bar', 'values' => array(0, 'integer' => 4, 100 => null, 'true', true, false, 'on', 'off', 'float' => 1.3, 1000.3, 'a string', array('foo', 'bar')), 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'));
 
         $this->assertEquals($expected, $actual, '->load() converts XML values to PHP ones');
     }
@@ -101,7 +101,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services4.xml');
 
         $actual = $container->getParameterBag()->all();
-        $expected = array('a string', 'foo' => 'bar', 'values' => array(true, false), 'foo_bar' => new Reference('foo_bar'), 'bar' => '%foo%', 'imported_from_ini' => true, 'imported_from_yaml' => true);
+        $expected = array('a string', 'foo' => 'bar', 'values' => array(true, false), 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'bar' => '%foo%', 'imported_from_ini' => true, 'imported_from_yaml' => true);
 
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
     }


### PR DESCRIPTION
```
<parameters>
    <parameter key="amazon.mws.config" type="collection">
        <parameter key="ServiceURL">https://mws.amazonservices.com</parameter>
    </parameter>
    <!-- other entries trimmed to keep it short -->
</parameters>


<services>
    <service id="amazon.mws.client.connection" class="MarketplaceWebService_Client" public="true">
        <argument>%amazon.aws.api_key%</argument>
        <argument>%amazon.aws.api_secret%</argument>
        <argument>%amazon.mws.config%</argument>
        <argument>%amazon.mws.application_name%</argument>
        <argument>%amazon.mws.application_version%</argument>
        <argument>%amazon.mws.useragent%</argument>
    </service>
</services>
```

Results in a broken client, because $config['ServiceURL'](mixed case key) was not defined.  It does
have a $config['serviceurl'](lower case key), which does no good.
The MarketplaceWebService_Client does not have a public setServiceUrl method,
so it must be passed in via the constructor.

The contents of the pull request feel a bit like a kludge, but it allows use of 3rd party libraries that don't follow the 'lowercase keys only' rule currently Symfony's DIC has.
