### PR TITLE
reset arguments array in phpdumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -118,6 +118,7 @@ EOF;
         foreach ($this->container->getInterfaceInjectors() as $injector) {
             $code .= sprintf("        if (\$instance instanceof \\%s) {\n", $injector->getClass());
             foreach ($injector->getMethodCalls() as $call) {
+                $arguments = array();
                 foreach ($call[1] as $value) {
                     $arguments[] = $this->dumpValue($value);
                 }


### PR DESCRIPTION
At the moment the arguments array is not reset after iterating over a interface. This makes the method call arguments stack up which might lead to unexpected results. This commit fixes it by resetting the array.
