### PR TITLE
Php globals

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -15,6 +15,7 @@
         <parameter key="templating.helper.code.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper</parameter>
         <parameter key="templating.helper.translator.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\TranslatorHelper</parameter>
         <parameter key="templating.helper.form.class">Symfony\Bundle\FrameworkBundle\Templating\Helper\FormHelper</parameter>
+        <parameter key="templating.globals.class">Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables</parameter>
     </parameters>
 
     <services>
@@ -70,6 +71,10 @@
         <service id="templating.helper.form" class="%templating.helper.form.class%">
             <tag name="templating.helper" alias="form" />
             <argument type="service" id="templating.engine.php" />
+        </service>
+
+        <service id="templating.globals" class="%templating.globals.class%">
+            <argument type="service" id="service_container" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -23,6 +23,7 @@
             <argument type="service" id="templating.name_parser" />
             <argument type="service" id="service_container" />
             <argument type="service" id="templating.loader" />
+            <argument type="service" id="templating.globals" />
             <call method="setCharset"><argument>%kernel.charset%</argument></call>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\TwigBundle;
+namespace Symfony\Bundle\FrameworkBundle\Templating;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
@@ -33,11 +33,12 @@ class PhpEngine extends BasePhpEngine implements EngineInterface
      * @param ContainerInterface          $container The DI container
      * @param LoaderInterface             $loader    A loader instance
      */
-    public function __construct(TemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader)
+    public function __construct(TemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader, GlobalVariables $globals)
     {
         $this->container = $container;
 
         parent::__construct($parser, $loader);
+        $this->addGlobal('app', $globals);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
+
+use Symfony\Bundle\FrameworkBundle\Templating\PhpEngine;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
+use Symfony\Component\Templating\TemplateNameParser;
+use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+
+class PhpEngineTest extends TestCase
+{
+    public function testEvaluateAddsAppGlobal()
+    {
+        $container = $this->getContainer();
+        $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
+        $engine = new PhpEngine(new TemplateNameParser(), $container, $loader, $app = new GlobalVariables($container));
+        $globals = $engine->getGlobals();
+        $this->assertSame($app, $globals['app']);
+    }
+
+    public function testEvaluateWithoutAvailableRequest()
+    {
+        $container = new Container();
+        $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
+        $engine = new PhpEngine(new TemplateNameParser(), $container, $loader, $app = new GlobalVariables($container));
+
+        $container->set('request', null);
+
+        $globals = $engine->getGlobals();
+        $this->assertEmpty($globals['app']->getRequest());
+    }
+
+    /**
+     * Creates a Container with a Session-containing Request service.
+     *
+     * @return Container
+     */
+    protected function getContainer()
+    {
+        $container = new Container();
+        $request = new Request();
+        $session = new Session(new ArraySessionStorage());
+
+        $request->setSession($session);
+        $container->set('request', $request);
+
+        return $container;
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -7,7 +7,6 @@
     <parameters>
         <parameter key="twig.class">Twig_Environment</parameter>
         <parameter key="twig.loader.class">Symfony\Bundle\TwigBundle\Loader\FilesystemLoader</parameter>
-        <parameter key="twig.globals.class">Symfony\Bundle\TwigBundle\GlobalVariables</parameter>
         <parameter key="templating.engine.twig.class">Symfony\Bundle\TwigBundle\TwigEngine</parameter>
         <parameter key="templating.cache_warmer.templates_cache.class">Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheCacheWarmer</parameter>
     </parameters>
@@ -30,11 +29,7 @@
         <service id="templating.engine.twig" class="%templating.engine.twig.class%" public="false">
             <argument type="service" id="twig" />
             <argument type="service" id="templating.name_parser" />
-            <argument type="service" id="twig.globals" />
-        </service>
-
-        <service id="twig.globals" class="%twig.globals.class%">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="templating.globals" />
         </service>
 
         <service id="twig.extension.trans" class="Symfony\Bundle\TwigBundle\Extension\TransExtension" public="false">

--- a/src/Symfony/Bundle/TwigBundle/Tests/TwigEngineTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TwigEngineTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
 use Symfony\Component\Templating\TemplateNameParser;
-use Symfony\Bundle\TwigBundle\GlobalVariables;
+use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 
 class TwigEngineTest extends TestCase
 {

--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\TwigBundle;
 
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\DependencyInjection\ContainerInterface;


### PR DESCRIPTION
This adds the `app` global variable in PHP templates as there is currently no way the current user in PHP templates for instance.
This makes https://github.com/symfony/symfony/pull/290 useless and is a cleaner way.
