### PR TITLE
Swift logging

### DIFF
--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/Configuration.php
@@ -27,9 +27,10 @@ class Configuration
     /**
      * Generates the configuration tree.
      *
+     * @param Boolean $kernelDebug
      * @return \Symfony\Component\Config\Definition\NodeInterface
      */
-    public function getConfigTree()
+    public function getConfigTree($kernelDebug)
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('swiftmailer', 'array');
@@ -66,7 +67,7 @@ class Configuration
             ->end()
             ->scalarNode('delivery_address')->end()
             ->booleanNode('disable_delivery')->end()
-            ->booleanNode('logging')->defaultValue(false)->end()
+            ->booleanNode('logging')->defaultValue($kernelDebug)->end()
         ;
 
         return $treeBuilder->buildTree();

--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -50,7 +50,7 @@ class SwiftmailerExtension extends Extension
 
         $configuration = new Configuration();
         $processor = new Processor();
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $processor->process($configuration->getConfigTree($container->getParameter('kernel.debug')), $configs);
 
         if (null === $config['transport']) {
             $transport = 'null';

--- a/src/Symfony/Bundle/SwiftmailerBundle/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -20,6 +20,7 @@ class SwiftmailerExtensionTest extends TestCase
     public function testConfigLoad()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
         $loader = new SwiftmailerExtension();
 
         $loader->load(array(array()), $container);
@@ -37,6 +38,7 @@ class SwiftmailerExtensionTest extends TestCase
     public function testSpool()
     {
         $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
         $loader = new SwiftmailerExtension();
 
         $loader->load(array(array('spool' => array())), $container);


### PR DESCRIPTION
This changes the default value of the logging to kernel.debug to be consistent with Doctrine bundles where the logging is activated by default in debug mode.
