### PR TITLE
[DependencyInjection] Php dumper typo fix

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -409,7 +409,7 @@ EOF;
         }
 
         if (!$this->container->isFrozen() && count($this->container->getInterfaceInjectors()) > 0) {
-            $calls = sprintf("\n        \$this->applyInterfaceInjectors(\$%s);\n", $variableName);
+            $calls .= sprintf("\n        \$this->applyInterfaceInjectors(\$%s);\n", $variableName);
         }
 
         return $calls;


### PR DESCRIPTION
fixed typo in addServiceMethodCalls() 
when using interface injectors it broke the code and removed all &lt;call&gt;ed methods from output.

was:
    $calls = sprintf("\n        \$this->applyInterfaceInjectors(\$%s);\n", $variableName);

changed to:
    $calls .= sprintf("\n        \$this->applyInterfaceInjectors(\$%s);\n", $variableName);
