### PR TITLE
[HttpKernel] added UploadedFile subclass for functional tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -136,7 +136,7 @@ class UploadedFile extends File
         if (!$this->moved) {
             $newPath = $directory . DIRECTORY_SEPARATOR . $filename;
 
-            if (!move_uploaded_file($this->getPath(), $newPath)) {
+            if (!$this->moveUploadedFile($newPath)) {
                 throw new FileException(sprintf('Could not move file %s to %s', $this->getPath(), $newPath));
             }
 
@@ -145,6 +145,18 @@ class UploadedFile extends File
         } else {
             parent::doMove($directory, $filename);
         }
+    }
+
+    /**
+     * Moves an uploaded file.
+     *
+     * @param string $newPath Where to move the file to
+     *
+     * @return Boolean Whether the move was successful
+     */
+    protected function moveUploadedFile($newPath)
+    {
+        return move_uploaded_file($this->getPath(), $newPath);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel;
 
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Test\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\BrowserKit\Client as BaseClient;
 use Symfony\Component\BrowserKit\Request as DomRequest;
@@ -95,7 +96,11 @@ EOF;
      */
     protected function filterRequest(DomRequest $request)
     {
-        return Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
+        $httpRequest = Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
+
+        $httpRequest->files->replace($this->filterFiles($httpRequest->files->all()));
+
+        return $httpRequest;
     }
 
     /**
@@ -108,5 +113,23 @@ EOF;
     protected function filterResponse($response)
     {
         return new DomResponse($response->getContent(), $response->getStatusCode(), $response->headers->all());
+    }
+
+    /**
+     * Filters files and replaces them with uploaded file classes compatible with functional tests.
+     *
+     * @param array $files An array of files
+     *
+     * @return array The filtered array
+     */
+    protected function filterFiles(array $files)
+    {
+        $filtered = array();
+
+        foreach ($files as $key => $value) {
+            $filtered[$key] = is_array($value) ? $this->filterFiles($value) : UploadedFile::wrap($value);
+        }
+
+        return $filtered;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Test/UploadedFile.php
+++ b/src/Symfony/Component/HttpKernel/Test/UploadedFile.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Test;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile as BaseUploadedFile;
+
+/**
+ * An uploaded file class the avoids PHP's native uploaded file checks.
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+class UploadedFile extends BaseUploadedFile
+{
+    /**
+     * Creates a new file with values from another.
+     *
+     * @param BaseUploadedFile $file An uploaded file
+     *
+     * @return UploadedFile A new uploaded file
+     */
+    static public function wrap(BaseUploadedFile $file)
+    {
+        return new static($file->getPath(), $file->getName(), $file->getMimeType(), $file->size(), $file->getError());
+    }
+
+    /**
+     * Assumes this isn't actually an uploaded file and moves it anyway.
+     */
+    protected function moveUploadedFile($newPath)
+    {
+        return rename($this->getPath(), $newPath);
+    }
+}


### PR DESCRIPTION
The current version of `UploadedFile` is not compatible with functional testing because it relies on PHP's `move_uploaded_file()` function. When you uploaded a file from a functional test, PHP sees that it was not uploaded via POST and refuses to move it.

This patch moves the PHP function into a protected method and creates a subclass of `UploadedFile` for functional tests that uses `rename()` instead. The file objects themselves are replaced in the HttpKernel `Client` class' `filterRequest()` method.
