### PR TITLE
fixed functional test + file upload issues

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -55,13 +55,21 @@ class FileFormField extends FormField
         if (null !== $value && is_readable($value)) {
             $error = UPLOAD_ERR_OK;
             $size = filesize($value);
+            $name = basename($value);
+
+            // copy to a tmp location
+            $tmp = tempnam(sys_get_temp_dir(), 'upload');
+            unlink($tmp);
+            copy($value, $tmp);
+            $value = $tmp;
         } else {
             $error = UPLOAD_ERR_NO_FILE;
             $size = 0;
+            $name = '';
             $value = '';
         }
 
-        $this->value = array('name' => basename($value), 'type' => '', 'tmp_name' => $value, 'error' => $error, 'size' => $size);
+        $this->value = array('name' => $name, 'type' => '', 'tmp_name' => $value, 'error' => $error, 'size' => $size);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -136,7 +136,7 @@ class UploadedFile extends File
         if (!$this->moved) {
             $newPath = $directory . DIRECTORY_SEPARATOR . $filename;
 
-            if (!move_uploaded_file($this->getPath(), $newPath)) {
+            if (!$this->moveUploadedFile($newPath)) {
                 throw new FileException(sprintf('Could not move file %s to %s', $this->getPath(), $newPath));
             }
 
@@ -145,6 +145,18 @@ class UploadedFile extends File
         } else {
             parent::doMove($directory, $filename);
         }
+    }
+
+    /**
+     * Moves an uploaded file.
+     *
+     * @param string $newPath Where to move the file to
+     *
+     * @return Boolean Whether the move was successful
+     */
+    protected function moveUploadedFile($newPath)
+    {
+        return move_uploaded_file($this->getPath(), $newPath);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Test/UploadedFile.php
+++ b/src/Symfony/Component/HttpKernel/Test/UploadedFile.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Test;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile as BaseUploadedFile;
+
+/**
+ * An uploaded file class the avoids PHP's native uploaded file checks.
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+class UploadedFile extends BaseUploadedFile
+{
+    /**
+     * Creates a new file with values from another.
+     *
+     * @param BaseUploadedFile $file An uploaded file
+     *
+     * @return UploadedFile A new uploaded file
+     */
+    static public function wrap(BaseUploadedFile $file)
+    {
+        return new static($file->getPath(), $file->getName(), $file->getMimeType(), $file->size(), $file->getError());
+    }
+
+    /**
+     * Assumes this isn't actually an uploaded file and moves it anyway.
+     */
+    protected function moveUploadedFile($newPath)
+    {
+        return rename($this->getPath(), $newPath);
+    }
+}

--- a/tests/Symfony/Tests/Component/DomCrawler/Field/FileFormFieldTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/Field/FileFormFieldTest.php
@@ -41,28 +41,33 @@ class FileFormFieldTest extends FormFieldTestCase
         }
     }
 
-    public function testSetValue()
+    /**
+     * @dataProvider getSetValueMethods
+     */
+    public function testSetValue($method)
     {
         $node = $this->createNode('input', '', array('type' => 'file'));
         $field = new FileFormField($node);
 
-        $field->setValue(null);
-        $this->assertEquals(array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => UPLOAD_ERR_NO_FILE, 'size' => 0), $field->getValue(), '->setValue() clears the uploaded file if the value is null');
+        $field->$method(null);
+        $this->assertEquals(array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => UPLOAD_ERR_NO_FILE, 'size' => 0), $field->getValue(), "->$method() clears the uploaded file if the value is null");
 
-        $field->setValue(__FILE__);
-        $this->assertEquals(array('name' => 'FileFormFieldTest.php', 'type' => '', 'tmp_name' => __FILE__, 'error' => 0, 'size' => filesize(__FILE__)), $field->getValue(), '->setValue() sets the value to the given file');
+        $field->$method(__FILE__);
+        $value = $field->getValue();
+
+        $this->assertEquals(basename(__FILE__), $value['name'], "->$method() sets the name of the file field");
+        $this->assertEquals('', $value['type'], "->$method() sets the type of the file field");
+        $this->assertInternalType('string', $value['tmp_name'], "->$method() sets the tmp_name of the file field");
+        $this->assertEquals(0, $value['error'], "->$method() sets the error of the file field");
+        $this->assertEquals(filesize(__FILE__), $value['size'], "->$method() sets the size of the file field");
     }
 
-    public function testUpload()
+    public function getSetValueMethods()
     {
-        $node = $this->createNode('input', '', array('type' => 'file'));
-        $field = new FileFormField($node);
-
-        $field->upload(null);
-        $this->assertEquals(array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => UPLOAD_ERR_NO_FILE, 'size' => 0), $field->getValue(), '->upload() clears the uploaded file if the value is null');
-
-        $field->upload(__FILE__);
-        $this->assertEquals(array('name' => 'FileFormFieldTest.php', 'type' => '', 'tmp_name' => __FILE__, 'error' => 0, 'size' => filesize(__FILE__)), $field->getValue(), '->upload() sets the value to the given file');
+        return array(
+            array('setValue'),
+            array('upload'),
+        );
     }
 
     public function testSetErrorCode()


### PR DESCRIPTION
This fixes issues the prevent testing file uploads in functional tests. I've added a subclass of `UploadedFile` that doesn't use `move_uploaded_file()` and also updated the DomCrawler's upload logic to copy the source file to a temporary location to better emulate the behavior of an actual upload.
