### PR TITLE
[Console] Moved message formatting routines into separate object

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -1,0 +1,223 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Formatter;
+
+/**
+ * Formatter class for console output.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class OutputFormatter implements OutputFormatterInterface
+{
+    private $decorated;
+    private $styles = array();
+
+    /**
+     * Initializes console output formatter.
+     *
+     * @param   boolean $decorated  Whether this formatter should actually decorate strings
+     * @param   array   $styles     Array of "name => FormatterStyle" instance
+     */
+    public function __construct($decorated = null, array $styles = array())
+    {
+        $this->decorated = (Boolean) $decorated;
+
+        $this->setStyle('error',    new OutputFormatterStyle('white', 'red'));
+        $this->setStyle('info',     new OutputFormatterStyle('green'));
+        $this->setStyle('comment',  new OutputFormatterStyle('yellow'));
+        $this->setStyle('question', new OutputFormatterStyle('black', 'cyan'));
+
+        foreach ($styles as $name => $style) {
+            $this->setStyle($name, $style);
+        }
+    }
+
+    /**
+     * Sets the decorated flag.
+     *
+     * @param Boolean $decorated Whether to decorated the messages or not
+     */
+    public function setDecorated($decorated)
+    {
+        $this->decorated = (Boolean) $decorated;
+    }
+
+    /**
+     * Gets the decorated flag.
+     *
+     * @return Boolean true if the output will decorate messages, false otherwise
+     */
+    public function isDecorated()
+    {
+        return $this->decorated;
+    }
+
+    /**
+     * Sets a new style.
+     *
+     * @param   string                          $name     The style name
+     * @param   OutputFormatterStyleInterface   $options  The style instance
+     */
+    public function setStyle($name, OutputFormatterStyleInterface $style)
+    {
+        $this->styles[strtolower($name)] = $style;
+    }
+
+    /**
+     * Checks if output formatter has style with specified name.
+     *
+     * @param   string  $name
+     *
+     * @return  boolean
+     */
+    public function hasStyle($name)
+    {
+        return isset($this->styles[strtolower($name)]);
+    }
+
+    /**
+     * Gets style options from style with specified name.
+     *
+     * @param   string  $name
+     *
+     * @return  OutputFormatterStyleInterface
+     */
+    public function getStyle($name)
+    {
+        if (!$this->hasStyle($name)) {
+            throw new \InvalidArgumentException('Undefined style: ' . $name);
+        }
+
+        return $this->styles[strtolower($name)];
+    }
+
+    /**
+     * Formats a message according to the given styles.
+     *
+     * @param  string $message The message to style
+     *
+     * @return string The styled message
+     */
+    public function format($message)
+    {
+        $message = preg_replace_callback(
+            $this->getBeginStyleRegex(), array($this, 'replaceBeginStyle'), $message
+        );
+
+        return preg_replace_callback(
+            $this->getEndStyleRegex(), array($this, 'replaceEndStyle'), $message
+        );
+    }
+
+    /**
+     * Gets regex for a style start.
+     *
+     * @return  string
+     */
+    protected function getBeginStyleRegex()
+    {
+        return '#<([a-z][a-z0-9\-_=;]+)>#i';
+    }
+
+    /**
+     * Gets regex for a style end.
+     *
+     * @return  string
+     */
+    protected function getEndStyleRegex()
+    {
+        return '#</([a-z][a-z0-9\-_]*)?>#i';
+    }
+
+    /**
+     * Replaces the starting style of the output.
+     *
+     * @param array $match
+     *
+     * @return string The replaced style
+     *
+     * @throws \InvalidArgumentException When style is unknown
+     */
+    private function replaceBeginStyle($match)
+    {
+        if (!$this->isDecorated()) {
+            return '';
+        }
+
+        if (isset($this->styles[strtolower($match[1])])) {
+            $style = $this->styles[strtolower($match[1])];
+        } else {
+            $style = $this->createStyleFromString($match[1]);
+
+            if (false === $style) {
+                return $match[0];
+            }
+        }
+
+        return $style->getBeginStyle();
+    }
+
+    /**
+     * Replaces the end style.
+     *
+     * @param string $match The text to match
+     *
+     * @return string The end style
+     */
+    private function replaceEndStyle($match)
+    {
+        if (!$this->isDecorated()) {
+            return '';
+        }
+
+        if ('style' == $match[1]) {
+            $style = new OutputFormatterStyle();
+        } else {
+            if (!isset($this->styles[strtolower($match[1])])) {
+                return $match[0];
+            }
+
+            $style = $this->styles[strtolower($match[1])];
+        }
+
+        return $style->getEndStyle();
+    }
+
+    /**
+     * Tryes to create new style instance from string.
+     *
+     * @param   string  $string
+     *
+     * @return  Symfony\Component\Console\Format\FormatterStyle|boolean false if string is not format string
+     */
+    private function createStyleFromString($string)
+    {
+        if (!preg_match_all('/([^=]+)=([^;]+)(;|$)/', strtolower($string), $matches, PREG_SET_ORDER)) {
+            return false;
+        }
+
+        $style = new OutputFormatterStyle();
+        foreach ($matches as $match) {
+            array_shift($match);
+
+            if ('fg' == $match[0]) {
+                $style->setForeground($match[1]);
+            } elseif ('bg' == $match[0]) {
+                $style->setBackground($match[1]);
+            } else {
+                $style->setOption($match[1]);
+            }
+        }
+
+        return $style;
+    }
+}

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Formatter;
+
+/**
+ * Formatter interface for console output.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+interface OutputFormatterInterface
+{
+    /**
+     * Sets the decorated flag.
+     *
+     * @param Boolean $decorated Whether to decorated the messages or not
+     */
+    function setDecorated($decorated);
+
+    /**
+     * Gets the decorated flag.
+     *
+     * @return Boolean true if the output will decorate messages, false otherwise
+     */
+    function isDecorated();
+
+    /**
+     * Sets a new style.
+     *
+     * @param   string                          $name     The style name
+     * @param   OutputFormatterStyleInterface   $options  The style instance
+     */
+    function setStyle($name, OutputFormatterStyleInterface $style);
+
+    /**
+     * Checks if output formatter has style with specified name.
+     *
+     * @param   string  $name
+     *
+     * @return  boolean
+     */
+    function hasStyle($name);
+
+    /**
+     * Gets style options from style with specified name.
+     *
+     * @param   string  $name
+     *
+     * @return  OutputFormatterStyleInterface
+     */
+    function getStyle($name);
+
+    /**
+     * Formats a message according to the given styles.
+     *
+     * @param  string $message The message to style
+     *
+     * @return string The styled message
+     */
+    function format($message);
+}

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Formatter;
+
+/**
+ * Formatter style class for defining styles.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+class OutputFormatterStyle implements OutputFormatterStyleInterface
+{
+    static private $availableForegroundColors = array(
+        'black'     => 30,
+        'red'       => 31,
+        'green'     => 32,
+        'yellow'    => 33,
+        'blue'      => 34,
+        'magenta'   => 35,
+        'cyan'      => 36,
+        'white'     => 37
+    );
+    static private $availableBackgroundColors = array(
+        'black'     => 40,
+        'red'       => 41,
+        'green'     => 42,
+        'yellow'    => 43,
+        'blue'      => 44,
+        'magenta'   => 45,
+        'cyan'      => 46,
+        'white'     => 47
+    );
+    static private $availableOptions = array(
+        'bold'          => 1,
+        'underscore'    => 4,
+        'blink'         => 5,
+        'reverse'       => 7,
+        'conceal'       => 8
+    );
+
+    private $foreground;
+    private $background;
+    private $options = array();
+
+    /**
+     * Initializes output formatter style.
+     *
+     * @param   string  $foreground     style foreground color name
+     * @param   string  $background     style background color name
+     * @param   array   $options        style options
+     */
+    public function __construct($foreground = null, $background = null, array $options = array())
+    {
+        if (null !== $foreground) {
+            $this->setForeground($foreground);
+        }
+        if (null !== $background) {
+            $this->setBackground($background);
+        }
+        if (count($options)) {
+            $this->setOptions($options);
+        }
+    }
+
+    /**
+     * Sets style foreground color.
+     *
+     * @param   string  $color  color name
+     */
+    public function setForeground($color = null)
+    {
+        if (null === $color) {
+            $this->foreground = null;
+
+            return;
+        }
+
+        if (!isset(static::$availableForegroundColors[$color])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid foreground color specified: "%s". Expected one of (%s)',
+                $color,
+                implode(', ', array_keys(static::$availableForegroundColors))
+            ));
+        }
+
+        $this->foreground = static::$availableForegroundColors[$color];
+    }
+
+    /**
+     * Sets style background color.
+     *
+     * @param   string  $color  color name
+     */
+    public function setBackground($color = null)
+    {
+        if (null === $color) {
+            $this->background = null;
+
+            return;
+        }
+
+        if (!isset(static::$availableBackgroundColors[$color])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid background color specified: "%s". Expected one of (%s)',
+                $color,
+                implode(', ', array_keys(static::$availableBackgroundColors))
+            ));
+        }
+
+        $this->background = static::$availableBackgroundColors[$color];
+    }
+
+    /**
+     * Sets some specific style option.
+     *
+     * @param   string  $option     option name
+     */
+    public function setOption($option)
+    {
+        if (!isset(static::$availableOptions[$option])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid option specified: "%s". Expected one of (%s)',
+                $option,
+                implode(', ', array_keys(static::$availableOptions))
+            ));
+        }
+
+        if (false === array_search(static::$availableOptions[$option], $this->options)) {
+            $this->options[] = static::$availableOptions[$option];
+        }
+    }
+
+    /**
+     * Unsets some specific style option.
+     *
+     * @param   string  $option     option name
+     */
+    public function unsetOption($option)
+    {
+        if (!isset(static::$availableOptions[$option])) {
+            throw new \InvalidArgumentException(sprintf(
+                'Invalid option specified: "%s". Expected one of (%s)',
+                $option,
+                implode(', ', array_keys(static::$availableOptions))
+            ));
+        }
+
+        $pos = array_search(static::$availableOptions[$option], $this->options);
+        if (false !== $pos) {
+            unset($this->options[$pos]);
+        }
+    }
+
+    /**
+     * Set multiple style options at once.
+     *
+     * @param   array   $options
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = array();
+
+        foreach ($options as $option) {
+            $this->setOption($option);
+        }
+    }
+
+    /**
+     * Returns begin style code.
+     *
+     * @return  string
+     */
+    public function getBeginStyle()
+    {
+        $codes = array();
+
+        if (null !== $this->foreground) {
+            $codes[] = $this->foreground;
+        }
+        if (null !== $this->background) {
+            $codes[] = $this->background;
+        }
+        if (count($this->options)) {
+            $codes = array_merge($codes, $this->options);
+        }
+
+        return "\033[" . implode(';', $codes) . 'm';
+    }
+
+    /**
+     * Returns end style code.
+     *
+     * @return  string
+     */
+    public function getEndStyle()
+    {
+        return "\033[0m";
+    }
+}

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Formatter;
+
+/**
+ * Formatter style interface for defining styles.
+ *
+ * @author Konstantin Kudryashov <ever.zet@gmail.com>
+ */
+interface OutputFormatterStyleInterface
+{
+    /**
+     * Sets style foreground color.
+     *
+     * @param   string  $color  color name
+     */
+    function setForeground($color = null);
+
+    /**
+     * Sets style background color.
+     *
+     * @param   string  $color  color name
+     */
+    function setBackground($color = null);
+
+    /**
+     * Sets some specific style option.
+     *
+     * @param   string  $option     option name
+     */
+    function setOption($option);
+
+    /**
+     * Unsets some specific style option.
+     *
+     * @param   string  $option     option name
+     */
+    function unsetOption($option);
+
+    /**
+     * Set multiple style options at once.
+     *
+     * @param   array   $options
+     */
+    function setOptions(array $options);
+
+    /**
+     * Returns begin style code.
+     *
+     * @return  string
+     */
+    function getBeginStyle();
+
+    /**
+     * Returns end style code.
+     *
+     * @return  string
+     */
+    function getEndStyle();
+}

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Output;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
 /**
  * ConsoleOutput is the default class for all CLI output. It uses STDOUT.
  *
@@ -31,9 +33,11 @@ class ConsoleOutput extends StreamOutput
      *
      * @param integer $verbosity The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL, self::VERBOSITY_VERBOSE)
      * @param Boolean $decorated Whether to decorate messages or not (null for auto-guessing)
+     * @param OutputFormatter   $formatter  Output formatter instance
      */
-    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null,
+                                OutputFormatter $formatter = null)
     {
-        parent::__construct(fopen('php://stdout', 'w'), $verbosity, $decorated);
+        parent::__construct(fopen('php://stdout', 'w'), $verbosity, $decorated, $formatter);
     }
 }

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -35,8 +35,7 @@ class ConsoleOutput extends StreamOutput
      * @param Boolean $decorated Whether to decorate messages or not (null for auto-guessing)
      * @param OutputFormatter   $formatter  Output formatter instance
      */
-    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null,
-                                OutputFormatter $formatter = null)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatter $formatter = null)
     {
         parent::__construct(fopen('php://stdout', 'w'), $verbosity, $decorated, $formatter);
     }

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -35,8 +35,8 @@ abstract class Output implements OutputInterface
     const OUTPUT_RAW = 1;
     const OUTPUT_PLAIN = 2;
 
-    protected $verbosity;
-    protected $formatter;
+    private $verbosity;
+    private $formatter;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -45,8 +45,7 @@ abstract class Output implements OutputInterface
      * @param Boolean                   $decorated  Whether to decorate messages or not (null for auto-guessing)
      * @param OutputFormatterInterface  $formatter  Output formatter instance
      */
-    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null,
-                                OutputFormatterInterface $formatter = null)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatterInterface $formatter = null)
     {
         if (null === $formatter) {
             $formatter = new OutputFormatter();

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Console\Output;
 
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
 /**
  * Base class for output classes.
  *
@@ -33,55 +36,45 @@ abstract class Output implements OutputInterface
     const OUTPUT_PLAIN = 2;
 
     protected $verbosity;
-    protected $decorated;
-
-    static private $styles = array(
-        'error'    => array('bg' => 'red', 'fg' => 'white'),
-        'info'     => array('fg' => 'green'),
-        'comment'  => array('fg' => 'yellow'),
-        'question' => array('bg' => 'cyan', 'fg' => 'black'),
-    );
-    static private $options    = array('bold' => 1, 'underscore' => 4, 'blink' => 5, 'reverse' => 7, 'conceal' => 8);
-    static private $foreground = array('black' => 30, 'red' => 31, 'green' => 32, 'yellow' => 33, 'blue' => 34, 'magenta' => 35, 'cyan' => 36, 'white' => 37);
-    static private $background = array('black' => 40, 'red' => 41, 'green' => 42, 'yellow' => 43, 'blue' => 44, 'magenta' => 45, 'cyan' => 46, 'white' => 47);
+    protected $formatter;
 
     /**
      * Constructor.
      *
-     * @param integer $verbosity The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL, self::VERBOSITY_VERBOSE)
-     * @param Boolean $decorated Whether to decorate messages or not (null for auto-guessing)
+     * @param integer                   $verbosity  The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL, self::VERBOSITY_VERBOSE)
+     * @param Boolean                   $decorated  Whether to decorate messages or not (null for auto-guessing)
+     * @param OutputFormatterInterface  $formatter  Output formatter instance
      */
-    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null)
+    public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null,
+                                OutputFormatterInterface $formatter = null)
     {
-        $this->decorated = (Boolean) $decorated;
-        $this->verbosity = null === $verbosity ? self::VERBOSITY_NORMAL : $verbosity;
-    }
-
-    /**
-     * Sets a new style.
-     *
-     * @param string $name    The style name
-     * @param array  $options An array of options
-     */
-    static public function setStyle($name, $options = array())
-    {
-        self::$styles[strtolower($name)] = $options;
-    }
-
-    /**
-     * Gets style options from style with specified name.
-     *
-     * @param   string  $name
-     *
-     * @return  array
-     */
-    static public function getStyle($name)
-    {
-        if (!isset(self::$styles[strtolower($name)])) {
-            throw new \InvalidArgumentException('Undefined style: ' . $name);
+        if (null === $formatter) {
+            $formatter = new OutputFormatter();
         }
 
-        return self::$styles[strtolower($name)];
+        $this->verbosity = null === $verbosity ? self::VERBOSITY_NORMAL : $verbosity;
+        $this->formatter = $formatter;
+        $this->formatter->setDecorated((Boolean) $decorated);
+    }
+
+    /**
+     * Sets output formatter.
+     *
+     * @param   OutputFormatterInterface    $formatter
+     */
+    public function setFormatter(OutputFormatterInterface $formatter)
+    {
+        $this->formatter = $formatter;
+    }
+
+    /**
+     * Returns current output formatter instance.
+     *
+     * @return  OutputFormatterInterface
+     */
+    public function getFormatter()
+    {
+        return $this->formatter;
     }
 
     /**
@@ -91,7 +84,7 @@ abstract class Output implements OutputInterface
      */
     public function setDecorated($decorated)
     {
-        $this->decorated = (Boolean) $decorated;
+        $this->formatter->setDecorated((Boolean) $decorated);
     }
 
     /**
@@ -101,7 +94,7 @@ abstract class Output implements OutputInterface
      */
     public function isDecorated()
     {
-        return $this->decorated;
+        return $this->formatter->isDecorated();
     }
 
     /**
@@ -157,12 +150,12 @@ abstract class Output implements OutputInterface
         foreach ($messages as $message) {
             switch ($type) {
                 case Output::OUTPUT_NORMAL:
-                    $message = $this->format($message);
+                    $message = $this->formatter->format($message);
                     break;
                 case Output::OUTPUT_RAW:
                     break;
                 case Output::OUTPUT_PLAIN:
-                    $message = strip_tags($this->format($message));
+                    $message = strip_tags($this->formatter->format($message));
                     break;
                 default:
                     throw new \InvalidArgumentException(sprintf('Unknown output type given (%s)', $type));
@@ -179,106 +172,4 @@ abstract class Output implements OutputInterface
      * @param Boolean $newline Whether to add a newline or not
      */
     abstract public function doWrite($message, $newline);
-
-    /**
-     * Gets regex for a style start.
-     *
-     * @return  string
-     */
-    protected function getBeginStyleRegex()
-    {
-        return '#<([a-z][a-z0-9\-_=;]+)>#i';
-    }
-
-    /**
-     * Gets regex for a style end.
-     *
-     * @return  string
-     */
-    protected function getEndStyleRegex()
-    {
-        return '#</([a-z][a-z0-9\-_]*)?>#i';
-    }
-
-    /**
-     * Formats a message according to the given styles.
-     *
-     * @param  string $message The message to style
-     *
-     * @return string The styled message
-     */
-    protected function format($message)
-    {
-        $message = preg_replace_callback($this->getBeginStyleRegex(), array($this, 'replaceBeginStyle'), $message);
-
-        return preg_replace_callback($this->getEndStyleRegex(), array($this, 'replaceEndStyle'), $message);
-    }
-
-    /**
-     * Replaces the starting style of the output.
-     *
-     * @param array $match
-     *
-     * @return string The replaced style
-     *
-     * @throws \InvalidArgumentException When style is unknown
-     */
-    private function replaceBeginStyle($match)
-    {
-        if (!$this->decorated) {
-            return '';
-        }
-
-        if (isset(self::$styles[strtolower($match[1])])) {
-            $parameters = self::$styles[strtolower($match[1])];
-        } else {
-            // bg=blue;fg=red
-            if (!preg_match_all('/([^=]+)=([^;]+)(;|$)/', strtolower($match[1]), $matches, PREG_SET_ORDER)) {
-                return $match[0];
-            }
-
-            $parameters = array();
-            foreach ($matches as $match) {
-                $parameters[$match[1]] = $match[2];
-            }
-        }
-
-        $codes = array();
-
-        if (isset($parameters['fg'])) {
-            $codes[] = self::$foreground[$parameters['fg']];
-        }
-
-        if (isset($parameters['bg'])) {
-            $codes[] = self::$background[$parameters['bg']];
-        }
-
-        foreach (self::$options as $option => $value) {
-            if (isset($parameters[$option]) && $parameters[$option]) {
-                $codes[] = $value;
-            }
-        }
-
-        return "\033[".implode(';', $codes).'m';
-    }
-
-    /**
-     * Replaces the end style.
-     *
-     * @param string $match The text to match
-     *
-     * @return string The end style
-     */
-    private function replaceEndStyle($match)
-    {
-        if (!isset(self::$styles[strtolower($match[1])])) {
-            return $match[0];
-        }
-
-        if (!$this->decorated) {
-            return '';
-        }
-
-        return "\033[0m";
-    }
 }

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Output;
 
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+
 /**
  * OutputInterface is the interface implemented by all Output classes.
  *
@@ -50,4 +52,18 @@ interface OutputInterface
      * @param Boolean $decorated Whether to decorated the messages or not
      */
     function setDecorated($decorated);
+
+    /**
+     * Sets output formatter.
+     *
+     * @param   OutputFormatterInterface    $formatter
+     */
+    function setFormatter(OutputFormatterInterface $formatter);
+
+    /**
+     * Returns current output formatter instance.
+     *
+     * @return  OutputFormatterInterface
+     */
+    function getFormatter();
 }

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -40,8 +40,7 @@ class StreamOutput extends Output
      *
      * @throws \InvalidArgumentException When first argument is not a real stream
      */
-    public function __construct($stream, $verbosity = self::VERBOSITY_NORMAL, $decorated = null,
-                                OutputFormatter $formatter = null)
+    public function __construct($stream, $verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatter $formatter = null)
     {
         if (!is_resource($stream) || 'stream' !== get_resource_type($stream)) {
             throw new \InvalidArgumentException('The StreamOutput class needs a stream as its first argument.');

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Output;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
 /**
  * StreamOutput writes the output to a given stream.
  *
@@ -34,10 +36,12 @@ class StreamOutput extends Output
      * @param mixed   $stream    A stream resource
      * @param integer $verbosity The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL, self::VERBOSITY_VERBOSE)
      * @param Boolean $decorated Whether to decorate messages or not (null for auto-guessing)
+     * @param OutputFormatter   $formatter  Output formatter instance
      *
      * @throws \InvalidArgumentException When first argument is not a real stream
      */
-    public function __construct($stream, $verbosity = self::VERBOSITY_NORMAL, $decorated = null)
+    public function __construct($stream, $verbosity = self::VERBOSITY_NORMAL, $decorated = null,
+                                OutputFormatter $formatter = null)
     {
         if (!is_resource($stream) || 'stream' !== get_resource_type($stream)) {
             throw new \InvalidArgumentException('The StreamOutput class needs a stream as its first argument.');
@@ -49,7 +53,7 @@ class StreamOutput extends Output
             $decorated = $this->hasColorSupport($decorated);
         }
 
-        parent::__construct($verbosity, $decorated);
+        parent::__construct($verbosity, $decorated, $formatter);
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterStyleTest.php
+++ b/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterStyleTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Console\Formatter;
+
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructor()
+    {
+        $style = new OutputFormatterStyle('green', 'black', array('bold', 'underscore'));
+
+        $this->assertEquals("\033[32;40;1;4m", $style->getBeginStyle());
+        $this->assertEquals("\033[0m", $style->getEndStyle());
+
+        $style = new OutputFormatterStyle('red', null, array('blink'));
+
+        $this->assertEquals("\033[31;5m", $style->getBeginStyle());
+        $this->assertEquals("\033[0m", $style->getEndStyle());
+
+        $style = new OutputFormatterStyle(null, 'white');
+
+        $this->assertEquals("\033[47m", $style->getBeginStyle());
+        $this->assertEquals("\033[0m", $style->getEndStyle());
+    }
+
+    public function testForeground()
+    {
+        $style = new OutputFormatterStyle();
+
+        $style->setForeground('black');
+
+        $this->assertEquals("\033[30m", $style->getBeginStyle());
+        $this->assertEquals("\033[0m", $style->getEndStyle());
+
+        $style->setForeground('blue');
+
+        $this->assertEquals("\033[34m", $style->getBeginStyle());
+        $this->assertEquals("\033[0m", $style->getEndStyle());
+
+        $this->setExpectedException('InvalidArgumentException');
+
+        $style->setForeground('undefined-color');
+    }
+
+    public function testBackground()
+    {
+        $style = new OutputFormatterStyle();
+
+        $style->setBackground('black');
+
+        $this->assertEquals("\033[40m", $style->getBeginStyle());
+        $this->assertEquals("\033[0m", $style->getEndStyle());
+
+        $style->setBackground('yellow');
+
+        $this->assertEquals("\033[43m", $style->getBeginStyle());
+
+        $this->setExpectedException('InvalidArgumentException');
+
+        $style->setBackground('undefined-color');
+    }
+
+    public function testOptions()
+    {
+        $style = new OutputFormatterStyle();
+
+        $style->setOptions(array('reverse', 'conceal'));
+
+        $this->assertEquals("\033[7;8m", $style->getBeginStyle());
+
+        $style->setOption('bold');
+
+        $this->assertEquals("\033[7;8;1m", $style->getBeginStyle());
+
+        $style->unsetOption('reverse');
+
+        $this->assertEquals("\033[8;1m", $style->getBeginStyle());
+
+        $style->setOption('bold');
+
+        $this->assertEquals("\033[8;1m", $style->getBeginStyle());
+
+        $style->setOptions(array('bold'));
+
+        $this->assertEquals("\033[1m", $style->getBeginStyle());
+    }
+}

--- a/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Console\Formatter;
+
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+class FormatterStyleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testBundledStyles()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $this->assertTrue($formatter->hasStyle('error'));
+        $this->assertTrue($formatter->hasStyle('info'));
+        $this->assertTrue($formatter->hasStyle('comment'));
+        $this->assertTrue($formatter->hasStyle('question'));
+
+        $this->assertEquals(
+            "\033[37;41msome error\033[0m", $formatter->format('<error>some error</error>')
+        );
+        $this->assertEquals(
+            "\033[32msome info\033[0m", $formatter->format('<info>some info</info>')
+        );
+        $this->assertEquals(
+            "\033[33msome comment\033[0m", $formatter->format('<comment>some comment</comment>')
+        );
+        $this->assertEquals(
+            "\033[30;46msome question\033[0m", $formatter->format('<question>some question</question>')
+        );
+    }
+
+    public function testNewStyle()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $style = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterStyleInterface')
+            ->getMock();
+        $formatter->setStyle('test', $style);
+
+        $this->assertEquals($style, $formatter->getStyle('test'));
+        $this->assertNotEquals($style, $formatter->getStyle('info'));
+
+        $style
+            ->expects($this->once())
+            ->method('getBeginStyle')
+            ->will($this->returnValue('[STYLE_BEG]'));
+
+        $style
+            ->expects($this->once())
+            ->method('getEndStyle')
+            ->will($this->returnValue('[STYLE_END]'));
+
+        $this->assertEquals(
+            "[STYLE_BEG]some custom msg[STYLE_END]", $formatter->format('<test>some custom msg</test>')
+        );
+    }
+
+    public function testRedefineStyle()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $style = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterStyleInterface')
+            ->getMock();
+        $formatter->setStyle('info', $style);
+
+        $style
+            ->expects($this->once())
+            ->method('getBeginStyle')
+            ->will($this->returnValue('[STYLE_BEG]'));
+
+        $style
+            ->expects($this->once())
+            ->method('getEndStyle')
+            ->will($this->returnValue('[STYLE_END]'));
+
+        $this->assertEquals(
+            "[STYLE_BEG]some custom msg[STYLE_END]", $formatter->format('<info>some custom msg</info>')
+        );
+    }
+
+    public function testInlineStyle()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $this->assertEquals(
+            "\033[34;41msome text\033[0m", $formatter->format('<fg=blue;bg=red>some text</style>')
+        );
+    }
+
+    public function testNotDecoratedFormatter()
+    {
+        $formatter = new OutputFormatter(false);
+
+        $this->assertTrue($formatter->hasStyle('error'));
+        $this->assertTrue($formatter->hasStyle('info'));
+        $this->assertTrue($formatter->hasStyle('comment'));
+        $this->assertTrue($formatter->hasStyle('question'));
+
+        $this->assertEquals(
+            "some error", $formatter->format('<error>some error</error>')
+        );
+        $this->assertEquals(
+            "some info", $formatter->format('<info>some info</info>')
+        );
+        $this->assertEquals(
+            "some comment", $formatter->format('<comment>some comment</comment>')
+        );
+        $this->assertEquals(
+            "some question", $formatter->format('<question>some question</question>')
+        );
+
+        $formatter->setDecorated(true);
+
+        $this->assertEquals(
+            "\033[37;41msome error\033[0m", $formatter->format('<error>some error</error>')
+        );
+        $this->assertEquals(
+            "\033[32msome info\033[0m", $formatter->format('<info>some info</info>')
+        );
+        $this->assertEquals(
+            "\033[33msome comment\033[0m", $formatter->format('<comment>some comment</comment>')
+        );
+        $this->assertEquals(
+            "\033[30;46msome question\033[0m", $formatter->format('<question>some question</question>')
+        );
+    }
+}

--- a/tests/Symfony/Tests/Component/Console/Output/OutputTest.php
+++ b/tests/Symfony/Tests/Component/Console/Output/OutputTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Tests\Component\Console\Output;
 
 use Symfony\Component\Console\Output\Output;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
 class OutputTest extends \PHPUnit_Framework_TestCase
 {
@@ -36,20 +37,9 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(Output::VERBOSITY_QUIET, $output->getVerbosity(), '->setVerbosity() sets the verbosity');
     }
 
-    public function testSetStyle()
-    {
-        Output::setStyle('FOO', array('bg' => 'red', 'fg' => 'yellow', 'blink' => true));
-
-        $r = new \ReflectionClass('Symfony\Component\Console\Output\Output');
-        $p = $r->getProperty('styles');
-        $p->setAccessible(true);
-        $styles = $p->getValue(null);
-
-        $this->assertEquals(array('bg' => 'red', 'fg' => 'yellow', 'blink' => true), $styles['foo'], '::setStyle() sets a new style');
-    }
-
     public function testWrite()
     {
+        $fooStyle = new OutputFormatterStyle('yellow', 'red', array('blink'));
         $output = new TestOutput(Output::VERBOSITY_QUIET);
         $output->writeln('foo');
         $this->assertEquals('', $output->output, '->writeln() outputs nothing if verbosity is set to VERBOSITY_QUIET');
@@ -72,6 +62,7 @@ class OutputTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("foo\n", $output->output, '->writeln() strips decoration tags if decoration is set to false');
 
         $output = new TestOutput();
+        $output->getFormatter()->setStyle('FOO', $fooStyle);
         $output->setDecorated(true);
         $output->writeln('<foo>foo</foo>');
         $this->assertEquals("\033[33;41;5mfoo\033[0m\n", $output->output, '->writeln() decorates the output');


### PR DESCRIPTION
Splitted actual Console Output class into 3 different logical objects:
1. `OutputFormatterStyle`
2. `OutputFormatter`
3. `Output`

First 2 is for formatter configuration and message decoration. Third is actual output writer. This change eliminates all privatisation problems and makes output logic much cleaner

I know, we don't accept BC breaks from now on. But i've tried hard to not add BC breaks with this really helpful update. It would be very cool for Symfony2, Behat, and other project's developers if you could merge this.
