### PR TITLE
Doctrine mapping configuration

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -135,7 +135,6 @@ class Configuration
                 ->fixXmlConfig('mapping')
                 ->arrayNode('mappings')
                     ->isRequired()
-                    ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
                         ->beforeNormalization()


### PR DESCRIPTION
It should be possible to define an entity_manager with an empty mappings set.

Actually it is not possible to do this:

```
    orm:
        auto_generate_proxy_classes: %kernel.debug%
        default_entity_manager: default
        entity_managers:
            default:
                mappings: []
```
