### PR TITLE
file upload fixes

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -55,13 +55,21 @@ class FileFormField extends FormField
         if (null !== $value && is_readable($value)) {
             $error = UPLOAD_ERR_OK;
             $size = filesize($value);
+            $name = basename($value);
+
+            // copy to a tmp location
+            $tmp = tempnam(sys_get_temp_dir(), 'upload');
+            unlink($tmp);
+            copy($value, $tmp);
+            $value = $tmp;
         } else {
             $error = UPLOAD_ERR_NO_FILE;
             $size = 0;
+            $name = '';
             $value = '';
         }
 
-        $this->value = array('name' => basename($value), 'type' => '', 'tmp_name' => $value, 'error' => $error, 'size' => $size);
+        $this->value = array('name' => $name, 'type' => '', 'tmp_name' => $value, 'error' => $error, 'size' => $size);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -16,14 +16,15 @@ use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser;
 
 /**
- * A file in the file system
+ * A file in the file system.
  *
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
  */
 class File
 {
     /**
-     * Assignment of mime types to their default extensions
+     * A map of mime types and their default extensions.
+     *
      * @var array
      */
     static protected $defaultExtensions = array(
@@ -440,33 +441,35 @@ class File
     );
 
     /**
-     * Stores the absolute path to the document root directory
+     * Stores the absolute path to the document root directory.
+     *
      * @var string
      */
     static protected $documentRoot;
 
     /**
-     * The absolute path to the file without dots
+     * The absolute path to the file without dots.
+     *
      * @var string
      */
     protected $path;
 
     /**
-     * Sets the path t the document root directory
+     * Sets the path to the document root directory.
      *
      * @param string $documentRoot
      */
     static public function setDocumentRoot($documentRoot)
     {
         if (!is_dir($documentRoot)) {
-            throw new \LogicException($documentRoot . ' is no directory');
+            throw new \LogicException($documentRoot . ' is not a directory.');
         }
 
         self::$documentRoot = realpath($documentRoot);
     }
 
     /**
-     * Returns the path to the document root directory
+     * Returns the path to the document root directory.
      *
      * @return string
      */
@@ -478,8 +481,9 @@ class File
     /**
      * Constructs a new file from the given path.
      *
-     * @param  string $path           The path to the file
-     * @throws FileNotFoundException  If the given path is no file
+     * @param string $path The path to the file
+     *
+     * @throws FileNotFoundException If the given path is not a file
      */
     public function __construct($path)
     {
@@ -491,7 +495,7 @@ class File
     }
 
     /**
-     * Alias for getPath()
+     * Alias for getPath().
      *
      * @return string
      */
@@ -501,7 +505,7 @@ class File
     }
 
     /**
-     * Returns the file name
+     * Returns the file name.
      *
      * @return string
      */
@@ -511,13 +515,13 @@ class File
     }
 
     /**
-     * Returns the file extension (with dot)
+     * Returns the file extension (with dot).
      *
      * @return string
      */
     public function getExtension()
     {
-        if ($ext = pathinfo($this->getName(), \PATHINFO_EXTENSION)) {
+        if ($ext = pathinfo($this->getName(), PATHINFO_EXTENSION)) {
             return '.' . $ext;
         }
 
@@ -525,7 +529,7 @@ class File
     }
 
     /**
-     * Returns the extension based on the mime type (with dot)
+     * Returns the extension based on the mime type (with dot).
      *
      * If the mime type is unknown, the actual extension is returned instead.
      *
@@ -543,7 +547,7 @@ class File
     }
 
     /**
-     * Returns the directory of the file
+     * Returns the directory of the file.
      *
      * @return string
      */
@@ -553,9 +557,9 @@ class File
     }
 
     /**
-     * Returns the absolute file path without dots
+     * Returns the absolute file path, without dots.
      *
-     * @returns string  The file path
+     * @return string
      */
     public function getPath()
     {
@@ -563,19 +567,19 @@ class File
     }
 
     /**
-     * Returns the path relative to the document root
+     * Returns the path relative to the document root.
      *
      * You can set the document root using the static method setDocumentRoot().
      * If the file is outside of the document root, this method returns an
      * empty string.
      *
-     * @return string  The relative file path
+     * @return string The relative file path
      */
     public function getWebPath()
     {
         $root = self::$documentRoot;
 
-        if (strpos($this->path, $root) === false) {
+        if (false === strpos($this->path, $root)) {
             return '';
         }
 
@@ -589,7 +593,7 @@ class File
      * and the system binary "file" (in this order), depending on which of those
      * is available on the current operating system.
      *
-     * @returns string  The guessed mime type, e.g. "application/pdf"
+     * @return string The guessed mime type (i.e. "application/pdf")
      */
     public function getMimeType()
     {
@@ -599,14 +603,15 @@ class File
     }
 
     /**
-     * Returns the size of this file
+     * Returns the size of this file.
      *
-     * @return integer  The file size in bytes
+     * @return integer The file size in bytes
      */
-    public function size()
+    public function getSize()
     {
-        if (false === ($size = @filesize($this->getPath()))) {
-            throw new FileException(sprintf('Could not read file size of %s', $this->getPath()));
+        if (false === $size = @filesize($this->getPath())) {
+            $error = error_get_last();
+            throw new FileException(sprintf('Could not read file size of %s (%s)', $this->getPath(), $error['message']));
         }
 
         return $size;
@@ -615,16 +620,18 @@ class File
     /**
      * Moves the file to a new directory and gives it a new filename
      *
-     * @param  string $directory   The new directory
-     * @param  string $filename    The new file name
-     * @throws FileException       When the file could not be moved
+     * @param string $directory The new directory
+     * @param string $filename  The new file name
+     *
+     * @throws FileException When the file could not be moved
      */
     protected function doMove($directory, $filename)
     {
         $newPath = $directory . DIRECTORY_SEPARATOR . $filename;
 
         if (!@rename($this->getPath(), $newPath)) {
-            throw new FileException(sprintf('Could not move file %s to %s', $this->getPath(), $newPath));
+            $error = error_get_last();
+            throw new FileException(sprintf('Could not move file %s to %s (%s)', $this->getPath(), $newPath, $error['message']));
         }
 
         $this->path = realpath($newPath);
@@ -633,8 +640,8 @@ class File
     /**
      * Moves the file to a new location.
      *
-     * @param string $directory   The destination folder
-     * @param string $name        The new file name
+     * @param string $directory The destination folder
+     * @param string $name      The new file name
      */
     public function move($directory, $name = null)
     {
@@ -646,9 +653,9 @@ class File
     }
 
     /**
-     * Renames the file
+     * Renames the file.
      *
-     * @param string $name  The new file name
+     * @param string $name The new file name
      */
     public function rename($name)
     {

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -12,78 +12,80 @@
 namespace Symfony\Component\HttpFoundation\File;
 
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
 
 /**
  * A file uploaded through a form.
  *
- * @author     Bernhard Schussek <bernhard.schussek@symfony.com>
- * @author     Florian Eckerstorfer <florian@eckerstorfer.org>
+ * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Florian Eckerstorfer <florian@eckerstorfer.org>
  */
 class UploadedFile extends File
 {
     /**
-     * The original name of the uploaded file
+     * The original name of the uploaded file.
+     *
      * @var string
      */
     protected $originalName;
 
     /**
-     * The mime type provided by the uploader
+     * The mime type provided by the uploader.
+     *
      * @var string
      */
     protected $mimeType;
 
     /**
-     * The file size provided by the uploader
+     * The file size provided by the uploader.
+     *
      * @var integer
      */
     protected $size;
 
     /**
-     * The UPLOAD_ERR_XXX constant provided by the uploader
+     * The UPLOAD_ERR_XXX constant provided by the uploader.
+     *
      * @var integer
      */
     protected $error;
 
     /**
-     * Whether the uploaded file has already been moved
-     * @var boolean
+     * Whether the uploaded file has already been moved.
+     *
+     * @var Boolean
      */
-    protected $moved = false;
+    protected $moved;
 
     /**
-     * Accepts the information of the uploaded file as provided by the PHP
-     * global $_FILES.
+     * Accepts the information of the uploaded file as provided by the PHP global $_FILES.
      *
-     * @param string  $tmpName  The full temporary path to the file
-     * @param string  $name     The original file name
-     * @param string  $type     The type of the file as provided by PHP
-     * @param integer $size     The file size
-     * @param string  $error    The error constant of the upload. Should be
-     *                          one of PHP's UPLOAD_ERR_XXX constants.
+     * @param string  $path         The full temporary path to the file
+     * @param string  $originalName The original file name
+     * @param string  $mimeType     The type of the file as provided by PHP
+     * @param integer $size         The file size
+     * @param integer $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
+     * @param Boolean $moved        Whether the file has been moved from its original location
+     *
+     * @throws FileException         If file_uploads is disabled
+     * @throws FileNotFoundException If the file does not exist
      */
-    public function __construct($path, $originalName, $mimeType, $size, $error)
+    public function __construct($path, $originalName, $mimeType, $size, $error, $moved = false)
     {
         if (!ini_get('file_uploads')) {
             throw new FileException(sprintf('Unable to create UploadedFile because "file_uploads" is disabled in your php.ini file (%s)', get_cfg_var('cfg_file_path')));
         }
 
-        if (is_file($path)) {
-            $this->path = realpath($path);
+        if (!is_file($path)) {
+            throw new FileNotFoundException($path);
         }
 
-        if (null === $error) {
-            $error = UPLOAD_ERR_OK;
-        }
-
-        if (null === $mimeType) {
-            $mimeType = 'application/octet-stream';
-        }
-
-        $this->originalName = (string)$originalName;
-        $this->mimeType = $mimeType;
+        $this->path = realpath($path);
+        $this->originalName = $originalName;
+        $this->mimeType = $mimeType ?: 'application/octet-stream';
         $this->size = $size;
-        $this->error = $error;
+        $this->error = $error ?: UPLOAD_ERR_OK;
+        $this->moved = (Boolean) $moved;
     }
 
     /**
@@ -91,28 +93,25 @@ class UploadedFile extends File
      */
     public function getMimeType()
     {
-        $mimeType = parent::getMimeType();
-
-        if (null === $mimeType) {
-            $mimeType = $this->mimeType;
-        }
-
-        return $mimeType;
+        return parent::getMimeType() ?: $this->mimeType;
     }
 
     /**
-     * Returns the absolute file name without dots
+     * @inheritDoc
+     */
+    public function getSize()
+    {
+        return null === $this->size ? parent::getSize() : $this->size;
+    }
+
+    /**
+     * Returns the absolute file name without dots.
      *
-     * Until the uploaded file is moved, it will return the name of the temporary file
-     *
-     * @returns string  The file path
+     * @return string The file path
      */
     public function getName()
     {
-        if (!$this->moved) {
-            return $this->originalName;
-        }
-        return parent::getName();
+        return $this->moved ? parent::getName() : $this->originalName;
     }
 
     /**
@@ -121,7 +120,7 @@ class UploadedFile extends File
      * If the upload was successful, the constant UPLOAD_ERR_OK is returned.
      * Otherwise one of the other UPLOAD_ERR_XXX constants is returned.
      *
-     * @returns integer  The upload error
+     * @return integer The upload error
      */
     public function getError()
     {
@@ -133,18 +132,18 @@ class UploadedFile extends File
      */
     protected function doMove($directory, $filename)
     {
-        if (!$this->moved) {
-            $newPath = $directory . DIRECTORY_SEPARATOR . $filename;
-
-            if (!move_uploaded_file($this->getPath(), $newPath)) {
-                throw new FileException(sprintf('Could not move file %s to %s', $this->getPath(), $newPath));
-            }
-
-            $this->moved = true;
-            $this->path = realpath($newPath);
-        } else {
-            parent::doMove($directory, $filename);
+        if ($this->moved) {
+            return parent::doMove($directory, $filename);
         }
+
+        $newPath = $directory . DIRECTORY_SEPARATOR . $filename;
+
+        if (!move_uploaded_file($this->getPath(), $newPath)) {
+            throw new FileException(sprintf('Could not move file %s to %s', $this->getPath(), $newPath));
+        }
+
+        $this->moved = true;
+        $this->path = realpath($newPath);
     }
 
     /**
@@ -152,14 +151,14 @@ class UploadedFile extends File
      */
     public function move($directory, $name = null)
     {
-        if (!$this->moved) {
-            $this->doMove($directory, $this->originalName);
+        if ($this->moved) {
+            return parent::move($directory, $name);
+        }
 
-            if (null !== $name) {
-                $this->rename($name);
-            }
-        } else {
-            parent::move($directory, $name);
+        $this->doMove($directory, $this->originalName);
+
+        if (null !== $name) {
+            $this->rename($name);
         }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  */
 class FileBag extends ParameterBag
 {
-    private $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
+    static private $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
 
     /**
      * Constructor.
@@ -77,24 +77,23 @@ class FileBag extends ParameterBag
         if ($file instanceof UploadedFile) {
             return $file;
         }
+
         $file = $this->fixPhpFilesArray($file);
         if (is_array($file)) {
             $keys = array_keys($file);
             sort($keys);
-            if ($keys == $this->fileKeys) {
-                $file['error'] = (int) $file['error'];
-            }
-            if ($keys != $this->fileKeys) {
-                $file = array_map(array($this, 'convertFileInformation'), $file);
-            } else {
-                if ($file['error'] === UPLOAD_ERR_NO_FILE) {
+
+            if ($keys == self::$fileKeys) {
+                if (UPLOAD_ERR_NO_FILE == $file['error']) {
                     $file = null;
                 } else {
-                    $file = new UploadedFile($file['tmp_name'], $file['name'],
-                    $file['type'], $file['size'], $file['error']);
+                    $file = new UploadedFile($file['tmp_name'], $file['name'], $file['type'], $file['size'], $file['error']);
                 }
+            } else {
+                $file = array_map(array($this, 'convertFileInformation'), $file);
             }
         }
+
         return $file;
     }
 
@@ -115,19 +114,22 @@ class FileBag extends ParameterBag
      */
     protected function fixPhpFilesArray($data)
     {
-        if (! is_array($data)) {
+        if (!is_array($data)) {
             return $data;
         }
+
         $keys = array_keys($data);
         sort($keys);
-        if ($this->fileKeys != $keys || ! isset($data['name']) ||
-         ! is_array($data['name'])) {
+
+        if (self::$fileKeys != $keys || !isset($data['name']) || !is_array($data['name'])) {
             return $data;
         }
+
         $files = $data;
-        foreach ($this->fileKeys as $k) {
+        foreach (self::$fileKeys as $k) {
             unset($files[$k]);
         }
+
         foreach (array_keys($data['name']) as $key) {
             $files[$key] = $this->fixPhpFilesArray(array(
                 'error'    => $data['error'][$key],
@@ -136,6 +138,7 @@ class FileBag extends ParameterBag
                 'size'     => $data['size'][$key]
             ));
         }
+
         return $files;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel;
 
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\BrowserKit\Client as BaseClient;
 use Symfony\Component\BrowserKit\Request as DomRequest;
@@ -95,7 +96,38 @@ EOF;
      */
     protected function filterRequest(DomRequest $request)
     {
-        return Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
+        $httpRequest = Request::create($request->getUri(), $request->getMethod(), $request->getParameters(), $request->getCookies(), $request->getFiles(), $request->getServer(), $request->getContent());
+
+        $httpRequest->files->replace($this->filterFiles($httpRequest->files->all()));
+
+        return $httpRequest;
+    }
+
+    /**
+     * Filters an array of files.
+     *
+     * This method marks all uploaded files as already moved thus avoiding
+     * UploadedFile's call to move_uploaded_file(), which would otherwise fail.
+     *
+     * @param array $files An array of files
+     *
+     * @return array An array with all uploaded files marked as already moved
+     */
+    protected function filterFiles(array $files)
+    {
+        $filtered = array();
+        foreach ($files as $key => $value) {
+            if (is_array($value)) {
+                $filtered[$key] = $this->filterFiles($value);
+            } elseif ($value instanceof UploadedFile) {
+                // create an already-moved uploaded file
+                $filtered[$key] = new UploadedFile($value->getPath(), $value->getName(), $value->getMimeType(), $value->getSize(), $value->getError(), true);
+            } else {
+                $filtered[$key] = $value;
+            }
+        }
+
+        return $filtered;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/DomCrawler/Field/FileFormFieldTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/Field/FileFormFieldTest.php
@@ -41,28 +41,33 @@ class FileFormFieldTest extends FormFieldTestCase
         }
     }
 
-    public function testSetValue()
+    /**
+     * @dataProvider getSetValueMethods
+     */
+    public function testSetValue($method)
     {
         $node = $this->createNode('input', '', array('type' => 'file'));
         $field = new FileFormField($node);
 
-        $field->setValue(null);
-        $this->assertEquals(array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => UPLOAD_ERR_NO_FILE, 'size' => 0), $field->getValue(), '->setValue() clears the uploaded file if the value is null');
+        $field->$method(null);
+        $this->assertEquals(array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => UPLOAD_ERR_NO_FILE, 'size' => 0), $field->getValue(), "->$method() clears the uploaded file if the value is null");
 
-        $field->setValue(__FILE__);
-        $this->assertEquals(array('name' => 'FileFormFieldTest.php', 'type' => '', 'tmp_name' => __FILE__, 'error' => 0, 'size' => filesize(__FILE__)), $field->getValue(), '->setValue() sets the value to the given file');
+        $field->$method(__FILE__);
+        $value = $field->getValue();
+
+        $this->assertEquals(basename(__FILE__), $value['name'], "->$method() sets the name of the file field");
+        $this->assertEquals('', $value['type'], "->$method() sets the type of the file field");
+        $this->assertInternalType('string', $value['tmp_name'], "->$method() sets the tmp_name of the file field");
+        $this->assertEquals(0, $value['error'], "->$method() sets the error of the file field");
+        $this->assertEquals(filesize(__FILE__), $value['size'], "->$method() sets the size of the file field");
     }
 
-    public function testUpload()
+    public function getSetValueMethods()
     {
-        $node = $this->createNode('input', '', array('type' => 'file'));
-        $field = new FileFormField($node);
-
-        $field->upload(null);
-        $this->assertEquals(array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => UPLOAD_ERR_NO_FILE, 'size' => 0), $field->getValue(), '->upload() clears the uploaded file if the value is null');
-
-        $field->upload(__FILE__);
-        $this->assertEquals(array('name' => 'FileFormFieldTest.php', 'type' => '', 'tmp_name' => __FILE__, 'error' => 0, 'size' => filesize(__FILE__)), $field->getValue(), '->upload() sets the value to the given file');
+        return array(
+            array('setValue'),
+            array('upload'),
+        );
     }
 
     public function testSetErrorCode()

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -333,6 +333,9 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
     public function testBindReadsRequestData()
     {
+        $path = tempnam(sys_get_temp_dir(), 'sf2');
+        touch($path);
+
         $values = array(
             'author' => array(
                 'name' => 'Bernhard',
@@ -344,7 +347,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
                 'error' => array('image' => array('file' => UPLOAD_ERR_OK)),
                 'name' => array('image' => array('file' => 'upload.png')),
                 'size' => array('image' => array('file' => 123)),
-                'tmp_name' => array('image' => array('file' => 'abcdef.png')),
+                'tmp_name' => array('image' => array('file' => $path)),
                 'type' => array('image' => array('file' => 'image/png')),
             ),
         );
@@ -358,7 +361,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         $form->bind($this->createPostRequest($values, $files));
 
-        $file = new UploadedFile('abcdef.png', 'upload.png', 'image/png', 123, UPLOAD_ERR_OK);
+        $file = new UploadedFile($path, 'upload.png', 'image/png', 123, UPLOAD_ERR_OK);
 
         $this->assertEquals('Bernhard', $form['name']->getData());
         $this->assertEquals('foobar.png', $form['image']['filename']->getData());

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
@@ -111,11 +111,13 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     public function testSizeReturnsFileSize()
     {
-        $this->assertEquals(filesize($this->file->getPath()), $this->file->size());
+        $this->assertEquals(filesize($this->file->getPath()), $this->file->getSize());
     }
 
     public function testSizeFailing()
     {
+        $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\FileException');
+
         $dir = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'directory';
         $path = $dir.DIRECTORY_SEPARATOR.'test.copy.gif';
         @unlink($path);
@@ -123,10 +125,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
         $file = new File($path);
         @unlink($path);
-
-        $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\FileException');
-        $file->size($path);
-
+        $file->getSize();
     }
 
     public function testMove()

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
@@ -15,87 +15,64 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class UploadedFileTest extends \PHPUnit_Framework_TestCase
 {
-
-    public function testFileUploadsMustBeEnabled()
+    protected function setUp()
     {
-        // we can't change this setting without modifying php.ini :(
         if (!ini_get('file_uploads')) {
-            $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\FileException');
-
-            new UploadedFile(
-                __DIR__.'/Fixtures/test.gif',
-                'original.gif',
-                'image/gif',
-                filesize(__DIR__.'/Fixtures/test.gif'),
-                UPLOAD_ERR_OK
-            );
+            $this->markTestSkipped('file_uploads is disabled in php.ini');
         }
     }
 
     public function testFileUploadsWithNoMimeType()
     {
-        // we can't change this setting without modifying php.ini :(
-        if (ini_get('file_uploads')) {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            null,
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            UPLOAD_ERR_OK
+        );
 
-            $file = new UploadedFile(
-                __DIR__.'/Fixtures/test.gif',
-                'original.gif',
-                null,
-                filesize(__DIR__.'/Fixtures/test.gif'),
-                UPLOAD_ERR_OK
-            );
-
-            $this->assertAttributeEquals('application/octet-stream', 'mimeType', $file);
-            $this->assertEquals('image/gif', $file->getMimeType());
-        }
+        $this->assertAttributeEquals('application/octet-stream', 'mimeType', $file);
+        $this->assertEquals('image/gif', $file->getMimeType());
     }
 
     public function testFileUploadsWithUnknownMimeType()
     {
-        // we can't change this setting without modifying php.ini :(
-        if (ini_get('file_uploads')) {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/.unknownextension',
+            'original.gif',
+            null,
+            filesize(__DIR__.'/Fixtures/.unknownextension'),
+            UPLOAD_ERR_OK
+        );
 
-            $file = new UploadedFile(
-                __DIR__.'/Fixtures/.unknownextension',
-                'original.gif',
-                null,
-                filesize(__DIR__.'/Fixtures/.unknownextension'),
-                UPLOAD_ERR_OK
-            );
-
-            $this->assertAttributeEquals('application/octet-stream', 'mimeType', $file);
-            $this->assertEquals('application/octet-stream', $file->getMimeType());
-        }
+        $this->assertAttributeEquals('application/octet-stream', 'mimeType', $file);
+        $this->assertEquals('application/octet-stream', $file->getMimeType());
     }
 
     public function testErrorIsOkByDefault()
     {
-        // we can't change this setting without modifying php.ini :(
-        if (ini_get('file_uploads')) {
-            $file = new UploadedFile(
-                __DIR__.'/Fixtures/test.gif',
-                'original.gif',
-                'image/gif',
-                filesize(__DIR__.'/Fixtures/test.gif'),
-                null
-            );
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null
+        );
 
-            $this->assertEquals(UPLOAD_ERR_OK, $file->getError());
-        }
+        $this->assertEquals(UPLOAD_ERR_OK, $file->getError());
     }
+
     public function testGetOriginalName()
     {
-        // we can't change this setting without modifying php.ini :(
-        if (ini_get('file_uploads')) {
-            $file = new UploadedFile(
-                __DIR__.'/Fixtures/test.gif',
-                'original.gif',
-                'image/gif',
-                filesize(__DIR__.'/Fixtures/test.gif'),
-                null
-            );
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null
+        );
 
-            $this->assertEquals('original.gif', $file->getName());
-        }
+        $this->assertEquals('original.gif', $file->getName());
     }
 }


### PR DESCRIPTION
This patches touches a bunch of components, but the motivation is to make it possible to upload files in functional tests. This isn't possible in the current codebase because of our reliance on `move_uploaded_file()`. I've also cleaned up some coding standards and added an exception to the `UploadedFile` constructor if the file does not exist so it matches the parent method's behavior. I also renamed `File::size()` to `File::getSize()` -- not sure why it was named differently in the first place.
