### PR TITLE
[Security] Fixed some class variables. Some where unused, others not declared

### DIFF
--- a/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
@@ -23,14 +23,14 @@ interface AdvancedUserInterface extends UserInterface
      *
      * @return Boolean true if the user's account is non expired, false otherwise
      */
-    function isAccountNonExpired();
+    function isUserNonExpired();
 
     /**
      * Checks whether the user is locked.
      *
      * @return Boolean true if the user is not locked, false otherwise
      */
-    function isAccountNonLocked();
+    function isUserNonLocked();
 
     /**
      * Checks whether the user's credentials (password) has expired.

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -72,8 +72,8 @@ class InMemoryUserProvider implements UserProviderInterface
 
         $user = $this->users[strtolower($username)];
 
-        return new User($user->getUsername(), $user->getPassword(), $user->getRoles(), $user->isEnabled(), $user->isAccountNonExpired(),
-                $user->isCredentialsNonExpired(), $user->isAccountNonLocked());
+        return new User($user->getUsername(), $user->getPassword(), $user->getRoles(), $user->isEnabled(), $user->isUserNonExpired(),
+                $user->isCredentialsNonExpired(), $user->isUserNonLocked());
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -36,9 +36,9 @@ final class User implements AdvancedUserInterface
         $this->username = $username;
         $this->password = $password;
         $this->enabled = $enabled;
-        $this->accountNonExpired = $userNonExpired;
+        $this->userNonExpired = $userNonExpired;
         $this->credentialsNonExpired = $credentialsNonExpired;
-        $this->accountNonLocked = $userNonLocked;
+        $this->userNonLocked = $userNonLocked;
         $this->roles = $roles;
     }
 
@@ -79,7 +79,7 @@ final class User implements AdvancedUserInterface
      */
     public function isAccountNonExpired()
     {
-        return $this->accountNonExpired;
+        return $this->userNonExpired;
     }
 
     /**
@@ -87,7 +87,7 @@ final class User implements AdvancedUserInterface
      */
     public function isAccountNonLocked()
     {
-        return $this->accountNonLocked;
+        return $this->userNonLocked;
     }
 
     /**
@@ -134,11 +134,11 @@ final class User implements AdvancedUserInterface
             return false;
         }
 
-        if ($this->accountNonExpired !== $user->isAccountNonExpired()) {
+        if ($this->userNonExpired !== $user->isAccountNonExpired()) {
             return false;
         }
 
-        if ($this->accountNonLocked !== $user->isAccountNonLocked()) {
+        if ($this->userNonLocked !== $user->isAccountNonLocked()) {
             return false;
         }
 

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -77,7 +77,7 @@ final class User implements AdvancedUserInterface
     /**
      * {@inheritdoc}
      */
-    public function isAccountNonExpired()
+    public function isUserNonExpired()
     {
         return $this->userNonExpired;
     }
@@ -85,7 +85,7 @@ final class User implements AdvancedUserInterface
     /**
      * {@inheritdoc}
      */
-    public function isAccountNonLocked()
+    public function isUserNonLocked()
     {
         return $this->userNonLocked;
     }
@@ -134,11 +134,11 @@ final class User implements AdvancedUserInterface
             return false;
         }
 
-        if ($this->userNonExpired !== $user->isAccountNonExpired()) {
+        if ($this->userNonExpired !== $user->isUserNonExpired()) {
             return false;
         }
 
-        if ($this->userNonLocked !== $user->isAccountNonLocked()) {
+        if ($this->userNonLocked !== $user->isUserNonLocked()) {
             return false;
         }
 

--- a/src/Symfony/Component/Security/Core/User/UserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/UserChecker.php
@@ -46,7 +46,7 @@ class UserChecker implements UserCheckerInterface
             return;
         }
 
-        if (!$user->isAccountNonLocked()) {
+        if (!$user->isUserNonLocked()) {
             throw new LockedException('User account is locked.', $user);
         }
 
@@ -54,7 +54,7 @@ class UserChecker implements UserCheckerInterface
             throw new DisabledException('User account is disabled.', $user);
         }
 
-        if (!$user->isAccountNonExpired()) {
+        if (!$user->isUserNonExpired()) {
             throw new AccountExpiredException('User account has expired.', $user);
         }
     }

--- a/tests/Symfony/Tests/Component/Security/Core/User/AccountCheckerTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/User/AccountCheckerTest.php
@@ -57,9 +57,9 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker = new UserChecker();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isUserNonLocked')->will($this->returnValue(true));
         $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isUserNonExpired')->will($this->returnValue(true));
 
         $this->assertNull($checker->checkPostAuth($account));
     }
@@ -72,7 +72,7 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker = new UserChecker();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isUserNonLocked')->will($this->returnValue(false));
 
         $checker->checkPostAuth($account);
     }
@@ -85,7 +85,7 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker = new UserChecker();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isUserNonLocked')->will($this->returnValue(true));
         $account->expects($this->once())->method('isEnabled')->will($this->returnValue(false));
 
         $checker->checkPostAuth($account);
@@ -99,9 +99,9 @@ class UserCheckerTest extends \PHPUnit_Framework_TestCase
         $checker = new UserChecker();
 
         $account = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
-        $account->expects($this->once())->method('isAccountNonLocked')->will($this->returnValue(true));
+        $account->expects($this->once())->method('isUserNonLocked')->will($this->returnValue(true));
         $account->expects($this->once())->method('isEnabled')->will($this->returnValue(true));
-        $account->expects($this->once())->method('isAccountNonExpired')->will($this->returnValue(false));
+        $account->expects($this->once())->method('isUserNonExpired')->will($this->returnValue(false));
 
         $checker->checkPostAuth($account);
     }

--- a/tests/Symfony/Tests/Component/Security/Core/User/UserTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/User/UserTest.php
@@ -67,15 +67,15 @@ class UserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\Security\Core\User\User::isAccountNonExpired
+     * @covers Symfony\Component\Security\Core\User\User::isUserNonExpired
      */
     public function testIsAccountNonExpired()
     {
         $user = new User('fabien', 'superpass');
-        $this->assertTrue($user->isAccountNonExpired());
+        $this->assertTrue($user->isUserNonExpired());
 
         $user = new User('fabien', 'superpass', array(), true, false);
-        $this->assertFalse($user->isAccountNonExpired());
+        $this->assertFalse($user->isUserNonExpired());
     }
 
     /**
@@ -91,15 +91,15 @@ class UserTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\Security\Core\User\User::isAccountNonLocked
+     * @covers Symfony\Component\Security\Core\User\User::isUserNonLocked
      */
-    public function testIsAccountNonLocked()
+    public function testIsUserNonLocked()
     {
         $user = new User('fabien', 'superpass');
-        $this->assertTrue($user->isAccountNonLocked());
+        $this->assertTrue($user->isUserNonLocked());
 
         $user = new User('fabien', 'superpass', array(), true, true, true, false);
-        $this->assertFalse($user->isAccountNonLocked());
+        $this->assertFalse($user->isUserNonLocked());
     }
 
     /**


### PR DESCRIPTION
Fixed some class variables Core/User/User.php. Some where unused, others not declared in the class.
Probably went wrong when AccountingInterfaces where renames to UserInterfaces.
