### PR TITLE
[DoctrineBundle] Fixed Notice level error, undefined $emName in doctrine:mapping:import

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/ImportMappingDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/ImportMappingDoctrineCommand.php
@@ -77,6 +77,9 @@ EOT
         $em = $this->getEntityManager($this->container, $input->getOption('em'));
         $databaseDriver = new DatabaseDriver($em->getConnection()->getSchemaManager());
         $em->getConfiguration()->setMetadataDriverImpl($databaseDriver);
+        
+        $emName = $input->getOption('em');
+        $emName = $emName ? $emName : 'default';
 
         $cmf = new DisconnectedClassMetadataFactory();
         $cmf->setEntityManager($em);


### PR DESCRIPTION
When running app/console doctrine:mapping:import a notice level error was thrown because in DoctrineBundle/Command/ImportMappingDoctrineCommand.php $emName was not defined, and because of that the command line message was uncomplete.
