### PR TITLE
[Form] friendly token generation in FileField

### DIFF
--- a/src/Symfony/Component/Form/FileField.php
+++ b/src/Symfony/Component/Form/FileField.php
@@ -88,6 +88,11 @@ class FileField extends Form
                     throw new FormException('A PHP extension stopped the file upload (UPLOAD_ERR_EXTENSION)');
                 case UPLOAD_ERR_OK:
                 default:
+                    // generate a token in case a field was added via javascript without a token
+                    if (!isset($data['token']) || empty($data['token'])) {
+                        $data['token'] = rand(100000, 999999);
+                    }
+
                     $data['file']->move($this->getTmpDir());
                     $data['file']->rename($this->getTmpName($data['token']));
                     $data['original_name'] = $data['file']->getName();

--- a/tests/Symfony/Tests/Component/Form/FileFieldTest.php
+++ b/tests/Symfony/Tests/Component/Form/FileFieldTest.php
@@ -242,4 +242,18 @@ class FileFieldTest extends \PHPUnit_Framework_TestCase
             'original_name' => ''
         ));
     }
+
+    public function testSubmitGeneratesToken()
+    {
+        $file = $this->getMock('Symfony\Component\HttpFoundation\File\UploadedFile', array(), array(), '', false);
+
+        $this->field->submit(array(
+            'file' => $file,
+            'token' => '',
+            'original_name' => ''
+        ));
+
+        $data = $this->field->getDisplayedData();
+        $this->assertNotEmpty($data['token'], '->submit() generates a token when necessary');
+    }
 }


### PR DESCRIPTION
I've added automatic generation of a FileField token on submit to make it easier to create new file fields using Javascript. Otherwise a token has to be generated client-side using something like `Math.random()`.
