### PR TITLE
Fix doctrine events

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -32,7 +32,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
         );
 
         foreach ($subscribers as $id => $instances) {
-            $definition->addMethodCall('addSubscriber', array(new Reference($id)));
+            $definition->addMethodCall('addEventSubscriber', array(new Reference($id)));
         }
     }
 
@@ -52,7 +52,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
             }
 
             if (0 < count($events)) {
-                $definition->addMethodCall('addListener', array(
+                $definition->addMethodCall('addEventListener', array(
                     $events,
                     new Reference($listenerId),
                 ));


### PR DESCRIPTION
Fix fatal error ("Fatal error: Call to undefined method Doctrine\Common\EventManager::addSubscriber()") when there are some services with tag "doctrine.common.event_subscriber" or "doctrine.common.event_listener".

This issue can be reproduce by using "charset" option with mysql driver for an dbal connection.
