### PR TITLE
[HttpFoundation] Make sure Request::getLanguages always returns an array

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -725,6 +725,7 @@ class Request
         }
 
         $languages = $this->splitHttpAcceptHeader($this->headers->get('Accept-Language'));
+        $this->languages = array();
         foreach ($languages as $lang) {
             if (strstr($lang, '-')) {
                 $codes = explode('-', $lang);


### PR DESCRIPTION
Actually if the request has no language, `Request::getLanguages` returns `null`. It should return `array()` instead.
