### PR TITLE
[Routing] Throw an exception on unsupported config keys

### DIFF
--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -139,7 +139,7 @@ class YamlFileLoader extends FileLoader
         foreach ($config as $key => $value) {
             if (!in_array($key, self::$availableKeys)) {
                 throw new \InvalidArgumentException(sprintf(
-                    'Unsupported config key given: "%s". Expected one of the (%s).',
+                    'Yaml routing loader does not support given key: "%s". Expected one of the (%s).',
                     $key, implode(', ', self::$availableKeys)
                 ));
             }

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -24,6 +24,10 @@ use Symfony\Component\Config\Loader\FileLoader;
  */
 class YamlFileLoader extends FileLoader
 {
+    private static $availableKeys = array(
+        'type', 'resource', 'prefix', 'pattern', 'options', 'defaults', 'requirements'
+    );
+
     /**
      * Loads a Yaml file.
      *
@@ -54,6 +58,8 @@ class YamlFileLoader extends FileLoader
         }
 
         foreach ($config as $name => $config) {
+            $config = $this->normalizeRouteConfig($config);
+
             if (isset($config['resource'])) {
                 $type = isset($config['type']) ? $config['type'] : null;
                 $prefix = isset($config['prefix']) ? $config['prefix'] : null;
@@ -117,5 +123,28 @@ class YamlFileLoader extends FileLoader
     protected function loadFile($file)
     {
         return Yaml::load($file);
+    }
+
+    /**
+     * Normalize route configuration.
+     *
+     * @param array  $config A resource config
+     *
+     * @return array
+     *
+     * @throws InvalidArgumentException if one of the provided config keys is not supported
+     */
+    private function normalizeRouteConfig(array $config)
+    {
+        foreach ($config as $key => $value) {
+            if (!in_array($key, self::$availableKeys)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Unsupported config key given: "%s". Expected one of the (%s).',
+                    $key, implode(', ', self::$availableKeys)
+                ));
+            }
+        }
+
+        return $config;
     }
 }

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/nonvalidkeys.yml
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/nonvalidkeys.yml
@@ -1,0 +1,3 @@
+someroute:
+  resource: path/to/some.yml
+  name_prefix: test_

--- a/tests/Symfony/Tests/Component/Routing/Loader/YamlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Loader/YamlFileLoaderTest.php
@@ -51,4 +51,13 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
         $loader->load('nonvalid.yml');
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadThrowsExceptionIfArrayHasUnsupportedKeys()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $loader->load('nonvalidkeys.yml');
+    }
 }


### PR DESCRIPTION
Before this update, yml routing loader silently accept unsupported values in config, which can lead to users confusion on typos and other routing types use:

```
my_route:
    resource: some/routing/file.yml
    name_prefix: test_
```

This configuration doesn't tell user anything about it's actually wrong. After this PR it will throw `InvalidArgumentException`:

```
InvalidArgumentException: Yaml routing loader does not support given key: "name_prefix". Expected one of the (type, resource, prefix, pattern, options, defaults, requirements).
```
