### PR TITLE
Toolbar alignment

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -17,6 +17,7 @@
             width: 100%;
             border-top: 1px solid #bbb;
             font: 11px Verdana, Arial, sans-serif;
+            text-align: left;
             color: #2f2f2f;"
     {% endif %}
 >


### PR DESCRIPTION
Added an explicit text-align: left CSS rule for the Symfony toolbar as otherwise the alignment is inherited from the body element (and can get randomly changed to center/ right/ whatever).  I assume text-align: left is what's intended as that's the general browser default.
