### PR TITLE
[SwiftmailerBundle] Change twig if syntax in panel datacollector

### DIFF
--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/views/Collector/swiftmailer.html.twig
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/views/Collector/swiftmailer.html.twig
@@ -23,7 +23,7 @@
 {% endblock %}
 
 {% block panel %}
-    <h2>Messages {% if not collector.isSpool %} sent {% else %} spooled {% endif %}</h2>
+    <h2>Messages {{ collector.isSpool ? 'spooled' : 'sent' }}</h2>
 
     {% if not collector.messages %}
         <p>


### PR DESCRIPTION
To be consistent with twig (and with henrikbjorn opinion cf https://github.com/dator/symfony/commit/f8dead7782304cfb453c1344765bfd235bb7d05a#comments) , 
this is a new commit for my previous one that take care off the ternary operator in twig.
