### PR TITLE
[Security] Redirect to Referrer is broken when the favicon is missing on a fully secured site.

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -152,7 +152,10 @@ class ExceptionListener
 
         // session isn't required when using http basic authentification mechanism for example
         if ($request->hasSession()) {
-            $request->getSession()->set('_security.target_path', $request->getUri());
+            $uri = $request->getUri();
+            if (!preg_match('#/favicon\.ico(\?|$)#i', $uri)) {
+                $request->getSession()->set('_security.target_path', $uri);
+            }
         }
 
         return $this->authenticationEntryPoint->start($request, $authException);


### PR DESCRIPTION
it goes like:

```
GET / => you get a login form, browser fetches page components, among which:
GET /favicon.ico => 404 => htaccess throws it at Symfony => overrides the _security.target_path value
```

Which sucks.

Now if you create 404s "on purpose" in your page, this is maybe your own problem, but the favicon is requested by browsers even if it's not defined in the markup, so this is a specific case that is worth addressing in the framework imo.
