### PR TITLE
Fix DoctrineBundle "doctrine:generate:entities" entity filter

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -60,7 +60,7 @@ EOT
             $entityGenerator = $this->getEntityGenerator();
 
             foreach ($metadatas as $metadata) {
-                if ($filterEntity && $metadata->reflClass->getShortName() == $filterEntity) {
+                if ($filterEntity && $metadata->reflClass->getShortName() !== $filterEntity) {
                     continue;
                 }
 


### PR DESCRIPTION
The result of the command line is the opposite that it should be.

```
> doctrine:generate:entities "MyBundle" --entity="A"
```

=> generates all entities of the bundle except "A" instead of only "A".
