### PR TITLE
[DependencyInjection] PhpDumper fixed InterfaceInjection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -375,6 +375,11 @@ EOF;
      */
     private function isSimpleInstance($id, $definition)
     {
+
+        if (!$this->container->isFrozen() && count($this->container->getInterfaceInjectors()) > 0) {
+         	return false;
+        }
+
         foreach (array_merge(array($definition), $this->getInlinedDefinitions($definition)) as $sDefinition) {
             if ($definition !== $sDefinition && !$this->hasReference($id, $sDefinition->getMethodCalls())) {
                 continue;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services_interfaces-1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services_interfaces-1.php
@@ -34,9 +34,12 @@ class ProjectServiceContainer extends Container
     protected function getFooService()
     {
         $class = $this->getParameter('cla').'o'.$this->getParameter('ss');
-        return $this->services['foo'] = new $class();
+        $this->services['foo'] = $instance = new $class();
+
 
         $this->applyInterfaceInjectors($instance);
+
+        return $instance;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services_interfaces-2.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services_interfaces-2.php
@@ -33,9 +33,12 @@ class ProjectServiceContainer extends Container
      */
     protected function getBarService()
     {
-        return $this->services['bar'] = $this->get('barFactory')->createBarClass();
+        $this->services['bar'] = $instance = $this->get('barFactory')->createBarClass();
+
 
         $this->applyInterfaceInjectors($instance);
+
+        return $instance;
     }
 
     /**
@@ -48,9 +51,12 @@ class ProjectServiceContainer extends Container
      */
     protected function getBarfactoryService()
     {
-        return $this->services['barfactory'] = new \BarClassFactory();
+        $this->services['barfactory'] = $instance = new \BarClassFactory();
+
 
         $this->applyInterfaceInjectors($instance);
+
+        return $instance;
     }
 
     /**


### PR DESCRIPTION
changed PhpDumper::isSimpleInstance() to return false if InterfaceInjectors are defined.
problem was code like this in the resulting dump:
        return $this->services['database'] = new \Database();
        $this->applyInterfaceInjectors($instance);
the injectors won't get called in this case.

this commit fixes this issue and also the according unit tests and fixtures since they didn't test this behaviour.
