### PR TITLE
Readdition of the base Controller redirect() method

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\DependencyInjection\ContainerAware;
 
 /**
@@ -49,6 +50,19 @@ class Controller extends ContainerAware
     public function forward($controller, array $path = array(), array $query = array())
     {
         return $this->container->get('http_kernel')->forward($controller, $path, $query);
+    }
+
+    /**
+     * Returns a RedirectResponse to the given URL.
+     *
+     * @param string  $url The URL to redirect to
+     * @param integer $status The status code to use for the Response
+     *
+     * @return RedirectResponse
+     */
+    public function redirect($url, $status = 302)
+    {
+        return new RedirectResponse($url, $status);
     }
 
     /**


### PR DESCRIPTION
Hey guys-

From the _make things really easy for beginners pull request series_, I think the "redirect" method should be added back to the base controller:

1) Assuming the base Controller is a good idea (which I _absolutely_ think it is, for beginners, adoption and rapid development), then we should exercise it to its fullest: helping the developer out as much as possible;

2) This removes the need to remember and declare one of the most commonly used namespaces in controllers (`Symfony\Component\HttpFoundation\RedirectResponse`).

I think adding things like this to the base Controller are just sensible, and we should think of other things to potentially add (e.g. `getFormBuilder()` when the new Form changes are merged in).

Thanks!
