### PR TITLE
Ticket 9611 external esi

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -54,16 +54,19 @@ class Esi
     /**
      * Checks that at least one surrogate has ESI/1.0 capability.
      *
-     * @param Request $request A Request instance
+     * @param Request $request      A Request instance
+     * @param Boolean $externalOnly Only test external surrogates
      *
      * @return Boolean true if one surrogate has ESI/1.0 capability, false otherwise
      */
-    public function hasSurrogateEsiCapability(Request $request)
+    public function hasSurrogateEsiCapability(Request $request, $externalOnly = false)
     {
         if (null === $value = $request->headers->get('Surrogate-Capability')) {
             return false;
         }
-
+        if ($externalOnly) {
+            $value = preg_replace('#symfony2="ESI/1\.0"#', '', $value);
+        }
         return (Boolean) preg_match('#ESI/1.0#', $value);
     }
 

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -555,7 +555,7 @@ class HttpCache implements HttpKernelInterface
 
     protected function processResponseBody(Request $request, Response $response)
     {
-        if (null !== $this->esi && $this->esi->needsEsiParsing($response)) {
+        if (null !== $this->esi && $this->esi->needsEsiParsing($response) && !$this->esi->hasSurrogateEsiCapability($request, true)) {
             $this->esi->process($request, $response);
         }
     }


### PR DESCRIPTION
Better support for detection and use of external ESI enabled surrogates.
Fix for http://trac.symfony-project.org/ticket/9611
