### PR TITLE
[AsseticBundle] basic bundle notation + glob support

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
@@ -30,11 +30,23 @@ class AssetFactory extends BaseAssetFactory
         parent::__construct($baseDir, $debug);
     }
 
+    /**
+     * Adds support for bundle notation and globs.
+     *
+     * Please note this is a naive implementation of globs in that it doesn't
+     * attempt to support bundle inheritance within the glob pattern itself.
+     */
     protected function parseInput($input)
     {
         // expand bundle notation
         if ('@' == $input[0] && false !== strpos($input, '/')) {
-            $input = $this->kernel->locateResource($input);
+            if (false !== $pos = strpos($input, '*')) {
+                // locateResource() does not support globs so we provide a naive implementation here
+                list($before, $after) = explode('*', $input, 2);
+                $input = $this->kernel->locateResource($before).'*'.$after;
+            } else {
+                $input = $this->kernel->locateResource($input);
+            }
         }
 
         return parent::parseInput($input);

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
@@ -39,4 +39,25 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->createAsset($input);
     }
+
+    /**
+     * @dataProvider getGlobs
+     */
+    public function testBundleGlobNotation($input)
+    {
+        $this->kernel->expects($this->once())
+            ->method('locateResource')
+            ->with('@MyBundle/Resources/css/')
+            ->will($this->returnValue('/path/to/bundle/Resources/css/'));
+
+        $this->factory->createAsset($input);
+    }
+
+    public function getGlobs()
+    {
+        return array(
+            array('@MyBundle/Resources/css/*'),
+            array('@MyBundle/Resources/css/*/*.css'),
+        );
+    }
 }


### PR DESCRIPTION
This is _basic_ support because bundle inheritance is not respected beyond the character immediately before the first `*`.
