### PR TITLE
BasicAuthenticationListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -85,9 +85,9 @@ class BasicAuthenticationListener implements ListenerInterface
                 return;
             }
 
-            $event->setProcessed();
+            $response = $this->authenticationEntryPoint->start($request, $failed);
 
-            return $this->authenticationEntryPoint->start($event, $request, $failed);
+            $event->setResponse($response);
         }
     }
 }


### PR DESCRIPTION
The BasicAuthenticationLister had a bug that occured, when bad credentials were passed in.

```
// BasicAuthenticationListener.php
public function handle(GetResponseEvent $event)
{
    // ...
    try {
        // ...
    } catch (AuthenticationException $failed) {
        // ...

        $event->setProcessed();

        return $this->authenticationEntryPoint->start($event, $request, $failed);
    }
}
```

The `$event` argument from `AuthenticationEntryPointInterface::start` has been at commit [a56dbec6](https://github.com/symfony/symfony/commit/a56dbec6d8a4a8600a3b7cac0c65a4c054632f8a#src/Symfony/Component/Security/Http/EntryPoint/BasicAuthenticationEntryPoint.php). The `GetResponseEvent::setProcessed` method has never existed? At least I could not find it in the history. And for sure it does not exist anymore.
