### PR TITLE
Improved "Unable to find controller" Exception message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -23,10 +23,7 @@ class ControllerNameParserTest extends TestCase
 {
     public function testParse()
     {
-        $kernel = new Kernel();
-        $kernel->boot();
-        $logger = new Logger();
-        $parser = new ControllerNameParser($kernel, $logger);
+        $parser = $this->createParser();
 
         $this->assertEquals('TestBundle\FooBundle\Controller\DefaultController::indexAction', $parser->parse('FooBundle:Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
         $this->assertEquals('TestBundle\FooBundle\Controller\Sub\DefaultController::indexAction', $parser->parse('FooBundle:Sub\Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
@@ -39,12 +36,37 @@ class ControllerNameParserTest extends TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws an \InvalidArgumentException if the controller is not an a:b:c string');
         }
+    }
+
+    /**
+     * @dataProvider getMissingControllersTest
+     */
+    public function testMissingControllers($name)
+    {
+        $parser = $this->createParser();
 
         try {
-            $parser->parse('BarBundle:Default:index');
-            $this->fail('->parse() throws a \InvalidArgumentException if the class is found but does not exist');
+            $parser->parse($name);
+            $this->fail('->parse() throws a \InvalidArgumentException if the string is in the valid format, but not matching class can be found');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws a \LogicException if the class is found but does not exist');
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws a \InvalidArgumentException if the class is found but does not exist');
         }
+    }
+
+    public function getMissingControllersTest()
+    {
+        return array(
+            array('FooBundle:Fake:index'),          // a normal bundle
+            array('SensioFooBundle:Fake:index'),    // a bundle with children
+        );
+    }
+
+    private function createParser()
+    {
+        $kernel = new Kernel();
+        $kernel->boot();
+        $logger = new Logger();
+
+        return new ControllerNameParser($kernel, $logger);
     }
 }


### PR DESCRIPTION
Hey guys-

Again, to help out the users. This will actually tell the user _where_ the framework thinks the controller should be (in the case of a bundle without children) or which bundles it was looking in (in the case of multiple bundles).

It adds a little bit to the code, but it's a subtle gain for the user. Comments warmly welcomed.

Thanks!
