### PR TITLE
New Autoloader Exception class - for helpful messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerResolver as BaseController
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\ClassLoader\ClassNotFoundException;
 
 /**
  * ControllerResolver.
@@ -69,7 +70,7 @@ class ControllerResolver extends BaseControllerResolver
         list($class, $method) = explode('::', $controller);
 
         if (!class_exists($class)) {
-            throw new \InvalidArgumentException(sprintf('Class "%s" does not exist.', $class));
+            throw new ClassNotFoundException($class);
         }
 
         $controller = new $class();

--- a/src/Symfony/Component/ClassLoader/ClassNotFoundException.php
+++ b/src/Symfony/Component/ClassLoader/ClassNotFoundException.php
@@ -27,6 +27,12 @@ class ClassNotFoundException extends \Exception
         parent::__construct($this->generateMessage($class), $code, $previous);
     }
 
+    /**
+     * Attempts to generate as helpful of a message as possible.
+     *
+     * @param  $class The class name that could not be found
+     * @return string
+     */
     private function generateMessage($class)
     {
         // create an array of "potential paths" for this file
@@ -38,17 +44,17 @@ class ClassNotFoundException extends \Exception
                 $obj = $autoloader[0];
 
                 if ($obj instanceof UniversalClassLoader) {
-                    $paths = array_merge($paths, $obj->getPotentialPathsForClass($class));
+                    $paths = array_merge($paths, $obj->getLoadTrace($class));
                 }
             }
         }
 
         if (0 == count($paths)) {
-            return sprintf('Class "%s" could not be found - check the class name or autoloader.', $class);
+            return sprintf('Class "%s" could not be found - check the class name or your autoloader configuration.', $class);
         } elseif (1 == count($paths)) {
             $path = $paths[0];
 
-            // the file doesn't exist
+            // the file doesn't exist at the one possible path
             if (!file_exists($path)) {
                 return sprintf('Class "%s" could not be found at "%s" - the file does not exist.', $class, $path);
             }
@@ -58,6 +64,6 @@ class ClassNotFoundException extends \Exception
         }
 
         // the class was looked for in multiple locations
-        return sprintf('Class "%s" could not be found, but was looked for in the following locations: %s.', $class, implode(', ', $paths));
+        return sprintf('Class "%s" could not be found, but was searched for in the following locations: %s.', $class, implode(', ', $paths));
     }
 }

--- a/src/Symfony/Component/ClassLoader/ClassNotFoundException.php
+++ b/src/Symfony/Component/ClassLoader/ClassNotFoundException.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader;
+
+/**
+ * A special exception that can be raised manually when a class is not found.
+ *
+ * When possible, this exception can be raised before using a class by checking
+ * class_exists(). The purpose of this exception is to give some information
+ * related to where the potential class should exist.
+ *
+ * @author Ryan Weaver <ryan@thatsquality.com>
+ */
+class ClassNotFoundException extends \Exception
+{
+    public function __construct ($class, $code = null, $previous = null)
+    {
+        parent::__construct($this->generateMessage($class), $code, $previous);
+    }
+
+    private function generateMessage($class)
+    {
+        // create an array of "potential paths" for this file
+        $autoloaders = spl_autoload_functions();
+        $paths = array();
+        foreach ($autoloaders as $autoloader) {
+            // check to see if the callable is an object:method callable
+            if (is_array($autoloader) && is_object($autoloader[0])) {
+                $obj = $autoloader[0];
+
+                if ($obj instanceof UniversalClassLoader) {
+                    $paths = array_merge($paths, $obj->getPotentialPathsForClass($class));
+                }
+            }
+        }
+
+        if (0 == count($paths)) {
+            return sprintf('Class "%s" could not be found - check the class name or autoloader.', $class);
+        } elseif (1 == count($paths)) {
+            $path = $paths[0];
+
+            // the file doesn't exist
+            if (!file_exists($path)) {
+                return sprintf('Class "%s" could not be found at "%s" - the file does not exist.', $class, $path);
+            }
+
+            // the file exists, but the class is not in it
+            return sprintf('The file "%s" was loaded, but the class "%s" was not found in it.', $path, $class);
+        }
+
+        // the class was looked for in multiple locations
+        return sprintf('Class "%s" could not be found, but was looked for in the following locations: %s.', $class, implode(', ', $paths));
+    }
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/ClassNotFoundExceptionTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/ClassNotFoundExceptionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\ClassLoader;
+
+use Symfony\Component\ClassLoader\ClassNotFoundException;
+
+class ClassNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGenerateException()
+    {
+        // basic sanity test
+        $e = new ClassNotFoundException('Foo');
+        $this->assertEquals('Class "Foo" could not be autoloaded: No possible paths could be found for the class or namespace. Check the class name or your autoloader configuration.', $e->getMessage());
+    }
+
+    /**
+     * A rare test of a private method, due to the overall class's use of
+     * the global autoloaders (making them difficult to test).
+     *
+     * This is meant to just be a sanity check, not to strictly test the
+     * exact messages.
+     *
+     * @dataProvider getCreateMessageParameters
+     */
+    public function testCreateMessage($paths, $universal, $other)
+    {
+        $e = new ClassNotFoundException('Foo');
+        $method = new \ReflectionMethod(
+          'Symfony\Component\ClassLoader\ClassNotFoundException', 'constructMessage'
+        );
+        $method->setAccessible(true);
+
+        $r = $method->invoke($e, 'Foo', $paths, $universal, $other);
+        $this->assertContains('Class "Foo" could not be autoloaded', $r);
+    }
+
+    public function getCreateMessageParameters()
+    {
+        return array(
+            // no universal autoloaders
+            array(
+                array(),
+                0,
+                1,
+            ),
+
+            // universal autoloaders + other autoloaders
+            array(
+                array(),
+                1,
+                2,
+            ),
+
+            // only universal, no paths
+            array(
+                array(),
+                2,
+                0,
+            ),
+
+            // only universal, 1 path, file does not exist
+            array(
+                array('/path/to/file'),
+                1,
+                0
+            ),
+
+            // only universal, 1 path, file exists
+            array(
+                array(__FILE__),
+                1,
+                0,
+            ),
+
+            // only universal, multiple paths
+            array(
+                array('/path/to/foo', '/path/to/bar'),
+                1,
+                0
+            ),
+        );
+    }
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/UniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/UniversalClassLoaderTest.php
@@ -160,4 +160,30 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
+
+    public function testGetLoadTrace()
+    {
+        $loader = new UniversalClassLoader();
+        $loader->registerNamespace('Foo\\Bar', '/path/to/namespace');
+        $loader->registerNamespaceFallback('/path/to/namespace-fallback');
+
+        $loader->registerPrefix('Foo_Bar', '/path/to/prefix');
+        $loader->registerPrefixFallback('/path/to/prefix-fallback');
+
+        // test namespaces
+        $paths = $loader->getLoadTrace('Foo\Bar\Baz');
+        $expected = array(
+            '/path/to/namespace/Foo/Bar/Baz.php',
+            '/path/to/namespace-fallback/Foo/Bar/Baz.php',
+        );
+        $this->assertEquals($expected, $paths);
+
+        // test prefixes
+        $paths = $loader->getLoadTrace('Foo_Bar_Baz');
+        $expected = array(
+            '/path/to/prefix/Foo/Bar/Baz.php',
+            '/path/to/prefix-fallback/Foo/Bar/Baz.php',
+        );
+        $this->assertEquals($expected, $paths);
+    }
 }


### PR DESCRIPTION
Hey guys-

This PR is definitely up for discussion. Th idea is to have a `ClassNotFoundException` that attempts to give you a helpful error message when a class isn't found (obviously, this only works after determining a class doesn't exist via `class_exists` somewhere else and then throwing this).

I think this is a great idea, but that exception message you get isn't an exact science: other autoloaders could be at work. Additionally, really long exception messages - since we can't use HTML formatting - start to be unreadable.

Example message when the user has messed up the class name or namespace in a file: http://i1140.photobucket.com/albums/n577/weaverryan/Screenshot2011-03-22at114214PM.png

I'm happy to be vetoed on this if everyone thinks this will hurt and not help. I've just included it in one spot for now, but it could be used also for the `Bundle:Controller:action` syntax (which I'm already modifying in another PR).

Thanks!
