### PR TITLE
[HttpKernel] ensured that all 4xx/5xx responses are handled by the exception listener

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -235,6 +235,16 @@ class Response
     }
 
     /**
+     * Retrieves status message for the current web response.
+     *
+     * @return string Status message
+     */
+    public function getStatusMessage()
+    {
+        return $this->statusText;
+    }
+
+    /**
      * Sets response charset.
      *
      * @param string $charset Character set
@@ -718,6 +728,11 @@ class Response
     public function isServerError()
     {
         return $this->statusCode >= 500 && $this->statusCode < 600;
+    }
+
+    public function isError()
+    {
+        return $this->statusCode >= 400 && $this->statusCode < 600;
     }
 
     public function isOk()

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpCache/TestHttpKernel.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpCache/TestHttpKernel.php
@@ -13,6 +13,7 @@ namespace Symfony\Tests\Component\HttpKernel\HttpCache;
 
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
@@ -42,7 +43,12 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = false)
     {
         $this->catch = $catch;
-        return parent::handle($request, $type, $catch);
+
+        try {
+            return parent::handle($request, $type, $catch);
+        } catch (HttpException $e) {
+            return new Response('', $e->getStatusCode());
+        }
     }
 
     public function isCatchingExceptions()

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpKernelTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpKernelTest.php
@@ -123,6 +123,16 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $kernel->handle(new Request())->getContent());
     }
 
+    /**
+     * @expectedException Symfony\Component\HttpKernel\Exception\HttpException
+     */
+    public function testHandleConvertsAnErrorResponseInstanceToAnHttpException()
+    {
+        $kernel = new HttpKernel(new EventDispatcher(), $this->getResolver(function () { return new Response('Not Found', 404); }));
+
+        $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
+    }
+
     protected function getResolver($controller = null)
     {
         if (null === $controller) {


### PR DESCRIPTION
This commit ensures that Symfony has the same behavior whether you use Exceptions or Response instances.

For instance, the controllers below will have now the same behavior:

```
function ()
{
    return new Response('Not Found', 404);
}

function ()
{
    throw new NotFoundHttpException();
}
```
