### PR TITLE
[PhpMatcherDumper] Clear name for goto syntax

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -85,6 +85,8 @@ class PhpMatcherDumper extends MatcherDumper
 
             $conditions = implode(' && ', $conditions);
 
+            $gotoname = 'not_'.preg_replace('/[^A-Za-z0-9_]/', '', $name);
+            
             $code[] = <<<EOF
         // $name
         if ($conditions) {
@@ -95,7 +97,7 @@ EOF;
                 $code[] = <<<EOF
             if (isset(\$this->context['method']) && !in_array(strtolower(\$this->context['method']), array('$req'))) {
                 \$allow = array_merge(\$allow, array('$req'));
-                goto not_$name;
+                goto $gotoname;
             }
 EOF;
             }
@@ -117,7 +119,7 @@ EOF
 
             if ($req) {
                 $code[] = <<<EOF
-        not_$name:
+        $gotoname:
 EOF;
             }
 

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
@@ -78,6 +78,19 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
         not_baz5:
 
+        // baz.baz6
+        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?P<foo>[^/\.]+?)/?$#x', $pathinfo, $matches)) {
+            if (isset($this->context['method']) && !in_array(strtolower($this->context['method']), array('put'))) {
+                $allow = array_merge($allow, array('put'));
+                goto not_bazbaz6;
+            }
+            if (substr($pathinfo, -1) !== '/') {
+                return array('_controller' => 'Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction', 'url' => $this->context['base_url'].$pathinfo.'/', 'permanent' => true, '_route' => 'baz.baz6');
+            }
+            return array_merge($this->mergeDefaults($matches, array ()), array('_route' => 'baz.baz6'));
+        }
+        not_bazbaz6:
+
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new NotFoundException();
     }
 }

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -62,6 +62,12 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array(),
             array('_method' => 'post')
         ));
+        // complex name
+        $collection->add('baz.baz6', new Route(
+            '/test/{foo}/',
+            array(),
+            array('_method' => 'put')
+        ));
 
         $dumper = new PhpMatcherDumper($collection);
         $this->assertStringEqualsFile(self::$fixturesPath.'/dumper/url_matcher1.php', $dumper->dump(), '->dump() dumps basic routes to the correct PHP file.');


### PR DESCRIPTION
Syntax problem arises when non-alphanumeric names for routing are used.
E.g. products.list, category.add and so on.
