### PR TITLE
[Form] getEntity() NoResultException fix

### DIFF
--- a/src/Symfony/Component/Form/EntityChoiceField.php
+++ b/src/Symfony/Component/Form/EntityChoiceField.php
@@ -312,7 +312,11 @@ class EntityChoiceField extends ChoiceField
             return $qb->andWhere($where)->getQuery()->getSingleResult();
         }
 
-        return $this->getOption('em')->find($this->getOption('class'), $key);
+        if (!$entity = $this->getOption('em')->find($this->getOption('class'), $key)) {
+          throw new NoResultException;
+        }
+        
+        return $entity;
     }
 
     /**


### PR DESCRIPTION
[Form] Fixed bug where getEntity would not throw the expected NoResultException when no Entity was found if the EntityManager->find method was used.
