### PR TITLE
[RequestListener] Wrong arguments for MethodNotAllowedHttpException

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -110,7 +110,7 @@ class RequestListener
             if (null !== $this->logger) {
                 $this->logger->err($message);
             }
-            throw new MethodNotAllowedHttpException($e->getAllowedMethods(), 'Method Not Allowed', $message, 0, $e);
+            throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e, 0);
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -110,7 +110,7 @@ class RequestListener
             if (null !== $this->logger) {
                 $this->logger->err($message);
             }
-            throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e, 0);
+            throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e);
         }
     }
 }


### PR DESCRIPTION
After exception classes' update, RequestListener sends wrong arguments.
