### PR TITLE
Doctrine alias

### DIFF
--- a/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
@@ -53,6 +53,9 @@ abstract class AbstractDoctrineExtension extends Extension
                 if (!isset($mappingConfig['prefix'])) {
                     $mappingConfig['prefix'] = false;
                 }
+                if (!isset($mappingConfig['alias'])) {
+                    $mappingConfig['alias'] = false;
+                }
 
                 $mappingConfig['dir'] = $container->getParameterBag()->resolveValue($mappingConfig['dir']);
                 // a bundle configuration is detected by realizing that the specified dir is not absolute and existing
@@ -101,7 +104,7 @@ abstract class AbstractDoctrineExtension extends Extension
      */
     protected function setMappingDriverAlias($mappingConfig, $mappingName)
     {
-        if (isset($mappingConfig['alias'])) {
+        if ($mappingConfig['alias']) {
             $this->aliasMap[$mappingConfig['alias']] = $mappingConfig['prefix'];
         } else {
             $this->aliasMap[$mappingName] = $mappingConfig['prefix'];
@@ -164,6 +167,9 @@ abstract class AbstractDoctrineExtension extends Extension
 
         if (!$bundleConfig['prefix']) {
             $bundleConfig['prefix'] = $bundle->getNamespaceName().'\\'.$this->getMappingObjectDefaultName();
+        }
+        if (!$bundleConfig['alias']) {
+            $bundleConfig['alias'] = substr($bundle->getShortName(), 0, -6);
         }
         return $bundleConfig;
     }

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -171,7 +171,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $calls = array_values($definition->getMethodCalls());
-        $this->assertEquals(array('YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity'), $calls[0][1][0]);
+        $this->assertEquals(array('Yaml' => 'Fixtures\Bundles\YamlBundle\Entity'), $calls[0][1][0]);
         $this->assertEquals('doctrine.orm.default_metadata_cache', (string) $calls[1][1][0]);
         $this->assertEquals('doctrine.orm.default_query_cache', (string) $calls[2][1][0]);
         $this->assertEquals('doctrine.orm.default_result_cache', (string) $calls[3][1][0]);
@@ -366,7 +366,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
-            array(array('YamlBundle' => 'Fixtures\Bundles\YamlBundle\Entity'))
+            array(array('Yaml' => 'Fixtures\Bundles\YamlBundle\Entity'))
         );
     }
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/AbstractMongoDBExtensionTest.php
@@ -229,8 +229,8 @@ abstract class AbstractMongoDBExtensionTest extends TestCase
 
         $definition = $container->getDefinition('doctrine.odm.mongodb.default_configuration');
         $calls = $definition->getMethodCalls();
-        $this->assertTrue(isset($calls[0][1][0]['YamlBundle']));
-        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\YamlBundle\Document', $calls[0][1][0]['YamlBundle']);
+        $this->assertTrue(isset($calls[0][1][0]['Yaml']));
+        $this->assertEquals('DoctrineMongoDBBundle\Tests\DependencyInjection\Fixtures\Bundles\YamlBundle\Document', $calls[0][1][0]['Yaml']);
     }
 
     public function testYamlBundleMappingDetection()


### PR DESCRIPTION
This removes the `Bundle` part of the doctrine alias as discussed today in the meeting.
