### PR TITLE
Moved ORM and ODM data:load commands out of their bundles into a new DoctrineFixturesBundle

### DIFF
--- a/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php
@@ -38,23 +38,23 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
     protected function configure()
     {
         $this
-            ->setName('doctrine:data:load')
+            ->setName('doctrine:fixtures:load')
             ->setDescription('Load data fixtures to your database.')
             ->addOption('fixtures', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The directory or file to load data fixtures from.')
             ->addOption('append', null, InputOption::VALUE_OPTIONAL, 'Whether or not to append the data fixtures.', false)
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->setHelp(<<<EOT
-The <info>doctrine:data:load</info> command loads data fixtures from your bundles:
+The <info>doctrine:fixtures:load</info> command loads data fixtures from your bundles:
 
-  <info>./app/console doctrine:data:load</info>
+  <info>./app/console doctrine:fixtures:load</info>
 
 You can also optionally specify the path to fixtures with the <info>--fixtures</info> option:
 
-  <info>./app/console doctrine:data:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
+  <info>./app/console doctrine:fixtures:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
 
 If you want to append the fixtures instead of flushing the database first you can use the <info>--append</info> option:
 
-  <info>./app/console doctrine:data:load --append</info>
+  <info>./app/console doctrine:fixtures:load --append</info>
 EOT
         );
     }

--- a/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\DoctrineBundle\Command;
+namespace Symfony\Bundle\DoctrineFixturesBundle\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Finder\Finder;
 use Symfony\Bundle\FrameworkBundle\Util\Filesystem;
 use Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader as DataFixturesLoader;
+use Symfony\Bundle\DoctrineBundle\Command\DoctrineCommand;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\ORM\EntityManager;

--- a/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -38,23 +38,23 @@ class LoadDataFixturesDoctrineODMCommand extends DoctrineODMCommand
     protected function configure()
     {
         $this
-            ->setName('doctrine:mongodb:data:load')
+            ->setName('doctrine:mongodb:fixtures:load')
             ->setDescription('Load data fixtures to your database.')
             ->addOption('fixtures', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The directory or file to load data fixtures from.')
             ->addOption('append', null, InputOption::VALUE_OPTIONAL, 'Whether or not to append the data fixtures.', false)
             ->addOption('dm', null, InputOption::VALUE_REQUIRED, 'The document manager to use for this command.')
             ->setHelp(<<<EOT
-The <info>doctrine:mongodb:data:load</info> command loads data fixtures from your bundles:
+The <info>doctrine:mongodb:fixtures:load</info> command loads data fixtures from your bundles:
 
-  <info>./app/console doctrine:mongodb:data:load</info>
+  <info>./app/console doctrine:mongodb:fixtures:load</info>
 
 You can also optionally specify the path to fixtures with the <info>--fixtures</info> option:
 
-  <info>./app/console doctrine:mongodb:data:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
+  <info>./app/console doctrine:mongodb:fixtures:load --fixtures=/path/to/fixtures1 --fixtures=/path/to/fixtures2</info>
 
 If you want to append the fixtures instead of flushing the database first you can use the <info>--append</info> option:
 
-  <info>./app/console doctrine:mongodb:data:load --append</info>
+  <info>./app/console doctrine:mongodb:fixtures:load --append</info>
 EOT
         );
     }

--- a/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineODMCommand.php
+++ b/src/Symfony/Bundle/DoctrineFixturesBundle/Command/LoadDataFixturesDoctrineODMCommand.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\DoctrineMongoDBBundle\Command;
+namespace Symfony\Bundle\DoctrineFixturesBundle\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Finder\Finder;
 use Symfony\Bundle\FrameworkBundle\Util\Filesystem;
 use Symfony\Bundle\DoctrineAbstractBundle\Common\DataFixtures\Loader as DataFixturesLoader;
+use Symfony\Bundle\DoctrineMongoDBBundle\Command\DoctrineODMCommand;
 use Doctrine\Common\DataFixtures\Executor\MongoDBExecutor;
 use Doctrine\Common\DataFixtures\Purger\MongoDBPurger;
 use Doctrine\ODM\MongoDB\DocumentManager;

--- a/src/Symfony/Bundle/DoctrineFixturesBundle/DoctrineFixturesBundle.php
+++ b/src/Symfony/Bundle/DoctrineFixturesBundle/DoctrineFixturesBundle.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineFixturesBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Bundle.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Jonathan H. Wage <jonwage@gmail.com>
+ */
+class DoctrineFixturesBundle extends Bundle
+{
+}


### PR DESCRIPTION
The command was moved out of the bundle to it's own Bundle, as discussed here:
https://groups.google.com/d/msg/symfony-devs/_L_hAdFxIXA/VOAkK-jCmtQJ

the `doctrine:data:load` command works by downloading the data fixtures extension on the vendors folder and registering the namespace on `autoload.php` just like before:

`'Doctrine\\Common\\DataFixtures' => __DIR__.'/../vendor/doctrine-data-fixtures/lib'`

Is there anything I missed that needs to be done?
