### PR TITLE
[Security] AclVoter fix

### DIFF
--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -18,6 +18,7 @@ use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 use Symfony\Component\Security\Acl\Model\AclProviderInterface;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityRetrievalStrategyInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface;
@@ -77,8 +78,14 @@ class AclVoter implements VoterInterface
                 } else {
                     $field = null;
                 }
+                
+                if ($object instanceof ObjectIdentityInterface) {
+                    $oid = $object;
+                } else {
+                    $oid = $this->objectIdentityRetrievalStrategy->getObjectIdentity($object);
+                }
 
-                if (null === $oid = $this->objectIdentityRetrievalStrategy->getObjectIdentity($object)) {
+                if (null === $oid) {
                     if (null !== $this->logger) {
                         $this->logger->debug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
                     }

--- a/tests/Symfony/Tests/Component/Security/Acl/Voter/AclVoterTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Voter/AclVoterTest.php
@@ -360,6 +360,52 @@ class AclVoterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(VoterInterface::ACCESS_DENIED, $voter->vote($this->getToken(), new FieldVote(new \stdClass(), 'foo'), array('VIEW')));
     }
+    
+    public function testWhenReceivingAnObjectIdentityInterfaceWeDontRetrieveANewObjectIdentity()
+    {
+        list($voter, $provider, $permissionMap, $oidStrategy, $sidStrategy) = $this->getVoter();
+        
+        $oid = new ObjectIdentity('someID','someType');
+        
+        $permissionMap
+            ->expects($this->once())
+            ->method('contains')
+            ->will($this->returnValue(true))
+        ;
+        $permissionMap
+            ->expects($this->once())
+            ->method('getMasks')
+            ->with($this->equalTo('VIEW'))
+            ->will($this->returnValue($masks = array(1, 2, 3)))
+        ;
+
+        $oidStrategy
+            ->expects($this->never())
+            ->method('getObjectIdentity')
+        ;
+
+        $sidStrategy
+            ->expects($this->once())
+            ->method('getSecurityIdentities')
+            ->will($this->returnValue($sids = array(new UserSecurityIdentity('johannes', 'Foo'), new RoleSecurityIdentity('ROLE_FOO'))))
+        ;
+
+        $provider
+            ->expects($this->once())
+            ->method('findAcl')
+            ->with($this->equalTo($oid), $this->equalTo($sids))
+            ->will($this->returnValue($acl = $this->getMock('Symfony\Component\Security\Acl\Model\AclInterface')))
+        ;
+
+        $acl
+            ->expects($this->once())
+            ->method('isGranted')
+            ->with($this->identicalTo($masks), $this->equalTo($sids), $this->isFalse())
+            ->will($this->throwException(new NoAceFoundException('No ACE')))
+        ;
+
+        $voter->vote($this->getToken(), $oid, array('VIEW'));
+    }
 
     protected function getToken()
     {


### PR DESCRIPTION
I've added a check before the call $this->objectIdentityRetrievalStrategy->getObjectIdentity($object) so it only gets an ObjectIdentity if $object is not already an ObjectIdentityInterface instance.

For more info:

http://groups.google.com/group/symfony-users/browse_thread/thread/5f57e3bb7889ba52/d9ec02329ee12aa5?#d9ec02329ee12aa5
