### PR TITLE
Longer error page

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.html.twig
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>An Error Occurred: {{ status_text }}</title>
     </head>
     <body>
         <h1>Oops! An Error Occurred</h1>


### PR DESCRIPTION
Hey guys-

Apparently an error page must be 512 bytes, else Chrome will display its own custom error page instead of the actual payload returned by the server. The default 404 page was coming up just a few bytes short, so I added a title tag to push it over the threshold. This should help avoid a little confusion for a user.

Thanks!
