### PR TITLE
Add support of two nesting level

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -78,6 +78,12 @@ class ParameterBag
      */
     public function get($key, $default = null)
     {
+        // no strict compare - is normal
+        if (($a = strpos($key, '[')) && ($b = strpos($key, ']'))) {
+            $arrayKey = substr($key, 0, $a);
+		$subArrayKey  = substr($key, $a+1, -1);
+		return array_key_exists($arrayKey, $this->parameters) && array_key_exists($subArrayKey, $this->parameters[$arrayKey]) ? $this->parameters[$arrayKey][$subArrayKey] : $default;
+        }
         return array_key_exists($key, $this->parameters) ? $this->parameters[$key] : $default;
     }
 


### PR DESCRIPTION
If in security.yml config file is line like this:

<pre>
username_parameter:             users_login[email]
password_parameter:             users_login[password]
</pre>


And your have a authorization form with parameters like this:

<pre>
users_login[email]
users_login[password]
</pre>


Than security bundle can`t get username & password parameters
