### PR TITLE
Validator

### DIFF
--- a/src/Symfony/Component/Form/FieldFactory/ValidatorFieldFactoryGuesser.php
+++ b/src/Symfony/Component/Form/FieldFactory/ValidatorFieldFactoryGuesser.php
@@ -108,7 +108,7 @@ class ValidatorFieldFactoryGuesser implements FieldFactoryGuesserInterface
     public function guessClassForConstraint(Constraint $constraint)
     {
         switch (get_class($constraint)) {
-            case 'Symfony\Component\Validator\Constraints\AssertType':
+            case 'Symfony\Component\Validator\Constraints\Type':
                 switch ($constraint->type) {
                     case 'boolean':
                     case 'bool':

--- a/src/Symfony/Component/Form/Resources/config/validation.xml
+++ b/src/Symfony/Component/Form/Resources/config/validation.xml
@@ -36,7 +36,7 @@
 
   <class name="Symfony\Component\Form\RepeatedField">
     <getter property="firstEqualToSecond">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The two values should be equal</option>
       </constraint>
     </getter>
@@ -44,22 +44,22 @@
 
   <class name="Symfony\Component\Form\DateField">
     <getter property="partiallyFilled">
-      <constraint name="AssertFalse">
+      <constraint name="False">
         <option name="message">The date is not fully selected</option>
       </constraint>
     </getter>
     <getter property="yearWithinRange">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The year is invalid</option>
       </constraint>
     </getter>
     <getter property="monthWithinRange">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The month is invalid</option>
       </constraint>
     </getter>
     <getter property="dayWithinRange">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The day is invalid</option>
       </constraint>
     </getter>
@@ -67,22 +67,22 @@
 
   <class name="Symfony\Component\Form\TimeField">
     <getter property="partiallyFilled">
-      <constraint name="AssertFalse">
+      <constraint name="False">
         <option name="message">The time is not fully selected</option>
       </constraint>
     </getter>
     <getter property="hourWithinRange">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The hour is invalid</option>
       </constraint>
     </getter>
     <getter property="minuteWithinRange">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The minutes are invalid</option>
       </constraint>
     </getter>
     <getter property="secondWithinRange">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The seconds are invalid</option>
       </constraint>
     </getter>
@@ -90,17 +90,17 @@
 
   <class name="Symfony\Component\Form\FileField">
     <getter property="iniSizeExceeded">
-      <constraint name="AssertFalse">
+      <constraint name="False">
         <option name="message">The file is too large. Please upload a smaller file</option>
       </constraint>
     </getter>
     <getter property="formSizeExceeded">
-      <constraint name="AssertFalse">
+      <constraint name="False">
         <option name="message">The file is too large. Please upload a smaller file</option>
       </constraint>
     </getter>
     <getter property="uploadComplete">
-      <constraint name="AssertTrue">
+      <constraint name="True">
         <option name="message">The file was only partially uploaded. Please try again</option>
       </constraint>
     </getter>

--- a/src/Symfony/Component/Validator/Constraints/False.php
+++ b/src/Symfony/Component/Validator/Constraints/False.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-class AssertTrue extends \Symfony\Component\Validator\Constraint
+class False extends \Symfony\Component\Validator\Constraint
 {
-    public $message = 'This value should be true';
+    public $message = 'This value should be false';
 
     /**
      * {@inheritDoc}

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-class AssertFalseValidator extends ConstraintValidator
+class FalseValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/True.php
+++ b/src/Symfony/Component/Validator/Constraints/True.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-class AssertFalse extends \Symfony\Component\Validator\Constraint
+class True extends \Symfony\Component\Validator\Constraint
 {
-    public $message = 'This value should be false';
+    public $message = 'This value should be true';
 
     /**
      * {@inheritDoc}

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-class AssertTrueValidator extends ConstraintValidator
+class TrueValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-class AssertType extends \Symfony\Component\Validator\Constraint
+class Type extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value should be of type {{ type }}';
     public $type;

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
-class AssertTypeValidator extends ConstraintValidator
+class TypeValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/AnnotationLoader.php
@@ -25,7 +25,7 @@ class AnnotationLoader implements LoaderInterface
     public function __construct(array $paths = null)
     {
         if (null === $paths) {
-            $paths = array('validation' => 'Symfony\\Component\\Validator\\Constraints\\');
+            $paths = array('assert' => 'Symfony\\Component\\Validator\\Constraints\\');
         }
 
         $this->reader = new AnnotationReader();

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AssertFalseValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AssertFalseValidatorTest.php
@@ -11,31 +11,31 @@
 
 namespace Symfony\Tests\Component\Validator;
 
-use Symfony\Component\Validator\Constraints\AssertFalse;
-use Symfony\Component\Validator\Constraints\AssertFalseValidator;
+use Symfony\Component\Validator\Constraints\False;
+use Symfony\Component\Validator\Constraints\FalseValidator;
 
-class AssertFalseValidatorTest extends \PHPUnit_Framework_TestCase
+class FalseValidatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $validator;
 
     protected function setUp()
     {
-        $this->validator = new AssertFalseValidator();
+        $this->validator = new FalseValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->assertTrue($this->validator->isValid(null, new AssertFalse()));
+        $this->assertTrue($this->validator->isValid(null, new False()));
     }
 
     public function testFalseIsValid()
     {
-        $this->assertTrue($this->validator->isValid(false, new AssertFalse()));
+        $this->assertTrue($this->validator->isValid(false, new False()));
     }
 
     public function testTrueIsInvalid()
     {
-        $constraint = new AssertFalse(array(
+        $constraint = new False(array(
             'message' => 'myMessage'
         ));
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AssertTrueValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AssertTrueValidatorTest.php
@@ -11,31 +11,31 @@
 
 namespace Symfony\Tests\Component\Validator;
 
-use Symfony\Component\Validator\Constraints\AssertTrue;
-use Symfony\Component\Validator\Constraints\AssertTrueValidator;
+use Symfony\Component\Validator\Constraints\True;
+use Symfony\Component\Validator\Constraints\TrueValidator;
 
-class AssertTrueValidatorTest extends \PHPUnit_Framework_TestCase
+class TrueValidatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $validator;
 
     protected function setUp()
     {
-        $this->validator = new AssertTrueValidator();
+        $this->validator = new TrueValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->assertTrue($this->validator->isValid(null, new AssertTrue()));
+        $this->assertTrue($this->validator->isValid(null, new True()));
     }
 
     public function testTrueIsValid()
     {
-        $this->assertTrue($this->validator->isValid(true, new AssertTrue()));
+        $this->assertTrue($this->validator->isValid(true, new True()));
     }
 
     public function testFalseIsInvalid()
     {
-        $constraint = new AssertTrue(array(
+        $constraint = new True(array(
             'message' => 'myMessage'
         ));
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Tests\Component\Validator;
 
-use Symfony\Component\Validator\Constraints\AssertType;
-use Symfony\Component\Validator\Constraints\AssertTypeValidator;
+use Symfony\Component\Validator\Constraints\Type;
+use Symfony\Component\Validator\Constraints\TypeValidator;
 
-class AssertTypeValidatorTest extends \PHPUnit_Framework_TestCase
+class TypeValidatorTest extends \PHPUnit_Framework_TestCase
 {
     protected static $file;
 
@@ -22,22 +22,22 @@ class AssertTypeValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->validator = new AssertTypeValidator();
+        $this->validator = new TypeValidator();
     }
 
     public function testNullIsValid()
     {
-        $this->assertTrue($this->validator->isValid(null, new AssertType(array('type' => 'integer'))));
+        $this->assertTrue($this->validator->isValid(null, new Type(array('type' => 'integer'))));
     }
 
     public function testEmptyIsValidIfString()
     {
-        $this->assertTrue($this->validator->isValid('', new AssertType(array('type' => 'string'))));
+        $this->assertTrue($this->validator->isValid('', new Type(array('type' => 'string'))));
     }
 
     public function testEmptyIsInvalidIfNoString()
     {
-        $this->assertFalse($this->validator->isValid('', new AssertType(array('type' => 'integer'))));
+        $this->assertFalse($this->validator->isValid('', new Type(array('type' => 'integer'))));
     }
 
     /**
@@ -45,7 +45,7 @@ class AssertTypeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValues($value, $type)
     {
-        $constraint = new AssertType(array('type' => $type));
+        $constraint = new Type(array('type' => $type));
 
         $this->assertTrue($this->validator->isValid($value, $constraint));
     }
@@ -79,7 +79,7 @@ class AssertTypeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidValues($value, $type)
     {
-        $constraint = new AssertType(array('type' => $type));
+        $constraint = new Type(array('type' => $type));
 
         $this->assertFalse($this->validator->isValid($value, $constraint));
     }
@@ -112,7 +112,7 @@ class AssertTypeValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testMessageIsSet()
     {
-        $constraint = new AssertType(array(
+        $constraint = new Type(array(
             'type' => 'numeric',
             'message' => 'myMessage'
         ));

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/Entity.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/Entity.php
@@ -7,22 +7,22 @@ require_once __DIR__.'/EntityInterface.php';
 
 /**
  * @Symfony\Tests\Component\Validator\Fixtures\ConstraintA
- * @validation:GroupSequence({"Foo", "Entity"})
+ * @assert:GroupSequence({"Foo", "Entity"})
  */
 class Entity extends EntityParent implements EntityInterface
 {
     /**
-     * @validation:NotNull
-     * @validation:Min(3)
-     * @validation:Set({
-     *   @validation:All({@validation:NotNull, @validation:Min(3)}),
-     *   @validation:All(constraints={@validation:NotNull, @validation:Min(3)})
+     * @assert:NotNull
+     * @assert:Min(3)
+     * @assert:Set({
+     *   @assert:All({@assert:NotNull, @assert:Min(3)}),
+     *   @assert:All(constraints={@assert:NotNull, @assert:Min(3)})
      * })
-     * @validation:Collection(fields={
-     *   "foo" = {@validation:NotNull, @validation:Min(3)},
-     *   "bar" = @validation:Min(5)
+     * @assert:Collection(fields={
+     *   "foo" = {@assert:NotNull, @assert:Min(3)},
+     *   "bar" = @assert:Min(5)
      * })
-     * @validation:Choice(choices={"A", "B"}, message="Must be one of %choices%")
+     * @assert:Choice(choices={"A", "B"}, message="Must be one of %choices%")
      */
     protected $firstName;
     protected $lastName;
@@ -41,7 +41,7 @@ class Entity extends EntityParent implements EntityInterface
     }
 
     /**
-     * @validation:NotNull
+     * @assert:NotNull
      */
     public function getLastName()
     {

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/EntityParent.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/EntityParent.php
@@ -8,7 +8,7 @@ class EntityParent
     private $internal;
 
     /**
-     * @validation:NotNull
+     * @assert:NotNull
      */
     protected $other;
 }


### PR DESCRIPTION
Removed "Assert" prefix from AssertTrue, AssertFalse and AssertType constraint. Changed annotation namespace prefix from "validation" to "assert", so anntations are now used like

```
@assert:True
@assert:Type
@assert:Email
```

etc.
