### PR TITLE
Allowing for null Swift Transport

### DIFF
--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/Configuration.php
@@ -41,7 +41,7 @@ class Configuration
                 ->scalarNode('transport')
                     ->defaultValue('smtp')
                     ->validate()
-                        ->ifNotInArray(array ('smtp', 'mail', 'sendmail', 'gmail'))
+                        ->ifNotInArray(array ('smtp', 'mail', 'sendmail', 'gmail', null))
                         ->thenInvalid('The %s transport is not supported')
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/SwiftmailerBundle/Tests/DependencyInjection/SwiftmailerExtensionTest.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Tests/DependencyInjection/SwiftmailerExtensionTest.php
@@ -24,15 +24,26 @@ class SwiftmailerExtensionTest extends TestCase
         $loader = new SwiftmailerExtension();
 
         $loader->load(array(array()), $container);
-        $this->assertEquals('Swift_Mailer', $container->getParameter('swiftmailer.class'), '->mailerLoad() loads the swiftmailer.xml file if not already loaded');
+        $this->assertEquals('Swift_Mailer', $container->getParameter('swiftmailer.class'), '->load() loads the swiftmailer.xml file if not already loaded');
 
         $loader->load(array(array('transport' => 'sendmail')), $container);
-        $this->assertEquals('sendmail', $container->getParameter('swiftmailer.transport.name'), '->mailerLoad() overrides existing configuration options');
+        $this->assertEquals('sendmail', $container->getParameter('swiftmailer.transport.name'), '->load() overrides existing configuration options');
         $this->assertEquals('swiftmailer.transport.sendmail', (string) $container->getAlias('swiftmailer.transport'));
 
         $loader->load(array(array()), $container);
-        $this->assertEquals('smtp', $container->getParameter('swiftmailer.transport.name'), '->mailerLoad() provides default values for configuration options');
+        $this->assertEquals('smtp', $container->getParameter('swiftmailer.transport.name'), '->load() provides default values for configuration options');
         $this->assertEquals('swiftmailer.transport.smtp', (string) $container->getAlias('swiftmailer.transport'));
+    }
+
+    public function testNullTransport()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', false);
+        $loader = new SwiftmailerExtension();
+
+        $loader->load(array(array('transport' => null)), $container);
+        $this->assertEquals('null', $container->getParameter('swiftmailer.transport.name'), '->load() uses the "null" string transport when transport is null');
+        $this->assertEquals('swiftmailer.transport.null', (string) $container->getAlias('swiftmailer.transport'));
     }
 
     public function testSpool()


### PR DESCRIPTION
Hey guys-

This is just a small bug on the `Configuration` class for the `SwiftmailerBundle` (outlined here: http://groups.google.com/group/symfony-devs/browse_thread/thread/aa8ece5638c0c44f/d71ebeaa017b84fb?show_docid=d71ebeaa017b84fb).

The "null" transport is legal, as you can see here: https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php#L55

Thanks!
