### PR TITLE
Kernel controller exception message

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -120,7 +120,13 @@ class HttpKernel implements HttpKernelInterface
             }
 
             if (!$response instanceof Response) {
-                throw new \LogicException(sprintf('The controller must return a response (%s given).', $this->varToString($response)));
+                $msg = sprintf('The controller must return a response (%s given).', $this->varToString($response));
+
+                // the user may have forgotten to return something
+                if (null === $response) {
+                    $msg .= ' Did you forget to add a return statement somewhere in your controller?';
+                }
+                throw new \LogicException($msg);
             }
         }
 
@@ -185,6 +191,10 @@ class HttpKernel implements HttpKernelInterface
 
         if (is_resource($var)) {
             return '[resource]';
+        }
+
+        if (null === $var) {
+            return 'null';
         }
 
         return str_replace("\n", '', var_export((string) $var, true));


### PR DESCRIPTION
Hey guys-

This improves the exception when a user may have forgotten to use a `return` statement in a controller. From a purist standpoint, this kind of stuff almost seems to muck up the code a little, but it's definitely good for a user.

Thoughts warmly welcome

Thanks!
