### PR TITLE
[HttpKernel] shorter bundle names

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
@@ -30,7 +30,7 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testBundleNotation()
     {
-        $input = '@MyBundle/Resources/css/main.css';
+        $input = '@My/Resources/css/main.css';
 
         $this->kernel->expects($this->once())
             ->method('locateResource')
@@ -47,7 +47,7 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $this->kernel->expects($this->once())
             ->method('locateResource')
-            ->with('@MyBundle/Resources/css/')
+            ->with('@My/Resources/css/')
             ->will($this->returnValue('/path/to/bundle/Resources/css/'));
 
         $this->factory->createAsset($input);
@@ -56,8 +56,8 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
     public function getGlobs()
     {
         return array(
-            array('@MyBundle/Resources/css/*'),
-            array('@MyBundle/Resources/css/*/*.css'),
+            array('@My/Resources/css/*'),
+            array('@My/Resources/css/*/*.css'),
         );
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Resources/Resources/views/layout.html.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Resources/Resources/views/layout.html.php
@@ -1,7 +1,7 @@
 <?php $view->extend('::base.html.php') ?>
 
 <?php $view['slots']->start('stylesheets') ?>
-    <?php foreach($view['assetic']->stylesheets('stylesheet1.css, stylesheet2.css, @TestBundle/Resources/css/bundle.css') as $url): ?>
+    <?php foreach($view['assetic']->stylesheets('stylesheet1.css, stylesheet2.css, @Test/Resources/css/bundle.css') as $url): ?>
         <link href="<?php echo $view->escape($url) ?>" type="text/css" rel="stylesheet" />
     <?php endforeach; ?>
 <?php $view['slots']->stop() ?>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Resources/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Resources/Resources/views/layout.html.twig
@@ -1,7 +1,7 @@
 {% extends '::base.html.twig' %}
 
 {% block stylesheets %}
-    {% stylesheets 'stylesheet1.css' 'stylesheet2.css' '@TestBundle/Resources/css/bundle.css' %}
+    {% stylesheets 'stylesheet1.css' 'stylesheet2.css' '@Test/Resources/css/bundle.css' %}
         <link href="{{ asset_url }}" type="text/css" rel="stylesheet" />
     {% endstylesheets %}
 {% endblock %}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Resources/config/config.yml
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Resources/config/config.yml
@@ -19,4 +19,4 @@ twig:
 assetic:
     use_controller: true
     read_from:      "%kernel.root_dir%/web"
-    bundles:        [TestBundle]
+    bundles:        [Test]

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
@@ -25,7 +25,7 @@
         </service>
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
-            <tag name="data_collector" template="DoctrineBundle:Collector:db" id="db" />
+            <tag name="data_collector" template="Doctrine:Collector:db" id="db" />
             <argument type="service" id="doctrine.dbal.logger" />
         </service>
 

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/views/Collector/db.html.twig
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/views/Collector/db.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -7,7 +7,7 @@
     {% set text %}
         <span title="{{ '%0.2f'|format(collector.time * 1000) }} ms">{{ collector.querycount }}</span>
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/config/mongodb.xml
@@ -89,7 +89,7 @@
             <argument type="service" id="logger" on-invalid="null" />
         </service>
         <service id="doctrine.odm.mongodb.data_collector" class="%doctrine.odm.mongodb.data_collector_class%" public="false">
-            <tag name="data_collector" template="DoctrineMongoDBBundle:Collector:mongodb" id="mongodb" />
+            <tag name="data_collector" template="DoctrineMongoDB:Collector:mongodb" id="mongodb" />
             <argument type="service" id="doctrine.odm.mongodb.logger" />
         </service>
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/views/Collector/mongodb.html.twig
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Resources/views/Collector/mongodb.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -7,7 +7,7 @@
     {% set text %}
         <span>{{ collector.querycount }}</span>
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -41,7 +41,7 @@ class Controller extends ContainerAware
     /**
      * Forwards the request to another controller.
      *
-     * @param  string  $controller The controller name (a string like BlogBundle:Post:index)
+     * @param  string  $controller The controller name (a string like Blog:Post:index)
      * @param  array   $path       An array of path parameters
      * @param  array   $query      An array of query parameters
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 /**
  * ControllerNameParser converts controller from the short notation a:b:c
- * (BlogBundle:Post:index) to a fully-qualified class::method string
+ * (Blog:Post:index) to a fully-qualified class::method string
  * (Bundle\BlogBundle\Controller\PostController::indexAction).
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -47,7 +47,7 @@ class HttpKernel extends BaseHttpKernel
     /**
      * Forwards the request to another controller.
      *
-     * @param  string  $controller The controller name (a string like BlogBundle:Post:index)
+     * @param  string  $controller The controller name (a string like Blog:Post:index)
      * @param  array   $attributes An array of request attributes
      * @param  array   $query      An array of request query parameters
      *
@@ -76,7 +76,7 @@ class HttpKernel extends BaseHttpKernel
      *  * standalone: whether to generate an esi:include tag or not when ESI is supported
      *  * comment: a comment to add when returning an esi:include tag
      *
-     * @param string $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
+     * @param string $controller A controller name to execute (a string like Blog:Post:index), or a relative URI
      * @param array  $options    An array of options
      *
      * @return string The Response content
@@ -152,7 +152,7 @@ class HttpKernel extends BaseHttpKernel
      *
      * This method uses the "_internal" route, which should be available.
      *
-     * @param string $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
+     * @param string $controller A controller name to execute (a string like Blog:Post:index), or a relative URI
      * @param array  $attributes An array of request attributes
      * @param array  $query      An array of request query parameters
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -16,38 +16,38 @@
 
     <services>
         <service id="data_collector.config" class="%data_collector.config.class%" public="false">
-            <tag name="data_collector" template="WebProfilerBundle:Collector:config" id="config" priority="255" />
+            <tag name="data_collector" template="WebProfiler:Collector:config" id="config" priority="255" />
             <argument type="service" id="kernel" />
         </service>
 
         <service id="data_collector.request" class="%data_collector.request.class%" public="false">
             <tag name="kernel.listener" event="onCoreController" />
-            <tag name="data_collector" template="WebProfilerBundle:Collector:request" id="request" priority="255" />
+            <tag name="data_collector" template="WebProfiler:Collector:request" id="request" priority="255" />
         </service>
 
         <service id="data_collector.exception" class="%data_collector.exception.class%" public="false">
-            <tag name="data_collector" template="WebProfilerBundle:Collector:exception" id="exception" priority="255" />
+            <tag name="data_collector" template="WebProfiler:Collector:exception" id="exception" priority="255" />
         </service>
 
         <service id="data_collector.events" class="%data_collector.events.class%" public="false">
-            <tag name="data_collector" template="WebProfilerBundle:Collector:events" id="events" priority="255" />
+            <tag name="data_collector" template="WebProfiler:Collector:events" id="events" priority="255" />
             <call method="setEventDispatcher">
                 <argument type="service" id="event_dispatcher" />
             </call>
         </service>
 
         <service id="data_collector.logger" class="%data_collector.logger.class%" public="false">
-            <tag name="data_collector" template="WebProfilerBundle:Collector:logger" id="logger" priority="255" />
+            <tag name="data_collector" template="WebProfiler:Collector:logger" id="logger" priority="255" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
 
         <service id="data_collector.timer" class="%data_collector.timer.class%" public="false">
-            <tag name="data_collector" template="WebProfilerBundle:Collector:timer" id="timer" priority="255" />
+            <tag name="data_collector" template="WebProfiler:Collector:timer" id="timer" priority="255" />
             <argument type="service" id="kernel" />
         </service>
 
         <service id="data_collector.memory" class="%data_collector.memory.class%" public="false">
-            <tag name="data_collector" template="WebProfilerBundle:Collector:memory" id="memory" priority="255" />
+            <tag name="data_collector" template="WebProfiler:Collector:memory" id="memory" priority="255" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/internal.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/internal.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
   <route id="_internal" pattern="/{controller}/{path}.{_format}">
-    <default key="_controller">FrameworkBundle:Internal:index</default>
+    <default key="_controller">Framework:Internal:index</default>
   </route>
 </routes>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.atom.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.atom.twig
@@ -1,1 +1,1 @@
-{% include 'FrameworkBundle:Exception:error.xml.twig' with { 'exception': exception } %}
+{% include 'Framework:Exception:error.xml.twig' with { 'exception': exception } %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.rdf.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/error.rdf.twig
@@ -1,1 +1,1 @@
-{% include 'FrameworkBundle:Exception:error.xml.twig' with { 'exception': exception } %}
+{% include 'Framework:Exception:error.xml.twig' with { 'exception': exception } %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.atom.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.atom.twig
@@ -1,1 +1,1 @@
-{% include 'FrameworkBundle:Exception:exception.xml.twig' with { 'exception': exception } %}
+{% include 'Framework:Exception:exception.xml.twig' with { 'exception': exception } %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.css.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.css.twig
@@ -1,3 +1,3 @@
 /*
-{% include 'FrameworkBundle:Exception:exception.txt.twig' with { 'exception': exception } %}
+{% include 'Framework:Exception:exception.txt.twig' with { 'exception': exception } %}
 */

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.html.twig
@@ -41,7 +41,7 @@
     </div>
 
     {% for position, e in exception.toarray %}
-        {% include 'FrameworkBundle:Exception:traces.html.twig' with { 'exception': e, 'position': position, 'count': previous_count } only %}
+        {% include 'Framework:Exception:traces.html.twig' with { 'exception': e, 'position': position, 'count': previous_count } only %}
     {% endfor %}
 
     {% if logger %}
@@ -68,7 +68,7 @@
             </div>
 
             <div id="logs">
-                {% include 'FrameworkBundle:Exception:logs.html.twig' with { 'logs': logger.logs } only %}
+                {% include 'Framework:Exception:logs.html.twig' with { 'logs': logger.logs } only %}
             </div>
 
         </div>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.js.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.js.twig
@@ -1,3 +1,3 @@
 /*
-{% include 'FrameworkBundle:Exception:exception.txt.twig' with { 'exception': exception } %}
+{% include 'Framework:Exception:exception.txt.twig' with { 'exception': exception } %}
 */

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.rdf.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.rdf.twig
@@ -1,1 +1,1 @@
-{% include 'FrameworkBundle:Exception:exception.xml.twig' with { 'exception': exception } %}
+{% include 'Framework:Exception:exception.xml.twig' with { 'exception': exception } %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.txt.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.txt.twig
@@ -2,6 +2,6 @@
 [message] {{ exception.message }}
 {% for i, e in exception.toarray %}
 [{{ i + 1 }}] {{ e.class }}: {{ e.message }}
-{% include 'FrameworkBundle:Exception:traces.txt.twig' with { 'exception': e } only %}
+{% include 'Framework:Exception:traces.txt.twig' with { 'exception': e } only %}
 
 {% endfor %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.xml.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.xml.twig
@@ -3,7 +3,7 @@
 <error code="{{ status_code }}" message="{{ status_text }}">
 {% for e in exception.toarray %}
     <exception class="{{ e.class }}" message="{{ e.message }}">
-{% include 'FrameworkBundle:Exception:traces.xml.twig' with { 'exception': e } only %}
+{% include 'Framework:Exception:traces.xml.twig' with { 'exception': e } only %}
     </exception>
 {% endfor %}
 </error>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception_full.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception_full.html.twig
@@ -1,5 +1,5 @@
-{% extends 'FrameworkBundle:Exception:layout.html.twig' %}
+{% extends 'Framework:Exception:layout.html.twig' %}
 
 {% block body %}
-    {% include 'FrameworkBundle:Exception:exception.html.twig' %}
+    {% include 'Framework:Exception:exception.html.twig' %}
 {% endblock %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.html.twig
@@ -18,7 +18,7 @@
     <ol class="traces list_exception" id="traces_{{ position }}" style="display: {{ 0 == position ? 'block' : 'none' }}">
         {% for i, trace in exception.trace %}
             <li>
-                {% include 'FrameworkBundle:Exception:trace.html.twig' with { 'prefix': position, 'i': i, 'trace': trace } only %}
+                {% include 'Framework:Exception:trace.html.twig' with { 'prefix': position, 'i': i, 'trace': trace } only %}
             </li>
         {% endfor %}
     </ol>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.txt.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.txt.twig
@@ -1,6 +1,6 @@
 {% if exception.trace|length %}
 {% for trace in exception.trace %}
-{% include 'FrameworkBundle:Exception:trace.txt.twig' with { 'trace': trace } only %}
+{% include 'Framework:Exception:trace.txt.twig' with { 'trace': trace } only %}
 
 {% endfor %}
 {% endif %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.xml.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.xml.twig
@@ -1,7 +1,7 @@
         <traces>
 {% for trace in exception.trace %}
             <trace>
-{% include 'FrameworkBundle:Exception:trace.txt.twig' with { 'trace': trace } only %}
+{% include 'Framework:Exception:trace.txt.twig' with { 'trace': trace } only %}
 
             </trace>
 {% endfor %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/money_field.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/money_field.html.php
@@ -1,4 +1,4 @@
 <?php echo str_replace('{{ widget }}',
-    $view['form']->render($field, array(), array(), 'FrameworkBundle:Form:number_field.html.php'),
+    $view['form']->render($field, array(), array(), 'Framework:Form:number_field.html.php'),
     $field->getPattern()
 ) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_field.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_field.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->render($field, array(), array(), 'FrameworkBundle:Form:number_field.html.php') ?> %
+<?php echo $view['form']->render($field, array(), array(), 'Framework:Form:number_field.html.php') ?> %

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
@@ -36,7 +36,7 @@ class ActionsHelper extends Helper
     /**
      * Returns the Response content for a given controller or URI.
      *
-     * @param string $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
+     * @param string $controller A controller name to execute (a string like Blog:Post:index), or a relative URI
      * @param array  $attributes An array of request attributes
      * @param array  $options    An array of options
      *

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -115,7 +115,7 @@ class FormHelper extends Helper
     public function row(/*FieldInterface*/ $field, $template = null)
     {
         if (null === $template) {
-            $template = 'FrameworkBundle:Form:field_row.html.php';
+            $template = 'Framework:Form:field_row.html.php';
         }
 
         return $this->engine->render($template, array(
@@ -126,7 +126,7 @@ class FormHelper extends Helper
     public function label(/*FieldInterface */$field, $label = false, array $parameters = array(), $template = null)
     {
         if (null === $template) {
-            $template = 'FrameworkBundle:Form:label.html.php';
+            $template = 'Framework:Form:label.html.php';
         }
 
         return $this->engine->render($template, array(
@@ -139,7 +139,7 @@ class FormHelper extends Helper
     public function errors(/*FieldInterface */$field, array $parameters = array(), $template = null)
     {
         if (null === $template) {
-            $template = 'FrameworkBundle:Form:errors.html.php';
+            $template = 'Framework:Form:errors.html.php';
         }
 
         return $this->engine->render($template, array(
@@ -151,7 +151,7 @@ class FormHelper extends Helper
     public function hidden(/*FormInterface */$form, array $parameters = array(), $template = null)
     {
         if (null === $template) {
-            $template = 'FrameworkBundle:Form:hidden.html.php';
+            $template = 'Framework:Form:hidden.html.php';
         }
 
         return $this->engine->render($template, array(
@@ -186,7 +186,7 @@ class FormHelper extends Helper
         } while (null === $template && false !== $currentFqClassName);
 
         if (null === $template && $field instanceof FormInterface) {
-            $template = 'FrameworkBundle:Form:form.html.php';
+            $template = 'Framework:Form:form.html.php';
         }
 
         self::$cache[$fqClassName] = $template;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -25,10 +25,10 @@ class ControllerNameParserTest extends TestCase
     {
         $parser = $this->createParser();
 
-        $this->assertEquals('TestBundle\FooBundle\Controller\DefaultController::indexAction', $parser->parse('FooBundle:Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
-        $this->assertEquals('TestBundle\FooBundle\Controller\Sub\DefaultController::indexAction', $parser->parse('FooBundle:Sub\Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
-        $this->assertEquals('TestBundle\Fabpot\FooBundle\Controller\DefaultController::indexAction', $parser->parse('SensioFooBundle:Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
-        $this->assertEquals('TestBundle\Sensio\Cms\FooBundle\Controller\DefaultController::indexAction', $parser->parse('SensioCmsFooBundle:Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
+        $this->assertEquals('TestBundle\FooBundle\Controller\DefaultController::indexAction', $parser->parse('Foo:Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
+        $this->assertEquals('TestBundle\FooBundle\Controller\Sub\DefaultController::indexAction', $parser->parse('Foo:Sub\Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
+        $this->assertEquals('TestBundle\Fabpot\FooBundle\Controller\DefaultController::indexAction', $parser->parse('SensioFoo:Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
+        $this->assertEquals('TestBundle\Sensio\Cms\FooBundle\Controller\DefaultController::indexAction', $parser->parse('SensioCmsFoo:Default:index'), '->parse() converts a short a:b:c notation string to a class::method string');
 
         try {
             $parser->parse('foo:');
@@ -56,8 +56,8 @@ class ControllerNameParserTest extends TestCase
     public function getMissingControllersTest()
     {
         return array(
-            array('FooBundle:Fake:index'),          // a normal bundle
-            array('SensioFooBundle:Fake:index'),    // a bundle with children
+            array('Foo:Fake:index'),          // a normal bundle
+            array('SensioFoo:Fake:index'),    // a bundle with children
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ProfilerPassTest.php
@@ -22,7 +22,7 @@ class ProfilerPassTest extends \PHPUnit_Framework_TestCase
      * an exception (both are needed if the template is specified). Thus,
      * a fully-valid tag looks something like this:
      *
-     *     <tag name="data_collector" template="YourBundle:Collector:templatename" id="your_collector_name" />
+     *     <tag name="data_collector" template="Your:Collector:templatename" id="your_collector_name" />
      */
     public function testTemplateNoIdThrowsException()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TestBundle/Fabpot/FooBundle/FabpotFooBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Fixtures/TestBundle/Fabpot/FooBundle/FabpotFooBundle.php
@@ -25,6 +25,6 @@ class FabpotFooBundle extends Bundle
      */
     public function getParent()
     {
-        return 'SensioFooBundle';
+        return 'SensioFoo';
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -46,11 +46,11 @@ class TemplateNameParserTest extends TestCase
     public function getLogicalNameToTemplateProvider()
     {
         return array(
-            array('FooBundle:Post:index.html.php', new TemplateReference('FooBundle', 'Post', 'index', 'html', 'php')),
-            array('FooBundle:Post:index.html.twig', new TemplateReference('FooBundle', 'Post', 'index', 'html', 'twig')),
-            array('FooBundle:Post:index.xml.php', new TemplateReference('FooBundle', 'Post', 'index', 'xml', 'php')),
-            array('SensioFooBundle:Post:index.html.php', new TemplateReference('SensioFooBundle', 'Post', 'index', 'html', 'php')),
-            array('SensioCmsFooBundle:Post:index.html.php', new TemplateReference('SensioCmsFooBundle', 'Post', 'index', 'html', 'php')),
+            array('Foo:Post:index.html.php', new TemplateReference('Foo', 'Post', 'index', 'html', 'php')),
+            array('Foo:Post:index.html.twig', new TemplateReference('Foo', 'Post', 'index', 'html', 'twig')),
+            array('Foo:Post:index.xml.php', new TemplateReference('Foo', 'Post', 'index', 'xml', 'php')),
+            array('SensioFoo:Post:index.html.php', new TemplateReference('SensioFoo', 'Post', 'index', 'html', 'php')),
+            array('SensioCmsFoo:Post:index.html.php', new TemplateReference('SensioCmsFoo', 'Post', 'index', 'html', 'php')),
             array(':Post:index.html.php', new TemplateReference('', 'Post', 'index', 'html', 'php')),
             array('::index.html.php', new TemplateReference('', '', 'index', 'html', 'php')),
         );
@@ -68,11 +68,11 @@ class TemplateNameParserTest extends TestCase
     public function getInvalidLogicalNameProvider()
     {
         return array(
-            array('BarBundle:Post:index.html.php'),
-            array('FooBundle:Post:index'),
+            array('Bar:Post:index.html.php'),
+            array('Foo:Post:index'),
             array('FooBundle:Post'),
-            array('FooBundle:Post:foo:bar'),
-            array('FooBundle:Post:index.foo.bar.foobar'),
+            array('Foo:Post:foo:bar'),
+            array('Foo:Post:index.foo.bar.foobar'),
         );
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateTest.php
@@ -40,8 +40,8 @@ class TemplateTest extends TestCase
     public function getTemplateToPathProvider()
     {
         return array(
-            array(new TemplateReference('FooBundle', 'Post', 'index', 'html', 'php'), '@FooBundle/Resources/views/Post/index.html.php'),
-            array(new TemplateReference('FooBundle', '', 'index', 'html', 'twig'), '@FooBundle/Resources/views/index.html.twig'),
+            array(new TemplateReference('Foo', 'Post', 'index', 'html', 'php'), '@Foo/Resources/views/Post/index.html.php'),
+            array(new TemplateReference('Foo', '', 'index', 'html', 'twig'), '@Foo/Resources/views/index.html.twig'),
             array(new TemplateReference('', 'Post', 'index', 'html', 'php'), 'views/Post/index.html.php'),
             array(new TemplateReference('', '', 'index', 'html', 'php'), 'views/index.html.php'),
         );

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="data_collector.security" class="%data_collector.security.class%" public="false">
-            <tag name="data_collector" template="SecurityBundle:Collector:security" id="security" />
+            <tag name="data_collector" template="Security:Collector:security" id="security" />
             <argument type="service" id="security.context" on-invalid="ignore" />
         </service>
     </services>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -13,7 +13,7 @@
             disabled
         {% endif %}
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}

--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -95,7 +95,7 @@ class SwiftmailerExtension extends Extension
 
         if ($config['logging']) {
             $container->findDefinition('swiftmailer.transport')->addMethodCall('registerPlugin', array(new Reference('swiftmailer.plugin.messagelogger')));
-            $container->findDefinition('data_collector.swiftmailer')->addTag('data_collector', array('template' => 'SwiftmailerBundle:Collector:swiftmailer', 'id' => 'swiftmailer'));
+            $container->findDefinition('data_collector.swiftmailer')->addTag('data_collector', array('template' => 'Swiftmailer:Collector:swiftmailer', 'id' => 'swiftmailer'));
         }
 
         if (isset($config['delivery_address']) && $config['delivery_address']) {

--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/views/Collector/swiftmailer.html.twig
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/views/Collector/swiftmailer.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.messagecount %}
@@ -8,7 +8,7 @@
         {% set text %}
             <span title="{{ collector.messagecount }} messages">{{ collector.messagecount }}</span>
         {% endset %}
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+        {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
     {% endif %}
 {% endblock %}
 

--- a/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
@@ -75,7 +75,7 @@ class TemplatingExtension extends \Twig_Extension
     /**
      * Returns the Response content for a given controller or URI.
      *
-     * @param string $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
+     * @param string $controller A controller name to execute (a string like Blog:Post:index), or a relative URI
      * @param array  $attributes An array of request attributes
      * @param array  $options    An array of options
      *
@@ -100,7 +100,7 @@ class TemplatingExtension extends \Twig_Extension
     public function getTokenParsers()
     {
         return array(
-            // {% render 'BlogBundle:Post:list' with { 'limit': 2 }, { 'alt': 'BlogBundle:Post:error' } %}
+            // {% render 'Blog:Post:list' with { 'limit': 2 }, { 'alt': 'Blog:Post:error' } %}
             new RenderTokenParser(),
 
             // {% include 'sometemplate.php' with { 'something' : 'something2' } %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -39,7 +39,7 @@ class ProfilerController extends ContainerAware
         $profiler = $this->container->get('profiler')->loadFromToken($token);
 
         if ($profiler->isEmpty()) {
-            return $this->container->get('templating')->renderResponse('WebProfilerBundle:Profiler:notfound.html.twig', array('token' => $token));
+            return $this->container->get('templating')->renderResponse('WebProfiler:Profiler:notfound.html.twig', array('token' => $token));
         }
 
         if (!$profiler->has($panel)) {
@@ -156,7 +156,7 @@ class ProfilerController extends ContainerAware
             // the profiler is not enabled
         }
 
-        return $this->container->get('templating')->renderResponse('WebProfilerBundle:Profiler:toolbar.html.twig', array(
+        return $this->container->get('templating')->renderResponse('WebProfiler:Profiler:toolbar.html.twig', array(
             'position'     => $position,
             'profiler'     => $profiler,
             'templates'    => $this->getTemplates($profiler),
@@ -180,7 +180,7 @@ class ProfilerController extends ContainerAware
         $limit = $session->get('_profiler_search_limit');
         $token = $session->get('_profiler_search_token');
 
-        return $this->container->get('templating')->renderResponse('WebProfilerBundle:Profiler:search.html.twig', array(
+        return $this->container->get('templating')->renderResponse('WebProfiler:Profiler:search.html.twig', array(
             'token'    => $token,
             'ip'       => $ip,
             'url'      => $url,
@@ -205,7 +205,7 @@ class ProfilerController extends ContainerAware
         $url = $session->get('_profiler_search_url');
         $limit = $session->get('_profiler_search_limit');
 
-        return $this->container->get('templating')->renderResponse('WebProfilerBundle:Profiler:results.html.twig', array(
+        return $this->container->get('templating')->renderResponse('WebProfiler:Profiler:results.html.twig', array(
             'token'    => $token,
             'profiler' => $profiler,
             'tokens'   => $profiler->find($ip, $url, $limit),

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -5,27 +5,27 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="_profiler_search" pattern="/search">
-        <default key="_controller">WebProfilerBundle:Profiler:search</default>
+        <default key="_controller">WebProfiler:Profiler:search</default>
     </route>
 
     <route id="_profiler_purge" pattern="/purge">
-        <default key="_controller">WebProfilerBundle:Profiler:purge</default>
+        <default key="_controller">WebProfiler:Profiler:purge</default>
     </route>
 
     <route id="_profiler_import" pattern="/import">
-        <default key="_controller">WebProfilerBundle:Profiler:import</default>
+        <default key="_controller">WebProfiler:Profiler:import</default>
     </route>
 
     <route id="_profiler_export" pattern="/export/{token}.txt">
-        <default key="_controller">WebProfilerBundle:Profiler:export</default>
+        <default key="_controller">WebProfiler:Profiler:export</default>
     </route>
 
     <route id="_profiler_search_results" pattern="/{token}/search/results">
-        <default key="_controller">WebProfilerBundle:Profiler:searchResults</default>
+        <default key="_controller">WebProfiler:Profiler:searchResults</default>
     </route>
 
     <route id="_profiler" pattern="/{token}">
-        <default key="_controller">WebProfilerBundle:Profiler:panel</default>
+        <default key="_controller">WebProfiler:Profiler:panel</default>
     </route>
 
 </routes>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/wdt.xml
@@ -5,6 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="_wdt" pattern="/{token}">
-        <default key="_controller">WebProfilerBundle:Profiler:toolbar</default>
+        <default key="_controller">WebProfiler:Profiler:toolbar</default>
     </route>
 </routes>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -1,10 +1,10 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
         <a href="http://symfony.com/"><img width="26" height="28" alt="Symfony" style="border-width: 0; margin: 0 5px 0 10px; vertical-align: middle;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAcCAYAAAB/E6/TAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABRZJREFUeNqkVnlM03cUb38tFFqKB4UyGZccYrZyVpnGEQzngAlOQATcFMiWJcZFOZzb4pYNFTYnmYh4/OVEFCSIYAYIbhzCNpm0BMjCBAqFUsohMHrQFmTvbf2RDosWfc3L93rf76e/d1MXFxcp+uTj5bc0F3Q8oiXuS942JpMdVKs1nnK5nK8vy2Qy/2IwGF2WlpZ3KirLb8BdLdyhGCKqISAQpgNA1ODAYK5SqXSnGEEAOGrDtcmtrKq4AEvNi4CoJ7NPb2j4paFgYmIimvISxGazH8XERO8+mnFkGJaLhoCoFwsvOV4vKq4HFblQXoHodLpiq//W6IIL+Q2wXMA9Qh+k+PqN+68KgjQ/P89qe9hWWXKzFN+i6gMx6+vun5mdnd242kcDAt7WItvachdyvj09/k5EuAr3tVot88rlK2WoTRKInpV5LK6vr2/PakHCwsPk/m/5i5uamk1GR2U08L5WXz/fDvJ8cvIJ78O0j9Jhaoo24oSHRjTLZDKP1YC4uLhoyspLb0dF7AqVSCTrcG/N2jV/q+fUZnNzc6aknIWFxZPmlkYebZO7R+C92nufrPRg/N44ZVBwkHy91XqKJZtNlUpH/1X3seNZDebmZm2XLl6OIGUBhAH2oenf12g05qJ+0STR2toauxJI9qlv+oNDgn8990P+uuqfaswlkhGKm5vrvJOzkzIsLPROTXWtOSkL8TPk6uqiNfSOWCyOImamZ3iGDp03Os9FRkYUT01NdZJ7oF76yIiUiI+Pa4HlY4FAuHS3rq5eJpVKCUNvgSpfJ8DTuIYOR6WjqILfQ0NDGiOjIsXkvkKhINzc3RBo0tTUhMHjvSlHzj93nq9QKGmG3hoYGHQgaDQ63dChSqUySTmQmoRy2Se/vsrz5Clxn8PhzPH5fkI0SVdnN6+zs8sC+UXOQ1Cp/wUUSbav2T5FfVtbW6tBNQngnrthuxnU+BDPHRzsp2CYQJcdHx+3NdZLn9GpGYOhsnewr1nU5abhYUkCDFNDQ0P4OGWDnZ0ENXj2TF6gsSBWHCsV4bF58/AyfbJSD6b5czhWShaLuQCR3g9eF3LrVlkUnnt5e6JzLPb29u4wFsjB3n6K7u3t1X236u7/6kx7u8ATRzTy7fKKHeB54eTZli38dhhovb19/sYCbfLwEBF7Yt/7Ge1hSACNDCBLhkZHcHR0FOfmfBewGvsk70+sRRv17k2IFxpzwY/vN4Rpv7Gh8WNjQQJ3Bkrt7OwECDSQmpZSggG6XKig8PxITu4pGbne/35Sw4EPUg5DYBpVdVks1tNPj2eVYnATOlf9LTMroxYS4FIVtLGx0Wzfvq1EJBr4E9e7ot+VXrta5NEh7Ag19muOph/5g8vl1sFUQlZYK8z6134s+uzs93lvkIKQ17oJgkaHn+2YbIwB5d3MWJCMzPTHScmJeZgGgUdIIEwdDsBRoP+0Lz4/wYNKS33ZCgva6UtM2lcI0ypgEdZB/Z7BVAe2EwpWzJcnvgpsedDCXA2Aj4+39tDhQwJfX5+bsKwG7ic7ouVdEOY9a3Qw4CChsGNnaUmpW3PTA/OVvhC6HgrEojo2PlYEJb0JthrR5phU9NuuZ/o6XTOBseMEjIHrjTEHTuA0Oytn9fT0sCHj0/h8/jSbbaHw8vbCzN4H3KFjVNUM2f08D4gkmq6xsMFcq/tSLNlrdTlyGkuFzmvHdIwA80Z1qs8BZWDO1TF+NcYddjzq5f/eEP0jwAAGCybA1KhGOwAAAABJRU5ErkJggg=="/></a>
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false, 'text': collector.symfonyversion } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': false, 'text': collector.symfonyversion } %}
 
     {% set text %}
         {% spaceless %}
@@ -15,7 +15,7 @@
             <span style="color: {{ collector.hasaccelerator ? '#759e1a' : '#a33' }}">accel</span>
         {% endspaceless %}
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false, 'icon': '' } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': false, 'icon': '' } %}
 
     {% set icon %}
         <img width="21" height="28" alt="Environment" style="border-width: 0; vertical-align: middle; margin-right: 5px;" src="data:image/png;base64,
@@ -38,7 +38,7 @@
             </span>
         {% endspaceless %}
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block menu %}
 <span class="label">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block head %}
     <link href="{{ asset('bundles/framework/css/exception.css') }}" rel="stylesheet" type="text/css" media="screen" />
@@ -25,6 +25,6 @@
             <em>No exception was thrown and uncaught during the request.</em>
         </p>
     {% else %}
-        {% render 'WebProfilerBundle:Exception:show' with { 'exception': collector.exception, 'format': 'html' } %}
+        {% render 'WebProfiler:Exception:show' with { 'exception': collector.exception, 'format': 'html' } %}
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% if collector.counterrors %}
@@ -8,7 +8,7 @@
         {% set text %}
             <span>{{ collector.counterrors }}</span>
         {% endset %}
-        {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+        {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
     {% endif %}
 {% endblock %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -7,5 +7,5 @@
     {% set text %}
         {{ '%.0f'|format(collector.memory / 1024) }} KB
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': false } %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -24,7 +24,7 @@
             <span>{{ collector.contenttype }}</span>
         {% endspaceless %}
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}
@@ -38,7 +38,7 @@
     <h2>Request GET Parameters</h2>
 
     {% if collector.requestquery.all|length %}
-        {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.requestquery } only %}
+        {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': collector.requestquery } only %}
     {% else %}
         <p>
             <em>No GET parameters</em>
@@ -48,7 +48,7 @@
     <h2>Request POST Parameters</h2>
 
     {% if collector.requestrequest.all|length %}
-        {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.requestrequest } only %}
+        {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': collector.requestrequest } only %}
     {% else %}
         <p>
             <em>No POST parameters</em>
@@ -58,7 +58,7 @@
     <h2>Request Attributes</h2>
 
     {% if collector.requestattributes.all|length %}
-        {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.requestattributes } only %}
+        {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': collector.requestattributes } only %}
     {% else %}
         <p>
             <em>No attributes</em>
@@ -68,7 +68,7 @@
     <h2>Request Cookies</h2>
 
     {% if collector.requestcookies.all|length %}
-        {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.requestcookies } only %}
+        {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': collector.requestcookies } only %}
     {% else %}
         <p>
             <em>No cookies</em>
@@ -77,15 +77,15 @@
 
     <h2>Requests Headers</h2>
 
-    {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.requestheaders } only %}
+    {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': collector.requestheaders } only %}
 
     <h2>Requests Server Parameters</h2>
 
-    {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.requestserver } only %}
+    {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': collector.requestserver } only %}
 
     <h2>Response Headers</h2>
 
-    {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.responseheaders } only %}
+    {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': collector.responseheaders } only %}
 
     <h2>Response Session Attributes</h2>
 
@@ -113,7 +113,7 @@
     {% if profiler.parent %}
         <h2><a href="{{ path('_profiler', { 'token': profiler.parent }) }}">Parent request: {{ profiler.parent }}</a></h2>
 
-        {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': profiler.parenttoken.get('request').requestattributes } only %}
+        {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': profiler.parenttoken.get('request').requestattributes } only %}
     {% endif %}
 
     {% if profiler.children|length %}
@@ -121,7 +121,7 @@
 
         {% for subrequest in profiler.children %}
             <h3><a href="{{ path('_profiler', { 'token': subrequest.token }) }}">{{ subrequest.token }}</a></h3>
-            {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': subrequest.get('request').requestattributes } only %}
+            {% include 'WebProfiler:Profiler:bag.html.twig' with { 'bag': subrequest.get('request').requestattributes } only %}
         {% endfor %}
     {% endif %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/timer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/timer.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block toolbar %}
     {% set icon %}
@@ -7,5 +7,5 @@
     {% set text %}
         {{ '%.0f'|format(collector.time * 1000) }} ms
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false } %}
+    {% include 'WebProfiler:Profiler:toolbar_item.html.twig' with { 'link': false } %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -1,11 +1,11 @@
-{% extends 'WebProfilerBundle:Profiler:base.html.twig' %}
+{% extends 'WebProfiler:Profiler:base.html.twig' %}
 
 {% block body %}
 
-    {% render 'WebProfilerBundle:Profiler:toolbar' with { 'token': token, 'position': 'normal' } %}
+    {% render 'WebProfiler:Profiler:toolbar' with { 'token': token, 'position': 'normal' } %}
 
     <div id="content">
-        {% include 'WebProfilerBundle:Profiler:header.html.twig' only %}
+        {% include 'WebProfiler:Profiler:header.html.twig' only %}
 
         {% if not profiler.isempty %}
             <div id="resume">
@@ -39,8 +39,8 @@
                             {% endfor %}
                         </ul>
                     {% endif %}
-                    {% render 'WebProfilerBundle:Profiler:searchBar' %}
-                    {% include 'WebProfilerBundle:Profiler:admin.html.twig' with { 'token': token } only %}
+                    {% render 'WebProfiler:Profiler:searchBar' %}
+                    {% include 'WebProfiler:Profiler:admin.html.twig' with { 'token': token } only %}
                 </div>
             </div>
         </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/notfound.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/notfound.html.twig
@@ -1,8 +1,8 @@
-{% extends 'WebProfilerBundle:Profiler:base.html.twig' %}
+{% extends 'WebProfiler:Profiler:base.html.twig' %}
 
 {% block body %}
     <div id="content">
-        {% include 'WebProfilerBundle:Profiler:header.html.twig' only %}
+        {% include 'WebProfiler:Profiler:header.html.twig' only %}
        
         <div id="resume">
             <p>
@@ -23,8 +23,8 @@
                     </div>
                 </div>
                 <div id="navigation">
-                    {% render 'WebProfilerBundle:Profiler:searchBar' with { 'token': token } %}
-                    {% include 'WebProfilerBundle:Profiler:admin.html.twig' with { 'token': token } only %}
+                    {% render 'WebProfiler:Profiler:searchBar' with { 'token': token } %}
+                    {% include 'WebProfiler:Profiler:admin.html.twig' with { 'token': token } only %}
                 </div>
             </div>
         </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends 'WebProfiler:Profiler:layout.html.twig' %}
 
 {% block panel %}
     <h2>Search Results</h2>

--- a/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
@@ -87,7 +87,7 @@ class WebDebugToolbarListener
         $content = $response->getContent();
 
         if (false !== $pos = $posrFunction($content, '</body>')) {
-            $toolbar = "\n".str_replace("\n", '', $this->templating->render('WebProfilerBundle:Profiler:toolbar_js.html.twig', array('token' => $response->headers->get('X-Debug-Token'))))."\n";
+            $toolbar = "\n".str_replace("\n", '', $this->templating->render('WebProfiler:Profiler:toolbar_js.html.twig', array('token' => $response->headers->get('X-Debug-Token'))))."\n";
             $content = $substrFunction($content, 0, $pos).$toolbar.$substrFunction($content, $pos);
             $response->setContent($content);
         }

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -115,6 +115,8 @@ abstract class Bundle extends ContainerAware implements BundleInterface
      * Returns the bundle name (the class short name).
      *
      * @return string The Bundle name
+     *
+     * @throws RuntimeException If the bundle class name does not end with "Bundle"
      */
     final public function getName()
     {
@@ -122,10 +124,14 @@ abstract class Bundle extends ContainerAware implements BundleInterface
             return $this->name;
         }
 
-        $name = get_class($this);
-        $pos = strrpos($name, '\\');
+        $fqcn = get_class($this);
+        $name = false === ($pos = strrpos($fqcn, '\\')) ? $fqcn : substr($fqcn, $pos + 1);
 
-        return $this->name = false === $pos ? $name :  substr($name, $pos + 1);
+        if ('Bundle' != substr($name, -6)) {
+            throw new \RuntimeException(sprintf('The bundle class name "%s" must end with "Bundle" to be valid.', $name));
+        }
+
+        return $this->name = substr($name, 0, -6);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -61,10 +61,10 @@ abstract class Bundle extends ContainerAware implements BundleInterface
      */
     public function build(ContainerBuilder $container)
     {
-        $class = $this->getNamespace().'\\DependencyInjection\\'.str_replace('Bundle', 'Extension', $this->getName());
+        $class = $this->getNamespace().'\\DependencyInjection\\'.$this->getName().'Extension';
         if (class_exists($class)) {
             $extension = new $class();
-            $alias = Container::underscore(str_replace('Bundle', '', $this->getName()));
+            $alias = Container::underscore($this->getName());
             if ($alias !== $extension->getAlias()) {
                 throw new \LogicException(sprintf('The extension alias for the default extension of a bundle must be the underscored version of the bundle name ("%s" vs "%s")', $alias, $extension->getAlias()));
             }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPass.php
@@ -25,7 +25,7 @@ class MergeExtensionConfigurationPass extends BaseMergeExtensionConfigurationPas
     {
         foreach ($container->getParameter('kernel.bundles') as $bundleName => $bundleClass) {
             $bundleRefl = new \ReflectionClass($bundleClass);
-            $extClass = $bundleRefl->getNamespaceName().'\\DependencyInjection\\'.substr($bundleName, 0, -6).'Extension';
+            $extClass = $bundleRefl->getNamespaceName().'\\DependencyInjection\\'.$bundleName.'Extension';
 
             if (class_exists($extClass)) {
                 $ext = new $extClass();

--- a/tests/Symfony/Tests/Component/HttpKernel/Bundle/BundleTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Bundle/BundleTest.php
@@ -24,13 +24,25 @@ class BundleTest extends \PHPUnit_Framework_TestCase
         $cmd = new FooCommand();
         $app = $this->getMock('Symfony\Component\Console\Application');
         $app->expects($this->once())->method('add')->with($this->equalTo($cmd));
-        
+
         $bundle = new ExtensionPresentBundle();
         $bundle->registerCommands($app);
-        
+
         $bundle2 = new ExtensionAbsentBundle();
-        
+
         $this->assertNull($bundle2->registerCommands($app));
-        
+    }
+
+    public function testGetName()
+    {
+        $bundle = new ExtensionPresentBundle();
+        $this->assertEquals('ExtensionPresent', $bundle->getName(), '->getName() rtrims "Bundle"');
+    }
+
+    public function testInvalidBundleName()
+    {
+        $this->setExpectedException('RuntimeException');
+        $bundle = $this->getMockForAbstractClass('Symfony\\Component\\HttpKernel\\Bundle\\Bundle');
+        $bundle->getName();
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPassTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPassTest.php
@@ -18,9 +18,9 @@ class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
     public function testAutoloadMainExtension()
     {
         $bundles = array(
-            'ExtensionAbsentBundle'  => 'Symfony\\Tests\\Component\\HttpKernel\\Fixtures\\ExtensionAbsentBundle\\ExtensionAbsentBundle',
-            'ExtensionLoadedBundle'  => 'Symfony\\Tests\\Component\\HttpKernel\\Fixtures\\ExtensionLoadedBundle\\ExtensionLoadedBundle',
-            'ExtensionPresentBundle' => 'Symfony\\Tests\\Component\\HttpKernel\\Fixtures\\ExtensionPresentBundle\\ExtensionPresentBundle',
+            'ExtensionAbsent'  => 'Symfony\\Tests\\Component\\HttpKernel\\Fixtures\\ExtensionAbsentBundle\\ExtensionAbsentBundle',
+            'ExtensionLoaded'  => 'Symfony\\Tests\\Component\\HttpKernel\\Fixtures\\ExtensionLoadedBundle\\ExtensionLoadedBundle',
+            'ExtensionPresent' => 'Symfony\\Tests\\Component\\HttpKernel\\Fixtures\\ExtensionPresentBundle\\ExtensionPresentBundle',
         );
 
         $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerBuilder');

--- a/tests/Symfony/Tests/Component/Routing/Annotation/RouteTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Annotation/RouteTest.php
@@ -39,7 +39,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
            array('requirements', array('_method' => 'GET'), 'getRequirements'),
            array('options', array('segment_separators' => array('/')), 'getOptions'),
            array('name', 'blog_index', 'getName'),
-           array('defaults', array('_controller' => 'MyBlogBundle:Blog:index'), 'getDefaults')
+           array('defaults', array('_controller' => 'MyBlog:Blog:index'), 'getDefaults')
         );
     }
 }

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/incomplete.yml
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/incomplete.yml
@@ -1,2 +1,2 @@
 blog_show:
-    defaults:  { _controller: MyBlogBundle:Blog:show }
+    defaults:  { _controller: MyBlog:Blog:show }

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/nonvalid.xml
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/nonvalid.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="blog_show" pattern="/blog/{slug}">
-        <default key="_controller">MyBundle:Blog:show</default>
+        <default key="_controller">My:Blog:show</default>
 		<requirement key="_method">GET</requirement>
 		<option key="segment_separators">/</option>
 	<!-- </route> -->

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/nonvalidroute.xml
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/nonvalidroute.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="blog_show" pattern="/blog/{slug}">
-        <default key="_controller">MyBundle:Blog:show</default>
+        <default key="_controller">My:Blog:show</default>
 		<requirement key="_method">GET</requirement>
 		<option key="segment_separators">/</option>
 		<foo key="bar">baz</foo>

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/validpattern.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/validpattern.php
@@ -4,7 +4,7 @@ use Symfony\Component\Routing\Route;
 
 $collection = new RouteCollection();
 $collection->add('blog_show', new Route('/blog/{slug}', array(
-    '_controller' => 'MyBlogBundle:Blog:show',
+    '_controller' => 'MyBlog:Blog:show',
 )));
 
 return $collection;

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/validpattern.xml
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/validpattern.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
     <route id="blog_show" pattern="/blog/{slug}">
-        <default key="_controller">MyBundle:Blog:show</default>
+        <default key="_controller">My:Blog:show</default>
 		<requirement key="_method">GET</requirement>
 		<option key="segment_separators">/</option>
     </route>

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/validpattern.yml
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/validpattern.yml
@@ -1,4 +1,4 @@
 blog_show:
     pattern:   /blog/{slug}
-    defaults:  { _controller: MyBlogBundle:Blog:show }
+    defaults:  { _controller: MyBlog:Blog:show }
 


### PR DESCRIPTION
As discussed in last week's IRC meeting, I've removed the trailing "Bundle" from a bundle's logical name. The only place I've left the trailing "Bundle" intact is when using the `@BlogBundle/Resources...` syntax because this resembles a directory structure. I'm happy to shorten that one as well.

**Controllers:**  
`BlogBundle:Post:show` is now `Blog:Post:show`

**Templates:**  
`BlogBundle:Post:show.html.twig` is now `Blog:Post:show.html.twig`

**Resources:**  
`@BlogBundle/Resources/config/blog.xml` is now `@Blog/Resources/config/blog.xml`

**Doctrine:**  
`$em->find('BlogBundle:Post', $id)` is now `$em->find('Blog:Post', $id)`

As you can see, only "Resources" is BC, everything else will break.
