### PR TITLE
[Process][Windows] Better detection of php executable path 

### DIFF
--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -78,8 +78,8 @@ class PhpProcess extends Process
      */
     private function getPhpBinary()
     {
-        if (getenv('PHP_PATH')) {
-            if (!is_executable($php = getenv('PHP_PATH'))) {
+        if ($php = getenv('PHP_PATH')) {
+            if (!is_executable($php)) {
                 throw new \RuntimeException('The defined PHP_PATH environment variable is not a valid PHP executable.');
             }
 

--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -93,6 +93,12 @@ class PhpProcess extends Process
             }
         }
 
+        if ($php = getenv('PHP_PEAR_PHP_BIN')) {
+            if (is_executable($php)) {
+                return $php;
+            }
+        }
+
         throw new \RuntimeException('Unable to find the PHP executable.');
     }
 }


### PR DESCRIPTION
[Process] Removed useless getenv
[Process] Better guess of php bin executable path

If PHP_PATH is not defined (default)
PHP_BINDIR is used to guess php exe, but on windows this constant seems to be hardcoded and doesn't point to the good folder
So before to throw an error we check if PEAR is installed, most of the time it is, and it will have good php bin path for sure.
