### PR TITLE
Untitled

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -194,7 +194,7 @@ abstract class Client
         $server['HTTP_HOST'] = parse_url($uri, PHP_URL_HOST);
         $server['HTTPS'] = 'https' == parse_url($uri, PHP_URL_SCHEME);
 
-        $request = new Request($uri, $method, $parameters, $files, $this->cookieJar->getValues($uri), $server, $content);
+        $request = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
 
         $this->request = $this->filterRequest($request);
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -28,8 +28,6 @@ use Symfony\Component\BrowserKit\Client;
  * you need to also implement the getScript() method.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 abstract class Client
 {
@@ -49,8 +47,6 @@ abstract class Client
      * @param array     $server    The server parameters (equivalent of $_SERVER)
      * @param History   $history   A History instance to store the browser history
      * @param CookieJar $cookieJar A CookieJar instance to store the cookies
-     *
-     * @api
      */
     public function __construct(array $server = array(), History $history = null, CookieJar $cookieJar = null)
     {
@@ -65,8 +61,6 @@ abstract class Client
      * Sets whether to automatically follow redirects or not.
      *
      * @param Boolean $followRedirect Whether to follow redirects
-     *
-     * @api
      */
     public function followRedirects($followRedirect = true)
     {
@@ -79,8 +73,6 @@ abstract class Client
      * @param Boolean $insulated Whether to insulate the requests or not
      *
      * @throws \RuntimeException When Symfony Process Component is not installed
-     *
-     * @api
      */
     public function insulate($insulated = true)
     {
@@ -97,8 +89,6 @@ abstract class Client
      * Sets server parameters.
      *
      * @param array $server An array of server parameters
-     *
-     * @api
      */
     public function setServerParameters(array $server)
     {
@@ -112,8 +102,6 @@ abstract class Client
      * Returns the History instance.
      *
      * @return History A History instance
-     *
-     * @api
      */
     public function getHistory()
     {
@@ -124,8 +112,6 @@ abstract class Client
      * Returns the CookieJar instance.
      *
      * @return CookieJar A CookieJar instance
-     *
-     * @api
      */
     public function getCookieJar()
     {
@@ -136,8 +122,6 @@ abstract class Client
      * Returns the current Crawler instance.
      *
      * @return Crawler A Crawler instance
-     *
-     * @api
      */
     public function getCrawler()
     {
@@ -148,8 +132,6 @@ abstract class Client
      * Returns the current Response instance.
      *
      * @return Response A Response instance
-     *
-     * @api
      */
     public function getResponse()
     {
@@ -160,8 +142,6 @@ abstract class Client
      * Returns the current Request instance.
      *
      * @return Request A Request instance
-     *
-     * @api
      */
     public function getRequest()
     {
@@ -172,8 +152,6 @@ abstract class Client
      * Clicks on a given link.
      *
      * @param Link $link A Link instance
-     *
-     * @api
      */
     public function click(Link $link)
     {
@@ -185,13 +163,10 @@ abstract class Client
      *
      * @param Form  $form   A Form instance
      * @param array $values An array of form field values
-     *
-     * @api
      */
     public function submit(Form $form, array $values = array())
     {
         $form->setValues($values);
-
         return $this->request($form->getMethod(), $form->getUri(), $form->getPhpValues(), $form->getPhpFiles());
     }
 
@@ -207,8 +182,6 @@ abstract class Client
      * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
      *
      * @return Crawler
-     *
-     * @api
      */
     public function request($method, $uri, array $parameters = array(), array $files = array(), array $server = array(), $content = null, $changeHistory = true)
     {
@@ -221,7 +194,7 @@ abstract class Client
         $server['HTTP_HOST'] = parse_url($uri, PHP_URL_HOST);
         $server['HTTPS'] = 'https' == parse_url($uri, PHP_URL_SCHEME);
 
-        $request = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
+        $request = new Request($uri, $method, $parameters, $files, $this->cookieJar->getValues($uri), $server, $content);
 
         $this->request = $this->filterRequest($request);
 
@@ -234,7 +207,6 @@ abstract class Client
         } else {
             $this->response = $this->doRequest($this->request);
         }
-
         $response = $this->filterResponse($this->response);
 
         $this->cookieJar->updateFromResponse($response, $uri);
@@ -244,8 +216,8 @@ abstract class Client
         if ($this->followRedirects && $this->redirect) {
             return $this->crawler = $this->followRedirect();
         }
-
-        return $this->crawler = $this->createCrawlerFromContent($request->getUri(), $response->getContent(), $response->getHeader('Content-Type'));
+		$this->crawler = $this->createCrawlerFromContent($request->getUri(), $response->getContent(), $response->getHeader('Content-Type'));
+        return $this->crawler;
     }
 
     /**
@@ -337,8 +309,6 @@ abstract class Client
      * Goes back in the browser history.
      *
      * @return Crawler
-     *
-     * @api
      */
     public function back()
     {
@@ -349,8 +319,6 @@ abstract class Client
      * Goes forward in the browser history.
      *
      * @return Crawler
-     *
-     * @api
      */
     public function forward()
     {
@@ -361,8 +329,6 @@ abstract class Client
      * Reloads the current browser.
      *
      * @return Crawler
-     *
-     * @api
      */
     public function reload()
     {
@@ -375,8 +341,6 @@ abstract class Client
      * @return Crawler
      *
      * @throws \LogicException If request was not a redirect
-     *
-     * @api
      */
     public function followRedirect()
     {
@@ -391,8 +355,6 @@ abstract class Client
      * Restarts the client.
      *
      * It flushes all cookies.
-     *
-     * @api
      */
     public function restart()
     {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -17,8 +17,6 @@ use Symfony\Component\CssSelector\Parser as CssParser;
  * Crawler eases navigation of a list of \DOMNode objects.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 class Crawler extends \SplObjectStorage
 {
@@ -34,17 +32,13 @@ class Crawler extends \SplObjectStorage
      * @param string $uri  The base URI to use for absolute links or form actions
      * @param string $base An optional base href for generating the uris for Form and Link.
      *                     This will be autodetected if $node has a <base> tag.
-     *
-     * @api
      */
-    public function __construct($node = null, $uri = null, $base = null)
+    public function __construct($node, $uri = null, $base = null)
     {
         $this->uri = $uri;
 
         list($this->host, $this->path) = $this->parseUri($this->uri);
-
-        $this->add($node);
-
+		$this->add($node);
         if ($base) {
             $this->base = $base;
         }
@@ -52,8 +46,6 @@ class Crawler extends \SplObjectStorage
 
     /**
      * Removes all the nodes.
-     *
-     * @api
      */
     public function clear()
     {
@@ -67,8 +59,6 @@ class Crawler extends \SplObjectStorage
      * on the type of the argument.
      *
      * @param null|\DOMNodeList|array|\DOMNode $node A node
-     *
-     * @api
      */
     public function add($node)
     {
@@ -83,18 +73,12 @@ class Crawler extends \SplObjectStorage
         }
     }
 
-    /**
-     * Adds HTML/XML content.
-     *
-     * @param string $content A string to parse as HTML/XML
-     * @param string $type    The content type of the string
-     */
     public function addContent($content, $type = null)
     {
         if (empty($type)) {
             $type = 'text/html';
         }
-
+		
         // DOM only for HTML/XML content
         if (!preg_match('/(x|ht)ml/i', $type, $matches)) {
             return null;
@@ -104,7 +88,6 @@ class Crawler extends \SplObjectStorage
         if (false !== $pos = strpos($type, 'charset=')) {
             $charset = substr($type, $pos + 8);
         }
-
         if ('x' === $matches[1]) {
             $this->addXmlContent($content, $charset);
         } else {
@@ -117,14 +100,13 @@ class Crawler extends \SplObjectStorage
      *
      * @param string $content The HTML content
      * @param string $charset The charset
-     *
-     * @api
      */
     public function addHtmlContent($content, $charset = 'UTF-8')
     {
+		libxml_use_internal_errors(true);
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
-
+		
         @$dom->loadHTML($content);
         $this->addDocument($dom);
 
@@ -140,8 +122,6 @@ class Crawler extends \SplObjectStorage
      *
      * @param string $content The XML content
      * @param string $charset The charset
-     *
-     * @api
      */
     public function addXmlContent($content, $charset = 'UTF-8')
     {
@@ -157,8 +137,6 @@ class Crawler extends \SplObjectStorage
      * Adds a \DOMDocument to the list of nodes.
      *
      * @param \DOMDocument $dom A \DOMDocument instance
-     *
-     * @api
      */
     public function addDocument(\DOMDocument $dom)
     {
@@ -171,8 +149,6 @@ class Crawler extends \SplObjectStorage
      * Adds a \DOMNodeList to the list of nodes.
      *
      * @param \DOMNodeList $nodes A \DOMNodeList instance
-     *
-     * @api
      */
     public function addNodeList(\DOMNodeList $nodes)
     {
@@ -185,8 +161,6 @@ class Crawler extends \SplObjectStorage
      * Adds an array of \DOMNode instances to the list of nodes.
      *
      * @param array $nodes An array of \DOMNode instances
-     *
-     * @api
      */
     public function addNodes(array $nodes)
     {
@@ -199,8 +173,6 @@ class Crawler extends \SplObjectStorage
      * Adds a \DOMNode instance to the list of nodes.
      *
      * @param \DOMNode $node A \DOMNode instance
-     *
-     * @api
      */
     public function addNode(\DOMNode $node)
     {
@@ -217,8 +189,6 @@ class Crawler extends \SplObjectStorage
      * @param integer $position The position
      *
      * @return A new instance of the Crawler with the selected node, or an empty Crawler if it does not exist.
-     *
-     * @api
      */
     public function eq($position)
     {
@@ -246,8 +216,6 @@ class Crawler extends \SplObjectStorage
      * @param \Closure $closure An anonymous function
      *
      * @return array An array of values returned by the anonymous function
-     *
-     * @api
      */
     public function each(\Closure $closure)
     {
@@ -267,8 +235,6 @@ class Crawler extends \SplObjectStorage
      * @param \Closure $closure An anonymous function
      *
      * @return Crawler A Crawler instance with the selected nodes.
-     *
-     * @api
      */
     public function reduce(\Closure $closure)
     {
@@ -286,8 +252,6 @@ class Crawler extends \SplObjectStorage
      * Returns the first node of the current selection
      *
      * @return Crawler A Crawler instance with the first selected node
-     *
-     * @api
      */
     public function first()
     {
@@ -298,8 +262,6 @@ class Crawler extends \SplObjectStorage
      * Returns the last node of the current selection
      *
      * @return Crawler A Crawler instance with the last selected node
-     *
-     * @api
      */
     public function last()
     {
@@ -312,8 +274,6 @@ class Crawler extends \SplObjectStorage
      * @return Crawler A Crawler instance with the sibling nodes
      *
      * @throws \InvalidArgumentException When current node is empty
-     *
-     * @api
      */
     public function siblings()
     {
@@ -330,8 +290,6 @@ class Crawler extends \SplObjectStorage
      * @return Crawler A Crawler instance with the next sibling nodes
      *
      * @throws \InvalidArgumentException When current node is empty
-     *
-     * @api
      */
     public function nextAll()
     {
@@ -346,8 +304,6 @@ class Crawler extends \SplObjectStorage
      * Returns the previous sibling nodes of the current selection
      *
      * @return Crawler A Crawler instance with the previous sibling nodes
-     *
-     * @api
      */
     public function previousAll()
     {
@@ -364,8 +320,6 @@ class Crawler extends \SplObjectStorage
      * @return Crawler A Crawler instance with the parents nodes of the current selection
      *
      * @throws \InvalidArgumentException When current node is empty
-     *
-     * @api
      */
     public function parents()
     {
@@ -391,8 +345,6 @@ class Crawler extends \SplObjectStorage
      * @return Crawler A Crawler instance with the children nodes
      *
      * @throws \InvalidArgumentException When current node is empty
-     *
-     * @api
      */
     public function children()
     {
@@ -411,8 +363,6 @@ class Crawler extends \SplObjectStorage
      * @return string The attribute value
      *
      * @throws \InvalidArgumentException When current node is empty
-     *
-     * @api
      */
     public function attr($attribute)
     {
@@ -429,8 +379,6 @@ class Crawler extends \SplObjectStorage
      * @return string The node value
      *
      * @throws \InvalidArgumentException When current node is empty
-     *
-     * @api
      */
     public function text()
     {
@@ -453,8 +401,6 @@ class Crawler extends \SplObjectStorage
      * @param array $attributes An array of attributes
      *
      * @return array An array of extracted values
-     *
-     * @api
      */
     public function extract($attributes)
     {
@@ -485,8 +431,6 @@ class Crawler extends \SplObjectStorage
      * @param string $xpath An XPath expression
      *
      * @return Crawler A new instance of Crawler with the filtered list of nodes
-     *
-     * @api
      */
     public function filterXPath($xpath)
     {
@@ -497,9 +441,20 @@ class Crawler extends \SplObjectStorage
         }
 
         $domxpath = new \DOMXPath($document);
-
-        return new static($domxpath->query($xpath), $this->uri, $this->base);
+		return new static($domxpath->query($xpath), $this->uri, $this->base);
+        
     }
+	
+	function savetofile($file='/tmp/behat_crawler.html'){
+		$document = new \DOMDocument('1.0', 'UTF-8');
+		$root = $document->appendChild($document->createElement('_root'));
+        foreach ($this as $node) {
+            $root->appendChild($document->importNode($node, true));
+        }
+
+        $domxpath = new \DOMXPath($document);
+		$document->saveHTMLFile($file);
+	}
 
     /**
      * Filters the list of nodes with a CSS selector.
@@ -511,8 +466,6 @@ class Crawler extends \SplObjectStorage
      * @return Crawler A new instance of Crawler with the filtered list of nodes
      *
      * @throws \RuntimeException if the CssSelector Component is not available
-     *
-     * @api
      */
     public function filter($selector)
     {
@@ -531,16 +484,12 @@ class Crawler extends \SplObjectStorage
      * @param  string $value The link text
      *
      * @return Crawler A new instance of Crawler with the filtered list of nodes
-     *
-     * @api
      */
-    public function selectLink($value)
-    {
-        $xpath  = sprintf('//a[contains(concat(\' \', normalize-space(string(.)), \' \'), %s)] ', static::xpathLiteral(' '.$value.' ')).
-                            sprintf('| //a/img[contains(concat(\' \', normalize-space(string(@alt)), \' \'), %s)]/ancestor::a', static::xpathLiteral(' '.$value.' '));
-
-        return $this->filterXPath($xpath);
-    }
+    public function selectLink($value,$selector='.') {
+        $xpath  = sprintf('//a[contains(concat(\' \', normalize-space(string('.$selector.')), \' \'), %s)] ', static::xpathLiteral(' '.$value.' ')).
+                            sprintf('| //a/img[contains(concat(\' \', normalize-space(string('.$selector.')), \' \'), %s)]/ancestor::a', static::xpathLiteral(' '.$value.' '));
+		return $this->filterXPath($xpath);
+	}
 
     /**
      * Selects a button by name or alt value for images.
@@ -548,17 +497,36 @@ class Crawler extends \SplObjectStorage
      * @param  string $value The button text
      *
      * @return Crawler A new instance of Crawler with the filtered list of nodes
-     *
-     * @api
      */
-    public function selectButton($value)
-    {
-        $xpath = sprintf('//input[((@type="submit" or @type="button") and contains(concat(\' \', normalize-space(string(@value)), \' \'), %s)) ', static::xpathLiteral(' '.$value.' ')).
+    public function selectButton($value,$selector='@value') {
+        $xpath = sprintf('//input[((@type="submit" or @type="button") and contains(concat(\' \', normalize-space(string('.$selector.')), \' \'), %s)) ', static::xpathLiteral(' '.$value.' ')).
                          sprintf('or (@type="image" and contains(concat(\' \', normalize-space(string(@alt)), \' \'), %s)) or @id="%s" or @name="%s"] ', static::xpathLiteral(' '.$value.' '), $value, $value).
-                         sprintf('| //button[contains(concat(\' \', normalize-space(string(.)), \' \'), %s) or @id="%s" or @name="%s"]', static::xpathLiteral(' '.$value.' '), $value, $value);
+                         sprintf('| //button[contains(concat(\' \', normalize-space(string('.$selector.')), \' \'), %s) or @id="%s" or @name="%s"]', static::xpathLiteral(' '.$value.' '), $value, $value);
+		return $this->filterXPath($xpath);
+	}
 
-        return $this->filterXPath($xpath);
-    }
+    /**
+     * Selects a button by name or alt value for images.
+     *
+     * @param  string $value The button text
+     *
+     * @return Crawler A new instance of Crawler with the filtered list of nodes
+     */
+    public function selectForm($value,$selector='@name') {
+        $xpath = sprintf('//form[contains(concat(\' \', normalize-space(string('.$selector.')), \' \'), %s)]', static::xpathLiteral(' '.$value.' '));
+		return $this->filterXPath($xpath);
+	}
+
+    /**
+     * Selects a button by name or alt value for images.
+     *
+     * @param  string $value The button text
+     *
+     * @return Crawler A new instance of Crawler with the filtered list of nodes
+     */
+    public function selectXpath($xpath) {
+		return $this->filterXPath($xpath);
+	}
 
     /**
      * Returns a Link object for the first node in the list.
@@ -568,8 +536,6 @@ class Crawler extends \SplObjectStorage
      * @return Link   A Link instance
      *
      * @throws \InvalidArgumentException If the current node list is empty
-     *
-     * @api
      */
     public function link($method = 'get')
     {
@@ -586,8 +552,6 @@ class Crawler extends \SplObjectStorage
      * Returns an array of Link objects for the nodes in the list.
      *
      * @return array An array of Link instances
-     *
-     * @api
      */
     public function links()
     {
@@ -608,17 +572,13 @@ class Crawler extends \SplObjectStorage
      * @return Form   A Form instance
      *
      * @throws \InvalidArgumentException If the current node list is empty
-     *
-     * @api
      */
     public function form(array $values = null, $method = null)
     {
         if (!count($this)) {
             throw new \InvalidArgumentException('The current node list is empty.');
         }
-
         $form = new Form($this->getNode(0), $method, $this->host, $this->path, $this->base);
-
         if (null !== $values) {
             $form->setValues($values);
         }

--- a/src/Symfony/Component/DomCrawler/Field/InputFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/InputFormField.php
@@ -18,8 +18,6 @@ namespace Symfony\Component\DomCrawler\Field;
  * specialized classes (cf. FileFormField and ChoiceFormField).
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 class InputFormField extends FormField
 {
@@ -30,7 +28,7 @@ class InputFormField extends FormField
      */
     protected function initialize()
     {
-        if ('input' != $this->node->nodeName) {
+        if ('input' != $this->node->nodeName && 'button' != $this->node->nodeName) {
             throw new \LogicException(sprintf('An InputFormField can only be created from an input tag (%s given).', $this->node->nodeName));
         }
 


### PR DESCRIPTION
First, notices on html parse was giving me some headaches when I was Behat-building. I have disabeld xml notices on parsing, so facebook namespace error is not being thrown already.

Finally you can meet with the need to test an external web without the possibility of pushing a send button, so I have added this feature. If you think it can be useful, perfect.
