### PR TITLE
[TwigBundle] Update the cache warmer

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
@@ -25,8 +25,6 @@ use Symfony\Component\Finder\Finder;
  */
 class TemplateCacheCacheWarmer extends CacheWarmer
 {
-    const TEMPLATES_PATH_IN_BUNDLE = '/Resources/views';
-
     protected $container;
     protected $parser;
     protected $kernel;
@@ -59,12 +57,15 @@ class TemplateCacheCacheWarmer extends CacheWarmer
         $twig = $this->container->get('twig');
 
         foreach ($this->kernel->getBundles() as $name => $bundle) {
-            foreach ($this->findTemplatesIn($bundle->getPath().self::TEMPLATES_PATH_IN_BUNDLE, $name) as $template) {
+            foreach ($this->findTemplatesIn($bundle->getPath().'/Resources/views', $name) as $template) {
+                $twig->loadTemplate($template);
+            }
+            foreach ($this->findTemplatesIn($this->rootDir.'/'.$name.'/views', $name) as $template) {
                 $twig->loadTemplate($template);
             }
         }
 
-        foreach ($this->findTemplatesIn($this->rootDir) as $template) {
+        foreach ($this->findTemplatesIn($this->rootDir.'/views') as $template) {
             $twig->loadTemplate($template);
         }
     }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -19,7 +19,7 @@
 
         <service id="twig.cache_warmer" class="%twig.cache_warmer.class%" public="false">
             <argument type="service" id="service_container" />
-            <argument>%kernel.root_dir%/views</argument>
+            <argument>%kernel.root_dir%/Resources</argument>
         </service>
 
         <service id="twig.loader" class="%twig.loader.class%">


### PR DESCRIPTION
This changes reflects what has been done [on the template warmer](https://github.com/symfony/symfony/commit/a2294106fb8eee0f9cdb10bf9b190c52485bd551#src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php)

*_This PR assumes that custom templates are stored in the app/Resources/BundleName/views *_

Notes:
- If think there are currently some problems with the template locator / warmer,
- There should be some common code for handling template paths (across Framework, Twig, Assetic, ... bundles).

So this PR should be considered as a temporary fix before we have a better solution. I'll post my thoughts on the dev ml in the coming days. 
