### PR TITLE
removed exit calls

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/CreateHydratorDirectoryPass.php
@@ -20,10 +20,10 @@ class CreateHydratorDirectoryPass implements CompilerPassInterface
         $hydratorCacheDir = $container->getParameter('doctrine.odm.mongodb.hydrator_dir');
         if (!is_dir($hydratorCacheDir)) {
             if (false === @mkdir($hydratorCacheDir, 0777, true)) {
-                exit(sprintf('Unable to create the Doctrine Hydrator directory (%s)', dirname($hydratorCacheDir)));
+                throw new \RuntimeException(sprintf('Unable to create the Doctrine Hydrator directory (%s)', dirname($hydratorCacheDir)));
             }
         } elseif (!is_writable($hydratorCacheDir)) {
-            exit(sprintf('Unable to write in the Doctrine Hydrator directory (%s)', $hydratorCacheDir));
+            throw new \RuntimeException(sprintf('Unable to write in the Doctrine Hydrator directory (%s)', $hydratorCacheDir));
         }
     }
 

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/CreateProxyDirectoryPass.php
@@ -20,10 +20,10 @@ class CreateProxyDirectoryPass implements CompilerPassInterface
         $proxyCacheDir = $container->getParameter('doctrine.odm.mongodb.proxy_dir');
         if (!is_dir($proxyCacheDir)) {
             if (false === @mkdir($proxyCacheDir, 0777, true)) {
-                exit(sprintf('Unable to create the Doctrine Proxy directory (%s)', dirname($proxyCacheDir)));
+                throw new \RuntimeException(sprintf('Unable to create the Doctrine Proxy directory (%s)', dirname($proxyCacheDir)));
             }
         } elseif (!is_writable($proxyCacheDir)) {
-            exit(sprintf('Unable to write in the Doctrine Proxy directory (%s)', $proxyCacheDir));
+            throw new \RuntimeException(sprintf('Unable to write in the Doctrine Proxy directory (%s)', $proxyCacheDir));
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -520,10 +520,10 @@ abstract class Kernel implements KernelInterface
             $dir = $container->getParameter(sprintf('kernel.%s_dir', $name));
             if (!is_dir($dir)) {
                 if (false === @mkdir($dir, 0777, true)) {
-                    exit(sprintf("Unable to create the %s directory (%s)\n", $name, dirname($dir)));
+                    throw new \RuntimeException(sprintf("Unable to create the %s directory (%s)\n", $name, dirname($dir)));
                 }
             } elseif (!is_writable($dir)) {
-                exit(sprintf("Unable to write in the %s directory (%s)\n", $name, $dir));
+                throw new \RuntimeException(sprintf("Unable to write in the %s directory (%s)\n", $name, $dir));
             }
         }
 


### PR DESCRIPTION
Replaces exit() calls with throwing a \RuntimeException.
