### PR TITLE
Fixed getPhpUnitXmlDir in WebTestCase for paths with spaces in them

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -88,10 +88,10 @@ abstract class WebTestCase extends BaseWebTestCase
     private function getPhpUnitCliConfigArgument()
     {
         $dir = null;
-        
-        foreach (array_reverse($_SERVER['argv']) as $argIndex=>$testArg) {
+        $reversedArgs = array_reverse($_SERVER['argv']);
+        foreach ($reversedArgs as $argIndex=>$testArg) {
             if ($testArg === '-c' || $testArg === '--configuration') {
-                $dir = realpath($_SERVER['argv'][$argIndex + 1]);
+                $dir = realpath($reversedArgs[$argIndex - 1]);
                 break;
             } else if (strpos($testArg, '--configuration=') === 0) {
                 $argPath = substr($testArg, strlen('--configuration='));

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -61,7 +61,9 @@ abstract class WebTestCase extends BaseWebTestCase
         }
 
         $dir = $this->getPhpUnitCliConfigArgument();
-        if ($dir === null && $this->doesPhpUnitConfigFileExistInCwd()) {
+        if ($dir === null && 
+            (file_exists(getcwd() . DIRECTORY_SEPARATOR . 'phpunit.xml') ||
+            file_exists(getcwd() . DIRECTORY_SEPARATOR . 'phpunit.xml.dist'))) {
             $dir = getcwd();
         }
 
@@ -101,17 +103,6 @@ abstract class WebTestCase extends BaseWebTestCase
         }
 
         return $dir;
-    }
-
-    /**
-     * Finds whether a phpunit configuration file exists in current directory
-     *
-     * @return Boolean true if a phpunit configuration file exists in current directory, false if not
-     */
-    private function doesPhpUnitConfigFileExistInCwd()
-    {
-        return (file_exists(getcwd() . DIRECTORY_SEPARATOR . 'phpunit.xml') ||
-                file_exists(getcwd() . DIRECTORY_SEPARATOR . 'phpunit.xml.dist'));
     }
 
     /**


### PR DESCRIPTION
The following style invocation was causing problems:

phpunit -c "D:\Projects\My Project"

Because the Regex was expecting no spaces in filepaths. This will probably come up a fair bit for windows users (like myself). Switched to a non regexed approach so only php takes care of command line parsing.
