### PR TITLE
[Windows] Fixed warning, error & some tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -22,6 +22,15 @@ use Symfony\Component\HttpFoundation\File\Exception\AccessDeniedException;
 class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
 {
     /**
+     * Returns whether this guesser is supported on the current OS
+     *
+     * @return Boolean
+     */
+    static public function isSupported()
+    {
+        return !strstr(PHP_OS, 'WIN');
+    }
+    /**
      * Guesses the mime type of the file with the given path
      *
      * @see MimeTypeGuesserInterface::guess()

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -63,7 +63,9 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
      */
     private function __construct()
     {
-        $this->register(new FileBinaryMimeTypeGuesser());
+        if (FileBinaryMimeTypeGuesser::isSupported()) {
+            $this->register(new FileBinaryMimeTypeGuesser());
+        }
 
         if (ContentTypeMimeTypeGuesser::isSupported()) {
             $this->register(new ContentTypeMimeTypeGuesser());

--- a/tests/Symfony/Tests/Component/Finder/FinderTest.php
+++ b/tests/Symfony/Tests/Component/Finder/FinderTest.php
@@ -265,7 +265,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testAppendWithAFinder()
     {
         $finder = new Finder();
-        $finder->files()->in(self::$tmpDir.'/foo');
+        $finder->files()->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
 
         $finder1 = new Finder();
         $finder1->directories()->in(self::$tmpDir);
@@ -278,7 +278,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     public function testAppendWithAnArray()
     {
         $finder = new Finder();
-        $finder->files()->in(self::$tmpDir.'/foo');
+        $finder->files()->in(self::$tmpDir.DIRECTORY_SEPARATOR.'foo');
 
         $finder->append($this->toAbsolute(array('foo', 'toto')));
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/MimeType/MimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/MimeType/MimeTypeTest.php
@@ -24,31 +24,51 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testGuessImageWithoutExtension()
     {
-        $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
+        if (extension_loaded('fileinfo')) {
+            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
+        } else {
+            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
+        }
     }
 
     public function testGuessImageWithContentTypeMimeTypeGuesser()
     {
         $guesser = MimeTypeGuesser::getInstance();
         $guesser->register(new ContentTypeMimeTypeGuesser());
-        $this->assertEquals('image/gif', $guesser->guess(__DIR__.'/../Fixtures/test'));
+        if (extension_loaded('fileinfo')) {
+            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
+        } else {
+            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
+        }
     }
 
     public function testGuessImageWithFileBinaryMimeTypeGuesser()
     {
         $guesser = MimeTypeGuesser::getInstance();
         $guesser->register(new FileBinaryMimeTypeGuesser());
-        $this->assertEquals('image/gif', $guesser->guess(__DIR__.'/../Fixtures/test'));
+        if (extension_loaded('fileinfo')) {
+            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
+        } else {
+            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test'));
+        }
     }
 
     public function testGuessImageWithKnownExtension()
     {
-        $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test.gif'));
+        if (extension_loaded('fileinfo')) {
+            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test.gif'));
+        } else {
+            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/test.gif'));
+        }
     }
 
     public function testGuessFileWithUnknownExtension()
     {
-        $this->assertEquals('application/octet-stream', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/.unknownextension'));
+        if (extension_loaded('fileinfo')) {
+            $this->assertEquals('application/octet-stream', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/.unknownextension'));
+        } else {
+            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/.unknownextension'));
+        }
     }
 
     public function testGuessWithIncorrectPath()

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
@@ -33,7 +33,11 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertAttributeEquals('application/octet-stream', 'mimeType', $file);
-        $this->assertEquals('image/gif', $file->getMimeType());
+        if (extension_loaded('fileinfo')) {
+            $this->assertEquals('image/gif', $file->getMimeType());
+        } else {
+            $this->assertEquals('application/octet-stream', $file->getMimeType());
+        }
     }
 
     public function testFileUploadsWithUnknownMimeType()


### PR DESCRIPTION
[HttpFoundation][Windows] Fixed guesser tests if Fileinfo extension is not loaded
Didn't test for presence of mime_content_type function since it's obsolete (deprecated) in PHP5
[Finder][Windows] Fixed windows tests
[HttpFoundation][Windows] Disabled FileBinaryMimeTypeGuesser for Windows OS
