### PR TITLE
JsonResponse

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * JsonResponse is a Response, that has JSON content.
+ *
+ * @author Christian Hoffmeister <choffmeister.github@googlemail.com>
+ */
+class JsonResponse extends Response
+{
+    /**
+     * Creates a response with the object in JSON representation as content.
+     *
+     * @param mixed   $object The object
+     * @param integer $status The status code (200 by default)
+     *
+     * @see http://tools.ietf.org/html/rfc2616#section-10.3.5
+     */
+    public function __construct($object, $status = 200)
+    {
+        parent::__construct(\json_encode($object), $status);
+    }
+}

--- a/tests/Symfony/Tests/Component/HttpFoundation/JsonResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/JsonResponseTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpFoundation;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * JsonResponseTest
+ *
+ * @author Christian Hoffmeister <choffmeister.github@googlemail.com>
+ */
+class ServerBagTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructor()
+    {
+        $data = array(
+            'first' => 1,
+            'second' => '2nd',
+            'third' => array(
+                3 => '3a',
+                'four' => 4,
+            ),
+        );
+
+        $jsonResponse1 = new JsonResponse($data);
+
+        $this->assertEquals('{"first":1,"second":"2nd","third":{"3":"3a","four":4}}', $jsonResponse1->getContent());
+        $this->assertEquals(200, $jsonResponse1->getStatusCode());
+    }
+}


### PR DESCRIPTION
A simple Response subclass, that takes an object as constructor parameter. This object is converted by `json_encode` to a JSON string an set as content.
