### PR TITLE
Add a configuration option to restrict profiler storage to the master request

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -90,6 +90,7 @@ class Configuration
                     ->canBeUnset()
                     ->children()
                         ->booleanNode('only_exceptions')->defaultValue(false)->end()
+                        ->booleanNode('only_master_requests')->defaultValue(false)->end()
                         ->scalarNode('dsn')->defaultValue('sqlite:%kernel.cache_dir%/profiler.db')->end()
                         ->scalarNode('username')->defaultValue('')->end()
                         ->scalarNode('password')->defaultValue('')->end()
@@ -143,7 +144,7 @@ class Configuration
                             }
                             return $v;
                         })
-                    ->end()                    
+                    ->end()
                     ->children()
                         ->booleanNode('auto_start')->end()
                         ->scalarNode('class')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -204,6 +204,7 @@ class FrameworkExtension extends Extension
 
         $container->getDefinition('profiler_listener')
             ->setArgument(2, $config['only_exceptions'])
+            ->setArgument(3, $config['only_master_requests'])
         ;
 
         // Choose storage class based on the DSN

--- a/src/Symfony/Bundle/FrameworkBundle/Profiler/ProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Profiler/ProfilerListener.php
@@ -44,8 +44,8 @@ class ProfilerListener
     {
         $this->container = $container;
         $this->matcher = $matcher;
-        $this->onlyException = $onlyException;
-        $this->onlyMasterRequests = $onlyMasterRequests;
+        $this->onlyException = (Boolean) $onlyException;
+        $this->onlyMasterRequests = (Boolean) $onlyMasterRequests;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Profiler/ProfilerListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Profiler/ProfilerListener.php
@@ -27,9 +27,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class ProfilerListener
 {
     protected $container;
-    protected $exception;
-    protected $onlyException;
     protected $matcher;
+    protected $onlyException;
+    protected $onlyMasterRequests;
+    protected $exception;
 
     /**
      * Constructor.
@@ -37,12 +38,14 @@ class ProfilerListener
      * @param ContainerInterface      $container     A ContainerInterface instance
      * @param RequestMatcherInterface $matcher       A RequestMatcher instance
      * @param Boolean                 $onlyException true if the profiler only collects data when an exception occurs, false otherwise
+     * @param Boolean                 $onlyMaster    true if the profiler only collects data when the request is a master request, false otherwise
      */
-    public function __construct(ContainerInterface $container, RequestMatcherInterface $matcher = null, $onlyException = false)
+    public function __construct(ContainerInterface $container, RequestMatcherInterface $matcher = null, $onlyException = false, $onlyMasterRequests = false)
     {
         $this->container = $container;
         $this->matcher = $matcher;
         $this->onlyException = $onlyException;
+        $this->onlyMasterRequests = $onlyMasterRequests;
     }
 
     /**
@@ -80,6 +83,10 @@ class ProfilerListener
     public function onCoreResponse(FilterResponseEvent $event)
     {
         $response = $event->getResponse();
+
+        if ($this->onlyMasterRequests && HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
+            return $response;
+        }
 
         if (null !== $this->matcher && !$this->matcher->matches($event->getRequest())) {
             return $response;

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -29,6 +29,7 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="profiler.request_matcher" on-invalid="null" />
             <argument /> <!-- Only exceptions? -->
+            <argument /> <!-- Only master requests? -->
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -54,6 +54,7 @@
         </xsd:all>
 
         <xsd:attribute name="only-exceptions" type="xsd:string" />
+        <xsd:attribute name="only-master-requests" type="xsd:string" />
         <xsd:attribute name="dsn" type="xsd:string" />
         <xsd:attribute name="username" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />


### PR DESCRIPTION
We a currently working on a project were a single requested URL typically leads to some hundred controller calls. Using the dev controller got incredibly slow since recent Symfony2 changes because for each controller
invocation a new entry gets added to the profiler storage (totalling over 100mb of data on each request in our case).

With the new configuration attribute "only-master-requests" it is possible to limit the profiler storage to the master requests, keeping the profiler usable for us.
