### PR TITLE
[DoctrineAbstractBundle] "static-php" to "staticphp"

### DIFF
--- a/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
@@ -153,7 +153,7 @@ abstract class AbstractDoctrineExtension extends Extension
         }
 
         if (!$bundleConfig['dir']) {
-            if (in_array($bundleConfig['type'], array('annotation', 'static-php'))) {
+            if (in_array($bundleConfig['type'], array('annotation', 'staticphp'))) {
                 $bundleConfig['dir'] = $bundleDir.'/'.$this->getMappingObjectDefaultName();
             } else {
                 $bundleConfig['dir'] = $bundleDir.'/'.$this->getMappingResourceConfigDirectory();
@@ -236,7 +236,7 @@ abstract class AbstractDoctrineExtension extends Extension
 
         if (!in_array($mappingConfig['type'], array('xml', 'yml', 'annotation', 'php', 'staticphp'))) {
             throw new \InvalidArgumentException("Can only configure 'xml', 'yml', 'annotation', 'php' or ".
-                "'static-php' through the DoctrineBundle. Use your own bundle to configure other metadata drivers. " .
+                "'staticphp' through the DoctrineBundle. Use your own bundle to configure other metadata drivers. " .
                 "You can register them by adding a a new driver to the ".
                 "'" . $this->getObjectManagerElementName($objectManagerName . ".metadata_driver")."' service definition."
             );


### PR DESCRIPTION
Hey guys-

Looks like these two strings just got mixed up. The parameter (in the ORM) `doctrine.orm.metadata.staticphp_class` is the end-target, so the version _without_ the dash is correct. The docs have already been updated.

Thanks!
