### PR TITLE
[FORM] Fixed DateField Month Choices

### DIFF
--- a/src/Symfony/Component/Form/DateField.php
+++ b/src/Symfony/Component/Form/DateField.php
@@ -119,7 +119,8 @@ class DateField extends HybridField
         $this->formatter = new \IntlDateFormatter(
             \Locale::getDefault(),
             self::$intlFormats[$this->getOption('format')],
-            \IntlDateFormatter::NONE
+            \IntlDateFormatter::NONE,
+            \DateTimeZone::UTC
         );
 
         if ($this->getOption('type') === self::STRING) {
@@ -206,7 +207,7 @@ class DateField extends HybridField
             $choices = array();
 
             foreach ($months as $month) {
-                $choices[$month] = $this->formatter->format(gmmktime(0, 0, 0, $month));
+                $choices[$month] = $this->formatter->format(gmmktime(0, 0, 0, $month, 1));
             }
 
             $this->formatter->setPattern($pattern);


### PR DESCRIPTION
The month choices were calculated using the current day of the month with
gmmktime rather than the 1st of the month. Additionally, this provides a
UTC timestamp which is passed to the formatter (IntlDateFormatter) which
converts the timestamp using the current timezone. This means that the UTC
timestamp for 1st March was being converted for my timezone (EST) and giving
a date of 28th February, leading to Feb appearing again in the popup form
instead of Mar.
