### PR TITLE
[Config] Alias used classes in NodeBuilderTest to avoid conflicts

### DIFF
--- a/tests/Symfony/Tests/Component/Config/Definition/Builder/NodeBuilderTest.php
+++ b/tests/Symfony/Tests/Component/Config/Definition/Builder/NodeBuilderTest.php
@@ -2,8 +2,8 @@
 
 namespace Symfony\Tests\Component\Config\Definition\Builder;
 
-use Symfony\Component\Config\Definition\Builder\NodeBuilder;
-use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder as BaseNodeBuilder;
+use Symfony\Component\Config\Definition\Builder\VariableNodeDefinition as BaseVariableNodeDefinition;
 
 class NodeBuilderTest extends \PHPUnit_Framework_TestCase
 {
@@ -12,7 +12,7 @@ class NodeBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsAnExceptionWhenTryingToCreateANonRegisteredNodeType()
     {
-        $builder = new NodeBuilder();
+        $builder = new BaseNodeBuilder();
         $builder->node('', 'foobar');
     }
 
@@ -21,7 +21,7 @@ class NodeBuilderTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsAnExceptionWhenTheNodeClassIsNotFound()
     {
-        $builder = new NodeBuilder();
+        $builder = new BaseNodeBuilder();
         $builder
             ->setNodeClass('noclasstype', '\\foo\\bar\\noclass')
             ->node('', 'noclasstype');
@@ -31,7 +31,7 @@ class NodeBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $class = __NAMESPACE__.'\\SomeNodeDefinition';
         
-        $builder = new NodeBuilder();
+        $builder = new BaseNodeBuilder();
         $node = $builder
             ->setNodeClass('newtype', $class)
             ->node('', 'newtype');
@@ -43,7 +43,7 @@ class NodeBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $class = __NAMESPACE__.'\\SomeNodeDefinition';
 
-        $builder = new NodeBuilder();
+        $builder = new BaseNodeBuilder();
         $node = $builder
             ->setNodeClass('variable', $class)
             ->node('', 'variable');
@@ -53,7 +53,7 @@ class NodeBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testNodeTypesAreNotCaseSensitive()
     {
-        $builder = new NodeBuilder();
+        $builder = new BaseNodeBuilder();
 
         $node1 = $builder->node('', 'VaRiAbLe');
         $node2 = $builder->node('', 'variable');
@@ -69,6 +69,6 @@ class NodeBuilderTest extends \PHPUnit_Framework_TestCase
     }    
 }
 
-class SomeNodeDefinition extends VariableNodeDefinition
+class SomeNodeDefinition extends BaseVariableNodeDefinition
 {
 }


### PR DESCRIPTION
[Config] Alias used classes in NodeBuilderTest to avoid conflicts with fixture classes required in TreeBuilderTest

Depending on the order of execution of Config\Definition\Builder tests (due to filesystem ordering), namespace conflicts can occur between real classes and fixtures loaded by the TreeBuilderTest.
