### PR TITLE
[FrameworkBundle] Change validator's annotation prefix from "validation" 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -16,7 +16,7 @@
         <parameter key="validator.mapping.loader.yaml_files_loader.class">Symfony\Component\Validator\Mapping\Loader\YamlFilesLoader</parameter>
         <parameter key="validator.validator_factory.class">Symfony\Bundle\FrameworkBundle\Validator\ConstraintValidatorFactory</parameter>
         <parameter key="validator.annotations.namespaces" type="collection">
-            <parameter key="validation">Symfony\Component\Validator\Constraints\</parameter>
+            <parameter key="assert">Symfony\Component\Validator\Constraints\</parameter>
         </parameter>
     </parameters>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -172,7 +172,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('validator.mapping.loader.annotation_loader'), '->registerValidationConfiguration() defines the annotation loader');
 
         $namespaces = $container->getParameter('validator.annotations.namespaces');
-        $this->assertEquals('Symfony\\Component\\Validator\\Constraints\\', $namespaces['validation'], '->registerValidationConfiguration() loads the default "validation" namespace');
+        $this->assertEquals('Symfony\\Component\\Validator\\Constraints\\', $namespaces['assert'], '->registerValidationConfiguration() loads the default "assert" prefix');
         $this->assertEquals('Application\\Validator\\Constraints\\', $namespaces['app'], '->registerValidationConfiguration() loads custom validation namespaces');
     }
 


### PR DESCRIPTION
[FrameworkBundle] Change validator's annotation prefix from "validation" to "assert"
