### PR TITLE
Fix for DoctrineBundle when default_connection key of doctrine.dbal is changed from default

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -57,7 +57,7 @@
         
         <service id="form.field_factory.doctrine_guesser" class="%form.field_factory.doctrine_guesser.class%" public="false">
         	<tag name="form.field_factory.guesser" />
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
[DoctrineBundle] fixes issues with $this->container->get('form.context')
when the value of default_connection key of doctrine.dbal is changed
from default in config.yml
