### PR TITLE
Introduction of a configuration base class

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -6,6 +6,14 @@ one. It only discusses changes that need to be done when using the "public"
 API of the framework. If you "hack" the core, you should probably follow the
 timeline closely anyway.
 
+PR10 to PR11
+------------
+
+* Extension configuration classes should now implement the
+`Symfony\Component\Config\Definition\ConfigurationInterface` interface. Note that
+the BC is kept but implementing this interface in your extensions will allow for
+further developments.
+
 PR9 to PR10
 -----------
 

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -99,11 +99,9 @@ class AsseticExtension extends Extension
      */
     static protected function processConfigs(array $configs, $debug, array $bundles)
     {
-        $configuration = new Configuration();
-        $tree = $configuration->getConfigTree($debug, $bundles);
-
         $processor = new Processor();
-        return $processor->process($tree, $configs);
+        $configuration = new Configuration($debug, $bundles);
+        return $processor->processConfiguration($configuration, $configs);
     }
 
     /**

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\AsseticBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -22,24 +23,36 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  * @author Christophe Coevoet <stof@notk.org>
  * @author Kris Wallsmith <kris@symfony.com>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
+    private $bundles;
+    private $debug;
+
     /**
-     * Generates the configuration tree.
+     * Constructor
      *
      * @param Boolean $debug    Wether to use the debug mode
      * @param array   $bundles  An array of bundle names
-     * 
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
      */
-    public function getConfigTree($debug, array $bundles)
+    public function __construct($debug, array $bundles)
     {
-        $tree = new TreeBuilder();
+        $this->debug = (Boolean) $debug;
+        $this->bundles = $bundles;
+    }
 
-        $tree->root('assetic')
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $builder = new TreeBuilder();
+
+        $builder->root('assetic')
             ->children()
-                ->booleanNode('debug')->defaultValue($debug)->end()
-                ->booleanNode('use_controller')->defaultValue($debug)->end()
+                ->booleanNode('debug')->defaultValue($this->debug)->end()
+                ->booleanNode('use_controller')->defaultValue($this->debug)->end()
                 ->scalarNode('read_from')->defaultValue('%kernel.root_dir%/../web')->end()
                 ->scalarNode('write_to')->defaultValue('%assetic.read_from%')->end()
                 ->scalarNode('java')->defaultValue('/usr/bin/java')->end()
@@ -51,7 +64,7 @@ class Configuration
             ->fixXmlConfig('bundle')
             ->children()
                 ->arrayNode('bundles')
-                    ->defaultValue($bundles)
+                    ->defaultValue($this->bundles)
                     ->requiresAtLeastOneElement()
                     ->beforeNormalization()
                         ->ifTrue(function($v) { return !is_array($v); })
@@ -84,6 +97,6 @@ class Configuration
             ->end()
         ;
 
-        return $tree->buildTree();
+        return $builder;
     }
 }

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\DoctrineBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -22,28 +23,34 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
-    private $kernelDebug;
+    private $debug;
 
     /**
-     * Generates the configuration tree.
+     * Constructor
      *
-     * @param Boolean $kernelDebug
-     *
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
+     * @param Boolean $debug Wether to use the debug mode
      */
-    public function getConfigTree($kernelDebug)
+    public function  __construct($debug)
     {
-        $this->kernelDebug = (bool) $kernelDebug;
-
+        $this->debug = (Boolean) $debug;
+    }
+    
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
+    {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('doctrine');
 
         $this->addDbalSection($rootNode);
         $this->addOrmSection($rootNode);
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 
     private function addDbalSection(ArrayNodeDefinition $node)
@@ -98,7 +105,7 @@ class Configuration
                     ->scalarNode('unix_socket')->end()
                     ->scalarNode('platform_service')->end()
                     ->scalarNode('charset')->end()
-                    ->booleanNode('logging')->defaultValue($this->kernelDebug)->end()
+                    ->booleanNode('logging')->defaultValue($this->debug)->end()
                 ->end()
                 ->fixXmlConfig('driver_class', 'driverClass')
                 ->children()

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -31,9 +31,9 @@ class DoctrineExtension extends AbstractDoctrineExtension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
         $processor = new Processor();
-        $config = $processor->process($configuration->getConfigTree($container->getParameter('kernel.debug')), $configs);
+        $configuration = new Configuration($container->getParameter('kernel.debug'));
+        $config = $processor->processConfiguration($configuration, $configs);
 
         if (!empty($config['dbal'])) {
             $this->dbalLoad($config['dbal'], $container);

--- a/src/Symfony/Bundle/DoctrineMigrationsBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMigrationsBundle/DependencyInjection/Configuration.php
@@ -3,20 +3,21 @@
 namespace Symfony\Bundle\DoctrineMigrationsBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * DoctrineMigrationsExtension configuration structure.
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
     /**
-     * Generates the configuration tree.
+     * Generates the configuration tree builder.
      *
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
-    public function getConfigTree()
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('doctrine_migrations', 'array');
@@ -30,6 +31,6 @@ class Configuration
             ->end()
         ;
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 }

--- a/src/Symfony/Bundle/DoctrineMigrationsBundle/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/Symfony/Bundle/DoctrineMigrationsBundle/DependencyInjection/DoctrineMigrationsExtension.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Bundle\DoctrineMigrationsBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * DoctrineMigrationsExtension.
@@ -33,7 +33,7 @@ class DoctrineMigrationsExtension extends Extension
         $processor = new Processor();
         $configuration = new Configuration();
 
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $processor->processConfiguration($configuration, $configs);
 
         foreach ($config as $key => $value) {
             $container->setParameter($this->getAlias().'.'.$key, $value);

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Configuration.php
@@ -4,13 +4,14 @@ namespace Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * FrameworkExtension configuration structure.
  *
  * @author Ryan Weaver <ryan@thatsquality.com>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
     private $debug;
 
@@ -25,11 +26,11 @@ class Configuration
     }
 
     /**
-     * Generates the configuration tree.
+     * Generates the configuration tree builder.
      *
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
-    public function getConfigTree()
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('doctrine_mongo_db');
@@ -49,7 +50,7 @@ class Configuration
             ->end()
         ;
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -17,8 +17,8 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineExtension;
 use Symfony\Component\Config\Definition\Processor;
+use Symfony\Bundle\DoctrineAbstractBundle\DependencyInjection\AbstractDoctrineExtension;
 
 /**
  * Doctrine MongoDB ODM extension.
@@ -40,7 +40,7 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
 
         $processor = new Processor();
         $configuration = new Configuration($container->getParameter('kernel.debug'));
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $processor->processConfiguration($configuration, $configs);
 
         // can't currently default this correctly in Configuration
         if (!isset($config['metadata_cache_driver'])) {

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\DoctrineMongoDBBundle\Tests\DependencyInjection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Configuration;
 use Symfony\Component\Yaml\Yaml;
-
 use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
@@ -23,7 +22,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->process($configuration->getConfigTree(), array());
+        $options = $processor->processConfiguration($configuration, array());
 
         $defaults = array(
             'auto_generate_hydrator_classes'    => false,
@@ -56,7 +55,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->process($configuration->getConfigTree(), array($config));
+        $options = $processor->processConfiguration($configuration, array($config));
 
         $expected = array(
             'proxy_namespace'                   => 'Test_Proxies',
@@ -141,7 +140,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->process($configuration->getConfigTree(), $configs);
+        $options = $processor->processConfiguration($configuration, $configs);
 
         foreach ($correctValues as $key => $correctVal)
         {
@@ -230,7 +229,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(false);
-        $options = $processor->process($configuration->getConfigTree(), array($config));
+        $options = $processor->processConfiguration($configuration, array($config));
         $this->assertSame($normalized, $options[$targetKey]);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -4,29 +4,40 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * FrameworkExtension configuration structure.
  *
  * @author Jeremy Mikola <jmikola@gmail.com>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
+    private $debug;
+
     /**
-     * Generates the configuration tree.
+     * Constructor
      *
-     * @param boolean $kernelDebug The kernel.debug DIC parameter
-     *
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
+     * @param Boolean $debug Wether to use the debug mode
      */
-    public function getConfigTree($kernelDebug)
+    public function  __construct($debug)
+    {
+        $this->debug = (Boolean) $debug;
+    }
+
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('framework');
 
         $rootNode
             ->children()
-                ->scalarNode('cache_warmer')->defaultValue(!$kernelDebug)->end()
+                ->scalarNode('cache_warmer')->defaultValue(!$this->debug)->end()
                 ->scalarNode('charset')->end()
                 ->scalarNode('document_root')->end()
                 ->scalarNode('error_handler')->end()
@@ -45,7 +56,7 @@ class Configuration
         $this->addTranslatorSection($rootNode);
         $this->addValidationSection($rootNode);
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 
     private function addCsrfProtectionSection(ArrayNodeDefinition $rootNode)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -15,12 +15,12 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * FrameworkExtension.
@@ -56,9 +56,8 @@ class FrameworkExtension extends Extension
         }
 
         $processor = new Processor();
-        $configuration = new Configuration();
-
-        $config = $processor->process($configuration->getConfigTree($container->getParameter('kernel.debug')), $configs);
+        $configuration = new Configuration($container->getParameter('kernel.debug'));
+        $config = $processor->processConfiguration($configuration, $configs);
 
         $container->setParameter('kernel.cache_warmup', $config['cache_warmer']);
 

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\MonologBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -22,14 +23,14 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  * @author Jordi Boggiano <j.boggiano@seld.be>
  * @author Christophe Coevoet <stof@notk.org>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
     /**
-     * Generates the configuration tree.
+     * Generates the configuration tree builder.
      *
-     * @return \Symfony\Component\Config\Definition\NodeInterface
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
-    public function getConfigTree()
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('monolog');
@@ -82,7 +83,7 @@ class Configuration
             ->append($this->getProcessorsNode())
         ;
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 
     private function getProcessorsNode()

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -40,7 +40,7 @@ class MonologExtension extends Extension
     {
         $configuration = new Configuration();
         $processor = new Processor();
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $processor->processConfiguration($configuration, $configs);
 
         if (isset($config['handlers'])) {
             $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/FactoryConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/FactoryConfiguration.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This class contains the configuration information for the following tags:
+ *
+ *   * security.config
+ *   * security.acl
+ *
+ * This information is solely responsible for how the different configuration
+ * sections are normalized, and merged.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class FactoryConfiguration implements ConfigurationInterface
+{
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $tb = new TreeBuilder();
+
+        $tb
+            ->root('security')
+                ->ignoreExtraKeys()
+                ->fixXmlConfig('factory', 'factories')
+                ->children()
+                    ->arrayNode('factories')
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $tb;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -4,6 +4,7 @@ namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This class contains the configuration information for the following tags:
@@ -16,31 +17,26 @@ use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
-class Configuration
+class MainConfiguration implements ConfigurationInterface
 {
-    /**
-     * Generates the configuration tree.
-     *
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
-     */
-    public function getFactoryConfigTree()
-    {
-        $tb = new TreeBuilder();
+    private $factories;
 
-        return $tb
-            ->root('security')
-                ->ignoreExtraKeys()
-                ->fixXmlConfig('factory', 'factories')
-                ->children()
-                    ->arrayNode('factories')
-                        ->prototype('scalar')->end()
-                    ->end()
-                ->end()
-            ->end()
-            ->buildTree();
+    /**
+     * Constructor.
+     *
+     * @param array $factories 
+     */
+    public function __construct(array $factories)
+    {
+        $this->factories = $factories;
     }
 
-    public function getMainConfigTree(array $factories)
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
     {
         $tb = new TreeBuilder();
         $rootNode = $tb->root('security');
@@ -69,11 +65,11 @@ class Configuration
         $this->addAclSection($rootNode);
         $this->addEncodersSection($rootNode);
         $this->addProvidersSection($rootNode);
-        $this->addFirewallsSection($rootNode, $factories);
+        $this->addFirewallsSection($rootNode, $this->factories);
         $this->addAccessControlSection($rootNode);
         $this->addRoleHierarchySection($rootNode);
 
-        return $tb->buildTree();
+        return $tb;
     }
 
     private function addAclSection(ArrayNodeDefinition $rootNode)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -20,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * SecurityExtension.
@@ -32,13 +32,7 @@ class SecurityExtension extends Extension
     private $requestMatchers = array();
     private $contextListeners = array();
     private $listenerPositions = array('pre_auth', 'form', 'http', 'remember_me');
-    private $configuration;
     private $factories;
-
-    public function __construct()
-    {
-        $this->configuration = new Configuration();
-    }
 
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -49,11 +43,13 @@ class SecurityExtension extends Extension
         $processor = new Processor();
 
         // first assemble the factories
-        $factories = $this->createListenerFactories($container, $processor->process($this->configuration->getFactoryConfigTree(), $configs));
+        $factoriesConfig = new FactoryConfiguration();
+        $config = $processor->processConfiguration($factoriesConfig, $configs);
+        $factories = $this->createListenerFactories($container, $config);
 
         // normalize and merge the actual configuration
-        $tree = $this->configuration->getMainConfigTree($factories);
-        $config = $processor->process($tree, $configs);
+        $mainConfig = new MainConfiguration($factories);
+        $config = $processor->processConfiguration($mainConfig, $configs);
 
         // load services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\Tests\DependencyInjection;
 
-use Symfony\Bundle\SecurityBundle\DependencyInjection\Configuration;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\MainConfiguration;
 use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
@@ -41,11 +41,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'factory'   => array('foo' => 'bar'),
             'factories' => array('lorem' => 'ipsum'),
         ));
-        
-        $configuration = new Configuration();
+
         $processor = new Processor();
-        $tree = $configuration->getMainConfigTree(array());
-        $config = $processor->process($tree, array($config));
+        $configuration = new MainConfiguration(array());
+        $config = $processor->processConfiguration($configuration, array($config));
 
         $this->assertFalse(array_key_exists('factory', $config), 'The factory key is silently removed without an exception');
         $this->assertEquals(array(), $config['factories'], 'The factories key is just an empty array');

--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\SwiftmailerBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -22,16 +23,26 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  *
  * @author Christophe Coevoet <stof@notk.org>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
+    private $debug;
+
     /**
-     * Generates the configuration tree.
+     * Constructor.
      *
-     * @param Boolean $kernelDebug
-     * 
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
+     * @param Boolean $debug The kernel.debug value
      */
-    public function getConfigTree($kernelDebug)
+    public function __construct($debug)
+    {
+        $this->debug = (Boolean) $debug;
+    }
+    
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('swiftmailer');
@@ -71,10 +82,10 @@ class Configuration
                 ->end()
                 ->scalarNode('delivery_address')->end()
                 ->booleanNode('disable_delivery')->end()
-                ->booleanNode('logging')->defaultValue($kernelDebug)->end()
+                ->booleanNode('logging')->defaultValue($this->debug)->end()
             ->end()
         ;
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 }

--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -48,9 +48,9 @@ class SwiftmailerExtension extends Extension
         $r = new \ReflectionClass('Swift_Message');
         $container->getDefinition('swiftmailer.mailer')->setFile(dirname(dirname(dirname($r->getFilename()))).'/swift_init.php');
 
-        $configuration = new Configuration();
         $processor = new Processor();
-        $config = $processor->process($configuration->getConfigTree($container->getParameter('kernel.debug')), $configs);
+        $configuration = new Configuration($container->getParameter('kernel.debug'));
+        $config = $processor->processConfiguration($configuration, $configs);
 
         if (null === $config['transport']) {
             $transport = 'null';

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -4,20 +4,21 @@ namespace Symfony\Bundle\TwigBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * TwigExtension configuration structure.
  *
  * @author Jeremy Mikola <jmikola@gmail.com>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
     /**
-     * Generates the configuration tree.
+     * Generates the configuration tree builder.
      *
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
-    public function getConfigTree()
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('twig');
@@ -33,7 +34,7 @@ class Configuration
         $this->addGlobalsSection($rootNode);
         $this->addTwigOptions($rootNode);
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 
     private function addExtensionsSection(ArrayNodeDefinition $rootNode)

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -39,8 +39,7 @@ class TwigExtension extends Extension
 
         $processor = new Processor();
         $configuration = new Configuration();
-
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $config = $processor->processConfiguration($configuration, $configs);
 
         $container->setParameter('twig.form.resources', $config['form']['resources']);
 

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\WebProfilerBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -21,14 +22,14 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Configuration
+class Configuration implements ConfigurationInterface
 {
     /**
-     * Generates the configuration tree.
+     * Generates the configuration tree builder.
      *
-     * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
      */
-    public function getConfigTree()
+    public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('web_profiler');
@@ -41,6 +42,6 @@ class Configuration
             ->end()
         ;
 
-        return $treeBuilder->buildTree();
+        return $treeBuilder;
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -39,9 +39,9 @@ class WebProfilerExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
         $processor = new Processor();
-        $config = $processor->process($configuration->getConfigTree(), $configs);
+        $configuration = new Configuration();
+        $config = $processor->processConfiguration($configuration, $configs);
 
         if ($config['toolbar']) {
             $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Symfony/Component/Config/Definition/ConfigurationInterface.php
+++ b/src/Symfony/Component/Config/Definition/ConfigurationInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Definition;
+
+/**
+ * Configuration interface
+ *
+ * @author Victor Berchet <victor@suumit.com>
+ */
+interface ConfigurationInterface
+{
+    /**
+     * Generates the configuration tree builder.
+     *
+     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The tree builder
+     */
+    function getConfigTreeBuilder();
+}

--- a/src/Symfony/Component/Config/Definition/Processor.php
+++ b/src/Symfony/Component/Config/Definition/Processor.php
@@ -19,11 +19,12 @@ namespace Symfony\Component\Config\Definition;
 class Processor
 {
     /**
-     * Processes a node tree.
+     * Processes an array of configurations.
      *
-     * @param NodeInterface $configTree The node tree to process
-     * @param array $configs An array of configuration items
-     * @return Boolean
+     * @param NodeInterface $configTree The node tree describing the configuration
+     * @param array         $configs    An array of configuration items to process
+     * 
+     * @return array The processed configuration
      */
     public function process(NodeInterface $configTree, array $configs)
     {
@@ -36,6 +37,19 @@ class Processor
         }
 
         return $configTree->finalize($currentConfig);
+    }
+
+    /**
+     * Processes an array of configurations.
+     *
+     * @param ConfigurationInterface $configuration  The configuration class
+     * @param array                  $configs        An array of configuration items to process
+     *
+     * @return array The processed configuration
+     */
+    public function processConfiguration(ConfigurationInterface $configuration, array $configs)
+    {
+        return $this->process($configuration->getConfigTreeBuilder()->buildTree(), $configs);
     }
 
     /**


### PR DESCRIPTION
The base class would be the extension point for implementing the generation of XSD and documentation, see http://groups.google.com/group/symfony-devs/browse_thread/thread/724e97607d30dd8c/520f3220aa9f7596.

This change is backward compatible: you don't have to use the base class (current extensions would work without any changes).

However introducing this change early will allow extension built on this to benefit from future extensions (XSD and doc generation, ...) when they are implemented.
