### PR TITLE
added default implementation for getNamespace()

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
@@ -82,7 +82,7 @@ abstract class Extension implements ExtensionInterface
      */
     public function getNamespace()
     {
-        return false;
+        return 'http://example.org/schema/dic/'.$this->getAlias();
     }
 
     /**


### PR DESCRIPTION
replaces https://github.com/symfony/symfony/pull/425
