### PR TITLE
Doctrine Entity Guesser Ref

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -57,7 +57,7 @@
         
         <service id="form.field_factory.doctrine_guesser" class="%form.field_factory.doctrine_guesser.class%" public="false">
         	<tag name="form.field_factory.guesser" />
-            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Fix usage of doctrine.orm.default_entity_manager to doctrine.orm.entity_manager alias, which is used by the first defined entity manager.
