### PR TITLE
[Form] [ChoiceField] Corrected the empty choice in ChoiceField 

### DIFF
--- a/src/Symfony/Component/Form/ChoiceField.php
+++ b/src/Symfony/Component/Form/ChoiceField.php
@@ -119,8 +119,8 @@ class ChoiceField extends HybridField
     {
         if (!$this->choices) {
             $this->choices = $this->getInitializedChoices();
-
-            if (!$this->isRequired()) {
+            if (!$this->isRequired() && !($this->isMultipleChoice() && $this->isExpanded())) {
++                // Add an empty choice only if the field is not required AND it is NOT multiple+expanded (checkboxes)
                 $this->choices = array('' => $this->getOption('empty_value')) + $this->choices;
             }
         }


### PR DESCRIPTION
The Choice Field would always add an empty choice when required=>false,
even for multiple+expanded which corresponds to checkboxes even though empty
checkboxes are not allowed (and make no sense)
