### PR TITLE
[HttpKernel] Wrapping the end of handleException() in a try-catch to prev

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -171,7 +171,11 @@ class HttpKernel implements HttpKernelInterface
             throw $e;
         }
 
-        return $this->filterResponse($event->getResponse(), $request, $type);
+        try {
+            return $this->filterResponse($event->getResponse(), $request, $type);
+        } catch (\Exception $e) {
+            return $event->getResponse();
+        }
     }
 
     private function varToString($var)


### PR DESCRIPTION
Hey guys-

This is an edge issue that causes for a bad exception. If a listener on the `onCoreResponse` event throws an exception when we're already handling an exception (e.g. `Kernel::handleException()` calls `Kernel::filterResponse()`), the pretty exception page can't be shown because we're outside of the kernel's main catch.

This prevents the second exception from being thrown - the first is thrown pretty, the second is silenced. I'm not worried about silencing the listener exception because as soon as you fix the main exception, the listener exception will fire normally.

Thanks!
