### PR TITLE
Better import exception and bug fix

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLoaderImportException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderImportException.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Exception;
+
+/**
+ * Exception class for when a resource cannot be imported.
+ *
+ * @author Ryan Weaver <ryan@thatsquality.com>
+ */
+class FileLoaderImportException extends \Exception
+{
+    /**
+     * @param  string    $resource The resource that could not be imported
+     * @param  string    $sourceResource The original resource importing the new resource
+     * @param  integer   $code     The error code
+     * @param  Exception $previous A previous exception
+     */
+    public function __construct($resource, $sourceResource, $code = null, $previous = null)
+    {
+        if (null === $sourceResource) {
+            $message = sprintf('Cannot import resource "%s".', $this->varToString($resource));
+        } else {
+            $message = sprintf('Cannot import resource "%s" from "%s".', $this->varToString($resource), $this->varToString($sourceResource));
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    private function varToString($var)
+    {
+        if (is_object($var)) {
+            return sprintf('[object](%s)', get_class($var));
+        }
+
+        if (is_array($var)) {
+            $a = array();
+            foreach ($var as $k => $v) {
+                $a[] = sprintf('%s => %s', $k, $this->varToString($v));
+            }
+
+            return sprintf("[array](%s)", implode(', ', $a));
+        }
+
+        if (is_resource($var)) {
+            return '[resource]';
+        }
+
+        if (null === $var) {
+            return 'null';
+        }
+
+        return str_replace("\n", '', var_export((string) $var, true));
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -107,7 +107,7 @@ class XmlFileLoader extends FileLoader
 
         foreach ($imports as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import((string) $import['resource'], null, (Boolean) $import->getAttributeAsPhp('ignore-errors'));
+            $this->import((string) $import['resource'], null, (Boolean) $import->getAttributeAsPhp('ignore-errors'), $file);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -107,7 +107,7 @@ class XmlFileLoader extends FileLoader
 
         foreach ($imports as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import((string) $import['resource'], (Boolean) $import->getAttributeAsPhp('ignore-errors'));
+            $this->import((string) $import['resource'], null, (Boolean) $import->getAttributeAsPhp('ignore-errors'));
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -97,7 +97,7 @@ class YamlFileLoader extends FileLoader
 
         foreach ($content['imports'] as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import($import['resource'], isset($import['ignore_errors']) ? (Boolean) $import['ignore_errors'] : false);
+            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (Boolean) $import['ignore_errors'] : false);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -97,7 +97,7 @@ class YamlFileLoader extends FileLoader
 
         foreach ($content['imports'] as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (Boolean) $import['ignore_errors'] : false);
+            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (Boolean) $import['ignore_errors'] : false, $file);
         }
     }
 

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -57,7 +57,7 @@ class XmlFileLoader extends FileLoader
                     $type = (string) $node->getAttribute('type');
                     $prefix = (string) $node->getAttribute('prefix');
                     $this->setCurrentDir(dirname($path));
-                    $collection->addCollection($this->import($resource, ('' !== $type ? $type : null)), $prefix);
+                    $collection->addCollection($this->import($resource, ('' !== $type ? $type : null), false, $file), $prefix);
                     break;
                 default:
                     throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -64,7 +64,7 @@ class YamlFileLoader extends FileLoader
                 $type = isset($config['type']) ? $config['type'] : null;
                 $prefix = isset($config['prefix']) ? $config['prefix'] : null;
                 $this->setCurrentDir(dirname($path));
-                $collection->addCollection($this->import($config['resource'], $type), $prefix);
+                $collection->addCollection($this->import($config['resource'], $type, false, $file), $prefix);
             } elseif (isset($config['pattern'])) {
                 $this->parseRoute($collection, $name, $config, $path);
             } else {

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services4_bad_import.xml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/services4_bad_import.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <imports>
+    <import resource="foo_fake.xml" ignore-errors="true" />
+  </imports>
+</container>

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services4_bad_import.yml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services4_bad_import.yml
@@ -1,0 +1,2 @@
+imports:
+  - { resource: foo_fake.yml, ignore_errors: true }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
@@ -104,6 +104,9 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $expected = array('a string', 'foo' => 'bar', 'values' => array(true, false), 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'bar' => '%foo%', 'imported_from_ini' => true, 'imported_from_yaml' => true);
 
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
+
+        // Bad import throws no exception due to ignore_errors value.
+        $loader->load('services4_bad_import.xml');
     }
 
     public function testLoadAnonymousServices()

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
@@ -90,6 +90,9 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $actual = $container->getParameterBag()->all();
         $expected = array('foo' => 'bar', 'values' => array(true, false), 'bar' => '%foo%', 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'imported_from_ini' => true, 'imported_from_xml' => true);
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
+
+        // Bad import throws no exception due to ignore_errors value.
+        $loader->load('services4_bad_import.yml');
     }
 
     public function testLoadServices()


### PR DESCRIPTION
Hey guys-

Two things:

 1) A plain bug fix with supporting tests

 2) A new exception that's thrown when a resource import fails so that the user knows exactly which resource failed to load and where that resource is attempting to be imported from.

The second really takes advantage of the nested exceptions - each gives some information. For example, if you import a non-existent resource from `routing.yml`, you'll get the following two nested exceptions:
- (the new exception) Cannot import `@Foo/Resources/config/routing/foo.yml` from `/path/to/app/config/routing.yml`
- (the deep exception highlighting the root cause) Bundle "Foo" does not exist or is not enabled

Thoughts? I came across #2 when updating to the non-"Bundle" version of Symfony, I got all sorts of `Bundle "FooBundle" does not exist` exceptions - but you couldn't easily tell where they were actually originating.

Thanks!
