### PR TITLE
@kriswallsmith: asseticbundle: add support for lessphp

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -53,6 +53,9 @@ class AsseticExtension extends Extension
         $container->setParameter('assetic.node.bin', $config['node']);
         $container->setParameter('assetic.sass.bin', $config['sass']);
         $container->setParameter('assetic.yui.jar', $config['yui']);
+        if (isset($config['lessc_inc'])) {
+            $container->setParameter('assetic.lessc_inc.php', $config['lessc_inc']);
+        }
 
         // register filters
         foreach ($config['filters'] as $name => $filter) {

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Configuration.php
@@ -29,7 +29,7 @@ class Configuration
      *
      * @param Boolean $debug    Wether to use the debug mode
      * @param array   $bundles  An array of bundle names
-     * 
+     *
      * @return \Symfony\Component\Config\Definition\ArrayNode The config tree
      */
     public function getConfigTree($debug, array $bundles)
@@ -47,6 +47,7 @@ class Configuration
                 ->scalarNode('node')->defaultNull()->end()
                 ->scalarNode('sass')->defaultNull()->end()
                 ->scalarNode('yui')->defaultNull()->end()
+                ->scalarNode('lessc_inc')->defaultNull()->end()
             ->end()
             ->fixXmlConfig('bundle')
             ->children()

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -19,6 +19,7 @@
         <parameter key="assetic.node.paths" type="collection"></parameter>
         <parameter key="assetic.sass.bin">/usr/bin/sass</parameter>
         <parameter key="assetic.yui.jar" />
+        <parameter key="assetic.lessc_inc.php">%kernel.root_dir%/../vendor/lessphp/lessc.inc.php</parameter>
 
         <parameter key="assetic.cache_dir">%kernel.cache_dir%/assetic</parameter>
     </parameters>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/lessphp.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/lessphp.xml
@@ -6,11 +6,13 @@
 
     <parameters>
         <parameter key="assetic.filter.lessphp.class">Assetic\Filter\LessphpFilter</parameter>
+        <parameter key="assetic.filter.lessphp.lessc_inc">%assetic.lessc_inc.php%</parameter>
     </parameters>
 
     <services>
         <service id="assetic.filter.lessphp" class="%assetic.filter.lessphp.class%">
             <tag name="assetic.filter" alias="lessphp" />
+            <file>%assetic.filter.lessphp.lessc_inc%</file>
             <argument>%assetic.read_from%</argument>
         </service>
     </services>


### PR DESCRIPTION
hi, next attempt for the support of lessphp in the asseticbundle. in AsseticExtension, i added an isset check for the parameter, otherwise it does not work with the default value. this should maybe be changed for node, sass and so on. or i completely misunderstood something.
