### PR TITLE
Exception template changes - for visibility

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.html.twig
@@ -25,7 +25,7 @@
                         <ul>
                             {% for i, previous in exception.previouses %}
                                 <li>
-                                    {{ previous.class|abbr_class }} <a href="#traces_link_{{ i + 1 }}" onclick="toggle('traces_{{ i + 1 }}', 'traces');">&raquo;</a>
+                                    {{ previous.class|abbr_class }} <a href="#traces_link_{{ i + 1 }}" onclick="toggle('traces_{{ i + 1 }}', 'traces'); switchIcons('icon_traces_{{ i + 1 }}_open', 'icon_traces_{{ i + 1 }}_close');">&raquo;</a>
                                 </li>
                             {% endfor %}
                         </ul>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/traces.html.twig
@@ -5,8 +5,8 @@
             {{ exception.class|abbr_class }}: {{ exception.message|replace({ "\n": '<br />' }) }}&nbsp;
             {% spaceless %}
             <a href="#" onclick="toggle('traces_{{ position }}', 'traces'); switchIcons('icon_traces_{{ position }}_open', 'icon_traces_{{ position }}_close'); return false;">
-                <img class="toggle" id="icon_traces_{{ position }}_close" alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}" style="visibility: {{ 0 == position ? 'display' : 'hidden' }}" />
-                <img class="toggle" id="icon_traces_{{ position }}_open" alt="+" src="{{ asset('bundles/framework/images/blue_picto_more.gif') }}" style="visibility: {{ 0 == position ? 'hidden' : 'display' }}; margin-left: -18px" />
+                <img class="toggle" id="icon_traces_{{ position }}_close" alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}" style="visibility: {{ 0 == count ? 'display' : 'hidden' }}" />
+                <img class="toggle" id="icon_traces_{{ position }}_open" alt="+" src="{{ asset('bundles/framework/images/blue_picto_more.gif') }}" style="visibility: {{ 0 == count ? 'hidden' : 'display' }}; margin-left: -18px" />
             </a>
             {% endspaceless %}
         </h2>
@@ -15,7 +15,7 @@
     {% endif %}
 
     <a id="traces_link_{{ position }}"></a>
-    <ol class="traces list_exception" id="traces_{{ position }}" style="display: {{ 0 == position ? 'block' : 'none' }}">
+    <ol class="traces list_exception" id="traces_{{ position }}" style="display: {{ 0 == count ? 'block' : 'none' }}">
         {% for i, trace in exception.trace %}
             <li>
                 {% include 'Framework:Exception:trace.html.twig' with { 'prefix': position, 'i': i, 'trace': trace } only %}


### PR DESCRIPTION
Hey guys:

1) A small big fix on the +/- icons

2) Hide the full stacktrace of all exceptions when the page is displaying more than one exception. This will help make each exception message more visible - it's a bit difficult to notice that there is more than one exception message when the full stacktrace of the first exception is displayed by default.

Thanks!
