### PR TITLE
[FrameworkBundle] Fix the cache template loader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -32,6 +32,7 @@ $container->loadFromExtension('framework', array(
     'templating' => array(
         'assets_version'   => 'SomeVersionScheme',
         'assets_base_urls' => 'http://cdn.example.com',
+        'cache'            => '/path/to/cache',
         'cache_warmer'     => true,
         'engines'          => array('php', 'twig'),
         'loader'           => array('loader.foo', 'loader.bar'),

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -12,7 +12,7 @@
         <app:profiler only-exceptions="true" />
         <app:router cache-warmer="true" resource="%kernel.root_dir%/config/routing.xml" type="xml" />
         <app:session auto-start="true" class="Session" default-locale="fr" storage-id="native" name="_SYMFONY" lifetime="86400" path="/" domain="example.com" secure="true" httponly="true" />
-        <app:templating assets-version="SomeVersionScheme" cache-warmer="true">
+        <app:templating assets-version="SomeVersionScheme" cache-warmer="true" cache="/path/to/cache" >
             <app:loader>loader.foo</app:loader>
             <app:loader>loader.bar</app:loader>
             <app:engine id="php" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -28,6 +28,7 @@ framework:
         cache_warmer:     true
         engines:          [php, twig]
         loader:           [loader.foo, loader.bar]
+        cache:            /path/to/cache
         packages:
             images:
                 version: 1.0.0

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -113,7 +113,11 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertEquals('templating.engine.delegating', (string) $container->getAlias('templating'), '->registerTemplatingConfiguration() configures delegating loader if multiple engines are provided');
 
-        $this->assertEquals('templating.loader.chain', (string) $container->getAlias('templating.loader'), '->registerTemplatingConfiguration() configures loader chain if multiple loaders are provided');
+        $this->assertEquals($container->getDefinition('templating.loader.chain'), $container->getDefinition('templating.loader.wrapped'), '->registerTemplatingConfiguration() configures loader chain if multiple loaders are provided');
+
+        $this->assertEquals($container->getDefinition('templating.loader'), $container->getDefinition('templating.loader.cache'), '->registerTemplatingConfiguration() configures the loader to use cache');
+
+        $this->assertEquals('/path/to/cache', $container->getParameter('templating.loader.cache.path'));
 
         $this->assertEquals(array('php', 'twig'), $container->getParameter('templating.engines'), '->registerTemplatingConfiguration() sets a templating.engines parameter');
     }

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -32,10 +32,10 @@ class CacheLoader extends Loader
     /**
      * Constructor.
      *
-     * @param Loader $loader A Loader instance
-     * @param string $dir    The directory where to store the cache files
+     * @param LoaderInterface $loader A Loader instance
+     * @param string          $dir    The directory where to store the cache files
      */
-    public function __construct(Loader $loader, $dir)
+    public function __construct(LoaderInterface $loader, $dir)
     {
         $this->loader = $loader;
         $this->dir = $dir;


### PR DESCRIPTION
This solves a bug triggered when the cache folder is set in the templating configuration.

i.e. `<framework:templating assets-version="123" cache="%kernel.cache_dir%/tmpl" >`

Templating\CacheLoader was expecting a `Loader` instance where the `FilesystemLoader` only implements the `LoaderInterface`.
