### PR TITLE
[HttpKernel] Fix the default extension name

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -61,10 +61,15 @@ abstract class Bundle extends ContainerAware implements BundleInterface
      */
     public function build(ContainerBuilder $container)
     {
-        $class = $this->getNamespace().'\\DependencyInjection\\'.str_replace('Bundle', 'Extension', $this->getName());
+        $name = $this->getName();
+        if (preg_match('/^(.+)Bundle$/', $name, $matches)) {
+            $name = $matches[1];
+        }
+
+        $class = $this->getNamespace().'\\DependencyInjection\\'.$name.'Extension';
         if (class_exists($class)) {
             $extension = new $class();
-            $alias = Container::underscore(str_replace('Bundle', '', $this->getName()));
+            $alias = Container::underscore($name);
             if ($alias !== $extension->getAlias()) {
                 throw new \LogicException(sprintf('The extension alias for the default extension of a bundle must be the underscored version of the bundle name ("%s" vs "%s")', $alias, $extension->getAlias()));
             }

--- a/tests/Symfony/Tests/Component/HttpKernel/Bundle/BundleTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Bundle/BundleTest.php
@@ -16,21 +16,64 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionPresentBundle\ExtensionPresentBundle;
 use Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle;
 use Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionPresentBundle\Command\FooCommand;
+use Symfony\Tests\Component\HttpKernel\Fixtures\BundlesBundle\BundlesBundle;
 
 class BundleTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @dataProvider getTestBuildData
+     */
+    public function testBuild($bundleClass, $expectedExtensionClass)
+    {
+        $container = $this->getMock(
+            'Symfony\Component\DependencyInjection\ContainerBuilder',
+            array('registerExtension')
+        );
+
+        if (false === $expectedExtensionClass) {
+            $container->expects($this->never())
+                ->method('registerExtension');
+        } else {
+            $extension = new $expectedExtensionClass();
+            $container->expects($this->once())
+                ->method('registerExtension')
+                ->with($this->isInstanceOf($expectedExtensionClass));
+        }
+
+        $bundle = new $bundleClass();
+        $bundle->build($container);
+    }
+
+    public function getTestBuildData()
+    {
+        return array(
+            array(
+                'Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionPresentBundle\ExtensionPresentBundle',
+                'Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionPresentBundle\DependencyInjection\ExtensionPresentExtension'
+            ),
+            array(
+                'Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle',
+                false
+            ),
+            array(
+                'Symfony\Tests\Component\HttpKernel\Fixtures\BundlesBundle\BundlesBundle',
+                'Symfony\Tests\Component\HttpKernel\Fixtures\BundlesBundle\DependencyInjection\BundlesExtension'
+            )
+        );
+    }
+
     public function testRegisterCommands()
     {
         $cmd = new FooCommand();
         $app = $this->getMock('Symfony\Component\Console\Application');
         $app->expects($this->once())->method('add')->with($this->equalTo($cmd));
-        
+
         $bundle = new ExtensionPresentBundle();
         $bundle->registerCommands($app);
-        
+
         $bundle2 = new ExtensionAbsentBundle();
-        
+
         $this->assertNull($bundle2->registerCommands($app));
-        
+
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/Fixtures/BundlesBundle/BundlesBundle.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Fixtures/BundlesBundle/BundlesBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpKernel\Fixtures\BundlesBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class BundlesBundle extends Bundle
+{
+}

--- a/tests/Symfony/Tests/Component/HttpKernel/Fixtures/BundlesBundle/DependencyInjection/BundlesExtension.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Fixtures/BundlesBundle/DependencyInjection/BundlesExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpKernel\Fixtures\BundlesBundle\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class BundlesExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+    }
+}


### PR DESCRIPTION
It allows to use the "Bundle" word in a bundle name (not at the end only) and it adds some tests.
