### PR TITLE
[FrameworkBundle] Fix for getting the file link format fallback to XDebug

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -31,7 +31,7 @@ class Configuration
                 ->scalarNode('document_root')->end()
                 ->scalarNode('error_handler')->end()
                 ->scalarNode('exception_controller')->defaultValue('Symfony\\Bundle\\FrameworkBundle\\Controller\\ExceptionController::showAction')->end()
-                ->scalarNode('ide')->end()
+                ->scalarNode('ide')->defaultNull()->end()
                 ->booleanNode('test')->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -84,10 +84,12 @@ class FrameworkExtension extends Extension
         $container->getDefinition('exception_listener')->setArgument(0, $config['exception_controller']);
 
         $links = array(
-            'textmate' => 'txmt://open?url=file://%%f&line=%%l',
-            'macvim'   => 'mvim://open?url=file://%%f&line=%%l',
+            'textmate' => 'txmt://open?url=file://%f&line=%l',
+            'macvim'   => 'mvim://open?url=file://%f&line=%l',
         );
-        $container->setParameter('debug.file_link_format', isset($links[$config['ide']]) ? $links[$config['ide']] : $config['ide']);
+
+        $link = isset($links[$config['ide']]) ? $links[$config['ide']] : $config['ide'];
+        $container->setParameter('debug.file_link_format', str_replace('%', '%%', $link));
 
         if (!empty($config['test'])) {
             $loader->load('test.xml');

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -83,15 +83,11 @@ class FrameworkExtension extends Extension
 
         $container->getDefinition('exception_listener')->setArgument(0, $config['exception_controller']);
 
-        $pattern = '';
-        if (isset($config['ide'])) {
-            $patterns = array(
-                'textmate' => 'txmt://open?url=file://%%f&line=%%l',
-                'macvim'   => 'mvim://open?url=file://%%f&line=%%l',
-            );
-            $pattern = isset($patterns[$config['ide']]) ? $patterns[$config['ide']] : $config['ide'];
-        }
-        $container->setParameter('debug.file_link_format', $pattern);
+        $links = array(
+            'textmate' => 'txmt://open?url=file://%%f&line=%%l',
+            'macvim'   => 'mvim://open?url=file://%%f&line=%%l',
+        );
+        $container->setParameter('debug.file_link_format', isset($links[$config['ide']]) ? $links[$config['ide']] : $config['ide']);
 
         if (!empty($config['test'])) {
             $loader->load('test.xml');


### PR DESCRIPTION
With the former code, the pattern would be [''](https://github.com/vicb/symfony/pull/new/file_link_format#L1L86) when no ide is specified in the configuration.

This is different from [null](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php#L32) resulting from the fallback to xdebug config not being used.
