### PR TITLE
[Templating] Fix for getting the file link format from XDebug settings

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -31,7 +31,7 @@ class CodeHelper extends Helper
      */
     public function __construct($fileLinkFormat, $rootDir)
     {
-        $this->fileLinkFormat = null !== $fileLinkFormat ? $fileLinkFormat : ini_get('xdebug.file_link_format');
+        $this->fileLinkFormat = empty($fileLinkFormat) ? ini_get('xdebug.file_link_format') : $fileLinkFormat;
         $this->rootDir = str_replace('\\', '/', $rootDir).'/';
     }
 


### PR DESCRIPTION
because [str_replace($from, $to, null)](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php#L326) returns an empty string
