### PR TITLE
[Security] Remove unneeded and invalid use statement

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall.php
+++ b/src/Symfony/Component/Security/Http/Firewall.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Security\Http;
 
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Events;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;


### PR DESCRIPTION
This is trying to import an Events symbol which already exists in the Symfony\Component\Security\Http namespace => fatal error. It breaks code coverage, and I guess any code relying on this class.
