### PR TITLE
Updates for base tag in DomCrawler

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -47,6 +47,9 @@ class Crawler extends \SplObjectStorage
 
         if ($base) {
             $this->base = $base;
+
+            // Remove the base from the uri if it contains it
+            $this->uri = stristr($this->uri, $base).'/';
         }
     }
 
@@ -224,11 +227,11 @@ class Crawler extends \SplObjectStorage
     {
         foreach ($this as $i => $node) {
             if ($i == $position) {
-                return new static($node, $this->uri);
+                return new static($node, $this->uri, $this->base);
             }
         }
 
-        return new static(null, $this->uri);
+        return new static(null, $this->uri, $this->base);
     }
 
     /**
@@ -279,7 +282,7 @@ class Crawler extends \SplObjectStorage
             }
         }
 
-        return new static($nodes, $this->uri);
+        return new static($nodes, $this->uri, $this->base);
     }
 
     /**
@@ -321,7 +324,7 @@ class Crawler extends \SplObjectStorage
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return new static($this->sibling($this->getNode(0)->parentNode->firstChild), $this->uri);
+        return new static($this->sibling($this->getNode(0)->parentNode->firstChild), $this->uri, $this->base);
     }
 
     /**
@@ -339,7 +342,7 @@ class Crawler extends \SplObjectStorage
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return new static($this->sibling($this->getNode(0)), $this->uri);
+        return new static($this->sibling($this->getNode(0)), $this->uri, $this->base);
     }
 
     /**
@@ -355,7 +358,7 @@ class Crawler extends \SplObjectStorage
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return new static($this->sibling($this->getNode(0), 'previousSibling'), $this->uri);
+        return new static($this->sibling($this->getNode(0), 'previousSibling'), $this->uri, $this->base);
     }
 
     /**
@@ -382,7 +385,7 @@ class Crawler extends \SplObjectStorage
             }
         }
 
-        return new static($nodes, $this->uri);
+        return new static($nodes, $this->uri, $this->base);
     }
 
     /**
@@ -400,7 +403,7 @@ class Crawler extends \SplObjectStorage
             throw new \InvalidArgumentException('The current node list is empty.');
         }
 
-        return new static($this->sibling($this->getNode(0)->firstChild), $this->uri);
+        return new static($this->sibling($this->getNode(0)->firstChild), $this->uri, $this->base);
     }
 
     /**
@@ -498,7 +501,7 @@ class Crawler extends \SplObjectStorage
 
         $domxpath = new \DOMXPath($document);
 
-        return new static($domxpath->query($xpath), $this->uri, $this->base);
+        return new static($domxpath->query($xpath), $this->uri, $this->base, $this->base);
     }
 
     /**

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -48,9 +48,48 @@ class Crawler extends \SplObjectStorage
         if ($base) {
             $this->base = $base;
 
-            // Remove the base from the uri if it contains it
-            $this->uri = stristr($this->uri, $base).'/';
+            $this->adjustUriForBase();
         }
+    }
+
+    /**
+     * Getter for $uri
+     *
+     * @return string
+     */
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     * Getter for host
+     *
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Getter for path
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Getter for base
+     *
+     * @return string
+     */
+    public function getBase()
+    {
+        return $this->base;
     }
 
     /**
@@ -135,6 +174,8 @@ class Crawler extends \SplObjectStorage
 
         if (count($base)) {
             $this->base = current($base);
+
+            $this->adjustUriForBase();
         }
     }
 
@@ -211,6 +252,22 @@ class Crawler extends \SplObjectStorage
             $this->attach($node->documentElement);
         } else {
             $this->attach($node);
+        }
+    }
+
+    /**
+     * Replaces the uri of this crawler if a base was found
+     *
+     * @return string
+     */
+    protected function adjustUriForBase()
+    {
+        // Remove the base from the uri if it contains it
+        $this->uri = preg_replace('/'.preg_quote($this->base, '/').'/i', '', $this->uri);
+
+        // If the base equaled the uri, make it root
+        if ( ! $this->uri) {
+            $this->uri = '/';
         }
     }
 

--- a/tests/Symfony/Tests/Component/DomCrawler/CrawlerTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/CrawlerTest.php
@@ -462,6 +462,26 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * Tests that when the $uri contains $base, the base is removed from the uri
+     *
+     * @return null
+     */
+    public function testUriRemovesBase()
+    {
+        $crawler = new Crawler(NULL, 'http://example.com/');
+        $this->assertSame('http://example.com/', $crawler->getUri());
+        $this->assertSame(NULL, $crawler->getBase());
+
+        $crawler = new Crawler(NULL, 'http://example.com/', 'http://example.com/');
+        $this->assertSame('/', $crawler->getUri());
+        $this->assertSame('http://example.com/', $crawler->getBase());
+        
+        $crawler->addHtmlContent('<html><base href="http://example.com/" /><div class="foo"></html>', 'UTF-8');
+        $this->assertSame('/', $crawler->getUri());
+        $this->assertSame('http://example.com/', $crawler->getBase());
+    }
+
     public function createTestCrawler($uri = null)
     {
         $dom = new \DOMDocument();


### PR DESCRIPTION
I found a problem when using Behat/Mink with DomCrawler, if the uri passed to the crawler includes the base string, things won't work properly, this fixes that problem.
