### PR TITLE
[Form] Use strict string comparison against "$$key$$" in CollectionField

### DIFF
--- a/src/Symfony/Component/Form/CollectionField.php
+++ b/src/Symfony/Component/Form/CollectionField.php
@@ -82,7 +82,7 @@ class CollectionField extends Form
         }
 
         foreach ($this as $name => $field) {
-            if (!$this->getOption('modifiable') || '$$key$$' != $name) {
+            if (!$this->getOption('modifiable') || '$$key$$' !== $name) {
                 $this->remove($name);
             }
         }
@@ -103,7 +103,7 @@ class CollectionField extends Form
         }
 
         foreach ($this as $name => $field) {
-            if (!isset($data[$name]) && $this->getOption('modifiable') && '$$key$$' != $name) {
+            if (!isset($data[$name]) && $this->getOption('modifiable') && '$$key$$' !== $name) {
                 $this->remove($name);
                 $this->removedFields[] = $name;
             }

--- a/tests/Symfony/Tests/Component/Form/CollectionFieldTest.php
+++ b/tests/Symfony/Tests/Component/Form/CollectionFieldTest.php
@@ -160,4 +160,19 @@ class CollectionFieldTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo@foo.com', $field[0]->getData());
         $this->assertEquals(array('foo@foo.com'), $field->getData());
     }
+
+    public function testRemovesFirstElementIfSubmittedWithoutFirstElementAndModifiable()
+    {
+        $field = new CollectionField('emails', array(
+            'prototype' => new TestField(),
+            'modifiable' => true,
+        ));
+        $field->setData(array('foo@bar.com', 'bar@bar.com'));
+        $field->submit(array('1' => 'bar@bar.com'));
+
+        $this->assertFalse($field->has('0'));
+        $this->assertTrue($field->has('1'));
+        $this->assertEquals('bar@bar.com', $field[1]->getData());
+        $this->assertEquals(array(1 => 'bar@bar.com'), $field->getData());
+    }
 }


### PR DESCRIPTION
Without strict comparison, the first element of a collection will never be removed if its key is integer zero.

I haven't tested @bschussek's revisions to the form component, so I can't confirm if this bug is fixed upstream. From what I saw, he uses a listener to handle resizing of form fields, so the offending code might naturally have disappeared.
