### PR TITLE
[Security] Dispatch event when SecurityContext is read from session in Co

### DIFF
--- a/src/Symfony/Component/Security/Http/Event/ReadContextFromSessionEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/ReadContextFromSessionEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Event;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+
+class ReadContextFromSessionEvent extends Event
+{
+    private $request;
+
+    private $securityContext;
+
+    public function __construct(Request $request, SecurityContextInterface $securityContext)
+    {
+        $this->request = $request;
+        $this->securityContext = $securityContext;
+    }
+
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    public function getSecurityContext()
+    {
+        return $this->securityContext;
+    }
+}

--- a/src/Symfony/Component/Security/Http/Events.php
+++ b/src/Symfony/Component/Security/Http/Events.php
@@ -15,5 +15,7 @@ final class Events
 {
     const onSecurityInteractiveLogin = 'onSecurityInteractiveLogin';
 
+    const onSecurityReadContextFromSession = 'onSecurityReadContextFromSession';
+
     const onSecuritySwitchUser = 'onSecuritySwitchUser';
 }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -23,6 +23,8 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Http\Events as SecurityEvents;
+use Symfony\Component\Security\Http\Event\ReadContextFromSessionEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -78,6 +80,11 @@ class ContextListener implements ListenerInterface
             }
 
             $this->context->setToken($token);
+
+            if (null !== $this->dispatcher) {
+                $readContextEvent = new ReadContextFromSessionEvent($request, $this->context);
+                $this->dispatcher->dispatch(SecurityEvents::onSecurityReadContextFromSession, $readContextEvent);
+            }
         }
     }
 


### PR DESCRIPTION
[Security] Dispatch event when SecurityContext is read from session in ContextListener::handle()

This event is helpful if the developer must observe the context's token when it is first initialized during the request, but before it may be overwritten by an authentication listener in that same request. Before this change, the closest events were onCoreRequest (before ContextListener::handle() is invoked, so too soon) or onSecurityInteractiveLogin (after the context's token is overwritten, so too late). Additionally, there were no suitable hooks within security component services (such as success/failure handlers in the authentication listeners).
