### PR TITLE
[FrameworkBundle] TemplateLocator: small tweak, better exception

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -60,7 +60,7 @@ class TemplateLocator implements FileLocatorInterface
         try {
             return $this->cache[$key] = $this->locator->locate($template->getPath(), $this->path);
         } catch (\InvalidArgumentException $e) {
-            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', json_encode($template), $this->path), 0, $e);
+            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', $template->getPath(), $this->path), 0, $e);
         }
     }
 }


### PR DESCRIPTION
Hey guys-

See the commit message - this actually spells out the template name in the exception, which we can do because we actually know the type of `$template`.

I believe the tests are fine (most run), but they're bombing on a `CoalescingDirectoryResource` class problem somewhere in assetic right now.

Thanks!
