### PR TITLE
Changed --without-debug to --with-debug in cache:clear.

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -89,6 +89,9 @@ beta1 to beta2
 
       app/Resources/translations/catalogue.fr.xml
 
+* In cache:clear command, the --without-debug option became --with-debug.
+  Now you have to force the debug kernel if you really need it.
+
 PR12 to beta1
 -------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -34,7 +34,7 @@ class CacheClearCommand extends Command
             ->setName('cache:clear')
             ->setDefinition(array(
                 new InputOption('no-warmup', '', InputOption::VALUE_NONE, 'Do not warm up the cache'),
-                new InputOption('without-debug', '', InputOption::VALUE_NONE, 'If the cache is warmed up, whether to disable debugging or not'),
+                new InputOption('with-debug', '', InputOption::VALUE_NONE, 'If the cache is warmed up, whether to force debugging or not'),
             ))
             ->setDescription('Clear the cache')
             ->setHelp(<<<EOF
@@ -42,7 +42,7 @@ The <info>cache:clear</info> command clears the application cache for a given en
 and debug mode:
 
 <info>./app/console cache:clear --env=dev</info>
-<info>./app/console cache:clear --env=prod --without-debug</info>
+<info>./app/console cache:clear --env=prod --with-debug</info>
 EOF
             )
         ;
@@ -65,7 +65,7 @@ EOF
         } else {
             $warmupDir = $realCacheDir.'_new';
 
-            $this->warmup(!$input->getOption('without-debug'), $warmupDir);
+            $this->warmup($input->getOption('with-debug'), $warmupDir);
 
             rename($realCacheDir, $oldCacheDir);
             rename($warmupDir, $realCacheDir);
@@ -139,6 +139,6 @@ EOF;
 
         $class = "$namespace\\$class";
 
-        return new $class($parent->getEnvironment(), $debug);
+        return new $class($parent->getEnvironment(), $debug ? $debug : $parent->isDebug());
     }
 }


### PR DESCRIPTION
When you are warming up the cache in production you usually specify --no-debug option.
So one would assume that the cache will be warmed up without debugging information
If you really want the debugging info you can override it.

I had a major WTF last week when we were going live because of this.
