### PR TITLE
getLogicalName() method in TemplateReference

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
@@ -35,7 +35,7 @@ class TemplateReference extends BaseTemplateReference
      * Returns the path to the template
      *  - as a path when the template is not part of a bundle
      *  - as a resource when the template is part of a bundle
-     * 
+     *
      * @return string A path to the template or a resource
      */
     public function getPath()
@@ -44,6 +44,17 @@ class TemplateReference extends BaseTemplateReference
         $path = (empty($controller) ? '' : $controller.'/').$this->get('name').'.'.$this->get('format').'.'.$this->get('engine');
 
         return empty($this->parameters['bundle']) ? 'views/'.$path : '@'.$this->get('bundle').'/Resources/views/'.$path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLogicalName()
+    {
+        $parts = sprintf('%s:%s:', $this->get('bundle'), $this->get('controller'));
+        $elements = sprintf('%s.%s.%s', $this->get('name'), $this->get('format'), $this->get('engine'));
+
+        return $parts . $elements;
     }
 
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -41,6 +41,8 @@ class TemplateNameParserTest extends TestCase
         $template = $this->parser->parse($name);
 
         $this->assertEquals($template->getSignature(), $ref->getSignature());
+        $this->assertEquals($template->getLogicalName(), $ref->getLogicalName());
+        $this->assertEquals($template->getLogicalName(), $name);
     }
 
     public function getLogicalNameToTemplateProvider()
@@ -82,7 +84,7 @@ class TemplateNameParserTest extends TestCase
     public function testParseFromFilename($file, $ref)
     {
         $template = $this->parser->parseFromFilename($file);
-        
+
         if ($ref === false) {
             $this->assertFalse($template);
         } else {

--- a/src/Symfony/Component/Templating/TemplateReference.php
+++ b/src/Symfony/Component/Templating/TemplateReference.php
@@ -82,4 +82,12 @@ class TemplateReference implements TemplateReferenceInterface
     {
         return $this->parameters['name'];
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getLogicalName()
+    {
+        return $this->parameters['name'];
+    }
 }

--- a/src/Symfony/Component/Templating/TemplateReference.php
+++ b/src/Symfony/Component/Templating/TemplateReference.php
@@ -34,7 +34,9 @@ class TemplateReference implements TemplateReferenceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the template signature
+     *
+     * @return string A UID for the template
      */
     public function getSignature()
     {
@@ -42,7 +44,14 @@ class TemplateReference implements TemplateReferenceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Sets a template parameter.
+     *
+     * @param string $name   The parameter name
+     * @param string $value  The parameter value
+     *
+     * @return TemplateReferenceInterface The TemplateReferenceInterface instance
+     *
+     * @throws  \InvalidArgumentException if the parameter is not defined
      */
     public function set($name, $value)
     {
@@ -56,7 +65,13 @@ class TemplateReference implements TemplateReferenceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Gets a template parameter.
+     *
+     * @param string $name The parameter name
+     *
+     * @return string The parameter value
+     *
+     * @throws  \InvalidArgumentException if the parameter is not defined
      */
     public function get($name)
     {
@@ -68,7 +83,9 @@ class TemplateReference implements TemplateReferenceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Gets the template parameters.
+     *
+     * @return array An array of parameters
      */
     public function all()
     {
@@ -76,7 +93,11 @@ class TemplateReference implements TemplateReferenceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the path to the template.
+     *
+     * By default, it just returns the template name.
+     *
+     * @return string A path to the template or a resource
      */
     public function getPath()
     {
@@ -84,7 +105,9 @@ class TemplateReference implements TemplateReferenceInterface
     }
 
     /**
-     * {@inheritDoc}
+     * Returns the template name
+     *
+     * @return string The template name
      */
     public function getLogicalName()
     {

--- a/src/Symfony/Component/Templating/TemplateReference.php
+++ b/src/Symfony/Component/Templating/TemplateReference.php
@@ -30,7 +30,7 @@ class TemplateReference implements TemplateReferenceInterface
 
     public function __toString()
     {
-        return json_encode($this->parameters);
+        return $this->getLogicalName();
     }
 
     /**

--- a/src/Symfony/Component/Templating/TemplateReferenceInterface.php
+++ b/src/Symfony/Component/Templating/TemplateReferenceInterface.php
@@ -63,4 +63,11 @@ interface TemplateReferenceInterface
      * @return string A path to the template or a resource
      */
     function getPath();
+
+    /**
+     * Returns the template name
+     *
+     * @return string The template name
+     */
+    function getLogicalName();
 }

--- a/tests/Symfony/Tests/Component/Templating/TemplateNameParserTest.php
+++ b/tests/Symfony/Tests/Component/Templating/TemplateNameParserTest.php
@@ -31,20 +31,20 @@ class TemplateNameParserTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getLogicalNameToTemplateProvider
      */
-    public function testParse($name, $ref, $refname)
+    public function testParse($name, $ref)
     {
         $template = $this->parser->parse($name);
 
         $this->assertEquals($template->getSignature(), $ref->getSignature());
-        $this->assertEquals($template->getLogicalName(), $refname);
+        $this->assertEquals($template->getLogicalName(), $name);
     }
 
     public function getLogicalNameToTemplateProvider()
     {
         return array(
-            array('/path/to/section/name.engine', new TemplateReference('/path/to/section/name.engine', 'engine'), '/path/to/section/name.engine'),
-            array('name.engine', new TemplateReference('name.engine', 'engine'), 'name.engine'),
-            array('name', new TemplateReference('name'), 'name'),
+            array('/path/to/section/name.engine', new TemplateReference('/path/to/section/name.engine', 'engine')),
+            array('name.engine', new TemplateReference('name.engine', 'engine')),
+            array('name', new TemplateReference('name')),
         );
     }
 }

--- a/tests/Symfony/Tests/Component/Templating/TemplateNameParserTest.php
+++ b/tests/Symfony/Tests/Component/Templating/TemplateNameParserTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Templating;
+
+use Symfony\Component\Templating\TemplateNameParser;
+use Symfony\Component\Templating\TemplateReference;
+
+class TemplateNameParserTest extends \PHPUnit_Framework_TestCase
+{
+    protected $parser;
+
+    protected function  setUp()
+    {
+        $this->parser = new TemplateNameParser();
+    }
+
+    protected function tearDown()
+    {
+        unset($this->parser);
+    }
+
+    /**
+     * @dataProvider getLogicalNameToTemplateProvider
+     */
+    public function testParse($name, $ref, $refname)
+    {
+        $template = $this->parser->parse($name);
+
+        $this->assertEquals($template->getSignature(), $ref->getSignature());
+        $this->assertEquals($template->getLogicalName(), $refname);
+    }
+
+    public function getLogicalNameToTemplateProvider()
+    {
+        return array(
+            array('/path/to/section/name.engine', new TemplateReference('/path/to/section/name.engine', 'engine'), '/path/to/section/name.engine'),
+            array('name.engine', new TemplateReference('name.engine', 'engine'), 'name.engine'),
+            array('name', new TemplateReference('name'), 'name'),
+        );
+    }
+}


### PR DESCRIPTION
PR replaces https://github.com/symfony/symfony/pull/444
