### PR TITLE
use .php.cache for all php files generated into the cache dir

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -89,7 +89,7 @@ class Translator extends BaseTranslator
             return parent::loadCatalogue($locale);
         }
 
-        $cache = new ConfigCache($this->options['cache_dir'].'/catalogue.'.$locale.'.php', $this->options['debug']);
+        $cache = new ConfigCache($this->options['cache_dir'].'/catalogue.'.$locale.'.php.cache', $this->options['debug']);
         if (!$cache->isFresh()) {
             $this->initialize();
 

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -32,7 +32,7 @@ class ClassCollectionLoader
      *
      * @throws \InvalidArgumentException When class can't be loaded
      */
-    static public function load($classes, $cacheDir, $name, $autoReload, $adaptive = false, $extension = '.php')
+    static public function load($classes, $cacheDir, $name, $autoReload, $adaptive = false, $extension = '.php.cache')
     {
         // each $name can only be loaded once per PHP process
         if (isset(self::$loaded[$name])) {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -443,7 +443,7 @@ abstract class Kernel implements KernelInterface
     protected function initializeContainer()
     {
         $class = $this->getContainerClass();
-        $cache = new ConfigCache($this->getCacheDir().'/'.$class.'.php', $this->debug);
+        $cache = new ConfigCache($this->getCacheDir().'/'.$class.'.php.cache', $this->debug);
         $fresh = true;
         if (!$cache->isFresh()) {
             $container = $this->buildContainer();

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -154,7 +154,7 @@ class Router implements RouterInterface
         }
 
         $class = $this->options['matcher_cache_class'];
-        $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
+        $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php.cache', $this->options['debug']);
         if (!$cache->isFresh($class)) {
             $dumper = new $this->options['matcher_dumper_class']($this->getRouteCollection());
 
@@ -187,7 +187,7 @@ class Router implements RouterInterface
         }
 
         $class = $this->options['generator_cache_class'];
-        $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
+        $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php.cache', $this->options['debug']);
         if (!$cache->isFresh($class)) {
             $dumper = new $this->options['generator_dumper_class']($this->getRouteCollection());
 


### PR DESCRIPTION
similar to the bootstrap.php.cache this prevents IDE's from indexing these files
