### PR TITLE
Shutdown the kernel before do the request in the test client

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -87,8 +87,8 @@ class Client extends BaseClient
      */
     protected function doRequest($request)
     {
-        $returnValue = $this->kernel->handle($request);
         $this->kernel->shutdown();
+        $returnValue = $this->kernel->handle($request);
 
         return $returnValue;
     }


### PR DESCRIPTION
This is to be able to test kernel stuff later of a request, for instance the model.
