### PR TITLE
Display template logical names in exception messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
@@ -69,7 +69,7 @@ class DelegatingEngine extends BaseDelegatingEngine implements EngineInterface
             }
         }
 
-        throw new \RuntimeException(sprintf('No engine is able to work with the %s template.', json_encode($name)));
+        throw new \RuntimeException(sprintf('No engine is able to work with the template "%s".', $name));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -60,7 +60,7 @@ class TemplateLocator implements FileLocatorInterface
         try {
             return $this->cache[$key] = $this->locator->locate($template->getPath(), $this->path);
         } catch (\InvalidArgumentException $e) {
-            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', $template->getLogicalName(), $this->path), 0, $e);
+            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', $template, $this->path), 0, $e);
         }
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -94,7 +94,7 @@ class FilesystemLoader implements \Twig_LoaderInterface
         }
 
         if (false === $file || null === $file) {
-            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', $tpl->getLogicalName()), -1, null, $previous);
+            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', $tpl), -1, null, $previous);
         }
 
         return $this->cache[$key] = $file;

--- a/src/Symfony/Component/Templating/DelegatingEngine.php
+++ b/src/Symfony/Component/Templating/DelegatingEngine.php
@@ -106,6 +106,6 @@ class DelegatingEngine implements EngineInterface
             }
         }
 
-        throw new \RuntimeException(sprintf('No engine is able to work with the %s template.', json_encode($name)));
+        throw new \RuntimeException(sprintf('No engine is able to work with the template "%s".', $name));
     }
 }

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -82,7 +82,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
         $parameters = array_replace($this->getGlobals(), $parameters);
         // render
         if (false === $content = $this->evaluate($storage, $parameters)) {
-            throw new \RuntimeException(sprintf('The template "%s" cannot be rendered.', $this->parser->parse($name)->getLogicalName()));
+            throw new \RuntimeException(sprintf('The template "%s" cannot be rendered.', $this->parser->parse($name)));
         }
 
         // decorator
@@ -496,7 +496,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
         $storage = $this->loader->load($template);
 
         if (false === $storage) {
-            throw new \InvalidArgumentException(sprintf('The template "%s" does not exist.', is_string($name) ? $name : json_encode($name)));
+            throw new \InvalidArgumentException(sprintf('The template "%s" does not exist.', $template));
         }
 
         return $this->cache[$key] = $storage;


### PR DESCRIPTION
- A few places were missed by the previous update,
- taking advantage of `__toString()` == `getLogicalName()`
