### PR TITLE
[Process][Windows] using windows specific option bypass_shell

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -60,7 +60,7 @@ class Process
         }
         $this->stdin = $stdin;
         $this->timeout = $timeout;
-        $this->options = array_merge($options, array('suppress_errors' => true, 'binary_pipes' => true));
+        $this->options = array_merge($options, array('suppress_errors' => true, 'binary_pipes' => true, 'bypass_shell' => true));
     }
 
     /**


### PR DESCRIPTION
[Process][Windows] Don't use cmd for launching process (fixing Sismo git.exe calling)

Fixing the 

> The git binary cannot be found ('git' n'est pas reconnu en tant que commande interneou externe, un programme >exécutable ou un fichier de commandes.)
