### PR TITLE
[FrameworkBundle] RequestListener log format tweak

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -91,7 +91,7 @@ class RequestListener
             $parameters = $this->router->match($request->getPathInfo());
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], json_encode($parameters)));
+                $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
             }
 
             $request->attributes->add($parameters);
@@ -112,5 +112,15 @@ class RequestListener
             }
             throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e);
         }
+    }
+
+    private function parametersToString(array $parameters)
+    {
+        $pieces = array();
+        foreach ($parameters as $key => $val) {
+            $pieces[] = sprintf('"%s": "%s"', $key, (is_string($val) ? $val : json_encode($val)));
+        }
+
+        return implode(', ', $pieces);
     }
 }


### PR DESCRIPTION
Hey guys-

Just a log format change - the `json_encode()` was great, but it results in printing escaped namespsaces (e.g. Symfony\Component\...). This is a little more work, but more honest.

Thanks!
