### PR TITLE
[FrameworkBundle] router:debug - better string dumping to avoid namespace

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -161,6 +161,10 @@ EOF
             return sprintf('object(%s)', get_class($value));
         }
 
+        if (is_string($value)) {
+            return $value;
+        }
+
         return preg_replace("/\n\s*/s", '', var_export($value, true));
     }
 }


### PR DESCRIPTION
Hey guys-

Sorry, lot's of tiny things - this avoids the namespace escaping from showing up. Screenshot (top before, bottom after)

http://dl.dropbox.com/u/1946956/router-debug.png

Thanks!
