### PR TITLE
[Templating] Fix some issues (WIP)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -368,6 +368,8 @@ class FrameworkExtension extends Extension
         if ($config['cache_warmer']) {
             $container->getDefinition('templating.cache_warmer.template_paths')->addTag('kernel.cache_warmer');
             $container->setAlias('templating.locator', 'templating.locator.cached');
+        } else {
+            $container->setAlias('templating.locator', 'templating.locator.uncached');
         }
 
         $this->addClassesToCompile(array(

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating.xml
@@ -25,7 +25,7 @@
             <argument type="service" id="kernel" />
         </service>
 
-        <service id="templating.locator" class="%templating.locator.class%" public="false">
+        <service id="templating.locator.uncached" class="%templating.locator.class%" public="false">
             <argument type="service" id="file_locator" />
             <argument>%kernel.root_dir%/Resources</argument>
         </service>
@@ -39,6 +39,7 @@
         <service id="templating.cache_warmer.template_paths" class="%templating.cache_warmer.template_paths.class%" public="false">
             <argument type="service" id="kernel" />
             <argument type="service" id="templating.name_parser" />
+            <argument type="service" id="templating.locator.uncached" />
             <argument>%kernel.root_dir%/Resources</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/CachedTemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/CachedTemplateLocator.php
@@ -49,13 +49,16 @@ class CachedTemplateLocator extends TemplateLocator
      *
      * @return string The full path for the file
      *
+     * @throws \InvalidArgumentException When the template is not an instance of TemplateReferenceInterface
      * @throws \InvalidArgumentException When file is not found
      */
     public function locate($template, $currentPath = null, $first = true)
     {
-        $key = $template->getSignature();
+        if (!$template instanceof TemplateReferenceInterface) {
+            throw new \InvalidArgumentException("The template must be an instance of TemplateReferenceInterface.");
+        }
 
-        $path = $this->getCachedTemplatePath($key);
+        $path = $this->getCachedTemplatePath($template);
 
         return $path === null ? parent::locate($template) : $path;
     }
@@ -63,12 +66,13 @@ class CachedTemplateLocator extends TemplateLocator
     /**
      * Returns the template path from the cache
      * 
-     * @param string $key The template signature
+     * @param TemplateReferenceInterface $template The template
      * 
-     * @return string|null The path when it is present in the call, false otherwise
+     * @return string|null The path when it is present in the cache, false otherwise
      */
-    protected function getCachedTemplatePath($key)
+    protected function getCachedTemplatePath(TemplateReferenceInterface $template)
     {
+        $key = $template->getSignature();
         return isset($this->templates[$key]) ? $this->templates[$key] : null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/CachedTemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/CachedTemplateLocator.php
@@ -55,10 +55,20 @@ class CachedTemplateLocator extends TemplateLocator
     {
         $key = $template->getSignature();
 
-        if (!isset($this->templates[$key])) {
-            return parent::locate($template, $currentPath, $first);
-        }
+        $path = $this->getCachedTemplatePath($key);
 
-        return $this->templates[$key];
+        return $path === null ? parent::locate($template) : $path;
+    }
+
+    /**
+     * Returns the template path from the cache
+     * 
+     * @param string $key The template signature
+     * 
+     * @return string|null The path when it is present in the call, false otherwise
+     */
+    protected function getCachedTemplatePath($key)
+    {
+        return isset($this->templates[$key]) ? $this->templates[$key] : null;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -47,10 +47,15 @@ class TemplateLocator implements FileLocatorInterface
      *
      * @return string The full path for the file
      *
-     * @throws \InvalidArgumentException When file is not found
+     * @throws \InvalidArgumentException When the template is not an instance of TemplateReferenceInterface
+     * @throws \InvalidArgumentException When the template file can not be found
      */
     public function locate($template, $currentPath = null, $first = true)
     {
+        if (!$template instanceof TemplateReferenceInterface) {
+            throw new \InvalidArgumentException("The template must be an instance of TemplateReferenceInterface.");
+        }
+
         $key = $template->getSignature();
 
         if (isset($this->cache[$key])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/CachedTemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/CachedTemplateLocatorTest.php
@@ -21,7 +21,7 @@ class CachedTemplateLocatorTest extends TestCase
     public function testLocateACachedTemplate()
     {
         $template = new TemplateReference('bundle', 'controller', 'name', 'format', 'engine');
-        
+
         $locator = $this
             ->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\Loader\CachedTemplateLocator')
             ->setMethods(array('getCachedTemplatePath'))
@@ -32,10 +32,25 @@ class CachedTemplateLocatorTest extends TestCase
         $locator
             ->expects($this->once())
             ->method('getCachedTemplatePath')
-            ->with($template->getSignature())
+            ->with($template)
             ->will($this->returnValue('/cached/path/to/template'))
         ;
 
         $this->assertEquals('/cached/path/to/template', $locator->locate($template));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsAnExceptionWhenTemplateIsNotATemplateReferenceInterface()
+    {
+        $locator = $this
+            ->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\Loader\CachedTemplateLocator')
+            ->setMethods(array('getCacheTemplatePath'))
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $locator->locate('template');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/CachedTemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/CachedTemplateLocatorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Loader;
+
+use Symfony\Bundle\FrameworkBundle\Templating\Loader\CachedTemplateLocator;
+use Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+
+class CachedTemplateLocatorTest extends TestCase
+{
+    public function testLocateACachedTemplate()
+    {
+        $template = new TemplateReference('bundle', 'controller', 'name', 'format', 'engine');
+        
+        $locator = $this
+            ->getMockBuilder('Symfony\Bundle\FrameworkBundle\Templating\Loader\CachedTemplateLocator')
+            ->setMethods(array('getCachedTemplatePath'))
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $locator
+            ->expects($this->once())
+            ->method('getCachedTemplatePath')
+            ->with($template->getSignature())
+            ->will($this->returnValue('/cached/path/to/template'))
+        ;
+
+        $this->assertEquals('/cached/path/to/template', $locator->locate($template));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -55,6 +55,15 @@ class TemplateLocatorTest extends TestCase
         $locator->locate($template);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsAnExceptionWhenTemplateIsNotATemplateReferenceInterface()
+    {
+        $locator = new TemplateLocator($this->getFileLocator(), '/path/to/fallback');
+        $locator->locate('template');
+    }
+
     protected function getFileLocator()
     {
         return $this

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Loader;
+
+use Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLocator;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+
+class TemplateLocatorTest extends TestCase
+{
+    public function testLocateATemplate()
+    {
+        $template = new TemplateReference('bundle', 'controller', 'name', 'format', 'engine');
+
+        $fileLocator = $this->getFileLocator();
+
+        $fileLocator
+            ->expects($this->once())
+            ->method('locate')
+            ->with($template->getPath(), '/path/to/fallback')
+            ->will($this->returnValue('/path/to/template'))
+        ;
+
+        $locator = new TemplateLocator($fileLocator, '/path/to/fallback');
+
+        $this->assertEquals('/path/to/template', $locator->locate($template));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testThrowsExceptionWhenTemplateNotFound()
+    {
+        $template = new TemplateReference('bundle', 'controller', 'name', 'format', 'engine');
+
+        $fileLocator = $this->getFileLocator();
+
+        $fileLocator
+            ->expects($this->once())
+            ->method('locate')
+            ->will($this->throwException(new \InvalidArgumentException()))
+        ;
+
+        $locator = new TemplateLocator($fileLocator, '/path/to/fallback');
+
+        $locator->locate($template);
+    }
+
+    protected function getFileLocator()
+    {
+        return $this
+            ->getMockBuilder('Symfony\Component\Config\FileLocator')
+            ->setMethods(array('locate'))
+            ->setConstructorArgs(array('/path/to/fallback'))
+            ->getMock()
+        ;
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
@@ -60,9 +60,6 @@ class TemplateCacheCacheWarmer extends CacheWarmer
             foreach ($this->findTemplatesIn($bundle->getPath().'/Resources/views', $name) as $template) {
                 $twig->loadTemplate($template);
             }
-            foreach ($this->findTemplatesIn($this->rootDir.'/'.$name.'/views', $name) as $template) {
-                $twig->loadTemplate($template);
-            }
         }
 
         foreach ($this->findTemplatesIn($this->rootDir.'/views') as $template) {
@@ -100,7 +97,7 @@ class TemplateCacheCacheWarmer extends CacheWarmer
                     if (null !== $bundle) {
                       $template->set('bundle', $bundle);
                     }
-                    $templates[] = $template;
+                    $templates[] = $template->getLogicalName();
                 }
             }
         }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -25,7 +25,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('cache_warmer')->end()
+                ->scalarNode('cache_warmer')->defaultFalse()->end()
             ->end();
         ;
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -60,7 +60,7 @@ class TwigExtension extends Extension
             }
         }
 
-        if (!empty($config['cache_warmer'])) {
+        if ($config['cache_warmer']) {
             $container->getDefinition('twig.cache_warmer')->addTag('kernel.cache_warmer');
         }
 

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -76,12 +76,18 @@ class FilesystemLoader implements \Twig_LoaderInterface
         return filemtime($this->findTemplate($name)) < $time;
     }
 
+    /**
+     * Returns the path to the template file
+     *
+     * @param $name The template logical name
+     *
+     * @return string The path to the template file
+     */
     protected function findTemplate($name)
     {
-        $tpl = ($name instanceof TemplateReferenceInterface) ? $name : $this->parser->parse($name);
+        $tpl = $this->parser->parse($name);
 
-        $key = $tpl->getSignature();
-        if (isset($this->cache[$key])) {
+        if (isset($this->cache[$key = $tpl->getSignature()])) {
             return $this->cache[$key];
         }
 


### PR DESCRIPTION
Replaces [PR497](https://github.com/symfony/symfony/pull/497)

I have submitted this PR to acknowledge that there are some issues and they are being fixed.
**It is still a WIP**

Addressed issues:
- The templating path cache warmer now handle Bundle inheritance correctly,
- The twig cache warmer use the template logical names (This is required for compiled templates getTemplateName() method)

Left to do:
- Check the AsseticBundle cache warmer,
- Try to factorize common code in a `TemplateCacheWarmer` base class (templating, twig, assetic),
- Review the code and add some more unit tests

I think this could be available some time next week but feel free to help if something is needed before.
