### PR TITLE
[Serializer] Fixed some bugs in XmlEncoder

### DIFF
--- a/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
@@ -111,6 +111,18 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
     }
+    
+    public function testEncodeScalarWithAttribute()
+    {
+        $array = array(
+            'person' => array('@gender' => 'M', '#' => 'Peter'),
+        );
+    
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response><person gender="M"><![CDATA[Peter]]></person></response>'."\n";
+    
+        $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+    }
 
     public function testDecodeScalar()
     {
@@ -135,6 +147,38 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(get_object_vars($obj), $this->encoder->decode($source, 'xml'));
     }
+    
+    public function testDecodeScalarWithAttribute()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<response><person gender="M">Peter</person></response>'."\n";
+      
+        $expected = array(
+            'person' => array('@gender' => 'M', '#' => 'Peter'),
+        );
+      
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
+    }
+    
+    public function testDecodeArray()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<response>'.
+            '<people>'.
+            '<person><firstname>Benjamin</firstname><lastname>Alexandre</lastname></person>'.
+            '<person><firstname>Damien</firstname><lastname>Clay</lastname></person>'.
+            '</people>'.
+            '</response>'."\n";
+        
+        $expected = array(
+            'people' => array('person' => array(
+                array('firstname' => 'Benjamin', 'lastname' => 'Alexandre'),
+                array('firstname' => 'Damien', 'lastname' => 'Clay')
+            ))
+        );
+        
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
+    }
 
     protected function getXmlSource()
     {
@@ -153,7 +197,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $obj = new Dummy;
         $obj->foo = 'foo';
         $obj->bar = array('a', 'b');
-        $obj->baz = array('key' => 'val', 'key2' => 'val', 'A B' => 'bar', "Barry" => array('FooBar' => array("@id"=>1,"Baz"=>"Ed")));
+        $obj->baz = array('key' => 'val', 'key2' => 'val', 'A B' => 'bar', "Barry" => array('FooBar' => array("Baz"=>"Ed", "@id"=>1)));
         $obj->qux = "1";
         return $obj;
     }


### PR DESCRIPTION
As i have talk here https://groups.google.com/forum/#!topic/symfony-devs/UVTmvjkN3M4 here is my PR that fixe somes bug in XmlEncoder :
- XmlEncoder can encode / decode this xml : &lt;element attr="val"&gt;value&lt;/element&gt; , using # as a special token to stock the value
- Fix a bug when same elements are array (see the testunit for example)

For decode i replace SimpleXmlElement with DOMDocument, because the first one can't decode this xml &lt;element attr="val"&gt;value&lt;/element&gt;

Don't worry this is BC
