### PR TITLE
do not add redundant method calls from interface injection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/InterfaceInjector.php
+++ b/src/Symfony/Component/DependencyInjection/InterfaceInjector.php
@@ -76,7 +76,9 @@ class InterfaceInjector
 
         foreach ($this->calls as $callback) {
             list($method, $arguments) = $callback;
-            $definition->addMethodCall($method, $arguments);
+            if (!$definition->hasMethodCall($method)) {
+                $definition->addMethodCall($method, $arguments);
+            }
         }
 
         $this->processedDefinitions[] = $definition;


### PR DESCRIPTION
do not add method calls from interface injection if a method call has already been set manually

fixes issue caused by https://github.com/symfony/symfony/pull/535
