### PR TITLE
[HttpKernel] private $traces property was not initialized to an empty arr

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -91,6 +91,7 @@ class HttpCache implements HttpKernelInterface
             'stale_if_error'         => 60,
         ), $options);
         $this->esi = $esi;
+        $this->traces = array();
     }
 
     /**


### PR DESCRIPTION
[HttpKernel] private $traces property was not initialized to an empty array. When using the getLog() method to debug traces, it led to a warning in the apache error log.
