### PR TITLE
disable interface injection for services where the user has set a manual 

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -230,14 +230,15 @@ class Definition
      * Sets the methods to call after service initialization.
      *
      * @param  array $calls An array of method calls
+     * @param  boolean $implicit If the method is added implicitly (via interface injection)
      *
      * @return Definition The current instance
      */
-    public function setMethodCalls(array $calls = array())
+    public function setMethodCalls(array $calls = array(), $implicit = false)
     {
         $this->calls = array();
         foreach ($calls as $call) {
-            $this->addMethodCall($call[0], $call[1]);
+            $this->addMethodCall($call[0], $call[1], $implicit);
         }
 
         return $this;
@@ -248,12 +249,13 @@ class Definition
      *
      * @param  string $method    The method name to call
      * @param  array  $arguments An array of arguments to pass to the method call
+     * @param  boolean $implicit If the method is added implicitly (via interface injection)
      *
      * @return Definition The current instance
      */
-    public function addMethodCall($method, array $arguments = array())
+    public function addMethodCall($method, array $arguments = array(), $implicit = false)
     {
-        $this->calls[] = array($method, $arguments);
+        $this->calls[] = array($method, $arguments, $implicit);
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/InterfaceInjector.php
+++ b/src/Symfony/Component/DependencyInjection/InterfaceInjector.php
@@ -74,12 +74,19 @@ class InterfaceInjector
             return;
         }
 
-        foreach ($this->calls as $callback) {
-            list($method, $arguments) = $callback;
-            $definition->addMethodCall($method, $arguments);
+        $this->processedDefinitions[] = $definition;
+
+        $calls = $definition->getMethodCalls();
+        foreach ($calls as $callback) {
+            if (empty($callback[2])) {
+                return;
+            }
         }
 
-        $this->processedDefinitions[] = $definition;
+        foreach ($this->calls as $callback) {
+            list($method, $arguments) = $callback;
+            $definition->addMethodCall($method, $arguments, true);
+        }
     }
 
     /**


### PR DESCRIPTION
disable interface injection for services where the user has set a manual method call, to allow the end users to keep full control over injection

see https://github.com/symfony/symfony/pull/541
