### PR TITLE
[HttpFoundation] force Response to be "public" if setSharedMaxAge() is ca

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -458,6 +458,7 @@ class Response
      */
     public function setSharedMaxAge($value)
     {
+        $this->setPublic();
         $this->headers->addCacheControlDirective('s-maxage', $value);
     }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -61,6 +61,15 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($response->getMaxAge(), '->getMaxAge() returns null if no freshness information available');
     }
 
+    public function testSetSharedMaxAge()
+    {
+        $response = new Response();
+        $response->setSharedMaxAge(20);
+
+        $cacheControl = $response->headers->get('Cache-Control');
+        $this->assertEquals('public, s-maxage=20', $cacheControl);
+    }
+
     public function testIsPrivate()
     {
         $response = new Response();
@@ -207,7 +216,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response->setCache($options);
         $this->assertEquals($response->getMaxAge(), 200);
 
-        $this->assertFalse($response->headers->hasCacheControlDirective('public'));
+        $this->assertTrue($response->headers->hasCacheControlDirective('public'));
         $this->assertFalse($response->headers->hasCacheControlDirective('private'));
 
         $response->setCache(array('public' => true));


### PR DESCRIPTION
[HttpFoundation] force Response to be "public" if setSharedMaxAge() is called.
