### PR TITLE
Better Excpetion Message for importing config files

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLoaderImportException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderImportException.php
@@ -29,7 +29,12 @@ class FileLoaderImportException extends \Exception
         if (null === $sourceResource) {
             $message = sprintf('Cannot import resource "%s".', $this->varToString($resource));
         } else {
-            $message = sprintf('Cannot import resource "%s" from "%s".', $this->varToString($resource), $this->varToString($sourceResource));
+            if (null === $previous) {
+                $message = sprintf('Cannot import resource "%s" from "%s".', $this->varToString($resource), $this->varToString($sourceResource));
+            } else {
+                $message = sprintf('Cannot import resource "%s" from "%s". The config file encountered ' .
+                    'the following error when trying to import: "%s".', $this->varToString($resource), $this->varToString($sourceResource), $previous->getMessage());
+            }
         }
 
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
Commit Message:

Add a more explicit exception message when the a previous error was encountered. This is helpful when you are importing a sub configuration file.

The exception message that you use to get was just that the file could not be imported cause an error was encountered. Now you will also see the previous error message which could contain information such as not being able to load a config extension like fos_user which is why the import failed.
