### PR TITLE
Fix bug rendering ChoiceField

### DIFF
--- a/src/Symfony/Component/Form/ChoiceField.php
+++ b/src/Symfony/Component/Form/ChoiceField.php
@@ -120,10 +120,8 @@ class ChoiceField extends HybridField
         if (!$this->choices) {
             $this->choices = $this->getInitializedChoices();
 
-	    if (!$this->isRequired()) {
-		if(!$this->isExpanded()){
-	            $this->choices = array('' => $this->getOption('empty_value')) + $this->choices;
-		}
+            if (!$this->isRequired() && !$this->isExpanded()) {
+                $this->choices = array('' => $this->getOption('empty_value')) + $this->choices;
             }
         }
     }

--- a/src/Symfony/Component/Form/ChoiceField.php
+++ b/src/Symfony/Component/Form/ChoiceField.php
@@ -120,8 +120,10 @@ class ChoiceField extends HybridField
         if (!$this->choices) {
             $this->choices = $this->getInitializedChoices();
 
-            if (!$this->isRequired()) {
-                $this->choices = array('' => $this->getOption('empty_value')) + $this->choices;
+	    if (!$this->isRequired()) {
+		if(!$this->isExpanded()){
+	            $this->choices = array('' => $this->getOption('empty_value')) + $this->choices;
+		}
             }
         }
     }


### PR DESCRIPTION
Fix bug, rendering ChoiceField with options required => false, expanded => true

```
modified:   src/Symfony/Component/Form/ChoiceField.php
```

During choices initializing of the ChoiceField, empty array item  added by default for generating empty select option in html, but if we configure our ChoiceField with option "expanded" => true and 'required' => false, we will got error like 'You cannot add anonymous fields' , because we try to create Field with empty name.
