### PR TITLE
fix Undefined property: Symfony\Bundle\FrameworkBundle\Command\CacheClearCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -57,7 +57,7 @@ EOF
         $oldCacheDir  = $realCacheDir.'_old';
 
         if (!is_writable($realCacheDir)) {
-            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $this->realCacheDir));
+            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $realCacheDir));
         }
 
         if ($input->getOption('no-warmup')) {


### PR DESCRIPTION
call to unexisting $this->realCacheDir instead of $realCacheDir in the exception.
