### PR TITLE
[FrameworkBundle] The $currentPath argument is not used for locating temp

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -61,7 +61,7 @@ class TemplateLocator implements FileLocatorInterface
         }
 
         try {
-            return $this->cache[$key] = $this->locator->locate($template->getPath(), $currentPath);
+            return $this->cache[$key] = $this->locator->locate($template->getPath());
         } catch (\InvalidArgumentException $e) {
             throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', $template, $this->path), 0, $e);
         }


### PR DESCRIPTION
[FrameworkBundle] The $currentPath argument is not used for locating templates
