### PR TITLE
Factorization in the template cache warmers (fmwk & twig)

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\TwigBundle\CacheWarmer;
 
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\TemplatePathsCacheWarmer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Finder\Finder;
 
@@ -26,25 +27,22 @@ use Symfony\Component\Finder\Finder;
 class TemplateCacheCacheWarmer extends CacheWarmer
 {
     protected $container;
-    protected $parser;
-    protected $kernel;
+    protected $warmer;
 
     /**
      * Constructor.
      *
-     * @param ContainerInterface   $container The dependency injection container
-     * @param string               $rootDir The directory where global templates can be stored
+     * @param ContainerInterface        $container The dependency injection container
+     * @param TemplatePathsCacheWarmer  $warmer    The template paths cache warmer
      */
-    public function __construct(ContainerInterface $container, $rootDir)
+    public function __construct(ContainerInterface $container, TemplatePathsCacheWarmer $warmer)
     {
-        // we don't inject the Twig environment directly as it needs
-        // the loader, which is a cached one, and the cache is not
-        // yet available when this instance is created (the
-        // TemplateCacheCacheWarmer has not been run yet).
+        // We don't inject the Twig environment directly as it depends on the
+        // template locator (via the loader) which might be a cached one.
+        // The cached template locator is available once the TemplatePathsCacheWarmer
+        // has been warmed up
         $this->container = $container;
-        $this->parser = $container->get('templating.name_parser');
-        $this->kernel = $container->get('kernel');
-        $this->rootDir = $rootDir;
+        $this->warmer = $warmer;
     }
 
     /**
@@ -56,14 +54,10 @@ class TemplateCacheCacheWarmer extends CacheWarmer
     {
         $twig = $this->container->get('twig');
 
-        foreach ($this->kernel->getBundles() as $name => $bundle) {
-            foreach ($this->findTemplatesIn($bundle->getPath().'/Resources/views', $name) as $template) {
+        foreach ($this->warmer->findAllTemplates() as $template) {
+            if ('twig' === $template->get('engine')) {
                 $twig->loadTemplate($template);
             }
-        }
-
-        foreach ($this->findTemplatesIn($this->rootDir.'/views') as $template) {
-            $twig->loadTemplate($template);
         }
     }
 
@@ -75,33 +69,5 @@ class TemplateCacheCacheWarmer extends CacheWarmer
     public function isOptional()
     {
         return true;
-    }
-
-    /**
-     * Find templates in the given directory
-     *
-     * @param string $dir       The folder where to look for templates
-     * @param string $bundle    The name of the bundle (null when out of a bundle)
-     *
-     * @return array An array of TemplateReference
-     */
-    protected function findTemplatesIn($dir, $bundle = null)
-    {
-        $templates = array();
-
-        if (is_dir($dir)) {
-            $finder = new Finder();
-            foreach ($finder->files()->followLinks()->in($dir) as $file) {
-                $template = $this->parser->parseFromFilename($file->getRelativePathname());
-                if (false !== $template && 'twig' == $template->get('engine')) {
-                    if (null !== $bundle) {
-                      $template->set('bundle', $bundle);
-                    }
-                    $templates[] = $template->getLogicalName();
-                }
-            }
-        }
-
-        return $templates;
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -19,7 +19,7 @@
 
         <service id="twig.cache_warmer" class="%twig.cache_warmer.class%" public="false">
             <argument type="service" id="service_container" />
-            <argument>%kernel.root_dir%/Resources</argument>
+            <argument type="service" id="templating.cache_warmer.template_paths" />
         </service>
 
         <service id="twig.loader" class="%twig.loader.class%">

--- a/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebDebugToolbarListener.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\WebProfilerBundle;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Bundle\TwigBundle\TwigEngine;


### PR DESCRIPTION
It now the responsability of the `TemplatePathsCacheWarmer` to build the list of all the templates. The cache warmer of twig only uses this list.

Choosing composition over inheritance allow for caching the template list and the filesystem does not have to be parsed twice (even if cache warmer performances are not critical)
