### PR TITLE
[HttpFoundation] fixed wrong method name

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -126,7 +126,7 @@ class Request
      *
      * @return Request A new request
      */
-    static public function createfromGlobals()
+    static public function createFromGlobals()
     {
         return new static($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER);
     }


### PR DESCRIPTION
createfromGlobals() -> createFromGlobals()
