### PR TITLE
[Form] AbstractType::getName() improvement

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -46,11 +46,7 @@ class FormFactory implements FormFactoryInterface
 
         // TESTME
         if (null === $name) {
-            $typeAsString = is_object($type) ? get_class($type) : $type;
-
-            if (preg_match('/\w+$/', $typeAsString, $matches)) {
-                $name = $matches[0];
-            }
+            $name = is_object($type) ? $type->getName() : $type;
         }
 
         while (null !== $type) {

--- a/src/Symfony/Component/Form/Type/AbstractType.php
+++ b/src/Symfony/Component/Form/Type/AbstractType.php
@@ -47,6 +47,10 @@ abstract class AbstractType implements FormTypeInterface
 
     public function getName()
     {
-        return get_class($this);
+        if (preg_match('/\\\\([a-z]+)(?:Form|Type)?$/im', get_class($this), $matches)) {
+            $name = strtolower($matches[1]);
+        }
+
+        return $name;
     }
 }

--- a/src/Symfony/Component/Form/Type/AbstractType.php
+++ b/src/Symfony/Component/Form/Type/AbstractType.php
@@ -47,7 +47,7 @@ abstract class AbstractType implements FormTypeInterface
 
     public function getName()
     {
-        if (preg_match('/\\\\([a-z]+)(?:Form|Type)?$/im', get_class($this), $matches)) {
+        if (preg_match('/\\\\([a-z]+)(?:Form|Type)$/im', get_class($this), $matches)) {
             $name = strtolower($matches[1]);
         }
 


### PR DESCRIPTION
Now it return last part of the class lowered and suffix like 'Form' or 'Type' are removed
