### PR TITLE
[Form] Only add blank choice for non-expanded choice fields when required is set to false

### DIFF
--- a/src/Symfony/Component/Form/ChoiceField.php
+++ b/src/Symfony/Component/Form/ChoiceField.php
@@ -120,7 +120,7 @@ class ChoiceField extends HybridField
         if (!$this->choices) {
             $this->choices = $this->getInitializedChoices();
 
-            if (!$this->isRequired()) {
+            if (!$this->isRequired() && !$this->isExpanded()) {
                 $this->choices = array('' => $this->getOption('empty_value')) + $this->choices;
             }
         }


### PR DESCRIPTION
I stumbled across this issue when working with a ChoiceField with expanded = true and multiple = true, by default each option in this field is given a 'required="required"' html attribute. This causes some browsers (like Chrome) to issue warnings unless all options are selected which is not the desired effect. When setting required to false however, an extra option is added resulting in an error: "You cannot add anonymous fields"

The solution is to only add a blank choice for non-expanded fields, in other words, only for select fields.
