### PR TITLE
[Forms] Allows form_row to specify label, other variables

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_row.html.php
@@ -1,5 +1,5 @@
 <div>
-    <?php echo $view['form']->label($form) ?>
+    <?php echo $view['form']->label($form, $label) ?>
     <?php echo $view['form']->errors($form) ?>
-    <?php echo $view['form']->widget($form) ?>
+    <?php echo $view['form']->widget($form, $parameters) ?>
 </div>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/hidden_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/hidden_row.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form) ?>
+<?php echo $view['form']->widget($form, $parameters) ?>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -82,7 +82,7 @@
 {% endblock csrf__widget %}
 
 {% block hidden__row %}
-    {{ form_widget(form) }}
+    {{ form_widget(form, _context) }}
 {% endblock hidden__row %}
 
 {% block textarea__widget %}
@@ -241,9 +241,9 @@
 {% block field__row %}
 {% spaceless %}
     <div>
-        {{ form_label(form) }}
+        {{ form_label(form, label) }}
         {{ form_errors(form) }}
-        {{ form_widget(form) }}
+        {{ form_widget(form, _context) }}
     </div>
 {% endspaceless %}
 {% endblock field__row %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/table_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/table_layout.html.twig
@@ -4,11 +4,11 @@
 {% spaceless %}
     <tr>
         <td>
-            {{ form_label(form) }}
+            {{ form_label(form, label) }}
         </td>
         <td>
             {{ form_errors(form) }}
-            {{ form_widget(form) }}
+            {{ form_widget(form, _context) }}
         </td>
     </tr>
 {% endspaceless %}
@@ -30,7 +30,7 @@
 {% spaceless %}
     <tr style="display: none">
         <td colspan="2">
-            {{ form_widget(form) }}
+            {{ form_widget(form, _context) }}
         </td>
     </tr>
 {% endspaceless %}


### PR DESCRIPTION
The `form_row()` Twig function already accepts an array of variables. These variables are now meaningfully passed down to the `form_widget()` and `form_label()` Twig functions, making the following possible:

```
{{ form_row(form.name, { 'label': 'foo', 'attr': { 'class': 'barclass' } }) }}
```

The same functionality has also been added to the PHP templates, though accessing "all" of the template variables via the `$parameters` variable, which is what all the template params are called inside the `PhpEngine` feels like a bit of a hack (but PHP templates are a bit of a hack).

Thanks!
