### PR TITLE
[DependencyInjection] make base class of generated container configurable

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -436,6 +436,18 @@ abstract class Kernel implements KernelInterface
     }
 
     /**
+     * Gets the container's base class.
+     *
+     * All names except Container must be fully qualified.
+     *
+     * @return string
+     */
+    protected function getContainerBaseClass()
+    {
+        return 'Container';
+    }
+
+    /**
      * Initializes the service container.
      *
      * The cached version of the service container is used when fresh, otherwise the
@@ -448,7 +460,7 @@ abstract class Kernel implements KernelInterface
         $fresh = true;
         if (!$cache->isFresh()) {
             $container = $this->buildContainer();
-            $this->dumpContainer($cache, $container, $class);
+            $this->dumpContainer($cache, $container, $class, $this->getContainerBaseClass());
 
             $fresh = false;
         }
@@ -556,12 +568,13 @@ abstract class Kernel implements KernelInterface
      * @param ConfigCache       $cache      The config cache
      * @param ContainerBuilder  $container  The service container
      * @param string            $class      The name of the class to generate
+     * @param string            $baseClass  The name of the container's base class
      */
-    protected function dumpContainer(ConfigCache $cache, ContainerBuilder $container, $class)
+    protected function dumpContainer(ConfigCache $cache, ContainerBuilder $container, $class, $baseClass)
     {
         // cache the container
         $dumper = new PhpDumper($container);
-        $content = $dumper->dump(array('class' => $class));
+        $content = $dumper->dump(array('class' => $class, 'base_class' => $baseClass));
         if (!$this->debug) {
             $content = self::stripComments($content);
         }


### PR DESCRIPTION
[DependencyInjection] make base class of generated container configurable

This is extremely helpful to add some features for debugging that you don't want in production.
