### PR TITLE
Form event name fix

### DIFF
--- a/src/Symfony/Component/Form/EventListener/StripTagsListener.php
+++ b/src/Symfony/Component/Form/EventListener/StripTagsListener.php
@@ -29,6 +29,6 @@ class StripTagsListener implements EventSubscriberInterface
 
     public static function getSubscribedEvents()
     {
-        return Events::onBindDataFromClient;
+        return Events::onBindClientData;
     }
 }


### PR DESCRIPTION
onBindDataFromClient event no longer exists it'snownamed onBindClientData
