### PR TITLE
[ContainerAwareEventDispatcher] RFC - fixing a bug with service event & scope

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
@@ -85,12 +85,16 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     {
         if (isset($this->listenerIds[$eventName])) {
             foreach ($this->listenerIds[$eventName] as $serviceId => $priority) {
-                if (isset($this->listeners[$eventName][$serviceId])) {
-                    $this->removeListener($eventName, $this->listeners[$eventName][$serviceId]);
-                }
                 $listener = $this->container->get($serviceId);
+
+                if (!isset($this->listeners[$eventName][$serviceId])) {
+                    $this->addListener($eventName, $listener, $priority);
+                } elseif ($listener !== $this->listeners[$eventName][$serviceId]) {
+                    $this->removeListener($eventName, $this->listeners[$eventName][$serviceId]);
+                    $this->addListener($eventName, $listener, $priority);
+                }
+
                 $this->listeners[$eventName][$serviceId] = $listener;
-                $this->addListener($eventName, $listener, $priority);
             }
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
@@ -37,6 +37,12 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     private $listenerIds = array();
 
     /**
+     * The services registered as listeners
+     * @var array
+     */
+    private $listeners = array();
+
+    /**
      * Constructor.
      *
      * @param ContainerInterface $container A ContainerInterface instance
@@ -79,7 +85,12 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     {
         if (isset($this->listenerIds[$eventName])) {
             foreach ($this->listenerIds[$eventName] as $serviceId => $priority) {
-                $this->addListener($eventName, $this->container->get($serviceId), $priority);
+                if (isset($this->listeners[$eventName][$serviceId])) {
+                    $this->removeListener($eventName, $this->listeners[$eventName][$serviceId]);
+                }
+                $listener = $this->container->get($serviceId);
+                $this->listeners[$eventName][$serviceId] = $listener;
+                $this->addListener($eventName, $listener, $priority);
             }
         }
 


### PR DESCRIPTION
I would like to hear your comments about this PR:

[cc89d4b](https://github.com/vicb/symfony/commit/cc89d4b1a52695cf50de49635dcd651494e9e653) fixes an issue when a scoped service is used as a listener and you re-enter the same scope - see the unit test for details.

[6ae61eb](https://github.com/vicb/symfony/commit/6ae61eb9ffa310ab9c1fa309d5d801dcf1138f6e) adds some optimization by calling `addListener` only when required as this call could be time consuming (need to re-sort events, ...)

Some [reference](https://github.com/symfony/symfony/commit/4e047b5e27af0a87ec188e78be04ff2e9f42f4b9#L1L45)
