### PR TITLE
platform fix affecting entity generation

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -164,8 +164,12 @@ abstract class DoctrineCommand extends Command
      */
     protected function findBasePathForBundle($bundle)
     {
-        $path = str_replace('\\', '/', $bundle->getNamespace());
-        $destination = str_replace('/'.$path, "", $bundle->getPath(), $c);
+        if (DIRECTORY_SEPARATOR == '/') {
+            $path = '/'.str_replace('\\', '/', $bundle->getNamespace());
+        } else {
+            $path = '\\'.$bundle->getNamespace();
+        }
+        $destination = str_replace($path, "", $bundle->getPath(), $c);
 
         if ($c != 1) {
             throw new \RuntimeException("Something went terribly wrong.");


### PR DESCRIPTION
I was trying to run the doctrine:generate:entities command in the windows environment and it was throwing a runtime exception.  I narrowed down the cause to the findBasePathForBundle function which seemed to only accept Unix file separator paths.  I added a conditional check and it works fine.  I don't have a project configured in the Unix environment, so if someone could kindly double check on Unix I would appreciate it.

This is only my second pull request to projects, so if I'm Doing it WrongTM, please be kind about it.
