### PR TITLE
Fix require_once in APC class loader

### DIFF
--- a/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
@@ -12,8 +12,50 @@
 namespace Symfony\Component\ClassLoader;
 
 /**
- * Class loader utilizing APC to remember where files are.
+ * ApcUniversalClassLoader implements a "universal" autoloader cached in APC for PHP 5.3.
  *
+ * It is able to load classes that use either:
+ *
+ *  * The technical interoperability standards for PHP 5.3 namespaces and
+ *    class names (http://groups.google.com/group/php-standards/web/psr-0-final-proposal);
+ *
+ *  * The PEAR naming convention for classes (http://pear.php.net/).
+ *
+ * Classes from a sub-namespace or a sub-hierarchy of PEAR classes can be
+ * looked for in a list of locations to ease the vendoring of a sub-set of
+ * classes for large projects.
+ *
+ * Example usage:
+ *
+ *     require 'vendor/symfony/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
+ *     require 'vendor/symfony/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php';
+ *
+ *     use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
+ *
+ *     $loader = new ApcUniversalClassLoader('apc.prefix.');
+ *
+ *     // register classes with namespaces
+ *     $loader->registerNamespaces(array(
+ *         'Symfony\Component' => __DIR__.'/component',
+ *         'Symfony'           => __DIR__.'/framework',
+ *         'Sensio'            => array(__DIR__.'/src', __DIR__.'/vendor'),
+ *     ));
+ *
+ *     // register a library using the PEAR naming convention
+ *     $loader->registerPrefixes(array(
+ *         'Swift_' => __DIR__.'/Swift',
+ *     ));
+ *
+ *     // activate the autoloader
+ *     $loader->register();
+ *
+ * In this example, if you try to use a class in the Symfony\Component
+ * namespace or one of its children (Symfony\Component\Console for instance),
+ * the autoloader will first look for the class under the component/
+ * directory, and it will then fallback to the framework/ directory if not
+ * found before giving up.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
  * @author Kris Wallsmith <kris.wallsmith@symfony.com>
  *
  * @api
@@ -34,6 +76,13 @@ class ApcUniversalClassLoader extends UniversalClassLoader
         $this->prefix = $prefix;
     }
 
+    /**
+     * Finds a file by class name while caching lookups to APC.
+     *
+     * @param string $class A class name to resolve to file
+     *
+     * @api
+     */
     public function findFile($class)
     {
         if (false === $file = apc_fetch($this->prefix.$class)) {

--- a/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcUniversalClassLoader.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\ClassLoader;
 
-require_once __DIR__.'/UniversalClassLoader.php';
-
 /**
  * Class loader utilizing APC to remember where files are.
  *

--- a/tests/Symfony/Tests/Component/ClassLoader/ApcUniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/ApcUniversalClassLoaderTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\ClassLoader;
+
+use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
+
+class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected function skipIfAPCExtensionIsNotLoadedOrEnabled()
+    {
+        if (!extension_loaded('apc')) {
+            $this->markTestSkipped('The apc extension is available.');
+        }
+
+        if (!(ini_get('apc.enabled') && ini_get('apc.enable_cli'))) {
+            $this->markTestSkipped('The apc extension is available, but not enabled.');
+        }
+    }
+
+    public function testConstructor()
+    {
+		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+
+        $loader = new ApcUniversalClassLoader('test.prefix.');
+        $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+
+        $this->assertEquals($loader->findFile('\Namespaced\Bar'), apc_fetch('test.prefix.\Namespaced\Bar'), '__construct() takes a prefix as its first argument');
+    }
+
+    /**
+     * @dataProvider getLoadClassTests
+     */
+    public function testLoadClass($className, $testClassName, $message)
+    {
+		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+
+        $loader = new ApcUniversalClassLoader('test.prefix.');
+        $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->loadClass($testClassName);
+        $this->assertTrue(class_exists($className), $message);
+    }
+
+    public function getLoadClassTests()
+    {
+        return array(
+            array('\\Namespaced\\Foo', 'Namespaced\\Foo',   '->loadClass() loads Namespaced\Foo class'),
+            array('\\Pearlike_Foo',    'Pearlike_Foo',      '->loadClass() loads Pearlike_Foo class'),
+            array('\\Namespaced\\Bar', '\\Namespaced\\Bar', '->loadClass() loads Namespaced\Bar class with a leading slash'),
+            array('\\Pearlike_Bar',    '\\Pearlike_Bar',    '->loadClass() loads Pearlike_Bar class with a leading slash'),
+        );
+    }
+
+    /**
+     * @dataProvider getLoadClassFromFallbackTests
+     */
+    public function testLoadClassFromFallback($className, $testClassName, $message)
+    {
+		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+
+        $loader = new ApcUniversalClassLoader('test.prefix.');
+        $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->registerNamespaceFallback(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback');
+        $loader->registerPrefixFallback(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback');
+        $loader->loadClass($testClassName);
+        $this->assertTrue(class_exists($className), $message);
+    }
+
+    public function getLoadClassFromFallbackTests()
+    {
+        return array(
+            array('\\Namespaced\\Baz',    'Namespaced\\Baz',    '->loadClass() loads Namespaced\Baz class'),
+            array('\\Pearlike_Baz',       'Pearlike_Baz',       '->loadClass() loads Pearlike_Baz class'),
+            array('\\Namespaced\\FooBar', 'Namespaced\\FooBar', '->loadClass() loads Namespaced\Baz class from fallback dir'),
+            array('\\Pearlike_FooBar',    'Pearlike_FooBar',    '->loadClass() loads Pearlike_Baz class from fallback dir'),
+        );
+    }
+
+    /**
+     * @dataProvider getLoadClassNamespaceCollisionTests
+     */
+    public function testLoadClassNamespaceCollision($namespaces, $className, $message)
+    {
+		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+
+        $loader = new ApcUniversalClassLoader('test.prefix.');
+        $loader->registerNamespaces($namespaces);
+
+        $loader->loadClass($className);
+        $this->assertTrue(class_exists($className), $message);
+    }
+
+    public function getLoadClassNamespaceCollisionTests()
+    {
+        return array(
+            array(
+                array(
+                    'NamespaceCollision\\A' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'NamespaceCollision\\A\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'NamespaceCollision\A\Foo',
+                '->loadClass() loads NamespaceCollision\A\Foo from alpha.',
+            ),
+            array(
+                array(
+                    'NamespaceCollision\\A\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'NamespaceCollision\\A' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'NamespaceCollision\A\Bar',
+                '->loadClass() loads NamespaceCollision\A\Bar from alpha.',
+            ),
+            array(
+                array(
+                    'NamespaceCollision\\A' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'NamespaceCollision\\A\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'NamespaceCollision\A\B\Foo',
+                '->loadClass() loads NamespaceCollision\A\B\Foo from beta.',
+            ),
+            array(
+                array(
+                    'NamespaceCollision\\A\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'NamespaceCollision\\A' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'NamespaceCollision\A\B\Bar',
+                '->loadClass() loads NamespaceCollision\A\B\Bar from beta.',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider getLoadClassPrefixCollisionTests
+     */
+    public function testLoadClassPrefixCollision($prefixes, $className, $message)
+    {
+		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+
+        $loader = new ApcUniversalClassLoader('test.prefix.');
+        $loader->registerPrefixes($prefixes);
+
+        $loader->loadClass($className);
+        $this->assertTrue(class_exists($className), $message);
+    }
+
+    public function getLoadClassPrefixCollisionTests()
+    {
+        return array(
+            array(
+                array(
+                    'PrefixCollision_A_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'PrefixCollision_A_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'PrefixCollision_A_Foo',
+                '->loadClass() loads PrefixCollision_A_Foo from alpha.',
+            ),
+            array(
+                array(
+                    'PrefixCollision_A_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'PrefixCollision_A_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'PrefixCollision_A_Bar',
+                '->loadClass() loads PrefixCollision_A_Bar from alpha.',
+            ),
+            array(
+                array(
+                    'PrefixCollision_A_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'PrefixCollision_A_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'PrefixCollision_A_B_Foo',
+                '->loadClass() loads PrefixCollision_A_B_Foo from beta.',
+            ),
+            array(
+                array(
+                    'PrefixCollision_A_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'PrefixCollision_A_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'PrefixCollision_A_B_Bar',
+                '->loadClass() loads PrefixCollision_A_B_Bar from beta.',
+            ),
+        );
+    }
+
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/ApcUniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/ApcUniversalClassLoaderTest.php
@@ -19,7 +19,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     protected function skipIfAPCExtensionIsNotLoadedOrEnabled()
     {
         if (!extension_loaded('apc')) {
-            $this->markTestSkipped('The apc extension is available.');
+            $this->markTestSkipped('The apc extension is not available.');
         }
 
         if (!(ini_get('apc.enabled') && ini_get('apc.enable_cli'))) {
@@ -29,7 +29,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructor()
     {
-		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
 
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
@@ -42,7 +42,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClass($className, $testClassName, $message)
     {
-		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
 
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
@@ -66,7 +66,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClassFromFallback($className, $testClassName, $message)
     {
-		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
 
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
@@ -92,7 +92,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClassNamespaceCollision($namespaces, $className, $message)
     {
-		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
 
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespaces($namespaces);
@@ -144,7 +144,7 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClassPrefixCollision($prefixes, $className, $message)
     {
-		$this->skipIfAPCExtensionIsNotLoadedOrEnabled();
+        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
 
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerPrefixes($prefixes);

--- a/tests/Symfony/Tests/Component/ClassLoader/ApcUniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/ApcUniversalClassLoaderTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
 class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
 {
 
-    protected function skipIfAPCExtensionIsNotLoadedOrEnabled()
+    protected function setUp()
     {
         if (!extension_loaded('apc')) {
             $this->markTestSkipped('The apc extension is not available.');
@@ -29,8 +29,6 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructor()
     {
-        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
-
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
 
@@ -42,8 +40,6 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClass($className, $testClassName, $message)
     {
-        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
-
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
         $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
@@ -66,8 +62,6 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClassFromFallback($className, $testClassName, $message)
     {
-        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
-
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
         $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
@@ -92,8 +86,6 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClassNamespaceCollision($namespaces, $className, $message)
     {
-        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
-
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerNamespaces($namespaces);
 
@@ -144,8 +136,6 @@ class ApcUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadClassPrefixCollision($prefixes, $className, $message)
     {
-        $this->skipIfAPCExtensionIsNotLoadedOrEnabled();
-
         $loader = new ApcUniversalClassLoader('test.prefix.');
         $loader->registerPrefixes($prefixes);
 

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/Bar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\Namespaced;
+
+class Bar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/Baz.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/Baz.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\Namespaced;
+
+class Baz
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/Foo.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\Namespaced;
+
+class Foo
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/FooBar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Namespaced/FooBar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\Namespaced;
+
+class FooBar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Pearlike/Bar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Pearlike/Bar.php
@@ -1,0 +1,6 @@
+<?php
+
+class Apc_Pearlike_Bar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Pearlike/Baz.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Pearlike/Baz.php
@@ -1,0 +1,6 @@
+<?php
+
+class Apc_Pearlike_Baz
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Pearlike/Foo.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/Pearlike/Foo.php
@@ -1,0 +1,6 @@
+<?php
+
+class Apc_Pearlike_Foo
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/ApcPrefixCollision/A/Bar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/ApcPrefixCollision/A/Bar.php
@@ -1,0 +1,6 @@
+<?php
+
+class ApcPrefixCollision_A_Bar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/ApcPrefixCollision/A/Foo.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/ApcPrefixCollision/A/Foo.php
@@ -1,0 +1,6 @@
+<?php
+
+class ApcPrefixCollision_A_Foo
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/NamespaceCollision/A/Bar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/NamespaceCollision/A/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\NamespaceCollision\A;
+
+class Bar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/NamespaceCollision/A/Foo.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/alpha/Apc/NamespaceCollision/A/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\NamespaceCollision\A;
+
+class Foo
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/ApcPrefixCollision/A/B/Bar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/ApcPrefixCollision/A/B/Bar.php
@@ -1,0 +1,6 @@
+<?php
+
+class ApcPrefixCollision_A_B_Bar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/ApcPrefixCollision/A/B/Foo.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/ApcPrefixCollision/A/B/Foo.php
@@ -1,0 +1,6 @@
+<?php
+
+class ApcPrefixCollision_A_B_Foo
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/NamespaceCollision/A/B/Bar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/NamespaceCollision/A/B/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\NamespaceCollision\A\B;
+
+class Bar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/NamespaceCollision/A/B/Foo.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/beta/Apc/NamespaceCollision/A/B/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\NamespaceCollision\A\B;
+
+class Foo
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/fallback/Apc/Pearlike/FooBar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/fallback/Apc/Pearlike/FooBar.php
@@ -1,0 +1,6 @@
+<?php
+
+class Apc_Pearlike_FooBar
+{
+    public static $loaded = true;
+}

--- a/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/fallback/Namespaced/FooBar.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/Fixtures/Apc/fallback/Namespaced/FooBar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Apc\Namespaced;
+
+class FooBar
+{
+    public static $loaded = true;
+}


### PR DESCRIPTION
The apc class loader doesn't work as it includes a require_once. The require_once throws a fatal error when called from the bootstrap.php.cache as it uses a **DIR** for the path.

The pull request removes the require once and adds basic unit tests from UniversalClassLoader.
