### PR TITLE
[DoctrineBundle] Fix data:load command (--append w/o value)

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/LoadDataFixturesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/LoadDataFixturesDoctrineCommand.php
@@ -40,7 +40,7 @@ class LoadDataFixturesDoctrineCommand extends DoctrineCommand
             ->setName('doctrine:data:load')
             ->setDescription('Load data fixtures to your database.')
             ->addOption('fixtures', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The directory or file to load data fixtures from.')
-            ->addOption('append', null, InputOption::VALUE_OPTIONAL, 'Whether or not to append the data fixtures.', false)
+            ->addOption('append', null, InputOption::VALUE_NONE, 'Append the data fixtures instead of flushing the database first.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->setHelp(<<<EOT
 The <info>doctrine:data:load</info> command loads data fixtures from your bundles:


### PR DESCRIPTION
Changed the <code>append</code> option in <code>doctrine:data:load</code> command to work without value.

Before:

<pre>doctrine:data:load --append=true</pre>


After:

<pre>doctrine:data:load --append</pre>
