### PR TITLE
[DoctrineMongoDBBundle] set annotation constraint namespace alias to asse

### DIFF
--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/AddValidatorNamespaceAliasPass.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/AddValidatorNamespaceAliasPass.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class AddValidatorNamespaceAliasPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('validator.mapping.loader.annotation_loader')) {
+            return;
+        }
+
+        $loader = $container->getDefinition('validator.mapping.loader.annotation_loader');
+        $args = $loader->getArguments();
+
+        $args[0]['assertMongoDB'] = 'Symfony\\Bundle\\DoctrineMongoDBBundle\\Validator\\Constraints\\';
+        $loader->setArgument(0, $args[0]);
+    }
+}

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/DoctrineMongoDBExtension.php
@@ -71,8 +71,6 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $config['metadata_cache_driver'],
             $container
         );
-
-        $this->loadConstraints($container);
     }
 
     /**
@@ -309,19 +307,6 @@ class DoctrineMongoDBExtension extends AbstractDoctrineExtension
             $method = $odmConfigDef->removeMethodCall('setDocumentNamespaces');
         }
         $odmConfigDef->addMethodCall('setDocumentNamespaces', array($this->aliasMap));
-    }
-
-    protected function loadConstraints(ContainerBuilder $container)
-    {
-        // FIXME: the validator.annotations.namespaces parameter does not exist anymore
-        // and anyway, it was not available in the FrameworkExtension code
-        // as each bundle is isolated from the others
-        if ($container->hasParameter('validator.annotations.namespaces')) {
-            $container->setParameter('validator.annotations.namespaces', array_merge(
-                $container->getParameter('validator.annotations.namespaces'),
-                array('mongodb' => 'Symfony\Bundle\DoctrineMongoDBBundle\Validator\Constraints\\')
-            ));
-        }
     }
 
     protected function getObjectManagerElementName($name)

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DoctrineMongoDBBundle.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DoctrineMongoDBBundle.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\DoctrineMongoDBBundle;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Compiler\AddValidatorNamespaceAliasPass;
 use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Compiler\CreateHydratorDirectoryPass;
 use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Compiler\CreateProxyDirectoryPass;
 use Symfony\Bundle\DoctrineMongoDBBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
@@ -31,6 +32,7 @@ class DoctrineMongoDBBundle extends Bundle
     {
         parent::build($container);
 
+        $container->addCompilerPass(new AddValidatorNamespaceAliasPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
         $container->addCompilerPass(new CreateProxyDirectoryPass(), PassConfig::TYPE_BEFORE_REMOVING);
         $container->addCompilerPass(new CreateHydratorDirectoryPass(), PassConfig::TYPE_BEFORE_REMOVING);


### PR DESCRIPTION
The annotation alias for the MongoDB constraint namespace is now `assertMongoDB`.
