### PR TITLE
[DependencyInjection] renamed 2 methods

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -6,6 +6,22 @@ one. It only discusses changes that need to be done when using the "public"
 API of the framework. If you "hack" the core, you should probably follow the
 timeline closely anyway.
 
+PR12 to PR13
+------------
+
+* Some methods in the DependencyInjection component's ContainerBuilder and
+  Definition classes have been renamed to be more specific and consistent:
+
+  Before:
+
+        $container->remove('my_definition');
+        $definition->setArgument(0, 'foo');
+
+  After:
+
+        $container->removeDefinition('my_definition');
+        $definition->replaceArgument(0, 'foo');
+
 PR11 to PR12
 ------------
 

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -76,12 +76,12 @@ class AsseticExtension extends Extension
             $loader->load('controller.xml');
             $container->setParameter('assetic.twig_extension.class', '%assetic.twig_extension.dynamic.class%');
             $container->getDefinition('assetic.helper.dynamic')->addTag('templating.helper', array('alias' => 'assetic'));
-            $container->remove('assetic.helper.static');
+            $container->removeDefinition('assetic.helper.static');
         } else {
             $loader->load('asset_writer.xml');
             $container->setParameter('assetic.twig_extension.class', '%assetic.twig_extension.static.class%');
             $container->getDefinition('assetic.helper.static')->addTag('templating.helper', array('alias' => 'assetic'));
-            $container->remove('assetic.helper.dynamic');
+            $container->removeDefinition('assetic.helper.dynamic');
         }
 
         // register config resources

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/AssetManagerPass.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/AssetManagerPass.php
@@ -48,7 +48,7 @@ class AssetManagerPass implements CompilerPassInterface
                 }
             }
         }
-        $am->setArgument(1, $loaders);
+        $am->replaceArgument(1, $loaders);
 
         // add resources
         foreach ($container->findTaggedServiceIds('assetic.formula_resource') as $id => $attributes) {

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/CheckClosureFilterPass.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/CheckClosureFilterPass.php
@@ -25,9 +25,9 @@ class CheckClosureFilterPass implements CompilerPassInterface
     {
         if ($container->hasDefinition('assetic.filter.closure.jar') &&
             $container->getParameterBag()->resolveValue($container->getParameter('assetic.filter.closure.jar'))) {
-            $container->remove('assetic.filter.closure.api');
+            $container->removeDefinition('assetic.filter.closure.api');
         } elseif ($container->hasDefinition('assetic.filter.closure.api')) {
-            $container->remove('assetic.filter.closure.jar');
+            $container->removeDefinition('assetic.filter.closure.jar');
         }
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/FilterManagerPass.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/FilterManagerPass.php
@@ -39,6 +39,6 @@ class FilterManagerPass implements CompilerPassInterface
 
         $container
             ->getDefinition('assetic.filter_manager')
-            ->setArgument(1, $mapping);
+            ->replaceArgument(1, $mapping);
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/TemplatingPass.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/Compiler/TemplatingPass.php
@@ -31,13 +31,13 @@ class TemplatingPass implements CompilerPassInterface
 
         if (!in_array('twig', $engines)) {
             foreach ($container->findTaggedServiceIds('assetic.templating.twig') as $id => $attr) {
-                $container->remove($id);
+                $container->removeDefinition($id);
             }
         }
 
         if (!in_array('php', $engines)) {
             foreach ($container->findTaggedServiceIds('assetic.templating.php') as $id => $attr) {
-                $container->remove($id);
+                $container->removeDefinition($id);
             }
         }
     }

--- a/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/AddValidatorNamespaceAliasPass.php
+++ b/src/Symfony/Bundle/DoctrineMongoDBBundle/DependencyInjection/Compiler/AddValidatorNamespaceAliasPass.php
@@ -17,6 +17,6 @@ class AddValidatorNamespaceAliasPass implements CompilerPassInterface
         $args = $loader->getArguments();
 
         $args[0]['assertMongoDB'] = 'Symfony\\Bundle\\DoctrineMongoDBBundle\\Validator\\Constraints\\';
-        $loader->setArgument(0, $args[0]);
+        $loader->replaceArgument(0, $args[0]);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheWarmerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheWarmerPass.php
@@ -41,7 +41,7 @@ class AddCacheWarmerPass implements CompilerPassInterface
         krsort($warmers);
         $warmers = call_user_func_array('array_merge', $warmers);
 
-        $container->getDefinition('cache_warmer')->setArgument(0, $warmers);
+        $container->getDefinition('cache_warmer')->replaceArgument(0, $warmers);
 
         if ('full' === $container->getParameter('kernel.cache_warmup')) {
             $container->getDefinition('cache_warmer')->addMethodCall('enableOptionalWarmers', array());

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddConstraintValidatorsPass.php
@@ -29,6 +29,6 @@ class AddConstraintValidatorsPass implements CompilerPassInterface
             }
         }
 
-        $container->getDefinition('validator.validator_factory')->setArgument(1, $validators);
+        $container->getDefinition('validator.validator_factory')->replaceArgument(1, $validators);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddFieldFactoryGuessersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddFieldFactoryGuessersPass.php
@@ -33,6 +33,6 @@ class AddFieldFactoryGuessersPass implements CompilerPassInterface
             return new Reference($id);
         }, array_keys($container->findTaggedServiceIds('form.field_factory.guesser')));
 
-        $container->getDefinition('form.field_factory')->setArgument(0, $guessers);
+        $container->getDefinition('form.field_factory')->replaceArgument(0, $guessers);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -75,12 +75,12 @@ class FrameworkExtension extends Extension
             } else {
                 $container
                     ->getDefinition('error_handler')->addMethodCall('register', array())
-                    ->setArgument(0, $config['error_handler'])
+                    ->replaceArgument(0, $config['error_handler'])
                 ;
             }
         }
 
-        $container->getDefinition('exception_listener')->setArgument(0, $config['exception_controller']);
+        $container->getDefinition('exception_listener')->replaceArgument(0, $config['exception_controller']);
 
         if (!empty($config['test'])) {
             $loader->load('test.xml');
@@ -194,8 +194,8 @@ class FrameworkExtension extends Extension
         $loader->load('collectors.xml');
 
         $container->getDefinition('profiler_listener')
-            ->setArgument(2, $config['only_exceptions'])
-            ->setArgument(3, $config['only_master_requests'])
+            ->replaceArgument(2, $config['only_exceptions'])
+            ->replaceArgument(3, $config['only_master_requests'])
         ;
 
         // Choose storage class based on the DSN
@@ -209,10 +209,10 @@ class FrameworkExtension extends Extension
         }
 
         $container->getDefinition('profiler.storage')
-            ->setArgument(0, $config['dsn'])
-            ->setArgument(1, $config['username'])
-            ->setArgument(2, $config['password'])
-            ->setArgument(3, $config['lifetime'])
+            ->replaceArgument(0, $config['dsn'])
+            ->replaceArgument(1, $config['username'])
+            ->replaceArgument(2, $config['password'])
+            ->replaceArgument(3, $config['lifetime'])
             ->setClass($supported[$class])
         ;
 
@@ -285,7 +285,7 @@ class FrameworkExtension extends Extension
             $container->setParameter('session.class', $config['class']);
         }
 
-        $container->getDefinition('session')->setArgument(1, $config['default_locale']);
+        $container->getDefinition('session')->replaceArgument(1, $config['default_locale']);
 
         $container->setAlias('session.storage', 'session.storage.'.$config['storage_id']);
 
@@ -323,7 +323,7 @@ class FrameworkExtension extends Extension
 
         $container
             ->getDefinition('templating.helper.code')
-            ->setArgument(0, str_replace('%', '%%', isset($links[$ide]) ? $links[$ide] : $ide))
+            ->replaceArgument(0, str_replace('%', '%%', isset($links[$ide]) ? $links[$ide] : $ide))
         ;
 
         if ($container->getParameter('kernel.debug')) {
@@ -339,9 +339,9 @@ class FrameworkExtension extends Extension
         }
         $container
             ->getDefinition('templating.helper.assets')
-            ->setArgument(1, isset($config['assets_base_urls']) ? $config['assets_base_urls'] : array())
-            ->setArgument(2, $config['assets_version'])
-            ->setArgument(3, $packages)
+            ->replaceArgument(1, isset($config['assets_base_urls']) ? $config['assets_base_urls'] : array())
+            ->replaceArgument(2, $config['assets_version'])
+            ->replaceArgument(3, $packages)
         ;
 
         if (!empty($config['loaders'])) {
@@ -360,7 +360,7 @@ class FrameworkExtension extends Extension
             // Wrap the existing loader with cache (must happen after loaders are registered)
             $container->setDefinition('templating.loader.wrapped', $container->findDefinition('templating.loader'));
             $loaderCache = $container->getDefinition('templating.loader.cache');
-            $loaderCache->setArgument(1, $config['cache']);
+            $loaderCache->replaceArgument(1, $config['cache']);
 
             $container->setDefinition('templating.loader', $loaderCache);
         }
@@ -403,7 +403,7 @@ class FrameworkExtension extends Extension
         if (1 === count($engines)) {
             $container->setAlias('templating', (string) reset($engines));
         } else {
-            $container->getDefinition('templating.engine.delegating')->setArgument(1, $engines);
+            $container->getDefinition('templating.engine.delegating')->replaceArgument(1, $engines);
             $container->setAlias('templating', 'templating.engine.delegating');
         }
     }
@@ -466,12 +466,12 @@ class FrameworkExtension extends Extension
 
         $container
             ->getDefinition('validator.mapping.loader.xml_files_loader')
-            ->setArgument(0, $this->getValidatorXmlMappingFiles($container))
+            ->replaceArgument(0, $this->getValidatorXmlMappingFiles($container))
         ;
 
         $container
             ->getDefinition('validator.mapping.loader.yaml_files_loader')
-            ->setArgument(0, $this->getValidatorYamlMappingFiles($container))
+            ->replaceArgument(0, $this->getValidatorYamlMappingFiles($container))
         ;
 
         if (isset($config['annotations'])) {
@@ -484,7 +484,7 @@ class FrameworkExtension extends Extension
             // Register annotation loader
             $container
                 ->getDefinition('validator.mapping.loader.annotation_loader')
-                ->setArgument(0, $namespaces)
+                ->replaceArgument(0, $namespaces)
             ;
 
             $loaderChain = $container->getDefinition('validator.mapping.loader.loader_chain');
@@ -495,7 +495,7 @@ class FrameworkExtension extends Extension
 
         if (isset($config['cache'])) {
             $container->getDefinition('validator.mapping.class_metadata_factory')
-                ->setArgument(1, new Reference('validator.mapping.cache.'.$config['cache']));
+                ->replaceArgument(1, new Reference('validator.mapping.cache.'.$config['cache']));
             $container->setParameter(
                 'validator.mapping.cache.prefix',
                 'validator_'.md5($container->getParameter('kernel.root_dir'))

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/Compiler/LoggerChannelPass.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/Compiler/LoggerChannelPass.php
@@ -39,7 +39,7 @@ class LoggerChannelPass implements CompilerPassInterface
                     $this->createLogger($tag['channel'], $loggerId, $container);
                     foreach ($definition->getArguments() as $index => $argument) {
                         if ($argument instanceof Reference && 'logger' === (string) $argument) {
-                            $definition->setArgument($index, new Reference($loggerId, $argument->getInvalidBehavior(), $argument->isStrict()));
+                            $definition->replaceArgument($index, new Reference($loggerId, $argument->getInvalidBehavior(), $argument->isStrict()));
                         }
                     }
                 }
@@ -51,7 +51,7 @@ class LoggerChannelPass implements CompilerPassInterface
     {
         if (!in_array($channel, $this->channels)) {
             $logger = new DefinitionDecorator('monolog.logger_prototype');
-            $logger->setArgument(0, $channel);
+            $logger->replaceArgument(0, $channel);
             $container->setDefinition($loggerId, $logger);
             array_push($this->channels, $channel);
         }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddSecurityVotersPass.php
@@ -40,6 +40,6 @@ class AddSecurityVotersPass implements CompilerPassInterface
         $voters = iterator_to_array($voters);
         ksort($voters);
 
-        $container->getDefinition('security.access.decision_manager')->setArgument(0, array_values($voters));
+        $container->getDefinition('security.access.decision_manager')->replaceArgument(0, array_values($voters));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -148,17 +148,17 @@ abstract class AbstractFactory implements SecurityFactoryInterface
     {
         $listenerId = $this->getListenerId();
         $listener = new DefinitionDecorator($listenerId);
-        $listener->setArgument(3, $id);
-        $listener->setArgument(4, array_intersect_key($config, $this->options));
+        $listener->replaceArgument(3, $id);
+        $listener->replaceArgument(4, array_intersect_key($config, $this->options));
 
         // success handler
         if (isset($config['success_handler'])) {
-            $listener->setArgument(5, new Reference($config['success_handler']));
+            $listener->replaceArgument(5, new Reference($config['success_handler']));
         }
 
         // failure handler
         if (isset($config['failure_handler'])) {
-            $listener->setArgument(6, new Reference($config['failure_handler']));
+            $listener->replaceArgument(6, new Reference($config['failure_handler']));
         }
 
         $listenerId .= '.'.$id;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -65,8 +65,8 @@ class FormLoginFactory extends AbstractFactory
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->setDefinition($provider, new DefinitionDecorator('security.authentication.provider.dao'))
-            ->setArgument(0, new Reference($userProviderId))
-            ->setArgument(2, $id)
+            ->replaceArgument(0, new Reference($userProviderId))
+            ->replaceArgument(2, $id)
         ;
 
         return $provider;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php
@@ -29,8 +29,8 @@ class HttpBasicFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->setDefinition($provider, new DefinitionDecorator('security.authentication.provider.dao'))
-            ->setArgument(0, new Reference($userProvider))
-            ->setArgument(2, $id)
+            ->replaceArgument(0, new Reference($userProvider))
+            ->replaceArgument(2, $id)
         ;
 
         // entry point
@@ -39,8 +39,8 @@ class HttpBasicFactory implements SecurityFactoryInterface
         // listener
         $listenerId = 'security.authentication.listener.basic.'.$id;
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.basic'));
-        $listener->setArgument(2, $id);
-        $listener->setArgument(3, new Reference($entryPointId));
+        $listener->replaceArgument(2, $id);
+        $listener->replaceArgument(3, new Reference($entryPointId));
 
         return array($provider, $listenerId, $entryPointId);
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -29,8 +29,8 @@ class HttpDigestFactory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.dao.'.$id;
         $container
             ->setDefinition($provider, new DefinitionDecorator('security.authentication.provider.dao'))
-            ->setArgument(0, new Reference($userProvider))
-            ->setArgument(2, $id)
+            ->replaceArgument(0, new Reference($userProvider))
+            ->replaceArgument(2, $id)
         ;
 
         // entry point
@@ -39,9 +39,9 @@ class HttpDigestFactory implements SecurityFactoryInterface
         // listener
         $listenerId = 'security.authentication.listener.digest.'.$id;
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.digest'));
-        $listener->setArgument(1, new Reference($userProvider));
-        $listener->setArgument(2, $id);
-        $listener->setArgument(3, new Reference($entryPointId));
+        $listener->replaceArgument(1, new Reference($userProvider));
+        $listener->replaceArgument(2, $id);
+        $listener->replaceArgument(3, new Reference($entryPointId));
 
         return array($provider, $listenerId, $entryPointId);
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -53,8 +53,8 @@ class RememberMeFactory implements SecurityFactoryInterface
         }
 
         $rememberMeServices = $container->setDefinition($rememberMeServicesId, new DefinitionDecorator($templateId));
-        $rememberMeServices->setArgument(1, $config['key']);
-        $rememberMeServices->setArgument(2, $id);
+        $rememberMeServices->replaceArgument(1, $config['key']);
+        $rememberMeServices->replaceArgument(2, $id);
 
         if (isset($config['token-provider'])) {
             // FIXME: make the naming assumption more flexible
@@ -64,7 +64,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         }
 
         // remember-me options
-        $rememberMeServices->setArgument(3, array_intersect_key($config, $this->options));
+        $rememberMeServices->replaceArgument(3, array_intersect_key($config, $this->options));
 
         // attach to remember-me aware listeners
         $userProviders = array();
@@ -88,12 +88,12 @@ class RememberMeFactory implements SecurityFactoryInterface
         if (count($userProviders) === 0) {
             throw new \RuntimeException('You must configure at least one remember-me aware listener (such as form-login) for each firewall that has remember-me enabled.');
         }
-        $rememberMeServices->setArgument(0, $userProviders);
+        $rememberMeServices->replaceArgument(0, $userProviders);
 
         // remember-me listener
         $listenerId = 'security.authentication.listener.rememberme.'.$id;
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.rememberme'));
-        $listener->setArgument(1, new Reference($rememberMeServicesId));
+        $listener->replaceArgument(1, new Reference($rememberMeServicesId));
 
         return array($authProviderId, $listenerId, $defaultEntryPoint);
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/X509Factory.php
@@ -30,16 +30,16 @@ class X509Factory implements SecurityFactoryInterface
         $provider = 'security.authentication.provider.pre_authenticated.'.$id;
         $container
             ->setDefinition($provider, new DefinitionDecorator('security.authentication.provider.pre_authenticated'))
-            ->setArgument(0, new Reference($userProvider))
+            ->replaceArgument(0, new Reference($userProvider))
             ->addArgument($id)
         ;
 
         // listener
         $listenerId = 'security.authentication.listener.x509.'.$id;
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.x509'));
-        $listener->setArgument(2, $id);
-        $listener->setArgument(3, $config['user']);
-        $listener->setArgument(4, $config['credentials']);
+        $listener->replaceArgument(2, $id);
+        $listener->replaceArgument(3, $config['user']);
+        $listener->replaceArgument(4, $config['credentials']);
 
         return array($provider, $listenerId, $defaultEntryPoint);
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -62,7 +62,7 @@ class SecurityExtension extends Extension
 
         // set some global scalars
         $container->setParameter('security.access.denied_url', $config['access_denied_url']);
-        $container->getDefinition('security.authentication.session_strategy')->setArgument(0, $config['session_fixation_strategy']);
+        $container->getDefinition('security.authentication.session_strategy')->replaceArgument(0, $config['session_fixation_strategy']);
         $container
             ->getDefinition('security.access.decision_manager')
             ->addArgument($config['access_decision_manager']['strategy'])
@@ -202,12 +202,12 @@ class SecurityExtension extends Extension
             $contextId = 'security.firewall.map.context.'.$name;
             $context = $container->setDefinition($contextId, new DefinitionDecorator('security.firewall.context'));
             $context
-                ->setArgument(0, $listeners)
-                ->setArgument(1, $exceptionListener)
+                ->replaceArgument(0, $listeners)
+                ->replaceArgument(1, $exceptionListener)
             ;
             $map[$contextId] = $matcher;
         }
-        $mapDef->setArgument(1, $map);
+        $mapDef->replaceArgument(1, $map);
 
         // add authentication providers to authentication manager
         $authenticationProviders = array_map(function($id) {
@@ -215,7 +215,7 @@ class SecurityExtension extends Extension
         }, array_values(array_unique($authenticationProviders)));
         $container
             ->getDefinition('security.authentication.manager')
-            ->setArgument(0, $authenticationProviders)
+            ->replaceArgument(0, $authenticationProviders)
         ;
     }
 
@@ -263,13 +263,13 @@ class SecurityExtension extends Extension
         if (isset($firewall['logout'])) {
             $listenerId = 'security.logout_listener.'.$id;
             $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.logout_listener'));
-            $listener->setArgument(1, $firewall['logout']['path']);
-            $listener->setArgument(2, $firewall['logout']['target']);
+            $listener->replaceArgument(1, $firewall['logout']['path']);
+            $listener->replaceArgument(2, $firewall['logout']['target']);
             $listeners[] = new Reference($listenerId);
 
             // add logout success handler
             if (isset($firewall['logout']['success_handler'])) {
-                $listener->setArgument(3, new Reference($firewall['logout']['success_handler']));
+                $listener->replaceArgument(3, new Reference($firewall['logout']['success_handler']));
             }
 
             // add session logout handler
@@ -324,7 +324,7 @@ class SecurityExtension extends Extension
 
         $listenerId = 'security.context_listener.'.count($this->contextListeners);
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.context_listener'));
-        $listener->setArgument(2, $contextKey);
+        $listener->replaceArgument(2, $contextKey);
 
         return $this->contextListeners[$contextKey] = $listenerId;
     }
@@ -356,7 +356,7 @@ class SecurityExtension extends Extension
             $listenerId = 'security.authentication.listener.anonymous.'.$id;
             $container
                 ->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.anonymous'))
-                ->setArgument(1, $firewall['anonymous']['key'])
+                ->replaceArgument(1, $firewall['anonymous']['key'])
             ;
 
             $listeners[] = new Reference($listenerId);
@@ -364,7 +364,7 @@ class SecurityExtension extends Extension
             $providerId = 'security.authentication.provider.anonymous.'.$id;
             $container
                 ->setDefinition($providerId, new DefinitionDecorator('security.authentication.provider.anonymous'))
-                ->setArgument(0, $firewall['anonymous']['key'])
+                ->replaceArgument(0, $firewall['anonymous']['key'])
             ;
 
             $authenticationProviders[] = $providerId;
@@ -496,13 +496,13 @@ class SecurityExtension extends Extension
     {
         $exceptionListenerId = 'security.exception_listener.'.$id;
         $listener = $container->setDefinition($exceptionListenerId, new DefinitionDecorator('security.exception_listener'));
-        $listener->setArgument(2, null === $defaultEntryPoint ? null : new Reference($defaultEntryPoint));
+        $listener->replaceArgument(2, null === $defaultEntryPoint ? null : new Reference($defaultEntryPoint));
 
         // access denied handler setup
         if (isset($config['access_denied_handler'])) {
-            $listener->setArgument(4, new Reference($config['access_denied_handler']));
+            $listener->replaceArgument(4, new Reference($config['access_denied_handler']));
         } else if (isset($config['access_denied_url'])) {
-            $listener->setArgument(3, $config['access_denied_url']);
+            $listener->replaceArgument(3, $config['access_denied_url']);
         }
 
         return $exceptionListenerId;
@@ -514,10 +514,10 @@ class SecurityExtension extends Extension
 
         $switchUserListenerId = 'security.authentication.switchuser_listener.'.$id;
         $listener = $container->setDefinition($switchUserListenerId, new DefinitionDecorator('security.authentication.switchuser_listener'));
-        $listener->setArgument(1, new Reference($userProvider));
-        $listener->setArgument(3, $id);
-        $listener->setArgument(6, $config['parameter']);
-        $listener->setArgument(7, $config['role']);
+        $listener->replaceArgument(1, new Reference($userProvider));
+        $listener->replaceArgument(3, $id);
+        $listener->replaceArgument(6, $config['parameter']);
+        $listener->replaceArgument(7, $config['role']);
 
         return $switchUserListenerId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -138,13 +138,13 @@ class SecurityExtension extends Extension
     private function createRoleHierarchy($config, ContainerBuilder $container)
     {
         if (!isset($config['role_hierarchy'])) {
-            $container->remove('security.access.role_hierarchy_voter');
+            $container->removeDefinition('security.access.role_hierarchy_voter');
 
             return;
         }
 
         $container->setParameter('security.role_hierarchy.roles', $config['role_hierarchy']);
-        $container->remove('security.access.simple_role_voter');
+        $container->removeDefinition('security.access.simple_role_voter');
     }
 
     private function createAuthorization($config, ContainerBuilder $container)

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -48,8 +48,8 @@ class WebProfilerExtension extends Extension
             $loader->load('toolbar.xml');
 
             $container->getDefinition('web_profiler.debug.toolbar')
-                ->setArgument(1, $config['intercept_redirects'])
-                ->setArgument(2, $config['verbose'])
+                ->replaceArgument(1, $config['intercept_redirects'])
+                ->replaceArgument(2, $config['verbose'])
             ;
         }
     }

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveAbstractDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveAbstractDefinitionsPass.php
@@ -22,7 +22,7 @@ class RemoveAbstractDefinitionsPass implements CompilerPassInterface
 
         foreach ($container->getDefinitions() as $id => $definition) {
             if ($definition->isAbstract()) {
-                $container->remove($id);
+                $container->removeDefinition($id);
                 $compiler->addLogMessage($formatter->formatRemoveService($this, $id, 'abstract'));
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -72,10 +72,10 @@ class RemoveUnusedDefinitionsPass implements RepeatablePassInterface
             if (1 === count($referencingAliases) && false === $isReferenced) {
                 $container->setDefinition((string) reset($referencingAliases), $definition);
                 $definition->setPublic(true);
-                $container->remove($id);
+                $container->removeDefinition($id);
                 $compiler->addLogMessage($formatter->formatRemoveService($this, $id, 'replaces alias '.reset($referencingAliases)));
             } else if (0 === count($referencingAliases) && false === $isReferenced) {
-                $container->remove($id);
+                $container->removeDefinition($id);
                 $compiler->addLogMessage($formatter->formatRemoveService($this, $id, 'unused'));
                 $hasChanged = true;
             }

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -47,7 +47,7 @@ class ReplaceAliasByActualDefinitionPass implements CompilerPassInterface
 
             $definition->setPublic(true);
             $container->setDefinition($id, $definition);
-            $container->remove($aliasId);
+            $container->removeDefinition($aliasId);
 
             $this->updateReferences($container, $aliasId, $id);
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -111,7 +111,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
             }
 
             $index = (integer) substr($k, strlen('index_'));
-            $def->setArgument($index, $v);
+            $def->replaceArgument($index, $v);
         }
 
         // merge properties

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -241,11 +241,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
-     * Removes a service.
+     * Removes a service definition.
      *
      * @param string $id The service identifier
      */
-    public function remove($id)
+    public function removeDefinition($id)
     {
         unset($this->definitions[strtolower($id)]);
     }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -205,7 +205,7 @@ class Definition
      *
      * @return Definition The current instance
      */
-    public function setArgument($index, $argument)
+    public function replaceArgument($index, $argument)
     {
         if ($index < 0 || $index > count($this->arguments) - 1) {
             throw new \OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, count($this->arguments) - 1));

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -129,7 +129,7 @@ class DefinitionDecorator extends Definition
      * @return DefinitionDecorator the current instance
      * @throws \InvalidArgumentException when $index isnt an integer
      */
-    public function setArgument($index, $value)
+    public function replaceArgument($index, $value)
     {
         if (!is_int($index)) {
             throw new \InvalidArgumentException('$index must be an integer.');

--- a/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPassTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPassTest.php
@@ -14,7 +14,7 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $container->register('parent', 'foo')->setArguments(array('moo', 'b'))->setProperty('foo', 'moo');
         $container->setDefinition('child', new DefinitionDecorator('parent'))
-            ->setArgument(0, 'a')
+            ->replaceArgument(0, 'a')
             ->setProperty('foo', 'bar')
             ->setClass('bar')
         ;
@@ -119,12 +119,12 @@ class ResolveDefinitionTemplatesPassTest extends \PHPUnit_Framework_TestCase
 
         $container
             ->setDefinition('child2', new DefinitionDecorator('child1'))
-            ->setArgument(1, 'b')
+            ->replaceArgument(1, 'b')
         ;
 
         $container
             ->setDefinition('child1', new DefinitionDecorator('parent'))
-            ->setArgument(0, 'a')
+            ->replaceArgument(0, 'a')
         ;
 
         $this->process($container);

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionDecoratorTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionDecoratorTest.php
@@ -57,7 +57,7 @@ class DefinitionDecoratorTest extends \PHPUnit_Framework_TestCase
         $def = new DefinitionDecorator('foo');
 
         $this->assertEquals(array(), $def->getArguments());
-        $this->assertSame($def, $def->setArgument(0, 'foo'));
+        $this->assertSame($def, $def->replaceArgument(0, 'foo'));
         $this->assertEquals(array('index_0' => 'foo'), $def->getArguments());
     }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
@@ -201,7 +201,7 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\DependencyInjection\Definition::setArgument
+     * @covers Symfony\Component\DependencyInjection\Definition::replaceArgument
      */
     public function testSetArgument()
     {
@@ -210,13 +210,13 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $def->addArgument('foo');
         $this->assertSame(array('foo'), $def->getArguments());
 
-        $this->assertSame($def, $def->setArgument(0, 'moo'));
+        $this->assertSame($def, $def->replaceArgument(0, 'moo'));
         $this->assertSame(array('moo'), $def->getArguments());
 
         $def->addArgument('moo');
         $def
-            ->setArgument(0, 'foo')
-            ->setArgument(1, 'bar')
+            ->replaceArgument(0, 'foo')
+            ->replaceArgument(1, 'bar')
         ;
         $this->assertSame(array('foo', 'bar'), $def->getArguments());
     }


### PR DESCRIPTION
Definition::setArgument() is now replaceArgument()
ContainerBuilder::remove() is now removeDefinition()

These names are more clear and consistent with other methods.
