### PR TITLE
fixing Fatal error: Call to a member function xyz on a non-object ... for sessions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -62,7 +62,7 @@ class RequestListener
         }
 
         // starts the session if a session cookie already exists in the request...
-        if ($request->hasSession()) {
+        if ($request->hasSession() && null !== $request->getSession()) {
             $request->getSession()->start();
         }
     }

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -64,7 +64,7 @@ class RequestDataCollector extends DataCollector
             'request_cookies'    => $request->cookies->all(),
             'request_attributes' => $attributes,
             'response_headers'   => $responseHeaders,
-            'session_attributes' => $request->hasSession() ? $request->getSession()->getAttributes() : array(),
+            'session_attributes' => $request->hasSession() && null !== $request->getSession() ? $request->getSession()->getAttributes() : array(),
         );
     }
 


### PR DESCRIPTION
$request->hasSession() only checks if the session with a specific name exists.
Which is ok, unless we have turned off session support in framework and we
get a malicious user trying to fake a session cookie with proper name
(which is not that hard as usually it's a default one e.g. PHPSESSID)
This prevents Fatal error: Call to a member function xyz on a non-object ...

I'd gladly provide a testcase for this but I'd really need some pointers.
