### PR TITLE
Removed realpath() in HttpFoundation\File

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -491,7 +491,7 @@ class File
             throw new FileNotFoundException($path);
         }
 
-        $this->path = realpath($path);
+        $this->path = $path;
     }
 
     /**


### PR DESCRIPTION
Closes http://trac.symfony-project.org/ticket/9118

The reason for this change is it does not allow you to symlink your "file storage" path for an application to another part of your system like a mounted iscsi volume. The symlink is expanded to the real system path, and this path is useless to store in a database (the file path is no longer portable across multiple systems)
