### PR TITLE
[AsseticBundle] Fix the cache warmers - needs Kris review & approval

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/CacheWarmer/AssetManagerCacheWarmer.php
+++ b/src/Symfony/Bundle/AsseticBundle/CacheWarmer/AssetManagerCacheWarmer.php
@@ -11,21 +11,22 @@
 
 namespace Symfony\Bundle\AsseticBundle\CacheWarmer;
 
-use Assetic\Factory\LazyAssetManager;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class AssetManagerCacheWarmer extends CacheWarmer
 {
-    protected $am;
+    private $container;
 
-    public function __construct(LazyAssetManager $am)
+    public function __construct(ContainerInterface $container)
     {
-        $this->am = $am;
+        $this->container = $container;
     }
 
     public function warmUp($cacheDir)
     {
-        $this->am->load();
+        $am = $this->container->get('assetic.asset_manager');
+        $am->load();
     }
 
     public function isOptional()

--- a/src/Symfony/Bundle/AsseticBundle/CacheWarmer/AssetWriterCacheWarmer.php
+++ b/src/Symfony/Bundle/AsseticBundle/CacheWarmer/AssetWriterCacheWarmer.php
@@ -11,24 +11,25 @@
 
 namespace Symfony\Bundle\AsseticBundle\CacheWarmer;
 
-use Assetic\AssetManager;
 use Assetic\AssetWriter;
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmer;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class AssetWriterCacheWarmer extends CacheWarmer
 {
-    protected $am;
-    protected $writer;
+    private $container;
+    private $writer;
 
-    public function __construct(AssetManager $am, AssetWriter $writer)
+    public function __construct(ContainerInterface $container, AssetWriter $writer)
     {
-        $this->am = $am;
+        $this->container = $container;
         $this->writer = $writer;
     }
 
     public function warmUp($cacheDir)
     {
-        $this->writer->writeManagerAssets($this->am);
+        $am = $this->container->get('assetic.asset_manager');
+        $this->writer->writeManagerAssets($am);
     }
 
     public function isOptional()

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/asset_writer.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/asset_writer.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="assetic.asset_writer_cache_warmer" class="%assetic.asset_writer_cache_warmer.class%" public="false">
             <tag name="kernel.cache_warmer" />
-            <argument type="service" id="assetic.asset_manager" />
+            <argument type="service" id="service_container" />
             <argument type="service" id="assetic.asset_writer" />
         </service>
         <service id="assetic.asset_writer" class="%assetic.asset_writer.class%" public="false">

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -42,7 +42,7 @@
 
         <service id="assetic.asset_manager_cache_warmer" class="%assetic.asset_manager_cache_warmer.class%" public="false">
             <tag name="kernel.cache_warmer" priority="10" />
-            <argument type="service" id="assetic.asset_manager" />
+            <argument type="service" id="service_container" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetManagerCacheWarmerTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetManagerCacheWarmerTest.php
@@ -24,13 +24,28 @@ class AssetManagerCacheWarmerTest extends \PHPUnit_Framework_TestCase
 
     public function testWarmUp()
     {
-        $am = $this->getMockBuilder('Assetic\\Factory\\LazyAssetManager')
+        $am = $this
+            ->getMockBuilder('Assetic\\Factory\\LazyAssetManager')
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMock()
+        ;
 
         $am->expects($this->once())->method('load');
+        
+        $container = $this
+            ->getMockBuilder('Symfony\\Component\\DependencyInjection\\Container')
+            ->setConstructorArgs(array())
+            ->getMock()
+        ;
+        
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('assetic.asset_manager')
+            ->will($this->returnValue($am))
+        ;
 
-        $warmer = new AssetManagerCacheWarmer($am);
+        $warmer = new AssetManagerCacheWarmer($container);
         $warmer->warmUp('/path/to/cache');
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetWriterCacheWarmerTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/CacheWarmer/AssetWriterCacheWarmerTest.php
@@ -25,15 +25,33 @@ class AssetWriterCacheWarmerTest extends \PHPUnit_Framework_TestCase
     public function testWarmUp()
     {
         $am = $this->getMock('Assetic\\AssetManager');
-        $writer = $this->getMockBuilder('Assetic\\AssetWriter')
+        
+        $writer = $this
+            ->getMockBuilder('Assetic\\AssetWriter')
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMock()
+        ;
 
-        $writer->expects($this->once())
+        $writer
+            ->expects($this->once())
             ->method('writeManagerAssets')
-            ->with($am);
+            ->with($am)
+        ;
+        
+        $container = $this
+            ->getMockBuilder('Symfony\\Component\\DependencyInjection\\Container')
+            ->setConstructorArgs(array())
+            ->getMock()
+        ;
+        
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with('assetic.asset_manager')
+            ->will($this->returnValue($am))
+        ;        
 
-        $warmer = new AssetWriterCacheWarmer($am, $writer);
+        $warmer = new AssetWriterCacheWarmer($container, $writer);
         $warmer->warmUp('/path/to/cache');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -370,7 +370,10 @@ class FrameworkExtension extends Extension
         }
 
         if ($config['cache_warmer']) {
-            $container->getDefinition('templating.cache_warmer.template_paths')->addTag('kernel.cache_warmer');
+            $container
+                ->getDefinition('templating.cache_warmer.template_paths')
+                ->addTag('kernel.cache_warmer', array('priority' => 20))
+            ;
             $container->setAlias('templating.locator', 'templating.locator.cached');
         } else {
             $container->setAlias('templating.locator', 'templating.locator.uncached');


### PR DESCRIPTION
Trying to fix http://trac.symfony-project.org/ticket/9662

This is for @kriswallsmith to review

The issue: "The assetic cache warmer has a dependency ... on the templating cache warmer"

Solved by injecting the container in place of the asset manager in the constructor which allow for retrieving the asset manager only when needed in the warmUp() method.

Other considerations:
- The template warmer should run first (it is given a priority of 20)
- The assetic cache warmer should run after the template warmer but before the router warmer (it keeps its priority of 10)
- The router warmer has a default priority of 0
