### PR TITLE
[HttpFoundation] added Request::getSubdomain()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -440,6 +440,24 @@ class Request
 
         return $name.':'.$port;
     }
+    
+    public function getSubdomain()
+    {
+        $serverName = $this->server->get('SERVER_NAME');
+        $parts = explode('.', $serverName);
+
+        // domain.com
+        if (count($parts) < 3) {
+            return null;
+        }
+
+        // foo.bar.domain.com
+        if (count($parts) > 3) {
+            return implode('.', array_slice($parts, 0, count($parts) - 2));
+        }
+
+        return $parts[0];
+    }
 
     public function getRequestUri()
     {

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -410,6 +410,27 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('www.host.com', $request->getHost(), '->getHost() value from Host header has priority over SERVER_NAME ');
     }
 
+    public function getSubdomains()
+    {
+        return array(
+            array('domain', null),
+            array('domain.com', null),
+            array('foo.domain.com', 'foo'),
+            array('bar.foo.domain.com', 'bar.foo'),
+            array('foo.bar.foo.domain.com', 'foo.bar.foo')
+        );
+    }
+    
+    /**
+     * @cover Symfony\Component\HttpFoundation\Request::getSubdomain
+     * @dataProvider getSubdomains
+     */
+    public function testGetSubdomain($host, $subdomain)
+    {
+        $request = new Request(array(), array(), array(), array(), array(), array('SERVER_NAME' => $host));
+        $this->assertEquals($subdomain, $request->getSubdomain());
+    } 
+
     /**
      * @covers Symfony\Component\HttpFoundation\Request::setMethod
      * @covers Symfony\Component\HttpFoundation\Request::getMethod


### PR DESCRIPTION
Since a long time i use a custom Request class to add this function to the Request object as there's no easy way or built-in function to easily get the subdomain with php. For now i haven't discussed it (and don't know if it has been discussed), but the idea to add a way to get the subdomain easily already convinced me that this method is quite useful =).
