### PR TITLE
security: do not set target_path in case of AJAX requests

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -152,7 +152,10 @@ class ExceptionListener
 
         // session isn't required when using http basic authentification mechanism for example
         if ($request->hasSession()) {
-            $request->getSession()->set('_security.target_path', $request->getUri());
+            // do not set target_path in case of xhr requests
+            if (!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || 'XMLHttpRequest' !== $_SERVER['HTTP_X_REQUESTED_WITH']) {
+                $request->getSession()->set('_security.target_path', $request->getUri());
+            }
         }
 
         return $this->authenticationEntryPoint->start($request, $authException);

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -152,8 +152,7 @@ class ExceptionListener
 
         // session isn't required when using http basic authentification mechanism for example
         if ($request->hasSession()) {
-            // do not set target_path in case of xhr requests
-            if (!isset($_SERVER['HTTP_X_REQUESTED_WITH']) || 'XMLHttpRequest' !== $_SERVER['HTTP_X_REQUESTED_WITH']) {
+            if (!$request->isXmlHttpRequest()) {
                 $request->getSession()->set('_security.target_path', $request->getUri());
             }
         }


### PR DESCRIPTION
Currently upon every request behind firewall, request URI is set as target_path. This does not make sense in case of XHR requests.

Use case:
1) expired session window is open
2) user tries to perform some action requiring xhr, server responds (security bundle default) with 302
3) user refreshes, logs in, is redirected to target_path, which points to the recent xhr call

I'm not sure this is the correct way to solve it, let's start a discussion if this is not optimal.
