### PR TITLE
[Form] remove extra TimezoneType options

### DIFF
--- a/src/Symfony/Component/Form/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Type/TimezoneType.php
@@ -18,17 +18,9 @@ class TimezoneType extends AbstractType
 {
     public function getDefaultOptions(array $options)
     {
-        $defaultOptions = array(
-            'preferred_choices' => array(),
+        return array(
+            'choice_list' => new TimezoneChoiceList(),
         );
-
-        $options = array_replace($defaultOptions, $options);
-
-        if (!isset($options['choice_list'])) {
-            $defaultOptions['choice_list'] = new TimezoneChoiceList();
-        }
-
-        return $defaultOptions;
     }
 
     public function getParent(array $options)


### PR DESCRIPTION
Hey guys-

I just don't think these options are necessary - they're certainly not in the other `choice` child types.

Thanks!
