### PR TITLE
[Validator] Modifying Choice message and adding a different multiple mess

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -18,9 +18,10 @@ class Choice extends \Symfony\Component\Validator\Constraint
     public $multiple = false;
     public $min = null;
     public $max = null;
-    public $message = 'This value should be one of the given choices';
-    public $minMessage = 'You should select at least {{ limit }} choices';
-    public $maxMessage = 'You should select at most {{ limit }} choices';
+    public $message = 'The value you selected is not a valid choice';
+    public $multipleMessage = 'One or more of the given values is invalid';
+    public $minMessage = 'You must select at least {{ limit }} choices';
+    public $maxMessage = 'You must select at most {{ limit }} choices';
 
     /**
      * {@inheritDoc}

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -54,7 +54,7 @@ class ChoiceValidator extends ConstraintValidator
         if ($constraint->multiple) {
             foreach ($value as $_value) {
                 if (!in_array($_value, $choices, true)) {
-                    $this->setMessage($constraint->message, array('{{ value }}' => $_value));
+                    $this->setMessage($constraint->multipleMessage, array('{{ value }}' => $_value));
 
                     return false;
                 }


### PR DESCRIPTION
Hey guys-

Small, iffy details:

 1) Changed the choice error message - it's strange because the validator _can_ be used outside of the form context, but in reality, it'll almost always be used for forms. So, finding language that sounds normal but isn't totally form-bound is difficult.

 2) Seems more natural to have a different message when the user is selecting multiple items. I don't know of a cleaner way to have two different messages for the "invalid" case based on the option value.

Comments appreciated - thanks!
