### PR TITLE
FormFactory::create() accepts $data now

### DIFF
--- a/src/Symfony/Component/Form/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/EventListener/ResizeFormListener.php
@@ -79,7 +79,7 @@ class ResizeFormListener implements EventSubscriberInterface
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
-            $form->add($this->factory->create($this->type, $name, array(
+            $form->add($this->factory->createNamed($this->type, $name, null, array(
                 'property_path' => '['.$name.']',
             )));
         }
@@ -112,7 +112,7 @@ class ResizeFormListener implements EventSubscriberInterface
         // Add all additional rows
         foreach ($data as $name => $value) {
             if (!$form->has($name)) {
-                $form->add($this->factory->create($this->type, $name, array(
+                $form->add($this->factory->createNamed($this->type, $name, null, array(
                     'property_path' => '['.$name.']',
                 )));
             }

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -364,9 +364,10 @@ class FormBuilder
     public function build($name, $type = null, array $options = array())
     {
         if (null !== $type) {
-            $builder = $this->getFormFactory()->createBuilder(
+            $builder = $this->getFormFactory()->createNamedBuilder(
                 $type,
                 $name,
+                null,
                 $options
             );
         } else {
@@ -377,6 +378,7 @@ class FormBuilder
             $builder = $this->getFormFactory()->createBuilderForProperty(
                 $this->dataClass,
                 $name,
+                null,
                 $options
             );
         }

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -13,11 +13,15 @@ namespace Symfony\Component\Form;
 
 interface FormFactoryInterface
 {
-    function createBuilder($type, $name = null, array $options = array());
+    function create($type, $data = null, array $options = array());
 
-    function createBuilderForProperty($class, $property, array $options = array());
+    function createNamed($type, $name, $data = null, array $options = array());
 
-    function create($type, $name = null, array $options = array());
+    function createForProperty($class, $property, $data = null, array $options = array());
 
-    function createForProperty($class, $property, array $options = array());
+    function createBuilder($type, $data = null, array $options = array());
+
+    function createNamedBuilder($type, $name, $data = null, array $options = array());
+
+    function createBuilderForProperty($class, $property, $data = null, array $options = array());
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/EntityTypeTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/EntityTypeTest.php
@@ -80,7 +80,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 //
 //        $this->persist(array($entity1, $entity2));
 //
-//        $field = $this->factory->create('entity', 'name', array(
+//        $field = $this->factory->createNamed('entity', 'name', null, array(
 //            'em' => $this->em,
 //            'class' => self::SINGLE_IDENT_CLASS,
 //            'required' => false,
@@ -96,7 +96,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
      */
     public function testConfigureQueryBuilderWithNonQueryBuilderAndNonClosure()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => new \stdClass(),
@@ -108,7 +108,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
      */
     public function testConfigureQueryBuilderWithClosureReturningNonQueryBuilder()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function () {
@@ -121,7 +121,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
     public function testSetDataSingleNull()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => false,
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
@@ -134,7 +134,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
     public function testSetDataMultipleExpandedNull()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => $this->em,
@@ -148,7 +148,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
     public function testSetDataMultipleNonExpandedNull()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => $this->em,
@@ -162,7 +162,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
     public function testSubmitSingleExpandedNull()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => false,
             'expanded' => true,
             'em' => $this->em,
@@ -176,7 +176,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
     public function testSubmitSingleNonExpandedNull()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => $this->em,
@@ -190,7 +190,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
     public function testSubmitMultipleNull()
     {
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
@@ -208,7 +208,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => $this->em,
@@ -230,7 +230,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => false,
             'expanded' => false,
             'em' => $this->em,
@@ -254,7 +254,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => $this->em,
@@ -279,7 +279,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => $this->em,
@@ -310,7 +310,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => $this->em,
@@ -336,7 +336,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'expanded' => false,
             'em' => $this->em,
@@ -366,7 +366,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => false,
             'expanded' => true,
             'em' => $this->em,
@@ -392,7 +392,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'multiple' => true,
             'expanded' => true,
             'em' => $this->em,
@@ -424,7 +424,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             // not all persisted entities should be displayed
@@ -448,7 +448,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -469,7 +469,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::COMPOSITE_IDENT_CLASS,
             'choices' => array($entity1, $entity2),
@@ -492,7 +492,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $repository = $this->em->getRepository(self::SINGLE_IDENT_CLASS);
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => $repository->createQueryBuilder('e')
@@ -514,7 +514,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::SINGLE_IDENT_CLASS,
             'query_builder' => function ($repository) {
@@ -538,7 +538,7 @@ class EntityTypeTest extends DoctrineOrmTestCase
 
         $this->persist(array($entity1, $entity2, $entity3));
 
-        $field = $this->factory->create('entity', 'name', array(
+        $field = $this->factory->createNamed('entity', 'name', null, array(
             'em' => $this->em,
             'class' => self::COMPOSITE_IDENT_CLASS,
             'query_builder' => function ($repository) {

--- a/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
@@ -17,7 +17,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->create('text', 'name');
+        $form = $this->factory->createNamed('text', 'name');
         $form->addError(new FormError('Error!'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -37,7 +37,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRow()
     {
-        $form = $this->factory->create('repeated', 'name');
+        $form = $this->factory->createNamed('repeated', 'name');
         $form->addError(new FormError('Error!'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -62,7 +62,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRest()
     {
-        $view = $this->factory->createBuilder('form', 'name')
+        $view = $this->factory->createNamedBuilder('form', 'name')
             ->add('field1', 'text')
             ->add('field2', 'repeated')
             ->add('field3', 'text')
@@ -103,9 +103,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testCollection()
     {
-        $form = $this->factory->create('collection', 'name', array(
+        $form = $this->factory->createNamed('collection', 'name', array('a', 'b'), array(
             'type' => 'text',
-            'data' => array('a', 'b'),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -121,7 +120,7 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testForm()
     {
-        $form = $this->factory->createBuilder('form', 'name')
+        $form = $this->factory->createNamedBuilder('form', 'name')
             ->add('firstName', 'text')
             ->add('lastName', 'text')
             ->getForm();
@@ -148,9 +147,8 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 
     public function testRepeated()
     {
-        $form = $this->factory->create('repeated', 'name', array(
+        $form = $this->factory->createNamed('repeated', 'name', 'foobar', array(
             'type' => 'text',
-            'data' => 'foobar',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),

--- a/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
@@ -104,7 +104,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testEnctype()
     {
-        $form = $this->factory->createBuilder('form', 'na&me', array('property_path' => 'name'))
+        $form = $this->factory->createNamedBuilder('form', 'na&me', null, array(
+                'property_path' => 'name',
+            ))
             ->add('file', 'file')
             ->getForm();
 
@@ -113,7 +115,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testNoEnctype()
     {
-        $form = $this->factory->createBuilder('form', 'na&me', array('property_path' => 'name'))
+        $form = $this->factory->createNamedBuilder('form', 'na&me', null, array(
+                'property_path' => 'name',
+            ))
             ->add('text', 'text')
             ->getForm();
 
@@ -122,7 +126,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testLabel()
     {
-        $form = $this->factory->create('text', 'na&me', array('property_path' => 'name'));
+        $form = $this->factory->createNamed('text', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
         $html = $this->renderLabel($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -135,7 +141,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testLabelWithCustomTextPassedAsOption()
     {
-        $form = $this->factory->create('text', 'na&me', array(
+        $form = $this->factory->createNamed('text', 'na&me', null, array(
             'property_path' => 'name',
             'label' => 'Custom label',
         ));
@@ -151,7 +157,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testLabelWithCustomTextPassedDirectly()
     {
-        $form = $this->factory->create('text', 'na&me', array('property_path' => 'name'));
+        $form = $this->factory->createNamed('text', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
         $html = $this->renderLabel($form->createView(), 'Custom label');
 
         $this->assertMatchesXpath($html,
@@ -164,7 +172,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testErrors()
     {
-        $form = $this->factory->create('text', 'na&me', array('property_path' => 'name'));
+        $form = $this->factory->createNamed('text', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
         $form->addError(new FormError('Error 1'));
         $form->addError(new FormError('Error 2'));
         $view = $form->createView();
@@ -183,9 +193,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckedCheckbox()
     {
-        $form = $this->factory->create('checkbox', 'na&me', array(
+        $form = $this->factory->createNamed('checkbox', 'na&me', true, array(
             'property_path' => 'name',
-            'data' => true,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -200,10 +209,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckedCheckboxWithValue()
     {
-        $form = $this->factory->create('checkbox', 'na&me', array(
+        $form = $this->factory->createNamed('checkbox', 'na&me', true, array(
             'property_path' => 'name',
             'value' => 'foo&bar',
-            'data' => true,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -218,9 +226,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testUncheckedCheckbox()
     {
-        $form = $this->factory->create('checkbox', 'na&me', array(
+        $form = $this->factory->createNamed('checkbox', 'na&me', false, array(
             'property_path' => 'name',
-            'data' => false,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -234,10 +241,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleChoice()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', '&a', array(
             'property_path' => 'name',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
-            'data' => '&a',
             'multiple' => false,
             'expanded' => false,
         ));
@@ -256,11 +262,10 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleChoiceWithPreferred()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', '&a', array(
             'property_path' => 'name',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'preferred_choices' => array('&b'),
-            'data' => '&a',
             'multiple' => false,
             'expanded' => false,
         ));
@@ -280,11 +285,10 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleChoiceNonRequired()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', '&a', array(
             'property_path' => 'name',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
             'required' => false,
-            'data' => '&a',
             'multiple' => false,
             'expanded' => false,
         ));
@@ -304,13 +308,12 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleChoiceGrouped()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', '&a', array(
             'property_path' => 'name',
             'choices' => array(
                 'Group&1' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
                 'Group&2' => array('&c' => 'Choice&C'),
             ),
-            'data' => '&a',
             'multiple' => false,
             'expanded' => false,
         ));
@@ -336,10 +339,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testMultipleChoice()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', array('&a'), array(
             'property_path' => 'name',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
-            'data' => array('&a'),
             'multiple' => true,
             'expanded' => false,
         ));
@@ -359,10 +361,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testMultipleChoiceNonRequired()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', array('&a'), array(
             'property_path' => 'name',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
-            'data' => array('&a'),
             'required' => false,
             'multiple' => true,
             'expanded' => false,
@@ -383,10 +384,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testSingleChoiceExpanded()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', '&a', array(
             'property_path' => 'name',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B'),
-            'data' => '&a',
             'multiple' => false,
             'expanded' => true,
         ));
@@ -406,10 +406,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testMultipleChoiceExpanded()
     {
-        $form = $this->factory->create('choice', 'na&me', array(
+        $form = $this->factory->createNamed('choice', 'na&me', array('&a', '&c'), array(
             'property_path' => 'name',
             'choices' => array('&a' => 'Choice&A', '&b' => 'Choice&B', '&c' => 'Choice&C'),
-            'data' => array('&a', '&c'),
             'multiple' => true,
             'expanded' => true,
             'required' => true,
@@ -432,9 +431,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testCountry()
     {
-        $form = $this->factory->create('country', 'na&me', array(
+        $form = $this->factory->createNamed('country', 'na&me', 'AT', array(
             'property_path' => 'name',
-            'data' => 'AT',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -452,7 +450,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
             ->method('generateCsrfToken')
             ->will($this->returnValue('foo&bar'));
 
-        $form = $this->factory->create('csrf', 'na&me', array('property_path' => 'name'));
+        $form = $this->factory->createNamed('csrf', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
@@ -464,7 +464,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testCsrfWithNonRootParent()
     {
-        $form = $this->factory->create('csrf', 'na&me', array('property_path' => 'name'));
+        $form = $this->factory->createNamed('csrf', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
         $form->setParent($this->factory->create('form'));
         $form->getParent()->setParent($this->factory->create('form'));
 
@@ -475,9 +477,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testDateTime()
     {
-        $form = $this->factory->create('datetime', 'na&me', array(
+        $form = $this->factory->createNamed('datetime', 'na&me', '2011-02-03 04:05:06', array(
             'property_path' => 'name',
-            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -516,9 +517,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testDateTimeWithSeconds()
     {
-        $form = $this->factory->create('datetime', 'na&me', array(
+        $form = $this->factory->createNamed('datetime', 'na&me', '2011-02-03 04:05:06', array(
             'property_path' => 'name',
-            'data' => '2011-02-03 04:05:06',
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -560,9 +560,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testDateChoice()
     {
-        $form = $this->factory->create('date', 'na&me', array(
+        $form = $this->factory->createNamed('date', 'na&me', '2011-02-03', array(
             'property_path' => 'name',
-            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'choice',
         ));
@@ -587,9 +586,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testDateText()
     {
-        $form = $this->factory->create('date', 'na&me', array(
+        $form = $this->factory->createNamed('date', 'na&me', '2011-02-03', array(
             'property_path' => 'name',
-            'data' => '2011-02-03',
             'input' => 'string',
             'widget' => 'text',
         ));
@@ -605,9 +603,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testEmail()
     {
-        $form = $this->factory->create('email', 'na&me', array(
+        $form = $this->factory->createNamed('email', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -622,9 +619,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testEmailWithMaxLength()
     {
-        $form = $this->factory->create('email', 'na&me', array(
+        $form = $this->factory->createNamed('email', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
             'max_length' => 123,
         ));
 
@@ -640,7 +636,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testFile()
     {
-        $form = $this->factory->create('file', 'na&me', array('property_path' => 'name'));
+        $form = $this->factory->createNamed('file', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/div
@@ -656,9 +654,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testHidden()
     {
-        $form = $this->factory->create('hidden', 'na&me', array(
+        $form = $this->factory->createNamed('hidden', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -672,9 +669,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testInteger()
     {
-        $form = $this->factory->create('integer', 'na&me', array(
+        $form = $this->factory->createNamed('integer', 'na&me', 123, array(
             'property_path' => 'name',
-            'data' => '123',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -688,9 +684,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testLanguage()
     {
-        $form = $this->factory->create('language', 'na&me', array(
+        $form = $this->factory->createNamed('language', 'na&me', 'de', array(
             'property_path' => 'name',
-            'data' => 'de',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -704,9 +699,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testLocale()
     {
-        $form = $this->factory->create('locale', 'na&me', array(
+        $form = $this->factory->createNamed('locale', 'na&me', 'de_AT', array(
             'property_path' => 'name',
-            'data' => 'de_AT',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -720,9 +714,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testMoney()
     {
-        $form = $this->factory->create('money', 'na&me', array(
+        $form = $this->factory->createNamed('money', 'na&me', 1234.56, array(
             'property_path' => 'name',
-            'data' => 1234.56,
             'currency' => 'EUR',
         ));
 
@@ -738,9 +731,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testNumber()
     {
-        $form = $this->factory->create('number', 'na&me', array(
+        $form = $this->factory->createNamed('number', 'na&me', 1234.56, array(
             'property_path' => 'name',
-            'data' => 1234.56,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -754,9 +746,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testPassword()
     {
-        $form = $this->factory->create('password', 'na&me', array(
+        $form = $this->factory->createNamed('password', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -770,7 +761,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testPasswordBoundNotAlwaysEmpty()
     {
-        $form = $this->factory->create('password', 'na&me', array(
+        $form = $this->factory->createNamed('password', 'na&me', null, array(
             'property_path' => 'name',
             'always_empty' => false,
         ));
@@ -787,9 +778,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testPasswordWithMaxLength()
     {
-        $form = $this->factory->create('password', 'na&me', array(
+        $form = $this->factory->createNamed('password', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
             'max_length' => 123,
         ));
 
@@ -805,9 +795,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testPercent()
     {
-        $form = $this->factory->create('percent', 'na&me', array(
+        $form = $this->factory->createNamed('percent', 'na&me', 0.1, array(
             'property_path' => 'name',
-            'data' => 0.1,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -822,9 +811,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckedRadio()
     {
-        $form = $this->factory->create('radio', 'na&me', array(
+        $form = $this->factory->createNamed('radio', 'na&me', true, array(
             'property_path' => 'name',
-            'data' => true,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -839,9 +827,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testCheckedRadioWithValue()
     {
-        $form = $this->factory->create('radio', 'na&me', array(
+        $form = $this->factory->createNamed('radio', 'na&me', true, array(
             'property_path' => 'name',
-            'data' => true,
             'value' => 'foo&bar',
         ));
 
@@ -857,9 +844,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testUncheckedRadio()
     {
-        $form = $this->factory->create('radio', 'na&me', array(
+        $form = $this->factory->createNamed('radio', 'na&me', false, array(
             'property_path' => 'name',
-            'data' => false,
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -873,9 +859,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testTextarea()
     {
-        $form = $this->factory->create('textarea', 'na&me', array(
+        $form = $this->factory->createNamed('textarea', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -888,9 +873,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testText()
     {
-        $form = $this->factory->create('text', 'na&me', array(
+        $form = $this->factory->createNamed('text', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -905,9 +889,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testTextWithMaxLength()
     {
-        $form = $this->factory->create('text', 'na&me', array(
+        $form = $this->factory->createNamed('text', 'na&me', 'foo&bar', array(
             'property_path' => 'name',
-            'data' => 'foo&bar',
             'max_length' => 123,
         ));
 
@@ -923,9 +906,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testTime()
     {
-        $form = $this->factory->create('time', 'na&me', array(
+        $form = $this->factory->createNamed('time', 'na&me', '04:05:06', array(
             'property_path' => 'name',
-            'data' => '04:05:06',
             'input' => 'string',
             'with_seconds' => false,
         ));
@@ -949,9 +931,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testTimeWithSeconds()
     {
-        $form = $this->factory->create('time', 'na&me', array(
+        $form = $this->factory->createNamed('time', 'na&me', '04:05:06', array(
             'property_path' => 'name',
-            'data' => '04:05:06',
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -979,9 +960,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testTimezone()
     {
-        $form = $this->factory->create('timezone', 'na&me', array(
+        $form = $this->factory->createNamed('timezone', 'na&me', 'Europe/Vienna', array(
             'property_path' => 'name',
-            'data' => 'Europe/Vienna',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -999,9 +979,9 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     public function testUrl()
     {
-        $form = $this->factory->create('url', 'na&me', array(
+        $url = 'http://www.google.com?foo1=bar1&foo2=bar2';
+        $form = $this->factory->createNamed('url', 'na&me', $url, array(
             'property_path' => 'name',
-            'data' => 'http://www.google.com?foo1=bar1&foo2=bar2',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),

--- a/tests/Symfony/Tests/Component/Form/AbstractTableLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractTableLayoutTest.php
@@ -17,7 +17,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 {
     public function testRow()
     {
-        $form = $this->factory->create('text', 'name');
+        $form = $this->factory->createNamed('text', 'name');
         $form->addError(new FormError('Error!'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -41,7 +41,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRow()
     {
-        $form = $this->factory->create('repeated', 'name');
+        $form = $this->factory->createNamed('repeated', 'name');
         $html = $this->renderRow($form->createView());
 
         $this->assertMatchesXpath($html,
@@ -66,7 +66,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeatedRowWithErrors()
     {
-        $form = $this->factory->create('repeated', 'name');
+        $form = $this->factory->createNamed('repeated', 'name');
         $form->addError(new FormError('Error!'));
         $view = $form->createView();
         $html = $this->renderRow($view);
@@ -97,7 +97,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRest()
     {
-        $view = $this->factory->createBuilder('form', 'name')
+        $view = $this->factory->createNamedBuilder('form', 'name')
             ->add('field1', 'text')
             ->add('field2', 'repeated')
             ->add('field3', 'text')
@@ -144,9 +144,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testCollection()
     {
-        $form = $this->factory->create('collection', 'name', array(
+        $form = $this->factory->createNamed('collection', 'name', array('a', 'b'), array(
             'type' => 'text',
-            'data' => array('a', 'b'),
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -162,7 +161,7 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testForm()
     {
-        $view = $this->factory->createBuilder('form', 'name')
+        $view = $this->factory->createNamedBuilder('form', 'name')
             ->add('firstName', 'text')
             ->add('lastName', 'text')
             ->getForm()
@@ -198,9 +197,8 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 
     public function testRepeated()
     {
-        $form = $this->factory->create('repeated', 'name', array(
+        $form = $this->factory->createNamed('repeated', 'name', 'foobar', array(
             'type' => 'text',
-            'data' => 'foobar',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),

--- a/tests/Symfony/Tests/Component/Form/EventListener/ResizeFormListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/EventListener/ResizeFormListenerTest.php
@@ -49,12 +49,12 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $this->factory->expects($this->at(0))
-            ->method('create')
-            ->with('text', 1, array('property_path' => '[1]'))
+            ->method('createNamed')
+            ->with('text', 1, null, array('property_path' => '[1]'))
             ->will($this->returnValue($this->getForm('1')));
         $this->factory->expects($this->at(1))
-            ->method('create')
-            ->with('text', 2, array('property_path' => '[2]'))
+            ->method('createNamed')
+            ->with('text', 2, null, array('property_path' => '[2]'))
             ->will($this->returnValue($this->getForm('2')));
 
         $data = array(1 => 'string', 2 => 'string');
@@ -104,7 +104,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testPreSetDataDealsWithNullData()
     {
-        $this->factory->expects($this->never())->method('create');
+        $this->factory->expects($this->never())->method('createNamed');
 
         $data = null;
         $event = new DataEvent($this->form, $data);
@@ -118,8 +118,8 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $this->factory->expects($this->once())
-            ->method('create')
-            ->with('text', 2, array('property_path' => '[2]'))
+            ->method('createNamed')
+            ->with('text', 2, null, array('property_path' => '[2]'))
             ->will($this->returnValue($this->getForm('2')));
 
         $data = array(0 => 'string', 2 => 'string');

--- a/tests/Symfony/Tests/Component/Form/FormBuilderTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormBuilderTest.php
@@ -114,8 +114,8 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
         $expectedOptions = array('bar' => 'baz');
 
         $this->factory->expects($this->once())
-                ->method('createBuilder')
-                ->with($this->equalTo($expectedType), $this->equalTo($expectedName), $this->equalTo($expectedOptions))
+                ->method('createNamedBuilder')
+                ->with($expectedType, $expectedName, null, $expectedOptions)
                 ->will($this->returnValue($this->getFormBuilder()));
 
         $this->builder->add($expectedName, $expectedType, $expectedOptions);
@@ -131,7 +131,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->once())
                 ->method('createBuilderForProperty')
-                ->with($this->equalTo('stdClass'), $this->equalTo($expectedName), $this->equalTo($expectedOptions))
+                ->with('stdClass', $expectedName, null, $expectedOptions)
                 ->will($this->returnValue($this->getFormBuilder()));
 
         $this->builder = new FormBuilder('name', $this->factory, $this->dispatcher, 'stdClass');

--- a/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
@@ -50,11 +50,11 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 Guess::HIGH_CONFIDENCE
             )));
 
-        $factory = $this->createMockFactory(array('createBuilder'), array($guesser1, $guesser2));
+        $factory = $this->createMockFactory(array('createNamedBuilder'), array($guesser1, $guesser2));
 
         $factory->expects($this->once())
-            ->method('createBuilder')
-            ->with('password', 'firstName', array('max_length' => 7))
+            ->method('createNamedBuilder')
+            ->with('password', 'firstName', null, array('max_length' => 7))
             ->will($this->returnValue('builderInstance'));
 
         $builder = $factory->createBuilderForProperty('Application\Author', 'firstName');
@@ -70,10 +70,10 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 ->with('Application\Author', 'firstName')
                 ->will($this->returnValue(null));
 
-        $factory = $this->createMockFactory(array('createBuilder'), array($guesser));
+        $factory = $this->createMockFactory(array('createNamedBuilder'), array($guesser));
 
         $factory->expects($this->once())
-            ->method('createBuilder')
+            ->method('createNamedBuilder')
             ->with('text', 'firstName')
             ->will($this->returnValue('builderInstance'));
 
@@ -94,16 +94,17 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                     Guess::MEDIUM_CONFIDENCE
                 )));
 
-        $factory = $this->createMockFactory(array('createBuilder'), array($guesser));
+        $factory = $this->createMockFactory(array('createNamedBuilder'), array($guesser));
 
         $factory->expects($this->once())
-            ->method('createBuilder')
-            ->with('text', 'firstName', array('max_length' => 11))
+            ->method('createNamedBuilder')
+            ->with('text', 'firstName', null, array('max_length' => 11))
             ->will($this->returnValue('builderInstance'));
 
         $builder = $factory->createBuilderForProperty(
             'Application\Author',
             'firstName',
+            null,
             array('max_length' => 11)
         );
 
@@ -130,11 +131,11 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                     Guess::HIGH_CONFIDENCE
                 )));
 
-        $factory = $this->createMockFactory(array('createBuilder'), array($guesser1, $guesser2));
+        $factory = $this->createMockFactory(array('createNamedBuilder'), array($guesser1, $guesser2));
 
         $factory->expects($this->once())
-            ->method('createBuilder')
-            ->with('text', 'firstName', array('max_length' => 20))
+            ->method('createNamedBuilder')
+            ->with('text', 'firstName', null, array('max_length' => 20))
             ->will($this->returnValue('builderInstance'));
 
         $builder = $factory->createBuilderForProperty(
@@ -165,11 +166,11 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                     Guess::HIGH_CONFIDENCE
                 )));
 
-        $factory = $this->createMockFactory(array('createBuilder'), array($guesser1, $guesser2));
+        $factory = $this->createMockFactory(array('createNamedBuilder'), array($guesser1, $guesser2));
 
         $factory->expects($this->once())
-            ->method('createBuilder')
-            ->with('text', 'firstName', array('required' => false))
+            ->method('createNamedBuilder')
+            ->with('text', 'firstName', null, array('required' => false))
             ->will($this->returnValue('builderInstance'));
 
         $builder = $factory->createBuilderForProperty(

--- a/tests/Symfony/Tests/Component/Form/Type/CheckboxTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/CheckboxTypeTest.php
@@ -17,7 +17,7 @@ class CheckboxTypeTest extends TestCase
 {
     public function testPassValueToView()
     {
-        $form = $this->factory->create('checkbox', 'name', array('value' => 'foobar'));
+        $form = $this->factory->create('checkbox', null, array('value' => 'foobar'));
         $view = $form->createView();
 
         $this->assertEquals('foobar', $view->get('value'));

--- a/tests/Symfony/Tests/Component/Form/Type/ChoiceTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/ChoiceTypeTest.php
@@ -51,7 +51,7 @@ class ChoiceTypeTest extends TestCase
      */
     public function testChoicesOptionExpectsArray()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'choices' => new \ArrayObject(),
         ));
     }
@@ -61,14 +61,14 @@ class ChoiceTypeTest extends TestCase
      */
     public function testChoiceListOptionExpectsChoiceListInterface()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'choice_list' => array('foo' => 'foo'),
         ));
     }
 
     public function testExpandedCheckboxesAreNeverRequired()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => true,
             'expanded' => true,
             'required' => true,
@@ -82,7 +82,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testExpandedRadiosAreRequiredIfChoiceFieldIsRequired()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => true,
@@ -96,7 +96,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testExpandedRadiosAreNotRequiredIfChoiceFieldIsNotRequired()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => false,
             'expanded' => true,
             'required' => false,
@@ -110,7 +110,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testBindSingleNonExpanded()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->choices,
@@ -124,7 +124,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testBindMultipleNonExpanded()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,
@@ -138,7 +138,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testBindSingleExpanded()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->choices,
@@ -161,7 +161,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testBindSingleExpandedNumericChoices()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => false,
             'expanded' => true,
             'choices' => $this->numericChoices,
@@ -184,7 +184,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testBindMultipleExpanded()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->choices,
@@ -207,7 +207,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testBindMultipleExpandedNumericChoices()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => true,
             'expanded' => true,
             'choices' => $this->numericChoices,
@@ -234,7 +234,7 @@ class ChoiceTypeTest extends TestCase
      */
     public function testSetDataSingleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => false,
             'expanded' => false,
             'choices' => $this->numericChoices,
@@ -248,7 +248,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testSetDataMultipleNonExpandedAcceptsBoolean()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->numericChoices,
@@ -270,7 +270,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testPassMultipleToView()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'multiple' => true,
             'choices' => $this->choices,
         ));
@@ -281,7 +281,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testPassExpandedToView()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'expanded' => true,
             'choices' => $this->choices,
         ));
@@ -293,7 +293,7 @@ class ChoiceTypeTest extends TestCase
     public function testPassChoicesToView()
     {
         $choices = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D');
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'choices' => $choices,
         ));
         $view = $form->createView();
@@ -304,7 +304,7 @@ class ChoiceTypeTest extends TestCase
     public function testPassPreferredChoicesToView()
     {
         $choices = array('a' => 'A', 'b' => 'B', 'c' => 'C', 'd' => 'D');
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->create('choice', null, array(
             'choices' => $choices,
             'preferred_choices' => array('b', 'd'),
         ));
@@ -316,7 +316,7 @@ class ChoiceTypeTest extends TestCase
 
     public function testAdjustNameForMultipleNonExpanded()
     {
-        $form = $this->factory->create('choice', 'name', array(
+        $form = $this->factory->createNamed('choice', 'name', null, array(
             'multiple' => true,
             'expanded' => false,
             'choices' => $this->choices,

--- a/tests/Symfony/Tests/Component/Form/Type/CollectionTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/CollectionTypeTest.php
@@ -20,7 +20,7 @@ class CollectionFormTest extends TestCase
 {
     public function testContainsOnlyCsrfTokenByDefault()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
             'csrf_field_name' => 'abc',
         ));
@@ -31,7 +31,7 @@ class CollectionFormTest extends TestCase
 
     public function testSetDataAdjustsSize()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
         ));
         $form->setData(array('foo@foo.com', 'foo@bar.com'));
@@ -51,7 +51,7 @@ class CollectionFormTest extends TestCase
 
     public function testSetDataAdjustsSizeIfModifiable()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
             'modifiable' => true,
             'prototype' => true,
@@ -72,7 +72,7 @@ class CollectionFormTest extends TestCase
 
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
         ));
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
@@ -81,7 +81,7 @@ class CollectionFormTest extends TestCase
 
     public function testModifiableCollectionsContainExtraForm()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
             'modifiable' => true,
             'prototype' => true,
@@ -95,7 +95,7 @@ class CollectionFormTest extends TestCase
 
     public function testNotResizedIfBoundWithMissingData()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
@@ -109,7 +109,7 @@ class CollectionFormTest extends TestCase
 
     public function testResizedIfBoundWithMissingDataAndModifiable()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
             'modifiable' => true,
         ));
@@ -123,7 +123,7 @@ class CollectionFormTest extends TestCase
 
     public function testNotResizedIfBoundWithExtraData()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
         ));
         $form->setData(array('foo@bar.com'));
@@ -136,7 +136,7 @@ class CollectionFormTest extends TestCase
 
     public function testResizedUpIfBoundWithExtraDataAndModifiable()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
             'modifiable' => true,
         ));
@@ -152,7 +152,7 @@ class CollectionFormTest extends TestCase
 
     public function testModifableButNoPrototype()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
             'modifiable' => true,
             'prototype' => false,
@@ -163,7 +163,7 @@ class CollectionFormTest extends TestCase
 
     public function testResizedDownIfBoundWithLessDataAndModifiable()
     {
-        $form = $this->factory->create('collection', 'emails', array(
+        $form = $this->factory->create('collection', null, array(
             'type' => 'field',
             'modifiable' => true,
         ));

--- a/tests/Symfony/Tests/Component/Form/Type/CsrfTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/CsrfTypeTest.php
@@ -41,7 +41,7 @@ class CsrfTypeTest extends TestCase
             ->with('%PAGE_ID%')
             ->will($this->returnValue('token'));
 
-        $form = $this->factory->create('csrf', 'name', array(
+        $form = $this->factory->create('csrf', null, array(
             'csrf_provider' => $this->provider,
             'page_id' => '%PAGE_ID%'
         ));
@@ -56,7 +56,7 @@ class CsrfTypeTest extends TestCase
             ->with('%PAGE_ID%', 'token')
             ->will($this->returnValue(true));
 
-        $form = $this->factory->create('csrf', 'name', array(
+        $form = $this->factory->create('csrf', null, array(
             'csrf_provider' => $this->provider,
             'page_id' => '%PAGE_ID%'
         ));
@@ -70,7 +70,7 @@ class CsrfTypeTest extends TestCase
         $this->provider->expects($this->never())
             ->method('isCsrfTokenValid');
 
-        $form = $this->factory->create('csrf', 'name', array(
+        $form = $this->factory->create('csrf', null, array(
             'csrf_provider' => $this->provider,
             'page_id' => '%PAGE_ID%'
         ));
@@ -96,7 +96,7 @@ class CsrfTypeTest extends TestCase
             ->with('%PAGE_ID%')
             ->will($this->returnValue('token2'));
 
-        $form = $this->factory->create('csrf', 'name', array(
+        $form = $this->factory->create('csrf', null, array(
             'csrf_provider' => $this->provider,
             'page_id' => '%PAGE_ID%'
         ));

--- a/tests/Symfony/Tests/Component/Form/Type/DateTimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/DateTimeTypeTest.php
@@ -21,7 +21,7 @@ class DateTimeTypeTest extends LocalizedTestCase
 {
     public function testSubmit_dateTime()
     {
-        $form = $this->factory->create('datetime', 'name', array(
+        $form = $this->factory->create('datetime', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -48,7 +48,7 @@ class DateTimeTypeTest extends LocalizedTestCase
 
     public function testSubmit_string()
     {
-        $form = $this->factory->create('datetime', 'name', array(
+        $form = $this->factory->create('datetime', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'input' => 'string',
@@ -73,7 +73,7 @@ class DateTimeTypeTest extends LocalizedTestCase
 
     public function testSubmit_timestamp()
     {
-        $form = $this->factory->create('datetime', 'name', array(
+        $form = $this->factory->create('datetime', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -100,7 +100,7 @@ class DateTimeTypeTest extends LocalizedTestCase
 
     public function testSubmit_withSeconds()
     {
-        $form = $this->factory->create('datetime', 'name', array(
+        $form = $this->factory->create('datetime', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'date_widget' => 'choice',
@@ -131,7 +131,7 @@ class DateTimeTypeTest extends LocalizedTestCase
 
     public function testSubmit_differentTimezones()
     {
-        $form = $this->factory->create('datetime', 'name', array(
+        $form = $this->factory->create('datetime', null, array(
             'data_timezone' => 'America/New_York',
             'user_timezone' => 'Pacific/Tahiti',
             'date_widget' => 'choice',

--- a/tests/Symfony/Tests/Component/Form/Type/DateTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/DateTypeTest.php
@@ -27,7 +27,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testSubmitFromInputDateTime()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -42,7 +42,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testSubmitFromInputString()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -57,7 +57,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testSubmitFromInputTimestamp()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -74,7 +74,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testSubmitFromInputRaw()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -95,7 +95,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testSubmitFromChoice()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -117,7 +117,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testSubmitFromChoiceEmpty()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -138,7 +138,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testSetData_differentTimezones()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'America/New_York',
             'user_timezone' => 'Pacific/Tahiti',
             // don't do this test with DateTime, because it leads to wrong results!
@@ -155,7 +155,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -171,7 +171,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -187,7 +187,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -207,7 +207,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -223,7 +223,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -239,7 +239,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -255,7 +255,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -275,7 +275,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -291,7 +291,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -307,7 +307,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -323,7 +323,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -345,7 +345,7 @@ class DateTypeTest extends LocalizedTestCase
 
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -361,7 +361,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'text',
@@ -376,7 +376,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -395,7 +395,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -414,7 +414,7 @@ class DateTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'widget' => 'choice',
@@ -439,7 +439,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testDontPassDatePatternIfText()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'widget' => 'text',
         ));
         $view = $form->createView();
@@ -449,7 +449,7 @@ class DateTypeTest extends LocalizedTestCase
 
     public function testPassWidgetToView()
     {
-        $form = $this->factory->create('date', 'name', array(
+        $form = $this->factory->create('date', null, array(
             'widget' => 'text',
         ));
         $view = $form->createView();

--- a/tests/Symfony/Tests/Component/Form/Type/FieldTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/FieldTypeTest.php
@@ -29,7 +29,7 @@ class FieldTypeTest extends TestCase
 {
     public function testGetPropertyPathDefaultPath()
     {
-        $form = $this->factory->create('field', 'title');
+        $form = $this->factory->createNamed('field', 'title');
 
         $this->assertEquals(new PropertyPath('title'), $form->getAttribute('property_path'));
     }
@@ -57,7 +57,7 @@ class FieldTypeTest extends TestCase
 
     public function testGetPropertyPathPathIsNull()
     {
-        $form = $this->factory->create('field', 'title', array('property_path' => null));
+        $form = $this->factory->createNamed('field', 'title', null, array('property_path' => null));
 
         $this->assertEquals(new PropertyPath('title'), $form->getAttribute('property_path'));
     }
@@ -112,7 +112,7 @@ class FieldTypeTest extends TestCase
 
     public function testPassIdAndNameToView()
     {
-        $form = $this->factory->create('field', 'name');
+        $form = $this->factory->createNamed('field', 'name');
         $view = $form->createView();
 
         $this->assertEquals('name', $view->get('id'));
@@ -121,8 +121,8 @@ class FieldTypeTest extends TestCase
 
     public function testPassIdAndNameToViewWithParent()
     {
-        $parent = $this->factory->create('field', 'parent');
-        $parent->add($this->factory->create('field', 'child'));
+        $parent = $this->factory->createNamed('field', 'parent');
+        $parent->add($this->factory->createNamed('field', 'child'));
         $view = $parent->createView();
 
         $this->assertEquals('parent_child', $view['child']->get('id'));
@@ -131,9 +131,9 @@ class FieldTypeTest extends TestCase
 
     public function testPassIdAndNameToViewWithGrandParent()
     {
-        $parent = $this->factory->create('field', 'parent');
-        $parent->add($this->factory->create('field', 'child'));
-        $parent['child']->add($this->factory->create('field', 'grand_child'));
+        $parent = $this->factory->createNamed('field', 'parent');
+        $parent->add($this->factory->createNamed('field', 'child'));
+        $parent['child']->add($this->factory->createNamed('field', 'grand_child'));
         $view = $parent->createView();
 
         $this->assertEquals('parent_child_grand_child', $view['child']['grand_child']->get('id'));
@@ -150,10 +150,10 @@ class FieldTypeTest extends TestCase
 
     public function testBindWithEmptyDataCreatesObjectIfClassAvailable()
     {
-        $form = $this->factory->create('form', 'author', array(
+        $form = $this->factory->create('form', null, array(
             'data_class' => 'Symfony\Tests\Component\Form\Fixtures\Author',
         ));
-        $form->add($this->factory->create('field', 'firstName'));
+        $form->add($this->factory->createNamed('field', 'firstName'));
 
         $form->setData(null);
         $form->bind(array('firstName' => 'Bernhard'));
@@ -169,8 +169,8 @@ class FieldTypeTest extends TestCase
      */
     public function testBindWithEmptyDataStoresArrayIfNoClassAvailable()
     {
-        $form = $this->factory->create('form', 'author');
-        $form->add($this->factory->create('field', 'firstName'));
+        $form = $this->factory->create('form');
+        $form->add($this->factory->createNamed('field', 'firstName'));
 
         $form->setData(null);
         $form->bind(array('firstName' => 'Bernhard'));
@@ -182,10 +182,10 @@ class FieldTypeTest extends TestCase
     {
         $author = new Author();
 
-        $form = $this->factory->create('form', 'author', array(
+        $form = $this->factory->create('form', null, array(
             'empty_data' => $author,
         ));
-        $form->add($this->factory->create('field', 'firstName'));
+        $form->add($this->factory->createNamed('field', 'firstName'));
 
         $form->bind(array('firstName' => 'Bernhard'));
 

--- a/tests/Symfony/Tests/Component/Form/Type/FileTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/FileTypeTest.php
@@ -33,7 +33,7 @@ class FileTypeTest extends TestCase
     {
         parent::setUp();
 
-        $this->form = $this->factory->create('file', 'file');
+        $this->form = $this->factory->create('file');
     }
 
     protected function tearDown()

--- a/tests/Symfony/Tests/Component/Form/Type/FormTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/FormTypeTest.php
@@ -65,7 +65,7 @@ class FormTypeTest extends TestCase
 {
     public function testCsrfProtectionByDefault()
     {
-        $form =  $this->factory->create('form', 'author', array(
+        $form =  $this->factory->create('form', null, array(
             'csrf_field_name' => 'csrf',
         ));
 
@@ -74,7 +74,7 @@ class FormTypeTest extends TestCase
 
     public function testCsrfProtectionCanBeDisabled()
     {
-        $form =  $this->factory->create('form', 'author', array(
+        $form =  $this->factory->create('form', null, array(
             'csrf_protection' => false,
         ));
 
@@ -90,7 +90,7 @@ class FormTypeTest extends TestCase
 
     public function testValidationGroupsCanBeSetToString()
     {
-        $form = $this->factory->create('form', 'author', array(
+        $form = $this->factory->create('form', null, array(
             'validation_groups' => 'group',
         ));
 
@@ -99,7 +99,7 @@ class FormTypeTest extends TestCase
 
     public function testValidationGroupsCanBeSetToArray()
     {
-        $form = $this->factory->create('form', 'author', array(
+        $form = $this->factory->create('form', null, array(
             'validation_groups' => array('group1', 'group2'),
         ));
 
@@ -108,7 +108,7 @@ class FormTypeTest extends TestCase
 
     public function testBindValidatesData()
     {
-        $builder = $this->factory->createBuilder('form', 'author', array(
+        $builder = $this->factory->createBuilder('form', null, array(
             'validation_groups' => 'group',
         ));
         $builder->add('firstName', 'field');
@@ -126,7 +126,7 @@ class FormTypeTest extends TestCase
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', 'author');
+        $builder = $this->factory->createBuilder('form');
         $builder->add('reference', 'form');
         $builder->get('reference')->add('firstName', 'field');
         $builder->setData($author);
@@ -148,7 +148,7 @@ class FormTypeTest extends TestCase
         $author = new FormTest_AuthorWithoutRefSetter(null);
         $newReference = new Author();
 
-        $builder = $this->factory->createBuilder('form', 'author');
+        $builder = $this->factory->createBuilder('form');
         $builder->add('referenceCopy', 'form');
         $builder->get('referenceCopy')->add('firstName', 'field');
         $builder->setData($author);
@@ -170,7 +170,7 @@ class FormTypeTest extends TestCase
     {
         $author = new FormTest_AuthorWithoutRefSetter(new Author());
 
-        $builder = $this->factory->createBuilder('form', 'author');
+        $builder = $this->factory->createBuilder('form');
         $builder->add('referenceCopy', 'form', array('by_reference' => false));
         $builder->get('referenceCopy')->add('firstName', 'field');
         $builder->setData($author);
@@ -191,7 +191,7 @@ class FormTypeTest extends TestCase
     {
         $author = new FormTest_AuthorWithoutRefSetter('scalar');
 
-        $builder = $this->factory->createBuilder('form', 'author');
+        $builder = $this->factory->createBuilder('form');
         $builder->add('referenceCopy', 'form');
         $builder->get('referenceCopy')->appendClientTransformer(new CallbackTransformer(
         function () {},
@@ -216,7 +216,7 @@ class FormTypeTest extends TestCase
         $ref2 = new Author();
         $author = array('referenceCopy' => $ref1);
 
-        $builder = $this->factory->createBuilder('form', 'author');
+        $builder = $this->factory->createBuilder('form');
         $builder->setData($author);
         $builder->add('referenceCopy', 'form');
         $builder->get('referenceCopy')->appendClientTransformer(new CallbackTransformer(

--- a/tests/Symfony/Tests/Component/Form/Type/IntegerTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/IntegerTypeTest.php
@@ -19,7 +19,7 @@ class IntegerTypeTest extends LocalizedTestCase
 {
     public function testSubmitCastsToInteger()
     {
-        $form = $this->factory->create('integer', 'name');
+        $form = $this->factory->create('integer');
 
         $form->bind('1.678');
 

--- a/tests/Symfony/Tests/Component/Form/Type/RadioTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/RadioTypeTest.php
@@ -17,7 +17,7 @@ class RadioTypeTest extends TestCase
 {
     public function testPassValueToView()
     {
-        $form = $this->factory->create('radio', 'name', array('value' => 'foobar'));
+        $form = $this->factory->create('radio', null, array('value' => 'foobar'));
         $view = $form->createView();
 
         $this->assertEquals('foobar', $view->get('value'));
@@ -25,8 +25,8 @@ class RadioTypeTest extends TestCase
 
     public function testPassParentNameToView()
     {
-        $parent = $this->factory->create('field', 'parent');
-        $parent->add($this->factory->create('radio', 'child'));
+        $parent = $this->factory->createNamed('field', 'parent');
+        $parent->add($this->factory->createNamed('radio', 'child'));
         $view = $parent->createView();
 
         $this->assertEquals('parent', $view['child']->get('name'));

--- a/tests/Symfony/Tests/Component/Form/Type/RepeatedTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/RepeatedTypeTest.php
@@ -24,7 +24,7 @@ class RepeatedTypeTest extends TestCase
     {
         parent::setUp();
 
-        $this->form = $this->factory->create('repeated', 'name', array(
+        $this->form = $this->factory->create('repeated', null, array(
             'type' => 'field',
         ));
         $this->form->setData(null);

--- a/tests/Symfony/Tests/Component/Form/Type/TestCase.php
+++ b/tests/Symfony/Tests/Component/Form/Type/TestCase.php
@@ -52,7 +52,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
         $this->factory = new FormFactory($this->typeLoader);
 
-        $this->builder = new FormBuilder('name', $this->factory, $this->dispatcher);
+        $this->builder = new FormBuilder(null, $this->factory, $this->dispatcher);
     }
 
     protected function getTypeLoaders()

--- a/tests/Symfony/Tests/Component/Form/Type/TimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/TimeTypeTest.php
@@ -19,7 +19,7 @@ class TimeTypeTest extends LocalizedTestCase
 {
     public function testSubmit_dateTime()
     {
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'input' => 'datetime',
@@ -40,7 +40,7 @@ class TimeTypeTest extends LocalizedTestCase
 
     public function testSubmit_string()
     {
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'input' => 'string',
@@ -59,7 +59,7 @@ class TimeTypeTest extends LocalizedTestCase
 
     public function testSubmit_timestamp()
     {
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'input' => 'timestamp',
@@ -80,7 +80,7 @@ class TimeTypeTest extends LocalizedTestCase
 
     public function testSubmit_array()
     {
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'input' => 'array',
@@ -104,7 +104,7 @@ class TimeTypeTest extends LocalizedTestCase
 
     public function testSetData_withSeconds()
     {
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
             'input' => 'datetime',
@@ -118,7 +118,7 @@ class TimeTypeTest extends LocalizedTestCase
 
     public function testSetData_differentTimezones()
     {
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'data_timezone' => 'America/New_York',
             'user_timezone' => 'Pacific/Tahiti',
             // don't do this test with DateTime, because it leads to wrong results!
@@ -146,7 +146,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'hours' => array(6, 7),
         ));
 
@@ -159,7 +159,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'hours' => array(6, 7),
         ));
 
@@ -172,7 +172,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'hours' => array(6, 7),
         ));
 
@@ -185,7 +185,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'minutes' => array(6, 7),
         ));
 
@@ -198,7 +198,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'minutes' => array(6, 7),
         ));
 
@@ -211,7 +211,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'minutes' => array(6, 7),
         ));
 
@@ -224,7 +224,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'seconds' => array(6, 7),
             'with_seconds' => true,
         ));
@@ -238,7 +238,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'seconds' => array(6, 7),
             'with_seconds' => true,
         ));
@@ -252,7 +252,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'seconds' => array(6, 7),
         ));
 
@@ -265,7 +265,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'seconds' => array(6, 7),
             'with_seconds' => true,
         ));
@@ -279,7 +279,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'widget' => 'choice',
         ));
 
@@ -295,7 +295,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -313,7 +313,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'widget' => 'choice',
         ));
 
@@ -329,7 +329,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -347,7 +347,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -365,7 +365,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));
@@ -383,7 +383,7 @@ class TimeTypeTest extends LocalizedTestCase
     {
         $this->markTestSkipped('Needs to be reimplemented using validators');
 
-        $form = $this->factory->create('time', 'name', array(
+        $form = $this->factory->create('time', null, array(
             'widget' => 'choice',
             'with_seconds' => true,
         ));

--- a/tests/Symfony/Tests/Component/Form/Type/UrlTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Type/UrlTypeTest.php
@@ -29,7 +29,7 @@ class UrlTypeTest extends LocalizedTestCase
 
     public function testSubmitAddsNoDefaultProtocolIfAlreadyIncluded()
     {
-        $form = $this->factory->create('url', 'name', array(
+        $form = $this->factory->create('url', null, array(
             'default_protocol' => 'http',
         ));
 
@@ -41,7 +41,7 @@ class UrlTypeTest extends LocalizedTestCase
 
     public function testSubmitAddsNoDefaultProtocolIfEmpty()
     {
-        $form = $this->factory->create('url', 'name', array(
+        $form = $this->factory->create('url', null, array(
             'default_protocol' => 'http',
         ));
 
@@ -53,7 +53,7 @@ class UrlTypeTest extends LocalizedTestCase
 
     public function testSubmitAddsNoDefaultProtocolIfSetToNull()
     {
-        $form = $this->factory->create('url', 'name', array(
+        $form = $this->factory->create('url', null, array(
             'default_protocol' => null,
         ));
 


### PR DESCRIPTION
[Form] Split signature of FormFactory::create() into create() and createNamed()

The data can now be passed to all creation methods:

```
$form = $factory->create('form', $data);
```

By default, a form will receive the name of its type ("form" in above example). If you wish to pass a custom name, use createNamed():

```
$form = $factory->createNamed('form', 'myform', $data);
```
