### PR TITLE
[Windows] fixing tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -176,12 +176,12 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $yamlArgs = $container->getDefinition('validator.mapping.loader.yaml_files_loader')->getArguments();
         $this->assertEquals(1, count($yamlArgs[0]));
-        $this->assertStringEndsWith('TestBundle/Resources/config/validation.yml', $yamlArgs[0][0]);
+        $this->assertStringEndsWith('TestBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'validation.yml', $yamlArgs[0][0]);
 
         $xmlArgs = $container->getDefinition('validator.mapping.loader.xml_files_loader')->getArguments();
         $this->assertEquals(2, count($xmlArgs[0]));
         $this->assertStringEndsWith('Component/Form/Resources/config/validation.xml', $xmlArgs[0][0]);
-        $this->assertStringEndsWith('TestBundle/Resources/config/validation.xml', $xmlArgs[0][1]);
+        $this->assertStringEndsWith('TestBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'validation.xml', $xmlArgs[0][1]);
     }
 
     protected function createContainer(array $data = array())

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/FileTest.php
@@ -25,12 +25,12 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPathReturnsAbsolutePath()
     {
-        $this->assertEquals(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'test.gif', $this->file->getPath());
+        $this->assertEquals(__DIR__.'/Fixtures/test.gif', $this->file->getPath());
     }
 
     public function test__toString()
     {
-        $this->assertEquals(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'test.gif', (string) $this->file);
+        $this->assertEquals(__DIR__.'/Fixtures/test.gif', (string) $this->file);
     }
 
     public function testGetWebPathReturnsPathRelativeToDocumentRoot()
@@ -73,7 +73,7 @@ class FileTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDirectoryReturnsDirectoryName()
     {
-        $this->assertEquals(__DIR__.DIRECTORY_SEPARATOR.'Fixtures', $this->file->getDirectory());
+        $this->assertEquals(__DIR__.'/Fixtures', $this->file->getDirectory());
     }
 
     public function testGetMimeTypeUsesMimeTypeGuessers()


### PR DESCRIPTION
[HttpFoundation][Windows] Fixed test after removal of realpath merk/symfony@03bb3580a69150948ab37d8418aab9f759682c88
[FrameworkBundle][Windows] Fixed testValidationPaths on windows
