### PR TITLE
renamed getPreviouses() to getAllPrevious()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Exception/exception.html.twig
@@ -19,11 +19,11 @@
                     <strong>{{ status_code }}</strong> {{ status_text }} - {{ exception.class|abbr_class }}
                 </div>
 
-                {% set previous_count = exception.previouses|length %}
-                {% if previous_count %}
+                {% set previous_count = exception.allPrevious|length %}
+                {% if previous_count|length %}
                     <div class="linked"><span><strong>{{ previous_count }}</strong> linked Exception{{ previous_count > 1 ? 's' : '' }}:</span>
                         <ul>
-                            {% for i, previous in exception.previouses %}
+                            {% for i, previous in exception.allPrevious %}
                                 <li>
                                     {{ previous.class|abbr_class }} <a href="#traces_link_{{ i + 1 }}" onclick="toggle('traces_{{ i + 1 }}', 'traces'); switchIcons('icon_traces_{{ i + 1 }}_open', 'icon_traces_{{ i + 1 }}_close');">&raquo;</a>
                                 </li>

--- a/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
@@ -47,7 +47,7 @@ class FlattenException
     public function toArray()
     {
         $exceptions = array();
-        foreach (array_merge(array($this), $this->getPreviouses()) as $exception) {
+        foreach (array_merge(array($this), $this->getAllPrevious()) as $exception) {
             $exceptions[] = array(
                 'message' => $exception->getMessage(),
                 'class'   => $exception->getClass(),
@@ -118,7 +118,7 @@ class FlattenException
         $this->previous = $previous;
     }
 
-    public function getPreviouses()
+    public function getAllPrevious()
     {
         $exceptions = array();
         $e = $this;

--- a/tests/Symfony/Tests/Component/HttpKernel/Exception/FlattenExceptionTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Exception/FlattenExceptionTest.php
@@ -42,7 +42,7 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($flattened2,$flattened->getPrevious());
 
-        $this->assertSame(array($flattened2),$flattened->getPreviouses());
+        $this->assertSame(array($flattened2),$flattened->getAllPrevious());
     }
 
     /**


### PR DESCRIPTION
previouses is not a proper english word.
