### PR TITLE
added a compile_classes_extension config option (defaults to .php.cache)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -44,6 +44,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('exception_controller')->defaultValue('Symfony\\Bundle\\FrameworkBundle\\Controller\\ExceptionController::showAction')->end()
                 ->scalarNode('ide')->defaultNull()->end()
                 ->booleanNode('test')->end()
+                ->booleanNode('compile_classes_extension')->defaultValue('.php.cache')->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -89,6 +89,8 @@ class FrameworkExtension extends Extension
             }
         }
 
+        $container->setParameter('kernel.compile_classes_extension', $config['compile_classes_extension']);
+
         if (isset($config['csrf_protection'])) {
             $this->registerCsrfProtectionConfiguration($config['csrf_protection'], $container);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -49,7 +49,8 @@ class FrameworkBundle extends Bundle
             $this->container->getParameter('kernel.cache_dir'),
             'classes',
             $this->container->getParameter('kernel.debug'),
-            true
+            true,
+            $this->container->getParameter('kernel.compile_classes_extension')
         );
 
         if ($this->container->has('error_handler')) {

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -32,7 +32,7 @@ class ClassCollectionLoader
      *
      * @throws \InvalidArgumentException When class can't be loaded
      */
-    static public function load($classes, $cacheDir, $name, $autoReload, $adaptive = false, $extension = '.php')
+    static public function load($classes, $cacheDir, $name, $autoReload, $adaptive = false, $extension = '.php.cache')
     {
         // each $name can only be loaded once per PHP process
         if (isset(self::$loaded[$name])) {


### PR DESCRIPTION
Supersedes https://github.com/symfony/symfony/pull/511

However the original PR also changed the extension for various other files with the .php extension in the cache folder. This only only changes is for the compiled classes since these overlap with class names defined inside the framework itself obviously while the others do not.
