### PR TITLE
[Doctrine][Form] Remove identificator restriction to numeric type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/EntityToIdTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/EntityToIdTransformer.php
@@ -65,10 +65,6 @@ class EntityToIdTransformer implements DataTransformerInterface
             return null;
         }
 
-        if (!is_numeric($key)) {
-            throw new UnexpectedTypeException($key, 'numeric');
-        }
-
         if (!($entity = $this->choiceList->getEntity($key))) {
             throw new TransformationFailedException('The entity with key "%s" could not be found', $key);
         }


### PR DESCRIPTION
Identificators needn't to be only of numeric type. E.g. identificator 'EUR' for currency.
Remove please the restriction for identificator.
