### PR TITLE
[Twig] Fix form extension template parameters

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -169,7 +169,10 @@ class FormExtension extends \Twig_Extension
                     $view->setRendered(true);
                 }
 
-                return $templates[$block]->renderBlock($block, array_merge($view->all(), $variables));
+                $parameters = $view->all();
+                $parameters['attr'] = $variables;
+
+                return $templates[$block]->renderBlock($block, $parameters);
             }
         }
 


### PR DESCRIPTION
Actually, the user variables passed through `form_widget(field, variables)`
are ignored. The form twig templates expect a `attr` array.
