### PR TITLE
[AsseticBundle] added configuration for compass filter

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/compass.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/compass.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.filter.compass.class">Assetic\Filter\CompassFilter</parameter>
+        <parameter key="assetic.filter.compass.sass">%assetic.sass.bin%</parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.filter.compass" class="%assetic.filter.compass.class%">
+            <tag name="assetic.filter" alias="compass" />
+            <argument>%assetic.filter.compass.sass%</argument>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
You can use Compass by adding the following configuration to config.yml:

```
assetic:
    filters:
        compass: ~
```

And in your Twig template:

``` jinja
{% stylesheets '@MyBundle/Resources/css/main.scss' filter='compass' output='css/main.css' %}
<link href="{{ asset_url }}" type="text/css" rel="stylesheet" />
{% endstylesheets %}
```
