### PR TITLE
Make casting scalar to array consistent

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -686,9 +686,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
     protected function getContainer($bundles = 'YamlBundle', $vendor = null)
     {
-        if (!is_array($bundles)) {
-            $bundles = array($bundles);
-        }
+        $bundles = (array) $bundles;
 
         $map = array();
         foreach ($bundles as $bundle) {

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -92,9 +92,7 @@ class HttpKernel extends BaseHttpKernel
             'comment'       => '',
         ), $options);
 
-        if (!is_array($options['alt'])) {
-            $options['alt'] = array($options['alt']);
-        }
+        $options['alt'] = (array) $options['alt'];
 
         if (null === $this->esiSupport) {
             $this->esiSupport = $this->container->has('esi') && $this->container->get('esi')->hasSurrogateEsiCapability($this->container->get('request'));

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -27,10 +27,7 @@ class FileLocator implements FileLocatorInterface
      */
     public function __construct($paths = array())
     {
-        if (!is_array($paths)) {
-            $paths = array($paths);
-        }
-        $this->paths = $paths;
+        $this->paths = (array) $paths;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -41,9 +41,7 @@ class FormatterHelper extends Helper
      */
     public function formatBlock($messages, $style, $large = false)
     {
-        if (!is_array($messages)) {
-            $messages = array($messages);
-        }
+        $messages = (array) $messages;
 
         $len = 0;
         $lines = array();

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -260,9 +260,7 @@ class ArgvInput extends Input
      */
     public function hasParameterOption($values)
     {
-        if (!is_array($values)) {
-            $values = array($values);
-        }
+        $values = (array) $values;
 
         foreach ($this->tokens as $v) {
             if (in_array($v, $values)) {
@@ -285,9 +283,7 @@ class ArgvInput extends Input
      */
     public function getParameterOption($values, $default = false)
     {
-        if (!is_array($values)) {
-            $values = array($values);
-        }
+        $values = (array) $values;
 
         $tokens = $this->tokens;
         while ($token = array_shift($tokens)) {

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -69,9 +69,7 @@ class ArrayInput extends Input
      */
     public function hasParameterOption($values)
     {
-        if (!is_array($values)) {
-            $values = array($values);
-        }
+        $values = (array) $values;
 
         foreach ($this->parameters as $k => $v) {
             if (!is_int($k)) {
@@ -99,9 +97,7 @@ class ArrayInput extends Input
      */
     public function getParameterOption($values, $default = false)
     {
-        if (!is_array($values)) {
-            $values = array($values);
-        }
+        $values = (array) $values;
 
         foreach ($this->parameters as $k => $v) {
             if (is_int($k) && in_array($v, $values)) {

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -154,9 +154,7 @@ abstract class Output implements OutputInterface
             return;
         }
 
-        if (!is_array($messages)) {
-            $messages = array($messages);
-        }
+        $messages = (array) $messages;
 
         foreach ($messages as $message) {
             switch ($type) {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -447,9 +447,7 @@ class Crawler extends \SplObjectStorage
      */
     public function extract($attributes)
     {
-        if (!is_array($attributes)) {
-            $attributes = array($attributes);
-        }
+        $attributes = (array) $attributes;
 
         $data = array();
         foreach ($this as $node) {

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -115,8 +115,8 @@ class ChoiceFormField extends FormField
                 throw new \InvalidArgumentException(sprintf('Input "%s" cannot take "%s" as a value (possible values: %s).', $this->name, $value, implode(', ', $this->options)));
             }
 
-            if ($this->multiple && !is_array($value)) {
-                $value = array($value);
+            if ($this->multiple) {
+                $value = (array) $value;
             }
 
             if (is_array($value)) {

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -327,9 +327,7 @@ class Finder implements \IteratorAggregate
      */
     public function in($dirs)
     {
-        if (!is_array($dirs)) {
-            $dirs = array($dirs);
-        }
+        $dirs = (array) $dirs;
 
         foreach ($dirs as $dir) {
             if (!is_dir($dir)) {

--- a/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
@@ -231,10 +231,6 @@ class DelegatingValidator implements FormValidatorInterface
             $groups = array('Default');
         }
 
-        if (!is_array($groups)) {
-            $groups = array($groups);
-        }
-
-        return $groups;
+        return (array) $groups;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -119,9 +119,7 @@ class HeaderBag
     {
         $key = strtr(strtolower($key), '_', '-');
 
-        if (!is_array($values)) {
-            $values = array($values);
-        }
+        $values = (array) $values;
 
         if (true === $replace || !isset($this->headers[$key])) {
             $this->headers[$key] = $values;

--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -237,9 +237,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
             return true;
         }
 
-        if (!is_array($sids)) {
-            $sids = array($sids);
-        }
+        $sids = (array) $sids;
 
         foreach ($sids as $sid) {
             if (!$sid instanceof SecurityIdentityInterface) {

--- a/src/Symfony/Component/Templating/Asset/AssetPackage.php
+++ b/src/Symfony/Component/Templating/Asset/AssetPackage.php
@@ -32,11 +32,7 @@ class AssetPackage implements AssetPackageInterface
         $this->baseUrls = array();
         $this->version = $version;
 
-        if (!is_array($baseUrls)) {
-            $baseUrls = (array) $baseUrls;
-        }
-
-        foreach ($baseUrls as $baseUrl) {
+        foreach ((array) $baseUrls as $baseUrl) {
             $this->baseUrls[] = rtrim($baseUrl, '/');
         }
     }

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -31,11 +31,7 @@ class FilesystemLoader extends Loader
      */
     public function __construct($templatePathPatterns)
     {
-        if (!is_array($templatePathPatterns)) {
-            $templatePathPatterns = array($templatePathPatterns);
-        }
-
-        $this->templatePathPatterns = $templatePathPatterns;
+        $this->templatePathPatterns = (array) $templatePathPatterns;
     }
 
     /**


### PR DESCRIPTION
This change is mainly for consistency across the source code.

I have measured the proposed implementation to be 5 times faster than the previous one with PHP 5.3.3 whether the initial value is already an array or not (of course this will be diluted and we can not expect any perf improvement)
