### PR TITLE
[Form] Fix DateTimeType by adding missing default options

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -110,6 +110,15 @@ class DateTimeType extends AbstractType
             'time_pattern' => null,
             'time_widget' => null,
             'time_format' => null,
+            /* Defaults for date field */
+            'years' => range(date('Y') - 5, date('Y') + 5),
+            'months' => range(1, 12),
+            'days' => range(1, 31),
+            /* Defaults for time field */
+            'hours' => range(0, 23),
+            'minutes' => range(0, 59),
+            'seconds' => range(0, 59),
+            'with_seconds' => false,
         );
     }
 


### PR DESCRIPTION
Example code that fails without this patch:

```
$builder->add('start', 'datetime', array('minutes' => range(0, 55, 5)));
```
