### PR TITLE
Uploaded file move() method leads to loosing a file on the server even when the new name was given as a second param

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -180,7 +180,7 @@ class UploadedFile extends File
 
         $newPath = $directory . DIRECTORY_SEPARATOR . $filename;
 
-        if (!move_uploaded_file($this->getPath(), $newPath)) {
+        if (!@move_uploaded_file($this->getPath(), $newPath)) {
             throw new FileException(sprintf('Could not move file %s to %s', $this->getPath(), $newPath));
         }
 
@@ -197,10 +197,10 @@ class UploadedFile extends File
             return parent::move($directory, $name);
         }
 
-        $this->doMove($directory, $this->originalName);
-
-        if (null !== $name) {
-            $this->rename($name);
+        if (null === $name) {
+            $name = $this->originalName;
         }
+
+        $this->doMove($directory, $name);
     }
 }


### PR DESCRIPTION
1. No need to generate a warning when checking for move_uploaded_file() since an exception on failure is generated. Extra warning is bad for AJAX requests.
2. When moving an uploaded file the new name should be used. Currently if the new name is given via `$name` parameter and if uploaded file had a name (on user's pc before uploading) which is the same as one of the files in the target directory - the file in the target directory will be overwritten and then renamed. This is bad! If programmer checks and resolves name conflicts he shouldn't loose a file on the server (when he gives the unique `$name` expecting the newly uploaded file to have that name since the file with the same name as uploaded file already exists).
