### PR TITLE
Doctrine auto mapping

### DIFF
--- a/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
@@ -42,6 +42,15 @@ abstract class AbstractDoctrineExtension extends Extension
      */
     protected function loadMappingInformation(array $objectManager, ContainerBuilder $container)
     {
+        if (!$objectManager['mappings'] && $objectManager['auto_mapping']) {
+            // automatically register bundle mappings
+            foreach (array_keys($container->getParameter('kernel.bundles')) as $bundle) {
+                if (!isset($objectManager['mappings'][$bundle])) {
+                    $objectManager['mappings'][$bundle] = null;
+                }
+            }
+        }
+
         foreach ($objectManager['mappings'] as $mappingName => $mappingConfig) {
             $mappingConfig = array_replace(array(
                 'dir'    => false,

--- a/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
@@ -52,6 +52,10 @@ abstract class AbstractDoctrineExtension extends Extension
         }
 
         foreach ($objectManager['mappings'] as $mappingName => $mappingConfig) {
+            if (false === $mappingConfig) {
+                continue;
+            }
+
             $mappingConfig = array_replace(array(
                 'dir'    => false,
                 'type'   => false,

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -156,13 +156,15 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('orm')
                     ->beforeNormalization()
-                        ->ifTrue(function ($v) { return is_array($v) && !array_key_exists('entity_managers', $v) && !array_key_exists('entity_manager', $v); })
+                        ->ifTrue(function ($v) { return null === $v || (is_array($v) && !array_key_exists('entity_managers', $v) && !array_key_exists('entity_manager', $v)); })
                         ->then(function ($v) {
+                            $v = (array) $v;
                             $entityManager = array();
                             foreach (array(
                                 'result_cache_driver', 'result-cache-driver',
                                 'metadata_cache_driver', 'metadata-cache-driver',
                                 'query_cache_driver', 'query-cache-driver',
+                                'auto_mapping', 'auto-mapping',
                                 'mappings', 'mapping',
                                 'connection'
                             ) as $key) {
@@ -206,6 +208,7 @@ class Configuration implements ConfigurationInterface
                 ->children()
                     ->scalarNode('connection')->end()
                     ->scalarNode('class_metadata_factory_name')->defaultValue('%doctrine.orm.class_metadata_factory_name%')->end()
+                    ->scalarNode('auto_mapping')->defaultFalse()->end()
                 ->end()
                 ->fixXmlConfig('hydrator')
                 ->children()
@@ -217,8 +220,6 @@ class Configuration implements ConfigurationInterface
                 ->fixXmlConfig('mapping')
                 ->children()
                     ->arrayNode('mappings')
-                        ->isRequired()
-                        ->requiresAtLeastOneElement()
                         ->useAttributeAsKey('name')
                         ->prototype('array')
                             ->beforeNormalization()

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -169,6 +169,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function loadOrmEntityManager(array $entityManager, ContainerBuilder $container)
     {
+        if ($entityManager['auto_mapping'] && count($container->getParameter('doctrine.orm.entity_managers')) > 1) {
+            throw new \LogicException('You cannot enable "auto_mapping" when several entity managers are defined.');
+        }
+
         $ormConfigDef = $container->setDefinition(sprintf('doctrine.orm.%s_configuration', $entityManager['name']), new DefinitionDecorator('doctrine.orm.configuration'));
 
         $this->loadOrmEntityManagerMappingInformation($entityManager, $ormConfigDef, $container);

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
@@ -71,6 +71,7 @@
             <xsd:element name="metadata-cache-driver" type="metadata_cache_driver" minOccurs="0" maxOccurs="1" />
         </xsd:choice>
 
+        <xsd:attribute name="auto-mapping" type="xsd:string" />
         <xsd:attribute name="default-entity-manager" type="xsd:string" />
         <xsd:attribute name="default-connection" type="xsd:string" />
 
@@ -99,6 +100,7 @@
             <xsd:element name="hydrator" type="type" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
 
+        <xsd:attribute name="auto-mapping" type="xsd:string" />
         <xsd:attribute name="connection" type="xsd:string" />
         <xsd:attribute name="name" type="xsd:string" />
         <xsd:attribute name="result-cache-driver" type="xsd:string" />


### PR DESCRIPTION
Most of the time, you just want to register all your bundle mappings (and the default configuration is just fine). It's a bit tedious to do it by hand, not because of the amount of configuration you need to type, but mainly because you can easily forget to do so (also see https://github.com/symfony/symfony/pull/502).

So, setting `auto_mapping` to `true` allows Symfony to automatically register the mappings it founds in the enabled bundles (default is `false`).

Even if `auto_mapping` is `true`, you can still define your mappings to add some more or to override the defaults.

This change means that the default configuration that works most of the time for most people is simple:

```
orm:
    auto_mapping: true
```

Can anyone see any problem?
