### PR TITLE
[Serializer] [XmlEncoder] Allow decoder to extract attributes in root element

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -54,8 +54,15 @@ class XmlEncoder extends AbstractEncoder implements DecoderInterface
     public function decode($data, $format)
     {
         $xml = simplexml_load_string($data);
-        if (!$xml->count()) {
+        if (!$xml->count() && !$xml->attributes()) {
             return (string) $xml;
+        } elseif (!$xml->count()) {
+            $data = array();
+            foreach ($xml->attributes() as $attrkey => $attr) {
+                $data['@'.$attrkey] = (string) $attr;
+            }
+            $data['#'] = (string) $xml;
+            return $data;
         }
         return $this->parseXml($xml);
     }
@@ -157,14 +164,14 @@ class XmlEncoder extends AbstractEncoder implements DecoderInterface
     private function parseXml($node)
     {
         $data = array();
+        if ($node->attributes()) {
+            foreach ($node->attributes() as $attrkey => $attr) {
+                $data['@'.$attrkey] = (string) $attr;
+            }
+        }
         foreach ($node->children() as $key => $subnode) {
             if ($subnode->count()) {
                 $value = $this->parseXml($subnode);
-                if ($subnode->attributes()) {
-                    foreach ($subnode->attributes() as $attrkey => $attr) {
-                        $value['@'.$attrkey] = (string) $attr;
-                    }
-                }
             } elseif ($subnode->attributes()) {
                 $value = array();
                 foreach ($subnode->attributes() as $attrkey => $attr) {

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -54,9 +54,10 @@ class XmlEncoder extends AbstractEncoder implements DecoderInterface
     public function decode($data, $format)
     {
         $xml = simplexml_load_string($data);
-        if (!$xml->count() && !$xml->attributes()) {
-            return (string) $xml;
-        } elseif (!$xml->count()) {
+        if (!$xml->count()) {
+            if (!$xml->attributes()) {
+                return (string) $xml;
+            }
             $data = array();
             foreach ($xml->attributes() as $attrkey => $attr) {
                 $data['@'.$attrkey] = (string) $attr;

--- a/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
@@ -111,6 +111,32 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
     }
+    
+    public function testEncodeScalarRootAttributes()
+    {
+        $array = array(
+          '#' => 'Paul',
+          '@gender' => 'm'  
+        );
+        
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response gender="m"><![CDATA[Paul]]></response>'."\n";
+        
+        $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+    }
+    
+    public function testEncodeRootAttributes()
+    {
+        $array = array(
+          'firstname' => 'Paul',
+          '@gender' => 'm'  
+        );
+        
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<response gender="m"><firstname><![CDATA[Paul]]></firstname></response>'."\n";
+        
+        $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+    }
 
     public function testEncodeScalarWithAttribute()
     {
@@ -157,6 +183,33 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
             'person' => array('@gender' => 'M', '#' => 'Peter'),
         );
 
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
+    }
+    
+    public function testDecodeScalarRootAttributes()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<person gender="M">Peter</person>'."\n";
+            
+        $expected = array(
+            '#' => 'Peter',
+            '@gender' => 'M'
+        );
+        
+        $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
+    }
+    
+    public function testDecodeRootAttributes()
+    {
+        $source = '<?xml version="1.0"?>'."\n".
+            '<person gender="M"><firstname>Peter</firstname><lastname>Mac Calloway</lastname></person>'."\n";
+            
+        $expected = array(
+            'firstname' => 'Peter',
+            'lastname' => 'Mac Calloway',
+            '@gender' => 'M'
+        );
+        
         $this->assertEquals($expected, $this->encoder->decode($source, 'xml'));
     }
 


### PR DESCRIPTION
Before this PR if we receive a response like that :

<?xml version="1.0" encoding="utf-8"?>
&lt;response status="OK">
  &lt;elem>TITI&lt;/elem>
&lt;/response>

Attribute "status" was not parsed.
