### PR TITLE
fixed typo on Exception message

### DIFF
--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -38,7 +38,7 @@ class Link
     public function __construct(\DOMNode $node, $currentUri, $method = 'get')
     {
         if (!in_array(substr($currentUri, 0, 4), array('http', 'file'))) {
-            throw new \InvalidArgumentException(sprintf('Current URI must be an asbolute URL ("%s").', $currentUri));
+            throw new \InvalidArgumentException(sprintf('Current URI must be an absolute URL ("%s").', $currentUri));
         }
 
         $this->setNode($node);


### PR DESCRIPTION
fix only typo - message 'Current URI must be an asbolute' -> 'Current URI must be an absolute'
