### PR TITLE
[Form] FormInterface extends IteratorAggregate instead of Traversable

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixFileUploadListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixFileUploadListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Events;
 use Symfony\Component\Form\Event\FilterDataEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Events;
 use Symfony\Component\Form\Event\FilterDataEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\Core\EventListener;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Events;
 use Symfony\Component\Form\Event\FilterDataEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -15,7 +15,6 @@ use Symfony\Component\Form\Events;
 use Symfony\Component\Form\Event\DataEvent;
 use Symfony\Component\Form\Event\FilterDataEvent;
 use Symfony\Component\Form\FormFactoryInterface;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -67,7 +67,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
  */
-class Form implements \IteratorAggregate, FormInterface
+class Form implements FormInterface
 {
     /**
      * The name of this form

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Form;
  *
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
  */
-interface FormInterface extends \ArrayAccess, \Traversable, \Countable
+interface FormInterface extends \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * Sets the parent form.

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -31,7 +31,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
     private function getForm(PropertyPath $propertyPath = null)
     {
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
 
         $form->expects($this->any())
             ->method('getAttribute')

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
@@ -19,7 +19,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
     public function testFixHttpUrl()
     {
         $data = "www.symfony.com";
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
         $event = new FilterDataEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
@@ -31,7 +31,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
     public function testSkipKnownUrl()
     {
         $data = "http://www.symfony.com";
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
         $event = new FilterDataEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
@@ -43,7 +43,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
     public function testSkipOtherProtocol()
     {
         $data = "ftp://www.symfony.com";
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
         $event = new FilterDataEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -40,7 +40,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockForm()
     {
-        return $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        return $this->getMock('Symfony\Component\Form\FormInterface');
     }
 
     public function testPreSetDataResizesForm()

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/TrimListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/TrimListenerTest.php
@@ -19,7 +19,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
     public function testTrim()
     {
         $data = " Foo! ";
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
         $event = new FilterDataEvent($form, $data);
 
         $filter = new TrimListener();
@@ -31,7 +31,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
     public function testTrimSkipNonStrings()
     {
         $data = 1234;
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
         $event = new FilterDataEvent($form, $data);
 
         $filter = new TrimListener();

--- a/tests/Symfony/Tests/Component/Form/Extension/Csrf/Type/CsrfTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Csrf/Type/CsrfTypeTest.php
@@ -24,7 +24,7 @@ class CsrfTypeTest extends TypeTestCase
 
     protected function getNonRootForm()
     {
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
         $form->expects($this->any())
             ->method('isRoot')
             ->will($this->returnValue(false));

--- a/tests/Symfony/Tests/Component/Form/Extension/Validator/Validator/DelegatingValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Validator/Validator/DelegatingValidatorTest.php
@@ -88,7 +88,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockForm()
     {
-        return $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        return $this->getMock('Symfony\Component\Form\FormInterface');
     }
 
     public function testUseValidateValueWhenValidationConstraintExist()

--- a/tests/Symfony/Tests/Component/Form/FormInterface.php
+++ b/tests/Symfony/Tests/Component/Form/FormInterface.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Symfony\Tests\Component\Form;
-
-interface FormInterface extends \Iterator, \Symfony\Component\Form\FormInterface
-{
-}

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -975,7 +975,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
     protected function getMockForm($name = 'name')
     {
-        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $form = $this->getMock('Symfony\Component\Form\FormInterface');
 
         $form->expects($this->any())
             ->method('getName')


### PR DESCRIPTION
Traversable appears to have special treatment in PHP, so previous attempts to simply mock FormInterface yielded:

```
Class Mock_FormInterface_d0094b05 must implement interface Traversable as part of either Iterator or IteratorAggregate
```

I see no reason why FormInterface can't directly extend IteratorAggregate. This fix also removes the FormInterface counterpart in the Tests namespace, which was arbitrarily extending Iterator.

Hat tip to @kriswallsmith for coming across this :)
