### PR TITLE
[Session] Used \Locale::setDefault() when the locale is setted

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -37,6 +37,7 @@ class Session implements \Serializable
         $this->storage = $storage;
         $this->defaultLocale = $defaultLocale;
         $this->attributes = array('_flash' => array(), '_locale' => $this->getDefaultLocale());
+        \Locale::setDefault($this->attributes['_locale']);
         $this->started = false;
     }
 
@@ -60,6 +61,8 @@ class Session implements \Serializable
         if (!isset($this->attributes['_locale'])) {
             $this->attributes['_locale'] = $this->getDefaultLocale();
         }
+
+        \Locale::setDefault($this->attributes['_locale']);
 
         // flag current flash messages to be removed at shutdown
         $this->oldFlashes = array_flip(array_keys($this->attributes['_flash']));
@@ -104,7 +107,11 @@ class Session implements \Serializable
             $this->start();
         }
 
-        $this->attributes[$name] = $value;
+        if ('_locale' === $name) {
+            $this->setLocale($value);
+        } else {
+            $this->attributes[$name] = $value;
+        }
     }
 
     /**
@@ -126,6 +133,10 @@ class Session implements \Serializable
     {
         if (false === $this->started) {
             $this->start();
+        }
+
+        if (isset($attributes['_locale'])) {
+            $this->setLocale($attributes['_locale']);
         }
 
         $this->attributes = $attributes;
@@ -208,7 +219,7 @@ class Session implements \Serializable
             $this->start();
         }
 
-        $this->attributes['_locale'] = $locale;
+        \Locale::setDefault($this->attributes['_locale'] = $locale);
     }
 
     public function getFlashes()
@@ -278,6 +289,7 @@ class Session implements \Serializable
         if (isset($this->attributes['_flash'])) {
             $this->attributes['_flash'] = array_diff_key($this->attributes['_flash'], $this->oldFlashes);
         }
+
         $this->storage->write('_symfony2', $this->attributes);
     }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
@@ -162,14 +162,20 @@ class SessionTest extends \PHPUnit_Framework_TestCase
     public function testLocale()
     {
         $this->assertSame('en', $this->session->getLocale(), 'default locale is en');
+        $this->assertSame('en', \Locale::getDefault(), '\Locale::getDefault() is en');
 
         $this->session->set('_locale','de');
-
         $this->assertSame('de', $this->session->getLocale(), 'locale is de');
+        $this->assertSame('de', \Locale::getDefault(), '\Locale::getDefault() is de');
 
         $this->session = $this->getSession();
         $this->session->setLocale('fr');
         $this->assertSame('fr', $this->session->getLocale(), 'locale is fr');
+        $this->assertSame('fr', \Locale::getDefault(), '\Locale::getDefault() is fr');
+
+        $this->session->setAttributes(array('_locale' => 'de'));
+        $this->assertSame('de', $this->session->getLocale(), 'locale is de');
+        $this->assertSame('de', \Locale::getDefault(), '\Locale::getDefault() is de');
     }
 
     public function testGetId()
@@ -182,11 +188,14 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->start();
 
         $this->assertSame('en', $this->session->getLocale());
+        $this->assertSame('en', \Locale::getDefault());
+
         $this->assertSame(array(), $this->session->getFlashes());
         $this->assertSame(array('_flash' => array(), '_locale' => 'en'), $this->session->getAttributes());
 
         $this->session->start();
         $this->assertSame('en', $this->session->getLocale());
+        $this->assertSame('en', \Locale::getDefault());
     }
 
     protected function getSession()


### PR DESCRIPTION
For `DateType` in form component (by example), `\Locale::getDefault()` is used to displayed the name of months.

If `\Locale` class is not used when the locale is setted in the session, the name of months is not in a good language.
This PR solves this problem.
