### PR TITLE
tweaks (drop \Closure)

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -85,12 +85,12 @@ class EntityChoiceList extends ArrayChoiceList
     {
         // If a query builder was passed, it must be a closure or QueryBuilder
         // instance
-        if (!(null === $queryBuilder || $queryBuilder instanceof QueryBuilder || $queryBuilder instanceof \Closure)) {
-            throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder or \Closure');
+        if (!(null === $queryBuilder || $queryBuilder instanceof QueryBuilder || is_callable($queryBuilder))) {
+            throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder or function');
         }
 
-        if ($queryBuilder instanceof \Closure) {
-            $queryBuilder = $queryBuilder($em->getRepository($class));
+        if (is_callable($queryBuilder)) {
+            $queryBuilder = call_user_func($queryBuilder, $em->getRepository($class));
 
             if (!$queryBuilder instanceof QueryBuilder) {
                 throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RequestDataCollector.php
@@ -50,7 +50,7 @@ class RequestDataCollector extends BaseRequestDataCollector
                     'file'   => $r->getFilename(),
                     'line'   => $r->getStartLine(),
                 );
-            } elseif ($controller instanceof \Closure) {
+            } elseif (is_callable($controller)) {
                 $this->data['controller'] = 'Closure';
             } else {
                 $this->data['controller'] = (string) $controller ?: 'n/a';

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
@@ -50,7 +50,7 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
      */
     public function addListener($eventNames, $listener, $priority = 0)
     {
-        if (!$listener instanceof \Closure) {
+        if (!is_callable($listener)) {
             foreach ((array) $eventNames as $method) {
                 if (!is_callable(array($listener, $method))) {
                     $msg = sprintf('The event method "%s()" is not callable on the class "%s".', $method, get_class($listener));
@@ -133,7 +133,7 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
     private function getListenerInfo($listener, $eventName)
     {
         $info = array('event' => $eventName);
-        if ($listener instanceof \Closure) {
+        if (is_callable($listener)) {
             $info += array('type' => 'Closure');
         } else {
             $class = get_class($listener);

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -176,7 +176,7 @@ abstract class BaseNode implements NodeInterface
     {
         // run custom normalization closures
         foreach ($this->normalizationClosures as $closure) {
-            $value = $closure($value);
+            $value = call_user_func($closure, $value);
         }
 
         // replace value with their equivalent
@@ -209,7 +209,7 @@ abstract class BaseNode implements NodeInterface
         // The closure is also allowed to return another value.
         foreach ($this->finalValidationClosures as $closure) {
             try {
-                $value = $closure($value);
+                $value = call_user_func($closure, $value);
             } catch (Exception $correctEx) {
                 throw $correctEx;
             } catch (\Exception $invalid) {

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -51,11 +51,15 @@ class ExprBuilder
      *
      * The default one tests if the value is true.
      *
-     * @param \Closure $closure
+     * @param function $closure
      * @return ExprBuilder
      */
-    public function ifTrue(\Closure $closure = null)
+    public function ifTrue($closure = null)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The parameter should be a function');
+        }
+        
         if (null === $closure) {
             $closure = function($v) { return true === $v; };
         }
@@ -132,12 +136,16 @@ class ExprBuilder
     /**
      * Sets the closure to run if the test pass.
      *
-     * @param \Closure $closure
+     * @param function $closure
      *
      * @return ExprBuilder
      */
-    public function then(\Closure $closure)
+    public function then($closure)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The parameter should be a function');
+        }
+        
         $this->thenPart = $closure;
 
         return $this;

--- a/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NormalizationBuilder.php
@@ -53,13 +53,17 @@ class NormalizationBuilder
     /**
      * Registers a closure to run before the normalization or an expression builder to build it if null is provided.
      *
-     * @param \Closure $closure
+     * @param function $closure
      *
      * @return ExprBuilder|NormalizationBuilder
      */
-    public function before(\Closure $closure = null)
+    public function before($closure = null)
     {
         if (null !== $closure) {
+            if (!is_callable($closure)) {
+                throw new \InvalidArgumentException('The parameter should be a function or null');
+            }
+            
             $this->before[] = $closure;
 
             return $this;

--- a/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ValidationBuilder.php
@@ -36,13 +36,17 @@ class ValidationBuilder
     /**
      * Registers a closure to run as normalization or an expression builder to build it if null is provided.
      *
-     * @param \Closure $closure
+     * @param function $closure
      *
      * @return ExprBuilder|ValidationBuilder
      */
-    public function rule(\Closure $closure = null)
+    public function rule($closure = null)
     {
         if (null !== $closure) {
+            if (!is_callable($closure)) {
+                throw new \InvalidArgumentException('The parameter should be a function');
+            }
+            
             $this->rules[] = $closure;
 
             return $this;

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -49,8 +49,9 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
      * {@inheritDoc}
      */
     public function getDefaultValue()
-    {
-        return $this->defaultValue instanceof \Closure ? call_user_func($this->defaultValue) : $this->defaultValue;
+    {       
+        $value = $this->defaultValue;
+        return !is_string($value) && is_callable($value) ? call_user_func($value) : $value;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -103,7 +103,7 @@ class Command
      * This method is not abstract because you can use this class
      * as a concrete class. In this case, instead of defining the
      * execute() method, you set the code to execute by passing
-     * a Closure to the setCode() method.
+     * a callback to the setCode() method.
      *
      * @param InputInterface  $input  An InputInterface instance
      * @param OutputInterface $output An OutputInterface instance
@@ -194,7 +194,7 @@ class Command
      * If this method is used, it overrides the code defined
      * in the execute() method.
      *
-     * @param \Closure $code A \Closure
+     * @param function $code A callback function
      *
      * @return Command The current instance
      *
@@ -202,8 +202,12 @@ class Command
      *
      * @api
      */
-    public function setCode(\Closure $code)
+    public function setCode($code)
     {
+        if (!is_callable($code)) {
+            throw new \InvalidArgumentException('The code should be a function');
+        }
+        
         $this->code = $code;
 
         return $this;

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -72,16 +72,20 @@ class DialogHelper extends Helper
      *
      * @param OutputInterface $output
      * @param string|array    $question
-     * @param Closure         $validator
+     * @param function        $validator
      * @param integer         $attempts Max number of times to ask before giving up (false by default, which means infinite)
      *
      * @return mixed
      *
      * @throws \Exception When any of the validator returns an error
      */
-    public function askAndValidate(OutputInterface $output, $question, \Closure $validator, $attempts = false)
+    public function askAndValidate(OutputInterface $output, $question, $validator, $attempts = false)
     {
         // @codeCoverageIgnoreStart
+        if (!is_callable($validator)) {
+            throw new \InvalidArgumentException('The validator should be a function');
+        }
+        
         $error = null;
         while (false === $attempts || $attempts--) {
             if (null !== $error) {
@@ -91,7 +95,7 @@ class DialogHelper extends Helper
             $value = $this->ask($output, $question, null);
 
             try {
-                return $validator($value);
+                return call_user_func($validator, $value);
             } catch (\Exception $error) {
             }
         }

--- a/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
@@ -38,11 +38,15 @@ class ClosureLoader extends Loader
     /**
      * Loads a Closure.
      *
-     * @param \Closure $closure The resource
+     * @param function $closure The resource
      * @param string   $type    The resource type
      */
     public function load($closure, $type = null)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The resource should be a function');
+        }
+        
         call_user_func($closure, $this->container);
     }
 
@@ -56,6 +60,6 @@ class ClosureLoader extends Loader
      */
     public function supports($resource, $type = null)
     {
-        return $resource instanceof \Closure;
+        return is_callable($resource);
     }
 }

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -232,17 +232,21 @@ class Crawler extends \SplObjectStorage
      *       return $node->nodeValue;
      *     });
      *
-     * @param \Closure $closure An anonymous function
+     * @param function $closure An anonymous function
      *
      * @return array An array of values returned by the anonymous function
      *
      * @api
      */
-    public function each(\Closure $closure)
+    public function each($closure)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The argument should be a function');
+        }
+        
         $data = array();
         foreach ($this as $i => $node) {
-            $data[] = $closure($node, $i);
+            $data[] = call_user_func($closure, $node, $i);
         }
 
         return $data;
@@ -253,17 +257,21 @@ class Crawler extends \SplObjectStorage
      *
      * To remove a node from the list, the anonymous function must return false.
      *
-     * @param \Closure $closure An anonymous function
+     * @param function $closure An anonymous function
      *
      * @return Crawler A Crawler instance with the selected nodes.
      *
      * @api
      */
-    public function reduce(\Closure $closure)
+    public function reduce($closure)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The argument should be a function');
+        }
+        
         $nodes = array();
         foreach ($this as $i => $node) {
-            if (false !== $closure($node, $i)) {
+            if (false !== call_user_func($closure, $node, $i)) {
                 $nodes[] = $node;
             }
         }

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -173,10 +173,10 @@ class EventDispatcher implements EventDispatcherInterface
      */
     protected function triggerListener($listener, $eventName, Event $event)
     {
-        if (is_callable($listener)) {
-            call_user_func($listener, $event);
+        if (is_callable(array($listener, $eventName))) {
+            $listener->$eventName($event);            
         } else {
-            $listener->$eventName($event);
+            call_user_func($listener, $event);
         }
     }
 

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -173,8 +173,8 @@ class EventDispatcher implements EventDispatcherInterface
      */
     protected function triggerListener($listener, $eventName, Event $event)
     {
-        if ($listener instanceof \Closure) {
-            $listener->__invoke($event);
+        if (is_callable($listener)) {
+            call_user_func($listener, $event);
         } else {
             $listener->$eventName($event);
         }

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -228,7 +228,7 @@ class Finder implements \IteratorAggregate
      *
      * This can be slow as all the matching files and directories must be retrieved for comparison.
      *
-     * @param  Closure $closure An anonymous function
+     * @param  function $closure An anonymous function
      *
      * @return Finder The current Finder instance
      *
@@ -236,8 +236,12 @@ class Finder implements \IteratorAggregate
      *
      * @api
      */
-    public function sort(\Closure $closure)
+    public function sort($closure)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The parameter should be a function');
+        }
+        
         $this->sort = $closure;
 
         return $this;
@@ -285,7 +289,7 @@ class Finder implements \IteratorAggregate
      * The anonymous function receives a \SplFileInfo and must return false
      * to remove files.
      *
-     * @param  Closure $closure An anonymous function
+     * @param  function $closure An anonymous function
      *
      * @return Finder The current Finder instance
      *
@@ -293,8 +297,12 @@ class Finder implements \IteratorAggregate
      *
      * @api
      */
-    public function filter(\Closure $closure)
+    public function filter($closure)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The parameter should be callable');
+        }
+        
         $this->filters[] = $closure;
 
         return $this;

--- a/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
@@ -27,7 +27,7 @@ class CustomFilterIterator extends \FilterIterator
      * Constructor.
      *
      * @param \Iterator $iterator The Iterator to filter
-     * @param array     $filters  An array of \Closure
+     * @param array     $filters  An array of functions
      */
     public function __construct(\Iterator $iterator, array $filters)
     {
@@ -46,7 +46,7 @@ class CustomFilterIterator extends \FilterIterator
         $fileinfo = $this->current();
 
         foreach ($this->filters as $filter) {
-            if (false === $filter($fileinfo)) {
+            if (false === call_user_func($filter, $fileinfo)) {
                 return false;
             }
         }

--- a/src/Symfony/Component/Finder/Iterator/SortableIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SortableIterator.php
@@ -25,7 +25,7 @@ class SortableIterator extends \ArrayIterator
      * Constructor.
      *
      * @param \Iterator        $iterator The Iterator to filter
-     * @param integer|\Closure $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a \Closure instance)
+     * @param integer|function $sort     The sort type (SORT_BY_NAME, SORT_BY_TYPE, or a function)
      */
     public function __construct(\Iterator $iterator, $sort)
     {
@@ -45,8 +45,8 @@ class SortableIterator extends \ArrayIterator
 
                 return strcmp($a->getRealpath(), $b->getRealpath());
             };
-        } elseif (!$sort instanceof \Closure) {
-            throw new \InvalidArgumentException(sprintf('The SortableIterator takes a \Closure or a valid built-in sort algorithm as an argument (%s given).', $sort));
+        } elseif (!is_callable($sort)) {
+            throw new \InvalidArgumentException(sprintf('The SortableIterator takes a function or a valid built-in sort algorithm as an argument (%s given).', $sort));
         }
 
         $array = new \ArrayObject(iterator_to_array($iterator));

--- a/src/Symfony/Component/Form/CallbackTransformer.php
+++ b/src/Symfony/Component/Form/CallbackTransformer.php
@@ -11,25 +11,35 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
 class CallbackTransformer implements DataTransformerInterface
 {
     private $transform;
 
     private $reverseTransform;
 
-    public function __construct(\Closure $transform, \Closure $reverseTransform)
+    public function __construct($transform, $reverseTransform)
     {
+        if (!is_callable($transform)) {
+            throw new UnexpectedTypeException($transform, 'function');
+        }
+        
+        if (!is_callable($reverseTransform)) {
+            throw new UnexpectedTypeException($reverseTransform, 'function');
+        }
+
         $this->transform = $transform;
         $this->reverseTransform = $reverseTransform;
     }
 
     public function transform($data)
     {
-        return $this->transform->__invoke($data);
+        return call_user_func($this->transform, $data);
     }
 
     public function reverseTransform($data)
     {
-        return $this->reverseTransform->__invoke($data);
+        return call_user_func($this->reverseTransform, $data);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ArrayChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ArrayChoiceList.php
@@ -21,8 +21,8 @@ class ArrayChoiceList implements ChoiceListInterface
 
     public function __construct($choices)
     {
-        if (!is_array($choices) && !$choices instanceof \Closure) {
-            throw new UnexpectedTypeException($choices, 'array or \Closure');
+        if (!(is_array($choices) || (!is_string($choices) && is_callable($choices)))) {
+            throw new UnexpectedTypeException($choices, 'array or function');
         }
 
         $this->choices = $choices;
@@ -44,8 +44,8 @@ class ArrayChoiceList implements ChoiceListInterface
     {
         $this->loaded = true;
 
-        if ($this->choices instanceof \Closure) {
-            $this->choices = $this->choices->__invoke();
+        if (is_callable($this->choices)) {
+            $this->choices = call_user_func($this->choices);
 
             if (!is_array($this->choices)) {
                 throw new UnexpectedTypeException($this->choices, 'array');

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class ValidatorTypeGuesser implements FormTypeGuesserInterface
 {
@@ -67,14 +68,18 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
      * Iterates over the constraints of a property, executes a constraints on
      * them and returns the best guess
      *
-     * @param string $class       The class to read the constraints from
-     * @param string $property    The property for which to find constraints
-     * @param \Closure $guessForConstraint   The closure that returns a guess
-     *                            for a given constraint
+     * @param string    $class              The class to read the constraints from
+     * @param string    $property           The property for which to find constraints
+     * @param function  $guessForConstraint The closure that returns a guess
+     *                                      for a given constraint
      * @return Guess  The guessed value with the highest confidence
      */
-    protected function guess($class, $property, \Closure $guessForConstraint)
+    protected function guess($class, $property, $guessForConstraint)
     {
+        if (!is_callable($guessForConstraint)) {
+            throw new UnexpectedTypeException($guessForConstraint, 'function');
+        }
+        
         $guesses = array();
         $classMetadata = $this->metadataFactory->getClassMetadata($class);
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -224,17 +224,17 @@ class Form implements \IteratorAggregate, FormInterface
             }
         }
 
-        $this->name = (string)$name;
+        $this->name = (string) $name;
         $this->types = $types;
         $this->dispatcher = $dispatcher;
         $this->clientTransformers = $clientTransformers;
         $this->normTransformers = $normTransformers;
         $this->validators = $validators;
         $this->dataMapper = $dataMapper;
-        $this->required = $required;
-        $this->readOnly = $readOnly;
+        $this->required = (Boolean) $required;
+        $this->readOnly = (Boolean) $readOnly;
         $this->attributes = $attributes;
-        $this->errorBubbling = $errorBubbling;
+        $this->errorBubbling = (Boolean) $errorBubbling;
         $this->emptyData = $emptyData;
 
         $this->setData(null);
@@ -361,7 +361,7 @@ class Form implements \IteratorAggregate, FormInterface
 
         // Treat data as strings unless a value transformer exists
         if (!$this->clientTransformers && !$this->normTransformers && is_scalar($appData)) {
-            $appData = (string)$appData;
+            $appData = (string) $appData;
         }
 
         // Synchronize representations - must not change the content!
@@ -396,7 +396,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if (is_scalar($clientData) || null === $clientData) {
-            $clientData = (string)$clientData;
+            $clientData = (string) $clientData;
         }
 
         // Initialize errors in the very beginning so that we don't lose any
@@ -449,8 +449,8 @@ class Form implements \IteratorAggregate, FormInterface
         if (null === $clientData || '' === $clientData) {
             $clientData = $this->emptyData;
 
-            if ($clientData instanceof \Closure) {
-                $clientData = $clientData->__invoke($this);
+            if (!is_string($clientData) && is_callable($clientData)) {
+                $clientData = call_user_func($clientData, $this);
             }
         }
 
@@ -913,8 +913,8 @@ class Form implements \IteratorAggregate, FormInterface
             return '' === $value ? null : $value;
         }
 
-        for ($i = count($this->clientTransformers) - 1; $i >= 0; --$i) {
-            $value = $this->clientTransformers[$i]->reverseTransform($value);
+        foreach (array_reverse($this->clientTransformers) as $transformer) {
+            $value = $transformer->reverseTransform($value);
         }
 
         return $value;

--- a/src/Symfony/Component/Form/FormTypeGuesserChain.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserChain.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class FormTypeGuesserChain implements FormTypeGuesserInterface
 {
@@ -57,16 +58,20 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
      * Executes a closure for each guesser and returns the best guess from the
      * return values
      *
-     * @param  \Closure $closure  The closure to execute. Accepts a guesser
+     * @param  function $closure  The closure to execute. Accepts a guesser
      *                            as argument and should return a Guess instance
      * @return FieldFactoryGuess  The guess with the highest confidence
      */
-    private function guess(\Closure $closure)
+    private function guess($closure)
     {
+        if (!is_callable($closure)) {
+            throw new UnexpectedTypeException($closure, 'function');
+        }
+        
         $guesses = array();
 
         foreach ($this->guessers as $guesser) {
-            if ($guess = $closure($guesser)) {
+            if ($guess = call_user_func($closure, $guesser)) {
                 $guesses[] = $guess;
             }
         }

--- a/src/Symfony/Component/Routing/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ClosureLoader.php
@@ -25,7 +25,7 @@ class ClosureLoader extends Loader
     /**
      * Loads a Closure.
      *
-     * @param \Closure $closure A Closure
+     * @param function $closure A callback function
      * @param string   $type    The resource type
      */
     public function load($closure, $type = null)
@@ -43,6 +43,6 @@ class ClosureLoader extends Loader
      */
     public function supports($resource, $type = null)
     {
-        return $resource instanceof \Closure && (!$type || 'closure' === $type);
+        return is_callable($resource) && (!$type || 'closure' === $type);
     }
 }

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -100,13 +100,17 @@ class Validator implements ValidatorInterface
         return $this->validateGraph($value, $walk, $groups);
     }
 
-    protected function validateGraph($root, \Closure $walk, $groups = null)
+    protected function validateGraph($root, $walk, $groups = null)
     {
+        if (!is_callable($walk)) {
+            throw new \InvalidArgumentException('$walk should be a function');
+        }
+        
         $walker = new GraphWalker($root, $this->metadataFactory, $this->validatorFactory);
         $groups = $groups ? (array) $groups : array(Constraint::DEFAULT_GROUP);
 
         foreach ($groups as $group) {
-            $walk($walker, $group);
+            call_user_func($walk, $walker, $group);
         }
 
         return $walker->getViolations();

--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -167,6 +167,30 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->dispatcher->hasListeners(self::preFoo));
         $this->assertFalse($this->dispatcher->hasListeners(self::postFoo));
     }
+    
+    public function testCallableObjectListener()
+    {
+        $listener = new CallableEventListener();
+        $this->dispatcher->addListener('onEvent', $listener);
+        $this->dispatcher->dispatch('onEvent');
+        $this->assertTrue($listener->onEvent, 'The event method is invoked when available');
+    }    
+}
+
+class CallableEventListener 
+{
+    public $onInvoke = false;
+    public $onEvent = false;
+    
+    public function __invoke(Event $e)
+    {
+        $this->onInvoke = true;
+    }
+    
+    public function onEvent(Event $e)
+    {
+        $this->onEvent = true;
+    }
 }
 
 class TestEventListener

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpCache/HttpCacheTestCase.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpCache/HttpCacheTestCase.php
@@ -138,7 +138,7 @@ class HttpCacheTestCase extends \PHPUnit_Framework_TestCase
     }
 
     // A basic response with 200 status code and a tiny body.
-    public function setNextResponse($statusCode = 200, array $headers = array(), $body = 'Hello World', \Closure $customizer = null)
+    public function setNextResponse($statusCode = 200, array $headers = array(), $body = 'Hello World', $customizer = null)
     {
         $this->kernel = new TestHttpKernel($body, $statusCode, $headers, $customizer);
     }

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpCache/TestHttpKernel.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpCache/TestHttpKernel.php
@@ -27,8 +27,12 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
     protected $customizer;
     protected $catch;
 
-    public function __construct($body, $status, $headers, \Closure $customizer = null)
+    public function __construct($body, $status, $headers, $customizer = null)
     {
+        if (null !== $customizer && !is_callable($customizer)) {
+            throw new \InvalidArgumentException('The customizer should be a function');
+        }
+        
         $this->body = $body;
         $this->status = $status;
         $this->headers = $headers;


### PR DESCRIPTION
This PR is an update of https://github.com/symfony/symfony/pull/682 with more explanation.

Why this change ?
From [php.net](http://fr.php.net/manual/en/functions.anonymous.php): Anonymous functions are currently implemented using the Closure class. This is an implementation detail and should not be relied upon.

I do not think that Closure have been blindly replaced: most of the time using `is_callable($closure)` over a Closure is fine but `$closure` might be a function name (`"myFunc"` or `"Foo::myMethod"`) in which case this is not equivalent. I think that the problematic spots have been handled.

Objects with an [__invoke](http://fr.php.net/manual/en/language.oop5.magic.php#language.oop5.magic.invoke) magic method are by definition callable.
