### PR TITLE
Form tweak - added ability to set fields checked as default

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -22,19 +22,21 @@ class CheckboxType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         $builder->appendClientTransformer(new BooleanToStringTransformer())
-            ->setAttribute('value', $options['value']);
+            ->setAttribute('value', $options['value'])
+            ->setAttribute('checked', (Boolean) $options['checked']);
     }
 
     public function buildView(FormView $view, FormInterface $form)
     {
         $view->set('value', $form->getAttribute('value'));
-        $view->set('checked', (Boolean) $form->getData());
+        $view->set('checked', $form->getAttribute('checked') ?: (Boolean) $form->getData());
     }
 
     public function getDefaultOptions(array $options)
     {
         return array(
-            'value' => '1',
+            'value'   => '1',
+            'checked' => false,
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Extension\Core\DataTransformer\BooleanToStringTransformer;
 use Symfony\Component\Form\FormView;
 
@@ -23,12 +23,13 @@ class RadioType extends AbstractType
     {
         $builder->appendClientTransformer(new BooleanToStringTransformer())
             ->setAttribute('value', $options['value']);
+            ->setAttribute('checked', (Boolean) $options['checked']);
     }
 
     public function buildView(FormView $view, FormInterface $form)
     {
         $view->set('value', $form->getAttribute('value'));
-        $view->set('checked', (Boolean) $form->getData());
+        $view->set('checked', $form->getAttribute('checked') ?: (Boolean) $form->getData());
 
         if ($view->hasParent()) {
             $view->set('name', $view->getParent()->get('name'));
@@ -38,7 +39,8 @@ class RadioType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         return array(
-            'value' => null,
+            'value'   => null,
+            'checked' => false,
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -22,7 +22,7 @@ class RadioType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         $builder->appendClientTransformer(new BooleanToStringTransformer())
-            ->setAttribute('value', $options['value']);
+            ->setAttribute('value', $options['value'])
             ->setAttribute('checked', (Boolean) $options['checked']);
     }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CheckboxTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CheckboxTypeTest.php
@@ -21,6 +21,14 @@ class CheckboxTypeTest extends TypeTestCase
         $this->assertEquals('foobar', $view->get('value'));
     }
 
+    public function testPassCheckedToView()
+    {
+        $form = $this->factory->create('checkbox', null, array('checked' => true));
+        $view = $form->createView();
+
+        $this->assertTrue($view->get('checked'));
+    }
+
     public function testCheckedIfDataTrue()
     {
         $form = $this->factory->create('checkbox');

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/RadioTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/RadioTypeTest.php
@@ -21,6 +21,14 @@ class RadioTypeTest extends TypeTestCase
         $this->assertEquals('foobar', $view->get('value'));
     }
 
+    public function testPassValueToView()
+    {
+        $form = $this->factory->create('radio', null, array('checked' => true));
+        $view = $form->createView();
+
+        $this->assertTrue($view->get('checked'));
+    }
+
     public function testPassParentNameToView()
     {
         $parent = $this->factory->createNamed('field', 'parent');


### PR DESCRIPTION
Hey,
I just write patch + tests, which allows to set checkbox/radio to be checked as default (at building form step) not only if some data is sended.
