### PR TITLE
[WebProfilerBundle] forced explicit extension

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/WebProfilerBundle.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebProfilerBundle.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\WebProfilerBundle;
 
+use Symfony\Bundle\WebProfilerBundle\DependencyInjection\WebProfilerExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -20,6 +22,11 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class WebProfilerBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        $container->registerExtension(new WebProfilerExtension());
+    }
+
     public function getContainerExtension()
     {
         // this extension must be explicitly loaded

--- a/src/Symfony/Bundle/WebProfilerBundle/WebProfilerBundle.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/WebProfilerBundle.php
@@ -20,4 +20,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class WebProfilerBundle extends Bundle
 {
+    public function getContainerExtension()
+    {
+        // this extension must be explicitly loaded
+    }
 }


### PR DESCRIPTION
The `web_profiler` extension will not load automatically anymore. This way we can remove the direct check of environment name in the kernel.
