### PR TITLE
adds docblock @link tag with url to symfony2 documentation for classes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  * It provides methods to common features needed in controllers.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/controller.html#the-base-controller-class
  */
 class Controller extends ContainerAware
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Test\WebTestCase as BaseWebTestCase;
  * WebTestCase is the base class for functional tests.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/testing.html#functional-tests
  */
 abstract class WebTestCase extends BaseWebTestCase
 {

--- a/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
+++ b/src/Symfony/Bundle/SecurityBundle/Security/FirewallMap.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Listeners will only be initialized if we really need them.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @link   http://symfony.com/doc/2.0/book/security/authentication.html#the-firewall-map
  */
 class FirewallMap implements FirewallMapInterface
 {

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -28,6 +28,7 @@ use Symfony\Component\BrowserKit\Client;
  * you need to also implement the getScript() method.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/testing.html#browsing
  *
  * @api
  */

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -54,6 +54,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @link   http://symfony.com/doc/2.0/book/service_container.html#what-is-a-service-container
  */
 class Container implements ContainerInterface
 {

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -17,6 +17,7 @@ use Symfony\Component\CssSelector\Parser as CssParser;
  * Crawler eases navigation of a list of \DOMNode objects.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/testing.html#the-crawler
  *
  * @api
  */

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -30,13 +30,13 @@ namespace Symfony\Component\EventDispatcher;
  * further listeners in your event listener.
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
  * @since   2.0
  * @version $Revision: 3938 $
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  * @author  Bernhard Schussek <bschussek@gmail.com>
+ * @link    http://symfony.com/doc/2.0/book/internals/event_dispatcher.html#events
  */
 class Event
 {

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -27,7 +27,6 @@ namespace Symfony\Component\EventDispatcher;
  * manager.
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
  * @since   2.0
  * @version $Revision: 3938 $
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
@@ -35,6 +34,7 @@ namespace Symfony\Component\EventDispatcher;
  * @author  Roman Borschel <roman@code-factory.org>
  * @author  Bernhard Schussek <bschussek@gmail.com>
  * @author  Fabien Potencier <fabien@symfony.com>
+ * @link    http://symfony.com/doc/2.0/book/internals/event_dispatcher.html#the-dispatcher
  *
  * @api
  */

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -27,12 +27,12 @@ namespace Symfony\Component\EventDispatcher;
  * returned events.
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
  * @since   2.0
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  * @author  Bernhard Schussek <bschussek@gmail.com>
+ * @link    http://symfony.com/doc/2.0/book/internals/event_dispatcher.html#using-event-subscribers
  */
 interface EventSubscriberInterface
 {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpFoundation\SessionStorage\NativeSessionStorage;
  * Request represents an HTTP request.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/controller.html#the-request-object
  */
 class Request
 {

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\HttpFoundation;
  * Response represents an HTTP response.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/controller.html#the-response-object
  */
 class Response
 {

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -22,6 +22,7 @@ use Symfony\Component\Finder\Finder;
  * for DependencyInjection extensions and Console commands.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/bundles.html
  */
 abstract class Bundle extends ContainerAware implements BundleInterface
 {

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  * A Controller can be any valid PHP callable.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/internals/kernel.html#controllers
  */
 interface ControllerResolverInterface
 {

--- a/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/KernelEvent.php
@@ -19,6 +19,7 @@ use Symfony\Component\EventDispatcher\Event;
  * Base class for events thrown in the HttpKernel component
  *
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/internals/kernel.html#events
  */
 class KernelEvent extends Event
 {

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -26,6 +26,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * HttpKernel notifies events to convert a Request object to a Response one.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/internals/kernel.html
  */
 class HttpKernel implements HttpKernelInterface
 {

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\Response;
  * HttpKernelInterface handles a Request to convert it to a Response.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/internals/kernel.html
  */
 interface HttpKernelInterface
 {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
  * Profiler.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/internals/profiler.html
  */
 class Profiler
 {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -19,6 +19,7 @@ use Symfony\Component\Config\ConfigCache;
  * routing system for easier use.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/routing.html
  */
 class Router implements RouterInterface
 {

--- a/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Security\Core\Encoder;
  * PasswordEncoderInterface is the interface for all encoders.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/security/users.html#encoding-passwords
  */
 interface PasswordEncoderInterface
 {

--- a/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Security\Core\User;
  * AdvancedUserInterface adds status flags to a regular account.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/security/users.html#advanceduserinterface
  */
 interface AdvancedUserInterface extends UserInterface
 {

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Security\Core\User;
  * UserInterface is the interface that user classes must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/security/users.html#userinterface
  */
 interface UserInterface
 {

--- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -16,6 +16,7 @@ namespace Symfony\Component\Security\Core\User;
  * implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/security/users.html#userproviderinterface
  */
 interface UserProviderInterface
 {

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Validator;
 
 /**
  * Represents a single violation of a constraint.
+ *
+ * @link http://symfony.com/doc/2.0/book/validation.html
  */
 class ConstraintViolation
 {

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Validator;
 
 /**
  * An array-acting object that holds many ConstrainViolation instances.
+ *
+ * @link http://symfony.com/doc/2.0/book/validation.html
  */
 class ConstraintViolationList implements \IteratorAggregate, \Countable, \ArrayAccess
 {

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -23,6 +23,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @link   http://symfony.com/doc/2.0/book/validation.html#using-the-validator-service
  */
 class Validator implements ValidatorInterface
 {


### PR DESCRIPTION
For those digging through code, links in the docblock to extensive documentation about the chapters provides a _huge_ amount of value.

I've added links to symfony2 documentation for classes with chapters or subchapters about them.  I only added links for classes that

  1) Have extensive documentation at the URL and
  2) Were referenced in the documentation itself

I would like to eventually add @link tags for Form Types, Constraints, etc, once the documentation is ready.
