### PR TITLE
[LICENSE, README.md, etc] wrapped text to fit the 80 char. width

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,18 @@
 Copyright (c) 2004-2011 Fabien Potencier
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is furnished
-to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Symfony2 is a PHP 5.3 full-stack web framework. It is written with speed and
 flexibility in mind. It allows developers to built better and easy to maintain
 websites with PHP.
 
-Symfony can be used to develop all kind of websites, from your personal blog
-to high traffic ones like Dailymotion or Yahoo! Answers.
+Symfony can be used to develop all kind of websites, from your personal blog to
+high traffic ones like Dailymotion or Yahoo! Answers.
 
 High Performance
 ----------------
 
 Built with performance in mind, Symfony2 is one of the fastest PHP frameworks.
-It is up to 3 times faster than symfony 1.4 or Zend Framework 1.10 and
-consumes half the memory.
+It is up to 3 times faster than symfony 1.4 or Zend Framework 1.10 and consumes
+half the memory.
 
 Requirements
 ------------
@@ -30,9 +30,9 @@ Symfony 2.0 is still in the early stages of development, but the
 "[Quick Tour][1]" tutorial can get you started fast.
 
 The "Quick Tour" tutorial barely scratches the surface of Symfony 2.0, but it
-gives you a first feeling of the framework. If, like us, you think that
-Symfony2 can help speed up your development and take the quality of your work
-to the next level, visit the official [Symfony2 website][2] to learn more.
+gives you a first feeling of the framework. If, like us, you think that Symfony2
+can help speed up your development and take the quality of your work to the next
+level, visit the official [Symfony2 website][2] to learn more.
 
 [1]: http://symfony.com/get_started
 [2]: http://symfony.com/

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -2,8 +2,8 @@ How to update your project?
 ===========================
 
 This document explains how to upgrade from one Symfony2 PR version to the next
-one. It only discusses changes that need to be done when using the "public"
-API of the framework. If you "hack" the core, you should probably follow the
+one. It only discusses changes that need to be done when using the "public" API
+of the framework. If you "hack" the core, you should probably follow the
 timeline closely anyway.
 
 PR12 to beta1
@@ -31,13 +31,13 @@ PR12 to beta1
   * The `class` option has been removed (use the `session.class` parameter
     instead);
 
-  * The PDO session storage configuration has been removed (a cookbook recipe
-    is in the work);
+  * The PDO session storage configuration has been removed (a cookbook recipe is
+    in the work);
 
   * The `storage_id` option now takes a service id instead of just part of it.
 
-* The `DoctrineMigrationsBundle` and `DoctrineFixturesBundle` bundles have
-  been moved to their own repositories.
+* The `DoctrineMigrationsBundle` and `DoctrineFixturesBundle` bundles have been
+  moved to their own repositories.
 
 * The form framework has been refactored extensively (more information in the
   documentation).
@@ -52,9 +52,9 @@ PR12 to beta1
     {% trans %}foo{% endtrans %}
     {{ foo|trans }}
 
-  This has been done to clarify the usage of the tag and filter and also to
-  make it clearer when the automatic output escaping rules are applied (see
-  the doc for more information).
+  This has been done to clarify the usage of the tag and filter and also to make
+  it clearer when the automatic output escaping rules are applied (see the doc
+  for more information).
 
 * Some methods in the DependencyInjection component's ContainerBuilder and
   Definition classes have been renamed to be more specific and consistent:
@@ -92,9 +92,9 @@ PR11 to PR12
         <app:engine>twig</app:engine>
         <twig:extension>twig.extension.debug</twig:extension>
 
-* Fixes a critical security issue which allowed all users to switch to 
-  arbitrary accounts when the SwitchUserListener was activated. Configurations
-  which do not use the SwitchUserListener are not affected.
+* Fixes a critical security issue which allowed all users to switch to arbitrary
+  accounts when the SwitchUserListener was activated. Configurations which do
+  not use the SwitchUserListener are not affected.
 
 * The Dependency Injection Container now strongly validates the references of 
   all your services at the end of its compilation process. If you have invalid


### PR DESCRIPTION
Just some cosmetic changes as I've done with documentation PR https://github.com/symfony/symfony-docs/pull/242 and symfony standard https://github.com/symfony/symfony-standard/pull/60
