### PR TITLE
[Form] Form should not swallow TransformationFailedException.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -55,6 +55,7 @@ class FieldType extends AbstractType
 
     public function buildView(FormView $view, FormInterface $form)
     {
+        $formName = $form->getName();
         if ($view->hasParent()) {
             $parentId = $view->getParent()->get('id');
             $parentName = $view->getParent()->get('name');
@@ -67,6 +68,7 @@ class FieldType extends AbstractType
 
         $view->set('form', $view);
         $view->set('id', $id);
+        $view->set('form_name', $formName);
         $view->set('name', $name);
         $view->set('errors', $form->getErrors());
         $view->set('value', $form->getClientData());

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -464,6 +464,7 @@ class Form implements \IteratorAggregate, FormInterface
             $normData = $this->clientToNorm($clientData);
             $synchronized = true;
         } catch (TransformationFailedException $e) {
+        	throw $e;
         }
 
         if ($synchronized) {


### PR DESCRIPTION
1. Added useful information to form view - original child form name (before the concatenation with parent ids).
2. Form needs to throw exception when Transform fails. (or log the exception)

Example: add date type to form, set date_default_timezone_set('America/Pacific'), DateTimeToArrayTransformer will fail at new \DateTime() - line 148. 
- Maybe a better way to handle this is 
  1. call addError(), so that developer can figure out what went wrong. Right now, DefaultValidator will return "The value is invalid".
  2. DateTimeToArrayTransformer should check the $outputTimezone to see if it valid first before using it blindly.

TransformationFailedException() exceptions are thrown with a lot of information and 
