### PR TITLE
[translations] Moved the application translations directory under Resources

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -44,6 +44,17 @@ beta1 to beta2
     Before: array('default', 'foo')
     After:  array('default' => 'doctrine.orm.default_entity_manager', 'foo' => 'doctrine.orm.foo_entity_manager'))
 
+* Application translation are now in the `Resources` folder:
+
+    Before:
+
+      app/translations/catalogue.fr.xml
+
+    After:
+ 
+      app/Resources/translations/catalogue.fr.xml
+
+
 PR12 to beta1
 -------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -440,7 +440,7 @@ class FrameworkExtension extends Extension
                     $dirs[] = $dir;
                 }
             }
-            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/translations')) {
+            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/translations')) {
                 $dirs[] = $dir;
             }
 


### PR DESCRIPTION
I propose to move the application "translations" directory under Resources to be consistent with bundles
