### PR TITLE
[HttpFoundation] Sanitize uploaded file original name

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -82,7 +82,7 @@ class UploadedFile extends File
         }
 
         $this->path = realpath($path);
-        $this->originalName = $originalName;
+        $this->originalName = basename($originalName);
         $this->mimeType = $mimeType ?: 'application/octet-stream';
         $this->size = $size;
         $this->error = $error ?: UPLOAD_ERR_OK;

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
@@ -77,6 +77,19 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             null
         );
 
-        $this->assertEquals('test.gif', $file->getName());
+        $this->assertEquals('original.gif', $file->getOriginalName());
     }
+    
+    public function testGetOriginalNameSanitizeFilename()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            '../../original.gif',
+            'image/gif',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null
+        );
+
+        $this->assertEquals('original.gif', $file->getOriginalName());
+    }    
 }


### PR DESCRIPTION
@fabpot could you please re-consider this ?

It has been [closed once](https://github.com/symfony/symfony/pull/666)

**HOWEVER**

It is true that it does not make the situation perfect but invalid chars would cause an exception while not using `basename()` could be a security issue (i.e. replacing a system file, altering or adding a file in the web folder).

And adding a comment on the method [is not always enough](https://github.com/symfony/symfony-docs/pull/245)
