### PR TITLE
[Routing] added setContext to RouterInterfaces as it is used on RouterInterface instance

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\Routing\Generator;
 
+use Symfony\Component\Routing\RequestContextAwareInterface;
+
 /**
  * UrlGeneratorInterface is the interface that all URL generator classes must implements.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface UrlGeneratorInterface
+interface UrlGeneratorInterface extends RequestContextAwareInterface
 {
     /**
      * Generates a URL from the given parameters.

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
@@ -11,12 +11,14 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\Routing\RequestContextAwareInterface;
+
 /**
  * UrlMatcherInterface is the interface that all URL matcher classes must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface UrlMatcherInterface
+interface UrlMatcherInterface extends RequestContextAwareInterface
 {
     /**
      * Tries to match a URL with a set of routes.

--- a/src/Symfony/Component/Routing/RequestContextAwareInterface.php
+++ b/src/Symfony/Component/Routing/RequestContextAwareInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing;
+
+interface RequestContextAwareInterface
+{
+    /**
+     * Sets the request context.
+     *
+     * @param RequestContext $context The context
+     */
+    function setContext(RequestContext $context);
+}


### PR DESCRIPTION
e.g. the RequestListener calls ->setContext on its RouterInterface instance. 

It's also called on the UrlMatcherInterface and UrlGeneratorInterface inside the Router class, so needed to introduce a new interface because of the way the interfaces converge
