### PR TITLE
ESI service public

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
@@ -10,7 +10,7 @@
     </parameters>
 
     <services>
-        <service id="esi" class="%esi.class%" public="false" />
+        <service id="esi" class="%esi.class%" />
 
         <service id="esi_listener" class="%esi_listener.class%">
           <tag name="kernel.listener" event="onCoreResponse" />


### PR DESCRIPTION
ESI was not working because the service definition was private but it is used in HttpKernel with $this->container->get('esi')
