### PR TITLE
Add move file upload listener

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MoveFileUploadListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MoveFileUploadListener.php
@@ -20,6 +20,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 /**
  * Moves uploaded files to a permanent location
  *
+ * @author Bernhard Schussek <bernhard.schussek@symfony-project.com>
  * @author Brent Shaffer <bshafs@gmail.com>
  */
 class MoveFileUploadListener implements EventSubscriberInterface

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MoveFileUploadListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MoveFileUploadListener.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\Form\Events;
+use Symfony\Component\Form\Event\FilterDataEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * Moves uploaded files to a permanent location
+ *
+ * @author Brent Shaffer <bshafs@gmail.com>
+ */
+class MoveFileUploadListener implements EventSubscriberInterface
+{
+    protected $path;
+
+    public function __construct($path)
+    {
+        $this->path = $path;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return Events::onBindClientData;
+    }
+
+    public function onBindClientData(FilterDataEvent $event)
+    {
+        $data = $event->getData();
+
+        // TODO should be disableable
+
+        // TESTME
+        $data = array_merge(array(
+            'file' => '',
+            'token' => '',
+            'name' => '',
+        ), $event->getData());
+
+        // Newly uploaded file
+        if ($data['file'] instanceof UploadedFile && $data['file']->isValid()) {
+            $data['name'] = $data['file']->getName().$data['file']->getExtension();
+            $data['file']->move($this->path, $data['name']);
+        }
+
+        // Existing uploaded file
+        if (!$data['file'] && $data['name']) {
+            $path = $this->path . DIRECTORY_SEPARATOR . $data ['name'];
+
+            if (file_exists($path)) {
+                $data['file'] = new File($path);
+            }
+        }
+
+        // Clear other fields if we still don't have a file, but keep
+        // possible existing files of the field
+        if (!$data['file']) {
+            $data = $form->getNormData();
+        }
+
+        $event->setData($data);
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Extension\Core\EventListener\FixFileUploadListener;
+use Symfony\Component\Form\Extension\Core\EventListener\MoveFileUploadListener;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DataTransformerChain;
 use Symfony\Component\Form\ReversedTransformer;
 use Symfony\Component\Form\Extension\Core\DataTransformer\FileToStringTransformer;
@@ -40,9 +41,16 @@ class FileType extends AbstractType
             );
         }
 
+        if (is_null($options['path'])) {
+          // Temporary storage if path is null
+          $subscriber = new FixFileUploadListener($this->storage);
+        } else {
+          $subscriber = new MoveFileUploadListener($options['path']);
+        }
+
         $builder
             ->appendNormTransformer(new FileToArrayTransformer())
-            ->addEventSubscriber(new FixFileUploadListener($this->storage), 10)
+            ->addEventSubscriber($subscriber, 10)
             ->add('file', 'field')
             ->add('token', 'hidden')
             ->add('name', 'hidden');
@@ -57,6 +65,7 @@ class FileType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         return array(
+            'path' => null,
             'type' => 'string',
             'csrf_protection' => false,
         );


### PR DESCRIPTION
In a [Pull request in the symfony-docs repository](https://github.com/symfony/symfony-docs/pull/245), Fabien suggested introducing the "path" option to `FileType`, since almost everyone will want this feature.  In short, this pull request does the following:
- adds a `path` option to `FileType`: an absolute path to move the uploaded file.
- the filename is hashed and the extension retained (similar to symfony1)

The extension being retained was a decision I made because every user will want to keep the file's extension.  Preventing harmful file injection is a matter of declaring the right Contraints... something that can be covered in documentation or the cookbook.

Let me explain how I decided to implement this change.  After much deliberation, I have added a new listener, MoveFileUploadField, to compliment the existing FixFileUploadField class.  These have to be separate, as the logic for temporary storage was very specific, and would be difficult to adhere to an interface.

I would prefer to have FileType accept a FileStorage interface object, which could take care of storing the file in a temporary or permanent location.  This seems most logical. However, with the current type hinting in FileType, and with the current logic in FixUploadFileListener, this would require a lot of changes, and I'm fairly sure my pull request wouldn't be accepted.

I hope everyone sees this to be a useful solution!  Let me know your thoughts. 
