### PR TITLE
[DoctrineBundle] introduced a Registry class

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -9,6 +9,26 @@ timeline closely anyway.
 beta1 to beta2
 --------------
 
+* With the introduction of a new Doctrine Registry class, the following
+  parameters have been removed (replaced by methods on the `doctrine.registry`
+  service):
+
+   * doctrine.orm.entity_managers
+   * doctrine.orm.default_entity_manager
+   * doctrine.dbal.default_connection
+
+  Before:
+
+        $container->getParameter('doctrine.orm.entity_managers')
+        $container->getParameter('doctrine.orm.default_entity_manager')
+        $container->getParameter('doctrine.orm.default_connection')
+
+  After:
+
+        $container->get('doctrine.registry')->getEntityManagerNames()
+        $container->get('doctrine.registry')->getDefaultEntityManagerName()
+        $container->get('doctrine.registry')->getDefaultConnectionName()
+
 * Doctrine event subscribers now use a unique "doctrine.event_subscriber" tag.
   Doctrine event listeners also use a unique "doctrine.event_listener" tag. To
   specify a connection, use the optional "connection" attribute.
@@ -38,11 +58,6 @@ beta1 to beta2
             tags:
                 - { name: doctrine.event_subscriber }                      # register for all connections
                 - { name: doctrine.event_subscriber, connection: default } # only for the default connection
-
-* The `doctrine.orm.entity_managers` is now hash of entity manager names/ids pairs:
-
-    Before: array('default', 'foo')
-    After:  array('default' => 'doctrine.orm.default_entity_manager', 'foo' => 'doctrine.orm.foo_entity_manager'))
 
 * Application translations are now stored in the `Resources` directory:
 

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -10,7 +10,7 @@ beta1 to beta2
 --------------
 
 * With the introduction of a new Doctrine Registry class, the following
-  parameters have been removed (replaced by methods on the `doctrine.registry`
+  parameters have been removed (replaced by methods on the `doctrine`
   service):
 
    * doctrine.orm.entity_managers
@@ -25,9 +25,22 @@ beta1 to beta2
 
   After:
 
-        $container->get('doctrine.registry')->getEntityManagerNames()
-        $container->get('doctrine.registry')->getDefaultEntityManagerName()
-        $container->get('doctrine.registry')->getDefaultConnectionName()
+        $container->get('doctrine')->getEntityManagerNames()
+        $container->get('doctrine')->getDefaultEntityManagerName()
+        $container->get('doctrine')->getDefaultConnectionName()
+
+  But you don't really need to use these methods anymore, as to get an entity
+  manager, you can now use the registry directly:
+
+  Before:
+
+        $em = $this->get('doctrine.orm.entity_manager');
+        $em = $this->get('doctrine.orm.foobar_entity_manager');
+
+  After:
+
+        $em = $this->get('doctrine')->getEntityManager();
+        $em = $this->get('doctrine')->getEntityManager('foobar');
 
 * Doctrine event subscribers now use a unique "doctrine.event_subscriber" tag.
   Doctrine event listeners also use a unique "doctrine.event_listener" tag. To

--- a/src/Symfony/Bundle/DoctrineBundle/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bundle/DoctrineBundle/CacheWarmer/ProxyCacheWarmer.php
@@ -64,7 +64,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
             return;
         }
 
-        foreach ($this->container->getParameter('doctrine.orm.entity_managers') as $id) {
+        foreach ($this->container->get('doctrine.registry')->getEntityManagerNames() as $id) {
             $em = $this->container->get($id);
             $classes = $em->getMetadataFactory()->getAllMetadata();
             $em->getProxyFactory()->generateProxyClasses($classes);

--- a/src/Symfony/Bundle/DoctrineBundle/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bundle/DoctrineBundle/CacheWarmer/ProxyCacheWarmer.php
@@ -64,7 +64,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
             return;
         }
 
-        foreach ($this->container->get('doctrine.registry')->getEntityManagerNames() as $id) {
+        foreach ($this->container->get('doctrine')->getEntityManagerNames() as $id) {
             $em = $this->container->get($id);
             $classes = $em->getMetadataFactory()->getAllMetadata();
             $em->getProxyFactory()->generateProxyClasses($classes);

--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -42,7 +42,7 @@ abstract class DoctrineCommand extends Command
 
     protected function getEntityManager($name)
     {
-        return $this->container->get('doctrine.registry')->getEntityManager($name);
+        return $this->container->get('doctrine')->getEntityManager($name);
     }
 
     /**
@@ -53,14 +53,14 @@ abstract class DoctrineCommand extends Command
      */
     protected function getDoctrineConnection($name)
     {
-        return $this->container->get('doctrine.registry')->getConnection($name);
+        return $this->container->get('doctrine')->getConnection($name);
     }
 
     protected function getBundleMetadatas(Bundle $bundle)
     {
         $namespace = $bundle->getNamespace();
         $bundleMetadatas = array();
-        foreach ($this->container->get('doctrine.registry')->getEntityManagerNames() as $id) {
+        foreach ($this->container->get('doctrine')->getEntityManagerNames() as $id) {
             $em = $this->container->get($id);
             $cmf = new DisconnectedClassMetadataFactory();
             $cmf->setEntityManager($em);

--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -42,14 +42,7 @@ abstract class DoctrineCommand extends Command
 
     protected function getEntityManager($name)
     {
-        $name = $name ?: $this->container->getParameter('doctrine.orm.default_entity_manager');
-
-        $ems = $this->container->getParameter('doctrine.orm.entity_managers');
-        if (!isset($ems[$name])) {
-            throw new \InvalidArgumentException(sprintf('Could not find Doctrine EntityManager named "%s"', $name));
-        }
-
-        return $this->container->get($ems[$name]);
+        return $this->container->get('doctrine.registry')->getEntityManager($name);
     }
 
     /**
@@ -60,21 +53,14 @@ abstract class DoctrineCommand extends Command
      */
     protected function getDoctrineConnection($name)
     {
-        $name = $name ?: $this->container->getParameter('doctrine.dbal.default_connection');
-
-        $connections = $this->container->getParameter('doctrine.dbal.connections');
-        if (!isset($connections[$name])) {
-            throw new \InvalidArgumentException(sprintf('<error>Could not find a connection named <comment>%s</comment></error>', $name));
-        }
-
-        return $this->container->get($connections[$name]);
+        return $this->container->get('doctrine.registry')->getConnection($name);
     }
 
     protected function getBundleMetadatas(Bundle $bundle)
     {
         $namespace = $bundle->getNamespace();
         $bundleMetadatas = array();
-        foreach ($this->container->getParameter('doctrine.orm.entity_managers') as $id) {
+        foreach ($this->container->get('doctrine.registry')->getEntityManagerNames() as $id) {
             $em = $this->container->get($id);
             $cmf = new DisconnectedClassMetadataFactory();
             $cmf->setEntityManager($em);

--- a/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
@@ -46,7 +46,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $entityManagerName = $input->getOption('em') ? $input->getOption('em') : $this->container->getParameter('doctrine.orm.default_entity_manager');
+        $entityManagerName = $input->getOption('em') ? $input->getOption('em') : $this->container->get('doctrine.registry')->getDefaultEntityManagerName();
 
         /* @var $entityManager Doctrine\ORM\EntityManager */
         $entityManager = $this->getEntityManager($input->getOption('em'));

--- a/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
@@ -46,7 +46,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $entityManagerName = $input->getOption('em') ? $input->getOption('em') : $this->container->get('doctrine.registry')->getDefaultEntityManagerName();
+        $entityManagerName = $input->getOption('em') ? $input->getOption('em') : $this->container->get('doctrine')->getDefaultEntityManagerName();
 
         /* @var $entityManager Doctrine\ORM\EntityManager */
         $entityManager = $this->getEntityManager($input->getOption('em'));

--- a/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DoctrineCommandHelper.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DoctrineCommandHelper.php
@@ -30,7 +30,7 @@ abstract class DoctrineCommandHelper
      */
     static public function setApplicationEntityManager(Application $application, $emName)
     {
-        $em = self::getEntityManager($application, $emName);
+        $em = $application->getKernel()->getContainer()->get('doctrine.registry')->getEntityManager($name);
         $helperSet = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
         $helperSet->set(new EntityManagerHelper($em), 'em');
@@ -38,42 +38,8 @@ abstract class DoctrineCommandHelper
 
     static public function setApplicationConnection(Application $application, $connName)
     {
-        $connection = self::getDoctrineConnection($application, $connName);
+        $connection = $application->getKernel()->getContainer()->get('doctrine.registry')->getConnection($name);
         $helperSet = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($connection), 'db');
-    }
-
-    static protected function getEntityManager(Application $application, $name)
-    {
-        $container = $application->getKernel()->getContainer();
-
-        $name = $name ?: $container->getParameter('doctrine.orm.default_entity_manager');
-
-        $ems = $container->getParameter('doctrine.orm.entity_managers');
-        if (!isset($ems[$name])) {
-            throw new \InvalidArgumentException(sprintf('Could not find Doctrine EntityManager named "%s"', $name));
-        }
-
-        return $container->get($ems[$name]);
-    }
-
-    /**
-     * Get a doctrine dbal connection by symfony name.
-     *
-     * @param string $name
-     * @return Doctrine\DBAL\Connection
-     */
-    static protected function getDoctrineConnection(Application $application, $name)
-    {
-        $container = $application->getKernel()->getContainer();
-
-        $name = $name ?: $container->getParameter('doctrine.dbal.default_connection');
-
-        $connections = $container->getParameter('doctrine.dbal.connections');
-        if (!isset($connections[$name])) {
-            throw new \InvalidArgumentException(sprintf('<error>Could not find a connection named <comment>%s</comment></error>', $name));
-        }
-
-        return $container->get($connections[$name]);
     }
 }

--- a/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DoctrineCommandHelper.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DoctrineCommandHelper.php
@@ -30,7 +30,7 @@ abstract class DoctrineCommandHelper
      */
     static public function setApplicationEntityManager(Application $application, $emName)
     {
-        $em = $application->getKernel()->getContainer()->get('doctrine.registry')->getEntityManager($name);
+        $em = $application->getKernel()->getContainer()->get('doctrine')->getEntityManager($name);
         $helperSet = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
         $helperSet->set(new EntityManagerHelper($em), 'em');
@@ -38,7 +38,7 @@ abstract class DoctrineCommandHelper
 
     static public function setApplicationConnection(Application $application, $connName)
     {
-        $connection = $application->getKernel()->getContainer()->get('doctrine.registry')->getConnection($name);
+        $connection = $application->getKernel()->getContainer()->get('doctrine')->getConnection($name);
         $helperSet = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($connection), 'db');
     }

--- a/src/Symfony/Bundle/DoctrineBundle/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DataCollector/DoctrineDataCollector.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\DoctrineBundle\Logger\DbalLogger;
+use Symfony\Bundle\DoctrineBundle\Registry;
 
 /**
  * DoctrineDataCollector.
@@ -27,10 +28,10 @@ class DoctrineDataCollector extends DataCollector
     private $managers;
     private $logger;
 
-    public function __construct($connections, $managers, DbalLogger $logger = null)
+    public function __construct(Registry $registry, DbalLogger $logger = null)
     {
-        $this->connections = $connections;
-        $this->managers = $managers;
+        $this->connections = $registry->getConnectionNames();
+        $this->managers = $registry->getEntityManagerNames();
         $this->logger = $logger;
     }
 

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -16,7 +16,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $this->container = $container;
-        $this->connections = $container->getParameter('doctrine.dbal.connections');
+        $this->connections = $container->getDefinition('doctrine.registry')->getArgument(1);
 
         foreach ($container->findTaggedServiceIds('doctrine.event_subscriber') as $subscriberId => $instances) {
             $this->registerSubscriber($subscriberId, $instances);

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -16,7 +16,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $this->container = $container;
-        $this->connections = $container->getDefinition('doctrine.registry')->getArgument(1);
+        $this->connections = $container->getDefinition('doctrine')->getArgument(1);
 
         foreach ($container->findTaggedServiceIds('doctrine.event_subscriber') as $subscriberId => $instances) {
             $this->registerSubscriber($subscriberId, $instances);

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -67,7 +67,6 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $container->setAlias('database_connection', sprintf('doctrine.dbal.%s_connection', $config['default_connection']));
         $container->setAlias('doctrine.dbal.event_manager', new Alias(sprintf('doctrine.dbal.%s_connection.event_manager', $config['default_connection']), false));
-        $container->setParameter('doctrine.dbal.default_connection', $config['default_connection']);
 
         $container->getDefinition('doctrine.dbal.connection_factory')->replaceArgument(0, $config['types']);
 
@@ -75,7 +74,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
         foreach (array_keys($config['connections']) as $name) {
             $connections[$name] = sprintf('doctrine.dbal.%s_connection', $name);
         }
-        $container->setParameter('doctrine.dbal.connections', $connections);
+        $container->getDefinition('doctrine.registry')->replaceArgument(1, $connections);
+        $container->getDefinition('doctrine.registry')->replaceArgument(3, $config['default_connection']);
 
         foreach ($config['connections'] as $name => $connection) {
             $this->loadDbalConnection($name, $connection, $container);
@@ -148,18 +148,19 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('orm.xml');
 
-        $entityManagers = array();
+        $this->entityManagers = array();
         foreach (array_keys($config['entity_managers']) as $name) {
-            $entityManagers[$name] = sprintf('doctrine.orm.%s_entity_manager', $name);
+            $this->entityManagers[$name] = sprintf('doctrine.orm.%s_entity_manager', $name);
         }
-        $container->setParameter('doctrine.orm.entity_managers', $entityManagers);
+        $container->getDefinition('doctrine.registry')->replaceArgument(2, $this->entityManagers);
 
         if (empty($config['default_entity_manager'])) {
-            $tmp = array_keys($entityManagers);
+            $tmp = array_keys($this->entityManagers);
             $config['default_entity_manager'] = reset($tmp);
         }
+        $container->getDefinition('doctrine.registry')->replaceArgument(4, $config['default_entity_manager']);
 
-        $options = array('default_entity_manager', 'auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
+        $options = array('auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
         foreach ($options as $key) {
             $container->setParameter('doctrine.orm.'.$key, $config[$key]);
         }
@@ -180,7 +181,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
      */
     protected function loadOrmEntityManager(array $entityManager, ContainerBuilder $container)
     {
-        if ($entityManager['auto_mapping'] && count($container->getParameter('doctrine.orm.entity_managers')) > 1) {
+        if ($entityManager['auto_mapping'] && count($this->entityManagers) > 1) {
             throw new \LogicException('You cannot enable "auto_mapping" when several entity managers are defined.');
         }
 
@@ -227,9 +228,12 @@ class DoctrineExtension extends AbstractDoctrineExtension
             new Reference($connectionId),
             new Reference(sprintf('doctrine.orm.%s_configuration', $entityManager['name']))
         );
+
         $ormEmDef = new Definition('%doctrine.orm.entity_manager.class%', $ormEmArgs);
         $ormEmDef->setFactoryClass('%doctrine.orm.entity_manager.class%');
         $ormEmDef->setFactoryMethod('create');
+        $ormEmDef->addMethodCall('setRegistry', array(new Reference('doctrine.registry')));
+        $ormEmDef->addMethodCall('setName', array($entityManager['name']));
         $container->setDefinition($entityManagerService, $ormEmDef);
 
         $container->setAlias(

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -74,8 +74,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
         foreach (array_keys($config['connections']) as $name) {
             $connections[$name] = sprintf('doctrine.dbal.%s_connection', $name);
         }
-        $container->getDefinition('doctrine.registry')->replaceArgument(1, $connections);
-        $container->getDefinition('doctrine.registry')->replaceArgument(3, $config['default_connection']);
+        $container->getDefinition('doctrine')->replaceArgument(1, $connections);
+        $container->getDefinition('doctrine')->replaceArgument(3, $config['default_connection']);
 
         foreach ($config['connections'] as $name => $connection) {
             $this->loadDbalConnection($name, $connection, $container);
@@ -152,13 +152,13 @@ class DoctrineExtension extends AbstractDoctrineExtension
         foreach (array_keys($config['entity_managers']) as $name) {
             $this->entityManagers[$name] = sprintf('doctrine.orm.%s_entity_manager', $name);
         }
-        $container->getDefinition('doctrine.registry')->replaceArgument(2, $this->entityManagers);
+        $container->getDefinition('doctrine')->replaceArgument(2, $this->entityManagers);
 
         if (empty($config['default_entity_manager'])) {
             $tmp = array_keys($this->entityManagers);
             $config['default_entity_manager'] = reset($tmp);
         }
-        $container->getDefinition('doctrine.registry')->replaceArgument(4, $config['default_entity_manager']);
+        $container->getDefinition('doctrine')->replaceArgument(4, $config['default_entity_manager']);
 
         $options = array('auto_generate_proxy_classes', 'proxy_dir', 'proxy_namespace');
         foreach ($options as $key) {
@@ -232,7 +232,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $ormEmDef = new Definition('%doctrine.orm.entity_manager.class%', $ormEmArgs);
         $ormEmDef->setFactoryClass('%doctrine.orm.entity_manager.class%');
         $ormEmDef->setFactoryMethod('create');
-        $ormEmDef->addMethodCall('setRegistry', array(new Reference('doctrine.registry')));
+        $ormEmDef->addMethodCall('setRegistry', array(new Reference('doctrine')));
         $ormEmDef->addMethodCall('setName', array($entityManager['name']));
         $container->setDefinition($entityManagerService, $ormEmDef);
 

--- a/src/Symfony/Bundle/DoctrineBundle/EntityManager.php
+++ b/src/Symfony/Bundle/DoctrineBundle/EntityManager.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineBundle;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager as BaseEntityManager;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Configuration;
+use Doctrine\Common\EventManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Doctrine Entity Manager that knows how to reload itself.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class EntityManager extends BaseEntityManager
+{
+    private $name;
+    private $registry;
+
+    /**
+     * Sets the registry under which this entity manager is known.
+     *
+     * @param Registry $registry
+     */
+    public function setRegistry(Registry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * Sets the name under which the entity manager is known by the registry.
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns a new (aka reloaded) entity manager for the current one.
+     *
+     * This method also replaces the entity manager.
+     */
+    public function reload()
+    {
+        $this->close();
+
+        return $this->registry->reloadEntityManager(isset($this->name) ? $this->name : $this);
+    }
+
+    // should be removed if https://github.com/doctrine/doctrine2/pull/51 is merged upstream
+    public static function create($conn, Configuration $config, EventManager $eventManager = null)
+    {
+        if (!$config->getMetadataDriverImpl()) {
+            throw ORMException::missingMappingDriverImpl();
+        }
+
+        if (is_array($conn)) {
+            $conn = \Doctrine\DBAL\DriverManager::getConnection($conn, $config, ($eventManager ?: new EventManager()));
+        } else if ($conn instanceof Connection) {
+            if ($eventManager !== null && $conn->getEventManager() !== $eventManager) {
+                 throw ORMException::mismatchedEventManager();
+            }
+        } else {
+            throw new \InvalidArgumentException("Invalid argument: " . $conn);
+        }
+
+        return new static($conn, $config, $conn->getEventManager());
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bundle\DoctrineBundle;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Doctrine\DBAL\Connection;
 
 /**
  * References all Doctrine connections and entity managers in a given Container.
@@ -43,11 +44,23 @@ class Registry
         $this->defaultEntityManager = $defaultEntityManager;
     }
 
+    /**
+     * Gets the default connection name.
+     *
+     * @return string The default connection name
+     */
     public function getDefaultConnectionName()
     {
         return $this->defaultConnection;
     }
 
+    /**
+     * Gets the named connection.
+     *
+     * @param string $name The connection name (null for the default one)
+     *
+     * @return Connection
+     */
     public function getConnection($name = null)
     {
         if (null === $name) {
@@ -61,17 +74,34 @@ class Registry
         return $this->container->get($this->connections[$name]);
     }
 
+    /**
+     * Gets all connection names.
+     *
+     * @return array An array of connection names
+     */
     public function getConnectionNames()
     {
         return $this->connections;
     }
 
+    /**
+     * Gets the default entity manager name.
+     *
+     * @return string The default entity manager name
+     */
     public function getDefaultEntityManagerName()
     {
         return $this->defaultEntityManager;
     }
 
-    public function getEntityManager($name)
+    /**
+     * Gets the named entity manager.
+     *
+     * @param string $name The entity manager name (null for the default one)
+     *
+     * @return EntityManager
+     */
+    public function getEntityManager($name = null)
     {
         if (null === $name) {
             return $this->container->get($this->entityManagers[$this->defaultEntityManager]);
@@ -84,13 +114,24 @@ class Registry
         return $this->container->get($this->entityManagers[$name]);
     }
 
+    /**
+     * Gets all connection names.
+     *
+     * @return array An array of connection names
+     */
     public function getEntityManagerNames()
     {
         return $this->entityManagers;
     }
 
     /**
+     * Reloads an entity manager.
+     *
+     * Useful when you need to close an entity manager (when doing a rollback for instance).
+     *
      * @param string|EntityManager
+     *
+     * @return EntityManager
      */
     public function reloadEntityManager($name)
     {

--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineBundle;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * References all Doctrine connections and entity managers in a given Container.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Registry
+{
+    private $container;
+    private $connections;
+    private $entityManagers;
+    private $defaultConnection;
+    private $defaultEntityManager;
+
+    public function __construct(ContainerInterface $container, array $connections, array $entityManagers, $defaultConnection, $defaultEntityManager)
+    {
+        $this->container = $container;
+        $this->connections = $connections;
+        $this->entityManagers = $entityManagers;
+
+        if (!isset($this->connections[$defaultConnection])) {
+            throw new \LogicException(sprintf('Default connection "%s" is not defined.', $defaultConnection));
+        }
+        $this->defaultConnection = $defaultConnection;
+
+        if (!isset($this->entityManagers[$defaultEntityManager])) {
+            throw new \LogicException(sprintf('Default entity manager "%s" is not defined.', $defaultEntityManager));
+        }
+        $this->defaultEntityManager = $defaultEntityManager;
+    }
+
+    public function getDefaultConnectionName()
+    {
+        return $this->defaultConnection;
+    }
+
+    public function getConnection($name = null)
+    {
+        if (null === $name) {
+            return $this->container->get($this->connections[$this->defaultConnection]);
+        }
+
+        if (!isset($this->connections[$name])) {
+            throw new \InvalidArgumentException(sprintf('Doctrine Connection named "%s" does not exist.', $name));
+        }
+
+        return $this->container->get($this->connections[$name]);
+    }
+
+    public function getConnectionNames()
+    {
+        return $this->connections;
+    }
+
+    public function getDefaultEntityManagerName()
+    {
+        return $this->defaultEntityManager;
+    }
+
+    public function getEntityManager($name)
+    {
+        if (null === $name) {
+            return $this->container->get($this->entityManagers[$this->defaultEntityManager]);
+        }
+
+        if (!isset($this->entityManagers[$name])) {
+            throw new \InvalidArgumentException(sprintf('Doctrine EntityManager named "%s" does not exist.', $name));
+        }
+
+        return $this->container->get($this->entityManagers[$name]);
+    }
+
+    public function getEntityManagerNames()
+    {
+        return $this->entityManagers;
+    }
+
+    /**
+     * @param string|EntityManager
+     */
+    public function reloadEntityManager($name)
+    {
+        $id = null;
+        $em = null;
+        if (is_string($name)) {
+            if (!isset($this->entityManagers[$name])) {
+                throw new \InvalidArgumentException(sprintf('The "%s" entity manager does not exist.', $name));
+            }
+
+            $id = $this->entityManagers[$name];
+            $em = $this->container->get($id);
+        } elseif (is_object($name) && $name instanceof EntityManager) {
+            foreach ($this->entityManagers as $managerId) {
+                if ($this->container->get($managerId) === $name) {
+                    $id = $managerId;
+                    $em = $name;
+                    break;
+                }
+            }
+
+            if (null === $em) {
+                throw new \InvalidArgumentException(sprintf('Unable to reload entity manager "%s" as it is not managed by the service container.', $class));
+            }
+        } else {
+            throw new \InvalidArgumentException('The name argument must be a string or an EntityManager instance.');
+        }
+
+        if ($em->isOpen()) {
+            $em->clear();
+
+            return $em;
+        }
+
+        // force the creation of a new entity manager
+        $this->container->set($id, null);
+
+        return $this->container->get($id);
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
@@ -14,7 +14,7 @@
         <parameter key="doctrine.dbal.connection_factory.class">Symfony\Bundle\DoctrineBundle\ConnectionFactory</parameter>
         <parameter key="doctrine.dbal.events.mysql_session_init.class">Doctrine\DBAL\Event\Listeners\MysqlSessionInit</parameter>
         <parameter key="doctrine.dbal.events.oracle_session_init.class">Doctrine\DBAL\Event\Listeners\OracleSessionInit</parameter>
-        <parameter key="doctrine.registry.class">Symfony\Bundle\DoctrineBundle\Registry</parameter>
+        <parameter key="doctrine.class">Symfony\Bundle\DoctrineBundle\Registry</parameter>
     </parameters>
 
     <services>
@@ -27,7 +27,7 @@
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
             <tag name="data_collector" template="DoctrineBundle:Collector:db" id="db" />
-            <argument type="service" id="doctrine.registry" />
+            <argument type="service" id="doctrine" />
             <argument type="service" id="doctrine.dbal.logger" />
         </service>
 
@@ -41,7 +41,7 @@
 
         <service id="doctrine.dbal.connection.configuration" class="%doctrine.dbal.configuration.class%" public="false" abstract="true" />
 
-        <service id="doctrine.registry" class="%doctrine.registry.class%">
+        <service id="doctrine" class="%doctrine.class%">
             <argument type="service" id="service_container" />
             <argument type="collection" /> <!-- connections -->
             <argument type="collection" /> <!-- entity managers -->

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
@@ -14,6 +14,7 @@
         <parameter key="doctrine.dbal.connection_factory.class">Symfony\Bundle\DoctrineBundle\ConnectionFactory</parameter>
         <parameter key="doctrine.dbal.events.mysql_session_init.class">Doctrine\DBAL\Event\Listeners\MysqlSessionInit</parameter>
         <parameter key="doctrine.dbal.events.oracle_session_init.class">Doctrine\DBAL\Event\Listeners\OracleSessionInit</parameter>
+        <parameter key="doctrine.registry.class">Symfony\Bundle\DoctrineBundle\Registry</parameter>
     </parameters>
 
     <services>
@@ -26,8 +27,7 @@
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
             <tag name="data_collector" template="DoctrineBundle:Collector:db" id="db" />
-            <argument>%doctrine.dbal.connections%</argument>
-            <argument>%doctrine.orm.entity_managers%</argument>
+            <argument type="service" id="doctrine.registry" />
             <argument type="service" id="doctrine.dbal.logger" />
         </service>
 
@@ -40,5 +40,13 @@
         <service id="doctrine.dbal.connection.event_manager" class="%doctrine.dbal.connection.event_manager.class%" public="false" abstract="true" />
 
         <service id="doctrine.dbal.connection.configuration" class="%doctrine.dbal.configuration.class%" public="false" abstract="true" />
+
+        <service id="doctrine.registry" class="%doctrine.registry.class%">
+            <argument type="service" id="service_container" />
+            <argument type="collection" /> <!-- connections -->
+            <argument type="collection" /> <!-- entity managers -->
+            <argument /> <!-- default connection name -->
+            <argument /> <!-- default entity manager name -->
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="doctrine.orm.configuration.class">Doctrine\ORM\Configuration</parameter>
-        <parameter key="doctrine.orm.entity_manager.class">Doctrine\ORM\EntityManager</parameter>
+        <parameter key="doctrine.orm.entity_manager.class">Symfony\Bundle\DoctrineBundle\EntityManager</parameter>
 
         <!-- cache -->
         <parameter key="doctrine.orm.cache.array.class">Doctrine\Common\Cache\ArrayCache</parameter>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/CacheWarmer/ProxyCacheWarmerTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/CacheWarmer/ProxyCacheWarmerTest.php
@@ -45,7 +45,7 @@ class ProxyCacheWarmerTest extends \Symfony\Bundle\DoctrineBundle\Tests\TestCase
                   ->will($this->returnValue(false));
         $container->expects($this->at(2))
                   ->method('get')
-                  ->with($this->equalTo('doctrine.registry'))
+                  ->with($this->equalTo('doctrine'))
                   ->will($this->returnValue($registry));
         $container->expects($this->at(3))
                   ->method('get')

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/CacheWarmer/ProxyCacheWarmerTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/CacheWarmer/ProxyCacheWarmerTest.php
@@ -29,6 +29,11 @@ class ProxyCacheWarmerTest extends \Symfony\Bundle\DoctrineBundle\Tests\TestCase
             __DIR__ . "/../DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity")
         );
 
+        $registry = $this->getMockBuilder('Symfony\Bundle\DoctrineBundle\Registry')->disableOriginalConstructor()->getMock();
+        $registry->expects($this->at(0))
+                  ->method('getEntityManagerNames')
+                  ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager', 'foo' => 'doctrine.orm.foo_entity_manager')));
+
         $container = $this->getMock('Symfony\Component\DependencyInjection\Container');
         $container->expects($this->at(0))
                   ->method('getParameter')
@@ -39,9 +44,9 @@ class ProxyCacheWarmerTest extends \Symfony\Bundle\DoctrineBundle\Tests\TestCase
                   ->with($this->equalTo('doctrine.orm.auto_generate_proxy_classes'))
                   ->will($this->returnValue(false));
         $container->expects($this->at(2))
-                  ->method('getParameter')
-                  ->with($this->equalTo('doctrine.orm.entity_managers'))
-                  ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager', 'foo' => 'doctrine.orm.foo_entity_manager')));
+                  ->method('get')
+                  ->with($this->equalTo('doctrine.registry'))
+                  ->will($this->returnValue($registry));
         $container->expects($this->at(3))
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -33,7 +33,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $loader->load(array(array(), array('dbal' => array('default_connection' => 'foo')), array()), $container);
 
         // doctrine.dbal.default_connection
-        $this->assertEquals('foo', $container->getParameter('doctrine.dbal.default_connection'), '->load() overrides existing configuration options');
+        $this->assertEquals('foo', $container->getDefinition('doctrine.registry')->getArgument(3), '->load() overrides existing configuration options');
     }
 
     public function testDbalLoad()
@@ -108,7 +108,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $this->assertFalse($container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
         $this->assertEquals('Doctrine\ORM\Configuration', $container->getParameter('doctrine.orm.configuration.class'));
-        $this->assertEquals('Doctrine\ORM\EntityManager', $container->getParameter('doctrine.orm.entity_manager.class'));
+        $this->assertEquals('Symfony\Bundle\DoctrineBundle\EntityManager', $container->getParameter('doctrine.orm.entity_manager.class'));
         $this->assertEquals('Proxies', $container->getParameter('doctrine.orm.proxy_namespace'));
         $this->assertEquals('Doctrine\Common\Cache\ArrayCache', $container->getParameter('doctrine.orm.cache.array.class'));
         $this->assertEquals('Doctrine\Common\Cache\ApcCache', $container->getParameter('doctrine.orm.cache.apc.class'));
@@ -153,7 +153,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
         $this->assertEquals('create', $definition->getFactoryMethod());
 
-        $this->assertEquals(array('default' => 'doctrine.orm.default_entity_manager'), $container->getParameter('doctrine.orm.entity_managers'), "Set of the existing EntityManagers names is incorrect.");
+        $this->assertEquals(array('default' => 'doctrine.orm.default_entity_manager'), $container->getDefinition('doctrine.registry')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
 
         $arguments = $definition->getArguments();
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
@@ -345,7 +345,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array())))))), $container);
+        $config = $this->getConnectionConfig();
+        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))));
+        $loader->load(array($config), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
@@ -358,7 +360,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer();
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array('alias' => 'yml'))))))), $container);
+        $config = $this->getConnectionConfig();
+        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array('alias' => 'yml')))));
+        $loader->load(array($config), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_configuration');
         $this->assertDICDefinitionMethodCallOnce($definition, 'setEntityNamespaces',
@@ -371,7 +375,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('YamlBundle');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array())))))), $container);
+        $config = $this->getConnectionConfig();
+        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('YamlBundle' => array()))));
+        $loader->load(array($config), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -385,7 +391,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('XmlBundle');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('XmlBundle' => array())))))), $container);
+        $config = $this->getConnectionConfig();
+        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('XmlBundle' => array()))));
+        $loader->load(array($config), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -399,7 +407,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array())))))), $container);
+        $config = $this->getConnectionConfig();
+        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array()))));
+        $loader->load(array($config), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallOnce($definition, 'addDriver', array(
@@ -413,18 +423,21 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer(array('XmlBundle', 'AnnotationsBundle'));
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array(
+        $config1 = $this->getConnectionConfig();
+        $config1['orm'] = array(
             'auto_generate_proxy_classes' => true,
             'default_entity_manager' => 'default',
             'entity_managers' => array(
                 'default' => array('mappings' => array('AnnotationsBundle' => array()))
-            ))),
-            array('orm' => array(
-                'auto_generate_proxy_classes' => false,
-                'default_entity_manager' => 'default',
-                'entity_managers' => array(
-                    'default' => array('mappings' => array('XmlBundle' => array()))
-        )))), $container);
+        ));
+        $config2 = $this->getConnectionConfig();
+        $config2['orm'] = array(
+            'auto_generate_proxy_classes' => false,
+            'default_entity_manager' => 'default',
+            'entity_managers' => array(
+                'default' => array('mappings' => array('XmlBundle' => array()))
+        ));
+        $loader->load(array($config1, $config2), $container);
 
         $definition = $container->getDefinition('doctrine.orm.default_metadata_driver');
         $this->assertDICDefinitionMethodCallAt(0, $definition, 'addDriver', array(
@@ -561,7 +574,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $this->compileContainer($container);
 
-        $this->assertEquals(array('em1' => 'doctrine.orm.em1_entity_manager', 'em2' => 'doctrine.orm.em2_entity_manager'), $container->getParameter('doctrine.orm.entity_managers'), "Set of the existing EntityManagers names is incorrect.");
+        $this->assertEquals(array('em1' => 'doctrine.orm.em1_entity_manager', 'em2' => 'doctrine.orm.em2_entity_manager'), $container->getDefinition('doctrine.registry')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
 
         $def1 = $container->getDefinition('doctrine.orm.em1_metadata_driver');
         $def2 = $container->getDefinition('doctrine.orm.em2_metadata_driver');
@@ -603,7 +616,9 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container = $this->getContainer('AnnotationsBundle', 'Vendor');
         $loader = new DoctrineExtension();
 
-        $loader->load(array(array('orm' => array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array())))))), $container);
+        $config = $this->getConnectionConfig();
+        $config['orm'] = array('default_entity_manager' => 'default', 'entity_managers' => array('default' => array('mappings' => array('AnnotationsBundle' => array()))));
+        $loader->load(array($config), $container);
 
         $calls = $container->getDefinition('doctrine.orm.default_metadata_driver')->getMethodCalls();
         $this->assertEquals('doctrine.orm.default_annotation_metadata_driver', (string) $calls[0][1][0]);
@@ -734,5 +749,10 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $container->getCompilerPassConfig()->setOptimizationPasses(array(new ResolveDefinitionTemplatesPass()));
         $container->getCompilerPassConfig()->setRemovingPasses(array());
         $container->compile();
+    }
+
+    protected function getConnectionConfig()
+    {
+        return array('dbal' => array('connections' => array('default' => array('password' => 'foo'))));
     }
 }

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -33,7 +33,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $loader->load(array(array(), array('dbal' => array('default_connection' => 'foo')), array()), $container);
 
         // doctrine.dbal.default_connection
-        $this->assertEquals('foo', $container->getDefinition('doctrine.registry')->getArgument(3), '->load() overrides existing configuration options');
+        $this->assertEquals('foo', $container->getDefinition('doctrine')->getArgument(3), '->load() overrides existing configuration options');
     }
 
     public function testDbalLoad()
@@ -153,7 +153,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertEquals('%doctrine.orm.entity_manager.class%', $definition->getFactoryClass());
         $this->assertEquals('create', $definition->getFactoryMethod());
 
-        $this->assertEquals(array('default' => 'doctrine.orm.default_entity_manager'), $container->getDefinition('doctrine.registry')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
+        $this->assertEquals(array('default' => 'doctrine.orm.default_entity_manager'), $container->getDefinition('doctrine')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
 
         $arguments = $definition->getArguments();
         $this->assertInstanceOf('Symfony\Component\DependencyInjection\Reference', $arguments[0]);
@@ -574,7 +574,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $this->compileContainer($container);
 
-        $this->assertEquals(array('em1' => 'doctrine.orm.em1_entity_manager', 'em2' => 'doctrine.orm.em2_entity_manager'), $container->getDefinition('doctrine.registry')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
+        $this->assertEquals(array('em1' => 'doctrine.orm.em1_entity_manager', 'em2' => 'doctrine.orm.em2_entity_manager'), $container->getDefinition('doctrine')->getArgument(2), "Set of the existing EntityManagers names is incorrect.");
 
         $def1 = $container->getDefinition('doctrine.orm.em1_metadata_driver');
         $def2 = $container->getDefinition('doctrine.orm.em2_metadata_driver');

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_functions.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_functions.xml
@@ -7,7 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal />
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm default-entity-manager="default">
             <entity-manager name="default">
                 <mapping name="YamlBundle" />

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_hydration_mode.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_hydration_mode.xml
@@ -7,7 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal />
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm default-entity-manager="default">
             <entity-manager name="default">
                 <hydrator name="test_hydrator">Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator</hydrator>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
@@ -7,6 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm
             auto-generate-proxy-classes="false"
             default-entity-manager="default"

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
@@ -7,6 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm default-entity-manager="em2">
             <entity-manager name="em1">
                 <mapping name="AnnotationsBundle" />

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_functions.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_functions.yml
@@ -1,5 +1,10 @@
 doctrine:
-    dbal: ~
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         entity_managers:
             default:

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_hydration_mode.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_hydration_mode.yml
@@ -1,5 +1,10 @@
 doctrine:
-    dbal: ~
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         entity_managers:
             default:

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
@@ -1,4 +1,10 @@
 doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         auto_generate_proxy_classes: false
         default_entity_manager: default

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
@@ -1,4 +1,10 @@
 doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         default_entity_manager: em2
         entity_managers:


### PR DESCRIPTION
The Registry knows all connections and entity managers declared into a service
container. The Registry is available via the 'doctrine.registry' service.

If can be used to get connections and entity managers by name (instead of
using DIC parameters -- more information in the UPDATE file), and to 'reload'
closed entity managers.

Reloading entity managers is useful when doing transactions with Doctrine2.
When you catch a Doctrine exception, you must close the entity manager. A
closed entity manager cannot be used anymore; so you need to get a fresh one.

In the 'catch' block, call 'reload()' method instead of 'close()' to get a new
entity manager:

```
$em->getConnection()->beginTransaction(); // suspend auto-commit
try {
    //... do some work
} catch (Exception $e) {
    $em->getConnection()->rollback();

    // call reload() instead of close()
    $em = $em->reload();
}
```
