### PR TITLE
[HttpKernel] Log 500+ errors as critical and not error

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ExceptionListener.php
@@ -77,7 +77,7 @@ class ExceptionListener
         } catch (\Exception $e) {
             $message = sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage());
             if (null !== $this->logger) {
-                if ($exception instanceof HttpExceptionInterface && $exception->getStatusCode() > 500) {
+                if ($exception instanceof HttpExceptionInterface && $exception->getStatusCode() >= 500) {
                     $this->logger->crit($message);
                 } else {
                     $this->logger->err($message);

--- a/src/Symfony/Component/HttpKernel/Debug/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ExceptionListener.php
@@ -77,7 +77,11 @@ class ExceptionListener
         } catch (\Exception $e) {
             $message = sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage());
             if (null !== $this->logger) {
-                $this->logger->err($message);
+                if ($exception instanceof HttpExceptionInterface && $exception->getStatusCode() > 500) {
+                    $this->logger->crit($message);
+                } else {
+                    $this->logger->err($message);
+                }
             } else {
                 error_log($message);
             }


### PR DESCRIPTION
This allows people to filter easily between 404 type of responses (that are mostly for users) and real errors in their application (where they probably want to get an email notification

Note: Didn't really try the patch, but I believe it's the only place where this has to be done?
