### PR TITLE
[Form] added listener to stash collection prototype during bind

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/PrototypeStashListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/PrototypeStashListener.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\Form\Events;
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Stash a collection prototype during bind.
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+class PrototypeStashListener implements EventSubscriberInterface
+{
+    private $stash;
+
+    public function __construct()
+    {
+        $this->stash = new \SplObjectStorage();
+    }
+
+    public function preBind(DataEvent $event)
+    {
+        $form = $event->getForm();
+        $this->stash[$form] = $form['$$name$$'];
+        unset($form['$$name$$']);
+    }
+
+    public function postBind(DataEvent $event)
+    {
+        $form = $event->getForm();
+        $form['$$name$$'] = $this->stash[$form];
+        unset($this->stash[$form]);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(Events::preBind, Events::postBind);
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\Extension\Core\EventListener\PrototypeStashListener;
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
 
 class CollectionType extends AbstractType
@@ -24,12 +25,16 @@ class CollectionType extends AbstractType
                 'property_path' => false,
                 'required' => false,
             ));
+
+            // stash the prototype during bind
+            $builder->addEventSubscriber(new PrototypeStashListener());
         }
 
-        $listener = new ResizeFormListener($builder->getFormFactory(),
-                $options['type'], $options['modifiable']);
-
-        $builder->addEventSubscriber($listener);
+        $builder->addEventSubscriber(new ResizeFormListener(
+            $builder->getFormFactory(),
+            $options['type'],
+            $options['modifiable']
+        ));
     }
 
     public function getDefaultOptions(array $options)

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/PrototypeStashListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/PrototypeStashListenerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\Form\Extension\Core\EventListener\PrototypeStashListener;
+
+class PrototypeStashListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStash()
+    {
+        $event = $this->getMockBuilder('Symfony\\Component\\Form\\Event\\DataEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $form = $this->getMockBuilder('Symfony\\Component\\Form\\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $field = $this->getMockBuilder('Symfony\\Component\\Form\\Form')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $event->expects($this->any())
+            ->method('getForm')
+            ->will($this->returnValue($form));
+        $form->expects($this->once())
+            ->method('offsetGet')
+            ->with('$$name$$')
+            ->will($this->returnValue($field));
+        $form->expects($this->once())
+            ->method('offsetUnset')
+            ->with('$$name$$');
+
+        $listener = new PrototypeStashListener();
+        $listener->preBind($event);
+
+        $form->expects($this->once())
+            ->method('offsetSet')
+            ->with('$$name$$', $field);
+
+        $listener->postBind($event);
+    }
+}


### PR DESCRIPTION
If the prototype isn't stashed it ends up having an empty string bound to it, which can lead to unexpected results. In my case the prototype is a `file` which ultimately leads to a string being passed into `array_merge()` in `FixFileUploadListener`.
