### PR TITLE
added a way to "reload" an entity manager

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -9,6 +9,39 @@ timeline closely anyway.
 beta1 to beta2
 --------------
 
+* With the introduction of a new Doctrine Registry class, the following
+  parameters have been removed (replaced by methods on the `doctrine`
+  service):
+
+   * doctrine.orm.entity_managers
+   * doctrine.orm.default_entity_manager
+   * doctrine.dbal.default_connection
+
+  Before:
+
+        $container->getParameter('doctrine.orm.entity_managers')
+        $container->getParameter('doctrine.orm.default_entity_manager')
+        $container->getParameter('doctrine.orm.default_connection')
+
+  After:
+
+        $container->get('doctrine')->getEntityManagerNames()
+        $container->get('doctrine')->getDefaultEntityManagerName()
+        $container->get('doctrine')->getDefaultConnectionName()
+
+  But you don't really need to use these methods anymore, as to get an entity
+  manager, you can now use the registry directly:
+
+  Before:
+
+        $em = $this->get('doctrine.orm.entity_manager');
+        $em = $this->get('doctrine.orm.foobar_entity_manager');
+
+  After:
+
+        $em = $this->get('doctrine')->getEntityManager();
+        $em = $this->get('doctrine')->getEntityManager('foobar');
+
 * Doctrine event subscribers now use a unique "doctrine.event_subscriber" tag.
   Doctrine event listeners also use a unique "doctrine.event_listener" tag. To
   specify a connection, use the optional "connection" attribute.
@@ -38,11 +71,6 @@ beta1 to beta2
             tags:
                 - { name: doctrine.event_subscriber }                      # register for all connections
                 - { name: doctrine.event_subscriber, connection: default } # only for the default connection
-
-* The `doctrine.orm.entity_managers` is now hash of entity manager names/ids pairs:
-
-    Before: array('default', 'foo')
-    After:  array('default' => 'doctrine.orm.default_entity_manager', 'foo' => 'doctrine.orm.foo_entity_manager'))
 
 * Application translations are now stored in the `Resources` directory:
 

--- a/src/Symfony/Bundle/DoctrineBundle/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bundle/DoctrineBundle/CacheWarmer/ProxyCacheWarmer.php
@@ -64,7 +64,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
             return;
         }
 
-        foreach ($this->container->getParameter('doctrine.orm.entity_managers') as $id) {
+        foreach ($this->container->get('doctrine')->getEntityManagerNames() as $id) {
             $em = $this->container->get($id);
             $classes = $em->getMetadataFactory()->getAllMetadata();
             $em->getProxyFactory()->generateProxyClasses($classes);

--- a/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/DoctrineCommand.php
@@ -42,14 +42,7 @@ abstract class DoctrineCommand extends Command
 
     protected function getEntityManager($name)
     {
-        $name = $name ?: $this->container->getParameter('doctrine.orm.default_entity_manager');
-
-        $ems = $this->container->getParameter('doctrine.orm.entity_managers');
-        if (!isset($ems[$name])) {
-            throw new \InvalidArgumentException(sprintf('Could not find Doctrine EntityManager named "%s"', $name));
-        }
-
-        return $this->container->get($ems[$name]);
+        return $this->container->get('doctrine')->getEntityManager($name);
     }
 
     /**
@@ -60,21 +53,14 @@ abstract class DoctrineCommand extends Command
      */
     protected function getDoctrineConnection($name)
     {
-        $name = $name ?: $this->container->getParameter('doctrine.dbal.default_connection');
-
-        $connections = $this->container->getParameter('doctrine.dbal.connections');
-        if (!isset($connections[$name])) {
-            throw new \InvalidArgumentException(sprintf('<error>Could not find a connection named <comment>%s</comment></error>', $name));
-        }
-
-        return $this->container->get($connections[$name]);
+        return $this->container->get('doctrine')->getConnection($name);
     }
 
     protected function getBundleMetadatas(Bundle $bundle)
     {
         $namespace = $bundle->getNamespace();
         $bundleMetadatas = array();
-        foreach ($this->container->getParameter('doctrine.orm.entity_managers') as $id) {
+        foreach ($this->container->get('doctrine')->getEntityManagerNames() as $id) {
             $em = $this->container->get($id);
             $cmf = new DisconnectedClassMetadataFactory();
             $cmf->setEntityManager($em);

--- a/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
@@ -46,7 +46,7 @@ EOT
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $entityManagerName = $input->getOption('em') ? $input->getOption('em') : $this->container->getParameter('doctrine.orm.default_entity_manager');
+        $entityManagerName = $input->getOption('em') ? $input->getOption('em') : $this->container->get('doctrine')->getDefaultEntityManagerName();
 
         /* @var $entityManager Doctrine\ORM\EntityManager */
         $entityManager = $this->getEntityManager($input->getOption('em'));

--- a/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DoctrineCommandHelper.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DoctrineCommandHelper.php
@@ -30,7 +30,7 @@ abstract class DoctrineCommandHelper
      */
     static public function setApplicationEntityManager(Application $application, $emName)
     {
-        $em = self::getEntityManager($application, $emName);
+        $em = $application->getKernel()->getContainer()->get('doctrine')->getEntityManager($name);
         $helperSet = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($em->getConnection()), 'db');
         $helperSet->set(new EntityManagerHelper($em), 'em');
@@ -38,42 +38,8 @@ abstract class DoctrineCommandHelper
 
     static public function setApplicationConnection(Application $application, $connName)
     {
-        $connection = self::getDoctrineConnection($application, $connName);
+        $connection = $application->getKernel()->getContainer()->get('doctrine')->getConnection($name);
         $helperSet = $application->getHelperSet();
         $helperSet->set(new ConnectionHelper($connection), 'db');
-    }
-
-    static protected function getEntityManager(Application $application, $name)
-    {
-        $container = $application->getKernel()->getContainer();
-
-        $name = $name ?: $container->getParameter('doctrine.orm.default_entity_manager');
-
-        $ems = $container->getParameter('doctrine.orm.entity_managers');
-        if (!isset($ems[$name])) {
-            throw new \InvalidArgumentException(sprintf('Could not find Doctrine EntityManager named "%s"', $name));
-        }
-
-        return $container->get($ems[$name]);
-    }
-
-    /**
-     * Get a doctrine dbal connection by symfony name.
-     *
-     * @param string $name
-     * @return Doctrine\DBAL\Connection
-     */
-    static protected function getDoctrineConnection(Application $application, $name)
-    {
-        $container = $application->getKernel()->getContainer();
-
-        $name = $name ?: $container->getParameter('doctrine.dbal.default_connection');
-
-        $connections = $container->getParameter('doctrine.dbal.connections');
-        if (!isset($connections[$name])) {
-            throw new \InvalidArgumentException(sprintf('<error>Could not find a connection named <comment>%s</comment></error>', $name));
-        }
-
-        return $container->get($connections[$name]);
     }
 }

--- a/src/Symfony/Bundle/DoctrineBundle/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DataCollector/DoctrineDataCollector.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bundle\DoctrineBundle\Logger\DbalLogger;
+use Symfony\Bundle\DoctrineBundle\Registry;
 
 /**
  * DoctrineDataCollector.
@@ -27,10 +28,10 @@ class DoctrineDataCollector extends DataCollector
     private $managers;
     private $logger;
 
-    public function __construct($connections, $managers, DbalLogger $logger = null)
+    public function __construct(Registry $registry, DbalLogger $logger = null)
     {
-        $this->connections = $connections;
-        $this->managers = $managers;
+        $this->connections = $registry->getConnectionNames();
+        $this->managers = $registry->getEntityManagerNames();
         $this->logger = $logger;
     }
 

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -16,7 +16,7 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $this->container = $container;
-        $this->connections = $container->getParameter('doctrine.dbal.connections');
+        $this->connections = $container->getDefinition('doctrine')->getArgument(1);
 
         foreach ($container->findTaggedServiceIds('doctrine.event_subscriber') as $subscriberId => $instances) {
             $this->registerSubscriber($subscriberId, $instances);

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -232,6 +232,8 @@ class DoctrineExtension extends AbstractDoctrineExtension
         $ormEmDef = new Definition('%doctrine.orm.entity_manager.class%', $ormEmArgs);
         $ormEmDef->setFactoryClass('%doctrine.orm.entity_manager.class%');
         $ormEmDef->setFactoryMethod('create');
+        $ormEmDef->addMethodCall('setRegistry', array(new Reference('doctrine')));
+        $ormEmDef->addMethodCall('setName', array($entityManager['name']));
         $container->setDefinition($entityManagerService, $ormEmDef);
 
         $container->setAlias(

--- a/src/Symfony/Bundle/DoctrineBundle/EntityManager.php
+++ b/src/Symfony/Bundle/DoctrineBundle/EntityManager.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineBundle;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManager as BaseEntityManager;
+use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Configuration;
+use Doctrine\Common\EventManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Doctrine Entity Manager that knows how to reload itself.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class EntityManager extends BaseEntityManager
+{
+    private $name;
+    private $registry;
+
+    /**
+     * Sets the registry under which this entity manager is known.
+     *
+     * @param Registry $registry
+     */
+    public function setRegistry(Registry $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * Sets the name under which the entity manager is known by the registry.
+     *
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * Returns a new (aka reloaded) entity manager for the current one.
+     *
+     * This method also replaces the entity manager.
+     */
+    public function reload()
+    {
+        $this->close();
+
+        return $this->registry->reloadEntityManager(isset($this->name) ? $this->name : $this);
+    }
+
+    // should be removed if https://github.com/doctrine/doctrine2/pull/51 is merged upstream
+    public static function create($conn, Configuration $config, EventManager $eventManager = null)
+    {
+        if (!$config->getMetadataDriverImpl()) {
+            throw ORMException::missingMappingDriverImpl();
+        }
+
+        if (is_array($conn)) {
+            $conn = \Doctrine\DBAL\DriverManager::getConnection($conn, $config, ($eventManager ?: new EventManager()));
+        } else if ($conn instanceof Connection) {
+            if ($eventManager !== null && $conn->getEventManager() !== $eventManager) {
+                 throw ORMException::mismatchedEventManager();
+            }
+        } else {
+            throw new \InvalidArgumentException("Invalid argument: " . $conn);
+        }
+
+        return new static($conn, $config, $conn->getEventManager());
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineBundle;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Doctrine\DBAL\Connection;
+
+/**
+ * References all Doctrine connections and entity managers in a given Container.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Registry
+{
+    private $container;
+    private $connections;
+    private $entityManagers;
+    private $defaultConnection;
+    private $defaultEntityManager;
+
+    public function __construct(ContainerInterface $container, array $connections, array $entityManagers, $defaultConnection, $defaultEntityManager)
+    {
+        $this->container = $container;
+        $this->connections = $connections;
+        $this->entityManagers = $entityManagers;
+
+        if (!isset($this->connections[$defaultConnection])) {
+            throw new \LogicException(sprintf('Default connection "%s" is not defined.', $defaultConnection));
+        }
+        $this->defaultConnection = $defaultConnection;
+
+        if (!isset($this->entityManagers[$defaultEntityManager])) {
+            throw new \LogicException(sprintf('Default entity manager "%s" is not defined.', $defaultEntityManager));
+        }
+        $this->defaultEntityManager = $defaultEntityManager;
+    }
+
+    /**
+     * Gets the default connection name.
+     *
+     * @return string The default connection name
+     */
+    public function getDefaultConnectionName()
+    {
+        return $this->defaultConnection;
+    }
+
+    /**
+     * Gets the named connection.
+     *
+     * @param string $name The connection name (null for the default one)
+     *
+     * @return Connection
+     */
+    public function getConnection($name = null)
+    {
+        if (null === $name) {
+            return $this->container->get($this->connections[$this->defaultConnection]);
+        }
+
+        if (!isset($this->connections[$name])) {
+            throw new \InvalidArgumentException(sprintf('Doctrine Connection named "%s" does not exist.', $name));
+        }
+
+        return $this->container->get($this->connections[$name]);
+    }
+
+    /**
+     * Gets all connection names.
+     *
+     * @return array An array of connection names
+     */
+    public function getConnectionNames()
+    {
+        return $this->connections;
+    }
+
+    /**
+     * Gets the default entity manager name.
+     *
+     * @return string The default entity manager name
+     */
+    public function getDefaultEntityManagerName()
+    {
+        return $this->defaultEntityManager;
+    }
+
+    /**
+     * Gets the named entity manager.
+     *
+     * @param string $name The entity manager name (null for the default one)
+     *
+     * @return EntityManager
+     */
+    public function getEntityManager($name = null)
+    {
+        if (null === $name) {
+            return $this->container->get($this->entityManagers[$this->defaultEntityManager]);
+        }
+
+        if (!isset($this->entityManagers[$name])) {
+            throw new \InvalidArgumentException(sprintf('Doctrine EntityManager named "%s" does not exist.', $name));
+        }
+
+        return $this->container->get($this->entityManagers[$name]);
+    }
+
+    /**
+     * Gets all connection names.
+     *
+     * @return array An array of connection names
+     */
+    public function getEntityManagerNames()
+    {
+        return $this->entityManagers;
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
@@ -14,6 +14,7 @@
         <parameter key="doctrine.dbal.connection_factory.class">Symfony\Bundle\DoctrineBundle\ConnectionFactory</parameter>
         <parameter key="doctrine.dbal.events.mysql_session_init.class">Doctrine\DBAL\Event\Listeners\MysqlSessionInit</parameter>
         <parameter key="doctrine.dbal.events.oracle_session_init.class">Doctrine\DBAL\Event\Listeners\OracleSessionInit</parameter>
+        <parameter key="doctrine.class">Symfony\Bundle\DoctrineBundle\Registry</parameter>
     </parameters>
 
     <services>
@@ -26,8 +27,7 @@
 
         <service id="data_collector.doctrine" class="%doctrine.data_collector.class%" public="false">
             <tag name="data_collector" template="DoctrineBundle:Collector:db" id="db" />
-            <argument>%doctrine.dbal.connections%</argument>
-            <argument>%doctrine.orm.entity_managers%</argument>
+            <argument type="service" id="doctrine" />
             <argument type="service" id="doctrine.dbal.logger" />
         </service>
 
@@ -40,5 +40,13 @@
         <service id="doctrine.dbal.connection.event_manager" class="%doctrine.dbal.connection.event_manager.class%" public="false" abstract="true" />
 
         <service id="doctrine.dbal.connection.configuration" class="%doctrine.dbal.configuration.class%" public="false" abstract="true" />
+
+        <service id="doctrine" class="%doctrine.class%">
+            <argument type="service" id="service_container" />
+            <argument type="collection" /> <!-- connections -->
+            <argument type="collection" /> <!-- entity managers -->
+            <argument /> <!-- default connection name -->
+            <argument /> <!-- default entity manager name -->
+        </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="doctrine.orm.configuration.class">Doctrine\ORM\Configuration</parameter>
-        <parameter key="doctrine.orm.entity_manager.class">Doctrine\ORM\EntityManager</parameter>
+        <parameter key="doctrine.orm.entity_manager.class">Symfony\Bundle\DoctrineBundle\EntityManager</parameter>
 
         <!-- cache -->
         <parameter key="doctrine.orm.cache.array.class">Doctrine\Common\Cache\ArrayCache</parameter>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/CacheWarmer/ProxyCacheWarmerTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/CacheWarmer/ProxyCacheWarmerTest.php
@@ -29,6 +29,11 @@ class ProxyCacheWarmerTest extends \Symfony\Bundle\DoctrineBundle\Tests\TestCase
             __DIR__ . "/../DependencyInjection/Fixtures/Bundles/AnnotationsBundle/Entity")
         );
 
+        $registry = $this->getMockBuilder('Symfony\Bundle\DoctrineBundle\Registry')->disableOriginalConstructor()->getMock();
+        $registry->expects($this->at(0))
+                  ->method('getEntityManagerNames')
+                  ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager', 'foo' => 'doctrine.orm.foo_entity_manager')));
+
         $container = $this->getMock('Symfony\Component\DependencyInjection\Container');
         $container->expects($this->at(0))
                   ->method('getParameter')
@@ -39,9 +44,9 @@ class ProxyCacheWarmerTest extends \Symfony\Bundle\DoctrineBundle\Tests\TestCase
                   ->with($this->equalTo('doctrine.orm.auto_generate_proxy_classes'))
                   ->will($this->returnValue(false));
         $container->expects($this->at(2))
-                  ->method('getParameter')
-                  ->with($this->equalTo('doctrine.orm.entity_managers'))
-                  ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager', 'foo' => 'doctrine.orm.foo_entity_manager')));
+                  ->method('get')
+                  ->with($this->equalTo('doctrine'))
+                  ->will($this->returnValue($registry));
         $container->expects($this->at(3))
                   ->method('get')
                   ->with($this->equalTo('doctrine.orm.default_entity_manager'))

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -108,7 +108,7 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
 
         $this->assertFalse($container->getParameter('doctrine.orm.auto_generate_proxy_classes'));
         $this->assertEquals('Doctrine\ORM\Configuration', $container->getParameter('doctrine.orm.configuration.class'));
-        $this->assertEquals('Doctrine\ORM\EntityManager', $container->getParameter('doctrine.orm.entity_manager.class'));
+        $this->assertEquals('Symfony\Bundle\DoctrineBundle\EntityManager', $container->getParameter('doctrine.orm.entity_manager.class'));
         $this->assertEquals('Proxies', $container->getParameter('doctrine.orm.proxy_namespace'));
         $this->assertEquals('Doctrine\Common\Cache\ArrayCache', $container->getParameter('doctrine.orm.cache.array.class'));
         $this->assertEquals('Doctrine\Common\Cache\ApcCache', $container->getParameter('doctrine.orm.cache.apc.class'));

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_functions.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_functions.xml
@@ -7,7 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal />
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm default-entity-manager="default">
             <entity-manager name="default">
                 <mapping name="YamlBundle" />

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_hydration_mode.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_hydration_mode.xml
@@ -7,7 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
-        <dbal />
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm default-entity-manager="default">
             <entity-manager name="default">
                 <hydrator name="test_hydrator">Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestHydrator</hydrator>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_imports_import.xml
@@ -7,6 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm
             auto-generate-proxy-classes="false"
             default-entity-manager="default"

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/xml/orm_multiple_em_bundle_mappings.xml
@@ -7,6 +7,10 @@
                         http://symfony.com/schema/dic/doctrine http://symfony.com/schema/dic/doctrine/doctrine-1.0.xsd">
 
     <config>
+        <dbal default-connection="default">
+            <connection name="default" dbname="db" />
+        </dbal>
+
         <orm default-entity-manager="em2">
             <entity-manager name="em1">
                 <mapping name="AnnotationsBundle" />

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_functions.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_functions.yml
@@ -1,5 +1,10 @@
 doctrine:
-    dbal: ~
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         entity_managers:
             default:

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_hydration_mode.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_hydration_mode.yml
@@ -1,5 +1,10 @@
 doctrine:
-    dbal: ~
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         entity_managers:
             default:

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_imports_import.yml
@@ -1,4 +1,10 @@
 doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         auto_generate_proxy_classes: false
         default_entity_manager: default

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_multiple_em_bundle_mappings.yml
@@ -1,4 +1,10 @@
 doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
     orm:
         default_entity_manager: em2
         entity_managers:


### PR DESCRIPTION
This was submitted as another PR before: https://github.com/symfony/symfony/pull/728

Only the second commit is relevant. The first is part of another PR: https://github.com/symfony/symfony/pull/735

Reloading entity managers is useful when doing transactions with Doctrine2.
When you catch a Doctrine exception, you must close the entity manager. A
closed entity manager cannot be used anymore; so you need to get a fresh one.

In the 'catch' block, call 'reload()' method instead of 'close()' to get a new
entity manager:

```
$em->getConnection()->beginTransaction(); // suspend auto-commit
try {
    //... do some work
} catch (Exception $e) {
    $em->getConnection()->rollback();

    // call reload() instead of close()
    $em = $em->reload();
}
```
