### PR TITLE
[Form] updated listener to check that data is an array

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixFileUploadListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixFileUploadListener.php
@@ -40,6 +40,11 @@ class FixFileUploadListener implements EventSubscriberInterface
     public function onBindClientData(FilterDataEvent $event)
     {
         $form = $event->getForm();
+        $data = $event->getData();
+
+        if (!is_array($data)) {
+            return;
+        }
 
         // TODO should be disableable
 
@@ -48,7 +53,7 @@ class FixFileUploadListener implements EventSubscriberInterface
             'file' => '',
             'token' => '',
             'name' => '',
-        ), $event->getData());
+        ), $data);
 
         // Newly uploaded file
         if ($data['file'] instanceof UploadedFile && $data['file']->isValid()) {


### PR DESCRIPTION
I've added a check that the data is an array before passing it into `array_merge()`. This is necessary if the field is a collection prototype (`$$name$$`) that isn't actually submitted.
