### PR TITLE
[FrameworkBundle][HttpKernel] added a default tearDown on the WebTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -156,8 +156,7 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected function tearDown()
     {
-        if ($this->kernel !== null && $this->kernel->isBooted())
-        {
+        if ($this->kernel !== null && $this->kernel->isBooted()) {
             $this->kernel->shutdown();
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -150,4 +150,15 @@ abstract class WebTestCase extends BaseWebTestCase
             isset($options['debug']) ? $options['debug'] : true
         );
     }
+    
+    /**
+     * Shuts the kernel down if it was used in the test
+     */
+    protected function tearDown()
+    {
+        if ($this->kernel !== null && $this->kernel->isBooted())
+        {
+            $this->kernel->shutdown();
+        }
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -292,6 +292,16 @@ abstract class Kernel implements KernelInterface
     {
         return $this->name;
     }
+    
+    /**
+     * Checks if the Kernel is currently booted.
+     *
+     * @return Boolean true if kernel is booted, false otherwise
+     */
+    public function isBooted()
+    {
+        return $this->booted;
+    }
 
     /**
      * Gets the environment.


### PR DESCRIPTION
I've used this change with the set of functional tests i have and i can't see any possible detriment to having it. In my particular test suite i saw an improvement of about 5-15% in memory usage depending which set of functional tests i ran
