### PR TITLE
[FrameworkBundle] added a check in Client to only shutdown the kernel

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -25,6 +25,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class Client extends BaseClient
 {
+    private $hasPerformedRequest = false;
+    
     /**
      * Returns the container.
      *
@@ -68,7 +70,11 @@ class Client extends BaseClient
      */
     protected function doRequest($request)
     {
-        $this->kernel->shutdown();
+        if ($this->hasPerformedRequest) {
+            $this->kernel->shutdown();
+        } else {
+            $this->hasPerformedRequest = true;
+        }
 
         return $this->kernel->handle($request);
     }


### PR DESCRIPTION
I had a problem with the Beta1 version with my WebTestCase tests. The pattern i used was to create a client in my test setUp, then populate the database with fixtures, then run my tests. e.g.:

```
protected function setUp()
{
    $this->client = $this->createClient();
    $fixtures = array(
        new UserDataFixture()
    );
    $this->populateWithTestDatabase($this->client, $fixtures);
}
```

When the actual test ran the database wasn't populated, the container in my controller was a different instance than the container i used to populate the database in the test case. The issue was that the FrameworkBundle Client shuts down the kernel before each request, meaning my in memory sqlite database had disappeared. Another user encountered this as well: http://groups.google.com/group/symfony-users/browse_thread/thread/892d58f7571b3f31#.

The solution I've added is to only shut down the kernel if a request has previously been made. Also in the current state most functional tests will result in the kernel booting twice at the start of a test
