### PR TITLE
[HttpKernel] Throw exception if no path is present in a resource

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -242,6 +242,10 @@ abstract class Kernel implements KernelInterface
             throw new \RuntimeException(sprintf('File name "%s" contains invalid characters (..).', $name));
         }
 
+        if (false === strpos($name, '/')) {
+            throw new \InvalidArgumentException(sprintf('A resource name must contain a path information (e.g. "@AcmeDemoBundle/Controller"), "%s" given.', $name));
+        }
+
         $name = substr($name, 1);
         list($bundleName, $path) = explode('/', $name, 2);
 


### PR DESCRIPTION
BTW: Those exceptions are pretty badly hidden by multiple layers of catching I think, basically if you have a bad rule in your routing like `resource: @FooBundle` you get an exception from FileLoader containing the exception from Loader, but no trace of the Kernel exception which has the proper message. I didn't have time to figure it out but it should be improved imo to give better reporting.
