### PR TITLE
[DependencyInjection] tweaked PhpDumper::exportParameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -774,12 +774,9 @@ EOF;
      */
     private function exportParameters($parameters, $indent = 12)
     {
-        $max_length = 0;
-
-        foreach (array_keys($parameters) as $key) {
-            $length = strlen(var_export($key, true));
-            $max_length = $length > $max_length ? $length : $max_length;
-        }
+        $length = array_reduce(array_keys($parameters), function($length, $key) {
+            return max(array($length, strlen(var_export($key, true))));
+        });
 
         $php = array();
         foreach ($parameters as $key => $value) {
@@ -795,7 +792,7 @@ EOF;
                 $value = var_export($value, true);
             }
 
-            $php[] = sprintf('%s%-'.$max_length.'s => %s,', str_repeat(' ', $indent), var_export($key, true), $value);
+            $php[] = sprintf('%s%-' . $length . 's => %s,', str_repeat(' ', $indent), var_export($key, true), $value);
         }
 
         return sprintf("array(\n%s\n%s)", implode("\n", $php), str_repeat(' ', $indent - 4));

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -774,6 +774,13 @@ EOF;
      */
     private function exportParameters($parameters, $indent = 12)
     {
+        $max_length = 0;
+
+        foreach (array_keys($parameters) as $key) {
+            $length = strlen(var_export($key, true));
+            $max_length = $length > $max_length ? $length : $max_length;
+        }
+
         $php = array();
         foreach ($parameters as $key => $value) {
             if (is_array($value)) {
@@ -788,7 +795,7 @@ EOF;
                 $value = var_export($value, true);
             }
 
-            $php[] = sprintf('%s%s => %s,', str_repeat(' ', $indent), var_export($key, true), $value);
+            $php[] = sprintf('%s%-'.$max_length.'s => %s,', str_repeat(' ', $indent), var_export($key, true), $value);
         }
 
         return sprintf("array(\n%s\n%s)", implode("\n", $php), str_repeat(' ', $indent - 4));

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services8.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services8.php
@@ -31,9 +31,9 @@ class ProjectServiceContainer extends Container
     protected function getDefaultParameters()
     {
         return array(
-            'foo' => '%baz%',
-            'baz' => 'bar',
-            'bar' => 'foo is %%foo bar',
+            'foo'    => '%baz%',
+            'baz'    => 'bar',
+            'bar'    => 'foo is %%foo bar',
             'values' => array(
                 0 => true,
                 1 => false,

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
@@ -154,7 +154,7 @@ class ProjectServiceContainer extends Container
         return array(
             'baz_class' => 'BazClass',
             'foo_class' => 'FooClass',
-            'foo' => 'bar',
+            'foo'       => 'bar',
         );
     }
 }


### PR DESCRIPTION
[DependencyInjection] tweaked PhpDumper::exportParameters to have values (of arrays) left aligned.

Now array values are nicely aligned. ;)

```
    return array(
        'foo'    => '%baz%',
        'baz'    => 'bar',
        'bar'    => 'foo is %%foo bar',
        'values' => array(
            0 => true,
            1 => false,
            2 => NULL,
            3 => 0,
            4 => 1000.3,
            5 => 'true',
            6 => 'false',
            7 => 'null',
        ),
    );
```
