### PR TITLE
[HttpFoundation] added support for X-Forwarded-Port request header

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -413,7 +413,7 @@ class Request
 
     public function getPort()
     {
-        return $this->server->get('SERVER_PORT');
+        return $this->headers->get('X-Forwarded-Port') ?: $this->server->get('SERVER_PORT');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -711,4 +711,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(null, $request->setRequestFormat('foo'));
         $this->assertEquals('foo', $request->getRequestFormat(null));
     }
+
+    public function testForwardedSecure()
+    {
+        $request = new Request();
+        $request->headers->set('X-Forwarded-Proto', 'https');
+        $request->headers->set('X-Forwarded-Port', 443);
+
+        $this->assertTrue($request->isSecure());
+        $this->assertEquals(443, $request->getPort());
+    }
 }


### PR DESCRIPTION
This is to compliment the check for X-Forwarded-Proto in isSecure(). Otherwise you get strage URLs like `https://example.com:80`.
