### PR TITLE
[Security] Fix for #772

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -150,8 +150,10 @@ class ExceptionListener
             $this->logger->debug('Calling Authentication entry point');
         }
 
-        // session isn't required when using http basic authentication mechanism for example
-        if ($request->hasSession()) {
+        // session isn't required when using http basic authentication mechanism
+        // for example so the value has to be set only when the session is
+        // activated in the project
+        if (null !== $request->getSession()) {
             $request->getSession()->set('_security.target_path', $request->getUri());
         }
 


### PR DESCRIPTION
This change the check used in the security component as the needed one is knowing if the session is activated (to be able to set a value in it), not if a session cookie exist. It fixes #772
