### PR TITLE
[2.3] [Validator] added comparison constraints and validators

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * copied the constraints `Optional` and `Required` to the
    `Symfony\Component\Validator\Constraints\` namespace and deprecated the original
    classes.
+ * added comparison validators (EqualTo, NotEqualTo, LessThan, LessThanOrEqualTo, GreaterThan, GreaterThanOrEqualTo, IdenticalTo, NotIdenticalTo)
 
 2.2.0
 -----

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparison.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+/**
+ * Used for the comparison of values.
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+abstract class AbstractComparison extends Constraint
+{
+    public $message;
+    public $value;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($options = null)
+    {
+        if (!isset($options['value'])) {
+            throw new ConstraintDefinitionException(sprintf(
+                'The %s constraint requires the "value" option to be set.',
+                get_class($this)
+            ));
+        }
+
+        parent::__construct($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'value';
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AbstractComparisonValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Provides a base class for the validation of property comparisons.
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+abstract class AbstractComparisonValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!$this->compareValues($value, $constraint->value, $constraint)) {
+            $this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $this->valueToString($constraint->value),
+                '{{ compared_value }}' => $this->valueToString($constraint->value),
+                '{{ compared_value_type }}' => $this->valueToType($constraint->value)
+            ));
+        }
+    }
+
+    /**
+     * Returns a string representation of the type of the value.
+     *
+     * @param  mixed $value
+     *
+     * @return string
+     */
+    private function valueToType($value)
+    {
+        return is_object($value) ? get_class($value) : gettype($value);
+    }
+
+    /**
+     * Returns a string representation of the value.
+     *
+     * @param  mixed  $value
+     *
+     * @return string
+     */
+    private function valueToString($value)
+    {
+        if ($value instanceof \DateTime) {
+            return $value->format('Y-m-d H:i:s');
+        }
+
+        return var_export($value, true);
+    }
+
+    /**
+     * Compares the two given values to find if their relationship is valid
+     *
+     * @param mixed      $value1     The first value to compare
+     * @param mixed      $value2     The second value to compare
+     *
+     * @return Boolean true if the relationship is valid, false otherwise
+     */
+    abstract protected function compareValues($value1, $value2);
+}

--- a/src/Symfony/Component/Validator/Constraints/EqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualTo.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class EqualTo extends AbstractComparison
+{
+    public $message = 'This value should be equal to {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/EqualToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EqualToValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values are equal (==).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class EqualToValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 == $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/GreaterThan.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThan.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class GreaterThan extends AbstractComparison
+{
+    public $message = 'This value should be greater than {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqual.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class GreaterThanOrEqual extends AbstractComparison
+{
+    public $message = 'This value should be greater than or equal to {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqualValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanOrEqualValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values are greater than or equal to the previous (>=).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class GreaterThanOrEqualValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 >= $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/GreaterThanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/GreaterThanValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values are greater than the previous (>).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class GreaterThanValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 > $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalTo.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class IdenticalTo extends AbstractComparison
+{
+    public $message = 'This value should be identical to {{ compared_value_type }} {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/IdenticalToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IdenticalToValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values are identical (===).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class IdenticalToValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 === $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/LessThan.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThan.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class LessThan extends AbstractComparison
+{
+    public $message = 'This value should be less than {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqual.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class LessThanOrEqual extends AbstractComparison
+{
+    public $message = 'This value should be less than or equal to {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/LessThanOrEqualValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanOrEqualValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values are less than or equal to the previous (<=).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class LessThanOrEqualValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 <= $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/LessThanValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LessThanValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values are less than the previous (<).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class LessThanValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 < $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualTo.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class NotEqualTo extends AbstractComparison
+{
+    public $message = 'This value should not be equal to {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/NotEqualToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotEqualToValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values are all unequal (!=).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class NotEqualToValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 != $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalTo.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * @Annotation
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class NotIdenticalTo extends AbstractComparison
+{
+    public $message = 'This value should not be identical to {{ compared_value_type }} {{ compared_value }}';
+}

--- a/src/Symfony/Component/Validator/Constraints/NotIdenticalToValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotIdenticalToValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+/**
+ * Validates values aren't identical (!==).
+ *
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class NotIdenticalToValidator extends AbstractComparisonValidator
+{
+    /**
+     * @inheritDoc
+     */
+    protected function compareValues($value1, $value2)
+    {
+        return $value1 !== $value2;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AbstractComparisonValidatorTestCase.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\AbstractComparisonValidator;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+abstract class AbstractComparisonValidatorTestCase extends \PHPUnit_Framework_TestCase
+{
+    private $validator;
+    private $context;
+
+    protected function setUp()
+    {
+        $this->validator = $this->createValidator();
+        $this->context = $this->getMockBuilder('Symfony\Component\Validator\ExecutionContext')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->validator->initialize($this->context);
+    }
+
+    /**
+     * @return AbstractComparisonValidator
+     */
+    abstract protected function createValidator();
+
+    public function testThrowsConstraintExceptionIfNoValueOrProperty()
+    {
+        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+
+        $comparison = $this->createConstraint(array());
+        $this->validator->validate('some value', $comparison);
+    }
+
+    /**
+     * @dataProvider provideValidComparisons
+     * @param mixed $dirtyValue
+     * @param mixed $comparisonValue
+     */
+    public function testValidComparisonToValue($dirtyValue, $comparisonValue)
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $constraint = $this->createConstraint(array('value' => $comparisonValue));
+
+        $this->context->expects($this->any())
+            ->method('getPropertyPath')
+            ->will($this->returnValue('property1'));
+
+        $this->validator->validate($dirtyValue, $constraint);
+    }
+
+    /**
+     * @return array
+     */
+    abstract public function provideValidComparisons();
+
+    /**
+     * @dataProvider provideInvalidComparisons
+     * @param mixed  $dirtyValue
+     * @param mixed  $comparedValue
+     * @param mixed  $comparedValueString
+     * @param string $comparedValueType
+     */
+    public function testInvalidComparisonToValue($dirtyValue, $comparedValue, $comparedValueString, $comparedValueType)
+    {
+        $constraint = $this->createConstraint(array('value' => $comparedValue));
+        $constraint->message = 'Constraint Message';
+
+        $this->context->expects($this->any())
+            ->method('getPropertyPath')
+            ->will($this->returnValue('property1'));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('Constraint Message', array(
+                '{{ value }}' => $comparedValueString,
+                '{{ compared_value }}' => $comparedValueString,
+                '{{ compared_value_type }}' => $comparedValueType
+            ));
+
+        $this->validator->validate($dirtyValue, $constraint);
+    }
+
+    /**
+     * @return array
+     */
+    abstract public function provideInvalidComparisons();
+
+    /**
+     * @param  array      $options Options for the constraint
+     * @return Constraint
+     */
+    abstract protected function createConstraint(array $options);
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EqualToValidatorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\EqualTo;
+use Symfony\Component\Validator\Constraints\EqualToValidator;
+use Symfony\Component\Validator\Tests\Constraints\AbstractComparisonValidatorTestCase;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class EqualToValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new EqualToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new EqualTo($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(3, 3),
+            array(3, '3'),
+            array('a', 'a'),
+            array(new \DateTime('2000-01-01'), new \DateTime('2000-01-01'))
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(1, 2, '2', 'integer'),
+            array('22', '333', "'333'", 'string'),
+            array(new \DateTime('2001-01-01'), new \DateTime('2000-01-01'), '2000-01-01 00:00:00', 'DateTime')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanOrEqualValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
+use Symfony\Component\Validator\Constraints\GreaterThanOrEqualValidator;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class GreaterThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new GreaterThanOrEqualValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new GreaterThanOrEqual($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(3, 2),
+            array(1, 1),
+            array(new \DateTime('2010/01/01'), new \DateTime('2000/01/01')),
+            array(new \DateTime('2000/01/01'), new \DateTime('2000/01/01')),
+            array('a', 'a'),
+            array('z', 'a'),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(1, 2, '2', 'integer'),
+            array(new \DateTime('2000/01/01'), new \DateTime('2005/01/01'), '2005-01-01 00:00:00', 'DateTime'),
+            array('b', 'c', "'c'", 'string')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/GreaterThanValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\GreaterThan;
+use Symfony\Component\Validator\Constraints\GreaterThanValidator;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class GreaterThanValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new GreaterThanValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new GreaterThan($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(2, 1),
+            array(new \DateTime('2005/01/01'), new \DateTime('2001/01/01')),
+            array('333', '22')
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(1, 2, '2', 'integer'),
+            array(2, 2, '2', 'integer'),
+            array(new \DateTime('2000/01/01'), new \DateTime('2005/01/01'), '2005-01-01 00:00:00', 'DateTime'),
+            array(new \DateTime('2000/01/01'), new \DateTime('2000/01/01'), '2000-01-01 00:00:00', 'DateTime'),
+            array('22', '333', "'333'", 'string'),
+            array('22', '22', "'22'", 'string')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IdenticalToValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\IdenticalTo;
+use Symfony\Component\Validator\Constraints\IdenticalToValidator;
+use Symfony\Component\Validator\Tests\Constraints\AbstractComparisonValidatorTestCase;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class IdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new IdenticalToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new IdenticalTo($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        $date = new \DateTime('2000-01-01');
+
+        return array(
+            array(3, 3),
+            array('a', 'a'),
+            array($date, $date)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(1, 2, '2', 'integer'),
+            array(2, '2', "'2'", 'string'),
+            array('22', '333', "'333'", 'string'),
+            array(new \DateTime('2001-01-01'), new \DateTime('2001-01-01'), '2001-01-01 00:00:00', 'DateTime'),
+            array(new \DateTime('2001-01-01'), new \DateTime('1999-01-01'), '1999-01-01 00:00:00', 'DateTime')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanOrEqualValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LessThanOrEqual;
+use Symfony\Component\Validator\Constraints\LessThanOrEqualValidator;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class LessThanOrEqualValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new LessThanOrEqualValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new LessThanOrEqual($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(1, 2),
+            array(1, 1),
+            array(new \DateTime('2000-01-01'), new \DateTime('2000-01-01')),
+            array(new \DateTime('2000-01-01'), new \DateTime('2020-01-01')),
+            array('a', 'a'),
+            array('a', 'z'),
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(2, 1, '1', 'integer'),
+            array(new \DateTime('2010-01-01'), new \DateTime('2000-01-01'), '2000-01-01 00:00:00', 'DateTime'),
+            array('c', 'b', "'b'", 'string')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LessThanValidatorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\LessThan;
+use Symfony\Component\Validator\Constraints\LessThanValidator;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class LessThanValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new LessThanValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new LessThan($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(1, 2),
+            array(new \DateTime('2000-01-01'), new \DateTime('2010-01-01')),
+            array('22', '333')
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(3, 2, '2', 'integer'),
+            array(2, 2, '2', 'integer'),
+            array(new \DateTime('2010-01-01'), new \DateTime('2000-01-01'), '2000-01-01 00:00:00', 'DateTime'),
+            array(new \DateTime('2000-01-01'), new \DateTime('2000-01-01'), '2000-01-01 00:00:00', 'DateTime'),
+            array('333', '22', "'22'", 'string')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotEqualToValidatorTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\NotEqualTo;
+use Symfony\Component\Validator\Constraints\NotEqualToValidator;
+use Symfony\Component\Validator\Tests\Constraints\AbstractComparisonValidatorTestCase;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class NotEqualToValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new NotEqualToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new NotEqualTo($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(1, 2),
+            array('22', '333'),
+            array(new \DateTime('2001-01-01'), new \DateTime('2000-01-01'))
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        return array(
+            array(3, 3, '3', 'integer'),
+            array('2', 2, '2', 'integer'),
+            array('a', 'a', "'a'", 'string'),
+            array(new \DateTime('2000-01-01'), new \DateTime('2000-01-01'), '2000-01-01 00:00:00', 'DateTime')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotIdenticalToValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\NotIdenticalTo;
+use Symfony\Component\Validator\Constraints\NotIdenticalToValidator;
+use Symfony\Component\Validator\Tests\Constraints\AbstractComparisonValidatorTestCase;
+
+/**
+ * @author Daniel Holmes <daniel@danielholmes.org>
+ */
+class NotIdenticalToValidatorTest extends AbstractComparisonValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new NotIdenticalToValidator();
+    }
+
+    protected function createConstraint(array $options)
+    {
+        return new NotIdenticalTo($options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideValidComparisons()
+    {
+        return array(
+            array(1, 2),
+            array('2', 2),
+            array('22', '333'),
+            array(new \DateTime('2001-01-01'), new \DateTime('2000-01-01')),
+            array(new \DateTime('2000-01-01'), new \DateTime('2000-01-01'))
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function provideInvalidComparisons()
+    {
+        $date = new \DateTime('2000-01-01');
+
+        return array(
+            array(3, 3, '3', 'integer'),
+            array('a', 'a', "'a'", 'string'),
+            array($date, $date, '2000-01-01 00:00:00', 'DateTime')
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -212,7 +212,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             'Failed',
             'Failed',
             array(),
-            '',
+            'Bernhard',
             '',
             'Bernhard'
         ));

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -160,7 +160,7 @@ class Validator implements ValidatorInterface
      */
     public function validateValue($value, $constraints, $groups = null)
     {
-        $context = new ExecutionContext($this->createVisitor(null), $this->translator, $this->translationDomain);
+        $context = new ExecutionContext($this->createVisitor($value), $this->translator, $this->translationDomain);
 
         $constraints = is_array($constraints) ? $constraints : array($constraints);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

They work on a class level and you specify a list of properties. Included are the standard GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual and Equal. e.g.:

``` php
<?php
/**
 * @assert:GreaterThan({"diedDate", "bornDate"})
 * @assert:LessThanOrEqual({"bornDate", "firstSchoolDayDate", "diedDate"})
 */
class Person
{
    private $bornDate;
    private $firstSchoolDayDate;
    private $diedDate;
}
```

I think it would also be useful if they worked on a property level rather than just class. I'm not sure what the default option should be though. e.g. is there a reliable way to determine what's a raw value and what's a property name:

``` php
<?php
/** @assert:GreaterThan(80) */
private $iq;
/** @assert:LessThan('dateDied') */
private $bornDate;
/** @assert:LessThanOrEqual('C') */
private $grade;
/** @assert:GreaterThanOrEqual({50, 'ageStartedSchool'}) */
private $age;
```
