### PR TITLE
[EventDispatcher] Allow arbitrary callbacks

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/controller.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/controller.xml
@@ -29,7 +29,7 @@
             <tag name="assetic.factory_worker" />
         </service>
         <service id="assetic.request_listener" class="%assetic.request_listener.class%">
-            <tag name="kernel.listener" event="onCoreRequest" />
+            <tag name="kernel.listener" event="core.request" method="onCoreRequest" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
@@ -83,14 +83,14 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     {
         if (isset($this->listenerIds[$eventName])) {
             foreach ($this->listenerIds[$eventName] as $args) {
-                $serviceId = $args[0];
+                list($serviceId, $method, $priority) = $args;
                 $listener = $this->container->get($serviceId);
 
                 if (!isset($this->listeners[$eventName][$serviceId])) {
-                    $this->addListener($eventName, array($listener, $args[1]), $args[2]);
+                    $this->addListener($eventName, array($listener, $method), $priority);
                 } elseif ($listener !== $this->listeners[$eventName][$serviceId]) {
-                    $this->removeListener($eventName, array($listener, $args[1]));
-                    $this->addListener($eventName, array($listener, $args[1]), $args[2]);
+                    $this->removeListener($eventName, array($this->listeners[$eventName][$serviceId], $method));
+                    $this->addListener($eventName, array($listener, $method), $priority);
                 }
 
                 $this->listeners[$eventName][$serviceId] = $listener;

--- a/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
@@ -55,22 +55,20 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     /**
      * Adds a service as event listener
      *
-     * @param string|array $eventNames One or more events for which the listener is added
-     * @param string       $serviceId  The ID of the listener service
-     * @param integer      $priority   The higher this value, the earlier an event listener
-     *                                 will be triggered in the chain.
-     *                                 Defaults to 0.
+     * @param string   $eventName Event for which the listener is added
+     * @param array    $callback  The service ID of the listener service & the method
+     *                            name that has to be called
+     * @param integer  $priority  The higher this value, the earlier an event listener
+     *                            will be triggered in the chain.
+     *                            Defaults to 0.
      */
-    public function addListenerService($eventNames, $serviceId, $priority = 0)
+    public function addListenerService($eventName, $callback, $priority = 0)
     {
-        if (!is_string($serviceId)) {
-            throw new \InvalidArgumentException('Expected a string argument');
+        if (!is_array($callback) || 2 !== count($callback)) {
+            throw new \InvalidArgumentException('Expected an array("service", "method") argument');
         }
 
-        foreach ((array) $eventNames as $eventName) {
-            // Prevent duplicate entries
-            $this->listenerIds[$eventName][$serviceId] = $priority;
-        }
+        $this->listenerIds[$eventName][$callback[0].'::'.$callback[1]] = array($callback[0], $callback[1], $priority);
     }
 
     /**
@@ -84,14 +82,15 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     public function dispatch($eventName, Event $event = null)
     {
         if (isset($this->listenerIds[$eventName])) {
-            foreach ($this->listenerIds[$eventName] as $serviceId => $priority) {
+            foreach ($this->listenerIds[$eventName] as $args) {
+                $serviceId = $args[0];
                 $listener = $this->container->get($serviceId);
 
                 if (!isset($this->listeners[$eventName][$serviceId])) {
-                    $this->addListener($eventName, $listener, $priority);
+                    $this->addListener($eventName, array($listener, $args[1]), $args[2]);
                 } elseif ($listener !== $this->listeners[$eventName][$serviceId]) {
-                    $this->removeListener($eventName, $this->listeners[$eventName][$serviceId]);
-                    $this->addListener($eventName, $listener, $priority);
+                    $this->removeListener($eventName, array($listener, $args[1]));
+                    $this->addListener($eventName, array($listener, $args[1]), $args[2]);
                 }
 
                 $this->listeners[$eventName][$serviceId] = $listener;

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
@@ -76,14 +76,7 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
     protected function doDispatch($listeners, $eventName, Event $event)
     {
         foreach ($listeners as $listener) {
-            // TODO: remove this before final release, temporary transitional code
-            if (is_object($listener) && method_exists($listener, $eventName)) {
-                $listener->$eventName($event);
-                trigger_error('Event listeners should now be registered using a complete callback as the listener instead of just an instance. Adjust your code ASAP.', E_USER_DEPRECATED);
-            } else {
-                // only this call should remain
-                call_user_func($listener, $event);
-            }
+            call_user_func($listener, $event);
 
             $info = $this->getListenerInfo($listener, $eventName);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
@@ -52,15 +52,15 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
     {
         if (!is_callable($listener)) {
             if (is_string($listener)) {
-                $type = '[string] '.$listener;
+                $typeDefinition = '[string] '.$listener;
             } elseif (is_array($listener)) {
-                $type = '[array] '.$listener[0].', '.$listener[1];
+                $typeDefinition = '[array] '.$listener[0].', '.$listener[1];
             } elseif (is_object($listener)) {
-                $type = '[object] '.get_class($listener);
+                $typeDefinition = '[object] '.get_class($listener);
             } else {
-                $type = '[?] '.var_export($listener, true);
+                $typeDefinition = '[?] '.var_export($listener, true);
             }
-            $msg = sprintf('The given callback (%s) for event "%s" is not callable.', $type, $eventName);
+            $msg = sprintf('The given callback (%s) for event "%s" is not callable.', $typeDefinition, $eventName);
             if (null !== $this->logger) {
                 $this->logger->err($msg);
             }
@@ -102,14 +102,18 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
 
                     foreach ($skippedListeners as $skippedListener) {
                         if ($skipped) {
-                            $typeDef = is_object($skippedListener)
-                                ? get_class($skippedListener)
-                                : is_array($skippedListener)
-                                    ? is_object($skippedListener[0])
-                                        ? get_class($skippedListener[0])
-                                        : implode('::', $skippedListener)
-                                    : implode('::', $skippedListener);
-                            $this->logger->debug(sprintf('Listener "%s" was not called for event "%s".', $typeDef, $eventName));
+                            if (is_object($skippedListener)) {
+                                $typeDefinition = get_class($skippedListener);
+                            } elseif (is_array($skippedListener)) {
+                                if (is_object($skippedListener[0])) {
+                                    $typeDefinition = get_class($skippedListener);
+                                } else {
+                                    $typeDefinition = implode('::', $skippedListener);
+                                }
+                            } else {
+                                $typeDefinition = $skippedListener;
+                            }
+                            $this->logger->debug(sprintf('Listener "%s" was not called for event "%s".', $typeDefinition, $eventName));
                         }
 
                         if ($skippedListener === $listener) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/RegisterKernelListenersPass.php
@@ -33,7 +33,11 @@ class RegisterKernelListenersPass implements CompilerPassInterface
                     throw new \InvalidArgumentException(sprintf('Service "%s" must define the "event" attribute on "kernel.listener" tags.', $id));
                 }
 
-                $definition->addMethodCall('addListenerService', array($event['event'], $id, $priority));
+                if (!isset($event['method'])) {
+                    throw new \InvalidArgumentException(sprintf('Service "%s" must define the "method" attribute on "kernel.listener" tags.', $id));
+                }
+
+                $definition->addMethodCall('addListenerService', array($event['event'], array($id, $event['method']), $priority));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/collectors.xml
@@ -21,7 +21,7 @@
         </service>
 
         <service id="data_collector.request" class="%data_collector.request.class%" public="false">
-            <tag name="kernel.listener" event="onCoreController" />
+            <tag name="kernel.listener" event="core.controller" method="onCoreController"/>
             <tag name="data_collector" template="WebProfilerBundle:Collector:request" id="request" priority="255" />
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
@@ -13,7 +13,7 @@
         <service id="esi" class="%esi.class%" />
 
         <service id="esi_listener" class="%esi_listener.class%">
-          <tag name="kernel.listener" event="onCoreResponse" />
+          <tag name="kernel.listener" event="core.response" method="onCoreResponse" />
           <argument type="service" id="esi" on-invalid="ignore" />
         </service>
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -24,9 +24,9 @@
         </service>
 
         <service id="profiler_listener" class="%profiler_listener.class%">
-            <tag name="kernel.listener" event="onCoreResponse" priority="-100" />
-            <tag name="kernel.listener" event="onCoreException" />
-            <tag name="kernel.listener" event="onCoreRequest" />
+            <tag name="kernel.listener" event="core.response" method="onCoreResponse" priority="-100" />
+            <tag name="kernel.listener" event="core.exception" method="onCoreException" />
+            <tag name="kernel.listener" event="core.request" method="onCoreRequest" />
             <argument type="service" id="service_container" />
             <argument type="service" id="profiler.request_matcher" on-invalid="null" />
             <argument>%profiler_listener.only_exceptions%</argument>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/test.xml
@@ -26,8 +26,8 @@
 
         <service id="test.session.listener" class="%test.session.listener.class%">
             <argument type="service" id="service_container" />
-            <tag name="kernel.listener" event="onCoreRequest" priority="128" />
-            <tag name="kernel.listener" event="onCoreResponse" priority="-128" />
+            <tag name="kernel.listener" event="core.request" method="onCoreRequest" priority="128" />
+            <tag name="kernel.listener" event="core.response" method="onCoreResponse" priority="-128" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -27,7 +27,7 @@
         </service>
 
         <service id="request_listener" class="%request_listener.class%">
-            <tag name="kernel.listener" event="onCoreRequest" />
+            <tag name="kernel.listener" event="core.request" method="onCoreRequest" />
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="service_container" />
             <argument type="service" id="router" />
@@ -37,12 +37,12 @@
         </service>
 
         <service id="response_listener" class="%response_listener.class%">
-            <tag name="kernel.listener" event="onCoreResponse" />
+            <tag name="kernel.listener" event="core.response" method="onCoreResponse" />
             <argument>%kernel.charset%</argument>
         </service>
 
         <service id="exception_listener" class="%exception_listener.class%">
-            <tag name="kernel.listener" event="onCoreException" priority="-128" />
+            <tag name="kernel.listener" event="core.exception" method="onCoreException" priority="-128" />
             <tag name="monolog.logger" channel="request" />
             <argument>%exception_listener.controller%</argument>
             <argument type="service" id="logger" on-invalid="null" />

--- a/src/Symfony/Bundle/FrameworkBundle/Test/SessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/SessionListener.php
@@ -55,7 +55,7 @@ class SessionListener
 
     /**
      * Checks if session was initialized and saves if current request is master
-     * Runs on 'onCoreResponse' in test environment
+     * Runs on 'core.response' in test environment
      *
      * @param FilterResponseEvent $event
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ContainerAwareEventDispatcherTest.php
@@ -25,7 +25,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $container->set('service.listener', $service);
 
         $dispatcher = new ContainerAwareEventDispatcher($container);
-        $dispatcher->addListenerService('onEvent', 'service.listener');
+        $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'));
 
         $dispatcher->dispatch('onEvent', $event);
     }
@@ -46,8 +46,8 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $container->set('service.listener', $service);
 
         $dispatcher = new ContainerAwareEventDispatcher($container);
-        $dispatcher->addListenerService('onEvent', 'service.listener', 5);
-        $dispatcher->addListenerService('onEvent', 'service.listener', 10);
+        $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'), 5);
+        $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'), 10);
 
         $dispatcher->dispatch('onEvent', $event);
     }
@@ -67,7 +67,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $container->set('service.listener', $service, 'scope');
 
         $dispatcher = new ContainerAwareEventDispatcher($container);
-        $dispatcher->addListenerService('onEvent', 'service.listener');
+        $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'));
 
         $container->leaveScope('scope');
         $dispatcher->dispatch('onEvent');
@@ -93,7 +93,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $container->set('service.listener', $service1, 'scope');
 
         $dispatcher = new ContainerAwareEventDispatcher($container);
-        $dispatcher->addListenerService('onEvent', 'service.listener');        
+        $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'));
         $dispatcher->dispatch('onEvent', $event);
 
         $service2 = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
@@ -118,6 +118,6 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
 class Service
 {
     function onEvent(Event $e)
-    {        
+    {
     }
 }

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -125,7 +125,7 @@ class MonologExtension extends Extension
                 $handler['level'],
                 $handler['bubble'],
             ));
-            $definition->addTag('kernel.listener', array('event' => 'onCoreResponse'));
+            $definition->addTag('kernel.listener', array('event' => 'core.response', 'method' => 'onCoreResponse'));
             break;
 
         case 'rotating_file':

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -66,7 +66,7 @@
         </service>
 
         <service id="security.encoder_factory" alias="security.encoder_factory.generic"></service>
-        
+
         <service id="security.user_checker" class="%security.user_checker.class%" public="false" />
 
 
@@ -98,7 +98,7 @@
 
         <!-- Firewall related services -->
         <service id="security.firewall" class="%security.firewall.class%">
-            <tag name="kernel.listener" event="onCoreRequest" priority="-128" />
+            <tag name="kernel.listener" event="core.request" method="onCoreRequest" priority="-128" />
             <argument type="service" id="security.firewall.map" />
             <argument type="service" id="event_dispatcher" />
         </service>

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
@@ -54,7 +54,7 @@
         </service>
 
         <service id="security.rememberme.response_listener" class="%security.rememberme.response_listener.class%">
-            <tag name="kernel.listener" event="onCoreResponse"/>
+            <tag name="kernel.listener" event="core.response" method="onCoreResponse" />
         </service>
     </services>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/toolbar.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="web_profiler.debug_toolbar" class="%web_profiler.debug_toolbar.class%">
-            <tag name="kernel.listener" event="onCoreResponse" priority="-128" />
+            <tag name="kernel.listener" event="core.response" method="onCoreResponse" priority="-128" />
             <argument type="service" id="templating.engine.twig" />
             <argument>%web_profiler.debug_toolbar.intercept_redirects%</argument>
             <argument>%web_profiler.debug_toolbar.verbose%</argument>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/events.html.twig
@@ -47,8 +47,11 @@
 {% macro display_listener(listener) %}
     {% if listener.type == "Closure" %}
         Closure
-    {% else %}
+    {% elseif listener.type == "Function" %}
         {% set link = listener.file|file_link(listener.line) %}
-        {{ listener.class|abbr_class }}::{% if link %}<a href="{{ link }}">{{ listener.event }}</a>{% else %}{{ listener.event }}{% endif %}
+        {% if link %}<a href="{{ link }}">{{ listener.function }}</a>{% else %}{{ listener.function }}{% endif %}
+    {% elseif listener.type == "Method" %}
+        {% set link = listener.file|file_link(listener.line) %}
+        {{ listener.class|abbr_class }}::{% if link %}<a href="{{ link }}">{{ listener.method }}</a>{% else %}{{ listener.method }}{% endif %}
     {% endif %}
 {% endmacro %}

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -74,7 +74,6 @@ class EventDispatcher implements EventDispatcherInterface
             return $this->sorted[$eventName];
         }
 
-        $sorted = array();
         foreach (array_keys($this->listeners) as $eventName) {
             if (!isset($this->sorted[$eventName])) {
                 $this->sortListeners($eventName);
@@ -85,7 +84,7 @@ class EventDispatcher implements EventDispatcherInterface
             }
         }
 
-        return $sorted;
+        return $this->sorted;
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -106,9 +106,6 @@ class EventDispatcher implements EventDispatcherInterface
     {
         foreach ((array) $eventNames as $eventName) {
             if (!isset($this->listeners[$eventName][$priority])) {
-                if (!isset($this->listeners[$eventName])) {
-                    $this->listeners[$eventName] = array();
-                }
                 $this->listeners[$eventName][$priority] = new \SplObjectStorage();
             }
 

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -27,14 +27,12 @@ namespace Symfony\Component\EventDispatcher;
  * manager.
  *
  * @license http://www.opensource.org/licenses/lgpl-license.php LGPL
- * @link    www.doctrine-project.org
- * @since   2.0
- * @version $Revision: 3938 $
  * @author  Guilherme Blanco <guilhermeblanco@hotmail.com>
  * @author  Jonathan Wage <jonwage@gmail.com>
  * @author  Roman Borschel <roman@code-factory.org>
  * @author  Bernhard Schussek <bschussek@gmail.com>
  * @author  Fabien Potencier <fabien@symfony.com>
+ * @author  Jordi Boggiano <j.boggiano@seld.be>
  *
  * @api
  */
@@ -58,13 +56,7 @@ class EventDispatcher implements EventDispatcherInterface
             $event = new Event();
         }
 
-        foreach ($this->getListeners($eventName) as $listener) {
-            $this->triggerListener($listener, $eventName, $event);
-
-            if ($event->isPropagationStopped()) {
-                break;
-            }
-        }
+        $this->doDispatch($this->getListeners($eventName), $eventName, $event);
     }
 
     /**
@@ -161,22 +153,27 @@ class EventDispatcher implements EventDispatcherInterface
     }
 
     /**
-     * Triggers the listener method for an event.
+     * Triggers the listeners of an event.
      *
      * This method can be overridden to add functionality that is executed
      * for each listener.
      *
-     * @param object $listener The event listener on which to invoke the listener method.
-     * @param string $eventName The name of the event to dispatch. The name of the event is
-     *                          the name of the method that is invoked on listeners.
-     * @param Event $event The event arguments to pass to the event handlers/listeners.
+     * @param array[callback] $listeners The event listeners.
+     * @param string $eventName The name of the event to dispatch.
+     * @param Event $event The event object to pass to the event handlers/listeners.
      */
-    protected function triggerListener($listener, $eventName, Event $event)
+    protected function doDispatch($listeners, $eventName, Event $event)
     {
-        if ($listener instanceof \Closure) {
-            $listener->__invoke($event);
-        } else {
-            $listener->$eventName($event);
+        foreach ($listeners as $listener) {
+            if ($listener instanceof \Closure) {
+                $listener->__invoke($event);
+            } else {
+                $listener->$eventName($event);
+            }
+
+            if ($event->isPropagationStopped()) {
+                break;
+            }
         }
     }
 

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -163,15 +163,7 @@ class EventDispatcher implements EventDispatcherInterface
     protected function doDispatch($listeners, $eventName, Event $event)
     {
         foreach ($listeners as $listener) {
-            // TODO: remove this before final release, temporary transitional code
-            if (is_object($listener) && method_exists($listener, $eventName)) {
-                $listener->$eventName($event);
-                //trigger_error('Event listeners should now be registered using a complete callback as the listener instead of just an instance. Adjust your code ASAP.', E_USER_DEPRECATED);
-            } else {
-                // only this call should remain
-                call_user_func($listener, $event);
-            }
-
+            call_user_func($listener, $event);
             if ($event->isPropagationStopped()) {
                 break;
             }

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -273,9 +273,9 @@ class FormBuilder
      *
      * @return FormBuilder The current builder
      */
-    public function addEventListener($eventNames, $listener, $priority = 0)
+    public function addEventListener($eventName, $listener, $priority = 0)
     {
-        $this->dispatcher->addListener($eventNames, $listener, $priority);
+        $this->dispatcher->addListener($eventName, $listener, $priority);
 
         return $this;
     }

--- a/src/Symfony/Component/HttpKernel/CoreEvents.php
+++ b/src/Symfony/Component/HttpKernel/CoreEvents.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpKernel;
  *
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>
  */
-final class Events
+final class CoreEvents
 {
     /**
      * The onCoreRequest event occurs at the very beginning of request
@@ -29,7 +29,7 @@ final class Events
      *
      * @var string
      */
-    const onCoreRequest = 'onCoreRequest';
+    const request = 'core.request';
 
     /**
      * The onCoreException event occurs when an uncaught exception appears
@@ -41,7 +41,7 @@ final class Events
      *
      * @var string
      */
-    const onCoreException = 'onCoreException';
+    const exception = 'core.exception';
 
     /**
      * The onCoreView event occurs when the return value of a controller
@@ -54,7 +54,7 @@ final class Events
      *
      * @var string
      */
-    const onCoreView = 'onCoreView';
+    const view = 'core.view';
 
     /**
      * The onCoreController event occurs once a controller was found for
@@ -66,7 +66,7 @@ final class Events
      *
      * @var string
      */
-    const onCoreController = 'onCoreController';
+    const controller = 'core.controller';
 
     /**
      * The onCoreController event occurs once a response was created for
@@ -78,5 +78,5 @@ final class Events
      *
      * @var string
      */
-    const onCoreResponse = 'onCoreResponse';
+    const response = 'core.response';
 }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -89,7 +89,7 @@ class HttpKernel implements HttpKernelInterface
     {
         // request
         $event = new GetResponseEvent($this, $request, $type);
-        $this->dispatcher->dispatch(Events::onCoreRequest, $event);
+        $this->dispatcher->dispatch(CoreEvents::request, $event);
 
         if ($event->hasResponse()) {
             return $this->filterResponse($event->getResponse(), $request, $type);
@@ -101,7 +101,7 @@ class HttpKernel implements HttpKernelInterface
         }
 
         $event = new FilterControllerEvent($this, $controller, $request, $type);
-        $this->dispatcher->dispatch(Events::onCoreController, $event);
+        $this->dispatcher->dispatch(CoreEvents::controller, $event);
         $controller = $event->getController();
 
         // controller arguments
@@ -113,7 +113,7 @@ class HttpKernel implements HttpKernelInterface
         // view
         if (!$response instanceof Response) {
             $event = new GetResponseForControllerResultEvent($this, $request, $type, $response);
-            $this->dispatcher->dispatch(Events::onCoreView, $event);
+            $this->dispatcher->dispatch(CoreEvents::view, $event);
 
             if ($event->hasResponse()) {
                 $response = $event->getResponse();
@@ -148,7 +148,7 @@ class HttpKernel implements HttpKernelInterface
     {
         $event = new FilterResponseEvent($this, $request, $type, $response);
 
-        $this->dispatcher->dispatch(Events::onCoreResponse, $event);
+        $this->dispatcher->dispatch(CoreEvents::response, $event);
 
         return $event->getResponse();
     }
@@ -165,7 +165,7 @@ class HttpKernel implements HttpKernelInterface
     private function handleException(\Exception $e, $request, $type)
     {
         $event = new GetResponseForExceptionEvent($this, $request, $type, $e);
-        $this->dispatcher->dispatch(Events::onCoreException, $event);
+        $this->dispatcher->dispatch(CoreEvents::exception, $event);
 
         if (!$event->hasResponse()) {
             throw $e;

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Events as KernelEvents;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -28,7 +28,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
-use Symfony\Component\Security\Http\Events;
+use Symfony\Component\Security\Http\SecurityEvents;
 
 /**
  * The AbstractAuthenticationListener is the preferred base class for all
@@ -216,7 +216,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
 
         if (null !== $this->dispatcher) {
             $loginEvent = new InteractiveLoginEvent($request, $token);
-            $this->dispatcher->dispatch(Events::onSecurityInteractiveLogin, $loginEvent);
+            $this->dispatcher->dispatch(SecurityEvents::interactiveLogin, $loginEvent);
         }
 
         if (null !== $this->successHandler) {

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -16,9 +16,9 @@ use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterfac
 use Symfony\Component\Security\Core\Authentication\Token\PreAuthenticatedToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
-use Symfony\Component\Security\Http\Events;
+use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Events as KernelEvents;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -82,7 +82,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
 
             if (null !== $this->dispatcher) {
                 $loginEvent = new InteractiveLoginEvent($request, $token);
-                $this->dispatcher->dispatch(Events::onSecurityInteractiveLogin, $loginEvent);
+                $this->dispatcher->dispatch(SecurityEvents::interactiveLogin, $loginEvent);
             }
         } catch (AuthenticationException $failed) {
             $this->securityContext->setToken(null);

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Events;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
@@ -49,7 +49,7 @@ class ContextListener implements ListenerInterface
         $this->contextKey = $contextKey;
 
         if (null !== $dispatcher) {
-            $dispatcher->addListener(Events::onCoreResponse, $this);
+            $dispatcher->addListener(CoreEvents::response, array($this, 'core.response'));
         }
     }
 

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Exception\InsufficientAuthenticationException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Events;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -59,7 +59,7 @@ class ExceptionListener
      */
     public function register(EventDispatcherInterface $dispatcher)
     {
-        $dispatcher->addListener(Events::onCoreException, $this);
+        $dispatcher->addListener(CoreEvents::exception, array($this, 'core.exception'));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Events as KernelEvents;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\Exception\CookieTheftException;
 use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
-use Symfony\Component\Security\Http\Events;
+use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /*
@@ -80,7 +80,7 @@ class RememberMeListener implements ListenerInterface
 
             if (null !== $this->dispatcher) {
                 $loginEvent = new InteractiveLoginEvent($request, $token);
-                $this->dispatcher->dispatch(Events::onSecurityInteractiveLogin, $loginEvent);
+                $this->dispatcher->dispatch(SecurityEvents::interactiveLogin, $loginEvent);
             }
 
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -27,7 +27,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
-use Symfony\Component\Security\Http\Events;
+use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -133,7 +133,7 @@ class SwitchUserListener implements ListenerInterface
 
         if (null !== $this->dispatcher) {
             $switchEvent = new SwitchUserEvent($request, $token->getUser());
-            $this->dispatcher->dispatch(Events::onSecuritySwitchUser, $switchEvent);
+            $this->dispatcher->dispatch(SecurityEvents::switchUser, $switchEvent);
         }
 
         return $token;
@@ -154,7 +154,7 @@ class SwitchUserListener implements ListenerInterface
 
         if (null !== $this->dispatcher) {
             $switchEvent = new SwitchUserEvent($request, $original->getUser());
-            $this->dispatcher->dispatch(Events::onSecuritySwitchUser, $switchEvent);
+            $this->dispatcher->dispatch(SecurityEvents::switchUser, $switchEvent);
         }
 
         return $original;

--- a/src/Symfony/Component/Security/Http/SecurityEvents.php
+++ b/src/Symfony/Component/Security/Http/SecurityEvents.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Security\Http;
 
-final class Events
+final class SecurityEvents
 {
-    const onSecurityInteractiveLogin = 'onSecurityInteractiveLogin';
+    const interactiveLogin = 'security.interactive_login';
 
-    const onSecuritySwitchUser = 'onSecuritySwitchUser';
+    const switchUser = 'security.switch_user';
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpCache/EsiListenerTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpCache/EsiListenerTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Tests\Component\HttpKernel\HttpCache;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 use Symfony\Component\HttpKernel\HttpCache\EsiListener;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Events;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,9 +29,9 @@ class EsiListenerTest extends \PHPUnit_Framework_TestCase
         $response = new Response('foo <esi:include src="" />');
         $listener = new EsiListener(new Esi());
 
-        $dispatcher->addListener(Events::onCoreResponse, $listener);
+        $dispatcher->addListener(CoreEvents::response, $listener);
         $event = new FilterResponseEvent($kernel, new Request(), HttpKernelInterface::SUB_REQUEST, $response);
-        $dispatcher->dispatch(Events::onCoreResponse, $event);
+        $dispatcher->dispatch(CoreEvents::response, $event);
 
         $this->assertEquals('', $event->getResponse()->headers->get('Surrogate-Control'));
     }
@@ -43,9 +43,9 @@ class EsiListenerTest extends \PHPUnit_Framework_TestCase
         $response = new Response('foo <esi:include src="" />');
         $listener = new EsiListener(new Esi());
 
-        $dispatcher->addListener(Events::onCoreResponse, $listener);
+        $dispatcher->addListener(CoreEvents::response, $listener);
         $event = new FilterResponseEvent($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, $response);
-        $dispatcher->dispatch(Events::onCoreResponse, $event);
+        $dispatcher->dispatch(CoreEvents::response, $event);
 
         $this->assertEquals('content="ESI/1.0"', $event->getResponse()->headers->get('Surrogate-Control'));
     }
@@ -57,9 +57,9 @@ class EsiListenerTest extends \PHPUnit_Framework_TestCase
         $response = new Response('foo');
         $listener = new EsiListener(new Esi());
 
-        $dispatcher->addListener(Events::onCoreResponse, $listener);
+        $dispatcher->addListener(CoreEvents::response, $listener);
         $event = new FilterResponseEvent($kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, $response);
-        $dispatcher->dispatch(Events::onCoreResponse, $event);
+        $dispatcher->dispatch(CoreEvents::response, $event);
 
         $this->assertEquals('', $event->getResponse()->headers->get('Surrogate-Control'));
     }

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpKernelTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpKernelTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Tests\Component\HttpKernel;
 
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Events;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -43,7 +43,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
     public function testHandleWhenControllerThrowsAnExceptionAndRawIsFalse()
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(Events::onCoreException, function ($event)
+        $dispatcher->addListener(CoreEvents::exception, function ($event)
         {
             $event->setResponse(new Response($event->getException()->getMessage()));
         });
@@ -56,7 +56,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
     public function testHandleWhenAListenerReturnsAResponse()
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(Events::onCoreRequest, function ($event)
+        $dispatcher->addListener(CoreEvents::request, function ($event)
         {
             $event->setResponse(new Response('hello'));
         });
@@ -143,7 +143,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
     public function testHandleWhenControllerDoesNotReturnAResponseButAViewIsRegistered()
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(Events::onCoreView, function ($event)
+        $dispatcher->addListener(CoreEvents::view, function ($event)
         {
             $event->setResponse(new Response($event->getControllerResult()));
         });
@@ -155,7 +155,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
     public function testHandleWithAResponseListener()
     {
         $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(Events::onCoreResponse, function ($event)
+        $dispatcher->addListener(CoreEvents::response, function ($event)
         {
             $event->setResponse(new Response('foo'));
         });

--- a/tests/Symfony/Tests/Component/HttpKernel/ResponseListenerTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/ResponseListenerTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Events;
+use Symfony\Component\HttpKernel\CoreEvents;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ResponseListenerTest extends \PHPUnit_Framework_TestCase
@@ -29,7 +29,7 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
     {
         $this->dispatcher = new EventDispatcher();
         $listener = new ResponseListener('UTF-8');
-        $this->dispatcher->addListener(Events::onCoreResponse, $listener);
+        $this->dispatcher->addListener(CoreEvents::response, $listener);
 
         $this->kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
 
@@ -39,7 +39,7 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
         $response = new Response('foo');
 
         $event = new FilterResponseEvent($this->kernel, new Request(), HttpKernelInterface::SUB_REQUEST, $response);
-        $this->dispatcher->dispatch(Events::onCoreResponse, $event);
+        $this->dispatcher->dispatch(CoreEvents::response, $event);
 
         $this->assertEquals('', $event->getResponse()->headers->get('content-type'));
     }
@@ -50,7 +50,7 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
         $response->headers->set('Content-Type', 'text/plain');
 
         $event = new FilterResponseEvent($this->kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, $response);
-        $this->dispatcher->dispatch(Events::onCoreResponse, $event);
+        $this->dispatcher->dispatch(CoreEvents::response, $event);
 
         $this->assertEquals('text/plain', $event->getResponse()->headers->get('content-type'));
     }
@@ -60,7 +60,7 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
         $response = new Response('foo');
 
         $event = new FilterResponseEvent($this->kernel, Request::create('/'), HttpKernelInterface::MASTER_REQUEST, $response);
-        $this->dispatcher->dispatch(Events::onCoreResponse, $event);
+        $this->dispatcher->dispatch(CoreEvents::response, $event);
 
         $this->assertEquals('text/html', $event->getResponse()->headers->get('content-type'));
     }
@@ -72,7 +72,7 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
         $request->setRequestFormat('json');
 
         $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
-        $this->dispatcher->dispatch(Events::onCoreResponse, $event);
+        $this->dispatcher->dispatch(CoreEvents::response, $event);
 
         $this->assertEquals('application/json', $event->getResponse()->headers->get('content-type'));
     }


### PR DESCRIPTION
Copy from the commit messages that are relevant:

```
[EventDispatcher] Allow registration of arbitrary callbacks

This in effect removes the direct link between event name and the method name on the handler.
Any callback can be given as a handler and the event name becomes an arbitrary string. Allowing for easier namespacing (see next commit)
```

And:

```
Update Core and Security events to latest model

The main benefit is that in XML/YML files we have common syntax (i.e. core.controller, form.pre_bind) that properly namespaces event names (before: onCoreController was ok, preBind was not).
On the other hand in PHP land we also have namespaced events, CoreEvents::controller, FormEvents::preBind, before it was Events::onCoreController, Events::onPreBind, we now have more context.
```

I'll update Forms if we can agree this is progress, because I already wasted enough time on this as it is.

Obviously the one huge drawback is BC breaks for everyone that registered events in their code, others should be unaffected.
