### PR TITLE
[Form] removed validation of form children

### DIFF
--- a/src/Symfony/Component/Form/Resources/config/validation.xml
+++ b/src/Symfony/Component/Form/Resources/config/validation.xml
@@ -11,8 +11,5 @@
         <value>validateFormData</value>
       </value>
     </constraint>
-    <property name="children">
-      <constraint name="Valid" />
-    </property>
   </class>
 </constraint-mapping>


### PR DESCRIPTION
Validation of form children is not necessary. You can use the `Valid` constraint to accomplish this when desired.
