### PR TITLE
[WebProfilerBundle] Prevent search engine indexing

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
@@ -2,6 +2,7 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="robots" content="noindex,nofollow" />
         <title>{% block title 'Profiler' %}</title>
         <link rel="shortcut icon" type="image/x-icon" href="{{ asset('bundles/webprofiler/favicon.ico') }}" />
         {% block head %}


### PR DESCRIPTION
I know it is recommended to switch off debug option and development scripts in production environment. But, some users forget it sometimes. Maybe we can improve security by prevent indexing the profiler by search engines.

By now you can find the first symfony2 projects by searching for:
http://www.google.de/search?q=symfony+accel
