### PR TITLE
[FrameworkBundle] Do not override the session storage for test

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -71,9 +71,6 @@ class FrameworkExtension extends Extension
 
         if (!empty($config['test'])) {
             $loader->load('test.xml');
-            if (isset($config['session'])) {
-                $config['session']['storage_id'] = 'session.storage.filesystem';
-            }
         }
 
         if (isset($config['csrf_protection'])) {


### PR DESCRIPTION
This is removed in favor of https://github.com/symfony/symfony-standard/pull/70

Otherwise, if you want to use your own session storage in tests it's impossible (or rather made overly difficult).
