### PR TITLE
[HttpFoundation] Do not auto-start the session when saving

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -272,7 +272,7 @@ class Session implements \Serializable
     public function save()
     {
         if (false === $this->started) {
-            $this->start();
+            return;
         }
 
         if (isset($this->attributes['_flash'])) {


### PR DESCRIPTION
In the current code, __destruct() always calls save(), which calls start(), so even without auto_start, the session is always started. Since all session getters/setters auto-start the session, this shouldn't be an issue. 

The only potential edge case is if someone sets a flash message, doesn't read them on the next request, and doesn't start the session either, then they won't be cleared. But I don't think this is a real use case we have to care about, people disabling session auto_start should know what they're doing with flash messages and all.
