### PR TITLE
[DoctrineBundle] Removed orm reference in DoctrineAbstractBundle

### DIFF
--- a/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineAbstractBundle/DependencyInjection/AbstractDoctrineExtension.php
@@ -263,11 +263,12 @@ abstract class AbstractDoctrineExtension extends Extension
         }
         $container->addResource(new FileResource($resource));
 
-        if (($files = glob($dir.'/'.$configPath.'/*.orm.xml')) && count($files)) {
+        $extension = $this->getMappingResourceExtension();
+        if (($files = glob($dir.'/'.$configPath.'/*.'.$extension.'.xml')) && count($files)) {
             return 'xml';
-        } elseif (($files = glob($dir.'/'.$configPath.'/*.orm.yml')) && count($files)) {
+        } elseif (($files = glob($dir.'/'.$configPath.'/*.'.$extension.'.yml')) && count($files)) {
             return 'yml';
-        } elseif (($files = glob($dir.'/'.$configPath.'/*.orm.php')) && count($files)) {
+        } elseif (($files = glob($dir.'/'.$configPath.'/*.'.$extension.'.php')) && count($files)) {
             return 'php';
         }
 
@@ -306,4 +307,11 @@ abstract class AbstractDoctrineExtension extends Extension
      * @return string
      */
     abstract protected function getMappingResourceConfigDirectory();
+
+    /**
+     * Extension used by the mapping files.
+     *
+     * @return string
+     */
+    abstract protected function getMappingResourceExtension();
 }

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -318,6 +318,11 @@ class DoctrineExtension extends AbstractDoctrineExtension
         return 'Resources/config/doctrine';
     }
 
+    protected function getMappingResourceExtension()
+    {
+        return 'orm';
+    }
+
     /**
      * Loads a configured entity managers cache drivers.
      *


### PR DESCRIPTION
This removes an ORM specific stuff in DoctrineAbstractBundle to avoid breaking DoctrineMongoDBBundle
