### PR TITLE
MaxLengthValidator: method_exists does not work if you append the () to the method name, thus

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
@@ -23,7 +23,7 @@ class MaxLengthValidator extends ConstraintValidator
             return true;
         }
 
-        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString()'))) {
+        if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
             throw new UnexpectedTypeException($value, 'string');
         }
 


### PR DESCRIPTION
method_exists does not work if you append the () to the method name, thus this never words for objects that actually have the __toString method. Removed the erroneous () so that this works as it appears to have been intended.
