### PR TITLE
[AsseticBundle] refactored assetic:dump command for runtime debug logic

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
+++ b/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
@@ -51,13 +51,19 @@ class DumpCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if ($input->getOption('watch')) {
-            return $this->watch($output);
+        if (!$input->getOption('watch')) {
+            foreach ($this->am->getNames() as $name) {
+                $this->dumpAsset($this->am->get($name), $output);
+            }
+
+            return;
         }
 
-        foreach ($this->am->getNames() as $name) {
-            $this->dumpAsset($this->am->get($name), $output);
+        if (!$this->debug) {
+            throw new \RuntimeException('The --watch option is only available in debug mode.');
         }
+
+        $this->watch($output);
     }
 
     /**
@@ -70,10 +76,6 @@ class DumpCommand extends Command
      */
     protected function watch(OutputInterface $output)
     {
-        if (!$this->debug) {
-            throw new \RuntimeException('The --watch option is only available in debug mode.');
-        }
-
         $refl = new \ReflectionClass('Assetic\\AssetManager');
         $prop = $refl->getProperty('assets');
         $prop->setAccessible(true);

--- a/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
+++ b/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
@@ -72,7 +72,7 @@ class DumpCommand extends Command
      *
      * @param OutputInterface $output The command output
      */
-    protected function watch(OutputInterface $output)
+    private function watch(OutputInterface $output)
     {
         $refl = new \ReflectionClass('Assetic\\AssetManager');
         $prop = $refl->getProperty('assets');
@@ -119,7 +119,7 @@ class DumpCommand extends Command
      *
      * @return AssetInterface|Boolean The asset if it should be dumped
      */
-    protected function checkAsset($name, array &$previously)
+    private function checkAsset($name, array &$previously)
     {
         $formula = $this->am->hasFormula($name) ? serialize($this->am->getFormula($name)) : null;
         $asset = $this->am->get($name);
@@ -145,7 +145,7 @@ class DumpCommand extends Command
      * @param string          $name   An asset name
      * @param OutputInterface $output The command output
      */
-    protected function dumpAsset($name, OutputInterface $output)
+    private function dumpAsset($name, OutputInterface $output)
     {
         $asset = $this->am->get($name);
         $formula = $this->am->getFormula($name);
@@ -169,7 +169,7 @@ class DumpCommand extends Command
      *
      * @throws RuntimeException If there is a problem writing the asset
      */
-    protected function doDump(AssetInterface $asset, OutputInterface $output)
+    private function doDump(AssetInterface $asset, OutputInterface $output)
     {
         $target = rtrim($this->basePath, '/').'/'.str_replace('_controller/', '', $asset->getTargetUrl());
         if (!is_dir($dir = dirname($target))) {

--- a/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
+++ b/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
@@ -28,6 +28,7 @@ class DumpCommand extends Command
 {
     private $basePath;
     private $am;
+    private $debug;
 
     protected function configure()
     {
@@ -45,12 +46,13 @@ class DumpCommand extends Command
 
         $this->basePath = $input->getArgument('write_to') ?: $this->container->getParameter('assetic.write_to');
         $this->am = $this->container->get('assetic.asset_manager');
+        $this->debug = $this->container->getParameter('assetic.debug');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getOption('watch')) {
-            return $this->watch($output, $this->container->getParameter('kernel.debug'));
+            return $this->watch($output);
         }
 
         foreach ($this->am->getNames() as $name) {
@@ -65,11 +67,10 @@ class DumpCommand extends Command
      * manager for changes.
      *
      * @param OutputInterface $output The command output
-     * @param Boolean         $debug  Debug mode
      */
-    protected function watch(OutputInterface $output, $debug = false)
+    protected function watch(OutputInterface $output)
     {
-        if (!$debug) {
+        if (!$this->debug) {
             throw new \RuntimeException('The --watch option is only available in debug mode.');
         }
 

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Command/DumpCommandTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Command/DumpCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Command;
+
+use Symfony\Bundle\AsseticBundle\Command\DumpCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class DumpCommandTest extends \PHPUnit_Framework_TestCase
+{
+    private $application;
+    private $definition;
+    private $kernel;
+    private $container;
+    private $am;
+
+    protected function setUp()
+    {
+        if (!class_exists('Assetic\\AssetManager')) {
+            $this->markTestSkipped('Assetic is not available.');
+        }
+
+        $this->application = $this->getMockBuilder('Symfony\\Bundle\\FrameworkBundle\\Console\\Application')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->definition = $this->getMockBuilder('Symfony\\Component\\Console\\Input\\InputDefinition')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
+        $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $this->am = $this->getMockBuilder('Assetic\\Factory\\LazyAssetManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->application->expects($this->any())
+            ->method('getDefinition')
+            ->will($this->returnValue($this->definition));
+        $this->definition->expects($this->any())
+            ->method('getArguments')
+            ->will($this->returnValue(array()));
+        $this->definition->expects($this->any())
+            ->method('getOptions')
+            ->will($this->returnValue(array()));
+        $this->application->expects($this->any())
+            ->method('getKernel')
+            ->will($this->returnValue($this->kernel));
+        $this->kernel->expects($this->any())
+            ->method('getContainer')
+            ->will($this->returnValue($this->container));
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with('assetic.asset_manager')
+            ->will($this->returnValue($this->am));
+
+        $this->command = new DumpCommand();
+        $this->command->setApplication($this->application);
+    }
+
+    public function testEmptyAssetManager()
+    {
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array()));
+
+        $this->command->run(new ArrayInput(array()), new NullOutput());
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Command/DumpCommandTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Command/DumpCommandTest.php
@@ -119,4 +119,47 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($this->writeTo.'/test_asset.css');
         $this->assertEquals('/* test_asset */', file_get_contents($this->writeTo.'/test_asset.css'));
     }
+
+    public function testDumpDebug()
+    {
+        $asset = $this->getMock('Assetic\\Asset\\AssetCollection');
+        $leaf = $this->getMock('Assetic\\Asset\\AssetInterface');
+
+        $this->am->expects($this->once())
+            ->method('getNames')
+            ->will($this->returnValue(array('test_asset')));
+        $this->am->expects($this->once())
+            ->method('get')
+            ->with('test_asset')
+            ->will($this->returnValue($asset));
+        $this->am->expects($this->once())
+            ->method('getFormula')
+            ->with('test_asset')
+            ->will($this->returnValue(array()));
+        $this->am->expects($this->once())
+            ->method('isDebug')
+            ->will($this->returnValue(true));
+        $asset->expects($this->once())
+            ->method('getTargetUrl')
+            ->will($this->returnValue('test_asset.css'));
+        $asset->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue('/* test_asset */'));
+        $asset->expects($this->once())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($leaf))));
+        $leaf->expects($this->once())
+            ->method('getTargetUrl')
+            ->will($this->returnValue('test_leaf.css'));
+        $leaf->expects($this->once())
+            ->method('dump')
+            ->will($this->returnValue('/* test_leaf */'));
+
+        $this->command->run(new ArrayInput(array()), new NullOutput());
+
+        $this->assertFileExists($this->writeTo.'/test_asset.css');
+        $this->assertFileExists($this->writeTo.'/test_leaf.css');
+        $this->assertEquals('/* test_asset */', file_get_contents($this->writeTo.'/test_asset.css'));
+        $this->assertEquals('/* test_leaf */', file_get_contents($this->writeTo.'/test_leaf.css'));
+    }
 }


### PR DESCRIPTION
This fixes an issue when the command is run in debug mode and not all assets are dumped.
