### PR TITLE
[MonologBundle] Added a proper exception when the handler type is invalid

### DIFF
--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
@@ -62,14 +62,27 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('facility')->defaultValue('user')->end() // syslog
                             ->scalarNode('max_files')->defaultValue(0)->end() // rotating
                             ->scalarNode('action_level')->defaultValue('WARNING')->end() // fingers_crossed
+                            ->booleanNode('stop_buffering')->defaultTrue()->end()// fingers_crossed
                             ->scalarNode('buffer_size')->defaultValue(0)->end() // fingers_crossed and buffer
                             ->scalarNode('handler')->end() // fingers_crossed and buffer
+                            ->scalarNode('from_email')->end() // swift_mailer and native_mailer
+                            ->scalarNode('to_email')->end() // swift_mailer and native_mailer
+                            ->scalarNode('subject')->end() // swift_mailer and native_mailer
+                            ->scalarNode('email_prototype')->end() // swift_mailer
                             ->scalarNode('formatter')->end()
                         ->end()
                         ->append($this->getProcessorsNode())
                         ->validate()
                             ->ifTrue(function($v) { return ('fingers_crossed' === $v['type'] || 'buffer' === $v['type']) && 1 !== count($v['handler']); })
                             ->thenInvalid('The handler has to be specified to use a FingersCrossedHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function($v) { return 'swift_mailer' === $v['type'] && empty($v['email_prototype']) && (empty($v['from_email']) || empty($v['to_email']) || empty($v['subject'])); })
+                            ->thenInvalid('The sender, recipient and subject or an email prototype have to be specified to use a SwiftMailerHandler')
+                        ->end()
+                        ->validate()
+                            ->ifTrue(function($v) { return 'native_mailer' === $v['type'] && (empty($v['from_email']) || empty($v['to_email']) || empty($v['subject'])); })
+                            ->thenInvalid('The sender, recipient and subject have to be specified to use a NativeMailerHandler')
                         ->end()
                         ->validate()
                             ->ifTrue(function($v) { return 'service' === $v['type'] && !isset($v['id']); })

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
@@ -57,12 +57,12 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('priority')->defaultValue(0)->end()
                             ->scalarNode('level')->defaultValue('DEBUG')->end()
                             ->booleanNode('bubble')->defaultFalse()->end()
-                            ->scalarNode('path')->end() // stream and rotating
-                            ->scalarNode('ident')->end() // syslog
-                            ->scalarNode('facility')->end() // syslog
-                            ->scalarNode('max_files')->end() // rotating
-                            ->scalarNode('action_level')->end() // fingers_crossed
-                            ->scalarNode('buffer_size')->end() // fingers_crossed and buffer
+                            ->scalarNode('path')->defaultValue('%kernel.logs_dir%/%kernel.environment%.log')->end() // stream and rotating
+                            ->scalarNode('ident')->defaultFalse()->end() // syslog
+                            ->scalarNode('facility')->defaultValue('user')->end() // syslog
+                            ->scalarNode('max_files')->defaultValue(0)->end() // rotating
+                            ->scalarNode('action_level')->defaultValue('WARNING')->end() // fingers_crossed
+                            ->scalarNode('buffer_size')->defaultValue(0)->end() // fingers_crossed and buffer
                             ->scalarNode('handler')->end() // fingers_crossed and buffer
                             ->scalarNode('formatter')->end()
                         ->end()

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -188,13 +188,18 @@ class MonologExtension extends Extension
             ));
             break;
 
-        default:
-            // Handler using the constructor of AbstractHandler without adding their own arguments
+        // Handlers using the constructor of AbstractHandler without adding their own arguments
+        case 'test':
+        case 'null':
+        case 'debug':
             $definition->setArguments(array(
                 $handler['level'],
                 $handler['bubble'],
             ));
             break;
+
+        default:
+            throw new \InvalidArgumentException(sprintf('Invalid handler type "%s" given for handler "%s"', $handler['type'], $name));
         }
 
         if (!empty($handler['formatter'])) {

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -112,10 +112,6 @@ class MonologExtension extends Extension
             return $handlerId;
 
         case 'stream':
-            if (!isset($handler['path'])) {
-                $handler['path'] = '%kernel.logs_dir%/%kernel.environment%.log';
-            }
-
             $definition->setArguments(array(
                 $handler['path'],
                 $handler['level'],
@@ -132,22 +128,15 @@ class MonologExtension extends Extension
             break;
 
         case 'rotating_file':
-            if (!isset($handler['path'])) {
-                $handler['path'] = '%kernel.logs_dir%/%kernel.environment%.log';
-            }
-
             $definition->setArguments(array(
                 $handler['path'],
-                isset($handler['max_files']) ? $handler['max_files'] : 0,
+                $handler['max_files'],
                 $handler['level'],
                 $handler['bubble'],
             ));
             break;
 
         case 'fingers_crossed':
-            if (!isset($handler['action_level'])) {
-                $handler['action_level'] = 'WARNING';
-            }
             $handler['action_level'] = is_int($handler['action_level']) ? $handler['action_level'] : constant('Monolog\Logger::'.strtoupper($handler['action_level']));
             $nestedHandlerId = $this->getHandlerId($handler['handler']);
             array_push($this->nestedHandlers, $nestedHandlerId);
@@ -155,7 +144,7 @@ class MonologExtension extends Extension
             $definition->setArguments(array(
                 new Reference($nestedHandlerId),
                 $handler['action_level'],
-                isset($handler['buffer_size']) ? $handler['buffer_size'] : 0,
+                $handler['buffer_size'],
                 $handler['bubble'],
             ));
             break;
@@ -166,20 +155,13 @@ class MonologExtension extends Extension
 
             $definition->setArguments(array(
                 new Reference($nestedHandlerId),
-                isset($handler['buffer_size']) ? $handler['buffer_size'] : 0,
+                $handler['buffer_size'],
                 $handler['level'],
                 $handler['bubble'],
             ));
             break;
 
         case 'syslog':
-            if (!isset($handler['ident'])) {
-                $handler['ident'] = false;
-            }
-            if (!isset($handler['facility'])) {
-                $handler['facility'] = 'user';
-            }
-
             $definition->setArguments(array(
                 $handler['ident'],
                 $handler['facility'],

--- a/src/Symfony/Bundle/MonologBundle/Resources/config/monolog.xml
+++ b/src/Symfony/Bundle/MonologBundle/Resources/config/monolog.xml
@@ -13,6 +13,8 @@
         <parameter key="monolog.handler.syslog.class">Monolog\Handler\SyslogHandler</parameter>
         <parameter key="monolog.handler.null.class">Monolog\Handler\NullHandler</parameter>
         <parameter key="monolog.handler.test.class">Monolog\Handler\TestHandler</parameter>
+        <parameter key="monolog.handler.swift_mailer.class">Monolog\Handler\SwiftMailerHandler</parameter>
+        <parameter key="monolog.handler.native_mailer.class">Monolog\Handler\NativeMailerHandler</parameter>
         <parameter key="monolog.handler.firephp.class">Symfony\Bundle\MonologBundle\Logger\FirePHPHandler</parameter>
         <parameter key="monolog.handler.debug.class">Symfony\Bundle\MonologBundle\Logger\DebugHandler</parameter>
     </parameters>

--- a/src/Symfony/Bundle/MonologBundle/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/src/Symfony/Bundle/MonologBundle/Tests/DependencyInjection/MonologExtensionTest.php
@@ -77,7 +77,7 @@ class MonologExtensionTest extends TestCase
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, '%monolog.handler.fingers_crossed.class%');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, false));
+        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, false, true));
     }
 
     public function testLoadWithOverwriting()
@@ -110,7 +110,7 @@ class MonologExtensionTest extends TestCase
 
         $handler = $container->getDefinition('monolog.handler.main');
         $this->assertDICDefinitionClass($handler, '%monolog.handler.fingers_crossed.class%');
-        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, false));
+        $this->assertDICConstructorArguments($handler, array(new Reference('monolog.handler.nested'), \Monolog\Logger::ERROR, 0, false, true));
     }
 
     public function testLoadWithNewAtEnd()

--- a/src/Symfony/Bundle/MonologBundle/Tests/DependencyInjection/MonologExtensionTest.php
+++ b/src/Symfony/Bundle/MonologBundle/Tests/DependencyInjection/MonologExtensionTest.php
@@ -189,6 +189,17 @@ class MonologExtensionTest extends TestCase
     }
 
     /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testExceptionWhenInvalidHandler()
+    {
+        $container = new ContainerBuilder();
+        $loader = new MonologExtension();
+
+        $loader->load(array(array('handlers' => array('main' => array('type' => 'invalid_handler')))), $container);
+    }
+
+    /**
      * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function testExceptionWhenUsingFingerscrossedWithoutHandler()


### PR DESCRIPTION
Added a proper exception at build time when the handler type is invalid instead of getting an exception due to the access to an invalid parameter in the container at runtime.
