### PR TITLE
[FrameworkBundle] Changed the priority of the ProfilerListener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -24,7 +24,7 @@
         </service>
 
         <service id="profiler_listener" class="%profiler_listener.class%">
-            <tag name="kernel.listener" event="onCoreResponse" />
+            <tag name="kernel.listener" event="onCoreResponse" priority="-100" />
             <tag name="kernel.listener" event="onCoreException" />
             <tag name="kernel.listener" event="onCoreRequest" />
             <argument type="service" id="service_container" />


### PR DESCRIPTION
Running it before other onCoreResponse listeners avoids seeing them
as called listeners in the event panel. The priority is set to -100
because it has to be called before the WebProfilerListener (-128) so
that the token is set.
