### PR TITLE
[Security] Fixed hardcoded table names

### DIFF
--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -251,9 +251,10 @@ SELECTCLAUSE;
     {
         $sql = <<<SELECTCLAUSE
             SELECT a.ancestor_id
-            FROM acl_object_identities o
-            INNER JOIN acl_classes c ON c.id = o.class_id
-            INNER JOIN acl_object_identity_ancestors a ON a.object_identity_id = o.id
+            FROM
+                {$this->options['oid_table_name']} o
+            INNER JOIN {$this->options['class_table_name']} c ON c.id = o.class_id
+            INNER JOIN {$this->options['oid_ancestors_table_name']} a ON a.object_identity_id = o.id
                WHERE (
 SELECTCLAUSE;
 


### PR DESCRIPTION
- Replaced hardcoded table names by acl configuration options

In AclProvider, the method `getAncestorLookupSql` is using hardcoded table names. Overriding the table names via the `acl:tables` option in `security.yml` is causing SQL errors. This PR resolves this issue.
