### PR TITLE
[Routing] made the AnnotationGlobLoader work

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -10,6 +10,7 @@
         <parameter key="filesystem.class">Symfony\Component\HttpKernel\Util\Filesystem</parameter>
         <parameter key="cache_warmer.class">Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate</parameter>
         <parameter key="file_locator.class">Symfony\Component\HttpKernel\Config\FileLocator</parameter>
+        <parameter key="glob_locator.class">Symfony\Component\Config\GlobLocator</parameter>
     </parameters>
 
     <services>
@@ -45,6 +46,10 @@
         <service id="file_locator" class="%file_locator.class%">
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%/Resources</argument>
+        </service>
+
+        <service id="glob_locator" class="%glob_locator.class%">
+            <argument>%kernel.root_dir%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Config/GlobLocator.php
+++ b/src/Symfony/Component/Config/GlobLocator.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config;
+
+/**
+ * GlobLocator uses an array of pre-defined paths to find files by glob pattern.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class GlobLocator implements FileLocatorInterface
+{
+    protected $paths;
+
+    /**
+     * Constructor.
+     *
+     * @param string|array $paths A path or an array of paths where to look for resources
+     */
+    public function __construct($paths = array())
+    {
+        $this->paths = (array) $paths;
+    }
+
+    /**
+     * Gets all absolute paths matched by expanding the glob pattern within all
+     * resource search paths.
+     *
+     * @param string  $glob
+     * @param string  $currentPath The current path
+     * @param Boolean $first       Whether to return the first occurrence or an array of filenames
+     *
+     * @return array An array of paths matching the glob pattern
+     *
+     * @throws \InvalidArgumentException When file is not found
+     */
+    public function locate($glob, $currentPath = null, $first = true)
+    {
+        $dirs = array();
+        foreach ($this->paths as $path) {
+            if (false !== ($d = glob($path.DIRECTORY_SEPARATOR.$glob, GLOB_ONLYDIR | GLOB_BRACE))) {
+                $dirs = array_merge($dirs, $d);
+            }
+        }
+
+        return $dirs;
+    }
+}

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Config\Loader;
 
+use Symfony\Component\Routing\Loader\AnnotationGlobLoader;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Exception\FileLoaderImportException;
 
@@ -60,7 +61,7 @@ abstract class FileLoader extends Loader
             $loader = $this->resolve($resource, $type);
 
             if ($loader instanceof FileLoader && null !== $this->currentDir) {
-                $resource = $this->locator->locate($resource, $this->currentDir);
+                $resource = $loader->locator->locate($resource, $this->currentDir);
             }
 
             return $loader->load($resource);

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Config\Loader;
 
-use Symfony\Component\Routing\Loader\AnnotationGlobLoader;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Exception\FileLoaderImportException;
 

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -34,11 +34,9 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
      */
     public function load($path, $type = null)
     {
-        $dir = $this->locator->locate($path);
-
         $collection = new RouteCollection();
-        $collection->addResource(new DirectoryResource($dir, '/\.php$/'));
-        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+        $collection->addResource(new DirectoryResource($path, '/\.php$/'));
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
             if (!$file->isFile() || '.php' !== substr($file->getFilename(), -4)) {
                 continue;
             }

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Routing\Loader;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Loader\FileLoader;
-use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\FileLocatorInterface;
 
 /**
  * AnnotationFileLoader loads routing information from annotations set
@@ -29,11 +29,11 @@ class AnnotationFileLoader extends FileLoader
     /**
      * Constructor.
      *
-     * @param FileLocator           $locator A FileLocator instance
+     * @param FileLocatorInterface  $locator A FileLocatorInterface instance
      * @param AnnotationClassLoader $loader  An AnnotationClassLoader instance
      * @param string|array          $paths   A path or an array of paths where to look for resources
      */
-    public function __construct(FileLocator $locator, AnnotationClassLoader $loader, $paths = array())
+    public function __construct(FileLocatorInterface $locator, AnnotationClassLoader $loader, $paths = array())
     {
         if (!function_exists('token_get_all')) {
             throw new \RuntimeException('The Tokenizer extension is required for the routing annotation loaders.');

--- a/src/Symfony/Component/Routing/Loader/AnnotationGlobLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationGlobLoader.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\Resource\DirectoryResource;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class AnnotationGlobLoader extends AnnotationFileLoader
+class AnnotationGlobLoader extends AnnotationDirectoryLoader
 {
     /**
      * Loads from annotations from a directory glob pattern.
@@ -36,16 +36,7 @@ class AnnotationGlobLoader extends AnnotationFileLoader
     {
         $collection = new RouteCollection();
         foreach ($paths as $path) {
-            $collection->addResource(new DirectoryResource($path, '/\.php$/'));
-            foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
-                if (!$file->isFile() || '.php' !== substr($file->getFilename(), -4)) {
-                    continue;
-                }
-
-                if ($class = $this->findClass($file)) {
-                    $collection->addCollection($this->loader->load($class, $type));
-                }
-            }
+            $collection->addCollection(parent::load($path, $type));
         }
 
         return $collection;

--- a/src/Symfony/Component/Routing/Loader/AnnotationGlobLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationGlobLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Config\Resource\DirectoryResource;
 
 /**
  * AnnotationGlobLoader loads routing information from annotations set
@@ -19,23 +20,32 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class AnnotationGlobLoader extends AnnotationDirectoryLoader
+class AnnotationGlobLoader extends AnnotationFileLoader
 {
     /**
      * Loads from annotations from a directory glob pattern.
      *
-     * @param string $glob A directory glob pattern containing "*"
+     * @param array $paths an array of directories matching pattern
      * @param string $type The resource type
      *
      * @return RouteCollection A RouteCollection instance
      *
      * @throws \InvalidArgumentException When route can't be parsed
      */
-    public function load($glob, $type = null)
+    public function load($paths, $type = null)
     {
         $collection = new RouteCollection();
-        foreach ($this->getAbsolutePaths($glob) as $path) {
-            $collection->addCollection(parent::load($path, $type));
+        foreach ($paths as $path) {
+            $collection->addResource(new DirectoryResource($path, '/\.php$/'));
+            foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+                if (!$file->isFile() || '.php' !== substr($file->getFilename(), -4)) {
+                    continue;
+                }
+
+                if ($class = $this->findClass($file)) {
+                    $collection->addCollection($this->loader->load($class, $type));
+                }
+            }
         }
 
         return $collection;
@@ -52,25 +62,5 @@ class AnnotationGlobLoader extends AnnotationDirectoryLoader
     public function supports($resource, $type = null)
     {
         return is_string($resource) && false !== strpos($resource, '*') && (!$type || 'annotation' === $type);
-    }
-
-    /**
-     * Gets all absolute paths matched by expanding the glob pattern within all
-     * resource search paths.
-     *
-     * @param string $glob
-     *
-     * @return array An array of paths matching the glob pattern
-     */
-    private function getAbsolutePaths($glob)
-    {
-        $dirs = array();
-        foreach ($this->paths as $path) {
-            if (false !== ($d = glob($path.DIRECTORY_SEPARATOR.$glob, GLOB_ONLYDIR | GLOB_BRACE))) {
-                $dirs = array_merge($dirs, $d);
-            }
-        }
-
-        return $dirs;
     }
 }

--- a/tests/Symfony/Tests/Component/Config/GlobLocatorTest.php
+++ b/tests/Symfony/Tests/Component/Config/GlobLocatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Config;
+
+use Symfony\Component\Config\GlobLocator;
+
+class GlobLocatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testLocateFindsOnlyDirs()
+    {
+        $loader = new GlobLocator(__DIR__.'/Fixtures');
+
+        $this->assertEquals(
+            array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/Again/', __DIR__.DIRECTORY_SEPARATOR.'Fixtures/Builder/'),
+            $loader->locate('*/'),
+            '->locate() returns the absolute dirname if the glob pattern matches directory the given path'
+        );
+
+        $this->assertEquals(
+            array(),
+            $loader->locate('*.php', __DIR__),
+            '->locate() returns an empty array if only files are matched'
+        );
+    }
+}


### PR DESCRIPTION
Importing routing resources with glob pattern made the routing loading fail:

``` yml

test:
    resource: "../src/Acme/*Bundle/Controller/"
    type:     annotation
    prefix:   /test

```

You can now add `glob matched` resources with path relative to `%kernel.root_dir%`.
It only matches directories, as the original implementation did.

This has to be used with: https://github.com/sensio/SensioFrameworkExtraBundle/pull/33
