### PR TITLE
Removed the Request::hasSession()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -67,7 +67,7 @@ class RequestListener
         }
 
         // starts the session if a session cookie already exists in the request...
-        if ($request->hasSession()) {
+        if (null !== $request->getSession() && $request->cookies->has(session_name())) {
             $request->getSession()->start();
         }
     }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -308,12 +308,6 @@ class Request
         return $this->session;
     }
 
-    public function hasSession()
-    {
-        // the check for $this->session avoids malicious users trying to fake a session cookie with proper name
-        return $this->cookies->has(session_name()) && null !== $this->session;
-    }
-
     public function setSession(Session $session)
     {
         $this->session = $session;

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -64,7 +64,7 @@ class RequestDataCollector extends DataCollector
             'request_cookies'    => $request->cookies->all(),
             'request_attributes' => $attributes,
             'response_headers'   => $responseHeaders,
-            'session_attributes' => $request->hasSession() ? $request->getSession()->getAttributes() : array(),
+            'session_attributes' => null !== $request->getSession() ? $request->getSession()->getAttributes() : array(),
         );
     }
 

--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -48,6 +48,10 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
+        if (null !== $request->getSession()) {
+            $request->getSession()->set('_security.target_path', $request->getUri());
+        }
+
         if ($this->useForward) {
             return $this->httpKernel->handle(Request::create($this->loginPath), HttpKernelInterface::SUB_REQUEST);
         }

--- a/src/Symfony/Component/Security/Http/EntryPoint/RetryAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/RetryAuthenticationEntryPoint.php
@@ -53,6 +53,10 @@ class RetryAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 
         $url = $scheme.'://'.$request->getHost().$port.$request->getBaseUrl().$request->getPathInfo().$qs;
 
+        if (null !== $request->getSession()) {
+            $request->getSession()->set('_security.target_path', $request->getUri());
+        }
+
         return new RedirectResponse($url, 301);
     }
 }

--- a/src/Symfony/Component/Security/Http/EntryPoint/RetryAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/RetryAuthenticationEntryPoint.php
@@ -53,10 +53,6 @@ class RetryAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 
         $url = $scheme.'://'.$request->getHost().$port.$request->getBaseUrl().$request->getPathInfo().$qs;
 
-        if (null !== $request->getSession()) {
-            $request->getSession()->set('_security.target_path', $request->getUri());
-        }
-
         return new RedirectResponse($url, 301);
     }
 }

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -60,11 +60,9 @@ class ContextListener implements ListenerInterface
      */
     public function handle(GetResponseEvent $event)
     {
-        $request = $event->getRequest();
+        $session = $event->getRequest()->getSession();
 
-        $session = $request->hasSession() ? $request->getSession() : null;
-
-        if (null === $session || null === $token = $session->get('_security_'.$this->contextKey)) {
+        if (null === $session || null === ($token = $session->get('_security_'.$this->contextKey))) {
             $this->context->setToken(null);
         } else {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -150,11 +150,6 @@ class ExceptionListener
             $this->logger->debug('Calling Authentication entry point');
         }
 
-        // session isn't required when using http basic authentication mechanism for example
-        if ($request->hasSession()) {
-            $request->getSession()->set('_security.target_path', $request->getUri());
-        }
-
         return $this->authenticationEntryPoint->start($request, $authException);
     }
 }


### PR DESCRIPTION
Currently, `Request::hasSession()` is used for a dual purpose as shown below:
1. Check the session cookie exists
   - `Bundle\FrameworkBundle\RequestListener`
2. Check the Request has the Session object
   - `Component\Security\Firewall\ContextListener`
   - `Component\Security\Firewall\ExceptionListener`
   - `Component\HttpKernel\DataCollector\RequestDataCollector`

This method seem to be implemented for first purpose. And there is some problems in the second case.

For example, the RequestDataCollector does not record the session data when in the process with the start of a new session. In the same condition, ExceptionListener does not save the target-path that is used as next path after authentication.

This method is used ambiguously(session object exists? session started?). I think this method shuld be removed and the callers should check the condition of the Request properly.
