### PR TITLE
[FrameworkBundle] added errormessage for windows in AssetsInstallCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -63,6 +63,11 @@ EOT
             throw new \InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
         }
 
+        if (!function_exists('symlink') && $input->getOption('symlink')) {
+            throw new \InvalidArgumentException('The symlink()-Function is not available on your system.'
+                    . ' You need to install the assets without the --symlink option.');
+        }
+
         $filesystem = $this->container->get('filesystem');
 
         // Create the bundles directory otherwise symlink will fail.


### PR DESCRIPTION
As it has recently been discussed [on the mailing-list](https://groups.google.com/group/symfony-devs/browse_thread/thread/4b8ad9634bdab155), windows doesn't
support symlinks for the assets:install command. In order to avoid a 'call to
undefined-function'-message in this case, this patch adds an exception which
will be thrown when the symlink-funktion isn't present and the
`--symlink`-Option was specified.
