### PR TITLE
[MonologBundle] Fixed compiled classes

### DIFF
--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -79,8 +79,8 @@ class MonologExtension extends Extension
                 'Monolog\\Handler\\StreamHandler',
                 'Monolog\\Handler\\FingersCrossedHandler',
                 'Monolog\\Logger',
-                'Symfony\\Bundle\\MonologBundle\\Logger\\Logger',
-                'Symfony\\Bundle\\MonologBundle\\Logger\\DebugHandler',
+                'Symfony\\Bridge\\Monolog\\Logger',
+                'Symfony\\Bridge\\Monolog\\Handler\\DebugHandler',
             ));
         }
     }


### PR DESCRIPTION
This fixes the compiled class which were missing in the PR moving the classes in the Bridge namespace.
