### PR TITLE
[MonologBundle] Fixed SwiftMailerHandler configuration

### DIFF
--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -176,6 +176,8 @@ class MonologExtension extends Extension
                 $prototype = $this->parseDefinition($handler['email_prototype']);
             } else {
                 $message = new Definition('Swift_Message');
+                $message->setFactoryService('mailer');
+                $message->setFactoryMethod('createMessage');
                 $message->setPublic(false);
                 $message->addMethodCall('setFrom', $handler['from_email']);
                 $message->addMethodCall('setTo', $handler['to_email']);


### PR DESCRIPTION
Fixed SwiftMailerHandler by using the mailer as message factory as the mailer needs to instantiated first to require the init file.
