### PR TITLE
Parameter bag interface

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -69,7 +69,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @return mixed  The parameter value
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws  NonExistentParameterException if the parameter is not defined
      */
     public function get($name)
     {
@@ -126,7 +126,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @param  mixed $value A value
      *
-     * @throws \InvalidArgumentException if a placeholder references a parameter that does not exist
+     * @throws NonExistentParameterException if a placeholder references a parameter that does not exist
      */
     public function resolveValue($value)
     {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -66,4 +66,18 @@ interface ParameterBagInterface
      * @return Boolean true if the parameter name is defined, false otherwise
      */
     function has($name);
+
+    /**
+     * Replaces parameter placeholders (%name%) by their values for all parameters.
+     */
+    public function resolve();
+
+    /**
+     * Replaces parameter placeholders (%name%) by their values.
+     *
+     * @param  mixed $value A value
+     *
+     * @throws NonExistentParameterException if a placeholder references a parameter that does not exist
+     */
+    public function resolveValue($value);
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -70,7 +70,7 @@ interface ParameterBagInterface
     /**
      * Replaces parameter placeholders (%name%) by their values for all parameters.
      */
-    public function resolve();
+    function resolve();
 
     /**
      * Replaces parameter placeholders (%name%) by their values.
@@ -79,5 +79,5 @@ interface ParameterBagInterface
      *
      * @throws NonExistentParameterException if a placeholder references a parameter that does not exist
      */
-    public function resolveValue($value);
+    function resolveValue($value);
 }


### PR DESCRIPTION
This adds some missing methods in the ParameterBagInterface. the container relies on resolve() which was not part of it.
