### PR TITLE
[Validator] Adding support for Closure in CallbackValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -45,7 +45,7 @@ class CallbackValidator extends ConstraintValidator
         $propertyPath = $context->getPropertyPath();
 
         foreach ($methods as $method) {
-            if (is_array($method)) {
+            if (is_array($method) || $method instanceof \Closure) {
                 if (!is_callable($method)) {
                     throw new ConstraintDefinitionException(sprintf('"%s::%s" targeted by Callback constraint is not a valid callable', $method[0], $method[1]));
                 }


### PR DESCRIPTION
Usage:
    $formBuilder = $this->get('form.factory')
            ->createBuilder('form');
    $formBuilder->setAttribute('validation_constraint', new Callback(array("methods"=>array(
        'validate' => function ($data, $context) use ($elements) {
           // logic to add violations depending on the elements
        }
    ))));
