### PR TITLE
Fixed : ask/validate loop ending too soon on askAndValidate

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -92,7 +92,7 @@ class DialogHelper extends Helper
 
             try {
                 $validatorResult = $validator($value);
-                if(false !== $validatorResult) {
+                if (false !== $validatorResult) {
                     return $validatorResult;
                 }    
             } catch (\Exception $error) {

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -91,7 +91,10 @@ class DialogHelper extends Helper
             $value = $this->ask($output, $question, null);
 
             try {
-                return $validator($value);
+                $validatorResult = $validator($value);
+                if(false !== $validatorResult) {
+                    return $validatorResult;
+                }    
             } catch (\Exception $error) {
             }
         }


### PR DESCRIPTION
Before this commit, the `while` always ended returning `$validator($value)`, that value being false or true.
This break of one the use case of `askAndValidate` : loop on the question until a good answer is provided.

With testing that `$validator($value)` isn't false before returning the value, we ensure that the loop continue if `$validator($value)` is false.
if `$validator($value)` isn't false, then it means that the callback validation function has validated `$value`, so it's the right time to end the loop by returning the value.

(sorry, no time to write a test...)
