### PR TITLE
[Profiler] Added SQLite3 timeout to SqliteProfilerStorage

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
@@ -31,6 +31,7 @@ class SqliteProfilerStorage extends PdoProfilerStorage
             }
             if (class_exists('SQLite3')) {
                 $db = new \SQLite3(substr($this->dsn, 7, strlen($this->dsn)), \SQLITE3_OPEN_READWRITE | \SQLITE3_OPEN_CREATE);
+                $db->busyTimeout(1000);
             } elseif (class_exists('PDO') && in_array('sqlite', \PDO::getAvailableDrivers(), true)) {
                 $db = new \PDO($this->dsn);
             } else {


### PR DESCRIPTION
This is to prevent the database locked exceptions that shows up sometime. I just set 1000ms for now, which I think is more than enough in most case.
Ref: http://www.php.net/manual/en/sqlite3.busytimeout.php
