### PR TITLE
[Security] Improving the exception when the security context has no token

### DIFF
--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -58,7 +58,7 @@ class SecurityContext implements SecurityContextInterface
     public final function isGranted($attributes, $object = null)
     {
         if (null === $this->token) {
-            throw new AuthenticationCredentialsNotFoundException('The security context contains no authentication token.');
+            throw new AuthenticationCredentialsNotFoundException('The security context contains no authentication token. One possible reason may be that there is no firewall configured for this URL.');
         }
 
         if ($this->alwaysAuthenticate || !$this->token->isAuthenticated()) {


### PR DESCRIPTION
[Security] Improving the exception when the security context has no token

This either mostly - or always - means that no firewall is currently activated. This message tries to alert the user to this.

Thanks!
