### PR TITLE
[DoctrineBundle] Do not try to fetch doctrine listeners if doctrine is disabled

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Compiler/RegisterEventListenersAndSubscribersPass.php
@@ -15,6 +15,10 @@ class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
 
     public function process(ContainerBuilder $container)
     {
+        if (!$container->hasDefinition('doctrine')) {
+            return;
+        }
+
         $this->container = $container;
         $this->connections = $container->getDefinition('doctrine')->getArgument(1);
 


### PR DESCRIPTION
If you have the doctrine bundle enabled but nothing in your config you get errors because of the compiler pass right now.
