### PR TITLE
[Form] added $builder->setName()

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -137,6 +137,20 @@ class FormBuilder
     }
 
     /**
+     * Renames the form.
+     *
+     * @param string $name The form name
+     *
+     * @return FormBuilder The current builder
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
      * Returns the name of the form.
      *
      * @return string The form name

--- a/tests/Symfony/Tests/Component/Form/FormBuilderTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormBuilderTest.php
@@ -32,17 +32,6 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
         $this->builder = new FormBuilder('name', $this->factory, $this->dispatcher);
     }
 
-    /**
-     * Changing the name is not allowed, otherwise the name and property path
-     * are not synchronized anymore
-     *
-     * @see FieldType::buildForm
-     */
-    public function testNoSetName()
-    {
-        $this->assertFalse(method_exists($this->builder, 'setName'));
-    }
-
     public function testAddNameNoString()
     {
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');


### PR DESCRIPTION
The test suite notes that the property path will no longer be synchronized if a form is renamed, but I think that's actually a good thing since the name of the field is decoupled from the name of the object property.
