### PR TITLE
[Form] Refer to FormView explicitly in its own getParent() type-hint

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -120,7 +120,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      *
      * @param FormView $parent The parent view
      */
-    public function setParent(self $parent = null)
+    public function setParent(FormView $parent = null)
     {
         $this->parent = $parent;
     }


### PR DESCRIPTION
Using "self" makes mocking impossible, as the type-hint would then refer to the extending class and make the declaration incompatible.
