### PR TITLE
[Security] Adding an exception when a form login redirect is detected

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/FormLoginFactory.php
@@ -32,6 +32,7 @@ class FormLoginFactory extends AbstractFactory
         $this->addOption('csrf_parameter', '_csrf_token');
         $this->addOption('csrf_page_id', 'form_login');
         $this->addOption('post_only', true);
+        $this->addOption('disallow_redirect_loop', true);
     }
 
     public function getPosition()
@@ -93,6 +94,7 @@ class FormLoginFactory extends AbstractFactory
             ->setDefinition($entryPointId, new DefinitionDecorator('security.authentication.form_entry_point'))
             ->addArgument($config['login_path'])
             ->addArgument($config['use_forward'])
+            ->addArgument($config['disallow_redirect_loop'])
         ;
 
         return $entryPointId;

--- a/tests/Symfony/Tests/Component/Security/Http/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/tests/Symfony/Tests/Component/Security/Http/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Symfony\Tests\Component\Security\Http\EntryPoint;
+
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Http\EntryPoint\FormAuthenticationEntryPoint;
+
+class FormAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNormalRedirect()
+    {
+        $ep = new FormAuthenticationEntryPoint($this->createKernelMock(), '/login_foo', false, false);
+
+        $request = $this->createRequestMock();
+        $request->expects($this->any())
+            ->method('getUriForPath')
+            ->will($this->returnValue('/login_foo'));
+
+        $response = $ep->start($request);
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertEquals('/login_foo', $response->headers->get('location'));
+    }
+
+    public function testRedirectLoopWithoutDisallowRedirect()
+    {
+        $ep = new FormAuthenticationEntryPoint($this->createKernelMock(), '/login_foo', false, false);
+
+        $request = $this->createRequestMock();
+        $request->expects($this->any())
+            ->method('getUri')
+            ->will($this->returnValue('/redirect-loop-url'));
+        $request->expects($this->any())
+            ->method('getUriForPath')
+            ->will($this->returnValue('/redirect-loop-url'));
+
+        $response = $ep->start($request);
+        // redirect loops are allowed because $disallowRedirectLoop is false
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\Response', $response);
+        $this->assertEquals('/redirect-loop-url', $response->headers->get('location'));
+    }
+
+    public function testRedirectLoopWithDisallowRedirectThrowsException()
+    {
+        $ep = new FormAuthenticationEntryPoint($this->createKernelMock(), '/login_foo', false, true);
+
+        $request = $this->createRequestMock();
+        $request->expects($this->any())
+            ->method('getUri')
+            ->will($this->returnValue('/redirect-loop-url'));
+        $request->expects($this->any())
+            ->method('getUriForPath')
+            ->will($this->returnValue('/redirect-loop-url'));
+
+        $this->setExpectedException('LogicException');
+        $ep->start($request);
+    }
+
+    private function createKernelMock()
+    {
+        return $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+    }
+
+    private function createRequestMock()
+    {
+        return $this->getMock('Symfony\Component\HttpFoundation\Request');
+    }
+}


### PR DESCRIPTION
Hey guys-

This tries to address the somewhat common "redirect loop" problem with form login, cause by having your login form covered by a firewall that does not allow anonymous users. Perhaps there are some issues with this approach, but I hope we can find a solution with a good error message like this.

I also added a few unit tests to sweeten the deal.

Thanks!
