### PR TITLE
[HttpKernel] Fix to disable busyTimeout if it does not exist.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
@@ -31,7 +31,10 @@ class SqliteProfilerStorage extends PdoProfilerStorage
             }
             if (class_exists('SQLite3')) {
                 $db = new \SQLite3(substr($this->dsn, 7, strlen($this->dsn)), \SQLITE3_OPEN_READWRITE | \SQLITE3_OPEN_CREATE);
-                $db->busyTimeout(1000);
+                if (method_exists($db, 'busyTimeout')) {
+                    // busyTimeout only exists for PHP >= 5.3.3
+                    $db->busyTimeout(1000);
+                }
             } elseif (class_exists('PDO') && in_array('sqlite', \PDO::getAvailableDrivers(), true)) {
                 $db = new \PDO($this->dsn);
             } else {


### PR DESCRIPTION
In trying to really dig into Symfony 2 today I ran into some issues with testing. In particular, there was a call in SqliteProfilerStorage that was completely killing the test. I asked about it on IRC and on Google Groups and came up with the following solution.

The Google Groups discussion is linked here:

https://groups.google.com/d/topic/symfony-devs/1yf70wAj_E8/discussion

Without this (or something like it) it sounds like Symfony 2 will only pass tests for PHP >= 5.3.3 which may not be desirable.

Happy to tweak this as needed.
