### PR TITLE
Throw an exception when APC is not loaded

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
+++ b/src/Symfony/Component/Validator/Mapping/Cache/ApcCache.php
@@ -10,6 +10,10 @@ class ApcCache implements CacheInterface
 
     public function __construct($prefix)
     {
+        if (!extension_loaded('apc')) {
+            throw new \RuntimeException('First you need to enable APC extension in your php.ini. In meanwhile you can just remove "cache" option from application configuration.');
+        }
+
         $this->prefix = $prefix;
     }
 


### PR DESCRIPTION
Throw an exception when APC is not loaded but cache is enabled in app config.
