### PR TITLE
XmlFileLoader overload refactor

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -48,23 +48,35 @@ class XmlFileLoader extends FileLoader
                 continue;
             }
 
-            switch ($node->tagName) {
-                case 'route':
-                    $this->parseRoute($collection, $node, $path);
-                    break;
-                case 'import':
-                    $resource = (string) $node->getAttribute('resource');
-                    $type = (string) $node->getAttribute('type');
-                    $prefix = (string) $node->getAttribute('prefix');
-                    $this->setCurrentDir(dirname($path));
-                    $collection->addCollection($this->import($resource, ('' !== $type ? $type : null), false, $file), $prefix);
-                    break;
-                default:
-                    throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
-            }
+            $this->parseNode($collection, $node, $path);
         }
 
         return $collection;
+    }
+
+    /**
+     * Parses a node from a loaded XML file.
+     *
+     * @param RouteCollection $collection the collection to associate with the node
+     * @param DOMElement $node the node to parse
+     * @param string $path the path of the XML file being processed
+     */
+    protected function parseNode(RouteCollection $collection, \DOMElement $node, $path)
+    {
+      switch ($node->tagName) {
+          case 'route':
+              $this->parseRoute($collection, $node, $path);
+              break;
+          case 'import':
+              $resource = (string) $node->getAttribute('resource');
+              $type = (string) $node->getAttribute('type');
+              $prefix = (string) $node->getAttribute('prefix');
+              $this->setCurrentDir(dirname($path));
+              $collection->addCollection($this->import($resource, ('' !== $type ? $type : null), false, $file), $prefix);
+              break;
+          default:
+              throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
+      }
     }
 
     /**


### PR DESCRIPTION
Refactored the processing of each individual node into it's own method, enabling easier overloading of behavior for Bundles such as FriendsOfSymfony/RestBundle
