### PR TITLE
[Yaml] added exceptions when non-utf8 encoding is detected

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -48,6 +48,10 @@ class Parser
         $this->currentLine = '';
         $this->lines = explode("\n", $this->cleanup($value));
 
+        if (function_exists('mb_detect_encoding') && false === mb_detect_encoding($value, 'UTF-8', true)) {
+            throw new ParserException('The input does not appear to be valid UTF8.');
+        }
+
         if (function_exists('mb_internal_encoding') && ((int) ini_get('mbstring.func_overload')) & 2) {
             $mbEncoding = mb_internal_encoding();
             mb_internal_encoding('UTF-8');

--- a/tests/Symfony/Tests/Component/Yaml/ParserTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/ParserTest.php
@@ -110,6 +110,31 @@ bar: 1
 EOF
         ), $b, '->parse() is able to dump objects');
     }
+
+    public function testNonUtf8Exception()
+    {
+        if(!function_exists('mb_detect_encoding')) {
+            $this->markTestSkipped('Exceptions for non-utf8 charsets require the mb_detect_encoding() function.');
+
+            return;
+        }
+
+        $yamls = array(
+            iconv("UTF-8", "ISO-8859-1", "foo: 'äöüß'"),
+            iconv("UTF-8", "ISO-8859-15", "euro: '€'"),
+            iconv("UTF-8", "CP1252", "cp1252: '©ÉÇáñ'")
+        );
+
+        foreach($yamls as $yaml) {
+            try {
+                $this->parser->parse($yaml);
+
+                $this->fail('charsets other than UTF-8 are rejected.');
+            } catch(\Exception $e) {
+                 $this->assertInstanceOf('Symfony\Component\Yaml\ParserException', $e, 'charsets other than UTF-8 are rejected.');
+            }
+        }
+    }
 }
 
 class B

--- a/tests/Symfony/Tests/Component/Yaml/ParserTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/ParserTest.php
@@ -113,7 +113,7 @@ EOF
 
     public function testNonUtf8Exception()
     {
-        if(!function_exists('mb_detect_encoding')) {
+        if (!function_exists('mb_detect_encoding')) {
             $this->markTestSkipped('Exceptions for non-utf8 charsets require the mb_detect_encoding() function.');
 
             return;
@@ -125,12 +125,12 @@ EOF
             iconv("UTF-8", "CP1252", "cp1252: '©ÉÇáñ'")
         );
 
-        foreach($yamls as $yaml) {
+        foreach ($yamls as $yaml) {
             try {
                 $this->parser->parse($yaml);
 
                 $this->fail('charsets other than UTF-8 are rejected.');
-            } catch(\Exception $e) {
+            } catch (\Exception $e) {
                  $this->assertInstanceOf('Symfony\Component\Yaml\ParserException', $e, 'charsets other than UTF-8 are rejected.');
             }
         }


### PR DESCRIPTION
encoding is detected using the `mb_detect_encoding()`-function
in strict-mode. Checking is done before the parsing starts.
Without this patch, the calls to `preg_replace()` using the
'u'-modifier would cause the non-utf8-string being processed
to be empty when parsing starts which makes the parsing return
no result.

(closes #913)
