### PR TITLE
[Process] Wrong descriptor mode for stderr

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -100,7 +100,7 @@ class Process
             }
         };
 
-        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
+        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'r'));
 
         $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -100,7 +100,14 @@ class Process
             }
         };
 
-        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
+        // Workaround for http://bugs.php.net/bug.php?id=51800
+        if (strstr(PHP_OS, 'WIN')) {
+            $stderrPipeMode = 'a';
+        } else {
+            $stderrPipeMode = 'w';
+        }
+
+        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', $stderrPipeMode));
 
         $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -100,7 +100,7 @@ class Process
             }
         };
 
-        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'r'));
+        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
 
         $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 


### PR DESCRIPTION
This led to a problem with assetic on a windows machine, maybe this affects nix-systems too.

Problem happens at `fgets($pipes[2], 1024)` in the Process:run method. Pipe 2, stderr, is declared in write mode, yet only read from. This led to a deadlock on the PHP process on the windows machine. This is only reproducable for me when the stdin given to the process is larger than 16kb, no problems using smaller input.

Asset relies on this class to pass the content of js files (like jquery) via stdin and retreive the compressed content via stdout.

With this change everything seems to be fine again.
