### PR TITLE
[DependencyInjection] Support for replacing CONSTANT and ENV in parameter

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -163,7 +163,7 @@ class ParameterBag implements ParameterBagInterface
     private function resolveValueCallback($match)
     {
         if (preg_match('/^([^:]+):(.+)$/', $match[1], $subMatch)) {
-            switch($subMatch[1]) {
+            switch ($subMatch[1]) {
                 case 'CONSTANT':
                     if (!defined($subMatch[2])) {
                         throw new \InvalidArgumentException('You have requested a non-existent constant "' . $subMatch[2] . '".');


### PR DESCRIPTION
I'd like to contribute the (optional) ability to reference constants and environment variables directly from parameters. I started a discussion on this on the symfony-dev group with mixed response so far:

https://groups.google.com/d/topic/symfony-devs/idEFAZBDZ14/discussion

Ok, mixed might be a little too generous. ;)

The inspiration for this came from seeing a pull request (now merged) to the cookbook for handling external parameters. I asked about the lack of support for constants from YAML in the docs and it turns out there was no current support for it. (discussion is on the pull request)

https://github.com/symfony/symfony-docs/pull/273

I understand that there is a way to handle the environment variables by following the convention of SYMFONY__ named variables but this has a dependency on HttpKernel. This code would allow someone who is only using the DependencyInjection component to leverage constant and env variables directly.

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/Kernel.php#L549

I'm happy to tweak this as needed.

If this gets merged in any form, I'd be happy to help try and contribute to some documentation on these features as well.
