### PR TITLE
[DependencyInjection] Fixed a property visibility in GraphvizDumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -30,6 +30,14 @@ class GraphvizDumper extends Dumper
 {
     private $nodes;
     private $edges;
+    private $options = array(
+            'graph' => array('ratio' => 'compress'),
+            'node'  => array('fontsize' => 11, 'fontname' => 'Arial', 'shape' => 'record'),
+            'edge'  => array('fontsize' => 9, 'fontname' => 'Arial', 'color' => 'grey', 'arrowhead' => 'open', 'arrowsize' => 0.5),
+            'node.instance' => array('fillcolor' => '#9999ff', 'style' => 'filled'),
+            'node.definition' => array('fillcolor' => '#eeeeee'),
+            'node.missing' => array('fillcolor' => '#ff9999', 'style' => 'filled'),
+        );
 
     /**
      * Dumps the service container as a graphviz graph.
@@ -49,15 +57,6 @@ class GraphvizDumper extends Dumper
      */
     public function dump(array $options = array())
     {
-        $this->options = array(
-            'graph' => array('ratio' => 'compress'),
-            'node'  => array('fontsize' => 11, 'fontname' => 'Arial', 'shape' => 'record'),
-            'edge'  => array('fontsize' => 9, 'fontname' => 'Arial', 'color' => 'grey', 'arrowhead' => 'open', 'arrowsize' => 0.5),
-            'node.instance' => array('fillcolor' => '#9999ff', 'style' => 'filled'),
-            'node.definition' => array('fillcolor' => '#eeeeee'),
-            'node.missing' => array('fillcolor' => '#ff9999', 'style' => 'filled'),
-        );
-
         foreach (array('graph', 'node', 'edge', 'node.instance', 'node.definition', 'node.missing') as $key) {
             if (isset($options[$key])) {
                 $this->options[$key] = array_merge($this->options[$key], $options[$key]);

--- a/tests/Symfony/Tests/Component/DependencyInjection/Dumper/GraphvizDumperTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Dumper/GraphvizDumperTest.php
@@ -29,9 +29,6 @@ class GraphvizDumperTest extends \PHPUnit_Framework_TestCase
 
         $this->assertStringEqualsFile(self::$fixturesPath.'/graphviz/services1.dot', $dumper->dump(), '->dump() dumps an empty container as an empty dot file');
 
-        $container = new ContainerBuilder();
-        $dumper = new GraphvizDumper($container);
-
         $container = include self::$fixturesPath.'/containers/container9.php';
         $dumper = new GraphvizDumper($container);
         $this->assertEquals(str_replace('%path%', __DIR__, file_get_contents(self::$fixturesPath.'/graphviz/services9.dot')), $dumper->dump(), '->dump() dumps services');


### PR DESCRIPTION
[DependencyInjection] Fixed a property visibility in GraphvizDumper and removed a useless instanciation in the test
