### PR TITLE
[Validator] PHP < 5.3.3 incorrectly assumes valid (but non-FQDN) hosts make for a valid email address.

### DIFF
--- a/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
@@ -70,8 +70,27 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
         return array(
             array('example'),
             array('example@'),
-            array('example@localhost'),
             array('example@example.com@example.com'),
+        );
+    }
+
+
+    /**
+     * @dataProvider getInvalidEmailsCompat
+     */
+    public function testInvalidEmailsCompat($email)
+    {
+        if (filter_var('valid-before-php533@localhost', FILTER_VALIDATE_EMAIL)) {
+            $this->markTestSkipped('FILTER_VALIDATE_EMAIL returns true for non fully qualified domain names');
+        } else {
+            $this->assertFalse($this->validator->isValid($email, new Email()));
+        }
+    }
+
+    public function getInvalidEmailsCompat()
+    {
+        return array(
+            array('example@localhost'),
         );
     }
 


### PR DESCRIPTION
This is a potential fix for #897 by simply skipping the test for example@localhost if it is probably going to fail. Happy to write a proper fix for EmailValidator (more invasive) if that is the preferred way to handle this.
