### PR TITLE
[Validator] metadata strip off namespace only if it's actually present

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -41,7 +41,11 @@ class ClassMetadata extends ElementMetadata
     {
         $this->name = $class;
         // class name without namespace
-        $this->defaultGroup = substr($class, strrpos($class, '\\') + 1);
+        if (false !== $nsSep = strrpos($class, '\\')) {
+            $this->defaultGroup = substr($class, $nsSep + 1);
+        } else {
+            $this->defaultGroup = $class;
+        }
     }
 
     /**


### PR DESCRIPTION
If the class name was not FQCN then the 1st character of the class name was removed
