### PR TITLE
[Validator] Fix to the propertyPath. Causes errors on embeded forms not t

### DIFF
--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -144,7 +144,7 @@ class GraphWalker
                 foreach ($value as $key => $element) {
                     // Ignore any scalar values in the collection
                     if (is_object($element) || is_array($element)) {
-                        $this->walkReference($element, $group, $propertyPath.'['.$key.']', $traverse);
+                        $this->walkReference($element, $group, $propertyPath.'.'.$key.'', $traverse);
                     }
                 }
             }


### PR DESCRIPTION
While working with embedded forms I discovered that the errors were bubbling all the way to the parent rather than matching on the field.

Here is bundle that will show it not working https://github.com/johnwards/FormDemoBundle

At the moment embedded forms don't work without this fix as the matching of the errors in the delegating validator don't look for the original propertyPath format.

However @bschussek might think that its the delegating validator that needs changed.
