### PR TITLE
[HttpFoundation] Charset fix for url encoded PUT & DELETE requests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -129,7 +129,7 @@ class Request
     {
         $request = new static($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER);
 
-        if ('application/x-www-form-urlencoded' == $request->server->get('CONTENT_TYPE')
+        if (0 === strpos($request->server->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
             && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE'))
         ) {
             parse_str($request->getContent(), $data);


### PR DESCRIPTION
Fixed content type for urlencoded forms being too specific. For example, this will now function will clients (such as Firefox) that append the charset to the content type header
