### PR TITLE
Skip tests if some vendor are not available.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Controller/ExceptionControllerTest.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Tests\Controller;
 
+use Symfony\Bundle\WebProfilerBundle\Tests\TestCase;
+
 use Symfony\Bundle\WebProfilerBundle\Controller\ExceptionController;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\DependencyInjection\Definition;
 
-class ExceptionControllerTest extends \PHPUnit_Framework_TestCase
+class ExceptionControllerTest extends TestCase
 {
     protected $controller;
     protected $container;
@@ -26,6 +28,8 @@ class ExceptionControllerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        parent::setUp();
+
         $this->flatten = $this->getMock('Symfony\Component\HttpKernel\Exception\FlattenException');
         $this->flatten->expects($this->once())->method('getStatusCode')->will($this->returnValue(404));
         $this->controller = new ExceptionController();

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bundle\WebProfilerBundle\Tests\DependencyInjection;
 
+use Symfony\Bundle\WebProfilerBundle\Tests\TestCase;
+
 use Symfony\Bundle\WebProfilerBundle\DependencyInjection\WebProfilerExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Container;
@@ -25,7 +27,7 @@ use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Scope;
 
-class WebProfilerExtensionTest extends \PHPUnit_Framework_TestCase
+class WebProfilerExtensionTest extends TestCase
 {
     private $kernel;
     /**
@@ -49,6 +51,7 @@ class WebProfilerExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        parent::setUp();
 
         $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/TestCase.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/TestCase.php
@@ -9,14 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\MonologBundle\Tests;
+namespace Symfony\Bundle\WebProfilerBundle\Tests;
 
 class TestCase extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
-        if (!class_exists('Monolog\\Logger')) {
-            $this->markTestSkipped('Monolog is not available.');
+        if (!class_exists('Twig_Environment')) {
+            $this->markTestSkipped('Twig is not available.');
         }
     }
 }

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/Fixtures/StubFilesystemLoader.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/Fixtures/StubFilesystemLoader.php
@@ -11,13 +11,19 @@
 
 namespace Symfony\Tests\Bridge\Twig\Extension\Fixtures;
 
-class StubFilesystemLoader extends \Twig_Loader_Filesystem
-{
-    protected function findTemplate($name)
+// Preventing autoloader throwing E_FATAL when Twig is now available
+if (!class_exists('Twig_Environment')) {
+    class StubFilesystemLoader {
+    }
+} else {
+    class StubFilesystemLoader extends \Twig_Loader_Filesystem
     {
-        // strip away bundle name
-        $parts = explode(':', $name);
-
-        return parent::findTemplate(end($parts));
+        protected function findTemplate($name)
+        {
+            // strip away bundle name
+            $parts = explode(':', $name);
+ 
+            return parent::findTemplate(end($parts));
+        }
     }
 }

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
@@ -25,6 +25,10 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 {
     protected function setUp()
     {
+        if (!class_exists('Twig_Environment')) {
+            $this->markTestSkipped('Twig is not available.');
+        }
+
         parent::setUp();
 
         $loader = new StubFilesystemLoader(array(

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionTableLayoutTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionTableLayoutTest.php
@@ -25,6 +25,10 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
 {
     protected function setUp()
     {
+        if (!class_exists('Twig_Environment')) {
+            $this->markTestSkipped('Twig is not available.');
+        }
+
         parent::setUp();
 
         $loader = new StubFilesystemLoader(array(


### PR DESCRIPTION
This fixes when someone (like me :) runs tests and don't have setuped some vendors.
