### PR TITLE
[Form] UploadedFile getExtensions doesn't return the extension if the file has been moved

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -111,7 +111,7 @@ class UploadedFile extends File
      */
     public function getExtension()
     {
-        if ($this->moved) {
+        if (!$this->moved) {
             return parent::getExtension();
         }
 


### PR DESCRIPTION
if the file has already been moved, it doesn't have extension anymore
