### PR TITLE
[Session] Fix getFlash()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -228,7 +228,7 @@ class Session implements \Serializable
 
     public function getFlash($name, $default = null)
     {
-        return array_key_exists($name, $this->attributes['_flash']) ? $this->attributes['_flash'][$name] : $default;
+        return array_key_exists($name, $this->getFlashes()) ? $this->attributes['_flash'][$name] : $default;
     }
 
     public function setFlash($name, $value)


### PR DESCRIPTION
Small fix. Without this I get a php Notice and Warnig if try getFlash() after clearing the session:

Notice: Undefined index: _flash in /var/www/test/symfony2/vendors/symfony/src/Symfony/Component/HttpFoundation/Session.php on line 231
Warning: array_key_exists() expects parameter 2 to be array, null given in /var/www/test/symfony2/vendors/symfony/src/Symfony/Component/HttpFoundation/Session.php on line 231
