### PR TITLE
[FrameworkBundle] Clarify exception when no route is matched for the home

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -108,7 +108,9 @@ class RequestListener
 
             $request->attributes->add($parameters);
         } catch (NotFoundException $e) {
-            $message = sprintf('No route found for "%s %s"', $request->getMethod(), $request->getPathInfo());
+            // translate the empty string into the more expressive "/"
+            $pathInfo = $request->getPathInfo() ? $request->getPathInfo() : '/';
+            $message = sprintf('No route found for "%s %s"', $request->getMethod(), $pathInfo);
             if (null !== $this->logger) {
                 $this->logger->err($message);
             }


### PR DESCRIPTION
The homepage is unique in that it matches for an empty string or `/`.

In the event of no matching route for the homepage, and the user accesses the application without the slash, this changes the exception from:

```
No route found for "GET "
```

to

```
No route found for "GET /"
```

So... very minor coverage for an idiosyncratic case.
