### PR TITLE
[AsseticBundle] updated for assetic changes

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
+++ b/src/Symfony/Bundle/AsseticBundle/Command/DumpCommand.php
@@ -171,7 +171,7 @@ class DumpCommand extends Command
      */
     private function doDump(AssetInterface $asset, OutputInterface $output)
     {
-        $target = rtrim($this->basePath, '/').'/'.str_replace('_controller/', '', $asset->getTargetUrl());
+        $target = rtrim($this->basePath, '/').'/'.str_replace('_controller/', '', $asset->getTargetPath());
         if (!is_dir($dir = dirname($target))) {
             $output->writeln('<info>[dir+]</info> '.$dir);
             if (false === @mkdir($dir, 0777, true)) {

--- a/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
@@ -42,15 +42,23 @@ class AssetFactory extends BaseAssetFactory
     }
 
     /**
-     * Adds support for bundle notation and globs.
+     * Adds support for bundle notation file and glob assets.
      *
-     * Please note this is a naive implementation of globs in that it doesn't
+     * FIXME: This is a naive implementation of globs in that it doesn't
      * attempt to support bundle inheritance within the glob pattern itself.
      */
     protected function parseInput($input, array $options = array())
     {
         // expand bundle notation
         if ('@' == $input[0] && false !== strpos($input, '/')) {
+            // use the bundle path as this asset's root
+            $bundle = substr($input, 1);
+            if (false !== $pos = strpos($bundle, '/')) {
+                $bundle = substr($bundle, 0, $pos);
+            }
+            $options['root'] = array($this->kernel->getBundle($bundle)->getPath());
+
+            // canonicalize the input
             if (false !== $pos = strpos($input, '*')) {
                 // locateResource() does not support globs so we provide a naive implementation here
                 list($before, $after) = explode('*', $input, 2);

--- a/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
@@ -47,7 +47,7 @@ class AssetFactory extends BaseAssetFactory
      * Please note this is a naive implementation of globs in that it doesn't
      * attempt to support bundle inheritance within the glob pattern itself.
      */
-    protected function parseInput($input)
+    protected function parseInput($input, array $options = array())
     {
         // expand bundle notation
         if ('@' == $input[0] && false !== strpos($input, '/')) {
@@ -60,7 +60,7 @@ class AssetFactory extends BaseAssetFactory
             }
         }
 
-        return parent::parseInput($input);
+        return parent::parseInput($input, $options);
     }
 
     protected function createAssetReference($name)

--- a/src/Symfony/Bundle/AsseticBundle/Factory/Worker/UseControllerWorker.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/Worker/UseControllerWorker.php
@@ -23,9 +23,9 @@ class UseControllerWorker implements WorkerInterface
 {
     public function process(AssetInterface $asset)
     {
-        $targetUrl = $asset->getTargetUrl();
+        $targetUrl = $asset->getTargetPath();
         if ($targetUrl && '/' != $targetUrl[0] && 0 !== strpos($targetUrl, '_controller/')) {
-            $asset->setTargetUrl('_controller/'.$targetUrl);
+            $asset->setTargetPath('_controller/'.$targetUrl);
         }
 
         return $asset;

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/compass.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/compass.xml
@@ -12,7 +12,6 @@
     <services>
         <service id="assetic.filter.compass" class="%assetic.filter.compass.class%">
             <tag name="assetic.filter" alias="compass" />
-            <argument>%assetic.read_from%</argument>
             <argument>%assetic.filter.compass.sass%</argument>
         </service>
     </services>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/less.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/less.xml
@@ -13,7 +13,6 @@
     <services>
         <service id="assetic.filter.less" class="%assetic.filter.less.class%">
             <tag name="assetic.filter" alias="less" />
-            <argument>%assetic.read_from%</argument>
             <argument>%assetic.filter.less.node%</argument>
             <argument>%assetic.filter.less.node_paths%</argument>
         </service>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/lessphp.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/lessphp.xml
@@ -11,7 +11,6 @@
     <services>
         <service id="assetic.filter.lessphp" class="%assetic.filter.lessphp.class%">
             <tag name="assetic.filter" alias="lessphp" />
-            <argument>%assetic.read_from%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/sass.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/sass.xml
@@ -12,7 +12,6 @@
     <services>
         <service id="assetic.filter.sass" class="%assetic.filter.sass.class%">
             <tag name="assetic.filter" alias="sass" />
-            <argument>%assetic.read_from%</argument>
             <argument>%assetic.filter.sass.bin%</argument>
         </service>
     </services>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/scss.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/scss.xml
@@ -12,7 +12,6 @@
     <services>
         <service id="assetic.filter.scss" class="%assetic.filter.scss.class%">
             <tag name="assetic.filter" alias="scss" />
-            <argument>%assetic.read_from%</argument>
             <argument>%assetic.filter.scss.sass%</argument>
         </service>
     </services>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/sprockets.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/sprockets.xml
@@ -12,7 +12,6 @@
     <services>
         <service id="assetic.filter.sprockets" class="%assetic.filter.sprockets.class%">
             <tag name="assetic.filter" alias="sprockets" />
-            <argument>%assetic.read_from%</argument>
             <argument>%assetic.filter.sprockets.bin%</argument>
         </service>
     </services>

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/stylus.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/stylus.xml
@@ -13,7 +13,6 @@
     <services>
         <service id="assetic.filter.stylus" class="%assetic.filter.stylus.class%">
             <tag name="assetic.filter" alias="stylus" />
-            <argument>%assetic.read_from%</argument>
             <argument>%assetic.filter.stylus.node%</argument>
             <argument>%assetic.filter.stylus.node_paths%</argument>
         </service>

--- a/src/Symfony/Bundle/AsseticBundle/Routing/AsseticLoader.php
+++ b/src/Symfony/Bundle/AsseticBundle/Routing/AsseticLoader.php
@@ -99,7 +99,7 @@ class AsseticLoader extends Loader
         );
 
         // remove the fake front controller
-        $pattern = str_replace('_controller/', '', $asset->getTargetUrl());
+        $pattern = str_replace('_controller/', '', $asset->getTargetPath());
 
         if ($format = pathinfo($pattern, PATHINFO_EXTENSION)) {
             $defaults['_format'] = $format;

--- a/src/Symfony/Bundle/AsseticBundle/Templating/StaticAsseticHelper.php
+++ b/src/Symfony/Bundle/AsseticBundle/Templating/StaticAsseticHelper.php
@@ -40,6 +40,6 @@ class StaticAsseticHelper extends AsseticHelper
 
     protected function getAssetUrl(AssetInterface $asset, $options = array())
     {
-        return $this->assetsHelper->getUrl($asset->getTargetUrl(), isset($options['package']) ? $options['package'] : null);
+        return $this->assetsHelper->getUrl($asset->getTargetPath(), isset($options['package']) ? $options['package'] : null);
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Command/DumpCommandTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Command/DumpCommandTest.php
@@ -108,7 +108,7 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
             ->method('isDebug')
             ->will($this->returnValue(false));
         $asset->expects($this->once())
-            ->method('getTargetUrl')
+            ->method('getTargetPath')
             ->will($this->returnValue('test_asset.css'));
         $asset->expects($this->once())
             ->method('dump')
@@ -140,7 +140,7 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
             ->method('isDebug')
             ->will($this->returnValue(true));
         $asset->expects($this->once())
-            ->method('getTargetUrl')
+            ->method('getTargetPath')
             ->will($this->returnValue('test_asset.css'));
         $asset->expects($this->once())
             ->method('dump')
@@ -149,7 +149,7 @@ class DumpCommandTest extends \PHPUnit_Framework_TestCase
             ->method('getIterator')
             ->will($this->returnValue(new \ArrayIterator(array($leaf))));
         $leaf->expects($this->once())
-            ->method('getTargetUrl')
+            ->method('getTargetPath')
             ->will($this->returnValue('test_leaf.css'));
         $leaf->expects($this->once())
             ->method('dump')

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
@@ -33,13 +33,25 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
     public function testBundleNotation()
     {
         $input = '@MyBundle/Resources/css/main.css';
+        $bundle = $this->getMock('Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface');
 
+        $this->kernel->expects($this->once())
+            ->method('getBundle')
+            ->with('MyBundle')
+            ->will($this->returnValue($bundle));
         $this->kernel->expects($this->once())
             ->method('locateResource')
             ->with($input)
-            ->will($this->returnValue('/path/to/bundle/Resources/css/main.css'));
+            ->will($this->returnValue('/path/to/MyBundle/Resources/css/main.css'));
+        $bundle->expects($this->once())
+            ->method('getPath')
+            ->will($this->returnValue('/path/to/MyBundle'));
 
-        $this->factory->createAsset($input);
+        $coll = $this->factory->createAsset($input)->all();
+        $asset = $coll[0];
+
+        $this->assertEquals('/path/to/MyBundle', $asset->getSourceRoot(), '->createAsset() sets the asset root');
+        $this->assertEquals('Resources/css/main.css', $asset->getSourcePath(), '->createAsset() sets the asset path');
     }
 
     /**
@@ -47,12 +59,25 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testBundleGlobNotation($input)
     {
+        $bundle = $this->getMock('Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface');
+
+        $this->kernel->expects($this->once())
+            ->method('getBundle')
+            ->with('MyBundle')
+            ->will($this->returnValue($bundle));
         $this->kernel->expects($this->once())
             ->method('locateResource')
             ->with('@MyBundle/Resources/css/')
-            ->will($this->returnValue('/path/to/bundle/Resources/css/'));
+            ->will($this->returnValue('/path/to/MyBundle/Resources/css/'));
+        $bundle->expects($this->once())
+            ->method('getPath')
+            ->will($this->returnValue('/path/to/MyBundle'));
 
-        $this->factory->createAsset($input);
+        $coll = $this->factory->createAsset($input)->all();
+        $asset = $coll[0];
+
+        $this->assertEquals('/path/to/MyBundle', $asset->getSourceRoot(), '->createAsset() sets the asset root');
+        $this->assertNull($asset->getSourcePath(), '->createAsset() sets the asset path to null');
     }
 
     public function getGlobs()

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Templating/AsseticHelperTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Templating/AsseticHelperTest.php
@@ -51,6 +51,6 @@ class AsseticHelperForTest extends AsseticHelper
 {
     protected function getAssetUrl(AssetInterface $asset, $options = array())
     {
-        return $asset->getTargetUrl();
+        return $asset->getTargetPath();
     }
 }

--- a/src/Symfony/Bundle/AsseticBundle/Twig/AsseticNode.php
+++ b/src/Symfony/Bundle/AsseticBundle/Twig/AsseticNode.php
@@ -27,7 +27,7 @@ class AsseticNode extends BaseAsseticNode
             ->raw('isset($context[\'assetic\'][\'use_controller\']) && $context[\'assetic\'][\'use_controller\'] ? ')
             ->subcompile($this->getPathFunction($name))
             ->raw(' : ')
-            ->subcompile($this->getAssetFunction($asset->getTargetUrl()))
+            ->subcompile($this->getAssetFunction($asset->getTargetPath()))
         ;
     }
 


### PR DESCRIPTION
This update fixes compatibility with Assetic master. Assets referenced using bundle notation that includes imports, such as SASS files, will now import correctly.
