### PR TITLE
[FrameworkBundle][Validator] Fixed validators config causing no validation to happen

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -48,15 +48,15 @@
         <service id="validator.mapping.loader.static_method_loader" class="%validator.mapping.loader.static_method_loader.class%" public="false" />
 
         <service id="validator.mapping.loader.annotation_loader" class="%validator.mapping.loader.annotation_loader.class%" public="false">
-            <argument type="collection">%validator.mapping.loader.annotation_loader.namespaces%</argument>
+            <argument>%validator.mapping.loader.annotation_loader.namespaces%</argument>
         </service>
 
         <service id="validator.mapping.loader.xml_files_loader" class="%validator.mapping.loader.xml_files_loader.class%" public="false">
-            <argument type="collection">%validator.mapping.loader.xml_files_loader.mapping_files%</argument>
+            <argument>%validator.mapping.loader.xml_files_loader.mapping_files%</argument>
         </service>
 
         <service id="validator.mapping.loader.yaml_files_loader" class="%validator.mapping.loader.yaml_files_loader.class%" public="false">
-            <argument type="collection">%validator.mapping.loader.yaml_files_loader.mapping_files%</argument>
+            <argument>%validator.mapping.loader.yaml_files_loader.mapping_files%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
The parameter in &lt;argument type="collection"&gt;%parameter...%&lt;/argument&gt; was ignored due to type="collection".

As a result mapping loaders are constructed with no path/namespace and no validation happen in `$validator->validate($object)`.
