### PR TITLE
[AsseticBundle] auto filters

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -81,12 +81,18 @@ class AsseticExtension extends Extension
             }
 
             if (isset($filter['apply_to'])) {
-                $worker = new DefinitionDecorator('assetic.worker.ensure_filter');
-                $worker->replaceArgument(0, '/'.$filter['apply_to'].'/');
-                $worker->replaceArgument(1, new Reference('assetic.filter.'.$name));
-                $worker->addTag('assetic.factory_worker');
+                if (!is_array($filter['apply_to'])) {
+                    $filter['apply_to'] = array($filter['apply_to']);
+                }
 
-                $container->setDefinition('assetic.filter.'.$name.'.worker', $worker);
+                foreach ($filter['apply_to'] as $i => $pattern) {
+                    $worker = new DefinitionDecorator('assetic.worker.ensure_filter');
+                    $worker->replaceArgument(0, '/'.$pattern.'/');
+                    $worker->replaceArgument(1, new Reference('assetic.filter.'.$name));
+                    $worker->addTag('assetic.factory_worker');
+
+                    $container->setDefinition('assetic.filter.'.$name.'.worker'.$i, $worker);
+                }
             }
 
             foreach ($filter as $key => $value) {

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -93,6 +93,8 @@ class AsseticExtension extends Extension
 
                     $container->setDefinition('assetic.filter.'.$name.'.worker'.$i, $worker);
                 }
+
+                unset($filter['apply_to']);
             }
 
             foreach ($filter as $key => $value) {

--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -77,6 +78,15 @@ class AsseticExtension extends Extension
             if (isset($filter['file'])) {
                 $container->getDefinition('assetic.filter.'.$name)->setFile($filter['file']);
                 unset($filter['file']);
+            }
+
+            if (isset($filter['apply_to'])) {
+                $worker = new DefinitionDecorator('assetic.worker.ensure_filter');
+                $worker->replaceArgument(0, '/'.$filter['apply_to'].'/');
+                $worker->replaceArgument(1, new Reference('assetic.filter.'.$name));
+                $worker->addTag('assetic.factory_worker');
+
+                $container->setDefinition('assetic.filter.'.$name.'.worker', $worker);
             }
 
             foreach ($filter as $key => $value) {

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -15,6 +15,7 @@
         <parameter key="assetic.coalescing_directory_resource.class">Assetic\Factory\Resource\CoalescingDirectoryResource</parameter>
         <parameter key="assetic.directory_resource.class">Symfony\Bundle\AsseticBundle\Factory\Resource\DirectoryResource</parameter>
         <parameter key="assetic.filter_manager.class">Symfony\Bundle\AsseticBundle\FilterManager</parameter>
+        <parameter key="assetic.worker.ensure_filter.class">Assetic\Factory\Worker\EnsureFilterWorker</parameter>
 
         <parameter key="assetic.node.paths" type="collection"></parameter>
         <parameter key="assetic.cache_dir">%kernel.cache_dir%/assetic</parameter>
@@ -53,6 +54,11 @@
         <service id="assetic.asset_manager_cache_warmer" class="%assetic.asset_manager_cache_warmer.class%" public="false">
             <tag name="kernel.cache_warmer" priority="10" />
             <argument type="service" id="service_container" />
+        </service>
+
+        <service id="assetic.worker.ensure_filter" class="%assetic.worker.ensure_filter.class%" abstract="true" public="false">
+            <argument /> <!-- pattern -->
+            <argument /> <!-- filter -->
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Resources/config/config.yml
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Resources/config/config.yml
@@ -32,7 +32,8 @@ assetic:
             inputs: css/widget.sass
             filters: sass
     filters:
-        sass: ~
+        sass:
+            apply_to: "\.sass$"
         yui_css:
             jar: %kernel.root_dir/java/yui-compressor-2.4.6.jar
     twig:


### PR DESCRIPTION
I've added an `apply_to` configuration setting that can be included within a filter configuration. This allows you apply filters to all assets based on their source or target path.

For instance, to automatically filter all CoffeeScript:

``` yaml
assetic:
    filters:
        coffee:
            apply_to: "\.coffee$"
```
