### PR TITLE
[FrameworkBundle] Empty annotation namespaces parameter because it is ref

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -462,6 +462,8 @@ class FrameworkExtension extends Extension
             $arguments = $loaderChain->getArguments();
             array_unshift($arguments[0], new Reference('validator.mapping.loader.annotation_loader'));
             $loaderChain->setArguments($arguments);
+        } else {
+            $container->setParameter('validator.mapping.loader.annotation_loader.namespaces', array());
         }
 
         if (isset($config['cache'])) {


### PR DESCRIPTION
[FrameworkBundle] Empty annotation namespaces parameter because it is referenced in validator.xml
