### PR TITLE
[Form] Added a search form field type

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -130,6 +130,9 @@
         <service id="form.type.repeated" class="Symfony\Component\Form\Extension\Core\Type\RepeatedType">
             <tag name="form.type" alias="repeated" />
         </service>
+        <service id="form.type.search" class="Symfony\Component\Form\Extension\Core\Type\SearchType">
+            <tag name="form.type" alias="search" />
+        </service>
         <service id="form.type.textarea" class="Symfony\Component\Form\Extension\Core\Type\TextareaType">
             <tag name="form.type" alias="textarea" />
         </service>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/search_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/search_widget.html.php
@@ -1,0 +1,8 @@
+<input type="search"
+    <?php echo $view['form']->attributes() ?>
+    name="<?php echo $view->escape($name) ?>"
+    value="<?php echo $view->escape($value) ?>"
+    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
+    <?php if ($required): ?>required="required"<?php endif ?>
+    <?php if ($max_length): ?>maxlength="<?php echo $max_length ?>"<?php endif ?>
+/>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -201,6 +201,13 @@
 {% endspaceless %}
 {% endblock url_widget %}
 
+{% block search_widget %}
+{% spaceless %}
+    {% set type = type|default('search') %}
+    {{ block('field_widget') }}
+{% endspaceless %}
+{% endblock search_widget %}
+
 {% block percent_widget %}
 {% spaceless %}
     {% set type = type|default('text') %}

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -52,6 +52,7 @@ class CoreExtension extends AbstractExtension
             new Type\PercentType(),
             new Type\RadioType(),
             new Type\RepeatedType(),
+            new Type\SearchType(),
             new Type\TextareaType(),
             new Type\TextType(),
             new Type\TimeType(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/SearchType.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractType;
+
+class SearchType extends AbstractType
+{
+    public function getParent(array $options)
+    {
+        return 'text';
+    }
+
+    public function getName()
+    {
+        return 'search';
+    }
+}


### PR DESCRIPTION
While I'm not sure it's necessarily correct to include form field types that map 100% 1:1 with the WHATWG HTML spec, I think for the sake of semantics a search field belongs in the framework.  There's no additional behaviour here (no coincidence as spec specifies none over text), but the default expectation would be that the type would render with a type="search" attribute.  I haven't found any discussion specifically on HTML5 input types such as this (and "tel") that have no real additional behaviour over "text", and indeed I realise that a text field with a type of search can be specified already, but... here's the PR.
