### PR TITLE
[DoctrineBundle] Refactoring doctrine:schema:* command descriptions

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/CreateSchemaDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/CreateSchemaDoctrineCommand.php
@@ -19,7 +19,8 @@ use Symfony\Component\Console\Output\Output;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\CreateCommand;
 
 /**
- * Command to create the database schema for a set of classes based on their mappings.
+ * Command to execute the SQL needed to generate the database schema for
+ * a given entity manager.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jonathan H. Wage <jonwage@gmail.com>
@@ -32,17 +33,21 @@ class CreateSchemaDoctrineCommand extends CreateCommand
 
         $this
             ->setName('doctrine:schema:create')
+            ->setDescription('Executes (or dumps) the SQL needed to generate the database schema.')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command')
             ->setHelp(<<<EOT
-The <info>doctrine:schema:create</info> command creates the default entity
-managers schema:
+The <info>doctrine:schema:create</info> command executes the SQL needed to
+generate the database schema for the default entity manager:
 
 <info>./app/console doctrine:schema:create</info>
 
-You can also optionally specify the name of a entity manager to create the
-schema for:
+You can also generate the database schema for a specific entity manager:
 
 <info>./app/console doctrine:schema:create --em=default</info>
+
+Finally, instead of executing the SQL, you can output the SQL:
+
+<info>./app/console doctrine:schema:create --dump-sql</info>
 EOT
         );
     }

--- a/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DropSchemaDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/DropSchemaDoctrineCommand.php
@@ -32,12 +32,17 @@ class DropSchemaDoctrineCommand extends DropCommand
 
         $this
             ->setName('doctrine:schema:drop')
+            ->setDescription('Executes (or dumps) the SQL needed to drop the current database schema.')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command')
             ->setHelp(<<<EOT
-The <info>doctrine:schema:drop</info> command drops the default entity
-managers schema:
+The <info>doctrine:schema:drop</info> command generates the SQL needed to
+drop the database schema of the default entity manager:
 
-<info>./app/console doctrine:schema:drop</info>
+<info>./app/console doctrine:schema:drop --dump-sql</info>
+
+Alternatively, you can execute the generated queries:
+
+<info>./app/console doctrine:schema:drop --force</info>
 
 You can also optionally specify the name of a entity manager to drop the
 schema for:

--- a/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/UpdateSchemaDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/Proxy/UpdateSchemaDoctrineCommand.php
@@ -19,7 +19,8 @@ use Symfony\Component\Console\Output\Output;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 
 /**
- * Command to update the database schema for a set of classes based on their mappings.
+ * Command to generate the SQL needed to update the database schema to match
+ * the current mapping information.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jonathan H. Wage <jonwage@gmail.com>
@@ -32,15 +33,23 @@ class UpdateSchemaDoctrineCommand extends UpdateCommand
 
         $this
             ->setName('doctrine:schema:update')
+            ->setDescription('Executes (or dumps) the SQL needed to update the database schema to match the current mapping metadata.')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command')
             ->setHelp(<<<EOT
-The <info>doctrine:schema:update</info> command updates the default entity
-managers schema:
+The <info>doctrine:schema:update</info> command generates the SQL needed to
+synchronize the database schema with the current mapping metadata of the
+default entity manager.
 
-<info>./app/console doctrine:schema:update</info>
+For example, if you add metadata for a new column to an entity, this command
+would generate and output the SQL needed to add the new column to the database:
 
-You can also optionally specify the name of a entity manager to update the
-schema for:
+<info>./app/console doctrine:schema:update --dump-sql</info>
+
+Alternatively, you can execute the generated queries:
+
+<info>./app/console doctrine:schema:update --force</info>
+
+You can also update the database schema for a specific entity manager:
 
 <info>./app/console doctrine:schema:update --em=default</info>
 EOT


### PR DESCRIPTION
Hey guys!

Since the `doctrine:schema:*` commands will be so important day-to-day for a developer, I wanted their descriptions to be a little bit less technical and to stand-out when listing the commands via `php app/console`.

If you agree, these changes should be communicated upstream to Doctrine. Really, there's no reason to override the `description`, but this gets the change into Symfony more quickly.

Thanks!
