### PR TITLE
Issue on 301 redirection when using another port than 80

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -470,6 +470,10 @@ class Request
     {
         $host = $this->headers->get('HOST');
         if (!empty($host)) {
+            
+            // Remove port number from host
+            $host = preg_replace('/:\d+$/', '', $host);
+            
             return $host;
         }
 


### PR DESCRIPTION
In SymfonyBundleFrameworkBundleControllerRedirectController::urlRedirectAction() SymfonyComponentHttpFoundationRequest::getHttpHost() is called. But this method returns the hostname with the port (mydomain:8080) proning a bug when a redirection is made (The 301 location will be http://mydomain:8080:8080/).
