### PR TITLE
Improve AclVoter to check if it supports passed class before voting

### DIFF
--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -88,6 +88,11 @@ class AclVoter implements VoterInterface
 
                     return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
                 }
+
+                if (!$this->supportsClass($oid->getType())) {
+                    return self::ACCESS_ABSTAIN;
+                }
+
                 $sids = $this->securityIdentityRetrievalStrategy->getSecurityIdentities($token);
 
                 try {


### PR DESCRIPTION
This allows you to easily extend AclVoter, if you only need to override one method --- supportsClass.

https://github.com/symfony/symfony/issues/865#comment_1171785
