### PR TITLE
[Validator] ConstraintViolation can handle array values

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -54,7 +54,17 @@ class ConstraintViolation
      */
     public function getMessage()
     {
-        return str_replace(array_keys($this->messageParameters), array_values($this->messageParameters), $this->messageTemplate);
+        $message = $this->messageTemplate;
+
+        foreach ($this->messageParameters as $key => $value) {
+            if (is_array($value)) {
+                $value = print_r($value, true);
+            }
+
+            $message = str_replace($key, $value, $message);
+        }
+
+        return $message;
     }
 
     public function getRoot()

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -58,7 +58,7 @@ class ConstraintViolation
 
         foreach ($this->messageParameters as $key => $value) {
             if (is_array($value)) {
-                $value = print_r($value, true);
+                $value = 'Array';
             }
 
             $message = str_replace($key, $value, $message);

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Tests\Component\Validator;
 
 use Symfony\Component\Validator\Constraints\Type;
 use Symfony\Component\Validator\Constraints\TypeValidator;
+use Symfony\Component\Validator\ConstraintViolation;
 
 class TypeValidatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -82,6 +83,22 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
         $constraint = new Type(array('type' => $type));
 
         $this->assertFalse($this->validator->isValid($value, $constraint));
+    }
+    
+    public function testConstraintViolationCanHandleArrayValue()
+    {
+        $constraint = new Type(array('type' => 'string'));
+        $this->validator->isValid(array(0 => "Test"), $constraint);
+        
+        $violation = new ConstraintViolation(
+            '{{ value }}',
+            $this->validator->getMessageParameters(),
+            '',
+            '',
+            ''
+        );
+        
+        $this->assertEquals('Array', $violation->getMessage());
     }
 
     public function getInvalidValues()


### PR DESCRIPTION
ConstraintViolation caused a "NOTICE: Array to string conversion ..." for the TypeValidator when the validated value was an array while executing str_replace.
