### PR TITLE
[Form] added default type to non-name create methods

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -131,7 +131,7 @@ class FormFactory implements FormFactoryInterface
      *
      * @throws FormException if any given option is not applicable to the given type
      */
-    public function create($type, $data = null, array $options = array())
+    public function create($type = 'form', $data = null, array $options = array())
     {
         return $this->createBuilder($type, $data, $options)->getForm();
     }
@@ -186,7 +186,7 @@ class FormFactory implements FormFactoryInterface
      *
      * @throws FormException if any given option is not applicable to the given type
      */
-    public function createBuilder($type, $data = null, array $options = array())
+    public function createBuilder($type = 'form', $data = null, array $options = array())
     {
         $name = is_object($type) ? $type->getName() : $type;
 


### PR DESCRIPTION
Unless I misunderstand, most of the time a user calls one of the form factory's create methods they're going to pass the `'form'` type. I've updated those methods that don't also ask for a form name to use the form type by default.
