### PR TITLE
Allow the usage of % in Twig-Trans-Nodes

### DIFF
--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -111,6 +111,8 @@ class TransNode extends \Twig_Node
             }
         }
 
+        $msg = preg_replace('/\\\%/', '%', $msg);
+
         return array(new \Twig_Node_Expression_Constant(trim($msg), $body->getLine()), $vars);
     }
 }

--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -104,7 +104,7 @@ class TransNode extends \Twig_Node
             $current[$name] = true;
         }
 
-        preg_match_all('/\%([^\%]+)\%/', $msg, $matches);
+        preg_match_all('/\%([^(\\\%)]+?)\%/', $msg, $matches);
         foreach ($matches[1] as $var) {
             if (!isset($current['%'.$var.'%'])) {
                 $vars->setNode('%'.$var.'%', new \Twig_Node_Expression_Name($var, $body->getLine()));


### PR DESCRIPTION
I have a trans-message that includes %-Signs. With the current implementation there is no way getting this working without hassle.

Sample: %closed% closed (%closed_percent%%), %open% open (%open_percent%%)

See the double %% after closed_percent.

I changed the regex in the TransNode so you are able to escape %-signs

So you can write: %closed% closed (%closed_percent%\%), %open% open (%open_percent%\%)
