### PR TITLE
DirectoryLoader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/DirectoryLoader.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader;
+
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\Config\FileLocatorInterface;
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * The DirectoryLoader loads all files within a directory and will pass
+ * each file to the DelegatingLoader.
+ *
+ * @author Kai-Arne Watermann <kaiwatermann@gmail.com>
+ */
+class DirectoryLoader extends Loader
+{
+    protected $locator;
+
+    protected $container;
+
+    /**
+     * Constructor.
+     *
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     * @param FileLocator      $locator   A FileLocator instance
+     */
+    public function __construct(ContainerBuilder $container, FileLocator $locator)
+    {
+        $this->locator   = $locator;
+        $this->container = $container;
+    }
+
+    /**
+     * Loads all files within the directory.
+     *
+     * @param mixed  $resource The resource
+     * @param string $type The resource type
+     */
+    public function load($resource, $type = null)
+    {
+        $path = $this->locator->locate($resource);
+        $directory = new \DirectoryIterator($path);
+        
+        $loader = new DelegatingLoader($this->resolver);
+        
+        foreach ($directory as $item) {
+            // Skip "." and ".." directory items
+            if ($item->isDot()) continue;
+            
+            if ($item->isDir()) {   
+                // Subdirectory
+                $loader->load($item->getPathname() . DIRECTORY_SEPARATOR);
+            } elseif ($item->isFile()) {
+                // File
+                $loader->load($item->getPathname());
+            }
+        }
+    }
+
+    /**
+     * Returns true if this class supports the given resource.
+     *
+     * @param mixed  $resource A resource
+     * @param string $type     The resource type
+     *
+     * @return Boolean true if this class supports the given resource, false otherwise
+     */
+    public function supports($resource, $type = null)
+    {
+        // Return false if resource is not of type string
+        if (!is_string($resource)) return false;
+        
+        // Check if last character of resource string equals to directory separator
+        $lastChar = substr($resource, -1, 1);
+        $isDirectory = ($lastChar == '/' || $lastChar == DIRECTORY_SEPARATOR);
+
+        return $isDirectory;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -71,7 +71,7 @@ class ControllerResolver implements ControllerResolverInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Using controller "%s::%s"', get_class($controller), $method));
+            $this->logger->debug(sprintf('Using controller "%s::%s"', get_class($controller), $method));
         }
 
         return array($controller, $method);

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
+use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -641,6 +642,7 @@ abstract class Kernel implements KernelInterface
             new YamlFileLoader($container, $locator),
             new IniFileLoader($container, $locator),
             new PhpFileLoader($container, $locator),
+            new DirectoryLoader($container, $locator),
             new ClosureLoader($container),
         ));
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/mixed/inifile.ini
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/mixed/inifile.ini
@@ -1,0 +1,2 @@
+[parameters]
+ini = ok

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/mixed/phpfile.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/mixed/phpfile.php
@@ -1,0 +1,3 @@
+<?php
+
+$container->setParameter('php', 'ok');

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/mixed/subdirectory/yamlfile.yml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/mixed/subdirectory/yamlfile.yml
@@ -1,0 +1,2 @@
+parameters:
+    yaml: ok

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/DirectoryLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/DirectoryLoaderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\DependencyInjection\Loader;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
+use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\Config\FileLocator;
+
+class DirectoryLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Symfony\Component\DependencyInjection\Loader\DirectoryLoader::supports
+     */
+    public function testSupports()
+    {
+        $loader = new DirectoryLoader(new ContainerBuilder(), new FileLocator());
+
+        $this->assertTrue($loader->supports('conf.d' . DIRECTORY_SEPARATOR), '->supports() returns true if the resource is loadable');
+        $this->assertFalse($loader->supports('config.xml'), '->supports() returns true if the resource is loadable');
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\Loader\DirectoryLoader::load
+     */
+    public function testLoad()
+    {
+        $fixturesPath = __DIR__.'/../Fixtures';
+        
+        $container = new ContainerBuilder();
+        
+        $resolver = new LoaderResolver(array(
+            new IniFileLoader($container, new FileLocator($fixturesPath)),
+            new PhpFileLoader($container, new FileLocator($fixturesPath)),
+            new YamlFileLoader($container, new FileLocator($fixturesPath)),
+            $loader = new DirectoryLoader($container, new FileLocator($fixturesPath)),
+        ));
+        
+        $loader->setResolver($resolver);
+        
+        $loader->load('mixed/');
+
+        $this->assertEquals('ok', $container->getParameter('php'), '->load() loads a PHP file resource from directory');
+        $this->assertEquals('ok', $container->getParameter('ini'), '->load() loads a INI file resource from directory');
+        $this->assertEquals('ok', $container->getParameter('yaml'), '->load() loads a YML file resource from subdirectory');
+    }
+}


### PR DESCRIPTION
As my list of imports keeps growing i was looking for a way to automatically import all files within a certain directory. This is a common behaviour, e. g. Apache's httpd.conf contains the statement "Include conf.d/". I implemented the same for symfony by adding the DirectoryLoader.

Yaml example:

imports:
    - { resource: anydir/ }

All files found within the directory will be passed to DelegatingLoader.
