### PR TITLE
do not try to load translation files from hidden folders

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -436,7 +436,7 @@ class FrameworkExtension extends Extension
             // Register translation resources
             if ($dirs) {
                 $finder = new Finder();
-                $finder->files()->filter(function (\SplFileInfo $file) { return 2 === substr_count($file->getBasename(), '.'); })->in($dirs);
+                $finder->files()->filter(function (\SplFileInfo $file) { return (FALSE === strpos($file->getRealPath(), DIRECTORY_SEPARATOR . '.') && 2 === substr_count($file->getBasename(), '.')); })->in($dirs);
                 foreach ($finder as $file) {
                     // filename is domain.locale.format
                     list($domain, $locale, $format) = explode('.', $file->getBasename());


### PR DESCRIPTION
translation files in hidden folders and hidden translation files should not be loaded.

Eg:
src/Acme/DemoBundle/Resources/translation/.AppleDouble/messages.de.yml
