### PR TITLE
Added support for request method overriding via X-HTTP-Method-Override

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -603,8 +603,6 @@ class Request
             $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
             if ('POST' === $this->method) {
                 $this->method = strtoupper($this->server->get('X-HTTP-METHOD-OVERRIDE', $this->request->get('_method', 'POST')));
-            } else if ('GET' === $this->method) {
-                $this->method = strtoupper($this->query->get('_method', 'GET'));
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -602,7 +602,9 @@ class Request
         if (null === $this->method) {
             $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
             if ('POST' === $this->method) {
-                $this->method = strtoupper($this->request->get('_method', 'POST'));
+                $this->method = strtoupper($this->server->get('X-HTTP-METHOD-OVERRIDE', $this->request->get('_method', 'POST')));
+            } else if ('GET' === $this->method) {
+                $this->method = strtoupper($this->query->get('_method', 'GET'));
             }
         }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -453,6 +453,20 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('POST');
         $request->request->set('_method', 'purge');
         $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returns the method from _method if defined and POST');
+        
+        $request->setMethod('POST');
+        $request->server->set('X-HTTP-METHOD-OVERRIDE', 'delete');
+        $this->assertEquals('DELETE', $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override even though _method is set if defined and POST');
+        
+        $request = new Request();
+        $request->setMethod('POST');
+        $request->server->set('X-HTTP-METHOD-OVERRIDE', 'delete');
+        $this->assertEquals('DELETE', $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override if defined and POST');
+
+        $request = new Request();
+        $request->setMethod('GET');
+        $request->query->set('_method', 'purge');
+        $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returns the method from _method if defined and GET');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -462,11 +462,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('POST');
         $request->server->set('X-HTTP-METHOD-OVERRIDE', 'delete');
         $this->assertEquals('DELETE', $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override if defined and POST');
-
-        $request = new Request();
-        $request->setMethod('GET');
-        $request->query->set('_method', 'purge');
-        $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returns the method from _method if defined and GET');
     }
 
     /**


### PR DESCRIPTION
This type of override is supported by MS MVC3 and is recommended by Google.
Also added ability to override request method via ?_method= when
request is made via GET.
