### PR TITLE
[HttpFoundation] Response cookie headers

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -65,8 +65,8 @@ class Cookie
     {
         $str = urlencode($this->getName()).'=';
 
-        if (null === $this->getValue()) {
-                $str .= 'deleted; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+        if ('' === (string) $this->getValue()) {
+            $str .= 'deleted; expires='.gmdate("D, d-M-Y H:i:s T", time()-31536001);
         } else {
             $str .= urlencode($this->getValue());
 

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -60,6 +60,39 @@ class Cookie
         $this->secure = (Boolean) $secure;
         $this->httpOnly = (Boolean) $httpOnly;
     }
+    
+    public function __toString()
+    {
+        $str = urlencode($this->getName()).'=';
+
+        if (null === $this->getValue()) {
+                $str .= 'deleted; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+        } else {
+            $str .= urlencode($this->getValue());
+
+            if ($this->getExpiresTime() > 0) {
+                $str .= '; expires='.gmdate("D, d-M-Y H:i:s T", $this->getExpiresTime());
+            }
+        }
+
+        if (null !== $this->getPath()) {
+            $str .= '; path='.$this->getPath();
+        }
+
+        if (null !== $this->getDomain()) {
+            $str .= '; domain='.$this->getDomain();
+        }
+
+        if (true === $this->isSecure()) {
+            $str .= '; secure';
+        }
+
+        if (true === $this->isHttpOnly()) {
+            $str .= '; httponly';
+        }
+
+        return $str;
+    }
 
     public function getName()
     {

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -70,7 +70,7 @@ class Cookie
         } else {
             $str .= urlencode($this->getValue());
 
-            if ($this->getExpiresTime() > 0) {
+            if ($this->getExpiresTime() !== 0) {
                 $str .= '; expires='.gmdate("D, d-M-Y H:i:s T", $this->getExpiresTime());
             }
         }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -33,6 +33,21 @@ class ResponseHeaderBag extends HeaderBag
             $this->set('cache-control', '');
         }
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        $cookies = '';
+        foreach ($this->cookies as $cookie) {
+            $cookies .= 'Set-Cookie: '.$cookie."\r\n";
+        }
+
+        return
+            parent::__toString().
+            $cookies;
+    }
 
     /**
      * {@inheritdoc}

--- a/tests/Symfony/Tests/Component/HttpFoundation/CookieTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/CookieTest.php
@@ -137,4 +137,15 @@ class CookieTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($cookie->isCleared(), '->isCleared() returns true if the cookie has expired');
     }
+    
+    public function testToString()
+    {
+        $cookie = new Cookie('foo', 'bar', strtotime('Fri, 20-May-2011 15:25:52 GMT'), '/', '.myfoodomain.com', true);
+
+        $this->assertEquals('foo=bar; expires=Fri, 20-May-2011 15:25:52 GMT; path=/; domain=.myfoodomain.com; secure; httponly', $cookie->__toString(), '->__toString() returns string representation of the cookie');
+        
+        $cookie = new Cookie('foo', null, 1, '/', '.myfoodomain.com');
+
+        $this->assertEquals('foo=deleted; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=.myfoodomain.com; httponly', $cookie->__toString(), '->__toString() returns string representation of a cleared cookie if value is NULL');
+    }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/CookieTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/CookieTest.php
@@ -145,7 +145,7 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo=bar; expires=Fri, 20-May-2011 15:25:52 GMT; path=/; domain=.myfoodomain.com; secure; httponly', $cookie->__toString(), '->__toString() returns string representation of the cookie');
         
         $cookie = new Cookie('foo', null, 1, '/', '.myfoodomain.com');
-
-        $this->assertEquals('foo=deleted; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=.myfoodomain.com; httponly', $cookie->__toString(), '->__toString() returns string representation of a cleared cookie if value is NULL');
+ 
+        $this->assertEquals('foo=deleted; expires=' . gmdate("D, d-M-Y H:i:s T", time()-31536001) . '; path=/; domain=.myfoodomain.com; httponly', $cookie->__toString(), '->__toString() returns string representation of a cleared cookie if value is NULL');
     }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseHeaderBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseHeaderBagTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Tests\Component\HttpFoundation;
 
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\Cookie;
 
 class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
 {
@@ -61,5 +62,17 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
         $bag = new ResponseHeaderBag();
         $bag->set('Last-Modified', 'abcde');
         $this->assertEquals('private, must-revalidate', $bag->get('Cache-Control'));
+    }
+    
+    public function testToStringIncludesCookieHeaders()
+    {
+        $bag = new ResponseHeaderBag(array());
+        $bag->setCookie(new Cookie('foo', 'bar'));
+        
+        $this->assertContains("Set-Cookie: foo=bar; path=/; httponly", explode("\r\n", $bag->__toString()));
+        
+        $bag->clearCookie('foo');
+
+        $this->assertContains("Set-Cookie: foo=deleted; expires=Thu, 01 Jan 1970 00:00:00 GMT; httponly", explode("\r\n", $bag->__toString()));
     }
 }


### PR DESCRIPTION
`Response::__toString()` now includes also the cookie headers.

For this, i added `Cookie::__toString()` and `ResponseHeaderBag::__toString()` which extends `HeaderBag::__toString()` to include the Set-Cookie headers.
