### PR TITLE
Remove the facing-slash from .gitignore "/vendor/". 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 phpunit.xml
 autoload.php
-/vendor/
+vendor/


### PR DESCRIPTION
The /vendor/ entry in .gitignore points to the project-root but
should be relative, as symfony is a vendor too.

This commit makes it possible again to use submodules or even add a vendor to a project-git-repo.
