### PR TITLE
[TwigBundle] Extensions cleanup

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
@@ -18,7 +18,6 @@ use Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper;
  * Twig extension for Symfony actions helper
  *
  * @author Fabien Potencier <fabien@symfony.com>
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
  */
 class ActionsExtension extends \Twig_Extension
 {

--- a/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\TwigBundle\Extension;
 
 use Symfony\Bundle\TwigBundle\TokenParser\RenderTokenParser;
-use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper;
 
 /**
  * Twig extension for Symfony actions helper
@@ -23,13 +23,18 @@ use Symfony\Component\HttpKernel\HttpKernel;
 class ActionsExtension extends \Twig_Extension
 {
     /**
-     * @var Symfony\Component\HttpKernel\HttpKernel
+     * @var Symfony\Bundle\FrameworkBundle\Templating\Helper\ActionsHelper
      */
-    private $kernel;
+    private $helper;
 
-    public function __construct(HttpKernel $kernel)
+    /**
+     * Construct the extension with a HTTP Kernel
+     *
+     * @param HttpKernel $kernel The kernel to use for sub-requests
+     */
+    public function __construct(ActionsHelper $helper)
     {
-        $this->kernel = $kernel;
+        $this->helper = $helper;
     }
 
     /**
@@ -43,9 +48,7 @@ class ActionsExtension extends \Twig_Extension
      */
     public function renderAction($controller, array $attributes = array(), array $options = array())
     {
-        $options['attributes'] = $attributes;
-
-        return $this->kernel->render($controller, $options);
+        return $this->helper->render($controller, $attributes, $options);
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/ActionsExtension.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Extension;
+
+use Symfony\Bundle\TwigBundle\TokenParser\RenderTokenParser;
+use Symfony\Component\HttpKernel\HttpKernel;
+
+/**
+ * Twig extension for Symfony actions helper
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
+ */
+class ActionsExtension extends \Twig_Extension
+{
+    /**
+     * @var Symfony\Component\HttpKernel\HttpKernel
+     */
+    private $kernel;
+
+    public function __construct(HttpKernel $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    /**
+     * Returns the Response content for a given controller or URI.
+     *
+     * @param string $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
+     * @param array  $attributes An array of request attributes
+     * @param array  $options    An array of options
+     *
+     * @see Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver::render()
+     */
+    public function renderAction($controller, array $attributes = array(), array $options = array())
+    {
+        $options['attributes'] = $attributes;
+
+        return $this->kernel->render($controller, $options);
+    }
+
+    /**
+     * Returns the token parser instance to add to the existing list.
+     *
+     * @return array An array of Twig_TokenParser instances
+     */
+    public function getTokenParsers()
+    {
+        return array(
+            // {% render 'BlogBundle:Post:list' with { 'limit': 2 }, { 'alt': 'BlogBundle:Post:error' } %}
+            new RenderTokenParser(),
+        );
+    }
+
+    public function getName()
+    {
+        return 'actions';
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
@@ -15,7 +15,6 @@ use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 
 /**
  * @author Fabien Potencier <fabien@symfony.com>
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
  */
 class AssetsExtension extends \Twig_Extension
 {

--- a/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
@@ -11,19 +11,22 @@
 
 namespace Symfony\Bundle\TwigBundle\Extension;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
 
 /**
- *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
  */
-class TemplatingExtension extends \Twig_Extension
+class AssetsExtension extends \Twig_Extension
 {
-    protected $container;
+    /**
+     * @var Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper
+     */
+    private $helper;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(AssetsHelper $helper)
     {
-        $this->container = $container;
+        $this->helper = $helper;
     }
 
     /**
@@ -51,7 +54,7 @@ class TemplatingExtension extends \Twig_Extension
      */
     public function getAssetUrl($path, $packageName = null)
     {
-        return $this->container->get('templating.helper.assets')->getUrl($path, $packageName);
+        return $this->helper->getUrl($path, $packageName);
     }
 
     /**
@@ -62,7 +65,7 @@ class TemplatingExtension extends \Twig_Extension
      */
     public function getAssetsVersion($packageName = null)
     {
-        return $this->container->get('templating.helper.assets')->getVersion($packageName);
+        return $this->helper->getVersion($packageName);
     }
 
     /**
@@ -72,6 +75,6 @@ class TemplatingExtension extends \Twig_Extension
      */
     public function getName()
     {
-        return 'templating';
+        return 'assets';
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Extension/CodeExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/CodeExtension.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Extension;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper;
+
+/**
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexandre Salomé <alexandre.salome@gmail.com>
+ */
+class CodeExtension extends \Twig_Extension
+{
+    private $helper;
+
+    /**
+     * Constructor of Twig Extension to provide functions for code formatting
+     *
+     * @param Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper $helper Helper to use
+     */
+    public function __construct(CodeHelper $helper)
+    {
+        $this->helper = $helper;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters()
+    {
+        return array(
+            'abbr_class'            => new \Twig_Filter_Method($this, 'abbrClass', array('is_safe' => array('html'))),
+            'abbr_method'           => new \Twig_Filter_Method($this, 'abbrMethod', array('is_safe' => array('html'))),
+            'format_args'           => new \Twig_Filter_Method($this, 'formatArgs', array('is_safe' => array('html'))),
+            'format_args_as_text'   => new \Twig_Filter_Method($this, 'formatArgsAsText'),
+            'file_excerpt'          => new \Twig_Filter_Method($this, 'fileExcerpt', array('is_safe' => array('html'))),
+            'format_file'           => new \Twig_Filter_Method($this, 'formatFile', array('is_safe' => array('html'))),
+            'format_file_from_text' => new \Twig_Filter_Method($this, 'formatFileFromText', array('is_safe' => array('html'))),
+            'file_link'             => new \Twig_Filter_Method($this, 'getFileLink', array('is_safe' => array('html'))),
+        );
+    }
+
+    public function abbrClass($class)
+    {
+        return $this->helper->abbrClass($class);
+    }
+
+    public function abbrMethod($method)
+    {
+        return $this->helper->abbrMethod($method);
+    }
+
+    public function formatArgs($args)
+    {
+        return $this->helper->formatArgs($args);
+    }
+
+    public function formatArgsAsText($args)
+    {
+        return $this->helper->formatArgsAsText($args);
+    }
+
+    public function fileExcerpt($file, $line)
+    {
+        return $this->helper->fileExcerpt($file, $line);
+    }
+
+    public function formatFile($file, $line, $text = null)
+    {
+        return $this->helper->formatFile($file, $line, $text);
+    }
+
+    public function getFileLink($file, $line)
+    {
+        return $this->helper->getFileLink($file, $line);
+    }
+
+    public function formatFileFromText($text)
+    {
+        return $this->helper->formatFileFromText($text);
+    }
+
+    public function getName()
+    {
+        return 'code';
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Extension/CodeExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/CodeExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Bundle\TwigBundle\Extension;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper;
 
 /**

--- a/src/Symfony/Bundle/TwigBundle/Extension/CodeExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/CodeExtension.php
@@ -16,7 +16,6 @@ use Symfony\Bundle\FrameworkBundle\Templating\Helper\CodeHelper;
 /**
  *
  * @author Fabien Potencier <fabien@symfony.com>
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
  */
 class CodeExtension extends \Twig_Extension
 {

--- a/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
@@ -27,23 +27,6 @@ class TemplatingExtension extends \Twig_Extension
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function getFilters()
-    {
-        return array(
-            'abbr_class'            => new \Twig_Filter_Method($this, 'abbrClass', array('is_safe' => array('html'))),
-            'abbr_method'           => new \Twig_Filter_Method($this, 'abbrMethod', array('is_safe' => array('html'))),
-            'format_args'           => new \Twig_Filter_Method($this, 'formatArgs', array('is_safe' => array('html'))),
-            'format_args_as_text'   => new \Twig_Filter_Method($this, 'formatArgsAsText'),
-            'file_excerpt'          => new \Twig_Filter_Method($this, 'fileExcerpt', array('is_safe' => array('html'))),
-            'format_file'           => new \Twig_Filter_Method($this, 'formatFile', array('is_safe' => array('html'))),
-            'format_file_from_text' => new \Twig_Filter_Method($this, 'formatFileFromText', array('is_safe' => array('html'))),
-            'file_link'             => new \Twig_Filter_Method($this, 'getFileLink', array('is_safe' => array('html'))),
-        );
-    }
-
-    /**
      * Returns a list of functions to add to the existing list.
      *
      * @return array An array of functions
@@ -80,46 +63,6 @@ class TemplatingExtension extends \Twig_Extension
     public function getAssetsVersion($packageName = null)
     {
         return $this->container->get('templating.helper.assets')->getVersion($packageName);
-    }
-
-    public function abbrClass($class)
-    {
-        return $this->container->get('templating.helper.code')->abbrClass($class);
-    }
-
-    public function abbrMethod($method)
-    {
-        return $this->container->get('templating.helper.code')->abbrMethod($method);
-    }
-
-    public function formatArgs($args)
-    {
-        return $this->container->get('templating.helper.code')->formatArgs($args);
-    }
-
-    public function formatArgsAsText($args)
-    {
-        return $this->container->get('templating.helper.code')->formatArgsAsText($args);
-    }
-
-    public function fileExcerpt($file, $line)
-    {
-        return $this->container->get('templating.helper.code')->fileExcerpt($file, $line);
-    }
-
-    public function formatFile($file, $line, $text = null)
-    {
-        return $this->container->get('templating.helper.code')->formatFile($file, $line, $text);
-    }
-
-    public function getFileLink($file, $line)
-    {
-        return $this->container->get('templating.helper.code')->getFileLink($file, $line);
-    }
-
-    public function formatFileFromText($text)
-    {
-        return $this->container->get('templating.helper.code')->formatFileFromText($text);
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/TemplatingExtension.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\TwigBundle\Extension;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Bundle\TwigBundle\TokenParser\RenderTokenParser;
 
 /**
  *
@@ -81,35 +80,6 @@ class TemplatingExtension extends \Twig_Extension
     public function getAssetsVersion($packageName = null)
     {
         return $this->container->get('templating.helper.assets')->getVersion($packageName);
-    }
-
-    /**
-     * Returns the Response content for a given controller or URI.
-     *
-     * @param string $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
-     * @param array  $attributes An array of request attributes
-     * @param array  $options    An array of options
-     *
-     * @see Symfony\Bundle\FrameworkBundle\Controller\ControllerResolver::render()
-     */
-    public function renderAction($controller, array $attributes = array(), array $options = array())
-    {
-        $options['attributes'] = $attributes;
-
-        return $this->container->get('http_kernel')->render($controller, $options);
-    }
-
-    /**
-     * Returns the token parser instance to add to the existing list.
-     *
-     * @return array An array of Twig_TokenParser instances
-     */
-    public function getTokenParsers()
-    {
-        return array(
-            // {% render 'BlogBundle:Post:list' with { 'limit': 2 }, { 'alt': 'BlogBundle:Post:error' } %}
-            new RenderTokenParser(),
-        );
     }
 
     public function abbrClass($class)

--- a/src/Symfony/Bundle/TwigBundle/Node/RenderNode.php
+++ b/src/Symfony/Bundle/TwigBundle/Node/RenderNode.php
@@ -32,7 +32,7 @@ class RenderNode extends \Twig_Node
     {
         $compiler
             ->addDebugInfo($this)
-            ->write("echo \$this->env->getExtension('templating')->renderAction(")
+            ->write("echo \$this->env->getExtension('actions')->renderAction(")
             ->subcompile($this->getNode('expr'))
             ->raw(', ')
             ->subcompile($this->getNode('attributes'))

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -45,7 +45,7 @@
 
         <service id="twig.extension.actions" class="Symfony\Bundle\TwigBundle\Extension\ActionsExtension" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="http_kernel" />
+            <argument type="service" id="templating.helper.actions" />
         </service>
 
         <service id="twig.extension.routing" class="Symfony\Bridge\Twig\Extension\RoutingExtension" public="false">

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -38,9 +38,9 @@
             <argument type="service" id="translator" />
         </service>
 
-        <service id="twig.extension.helpers" class="Symfony\Bundle\TwigBundle\Extension\TemplatingExtension" public="false">
+        <service id="twig.extension.assets" class="Symfony\Bundle\TwigBundle\Extension\AssetsExtension" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="service_container" />
+            <argument type="service" id="templating.helper.assets" />
         </service>
 
         <service id="twig.extension.actions" class="Symfony\Bundle\TwigBundle\Extension\ActionsExtension" public="false">

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -48,6 +48,11 @@
             <argument type="service" id="templating.helper.actions" />
         </service>
 
+        <service id="twig.extension.code" class="Symfony\Bundle\TwigBundle\Extension\CodeExtension" public="false">
+            <tag name="twig.extension" />
+            <argument type="service" id="templating.helper.code" />
+        </service>
+
         <service id="twig.extension.routing" class="Symfony\Bridge\Twig\Extension\RoutingExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="router" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -43,6 +43,11 @@
             <argument type="service" id="service_container" />
         </service>
 
+        <service id="twig.extension.actions" class="Symfony\Bundle\TwigBundle\Extension\ActionsExtension" public="false">
+            <tag name="twig.extension" />
+            <argument type="service" id="http_kernel" />
+        </service>
+
         <service id="twig.extension.routing" class="Symfony\Bridge\Twig\Extension\RoutingExtension" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="router" />

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -9,6 +9,15 @@
         <parameter key="twig.loader.class">Symfony\Bundle\TwigBundle\Loader\FilesystemLoader</parameter>
         <parameter key="templating.engine.twig.class">Symfony\Bundle\TwigBundle\TwigEngine</parameter>
         <parameter key="twig.cache_warmer.class">Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheCacheWarmer</parameter>
+        <parameter key="twig.extension.trans.class">Symfony\Bridge\Twig\Extension\TranslationExtension</parameter>
+        <parameter key="twig.extension.assets.class">Symfony\Bundle\TwigBundle\Extension\AssetsExtension</parameter>
+        <parameter key="twig.extension.actions.class">Symfony\Bundle\TwigBundle\Extension\ActionsExtension</parameter>
+        <parameter key="twig.extension.code.class">Symfony\Bundle\TwigBundle\Extension\CodeExtension</parameter>
+        <parameter key="twig.extension.routing.class">Symfony\Bridge\Twig\Extension\RoutingExtension</parameter>
+        <parameter key="twig.extension.yaml.class">Symfony\Bridge\Twig\Extension\YamlExtension</parameter>
+        <parameter key="twig.extension.form.class">Symfony\Bridge\Twig\Extension\FormExtension</parameter>
+        <parameter key="twig.extension.text.class">Twig_Extensions_Extension_Text</parameter>
+        <parameter key="twig.extension.debug.class">Twig_Extensions_Extension_Debug</parameter>
     </parameters>
 
     <services>
@@ -33,42 +42,42 @@
             <argument type="service" id="templating.globals" />
         </service>
 
-        <service id="twig.extension.trans" class="Symfony\Bridge\Twig\Extension\TranslationExtension" public="false">
+        <service id="twig.extension.trans" class="%twig.extension.trans.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="translator" />
         </service>
 
-        <service id="twig.extension.assets" class="Symfony\Bundle\TwigBundle\Extension\AssetsExtension" public="false">
+        <service id="twig.extension.assets" class="%twig.extension.assets.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="templating.helper.assets" />
         </service>
 
-        <service id="twig.extension.actions" class="Symfony\Bundle\TwigBundle\Extension\ActionsExtension" public="false">
+        <service id="twig.extension.actions" class="%twig.extension.actions.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="templating.helper.actions" />
         </service>
 
-        <service id="twig.extension.code" class="Symfony\Bundle\TwigBundle\Extension\CodeExtension" public="false">
+        <service id="twig.extension.code" class="%twig.extension.code.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="templating.helper.code" />
         </service>
 
-        <service id="twig.extension.routing" class="Symfony\Bridge\Twig\Extension\RoutingExtension" public="false">
+        <service id="twig.extension.routing" class="%twig.extension.routing.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="router" />
         </service>
 
-        <service id="twig.extension.yaml" class="Symfony\Bridge\Twig\Extension\YamlExtension" public="false">
+        <service id="twig.extension.yaml" class="%twig.extension.yaml.class%" public="false">
             <tag name="twig.extension" />
         </service>
 
-        <service id="twig.extension.form" class="Symfony\Bridge\Twig\Extension\FormExtension" public="false">
+        <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">
             <tag name="twig.extension" />
             <argument>%twig.form.resources%</argument>
         </service>
 
-        <service id="twig.extension.text" class="Twig_Extensions_Extension_Text" public="false" />
+        <service id="twig.extension.text" class="%twig.extension.text.class%" public="false" />
 
-        <service id="twig.extension.debug" class="Twig_Extensions_Extension_Debug" public="false" />
+        <service id="twig.extension.debug" class="%twig.extension.debug.class%" public="false" />
     </services>
 </container>


### PR DESCRIPTION
Some refactoring into the TwigBundle :
- Separate the business of the global twig extension to different helpers : assets, actions, code
- Reduce dependency of extensions to associated PHP helpers in FrameworkBundle
- Move all class names to parameters of DIC
