### PR TITLE
Fix process creation under Win7 Ultimate (app/console assetic:dump ./web)

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -46,7 +46,7 @@ class Process
      *
      * @api
      */
-    public function __construct($commandline, $cwd = null, array $env = array(), $stdin = null, $timeout = 60, array $options = array())
+    public function __construct($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
     {
         if (!function_exists('proc_open')) {
             throw new \RuntimeException('The Process class relies on proc_open, which is not available on your PHP installation.');
@@ -54,13 +54,17 @@ class Process
 
         $this->commandline = $commandline;
         $this->cwd = null === $cwd ? getcwd() : $cwd;
-        $this->env = array();
-        foreach ($env as $key => $value) {
-            $this->env[(binary) $key] = (binary) $value;
+        if (null !== $env) {
+            $this->env = array();
+            foreach ($env as $key => $value) {
+                $this->env[(binary) $key] = (binary) $value;
+            }
+        } else {
+            $this->env = null;
         }
         $this->stdin = $stdin;
         $this->timeout = $timeout;
-        $this->options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true, 'bypass_shell' => true), $options);
+        $this->options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true, 'bypass_shell' => false), $options);
     }
 
     /**


### PR DESCRIPTION
Fix process creation under Win7 Ultimate (app/console assetic:dump ./web):
- Set the default $env to NULL, thus inheriting the system's environment settings (array() is no good).
- Set bypass_shell to false, otherwise process creation will fail (I don't know if this should happen only on Win7)
