### PR TITLE
[Routing] Yaml routing loader

### DIFF
--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -65,10 +65,8 @@ class YamlFileLoader extends FileLoader
                 $prefix = isset($config['prefix']) ? $config['prefix'] : null;
                 $this->setCurrentDir(dirname($path));
                 $collection->addCollection($this->import($config['resource'], $type, false, $file), $prefix);
-            } elseif (isset($config['pattern'])) {
-                $this->parseRoute($collection, $name, $config, $path);
             } else {
-                throw new \InvalidArgumentException(sprintf('Unable to parse the "%s" route.', $name));
+                $this->parseRoute($collection, $name, $config, $path);
             }
         }
 


### PR DESCRIPTION
[Routing] Remove exception condition in YamlFileLoader::load() as its duplicating a check that is done in parseRoute() anyways. This changes allows to extend the YamlFileLoader without having to duplicate the whole method.
