### PR TITLE
New Form Type - RangeType

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -80,6 +80,9 @@
         <service id="form.type.choice" class="Symfony\Component\Form\Extension\Core\Type\ChoiceType">
             <tag name="form.type" alias="choice" />
         </service>
+        <service id="form.type.range" class="Symfony\Component\Form\Extension\Core\Type\RangeType">
+            <tag name="form.type" alias="range" />
+        </service>
         <service id="form.type.collection" class="Symfony\Component\Form\Extension\Core\Type\CollectionType">
             <tag name="form.type" alias="collection" />
         </service>

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -133,6 +133,10 @@
 {% endspaceless %}
 {% endblock choice_widget %}
 
+{% block range_widget %}
+    {{ block('choice_widget') }}
+{% endblock range_widget %}
+
 {% block checkbox_widget %}
 {% spaceless %}
     <input type="checkbox" {{ block('attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -37,6 +37,7 @@ class CoreExtension extends AbstractExtension
             new Type\BirthdayType(),
             new Type\CheckboxType(),
             new Type\ChoiceType(),
+            new Type\RangeType(),
             new Type\CollectionType(),
             new Type\CountryType(),
             new Type\DateType(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -20,25 +20,31 @@ class RangeType extends ChoiceType
 {
     public function buildForm(FormBuilder $builder, Array $options)
     {
-        if (!$options['range'] || !count($options['range'])) {
-            throw new FormException('The option "range" is required and must be an array of the start and end values');
-        }
-
-        if ($options['range'] && !is_array($options['range'])) {
-            throw new UnexpectedTypeException('The option "range" must be an array');
+        if (!$options['start']) {
+            throw new FormException('The option "start" is required');
         }
         
-        $range = call_user_func_array('range', $options['range']);
+        if (!$options['end']) {
+            throw new FormException('The option "end" is required');
+        }
+        
+        $range = call_user_func_array('range', array(
+            $options['start'],
+            $options['end'],
+            $options['step']
+        ));
         
         $options['choices'] += array_combine($range, $range);
         
         parent::buildForm($builder, $options);
     }
-
+    
     public function getDefaultOptions(Array $options)
     {
         return array_merge(parent::getDefaultOptions($options), array(
-            'range' => array(),
+            'start' => null,
+            'end'   => null,
+            'step'  => 1,
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\FormBuilder;
+
+class RangeType extends ChoiceType
+{
+
+    public function buildForm(FormBuilder $builder, Array $options)
+    {
+        if (!$options['range'] || !count($options['range'])) {
+            throw new FormException('The option "range" is required and must be an array of the start and end values');
+        }
+
+        if ($options['range'] && !is_array($options['range'])) {
+            throw new UnexpectedTypeException('The option "range" must be an array');
+        }
+        
+        $range = call_user_func_array('range', $options['range']);
+        
+        $options['choices'] += array_combine($range, $range);
+        
+        parent::buildForm($builder, $options);
+    }
+
+    public function getDefaultOptions(Array $options)
+    {
+        return array_merge(parent::getDefaultOptions($options), array(
+            'range' => array(),
+        ));
+    }
+
+    public function getName()
+    {
+        return 'range';
+    }
+
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RangeType.php
@@ -18,7 +18,6 @@ use Symfony\Component\Form\FormBuilder;
 
 class RangeType extends ChoiceType
 {
-
     public function buildForm(FormBuilder $builder, Array $options)
     {
         if (!$options['range'] || !count($options['range'])) {
@@ -47,5 +46,4 @@ class RangeType extends ChoiceType
     {
         return 'range';
     }
-
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/RangeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/RangeTypeTest.php
@@ -15,30 +15,44 @@ use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class RangeTypeTest extends TypeTestCase
 {
-    private $range = array(1, 3);
-
     /**
      * @expectedException Symfony\Component\Form\Exception\FormException
      */
-    public function testRangeOptionExpectsArray()
+    public function testStartOptionIsRequired()
     {
         $form = $this->factory->create('range', null, array(
-            'range' => new \ArrayObject,
+            'start' => null,
+            'end'   => 3,
+            'step'  => 1,
         ));
     }
 
     /**
      * @expectedException Symfony\Component\Form\Exception\FormException
      */
-    public function testRequiresChoicesOrChoiceListOption()
+    public function testEndOptionIsRequired()
     {
-        $this->factory->create('range', 'name');
+        $form = $this->factory->create('range', null, array(
+            'start' => 1,
+            'end'   => null,
+            'step'  => 1,
+        ));
+    }
+
+    public function testStepOptionIsOptional()
+    {
+        $form = $this->factory->create('range', null, array(
+            'start' => 1,
+            'end'   => 3,
+        ));
     }
 
     public function testRangeCreatesChoices()
     {
         $form = $this->factory->create('range', null, array(
-            'range' => $this->range,
+            'start' => 1,
+            'end'   => 3,
+            'step'  => 1,
         ));
         
         $view = $form->createView();
@@ -46,4 +60,24 @@ class RangeTypeTest extends TypeTestCase
         $this->assertSame(array(1 => 1, 2 => 2, 3 => 3), $view->get('choices'));
     }
 
+    public function testRangeAppendsToExistingChoices()
+    {
+        $form = $this->factory->create('range', null, array(
+            'start'     => 1,
+            'end'       => 3,
+            'step'      => 1,
+            'choices'   => array(
+                0 => 0,
+            )
+        ));
+        
+        $view = $form->createView();
+        
+        $this->assertSame(array(
+            0 => 0,
+            1 => 1,
+            2 => 2,
+            3 => 3
+        ), $view->get('choices'));
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/RangeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/RangeTypeTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+class RangeTypeTest extends TypeTestCase
+{
+    private $range = array(1, 3);
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\FormException
+     */
+    public function testRangeOptionExpectsArray()
+    {
+        $form = $this->factory->create('range', null, array(
+            'range' => new \ArrayObject,
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\FormException
+     */
+    public function testRequiresChoicesOrChoiceListOption()
+    {
+        $this->factory->create('range', 'name');
+    }
+
+    public function testRangeCreatesChoices()
+    {
+        $form = $this->factory->create('range', null, array(
+            'range' => $this->range,
+        ));
+        
+        $view = $form->createView();
+        
+        $this->assertSame(array(1 => 1, 2 => 2, 3 => 3), $view->get('choices'));
+    }
+
+}


### PR DESCRIPTION
Very simple.

```
    $form = $this->factory->create('range', 'gpa', array(
        'range' => array(1, 5, 0.25),
    ));
```

Accepts a `range` option that's passed through PHP's `range` function to generate `choices` for the underlying `ChoiceType`.

We created this because our forms often have age ranges, year ranges, GPA ranges, etc., so this made it forms via configuration a breeze.

Didn't know if [HTML5 range inputs](http://diveintohtml5.org/forms.html#type-number) were _in_ just yet :)
