### PR TITLE
Fix for `form_rest` not rendering expanded choice's child elements (radio fields)

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -128,7 +128,7 @@ class ChoiceType extends AbstractType
 
     public function getParent(array $options)
     {
-        return $options['expanded'] ? 'form' : 'field';
+        return 'field';
     }
 
     public function getName()


### PR DESCRIPTION
Conditionally using the `form` as the parent when caused the expanded choice's child fields not to be rendered by `form_rest` (looks to be because of the `rendered` boolean).

Having the parent set to `field` in all cases fixed this, and doesn't appear to affect the rendering of the other choice templates.
