### PR TITLE
[Form] Fix for nested forms getting erroneously set as rendered

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -29,7 +29,7 @@ class FormType extends AbstractType
     {
         $multipart = false;
 
-        foreach ($view as $child) {
+        foreach ($view->getChildren() as $child) {
             if ($child->get('multipart')) {
                 $multipart = true;
                 break;

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FormTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FormTypeTest.php
@@ -193,4 +193,13 @@ class FormTypeTest extends TypeTestCase
 
         $this->assertTrue($view->get('multipart'));
     }
+
+    public function testCreateViewDoNoMarkItAsRendered()
+    {
+        $form = $this->factory->create('form');
+        $form->add($this->factory->create('form'));
+        $view = $form->createView();
+
+        $this->assertFalse($view->isRendered());
+    }
 }


### PR DESCRIPTION
This is a fix for [issue #779](https://github.com/symfony/symfony/issues/779) reported by @brikou
I believe this is the proper this for [PR #1012](https://github.com/symfony/symfony/pull/1012) submitted by @ericclemmons

Some details on the fix can be found in eric's PR.
