### PR TITLE
[2.1] PropertyPath - get() & set() support

### DIFF
--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -298,6 +298,9 @@ class PropertyPath implements \IteratorAggregate
                 }
 
                 return $object->$isser();
+            } else if ($reflClass->hasMethod('get')) {
+                // support `get` accessor method
+                return $object->get($property);
             } else if ($reflClass->hasMethod('__get')) {
                 // needed to support magic method __get
                 return $object->$property;
@@ -344,6 +347,9 @@ class PropertyPath implements \IteratorAggregate
                 }
 
                 $objectOrArray->$setter($value);
+            } else if ($reflClass->hasMethod('set')) {
+                // support `set` setter method
+                return $objectOrArray->set($property, $value);
             } else if ($reflClass->hasMethod('__set')) {
                 // needed to support magic method __set
                 $objectOrArray->$property = $value;

--- a/tests/Symfony/Tests/Component/Form/Fixtures/GetterSetter.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/GetterSetter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+class GetterSetter
+{
+    private $foobar;
+
+    public function set($property, $value)
+    {
+        $this->$property = $value;
+    }
+
+    public function get($property)
+    {
+        return isset($this->$property) ? $this->$property : null;
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/PropertyPathTest.php
+++ b/tests/Symfony/Tests/Component/Form/PropertyPathTest.php
@@ -12,10 +12,12 @@
 namespace Symfony\Tests\Component\Form;
 
 require_once __DIR__ . '/Fixtures/Author.php';
+require_once __DIR__ . '/Fixtures/GetterSetter.php';
 require_once __DIR__ . '/Fixtures/Magician.php';
 
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Tests\Component\Form\Fixtures\Author;
+use Symfony\Tests\Component\Form\Fixtures\GetterSetter;
 use Symfony\Tests\Component\Form\Fixtures\Magician;
 
 class PropertyPathTest extends \PHPUnit_Framework_TestCase
@@ -173,6 +175,16 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(false, $path->getValue($object));
     }
 
+    public function testGetValueReadsGetMethod()
+    {
+        $path = new PropertyPath('getterProperty');
+
+        $object = new GetterSetter();
+        $object->set('getterProperty', 'foobar');
+
+        $this->assertSame('foobar', $path->getValue($object));
+    }
+
     public function testGetValueReadsMagicGet()
     {
         $path = new PropertyPath('magicProperty');
@@ -278,6 +290,16 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         $path->setValue($object, 'Bernhard');
 
         $this->assertEquals('Bernhard', $object['firstName']);
+    }
+
+    public function testSetValueUpdateSetMethod()
+    {
+        $object = new GetterSetter();
+
+        $path = new PropertyPath('setterProperty');
+        $path->setValue($object, 'foobar');
+
+        $this->assertEquals('foobar', $object->get('setterProperty'));
     }
 
     public function testSetValueUpdateMagicSet()


### PR DESCRIPTION
There's support for most uses cases (even including magic methods), but was missing `get()` and `set()`.
(Used in `ParameterBag`, `FormBuilder`, etc.)

Figured this could be useful for others out there as well...
