### PR TITLE
[Form] Removed dead code in DateType buildForm method

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\PaddedChoiceList;
 use Symfony\Component\Form\Extension\Core\ChoiceList\MonthChoiceList;
 use Symfony\Component\Form\FormView;
@@ -80,8 +79,6 @@ class DateType extends AbstractType
             $builder->appendNormTransformer(new ReversedTransformer(
                 new DateTimeToArrayTransformer($options['data_timezone'], $options['data_timezone'], array('year', 'month', 'day'))
             ));
-        } else if ($options['input'] !== 'datetime') {
-            throw new FormException('The "input" option must be "datetime", "string", "timestamp" or "array".');
         }
 
         $builder


### PR DESCRIPTION
With the introduction of the getAllowedOptionValues mechanics, the validation of 
the `input` option is performed prior to the buildForm call. Thus, maybe the check in
the `DateType` class is not required anymore. 
- If it should be removed, this PR remove the dead lines and the use statement.
- If the validation in `DateType` should stay, then I think the `FormException` should 
  be changed to a `CreateException` to be consistent with `FormFactory`. 

This was discussed with @vicb in this other [PR](https://github.com/symfony/symfony/pull/694/files#r33706).
