### PR TITLE
[BrowserKit] dealing with raw value for cookies

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -41,7 +41,7 @@ class Cookie
      * @param  string  $domain   The domain that the cookie is available
      * @param  Boolean $secure   Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
      * @param  Boolean $httponly The cookie httponly flag
-     * @param  bool    $passedRawValue $value is raw or urldecoded
+     * @param  Boolean $passedRawValue $value is raw or urldecoded
      *
      * @api
      */
@@ -201,7 +201,7 @@ class Cookie
     }
 
     /**
-     * Gets the value of the cookie.
+     * Gets the raw value of the cookie.
      *
      * @return string The cookie value
      *

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -101,10 +101,11 @@ class CookieJar
      * Returns not yet expired cookie values for the given URI.
      *
      * @param string $uri A URI
+     * @param bool   $returnsRawValue returnes raw value or urldecoded value
      *
      * @return array An array of cookie values
      */
-    public function allValues($uri)
+    public function allValues($uri, $returnsRawValue = false)
     {
         $this->flushExpiredCookies();
 
@@ -124,10 +125,25 @@ class CookieJar
                 continue;
             }
 
-            $cookies[$cookie->getName()] = $cookie->getValue();
+            if ($returnsRawValue) {
+                $cookies[$cookie->getName()] = $cookie->getRawValue();
+            } else {
+                $cookies[$cookie->getName()] = $cookie->getValue();
+            }
         }
 
         return $cookies;
+    }
+
+    /**
+     * Returns not yet expired raw cookie values for the given URI.
+     *
+     * @param string $uri A URI
+     *
+     * @return array An array of cookie values
+     */
+    public function allRawValues($uri) {
+        return $this->allValues($uri, true);
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -100,8 +100,8 @@ class CookieJar
     /**
      * Returns not yet expired cookie values for the given URI.
      *
-     * @param string $uri A URI
-     * @param bool   $returnsRawValue returnes raw value or urldecoded value
+     * @param string  $uri A URI
+     * @param Boolean $returnsRawValue returnes raw value or urldecoded value
      *
      * @return array An array of cookie values
      */

--- a/tests/Symfony/Tests/Component/BrowserKit/CookieJarTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/CookieJarTest.php
@@ -95,4 +95,20 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
             array('http://www.example.com/foo/bar', array('foo_nothing', 'foo_path', 'foo_domain')),
         );
     }
+
+    /**
+     * @dataProvider provideAllValuesValues
+     */
+    public function testAllRawValues($uri, $values)
+    {
+        $cookieJar = new CookieJar();
+        $cookieJar->set($cookie1 = new Cookie('foo_nothing', 'foo'));
+        $cookieJar->set($cookie2 = new Cookie('foo_expired', 'foo', time() - 86400));
+        $cookieJar->set($cookie3 = new Cookie('foo_path', 'foo', null, '/foo'));
+        $cookieJar->set($cookie4 = new Cookie('foo_domain', 'foo', null, '/', 'example.com'));
+        $cookieJar->set($cookie5 = new Cookie('foo_secure', 'foo', null, '/', '', true));
+
+        $this->assertEquals($values, array_keys($cookieJar->allRawValues($uri)), '->allRawValues() returns the cookie for a given URI');
+    }
+
 }

--- a/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
@@ -33,6 +33,8 @@ class CookieTest extends \PHPUnit_Framework_TestCase
             array('foo=bar; secure'),
             array('foo=bar; httponly'),
             array('foo=bar; domain=google.com; path=/foo; secure; httponly'),
+            array('foo=bar=baz'),
+            array('foo=bar%3Dbaz'),
         );
     }
 
@@ -70,6 +72,17 @@ class CookieTest extends \PHPUnit_Framework_TestCase
     {
         $cookie = new Cookie('foo', 'bar');
         $this->assertEquals('bar', $cookie->getValue(), '->getValue() returns the cookie value');
+
+        $cookie = new Cookie('foo', 'bar%3Dbaz', null, '/', '', false, true, true); // raw value
+        $this->assertEquals('bar=baz', $cookie->getValue(), '->getValue() returns the urldecoded cookie value');
+    }
+
+    public function testGetRawValue()
+    {
+        $cookie = new Cookie('foo', 'bar=baz'); // decoded value
+        $this->assertEquals('bar%3Dbaz', $cookie->getRawValue(), '->getRawValue() returns the urlencoded cookie value');
+        $cookie = new Cookie('foo', 'bar%3Dbaz', null, '/', '', false, true, true); // raw value
+        $this->assertEquals('bar%3Dbaz', $cookie->getRawValue(), '->getRawValue() returns the non-urldecoded cookie value');
     }
 
     public function testGetPath()


### PR DESCRIPTION
The cookie class of Symfony2 automatically urldecodes the values in Cookie and Set-Cookie headers. This is same behavior with PHP, so it's no problem in a usual situation.

However, some web servers use non-urlencoded Cookie value. For example, Set-Cookie header of www.google.com is like this:

<pre>
Set-Cookie: PREF=ID=0fb5073ce27cab6c:FF=0:LD=en:CR=2:TM=1306094799:LM=1306094799:S=3D0yA7VNs5AWx1bT; expires=Tue, 21-May-2013 20:06:39 GMT; path=/; domain=.google.com"
</pre>


Not "%3d" but "=" is in value of Cookie. Automatic urldecoding never distinguish url-encoded value or raw value in original header.

So, I added Symfony\Component\BrowserKit\Cookie#getRawValue method. This is useful when we need to deal with cookie value puroduced by non-PHP servers.
