### PR TITLE
[Form] Added support for additional attributes

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -35,8 +35,8 @@ class FieldType extends AbstractType
         } else {
             $options['property_path'] = new PropertyPath($options['property_path']);
         }
-        if (!is_array($options['attributes'])) {
-            throw new FormException('attributes option should be array');
+        if (!is_array($options['attr'])) {
+            throw new FormException('The "attr" option must be "array".');
         }
         
         $builder
@@ -50,7 +50,7 @@ class FieldType extends AbstractType
             ->setAttribute('max_length', $options['max_length'])
             ->setAttribute('pattern', $options['pattern'])
             ->setAttribute('label', $options['label'] ?: $this->humanize($builder->getName()))
-            ->setAttribute('attributes', $options['attributes'] ?: array())
+            ->setAttribute('attr', $options['attr'] ?: array())
             ->setData($options['data'])
             ->addValidator(new DefaultValidator())
         ;
@@ -93,7 +93,7 @@ class FieldType extends AbstractType
             ->set('size', null)
             ->set('label', $form->getAttribute('label'))
             ->set('multipart', false)
-            ->set('attr', $form->getAttribute('attributes'))
+            ->set('attr', $form->getAttribute('attr'))
             ->set('types', $types)
         ;
     }
@@ -113,7 +113,7 @@ class FieldType extends AbstractType
             'error_bubbling'    => false,
             'error_mapping'     => array(),
             'label'             => null,
-            'attributes'        => array(),
+            'attr'              => array(),
         );
 
         $class = isset($options['data_class']) ? $options['data_class'] : null;

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Extension\Core\EventListener\TrimListener;
 use Symfony\Component\Form\Extension\Core\Validator\DefaultValidator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Exception\FormException;
 
 class FieldType extends AbstractType
 {
@@ -34,7 +35,10 @@ class FieldType extends AbstractType
         } else {
             $options['property_path'] = new PropertyPath($options['property_path']);
         }
-
+        if (!is_array($options['attributes'])) {
+            throw new FormException('attributes option should be array');
+        }
+        
         $builder
             ->setRequired($options['required'])
             ->setReadOnly($options['read_only'])
@@ -46,6 +50,7 @@ class FieldType extends AbstractType
             ->setAttribute('max_length', $options['max_length'])
             ->setAttribute('pattern', $options['pattern'])
             ->setAttribute('label', $options['label'] ?: $this->humanize($builder->getName()))
+            ->setAttribute('attributes', $options['attributes'] ?: array())
             ->setData($options['data'])
             ->addValidator(new DefaultValidator())
         ;
@@ -88,7 +93,7 @@ class FieldType extends AbstractType
             ->set('size', null)
             ->set('label', $form->getAttribute('label'))
             ->set('multipart', false)
-            ->set('attr', array())
+            ->set('attr', $form->getAttribute('attributes'))
             ->set('types', $types)
         ;
     }
@@ -108,6 +113,7 @@ class FieldType extends AbstractType
             'error_bubbling'    => false,
             'error_mapping'     => array(),
             'label'             => null,
+            'attributes'        => array(),
         );
 
         $class = isset($options['data_class']) ? $options['data_class'] : null;

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
@@ -198,9 +198,9 @@ class FieldTypeTest extends TypeTestCase
     
     public function testGetAttributesIsEmpty()
     {
-        $form = $this->factory->create('field', null, array('attributes' => array()));
+        $form = $this->factory->create('field', null, array('attr' => array()));
 
-        $this->assertEquals(0, count($form->getAttribute('attributes')));
+        $this->assertEquals(0, count($form->getAttribute('attr')));
     }
 
     /**
@@ -208,7 +208,7 @@ class FieldTypeTest extends TypeTestCase
      */
     public function testAttributesException()
     {
-        $form = $this->factory->create('field', null, array('attributes' => ''));
+        $form = $this->factory->create('field', null, array('attr' => ''));
     }
 
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
@@ -195,4 +195,20 @@ class FieldTypeTest extends TypeTestCase
         $this->assertSame($author, $form->getData());
         $this->assertEquals('Bernhard', $author->firstName);
     }
+    
+    public function testGetAttributesIsEmpty()
+    {
+        $form = $this->factory->create('field', null, array('attributes' => array()));
+
+        $this->assertEquals(0, count($form->getAttribute('attributes')));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\FormException
+     */
+    public function testAttributesException()
+    {
+        $form = $this->factory->create('field', null, array('attributes' => ''));
+    }
+
 }


### PR DESCRIPTION
Added support for additional attributes in Form types that list field as their parent.

This is needed particularity for html5 data and data- attributes support, unfortunately $options['data'] is already taken, so adding a general $options['attributes'] is the easiest solution without breaking BC.

Now I know that this will be tempting for some to stuck style and class attributes here also, but I'd rather not restrict the keys that are passed in.
