### PR TITLE
Fixed bug where FormFactory assumed invalid option existed at key 0

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -252,7 +252,7 @@ class FormFactory implements FormFactoryInterface
         }
 
         if (count($diff) > 0) {
-            throw new CreationException(sprintf('The option "%s" does not exist', $diff[0]));
+            throw new CreationException(sprintf('The option "%s" does not exist', array_shift($diff)));
         }
 
         foreach ($optionValues as $option => $allowedValues) {


### PR DESCRIPTION
When working with the ChoiceType, sometimes using a mix of valid & invalid options resulted in:

> Notice: Undefined offset: 0 in /home/eric/Sites/EDUDirect/vendor/symfony/src/Symfony/Component/Form/FormFactory.php line 255

Rather than assume an individual invalid option exists at key 0, I opted for `array_shift`, which fixes the issue.
