### PR TITLE
[Assetic] Added call to setOptimize in config for assetic filter jpegtran

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/jpegtran.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/jpegtran.xml
@@ -7,12 +7,16 @@
     <parameters>
         <parameter key="assetic.filter.jpegtran.class">Assetic\Filter\JpegtranFilter</parameter>
         <parameter key="assetic.filter.jpegtran.bin">/usr/bin/jpegtran</parameter>
+        <parameter key="assetic.filter.jpegtran.optimize">false</parameter>
     </parameters>
 
     <services>
         <service id="assetic.filter.jpegtran" class="%assetic.filter.jpegtran.class%">
             <tag name="assetic.filter" alias="jpegtran" />
             <argument>%assetic.filter.jpegtran.bin%</argument>
+            <call method="setOptimize">
+                <argument>%assetic.filter.jpegtran.optimize%</argument>
+            </call>
         </service>
     </services>
 </container>


### PR DESCRIPTION
Could not see anyway that the setOptimize method would be called for Assetic\FilterJpegtranFilter as a result of settings in an app's config.yml file. Without calling this method the image is not optimised. Adding the method call to the config file allows this.
