### PR TITLE
Fix problem with searching files while the open_basedir is in use

### DIFF
--- a/src/Symfony/Component/Process/ExecutableFinder.php
+++ b/src/Symfony/Component/Process/ExecutableFinder.php
@@ -41,7 +41,7 @@ class ExecutableFinder
      */
     public function find($name, $default = null)
     {
-        $dirs = explode(PATH_SEPARATOR, getenv('PATH') ? getenv('PATH') : getenv('Path'));
+        $dirs = explode(PATH_SEPARATOR, ini_get('open_basedir') ? ini_get('open_basedir') : (getenv('PATH') ? getenv('PATH') : getenv('Path')));
         $suffixes = DIRECTORY_SEPARATOR == '\\' ? (getenv('PATHEXT') ? explode(PATH_SEPARATOR, getenv('PATHEXT')) : $this->suffixes) : array('');
         foreach ($suffixes as $suffix) {
             foreach ($dirs as $dir) {


### PR DESCRIPTION
I've tried to run the Symfony 2 Beta 1 package on my CPanel hosted server but since I've had configured open_basedir there for security reasons, I couldn't even start using the demo from SF2.

The error was:

ErrorException: Warning: is_file() [function.is-file]: open_basedir restriction in effect. File(/bin/java) is not within the allowed path(s): (/home/***_:/usr/lib/php:/usr/local/lib/php:/tmp) in ***_***/vendor/symfony/src/Symfony/Component/Process/ExecutableFinder.php line 48

This fixes the problem on my server and as far as I've seen it doesn't affect any other operations.
