### PR TITLE
Edited tests/Symfony/Tests/Component/BrowserKit/CookieJarTest.php via Git

### DIFF
--- a/tests/Symfony/Tests/Component/BrowserKit/CookieJarTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/CookieJarTest.php
@@ -95,4 +95,40 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
             array('http://www.example.com/foo/bar', array('foo_nothing', 'foo_path', 'foo_domain')),
         );
     }
+
+    public function testDomain()
+    {
+        $uri = "http://example.com/";
+        $domain = 'example.com';
+        $parts = parse_url($uri);
+
+        $cookieJar = new CookieJar();
+        $cookieJar->set($cookie = new Cookie('foo', 'bar', null, '/', $domain));
+
+        $this->assertNotEmpty($cookieJar->allValues($uri), '->allValues() returns the cookie for a given URI and domain');
+    }
+
+    public function testSubDomain()
+    {
+        $uri = "http://example.com/";
+        $domain = '.example.com';
+        $parts = parse_url($uri);
+
+        $cookieJar = new CookieJar();
+        $cookieJar->set($cookie = new Cookie('foo', 'bar', null, '/', $domain));
+
+        $this->assertNotEmpty($cookieJar->allValues($uri), '->allValues() returns the cookie for a given URI and subdomain');
+    }
+
+    public function testEmptyPath()
+    {
+        $uri = "http://example.com";
+        $domain = 'example.com';
+        $parts = parse_url($uri);
+        
+        $cookieJar = new CookieJar();
+        $cookieJar->set($cookie = new Cookie('foo', 'bar', null, '/', $domain));
+
+        $this->assertNotEmpty($cookieJar->allValues($uri), '->allValues() returns the cookie for a given URI with empty path');
+    }
 }


### PR DESCRIPTION
Tests for the patch of https://github.com/symfony/BrowserKit/pull/1 (During a successful signing in the session is not saved and the new one is generated)
