### PR TITLE
[DependencyInjection] ContainerBuilder private services FIX

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -742,8 +742,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             foreach ($value as &$v) {
                 $v = $this->resolveServices($v);
             }
-        } else if (is_object($value) && $value instanceof Reference) {
+        } elseif (is_object($value) && $value instanceof Reference) {
             $value = $this->get((string) $value, $value->getInvalidBehavior());
+        } elseif (is_object($value) && $value instanceof Definition) {
+            $value = $this->createService($value, null);
         }
 
         return $value;

--- a/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
@@ -470,6 +470,23 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $container->compile();
     }
 
+    public function testPrivateServiceUser()
+    {
+        $fooDefinition     = new Definition('BarClass');
+        $fooUserDefinition = new Definition('BarUserClass', array(new Reference('bar')));
+        $container         = new ContainerBuilder();
+
+        $fooDefinition->setPublic(false);
+
+        $container->addDefinitions(array(
+            'bar'       => $fooDefinition,
+            'bar_user'  => $fooUserDefinition
+        ));
+
+        $container->compile();
+        $this->assertInstanceOf('BarClass', $container->get('bar_user')->bar);
+    }
+
     /**
      * @expectedException BadMethodCallException
      */

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/classes.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/classes.php
@@ -30,3 +30,13 @@ class BazClass
     {
     }
 }
+
+class BarUserClass
+{
+    public $bar;
+
+    public function __construct(BarClass $bar)
+    {
+        $this->bar = $bar;
+    }
+}


### PR DESCRIPTION
Private service references gets replaced with service definitions on `ContainerBuilder::compile()`, but before this PR, `ContainerBuilder` never really constructs them on service resolving, so instead of real objects, services get `Definition` objects during creation process:

``` php
<?php
class BarClass {}
class BarUserClass
{
    public $bar;
    public function __construct(BarClass $bar)
    {
        $this->bar = $bar;
    }
}

$fooDefinition     = new Definition('BarClass');
$fooUserDefinition = new Definition('BarUserClass', array(new Reference('bar')));
$container         = new ContainerBuilder();

$fooDefinition->setPublic(false);

$container->addDefinitions(array(
    'bar'       => $fooDefinition,
    'bar_user'  => $fooUserDefinition
));

$container->compile();
$container->get('bar_user');
// will throw Exception, cuz it wants FooClass as first argument,
// but will get Definition object instead
```

PR fixes this bug.
