### PR TITLE
Doctrine Proxy and Validation framework

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
@@ -42,7 +42,7 @@ class GetterMetadata extends MemberMetadata
      */
     public function getValue($object)
     {
-        return $this->getReflectionMember()->invoke($object);
+        return $object->{$this->getName()}();
     }
 
     /**


### PR DESCRIPTION
 Doctrine uses a Proxy class to load related object. So if we have a Model and the related ModelProxy. The validation is set on Model. The ReflectionMethod::invoke will use the method set in Model and not in ModelProxy. So the lazy loading will not work, so the related object will not be loaded, and the related validation will fail!
