### PR TITLE
Throw a RuntimeException when trying to directly retrieve a service which is not ready yet.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -668,7 +668,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             $service = call_user_func_array(array($factory, $definition->getFactoryMethod()), $arguments);
         } else {
             if (null === ($value = $this->getParameterBag()->resolveValue($definition->getClass()))) {
-                throw new RuntimeException('Unable to retrieve a value for the class definition. Maybe you tried direct access using $container->get(...) instead of using the Definition / Reference classes?', $definition->getClass());
+                throw new RuntimeException('Unable to retrieve a value for the class definition. Maybe you tried direct access using $container->get(...) instead of using the Definition / Reference classes?');
             }
 
             $r = new \ReflectionClass($value);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\ResourceInterface;
 
@@ -648,6 +649,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      */
     private function createService(Definition $definition, $id)
     {
+
         if (null !== $definition->getFile()) {
             require_once $this->getParameterBag()->resolveValue($definition->getFile());
         }
@@ -665,7 +667,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
             $service = call_user_func_array(array($factory, $definition->getFactoryMethod()), $arguments);
         } else {
-            $r = new \ReflectionClass($this->getParameterBag()->resolveValue($definition->getClass()));
+            if (null === ($value = $this->getParameterBag()->resolveValue($definition->getClass()))) {
+                throw new RuntimeException('Unable to retrieve a value for the class %s. Maybe you tried direct access using $container->get(...) instead of using the Definition / Reference classes?');
+            }
+
+            $r = new \ReflectionClass($value);
 
             $service = null === $r->getConstructor() ? $r->newInstance() : $r->newInstanceArgs($arguments);
         }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -668,7 +668,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             $service = call_user_func_array(array($factory, $definition->getFactoryMethod()), $arguments);
         } else {
             if (null === ($value = $this->getParameterBag()->resolveValue($definition->getClass()))) {
-                throw new RuntimeException('Unable to retrieve a value for the class %s. Maybe you tried direct access using $container->get(...) instead of using the Definition / Reference classes?');
+                throw new RuntimeException('Unable to retrieve a value for the class definition. Maybe you tried direct access using $container->get(...) instead of using the Definition / Reference classes?', $definition->getClass());
             }
 
             $r = new \ReflectionClass($value);

--- a/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
@@ -489,6 +489,22 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $container->compile();
         $container->setDefinition('a', new Definition());
     }
+
+    /**
+     * @expectedException Symfony\Component\DependencyInjection\Exception\RuntimeException
+     */
+    public function testThrowsExceptionWhenGetUnavailableService()
+    {
+        $definition = $this->getMock('Symfony\\Component\\DependencyInjection\\Definition');
+        $definition->expects($this->any())->method('getFactoryMethod')->will($this->returnValue(null));
+
+        $bag = $this->getMock('Symfony\\Component\\DependencyInjection\\ParameterBag\\ParameterBag');
+        $bag->expects($this->any())->method('resolveValue')->will($this->returnValue(null));
+
+        $container = new ContainerBuilder($bag);
+        $container->setDefinition('a', $definition);
+        $container->get('a');
+    }
 }
 
 


### PR DESCRIPTION
I ran into a weird issue a few days ago (http://groups.google.com/group/symfony-devs/browse_thread/thread/f558924f9c364aab), basically I was misusing the DIC by trying to retrieve an instance of one of my services directly from a CompilerPass class, which is wrong. Basically, the result was PHP trying to create a ReflectionClass instance of "null" which resulted in a ReflectionException : "class  does not exist".

As it's not really explicit, I changed the ContainerBuilder to make it throw a "Symfony\Component\DependencyInjection\Exception\RuntimeException" with a more precise message. Of course, I'll update it if you think there is a more relevant exception than the one I chose, and I can change the message if you think it's too long or not clear enough. 
