### PR TITLE
Add {} around @inheritDoc annotation to fix this class in SF beta2

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -91,7 +91,7 @@ class UploadedFile extends File
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getMimeType()
     {
@@ -99,7 +99,7 @@ class UploadedFile extends File
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getSize()
     {
@@ -107,7 +107,7 @@ class UploadedFile extends File
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function getExtension()
     {
@@ -160,7 +160,7 @@ class UploadedFile extends File
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function move($directory, $name = null)
     {


### PR DESCRIPTION
The annotation update broke this class due to the {} missing around @inheritDoc. This PR adds them.
