### PR TITLE
Add {} around @inheritDoc.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -63,7 +63,7 @@ class Ip extends \Symfony\Component\Validator\Constraint
     public $message = 'This is not a valid IP address';
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function __construct($options = null)
     {


### PR DESCRIPTION
Add missing {} around @inheritDoc to fix this class in SF beta2.
