### PR TITLE
Add missing {} around @inheritDoc to fix this class in SF beta2.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -28,7 +28,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function guessType($class, $property)
     {
@@ -40,7 +40,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function guessRequired($class, $property)
     {
@@ -52,7 +52,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function guessMaxLength($class, $property)
     {
@@ -64,7 +64,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
      */
     public function guessMinLength($class, $property)
     {


### PR DESCRIPTION
Add missing {} around @inheritDoc to fix this class in SF beta2.
