### PR TITLE
Global mapping file is seen as class name

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Mapping/Driver/XmlDriver.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Mapping/Driver/XmlDriver.php
@@ -50,7 +50,15 @@ class XmlDriver extends BaseXmlDriver
                 );
 
                 foreach ($iterator as $file) {
-                    if (($fileName = $file->getBasename($this->_fileExtension)) == $file->getBasename()) {
+
+                    $fileName = $file->getBasename($this->_fileExtension);
+
+                    if ($fileName == $file->getBasename()) {
+                        continue;
+                    }
+
+                    // check if file is not global file
+                    if ($fileName == $this->_globalFile) {
                         continue;
                     }
 

--- a/src/Symfony/Bundle/DoctrineBundle/Mapping/Driver/YamlDriver.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Mapping/Driver/YamlDriver.php
@@ -50,7 +50,15 @@ class YamlDriver extends BaseYamlDriver
                 );
 
                 foreach ($iterator as $file) {
-                    if (($fileName = $file->getBasename($this->_fileExtension)) == $file->getBasename()) {
+
+                    $fileName = $file->getBasename($this->_fileExtension);
+
+                    if ($fileName == $file->getBasename()) {
+                        continue;
+                    }
+
+                    // check if file is not global file
+                    if ($fileName == $this->_globalFile) {
                         continue;
                     }
 


### PR DESCRIPTION
When updating my entities, using the doctrine:generate:entities command, I got an error saying `[namespace]\mapping is not a valid entity or mapped super class`. My global mapping file (`mapping.orm.yml`) is recognized as an entity mapping. I've altered the `getAllClassNames` method to check if the mappings' file name is not the global file name. 
