### PR TITLE
fix invalid schema in monolog bundle

### DIFF
--- a/src/Symfony/Bundle/MonologBundle/Resources/config/schema/monolog-1.0.xsd
+++ b/src/Symfony/Bundle/MonologBundle/Resources/config/schema/monolog-1.0.xsd
@@ -15,12 +15,10 @@
     </xsd:complexType>
 
     <xsd:complexType name="handler">
-        <xsd:choice minOccurs="0" maxOccurs="unbounded">
-            <xsd:element name="processor" type="xsd:string" />
-        </xsd:choice>
-        <xsd:choice minOccurs="0" maxOccurs="unbounded">
-            <xsd:element name="member" type="xsd:string" />
-        </xsd:choice>
+        <xsd:sequence>
+            <xsd:element name="processor" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="member" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
         <xsd:attribute name="type" type="xsd:string" use="required" />
         <xsd:attribute name="priority" type="xsd:integer" />
         <xsd:attribute name="level" type="level" />


### PR DESCRIPTION
The current schema monolog-1.0.xsd in the MonologBundle leads to a validation error when parsing the configuration:

[Tue May 24 14:26:12 2011] [error] [client 192.168.163.1] PHP Fatal error:  Uncaught exception 'InvalidArgumentException' with message '[ERROR 3033] Element '{http://www.w3.org/2001/XMLSchema}complexType': The content is not valid. Expected is (annotation?, (simpleContent | complexContent | ((group | all | choice | sequence)?, ((attribute | attributeGroup)*, anyAttribute?)))). (in file:////var/www/app/ocm.local/symfony2/vendor/symfony/src/Symfony/Bundle/MonologBundle/DependencyInjection/../Resources/config/schema//monolog-1.0.xsd - line 21, column 0)' in /var/www/app/ocm.local/symfony2/vendor/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php:362\nStack trace:\n#0 /var/www/app/ocm.local/symfony2/vendor/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php(288): Symfony\Component\DependencyInjection\Loader\XmlFileLoader->validateSchema(Object(DOMDocument), '/var/www/app/oc...')\n#1 /var/www/app/ocm.local/symfony2/vendor/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php(218): Symfony\Component\DependencyInjection\Loader in /var/www/app/ocm.local/symfony2/vendor/symfony/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php on line 362

This patch fixes the problem by using a sequence instead of two choices (which is not allowed in XML schema files).
