### PR TITLE
[SecurityBundle] Using a DelegatingLoader so that security factories can 

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -15,6 +15,10 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
@@ -566,7 +570,15 @@ class SecurityExtension extends Extension
         // load service templates
         $c = new ContainerBuilder();
         $parameterBag = $container->getParameterBag();
-        $loader = new XmlFileLoader($c, new FileLocator(__DIR__.'/../Resources/config'));
+
+        $locator = new FileLocator(__DIR__.'/../Resources/config');
+        $resolver = new LoaderResolver(array(
+            new XmlFileLoader($c, $locator),
+            new YamlFileLoader($c, $locator),
+            new PhpFileLoader($c, $locator),
+        ));
+        $loader = new DelegatingLoader($resolver);
+
         $loader->load('security_factories.xml');
 
         // load user-created listener factories


### PR DESCRIPTION
Hey guys-

I don't like hard-coding in these loaders, but this follows how the Kernel works so that, at the very least, the standard formats are supported for loading security factory resources.

Of course, because the Container doesn't have access to the kernel, the paths to the resources still must be fully-qualified file paths. That part doesn't seem as easy to rectify, but this is a quite advanced feature anyways.

Thanks!
