### PR TITLE
Log levels

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -76,15 +76,15 @@ class ControllerNameParser
 
     private function handleControllerNotFoundException($bundle, $controller, array $logs)
     {
-        if (null !== $this->logger) {
-            foreach ($logs as $log) {
-                $this->logger->info($log);
-            }
-        }
-
         // just one log, return it as the exception
         if (1 == count($logs)) {
             throw new \InvalidArgumentException($logs[0]);
+        }
+        
+        if (null !== $this->logger) {
+            foreach ($logs as $log) {
+                $this->logger->error($log);
+            }
         }
 
         // many logs, use a message that mentions each searched bundle

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -76,15 +76,15 @@ class ControllerNameParser
 
     private function handleControllerNotFoundException($bundle, $controller, array $logs)
     {
+        if (null !== $this->logger) {
+            foreach ($logs as $log) {
+                $this->logger->info($log);
+            }
+        }
+
         // just one log, return it as the exception
         if (1 == count($logs)) {
             throw new \InvalidArgumentException($logs[0]);
-        }
-        
-        if (null !== $this->logger) {
-            foreach ($logs as $log) {
-                $this->logger->error($log);
-            }
         }
 
         // many logs, use a message that mentions each searched bundle

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -76,12 +76,6 @@ class ControllerNameParser
 
     private function handleControllerNotFoundException($bundle, $controller, array $logs)
     {
-        if (null !== $this->logger) {
-            foreach ($logs as $log) {
-                $this->logger->info($log);
-            }
-        }
-
         // just one log, return it as the exception
         if (1 == count($logs)) {
             throw new \InvalidArgumentException($logs[0]);

--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -103,7 +103,7 @@ class RequestListener
             $parameters = $this->router->match($request->getPathInfo());
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
+                $this->logger->debug(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
             }
 
             $request->attributes->add($parameters);

--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -109,15 +109,11 @@ class RequestListener
             $request->attributes->add($parameters);
         } catch (ResourceNotFoundException $e) {
             $message = sprintf('No route found for "%s %s"', $request->getMethod(), $request->getPathInfo());
-            if (null !== $this->logger) {
-                $this->logger->err($message);
-            }
+
             throw new NotFoundHttpException($message, $e);
         } catch (MethodNotAllowedException $e) {
             $message = sprintf('No route found for "%s %s": Method Not Allowed (Allow: %s)', $request->getMethod(), $request->getPathInfo(), strtoupper(implode(', ', $e->getAllowedMethods())));
-            if (null !== $this->logger) {
-                $this->logger->err($message);
-            }
+
             throw new MethodNotAllowedHttpException($e->getAllowedMethods(), $message, $e);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
@@ -41,7 +41,7 @@ class Debugger implements DebuggerInterface
     public function log($message)
     {
         if (null !== $this->logger) {
-            $this->logger->info($message);
+            $this->logger->debug($message);
         }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -71,7 +71,7 @@ class ControllerResolver implements ControllerResolverInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Using controller "%s::%s"', get_class($controller), $method));
+            $this->logger->debug(sprintf('Using controller "%s::%s"', get_class($controller), $method));
         }
 
         return array($controller, $method);

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -80,7 +80,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
             return $authenticatedToken;
         } catch (UsernameNotFoundException $notFound) {
             if ($this->hideUserNotFoundExceptions) {
-                throw new BadCredentialsException('Bad credentials', 0, $notFound);
+                throw new BadCredentialsException(sprintf('Bad credentials for user "%s"', $username), 0, $notFound);
             }
 
             throw $notFound;

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -169,7 +169,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     private function onFailure(GetResponseEvent $event, Request $request, AuthenticationException $failed)
     {
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Authentication request failed: %s', $failed->getMessage()));
+            $this->logger->info(sprintf('Authentication request failed: %s', $failed->getMessage()));
         }
 
         $this->securityContext->setToken(null);
@@ -205,7 +205,10 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
     private function onSuccess(GetResponseEvent $event, Request $request, TokenInterface $token)
     {
         if (null !== $this->logger) {
-            $this->logger->debug('User has been authenticated successfully');
+            $this->logger->info(sprintf(
+                'User "%s" has been authenticated successfully',
+                $token->getUsername()
+            ));
         }
 
         $this->securityContext->setToken($token);

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -76,7 +76,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             $token = $this->authenticationManager->authenticate(new PreAuthenticatedToken($user, $credentials, $this->providerKey));
 
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Authentication success: %s', $token));
+                $this->logger->info(sprintf('Authentication success: %s', $token));
             }
             $this->securityContext->setToken($token);
 
@@ -88,7 +88,7 @@ abstract class AbstractPreAuthenticatedListener implements ListenerInterface
             $this->securityContext->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf("Cleared security context due to exception: %s", $failed->getMessage()));
+                $this->logger->info(sprintf("Cleared security context due to exception: %s", $failed->getMessage()));
             }
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -68,7 +68,7 @@ class BasicAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Basic Authentication Authorization header found for user "%s"', $username));
+            $this->logger->info(sprintf('Basic Authentication Authorization header found for user "%s"', $username));
         }
 
         try {
@@ -78,7 +78,7 @@ class BasicAuthenticationListener implements ListenerInterface
             $this->securityContext->setToken(null);
 
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Authentication request failed: %s', $failed->getMessage()));
+                $this->logger->info(sprintf('Authentication request failed for user "%s": %s', $username, $failed->getMessage()));
             }
 
             if ($this->ignoreFailure) {

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -138,7 +138,7 @@ class ContextListener implements ListenerInterface
                 // let's try the next user provider
             } catch (UsernameNotFoundException $notFound) {
                 if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Username "%s" could not be found.', $user->getUsername()));
+                    $this->logger->warn(sprintf('Username "%s" could not be found.', $user->getUsername()));
                 }
 
                 return null;

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -115,7 +115,7 @@ class DigestAuthenticationListener implements ListenerInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Authentication success for user "%s" with response "%s"', $digestAuth->getUsername(), $digestAuth->getResponse()));
+            $this->logger->info(sprintf('Authentication success for user "%s" with response "%s"', $digestAuth->getUsername(), $digestAuth->getResponse()));
         }
 
         $this->securityContext->setToken(new UsernamePasswordToken($user, $user->getPassword(), $this->providerKey));
@@ -126,7 +126,7 @@ class DigestAuthenticationListener implements ListenerInterface
         $this->securityContext->setToken(null);
 
         if (null !== $this->logger) {
-            $this->logger->debug($authException);
+            $this->logger->info($authException);
         }
 
         $event->setResponse($this->authenticationEntryPoint->start($request, $authException));

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -88,7 +88,7 @@ class ExceptionListener
             $token = $this->context->getToken();
             if (!$this->authenticationTrustResolver->isFullFledged($token)) {
                 if (null !== $this->logger) {
-                    $this->logger->info('Access denied (user is not fully authenticated); redirecting to authentication entry point');
+                    $this->logger->debug('Access denied (user is not fully authenticated); redirecting to authentication entry point');
                 }
 
                 try {
@@ -100,7 +100,7 @@ class ExceptionListener
                 }
             } else {
                 if (null !== $this->logger) {
-                    $this->logger->info('Access is denied (and user is neither anonymous, nor remember-me)');
+                    $this->logger->debug('Access is denied (and user is neither anonymous, nor remember-me)');
                 }
 
                 try {

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -88,7 +88,7 @@ class RememberMeListener implements ListenerInterface
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {
-                $this->logger->debug(
+                $this->logger->warn(
                     'SecurityContext not populated with remember-me token as the'
                    .' AuthenticationManager rejected the AuthenticationToken returned'
                    .' by the RememberMeServices: '.$failed->getMessage()

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -88,7 +88,7 @@ class SwitchUserListener implements ListenerInterface
                 $this->securityContext->setToken($this->attemptSwitchUser($request));
             } catch (AuthenticationException $e) {
                 if (null !== $this->logger) {
-                    $this->logger->debug(sprintf('Switch User failed: "%s"', $e->getMessage()));
+                    $this->logger->warn(sprintf('Switch User failed: "%s"', $e->getMessage()));
                 }
             }
         }
@@ -120,7 +120,7 @@ class SwitchUserListener implements ListenerInterface
         $username = $request->get($this->usernameParameter);
 
         if (null !== $this->logger) {
-            $this->logger->debug(sprintf('Attempt to switch to user "%s"', $username));
+            $this->logger->info(sprintf('Attempt to switch to user "%s"', $username));
         }
 
         $user = $this->provider->loadUserByUsername($username);

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -56,7 +56,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     {
         if ($this->options['post_only'] && 'post' !== strtolower($request->getMethod())) {
             if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Authentication method not supported: %s.', $request->getMethod()));
+                $this->logger->err(sprintf('Authentication method not supported: %s.', $request->getMethod()));
             }
 
             return null;

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -122,15 +122,15 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             throw $theft;
         } catch (UsernameNotFoundException $notFound) {
             if (null !== $this->logger) {
-                $this->logger->debug('User for remember-me cookie not found.');
+                $this->logger->info('User for remember-me cookie not found.');
             }
         } catch (UnsupportedUserException $unSupported) {
             if (null !== $this->logger) {
-                $this->logger->debug('User class for remember-me cookie not supported.');
+                $this->logger->err('User class for remember-me cookie not supported.');
             }
         } catch (AuthenticationException $invalid) {
             if (null !== $this->logger) {
-                $this->logger->debug('Remember-Me authentication failed: '.$invalid->getMessage());
+                $this->logger->err('Remember-Me authentication failed: '.$invalid->getMessage());
             }
         }
 


### PR DESCRIPTION
Just wanted to ask if the log level INFO is still correct for these messages?

As there are only four log levels left (DEBUG, INFO, WARNING, ERROR), DEBUG might be the more appropriate level for these messages now.

Let me give an example: An application is logging user actions (maybe to database) in order to assure comprehensibility, e. g. "User %s deleted post %d", "User %s written a message to user %s". These are not warnings of course, so the only suitable log level is INFO.
But they will be thrown together with these very common (at least two per request?) "Using controller..." and "Matched route..." messages when choosing INFO as log level.
