### PR TITLE
[Tests] Skip test if Doctrine Common is not available.

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Tests/Mapping/Driver/AbstractDriverTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/Mapping/Driver/AbstractDriverTest.php
@@ -55,6 +55,10 @@ abstract class AbstractDriverTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        if (!class_exists('Doctrine\\Common\\Version')) {
+            $this->markTestSkipped('Doctrine is not available.');
+        }
+
         $this->dir = sys_get_temp_dir().'/abstract_driver_test';
         @mkdir($this->dir, 0777, true);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -170,6 +170,10 @@ abstract class FrameworkExtensionTest extends TestCase
 
     public function testAnnotations()
     {
+        if (!class_exists('Doctrine\\Common\\Version')) {
+            $this->markTestSkipped('Doctrine is not available.');
+        }
+
         $container = $this->createContainerFromFile('full');
 
         $this->assertEquals($container->getParameter('kernel.cache_dir').'/annotations', $container->getDefinition('annotations.file_cache_reader')->getArgument(1));


### PR DESCRIPTION
Prevent fatal errors when vendors are not configured.
