### PR TITLE
[FrameworkBundle] added configuration for autoloading annotation classes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -276,6 +276,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('cache')->defaultValue('file')->end()
                         ->scalarNode('file_cache_dir')->defaultValue('%kernel.cache_dir%/annotations')->end()
                         ->booleanNode('debug')->defaultValue($this->debug)->end()
+                        ->booleanNode('autoload')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -257,7 +257,7 @@ class Configuration implements ConfigurationInterface
                     ->treatNullLike(array('enabled' => true))
                     ->treatTrueLike(array('enabled' => true))
                     ->children()
-                    ->booleanNode('enabled')->defaultTrue()->end()
+                        ->booleanNode('enabled')->defaultTrue()->end()
                         ->scalarNode('cache')->end()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
                     ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -536,6 +536,13 @@ class FrameworkExtension extends Extension
             ;
             $container->setAlias('annotation_reader', 'annotations.cached_reader');
         }
+
+        if (isset($config['autoload'])) {
+            $container
+                ->getDefinition('annotations.reader')
+                ->addMethodCall('setAutoloadAnnotations', array($config['autoload']))
+            ;
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -131,5 +131,6 @@
         <xsd:attribute name="cache" type="xsd:string" />
         <xsd:attribute name="debug" type="xsd:string" />
         <xsd:attribute name="file-cache-dir" type="xsd:string" />
+        <xsd:attribute name="autoload" type="xsd:string" />
     </xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
I left the default unset in Configuration because the default is different in the 3.0.x and 2.1-DEV branches of Common.
