### PR TITLE
[Validator] Refactor validators constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -199,5 +199,8 @@ abstract class Constraint
      *
      * @return string|array  One or more constant values
      */
-    abstract public function getTargets();
+    public function getTargets()
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
 }

--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -24,12 +24,4 @@ class All extends \Symfony\Component\Validator\Constraint
     {
         return array('constraints');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Blank.php
+++ b/src/Symfony/Component/Validator/Constraints/Blank.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class Blank extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value should be blank';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Choice.php
+++ b/src/Symfony/Component/Validator/Constraints/Choice.php
@@ -30,12 +30,4 @@ class Choice extends \Symfony\Component\Validator\Constraint
     {
         return 'choices';
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -37,12 +37,4 @@ class Collection extends \Symfony\Component\Validator\Constraint
     {
         return array('fields');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Country.php
+++ b/src/Symfony/Component/Validator/Constraints/Country.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class Country extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value is not a valid country';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class Date extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value is not a valid date';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -15,12 +15,4 @@ class Email extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value is not a valid email address';
     public $checkMX = false;
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/False.php
+++ b/src/Symfony/Component/Validator/Constraints/False.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class False extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value should be false';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -19,12 +19,4 @@ class File extends \Symfony\Component\Validator\Constraint
     public $notReadableMessage = 'The file is not readable';
     public $maxSizeMessage = 'The file is too large ({{ size }}). Allowed maximum size is {{ limit }}';
     public $mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Ip.php
+++ b/src/Symfony/Component/Validator/Constraints/Ip.php
@@ -73,12 +73,4 @@ class Ip extends \Symfony\Component\Validator\Constraint
             throw new ConstraintDefinitionException(sprintf('The option "version" must be one of "%s"', implode('", "', self::$versions)));
         }
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Language.php
+++ b/src/Symfony/Component/Validator/Constraints/Language.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class Language extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value is not a valid language';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Locale.php
+++ b/src/Symfony/Component/Validator/Constraints/Locale.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class Locale extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value is not a valid locale';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Max.php
+++ b/src/Symfony/Component/Validator/Constraints/Max.php
@@ -31,12 +31,4 @@ class Max extends \Symfony\Component\Validator\Constraint
     {
         return array('limit');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/MaxLength.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLength.php
@@ -32,12 +32,4 @@ class MaxLength extends \Symfony\Component\Validator\Constraint
     {
         return array('limit');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Min.php
+++ b/src/Symfony/Component/Validator/Constraints/Min.php
@@ -31,12 +31,4 @@ class Min extends \Symfony\Component\Validator\Constraint
     {
         return array('limit');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/MinLength.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLength.php
@@ -32,12 +32,4 @@ class MinLength extends \Symfony\Component\Validator\Constraint
     {
         return array('limit');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlank.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlank.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class NotBlank extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value should not be blank';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotNull.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNull.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class NotNull extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value should not be null';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Null.php
+++ b/src/Symfony/Component/Validator/Constraints/Null.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class Null extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value should be null';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -32,12 +32,4 @@ class Regex extends \Symfony\Component\Validator\Constraint
     {
         return array('pattern');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Time.php
+++ b/src/Symfony/Component/Validator/Constraints/Time.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class Time extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value is not a valid time';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/True.php
+++ b/src/Symfony/Component/Validator/Constraints/True.php
@@ -14,12 +14,4 @@ namespace Symfony\Component\Validator\Constraints;
 class True extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value should be true';
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Type.php
+++ b/src/Symfony/Component/Validator/Constraints/Type.php
@@ -31,12 +31,4 @@ class Type extends \Symfony\Component\Validator\Constraint
     {
         return array('type');
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Url.php
+++ b/src/Symfony/Component/Validator/Constraints/Url.php
@@ -15,12 +15,4 @@ class Url extends \Symfony\Component\Validator\Constraint
 {
     public $message = 'This value is not a valid URL';
     public $protocols = array('http', 'https');
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/src/Symfony/Component/Validator/Constraints/Valid.php
+++ b/src/Symfony/Component/Validator/Constraints/Valid.php
@@ -11,17 +11,7 @@
 
 namespace Symfony\Component\Validator\Constraints;
 
-use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
-
 class Valid extends \Symfony\Component\Validator\Constraint
 {
     public $traverse = true;
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 }

--- a/tests/Symfony/Tests/Component/Validator/ConstraintTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ConstraintTest.php
@@ -11,10 +11,12 @@
 
 namespace Symfony\Tests\Component\Validator;
 
+require_once __DIR__.'/Fixtures/ClassConstraint.php';
 require_once __DIR__.'/Fixtures/ConstraintA.php';
 require_once __DIR__.'/Fixtures/ConstraintB.php';
 require_once __DIR__.'/Fixtures/ConstraintC.php';
 
+use Symfony\Tests\Component\Validator\Fixtures\ClassConstraint;
 use Symfony\Tests\Component\Validator\Fixtures\ConstraintA;
 use Symfony\Tests\Component\Validator\Fixtures\ConstraintB;
 use Symfony\Tests\Component\Validator\Fixtures\ConstraintC;
@@ -106,5 +108,19 @@ class ConstraintTest extends \PHPUnit_Framework_TestCase
     public function testCanCreateConstraintWithNoDefaultOptionAndEmptyArray()
     {
         new ConstraintB(array());
+    }
+
+    public function testGetTargetsCanBeString()
+    {
+        $constraint = new ClassConstraint;
+
+        $this->assertEquals('class', $constraint->getTargets());
+    }
+
+    public function testGetTargetsCanBeArray()
+    {
+        $constraint = new ConstraintA;
+
+        $this->assertEquals(array('property', 'class'), $constraint->getTargets());
     }
 }


### PR DESCRIPTION
- remove need for defining `getTargets()` method as 95% of validators use same one
- replace abstract `Constraint::getTargets()` with one that use 95% of validator constraints
- add additional tests for `Constraint::getTargets()` method
- remove unused `use` statement in `Constraint\Valid`
