### PR TITLE
[PdoSessionStorage] manual activation of GC if probability is on 0

### DIFF
--- a/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
@@ -70,7 +70,7 @@ class PdoSessionStorage extends NativeSessionStorage
 
         // use to prevent the sessions database from growing endlessly
         // if session.gc_probability is on 0 (like Debian system)
-        if ((int) ini_get('session.gc_probability') == 0) {
+        if ((int) ini_get('session.gc_probability') <= 0) {
             if (rand(1, ini_get('session.gc_divisor') + 1) === 1) {
                 $this->sessionGC($this->options['lifetime']);
             }

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
@@ -70,7 +70,7 @@ class PdoSessionStorage extends NativeSessionStorage
 
         // use to prevent the sessions database from growing endlessly
         // if session.gc_probability is on 0 (like Debian system)
-        if( (int) ini_get('session.gc_probability') == 0) {
+        if ((int) ini_get('session.gc_probability') == 0) {
             if (rand(1, ini_get('session.gc_divisor') + 1) === 1) {
                 $this->sessionGC($this->options['lifetime']);
             }

--- a/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
@@ -68,6 +68,14 @@ class PdoSessionStorage extends NativeSessionStorage
             array($this, 'sessionGC')
         );
 
+        // use to prevent the sessions database from growing endlessly
+        // if session.gc_probability is on 0 (like Debian system)
+        if( (int) ini_get('session.gc_probability') == 0) {
+            if (rand(1, ini_get('session.gc_divisor') + 1) === 1) {
+                $this->sessionGC($this->options['lifetime']);
+            }
+        }
+
         parent::start();
     }
 


### PR DESCRIPTION
On systems like Debian, the GC probability  is on 0 , because Debian manually cleared the sessions files, session_set_save_handler depend on it, so you need to manually clear to prevent the sessions database from growing endlessly.
