### PR TITLE
[2.1] [Config] added ability to set info message to node definition

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -31,7 +31,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 {
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration($container->getParameter('kernel.debug'));
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         if (!empty($config['dbal'])) {
@@ -411,5 +411,10 @@ class DoctrineExtension extends AbstractDoctrineExtension
     public function getNamespace()
     {
         return 'http://symfony.com/schema/dic/doctrine';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration($container->getParameter('kernel.debug'));
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -13,6 +13,8 @@ namespace Symfony\Bundle\FrameworkBundle\DependencyInjection;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -56,7 +58,7 @@ class FrameworkExtension extends Extension
             $container->setAlias('debug.controller_resolver', 'controller_resolver');
         }
 
-        $configuration = new Configuration($container->getParameter('kernel.debug'));
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         if (isset($config['charset'])) {
@@ -144,6 +146,11 @@ class FrameworkExtension extends Extension
             'Symfony\\Bundle\\FrameworkBundle\\ContainerAwareEventDispatcher',
             'Symfony\\Bundle\\FrameworkBundle\\HttpKernel',
         ));
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration($container->getParameter('kernel.debug'));
     }
 
     /**

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -36,7 +36,7 @@ class MonologExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         if (isset($config['handlers'])) {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -48,9 +48,9 @@ class SecurityExtension extends Extension
         if (!array_filter($configs)) {
             return;
         }
-
-        // normalize and merge the actual configuration
-        $mainConfig = new MainConfiguration($this->factories, $this->userProviderFactories);
+        
+        $mainConfig = $this->getConfiguration($configs, $container);
+        
         $config = $this->processConfiguration($mainConfig, $configs);
 
         // load services
@@ -568,6 +568,12 @@ class SecurityExtension extends Extension
     public function getNamespace()
     {
         return 'http://symfony.com/schema/dic/security';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        // first assemble the factories
+        return new MainConfiguration($this->factories, $this->userProviderFactories);
     }
 }
 

--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -43,7 +43,7 @@ class SwiftmailerExtension extends Extension
         $loader->load('swiftmailer.xml');
         $container->setAlias('mailer', 'swiftmailer.mailer');
 
-        $configuration = new Configuration($container->getParameter('kernel.debug'));
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         if (null === $config['transport']) {
@@ -144,5 +144,10 @@ class SwiftmailerExtension extends Extension
     public function getNamespace()
     {
         return 'http://symfony.com/schema/dic/swiftmailer';
+    }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return new Configuration($container->getParameter('kernel.debug'));
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -36,7 +36,7 @@ class TwigExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('twig.xml');
 
-        $configuration = new Configuration();
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('twig.exception_listener.controller', $config['exception_controller']);

--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -39,7 +39,7 @@ class WebProfilerExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
+        $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -49,6 +49,16 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         $this->allowNewKeys = true;
         $this->performDeepMerging = true;
     }
+    
+    /**
+     * Retrieves the children of this node.
+     * 
+     * @return array The children
+     */
+    public function getChildren()
+    {
+        return $this->children;
+    }
 
     /**
      * Sets the xml remappings that should be performed.

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -29,6 +29,8 @@ abstract class BaseNode implements NodeInterface
     protected $allowOverwrite;
     protected $required;
     protected $equivalentValues;
+    protected $info;
+    protected $example;
 
     /**
      * Constructor.
@@ -50,6 +52,46 @@ abstract class BaseNode implements NodeInterface
         $this->allowOverwrite = true;
         $this->required = false;
         $this->equivalentValues = array();
+    }
+    
+    /**
+     * Sets info message
+     * 
+     * @param string $info The info text
+     */
+    public function setInfo($info)
+    {
+        $this->info = $info;
+    }
+    
+    /**
+     * Returns info message
+     *
+     * @return string The info text
+     */
+    public function getInfo()
+    {
+        return $this->info;
+    }
+
+    /**
+     * Sets the example configuration for this node.
+     * 
+     * @param array $example 
+     */
+    public function setExample($example)
+    {
+        $this->example = $example;
+    }
+
+    /**
+     * Retrieves the example configuration for this node.
+     * 
+     * @return mixed The example
+     */
+    public function getExample()
+    {
+        return $this->example;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -32,6 +32,8 @@ abstract class NodeDefinition implements NodeParentInterface
     protected $trueEquivalent;
     protected $falseEquivalent;
     protected $parent;
+    protected $info;
+    protected $example;
 
     /**
      * Constructor
@@ -58,6 +60,34 @@ abstract class NodeDefinition implements NodeParentInterface
     {
         $this->parent = $parent;
 
+        return $this;
+    }
+    
+    /**
+     * Sets info message
+     * 
+     * @param string $info The info text
+     * 
+     * @return NodeDefinition
+     */
+    public function setInfo($info)
+    {
+        $this->info = $info;
+        
+        return $this;
+    }
+
+    /**
+     * Sets example configuration
+     * 
+     * @param example $example
+     * 
+     * @return NodeDefinition
+     */
+    public function setExample($example)
+    {
+        $this->example = $example;
+        
         return $this;
     }
 
@@ -91,8 +121,13 @@ abstract class NodeDefinition implements NodeParentInterface
         if (null !== $this->validation) {
             $this->validation->rules = ExprBuilder::buildExpressions($this->validation->rules);
         }
+        
+        $node = $this->createNode();
+        
+        $node->setInfo($this->info);
+        $node->setExample($this->example);
 
-        return $this->createNode();
+        return $node;
     }
 
     /**

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -79,6 +79,16 @@ class PrototypedArrayNode extends ArrayNode
     }
 
     /**
+     * Retrieves the name of the attribute which value should be used as key.
+     * 
+     * @return string The name of the attribute
+     */
+    public function getKeyAttribute()
+    {
+        return $this->keyAttribute;
+    }
+
+    /**
      * Sets the default value of this node.
      *
      * @param string $value
@@ -121,6 +131,16 @@ class PrototypedArrayNode extends ArrayNode
     public function setPrototype(PrototypeNodeInterface $node)
     {
         $this->prototype = $node;
+    }
+    
+    /**
+     * Retrieves the prototype
+     * 
+     * @return PrototypeNodeInterface The prototype
+     */
+    public function getPrototype()
+    {
+        return $this->prototype;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Extension/ConfigurationExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ConfigurationExtensionInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Extension;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+    
+/**
+ * ConfigurationExtensionInterface is the interface implemented by container extension classes.
+ *
+ * @author Kevin Bond <kevinbond@gmail.com>
+ */
+interface ConfigurationExtensionInterface
+{
+    /**
+     * Returns extension configuration
+     * 
+     * @param array $config    $config    An array of configuration values
+     * @param ContainerBuilder $container A ContainerBuilder instance
+     * 
+     * @return ConfigurationInterface|null The configuration or null
+     */
+    function getConfiguration(array $config, ContainerBuilder $container);
+}

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
@@ -5,6 +5,9 @@ namespace Symfony\Component\HttpKernel\DependencyInjection;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Container;
 
 /*
@@ -21,7 +24,7 @@ use Symfony\Component\DependencyInjection\Container;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-abstract class Extension implements ExtensionInterface
+abstract class Extension implements ExtensionInterface, ConfigurationExtensionInterface
 {
     private $classes = array();
 
@@ -99,5 +102,25 @@ abstract class Extension implements ExtensionInterface
         $processor = new Processor();
 
         return $processor->processConfiguration($configuration, $configs);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        $reflected = new \ReflectionClass($this);
+        $namespace = $reflected->getNamespaceName();
+
+        $class = $namespace . '\\Configuration';
+        if (class_exists($class)) {
+            if (!method_exists($class, '__construct')) {
+                $configuration = new $class();
+
+                return $configuration;
+            }
+        }
+
+        return null;
     }
 }

--- a/tests/Symfony/Tests/Component/Config/Definition/Builder/TreeBuilderTest.php
+++ b/tests/Symfony/Tests/Component/Config/Definition/Builder/TreeBuilderTest.php
@@ -89,4 +89,39 @@ class TreeBuilderTest extends \PHPUnit_Framework_TestCase
             ->end()
         ->end();
     }
+
+    public function testDefinitionInfoGetsTransferedToNode()
+    {
+        $builder = new TreeBuilder();
+
+        $builder->root('test')->setInfo('root info')
+            ->children()
+                ->node('child', 'variable')->setInfo('child info')->defaultValue('default')
+            ->end()
+        ->end();
+
+        $tree = $builder->buildTree();
+        $children = $tree->getChildren();
+
+        $this->assertEquals('root info', $tree->getInfo());
+        $this->assertEquals('child info', $children['child']->getInfo());
+    }
+
+    public function testDefinitionExampleGetsTransferedToNode()
+    {
+        $builder = new TreeBuilder();
+
+        $builder->root('test')
+            ->setExample(array('key' => 'value'))
+            ->children()
+                ->node('child', 'variable')->setInfo('child info')->defaultValue('default')->setExample('example')
+            ->end()
+        ->end();
+
+        $tree = $builder->buildTree();
+        $children = $tree->getChildren();
+
+        $this->assertTrue(is_array($tree->getExample()));
+        $this->assertEquals('example', $children['child']->getExample());
+    }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/ProjectExtension.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/ProjectExtension.php
@@ -33,4 +33,9 @@ class ProjectExtension implements ExtensionInterface
     {
         return 'project';
     }
+
+    public function getConfiguration(array $config, ContainerBuilder $container)
+    {
+        return null;
+    }
 }


### PR DESCRIPTION
The configuration TreeBuilder lends itself to be hooked into for reference documentation generation.  This `setInfo()` method allows the addition of a message to a node for use in doc generation.  

Example (`Symfony/Bundle/WebProfilerBundle/DependencyInjection/Configuration.php`):

``` php
<?php
// ...
$treeBuilder = new TreeBuilder();
$rootNode = $treeBuilder->root('web_profiler');

$rootNode
    ->children()
        ->booleanNode('verbose')->defaultTrue()
            ->setInfo('Setting to false hides some secondary information to make the toolbar shorter.')->end()
        ->booleanNode('toolbar')->defaultFalse()
            ->setInfo('Enable/Disable the display of the web debug toolbar containing a summary of the profiling data.')->end()
        ->booleanNode('intercept_redirects')->defaultFalse()
            ->setInfo('Intercepts the redirects and gives you the opportunity to look at the collected data before following the redirect.')->end()
    ->end()
;

return $treeBuilder;
// ...
```

I think a core console command would be great (ie: `config:reference:dump web_profiler`) or even a frame in the profiler.  The way bundle configuration processing is not enforced makes this difficult currently.  Perhaps adding a `getConfiguration()` method to `ExtensionInterface`.  Thoughts?

Certainly this change would allow for a third party bundles or sites (ie symfony.com) to generate bundle reference docs.
