### PR TITLE
[Form] Improved DefaultValidator Error Message

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Validator/DefaultValidator.php
+++ b/src/Symfony/Component/Form/Extension/Core/Validator/DefaultValidator.php
@@ -20,7 +20,7 @@ class DefaultValidator implements FormValidatorInterface
     public function validate(FormInterface $form)
     {
         if (!$form->isSynchronized()) {
-            $form->addError(new FormError('The value is invalid'));
+            $form->addError(new FormError(sprintf('The value for "%s" is invalid', $form->getName())));
         }
 
         if (count($form->getExtraData()) > 0) {


### PR DESCRIPTION
Currently, when the form is not synchronized it adds the error:

> The value is invalid

This patch changes it to:

> The value for "{{ form.name }}" is invalid

(Obviously no Twig templating here :P)

Anyway, makes error messages much more useful :)
