### PR TITLE
[DoctrineBundle] doctrine:generate:entities - changed method declaration from private to protected. 

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -107,7 +107,7 @@ EOT
         }
     }
 
-    private function getBundleInfo($bundle)
+    protected function getBundleInfo($bundle)
     {
         $namespace = $bundle->getNamespace();
         if (!$metadatas = $this->findMetadatasByNamespace($namespace)) {
@@ -119,7 +119,7 @@ EOT
         return array($metadatas, $bundle->getNamespace(), $path);
     }
 
-    private function getClassInfo($class, $path)
+    protected function getClassInfo($class, $path)
     {
         if (!$metadatas = $this->findMetadatasByClass($class)) {
             throw new \RuntimeException(sprintf('Entity "%s" is not a mapped entity.', $class));
@@ -135,7 +135,7 @@ EOT
         return array($metadatas, $r->getNamespacename(), $path);
     }
 
-    private function getNamespaceInfo($namespace, $path)
+    protected function getNamespaceInfo($namespace, $path)
     {
         if (!$metadatas = $this->findMetadatasByNamespace($namespace)) {
             throw new \RuntimeException(sprintf('Namespace "%s" does not contain any mapped entities.', $namespace));


### PR DESCRIPTION
Reason: I'm developing a bundle for a Propel2 integration. To generate entities, I'd like to re-use the basic concept and mechanics of this command, just replacing the code generation. Right now I have to copy/paste those three methods, as I cannot use them if they're declared private.

Right now I see no valid reason why they must be declared as private.
