### PR TITLE
Issue #1058 - Fix RadioInputListener with Expanded ChoiceType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -27,7 +27,7 @@ class FixRadioInputListener implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        $event->setData(count((array)$data) === 0 ? array() : array($data => true));
+        $event->setData(empty($data) ? array() : array($data => true));
     }
 
     public static function getSubscribedEvents()

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/ChoiceTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/ChoiceTypeTest.php
@@ -157,6 +157,20 @@ class ChoiceTypeTest extends TypeTestCase
         $this->assertSame('', $form['e']->getClientData());
     }
 
+    public function testBindSingleExpandedWithFalseDoesNotHaveExtraFields()
+    {
+        $form = $this->factory->create('choice', null, array(
+            'multiple' => false,
+            'expanded' => true,
+            'choices' => $this->choices,
+        ));
+        
+        $form->bind(false);
+        
+        $this->assertEmpty($form->getExtraData());
+        $this->assertNull($form->getData());
+    }
+
     public function testBindSingleExpandedNumericChoices()
     {
         $form = $this->factory->create('choice', null, array(


### PR DESCRIPTION
Refs #1058 (Better description there)

In short, the RadioInputListener mistakenly converts missing values `""` to `[0] => ""`, which in turn adds _extra data_ to form, making it _invalid_.
