### PR TITLE
[BrowserKit] fixed explicit cookie params being overriden by url

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -45,7 +45,7 @@ class Cookie
      *
      * @api
      */
-    public function __construct($name, $value, $expires = null, $path = '/', $domain = '', $secure = false, $httponly = true, $encodedValue = false)
+    public function __construct($name, $value, $expires = null, $path = null, $domain = '', $secure = false, $httponly = true, $encodedValue = false)
     {
         if ($encodedValue) {
             $this->value    = urldecode($value);
@@ -56,7 +56,7 @@ class Cookie
         }
         $this->name     = $name;
         $this->expires  = null === $expires ? null : (integer) $expires;
-        $this->path     = empty($path) ? '/' : $path;
+        $this->path     = empty($path) ? null : $path;
         $this->domain   = $domain;
         $this->secure   = (Boolean) $secure;
         $this->httponly = (Boolean) $httponly;
@@ -81,7 +81,7 @@ class Cookie
             $cookie .= '; domain='.$this->domain;
         }
 
-        if ('/' !== $this->path) {
+        if (null !== $this->path) {
             $cookie .= '; path='.$this->path;
         }
 
@@ -120,7 +120,7 @@ class Cookie
             'name'     => trim($name),
             'value'    => trim($value),
             'expires'  =>  null,
-            'path'     => '/',
+            'path'     => null,
             'domain'   => '',
             'secure'   => false,
             'httponly' => false,
@@ -128,10 +128,11 @@ class Cookie
         );
 
         if (null !== $url) {
-            if ((false === $parts = parse_url($url)) || !isset($parts['host']) || !isset($parts['path'])) {
+            if ((false === $urlParts = parse_url($url)) || !isset($urlParts['host']) || !isset($urlParts['path'])) {
                 throw new \InvalidArgumentException(sprintf('The URL "%s" is not valid.', $url));
             }
-
+            $parts = array_merge($urlParts, $parts);
+            
             $values['domain'] = $parts['host'];
             $values['path'] = substr($parts['path'], 0, strrpos($parts['path'], '/'));
         }
@@ -233,7 +234,7 @@ class Cookie
      */
     public function getPath()
     {
-        return $this->path;
+        return (null !== $this->path)?$this->path:'/';
     }
 
     /**

--- a/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
@@ -42,6 +42,8 @@ class CookieTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('foo=bar; domain=www.example.com', (string) Cookie::FromString('foo=bar', 'http://www.example.com/'));
         $this->assertEquals('foo=bar; domain=www.example.com; path=/foo', (string) Cookie::FromString('foo=bar', 'http://www.example.com/foo/bar'));
+        $this->assertEquals('foo=bar; domain=www.example.com; path=/', (string) Cookie::FromString('foo=bar; path=/', 'http://www.example.com/foo/bar'));
+        $this->assertEquals('foo=bar; domain=www.myotherexample.com', (string) Cookie::FromString('foo=bar; domain=www.myotherexample.com', 'http://www.example.com/'));
     }
 
     public function testFromStringThrowsAnExceptionIfCookieIsNotValid()


### PR DESCRIPTION
I encountered these problem during some functional tests related to authentication. The high level problem - if I i login to a url /user/login-check then place a request outside of /user, then the user was anonymous. In a browser it works fine.

On a lower level, the browser response set the session cookie with path=/, in functional tests it was being set with path=/user. (The browser response comes from SessionListener in FrameworkBundle, the functional test response frmo browserkit)

The source was that the fromString method of a cookie would override the cookie's parameters (domain and path) with those of the given url. fromString is only used within the updateFromResponse of the CookieJar, which is only used within the BrowserKit Client. 
