### PR TITLE
[Symfony\Bridge\Doctrine\Form\Type\EntityType] Changed entity manager to protected to allow extension.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -22,7 +22,7 @@ use Doctrine\ORM\EntityManager;
 
 class EntityType extends AbstractType
 {
-    private $em;
+    protected $em;
 
     public function __construct(EntityManager $em)
     {


### PR DESCRIPTION
I don't know if this would cause an issue but changing the entity manager to protected would allow this form type to be extended!

Would this cause any problems?

Regards,

Andy
