### PR TITLE
[Security] Security tweaks to SecurityExtension

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -58,7 +58,7 @@ class MainConfiguration implements ConfigurationInterface
             // add a faux-entry for factories, so that no validation error is thrown
             ->fixXmlConfig('factory', 'factories')
             ->children()
-                ->arrayNode('factories')->ignoreExtraKeys()->end()
+                ->arrayNode('factories')->ignoreExtraKeys()->addDefaultsIfNotSet()->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -106,7 +106,7 @@ class SecurityExtension extends Extension
      * Takes in the config arrays, validates and flattens them into one array
      *
      * @param array $configs The raw array of configuration arrays
-     * @param \Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface $parameterBag
+     * @param ParameterBagInterface $parameterBag
      * @return array The flattened configuration
      */
     private function processConfigs(array $configs, ParameterBagInterface $parameterBag)
@@ -206,8 +206,8 @@ class SecurityExtension extends Extension
     /**
      * Configures everything in the service container necessary for the configured firewalls
      *
-     * @param  array $config The security configuration array
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param array $config The security configuration array
+     * @param ContainerBuilder $container
      */
     private function createFirewalls(array $config, ContainerBuilder $container)
     {
@@ -271,11 +271,11 @@ class SecurityExtension extends Extension
      * manager then passes the token to the corresponding authentication
      * provider to pass back the authenticated token (or throw an exception).
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param  string $firewallName The name of the firewall
-     * @param  array  $firewallConfig     The firewall array configuration
-     * @param  array  $authenticationProviders The authentication providers
-     * @param  array  $providerIds  The service ids of the user providers
+     * @param ContainerBuilder $container
+     * @param string $firewallName The name of the firewall
+     * @param array  $firewallConfig     The firewall array configuration
+     * @param array  $authenticationProviders The authentication providers
+     * @param array  $providerIds  The service ids of the user providers
      * @param array   $factories    Array of security factory objects
      *
      * @return array An array of the Reference to the request matcher, listeners, and exception listener
@@ -387,8 +387,8 @@ class SecurityExtension extends Extension
      * Returns a service id that refers to a ContextListener with the given
      * context key.
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param  string $contextKey The identifier for this context listener
+     * @param ContainerBuilder $container
+     * @param string $contextKey The identifier for this context listener
      *
      * @return string The service id to the context listener
      */
@@ -415,11 +415,11 @@ class SecurityExtension extends Extension
      * also returns an additional authentication provider, which is pushed
      * onto the authenticationProviders array.
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param  string $firewallName The name of the firewall being configured
-     * @param  array $firewallConfig The raw firewall configuration array
-     * @param  array $authenticationProviders The authentication providers
-     * @param  string $defaultUserProviderId The service id for the default user provider
+     * @param ContainerBuilder $container
+     * @param string $firewallName The name of the firewall being configured
+     * @param array $firewallConfig The raw firewall configuration array
+     * @param array $authenticationProviders The authentication providers
+     * @param string $defaultUserProviderId The service id for the default user provider
      * @param array $providerIds The available, valid user provider ids
      * @param array $factories The array of security factory objects
      *
@@ -600,10 +600,10 @@ class SecurityExtension extends Extension
      * Configures and returns the exception listener service id for the given
      * firewall based on the firewall configuration and entry point.
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
-     * @param  array $firewallConfig The firewall configuration
-     * @param  string $firewallName The name of the firewall
-     * @param  $entryPointId The service id to the entry point to use
+     * @param ContainerBuilder $container
+     * @param array $firewallConfig The firewall configuration
+     * @param string $firewallName The name of the firewall
+     * @param $entryPointId The service id to the entry point to use
      *
      * @return string The exception listener service id
      */
@@ -641,7 +641,7 @@ class SecurityExtension extends Extension
      * Creates a RequestMatcher instance based on the given parameters and
      * returns a Reference referring to the service.
      *
-     * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
+     * @param ContainerBuilder $container
      * @param string $path The path/pattern that the request matcher should match
      * @param string $host The host pattern to match
      * @param string|array $methods The array of HTTP methods to match
@@ -649,7 +649,7 @@ class SecurityExtension extends Extension
      * @param array $attributes Any other request attributes to match
      * @return array|\Symfony\Component\DependencyInjection\Reference
      *
-     * @return \Symfony\Component\DependencyInjection\Reference
+     * @return Reference
      */
     private function createRequestMatcherReference(ContainerBuilder $container, $path, $host = null, $methods = null, $ip = null, array $attributes = array())
     {

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -69,7 +69,7 @@
         <service id="security.context_listener" class="%security.context_listener.class%" public="false">
             <tag name="monolog.logger" channel="security" />
             <argument type="service" id="security.context" />
-            <argument type="collection"></argument>
+            <argument type="collection" />
             <argument /> <!-- Provider Key -->
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="event_dispatcher" on-invalid="null"/>

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -32,7 +32,6 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     private $aliases          = array();
     private $resources        = array();
     private $extensionConfigs = array();
-    private $injectors        = array();
     private $compiler;
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -45,11 +45,11 @@ class ContextListener implements ListenerInterface
     private $userProviders;
 
     /**
-     * @param \Symfony\Component\Security\Core\SecurityContext $context
+     * @param SecurityContext $context
      * @param array   $userProviders The available user providers to load users from
      * @param string $contextKey The key used when storing information to the session
-     * @param \Symfony\Component\HttpKernel\Log\LoggerInterface $logger
-     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
+     * @param LoggerInterface $logger
+     * @param EventDispatcherInterface $dispatcher
      */
     public function __construct(SecurityContext $context, array $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -28,6 +28,12 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 /**
  * ContextListener manages the SecurityContext persistence through a session.
  *
+ * The listener serializes the security token and stores it on the session.
+ * On subsequent requests, the token is fetched from the session and set on
+ * the security context. During that process, the appropriate user provider
+ * is called so that the user can be refreshed (e.g. a user object corresponding
+ * to a user in a database will need to be refreshed).
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
@@ -38,6 +44,13 @@ class ContextListener implements ListenerInterface
     private $logger;
     private $userProviders;
 
+    /**
+     * @param \Symfony\Component\Security\Core\SecurityContext $context
+     * @param array   $userProviders The available user providers to load users from
+     * @param string $contextKey The key used when storing information to the session
+     * @param \Symfony\Component\HttpKernel\Log\LoggerInterface $logger
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
+     */
     public function __construct(SecurityContext $context, array $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         if (empty($contextKey)) {


### PR DESCRIPTION
Hey guys-

Comments in the commit message. Due to their nature, the DI Extension classes tend to be hard to read. This includes several changes to `SecurityExtension` that were a result of me trying to go through the class, study, debug, etc.

Side note: I think the way that factories are processed (by calling `SecurityFactoryInterface::create()`, which returns an array of several things) can use some improvement. There are a few places where the return signature to functions is an array of several different items, which is hard to follow.

Thanks!
