### PR TITLE
increased chance of toolbar not hiding page content

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,6 +1,6 @@
 <!-- START of Symfony2 Web Debug Toolbar -->
 {% if 'normal' != position %}
-    <div style="clear: both; height: 40px;"></div>
+    <div style="clear: both; height: 80px;"></div>
 {% endif %}
 
 <div class="sf-toolbarreset"


### PR DESCRIPTION
The toolbar wraps to a 2nd line for long route names which makes it hiding page content, thus better show more white space instead of overlaying content with the toolbar.
