### PR TITLE
[Form] DateType single-text should be single_text

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -6,6 +6,11 @@ one. It only discusses changes that need to be done when using the "public"
 API of the framework. If you "hack" the core, you should probably follow the
 timeline closely anyway.
 
+beta3 to beta4
+--------------
+
+* Form DateType parameter single-text changed to single_text 
+
 beta2 to beta3
 --------------
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
@@ -1,4 +1,4 @@
-<?php if ($widget == 'single-text'): ?>
+<?php if ($widget == 'single_text'): ?>
     <input type="text"
         <?php echo $view['form']->attributes() ?>
         name="<?php echo $view->escape($full_name) ?>"

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -158,7 +158,7 @@
 
 {% block date_widget %}
 {% spaceless %}
-    {% if widget == 'single-text' %}
+    {% if widget == 'single_text' %}
         {{ block('text_widget') }}
     {% else %}
         <div {{ block('container_attributes') }}>

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -123,7 +123,7 @@ class DateTimeType extends AbstractType
             ),
             'date_widget'   => array(
                 null, // inherit default from DateType
-                'single-text',
+                'single_text',
                 'text',
                 'choice',
             ),

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -34,7 +34,7 @@ class DateType extends AbstractType
             \DateTimeZone::UTC
         );
 
-        if ($options['widget'] === 'single-text') {
+        if ($options['widget'] === 'single_text') {
             $builder->appendClientTransformer(new DateTimeToLocalizedStringTransformer($options['data_timezone'], $options['user_timezone'], $options['format'], \IntlDateFormatter::NONE));
         } else {
             $yearOptions = $monthOptions = $dayOptions = array();
@@ -135,7 +135,7 @@ class DateType extends AbstractType
                 'array',
             ),
             'widget'    => array(
-                'single-text',
+                'single_text',
                 'text',
                 'choice',
             ),
@@ -150,7 +150,7 @@ class DateType extends AbstractType
 
     public function getParent(array $options)
     {
-        return $options['widget'] === 'single-text' ? 'field' : 'form';
+        return $options['widget'] === 'single_text' ? 'field' : 'form';
     }
 
     public function getName()

--- a/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
@@ -623,7 +623,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
         $form = $this->factory->createNamed('date', 'na&me', '2011-02-03', array(
             'property_path' => 'name',
             'input' => 'string',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
@@ -50,7 +50,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'input' => 'datetime',
         ));
 
@@ -65,7 +65,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'input' => 'string',
         ));
 
@@ -80,7 +80,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'input' => 'timestamp',
         ));
 
@@ -97,7 +97,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'input' => 'array',
         ));
 
@@ -185,7 +185,7 @@ class DateTypeTest extends LocalizedTestCase
             'user_timezone' => 'Pacific/Tahiti',
             // don't do this test with DateTime, because it leads to wrong results!
             'input' => 'string',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
         ));
 
         $form->setData('2010-06-02');
@@ -200,7 +200,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'years' => array(2010, 2011),
         ));
 
@@ -216,7 +216,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'years' => array(2010, 2011),
         ));
 
@@ -252,7 +252,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'years' => array(2010, 2012),
         ));
 
@@ -268,7 +268,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'months' => array(6, 7),
         ));
 
@@ -284,7 +284,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'months' => array(6, 7),
         ));
 
@@ -320,7 +320,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'months' => array(6, 8),
         ));
 
@@ -336,7 +336,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'days' => array(6, 7),
         ));
 
@@ -352,7 +352,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'days' => array(6, 7),
         ));
 
@@ -390,7 +390,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
             'days' => array(6, 8),
         ));
 
@@ -406,7 +406,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date', null, array(
             'data_timezone' => 'UTC',
             'user_timezone' => 'UTC',
-            'widget' => 'single-text',
+            'widget' => 'single_text',
         ));
 
         $form->bind('7.6.2010');
@@ -482,7 +482,7 @@ class DateTypeTest extends LocalizedTestCase
     public function testDontPassDatePatternIfText()
     {
         $form = $this->factory->create('date', null, array(
-            'widget' => 'single-text',
+            'widget' => 'single_text',
         ));
         $view = $form->createView();
 
@@ -492,10 +492,10 @@ class DateTypeTest extends LocalizedTestCase
     public function testPassWidgetToView()
     {
         $form = $this->factory->create('date', null, array(
-            'widget' => 'single-text',
+            'widget' => 'single_text',
         ));
         $view = $form->createView();
 
-        $this->assertSame('single-text', $view->get('widget'));
+        $this->assertSame('single_text', $view->get('widget'));
     }
 }


### PR DESCRIPTION
all parameters in form type use _ as delimiter so proper parameter name is single_text
