### PR TITLE
Serializer tweaks

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -9,6 +9,10 @@ timeline closely anyway.
 beta4 to beta5
 --------------
 
+* Expanded the SerializerInterface, while reducing the number of public
+  methods in the Serializer class itself and adding component specific
+  Exception classes.
+
 * The temporary storage for file uploads has been removed
 
 * The `Symfony\Component\HttpFoundation\File\File::getExtension()` and

--- a/UPDATE.md
+++ b/UPDATE.md
@@ -10,8 +10,8 @@ beta4 to beta5
 --------------
 
 * Expanded the SerializerInterface, while reducing the number of public
-  methods in the Serializer class itself and adding component specific
-  Exception classes.
+  methods in the Serializer class itself breaking BC and adding component
+  specific Exception classes.
 
 * The temporary storage for file uploads has been removed
 

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface DecoderInterface
+interface DecoderInterface extends EncoderInterface
 {
     /**
      * Decodes a string into PHP data

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -18,7 +18,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-interface DecoderInterface extends EncoderInterface
+interface DecoderInterface
 {
     /**
      * Decodes a string into PHP data

--- a/src/Symfony/Component/Serializer/Encoder/SerializerAwareEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/SerializerAwareEncoder.php
@@ -19,7 +19,7 @@ use Symfony\Component\Serializer\SerializerAwareInterface;
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
  */
-abstract class SerializerAwareEncoder implements SerializerAwareInterface, EncoderInterface
+abstract class SerializerAwareEncoder implements SerializerAwareInterface
 {
     protected $serializer;
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
  * @author John Wards <jwards@whiteoctober.co.uk>
  * @author Fabian Vogler <fabian@equivalence.ch>
  */
-class XmlEncoder extends SerializerAwareEncoder implements DecoderInterface, NormalizationAwareInterface
+class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, DecoderInterface, NormalizationAwareInterface
 {
     private $dom;
     private $format;

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -254,7 +254,7 @@ class XmlEncoder extends SerializerAwareEncoder implements DecoderInterface, Nor
             return $append;
         }
         if (is_object($data)) {
-            $data = $this->serializer->normalizeObject($data, $this->format);
+            $data = $this->serializer->normalize($data, $this->format);
             if (null !== $data && !is_scalar($data)) {
                 return $this->buildXml($parentNode, $data);
             }
@@ -312,7 +312,7 @@ class XmlEncoder extends SerializerAwareEncoder implements DecoderInterface, Nor
         } elseif ($val instanceof \Traversable) {
             $this->buildXml($node, $val);
         } elseif (is_object($val)) {
-            return $this->buildXml($node, $this->serializer->normalizeObject($val, $this->format));
+            return $this->buildXml($node, $this->serializer->normalize($val, $this->format));
         } elseif (is_numeric($val)) {
             return $this->appendText($node, (string) $val);
         } elseif (is_string($val)) {

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Serializer\Encoder;
 
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Exception\UnexpectedValueException;
 
 /*
  * This file is part of the Symfony framework.
@@ -268,7 +269,7 @@ class XmlEncoder extends SerializerAwareEncoder implements DecoderInterface, Nor
 
             return $this->appendNode($parentNode, $data, 'data');
         }
-        throw new \UnexpectedValueException('An unexpected value could not be serialized: '.var_export($data, true));
+        throw new UnexpectedValueException('An unexpected value could not be serialized: '.var_export($data, true));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Exception/Exception.php
+++ b/src/Symfony/Component/Serializer/Exception/Exception.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * Base exception
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+interface Exception
+{
+}

--- a/src/Symfony/Component/Serializer/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Serializer/Exception/InvalidArgumentException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * InvalidArgumentException
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements Exception
+{
+}

--- a/src/Symfony/Component/Serializer/Exception/LogicException.php
+++ b/src/Symfony/Component/Serializer/Exception/LogicException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * LogicException
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class LogicException extends \LogicException implements Exception
+{
+}

--- a/src/Symfony/Component/Serializer/Exception/RuntimeException.php
+++ b/src/Symfony/Component/Serializer/Exception/RuntimeException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * RuntimeException
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class RuntimeException extends \RuntimeException implements Exception
+{
+}

--- a/src/Symfony/Component/Serializer/Exception/UnexpectedValueException.php
+++ b/src/Symfony/Component/Serializer/Exception/UnexpectedValueException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * UnexpectedValueException
+ *
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class UnexpectedValueException extends \UnexpectedValueException implements Exception
+{
+}

--- a/src/Symfony/Component/Serializer/Exception/UnsupportedException.php
+++ b/src/Symfony/Component/Serializer/Exception/UnsupportedException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\Serializer\Exception;
+
+/**
+ * UnsupportedException
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class UnsupportedException extends InvalidArgumentException
+{
+}

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Exception\RuntimeException;
 
 /*
  * This file is part of the Symfony framework.
@@ -80,7 +81,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer
                     // don't run set for a parameter passed to the constructor
                     unset($data[$paramName]);
                 } else if (!$constructorParameter->isOptional()) {
-                    throw new \RuntimeException(
+                    throw new RuntimeException(
                         'Cannot create an instance of ' . $class .
                         ' from serialized data because its constructor requires ' .
                         'parameter "' . $constructorParameter->getName() .

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -109,7 +109,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer
      */
     public function supportsNormalization($data, $format = null)
     {
-        return $this->supports(get_class($data));
+        return is_object($data) && $this->supports(get_class($data));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -27,9 +27,11 @@ use Symfony\Component\Serializer\Exception\UnexpectedValueException;
  *
  * $serializer->serialize($obj, 'xml')
  * $serializer->decode($data, 'xml')
- * $serializer->denormalizeObject($data, 'Class', 'xml')
+ * $serializer->denormalize($data, 'Class', 'xml')
  *
  * @author Jordi Boggiano <j.boggiano@seld.be>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
 class Serializer implements SerializerInterface
 {
@@ -38,10 +40,27 @@ class Serializer implements SerializerInterface
     protected $normalizerCache = array();
     protected $denormalizerCache = array();
 
+    public function __construct(array $normalizers = array(), array $encoders = array())
+    {
+        foreach ($normalizers as $normalizer) {
+            if ($normalizer instanceof SerializerAwareInterface) {
+                $normalizer->setSerializer($this);
+            }
+        }
+        $this->normalizers = $normalizers;
+
+        foreach ($encoders as $encoder) {
+            if ($encoder instanceof SerializerAwareInterface) {
+                $encoder->setSerializer($this);
+            }
+        }
+        $this->encoders = $encoders;
+    }
+
     /**
      * {@inheritdoc}
      */
-    public function serialize($data, $format)
+    public final function serialize($data, $format)
     {
         if (!isset($this->encoders[$format])) {
             throw new UnexpectedValueException('No encoder registered for the '.$format.' format');

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -204,7 +204,7 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function hasEncoder($format)
+    public function supportsSerialization($format)
     {
         return isset($this->encoders[$format]);
     }
@@ -212,7 +212,7 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function hasDecoder($format)
+    public function supportsDeserialization($format)
     {
         return isset($this->encoders[$format]) && $this->encoders[$format] instanceof DecoderInterface;
     }

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -121,11 +121,7 @@ class Serializer implements SerializerInterface
      */
     public final function encode($data, $format)
     {
-        if (!isset($this->encoders[$format])) {
-            throw new \UnexpectedValueException('No encoder registered for the '.$format.' format');
-        }
-
-        return $this->encoders[$format]->encode($data, $format);
+        return $this->getEncoder($format)->encode($data, $format);
     }
 
     /**
@@ -133,11 +129,7 @@ class Serializer implements SerializerInterface
      */
     public final function decode($data, $format)
     {
-        if (!isset($this->encoders[$format])) {
-            throw new \UnexpectedValueException('No decoder registered for the '.$format.' format');
-        }
-
-        return $this->encoders[$format]->decode($data, $format);
+        return $this->getEncoder($format)->decode($data, $format);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -75,8 +75,11 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public final function deserialize($data, $type, $format) {
-        return $this->denormalize($this->decode($data, $format), $type, $format);
+    public final function deserialize($data, $type, $format)
+    {
+        $data = $this->decode($data, $format);
+
+        return $this->denormalize($data, $type, $format);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -204,7 +204,7 @@ class Serializer implements SerializerInterface
      */
     public function hasEncoder($format)
     {
-        return isset($this->encoder[$format]) && $this->encoder[$format] instanceof EncoderInterface;
+        return isset($this->encoder[$format]);
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -204,7 +204,7 @@ class Serializer implements SerializerInterface
      */
     public function hasEncoder($format)
     {
-        return isset($this->encoder[$format]);
+        return isset($this->encoders[$format]);
     }
 
     /**
@@ -212,7 +212,7 @@ class Serializer implements SerializerInterface
      */
     public function hasDecoder($format)
     {
-        return isset($this->encoder[$format]) && $this->encoder[$format] instanceof DecoderInterface;
+        return isset($this->encoders[$format]) && $this->encoders[$format] instanceof DecoderInterface;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -211,44 +211,4 @@ class Serializer implements SerializerInterface
 
         return $this->encoders[$format];
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setEncoder($format, EncoderInterface $encoder)
-    {
-        $this->encoders[$format] = $encoder;
-        if ($encoder instanceof SerializerAwareInterface) {
-            $encoder->setSerializer($this);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeEncoder($format)
-    {
-        if (isset($this->encoders[$format])) {
-            unset($this->encoders[$format]);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function addNormalizer(NormalizerInterface $normalizer)
-    {
-        $this->normalizers[] = $normalizer;
-        if ($normalizer instanceof SerializerAwareInterface) {
-            $normalizer->setSerializer($this);
-        }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function removeNormalizer(NormalizerInterface $normalizer)
-    {
-        unset($this->normalizers[array_search($normalizer, $this->normalizers, true)]);
-    }
 }

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -62,10 +62,11 @@ class Serializer implements SerializerInterface
      */
     public final function serialize($data, $format)
     {
-        if (!isset($this->encoders[$format])) {
+        $encoder = $this->getEncoder($format);
+        if (!isset($encoder)) {
             throw new UnexpectedValueException('No encoder registered for the '.$format.' format');
         }
-        if (!$this->encoders[$format] instanceof NormalizationAwareInterface) {
+        if (!$encoder instanceof NormalizationAwareInterface) {
             $data = $this->normalize($data);
         }
 

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -119,9 +119,13 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Normalizes an object into a set of arrays/scalars
+     *
+     * @param object $object object to normalize
+     * @param string $format format name, present to give the option to normalizers to act differently based on formats
+     * @return array|scalar
      */
-    public function normalizeObject($object, $format = null)
+    private function normalizeObject($object, $format = null)
     {
         if (!$this->normalizers) {
             throw new \LogicException('You must register at least one normalizer to be able to normalize objects.');
@@ -141,9 +145,14 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Denormalizes data back into an object of the given class
+     *
+     * @param mixed $data data to restore
+     * @param string $class the expected class to instantiate
+     * @param string $format format name, present to give the option to normalizers to act differently based on formats
+     * @return object
      */
-    public function denormalizeObject($data, $class, $format = null)
+    private function denormalizeObject($data, $class, $format = null)
     {
         if (!$this->normalizers) {
             throw new \LogicException('You must register at least one normalizer to be able to denormalize objects.');

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -196,7 +196,9 @@ class Serializer implements SerializerInterface
      */
     public function getEncoder($format)
     {
-        return $this->encoders[$format];
+        if (isset($this->encoders[$format])) {
+            return $this->encoders[$format];
+        }
     }
 
     /**
@@ -220,6 +222,8 @@ class Serializer implements SerializerInterface
      */
     public function removeEncoder($format)
     {
-        unset($this->encoders[$format]);
+        if (isset($this->encoders[$format])) {
+            unset($this->encoders[$format]);
+        }
     }
 }

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -187,31 +187,17 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function addNormalizer(NormalizerInterface $normalizer)
+    public function supportsSerialization($format)
     {
-        $this->normalizers[] = $normalizer;
-        if ($normalizer instanceof SerializerAwareInterface) {
-            $normalizer->setSerializer($this);
-        }
+        return isset($this->encoders[$format]);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function removeNormalizer(NormalizerInterface $normalizer)
+    public function supportsDeserialization($format)
     {
-        unset($this->normalizers[array_search($normalizer, $this->normalizers, true)]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setEncoder($format, EncoderInterface $encoder)
-    {
-        $this->encoders[$format] = $encoder;
-        if ($encoder instanceof SerializerAwareInterface) {
-            $encoder->setSerializer($this);
-        }
+        return isset($this->encoders[$format]) && $this->encoders[$format] instanceof DecoderInterface;
     }
 
     /**
@@ -229,17 +215,12 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsSerialization($format)
+    public function setEncoder($format, EncoderInterface $encoder)
     {
-        return isset($this->encoders[$format]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsDeserialization($format)
-    {
-        return isset($this->encoders[$format]) && $this->encoders[$format] instanceof DecoderInterface;
+        $this->encoders[$format] = $encoder;
+        if ($encoder instanceof SerializerAwareInterface) {
+            $encoder->setSerializer($this);
+        }
     }
 
     /**
@@ -250,5 +231,24 @@ class Serializer implements SerializerInterface
         if (isset($this->encoders[$format])) {
             unset($this->encoders[$format]);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addNormalizer(NormalizerInterface $normalizer)
+    {
+        $this->normalizers[] = $normalizer;
+        if ($normalizer instanceof SerializerAwareInterface) {
+            $normalizer->setSerializer($this);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeNormalizer(NormalizerInterface $normalizer)
+    {
+        unset($this->normalizers[array_search($normalizer, $this->normalizers, true)]);
     }
 }

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -73,9 +73,9 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
-    public function deserialize($data, $type, $format) {
+    public final function deserialize($data, $type, $format) {
         return $this->denormalize($this->decode($data, $format), $type, $format);
     }
 
@@ -109,7 +109,7 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * {@inheritDoc}
+     * {@inheritdoc}
      */
     public function denormalize($data, $type, $format = null)
     {
@@ -119,7 +119,7 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function encode($data, $format)
+    public final function encode($data, $format)
     {
         if (!isset($this->encoders[$format])) {
             throw new \UnexpectedValueException('No encoder registered for the '.$format.' format');
@@ -131,7 +131,7 @@ class Serializer implements SerializerInterface
     /**
      * {@inheritdoc}
      */
-    public function decode($data, $format)
+    public final function decode($data, $format)
     {
         if (!isset($this->encoders[$format])) {
             throw new \UnexpectedValueException('No decoder registered for the '.$format.' format');

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -30,9 +30,8 @@ use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
  */
 class Serializer implements SerializerInterface
 {
-    private $normalizers = array();
-    private $encoders = array();
-    private $decoders = array();
+    protected $normalizers = array();
+    protected $encoders = array();
     protected $normalizerCache = array();
     protected $denormalizerCache = array();
 
@@ -112,19 +111,15 @@ class Serializer implements SerializerInterface
      */
     public function decode($data, $format)
     {
-        if (!isset($this->decoders[$format])) {
+        if (!isset($this->encoders[$format])) {
             throw new \UnexpectedValueException('No decoder registered for the '.$format.' format');
         }
 
-        return $this->decoders[$format]->decode($data, $format);
+        return $this->encoders[$format]->decode($data, $format);
     }
 
     /**
-     * Normalizes an object into a set of arrays/scalars
-     *
-     * @param object $object object to normalize
-     * @param string $format format name, present to give the option to normalizers to act differently based on formats
-     * @return array|scalar
+     * {@inheritdoc}
      */
     public function normalizeObject($object, $format = null)
     {
@@ -146,12 +141,7 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * Denormalizes data back into an object of the given class
-     *
-     * @param mixed $data data to restore
-     * @param string $class the expected class to instantiate
-     * @param string $format format name, present to give the option to normalizers to act differently based on formats
-     * @return object
+     * {@inheritdoc}
      */
     public function denormalizeObject($data, $class, $format = null)
     {
@@ -172,7 +162,7 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * @param NormalizerInterface $normalizer
+     * {@inheritdoc}
      */
     public function addNormalizer(NormalizerInterface $normalizer)
     {
@@ -183,15 +173,7 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * @return array[]NormalizerInterface
-     */
-    public function getNormalizers()
-    {
-        return $this->normalizers;
-    }
-
-    /**
-     * @param NormalizerInterface $normalizer
+     * {@inheritdoc}
      */
     public function removeNormalizer(NormalizerInterface $normalizer)
     {
@@ -199,8 +181,7 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * @param string           $format  format name
-     * @param EncoderInterface $encoder
+     * {@inheritdoc}
      */
     public function setEncoder($format, EncoderInterface $encoder)
     {
@@ -211,35 +192,7 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * @param string           $format  format name
-     * @param DecoderInterface $decoder
-     */
-    public function setDecoder($format, DecoderInterface $decoder)
-    {
-        $this->decoders[$format] = $decoder;
-        if ($decoder instanceof SerializerAwareInterface) {
-            $decoder->setSerializer($this);
-        }
-    }
-
-    /**
-     * @return array[]EncoderInterface
-     */
-    public function getEncoders()
-    {
-        return $this->encoders;
-    }
-
-    /**
-     * @return array[]DecoderInterface
-     */
-    public function getDecoders()
-    {
-        return $this->decoders;
-    }
-
-    /**
-     * @return EncoderInterface
+     * {@inheritdoc}
      */
     public function getEncoder($format)
     {
@@ -247,48 +200,26 @@ class Serializer implements SerializerInterface
     }
 
     /**
-     * @return DecoderInterface
-     */
-    public function getDecoder($format)
-    {
-        return $this->decoders[$format];
-    }
-
-    /**
-     * Checks whether the serializer has an encoder registered for the given format
-     *
-     * @param string $format format name
-     * @return Boolean
+     * {@inheritdoc}
      */
     public function hasEncoder($format)
     {
-        return isset($this->encoders[$format]);
+        return isset($this->encoder[$format]) && $this->encoder[$format] instanceof EncoderInterface;
     }
 
     /**
-     * Checks whether the serializer has a decoder registered for the given format
-     *
-     * @param string $format format name
-     * @return Boolean
+     * {@inheritdoc}
      */
     public function hasDecoder($format)
     {
-        return isset($this->decoders[$format]);
+        return isset($this->encoder[$format]) && $this->encoder[$format] instanceof DecoderInterface;
     }
 
     /**
-     * @param string $format format name
+     * {@inheritdoc}
      */
     public function removeEncoder($format)
     {
         unset($this->encoders[$format]);
-    }
-
-    /**
-     * @param string $format format name
-     */
-    public function removeDecoder($format)
-    {
-        unset($this->decoders[$format]);
     }
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -84,7 +84,7 @@ interface SerializerInterface
     function decode($data, $format);
 
     /**
-     * Checks whether the serializer can serialize the given format
+     * Checks whether the serializer can serialize to given format
      *
      * @param string $format format name
      * @return Boolean
@@ -92,12 +92,28 @@ interface SerializerInterface
     function supportsSerialization($format);
 
     /**
-     * Checks whether the serializer can deserialize the given format
+     * Checks whether the serializer can deserialize from given format
      *
      * @param string $format format name
      * @return Boolean
      */
     function supportsDeserialization($format);
+
+    /**
+     * Checks whether the serializer can encode to given format
+     *
+     * @param string $format format name
+     * @return Boolean
+     */
+    function supportsEncoding($format);
+
+    /**
+     * Checks whether the serializer can decode from given format
+     *
+     * @param string $format format name
+     * @return Boolean
+     */
+    function supportsDecoding($format);
 
     /**
      * @return EncoderInterface

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -84,46 +84,6 @@ interface SerializerInterface
     function decode($data, $format);
 
     /**
-     * Normalizes an object into a set of arrays/scalars
-     *
-     * @param object $object object to normalize
-     * @param string $format format name, present to give the option to normalizers to act differently based on formats
-     * @return array|scalar
-     */
-    function normalizeObject($object, $format = null);
-
-    /**
-     * Denormalizes data back into an object of the given class
-     *
-     * @param mixed $data data to restore
-     * @param string $class the expected class to instantiate
-     * @param string $format format name, present to give the option to normalizers to act differently based on formats
-     * @return object
-     */
-    function denormalizeObject($data, $class, $format = null);
-
-    /**
-     * @param NormalizerInterface $normalizer
-     */
-    function addNormalizer(NormalizerInterface $normalizer);
-
-    /**
-     * @param NormalizerInterface $normalizer
-     */
-    function removeNormalizer(NormalizerInterface $normalizer);
-
-    /**
-     * @param string           $format  format name
-     * @param EncoderInterface $encoder
-     */
-    function setEncoder($format, EncoderInterface $encoder);
-
-    /**
-     * @return EncoderInterface
-     */
-    function getEncoder($format);
-
-    /**
      * Checks whether the serializer can serialize the given format
      *
      * @param string $format format name
@@ -140,7 +100,28 @@ interface SerializerInterface
     function supportsDeserialization($format);
 
     /**
+     * @return EncoderInterface
+     */
+    function getEncoder($format);
+
+    /**
+     * @param string           $format  format name
+     * @param EncoderInterface $encoder
+     */
+    function setEncoder($format, EncoderInterface $encoder);
+
+    /**
      * @param string $format format name
      */
     function removeEncoder($format);
+
+    /**
+     * @param NormalizerInterface $normalizer
+     */
+    function addNormalizer(NormalizerInterface $normalizer);
+
+    /**
+     * @param NormalizerInterface $normalizer
+     */
+    function removeNormalizer(NormalizerInterface $normalizer);
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -39,6 +39,7 @@ interface SerializerInterface
      * @param mixed $data
      * @param string $type
      * @param string $format
+     * @api
      */
     function deserialize($data, $type, $format);
 
@@ -58,8 +59,8 @@ interface SerializerInterface
      * @param mixed $data
      * @param string $type
      * @param string $format
-     *
      * @return mixed
+     * @api
      */
     function denormalize($data, $type, $format = null);
 
@@ -88,6 +89,7 @@ interface SerializerInterface
      *
      * @param string $format format name
      * @return Boolean
+     * @api
      */
     function supportsSerialization($format);
 
@@ -96,6 +98,7 @@ interface SerializerInterface
      *
      * @param string $format format name
      * @return Boolean
+     * @api
      */
     function supportsDeserialization($format);
 
@@ -104,6 +107,7 @@ interface SerializerInterface
      *
      * @param string $format format name
      * @return Boolean
+     * @api
      */
     function supportsEncoding($format);
 
@@ -112,11 +116,15 @@ interface SerializerInterface
      *
      * @param string $format format name
      * @return Boolean
+     * @api
      */
     function supportsDecoding($format);
 
     /**
+     * Get the encoder for the given format
+     * 
      * @return EncoderInterface
+     * @api
      */
     function getEncoder($format);
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -103,25 +103,4 @@ interface SerializerInterface
      * @return EncoderInterface
      */
     function getEncoder($format);
-
-    /**
-     * @param string           $format  format name
-     * @param EncoderInterface $encoder
-     */
-    function setEncoder($format, EncoderInterface $encoder);
-
-    /**
-     * @param string $format format name
-     */
-    function removeEncoder($format);
-
-    /**
-     * @param NormalizerInterface $normalizer
-     */
-    function addNormalizer(NormalizerInterface $normalizer);
-
-    /**
-     * @param NormalizerInterface $normalizer
-     */
-    function removeNormalizer(NormalizerInterface $normalizer);
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -2,8 +2,10 @@
 
 namespace Symfony\Component\Serializer;
 
-use Symfony\Component\Serializer\Encoder\EncoderInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Encoder\EncoderInterface;
+use Symfony\Component\Serializer\Encoder\DecoderInterface;
+use Symfony\Component\Serializer\Encoder\NormalizationAwareInterface;
 
 /*
  * This file is part of the Symfony framework.
@@ -80,4 +82,65 @@ interface SerializerInterface
      * @api
      */
     function decode($data, $format);
+
+    /**
+     * Normalizes an object into a set of arrays/scalars
+     *
+     * @param object $object object to normalize
+     * @param string $format format name, present to give the option to normalizers to act differently based on formats
+     * @return array|scalar
+     */
+    function normalizeObject($object, $format = null);
+
+    /**
+     * Denormalizes data back into an object of the given class
+     *
+     * @param mixed $data data to restore
+     * @param string $class the expected class to instantiate
+     * @param string $format format name, present to give the option to normalizers to act differently based on formats
+     * @return object
+     */
+    function denormalizeObject($data, $class, $format = null);
+
+    /**
+     * @param NormalizerInterface $normalizer
+     */
+    function addNormalizer(NormalizerInterface $normalizer);
+
+    /**
+     * @param NormalizerInterface $normalizer
+     */
+    function removeNormalizer(NormalizerInterface $normalizer);
+
+    /**
+     * @param string           $format  format name
+     * @param EncoderInterface $encoder
+     */
+    function setEncoder($format, EncoderInterface $encoder);
+
+    /**
+     * @return EncoderInterface
+     */
+    function getEncoder($format);
+
+    /**
+     * Checks whether the serializer has an encoder registered for the given format
+     *
+     * @param string $format format name
+     * @return Boolean
+     */
+    function hasEncoder($format);
+
+    /**
+     * Checks whether the serializer has a decoder registered for the given format
+     *
+     * @param string $format format name
+     * @return Boolean
+     */
+    function hasDecoder($format);
+
+    /**
+     * @param string $format format name
+     */
+    function removeEncoder($format);
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -124,20 +124,20 @@ interface SerializerInterface
     function getEncoder($format);
 
     /**
-     * Checks whether the serializer has an encoder registered for the given format
+     * Checks whether the serializer can serialize the given format
      *
      * @param string $format format name
      * @return Boolean
      */
-    function hasEncoder($format);
+    function supportsSerialization($format);
 
     /**
-     * Checks whether the serializer has a decoder registered for the given format
+     * Checks whether the serializer can deserialize the given format
      *
      * @param string $format format name
      * @return Boolean
      */
-    function hasDecoder($format);
+    function supportsDeserialization($format);
 
     /**
      * @param string $format format name

--- a/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/Encoder/XmlEncoderTest.php
@@ -24,10 +24,9 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $serializer = new Serializer;
         $this->encoder = new XmlEncoder;
-        $serializer->setEncoder('xml', $this->encoder);
-        $serializer->addNormalizer(new CustomNormalizer);
+        $serializer = new Serializer(array(new CustomNormalizer), array('xml' => new XmlEncoder()));
+        $this->encoder->setSerializer($serializer);
     }
 
     public function testEncodeScalar()

--- a/tests/Symfony/Tests/Component/Serializer/SerializerTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/SerializerTest.php
@@ -17,39 +17,34 @@ use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
 class SerializerTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    public function testNormalizeNoMatch()
     {
-        $this->serializer = new Serializer();
+        $this->serializer = new Serializer(array($this->getMock('Symfony\Component\Serializer\Normalizer\CustomNormalizer')));
+        $this->serializer->normalize(new \stdClass, 'xml');
     }
 
     /**
      * @expectedException \UnexpectedValueException
      */
-    public function testNormalizeObjectNoMatch()
+    public function testDenormalizeNoMatch()
     {
-        $this->serializer->addNormalizer($this->getMock('Symfony\Component\Serializer\Normalizer\CustomNormalizer'));
-        $this->serializer->normalizeObject(new \stdClass, 'xml');
-    }
-
-    /**
-     * @expectedException \UnexpectedValueException
-     */
-    public function testDenormalizeObjectNoMatch()
-    {
-        $this->serializer->addNormalizer($this->getMock('Symfony\Component\Serializer\Normalizer\CustomNormalizer'));
-        $this->serializer->denormalizeObject('foo', 'stdClass');
+        $this->serializer = new Serializer(array($this->getMock('Symfony\Component\Serializer\Normalizer\CustomNormalizer')));
+        $this->serializer->denormalize('foo', 'stdClass');
     }
 
     public function testSerializeScalar()
     {
-        $this->serializer->setEncoder('json', new JsonEncoder());
+        $this->serializer = new Serializer(array(), array('json' => new JsonEncoder()));
         $result = $this->serializer->serialize('foo', 'json');
         $this->assertEquals('"foo"', $result);
     }
 
     public function testSerializeArrayOfScalars()
     {
-        $this->serializer->setEncoder('json', new JsonEncoder());
+        $this->serializer = new Serializer(array(), array('json' => new JsonEncoder()));
         $data = array('foo', array(5, 3));
         $result = $this->serializer->serialize($data, 'json');
         $this->assertEquals(json_encode($data), $result);
@@ -57,7 +52,7 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
     public function testEncode()
     {
-        $this->serializer->setEncoder('json', new JsonEncoder());
+        $this->serializer = new Serializer(array(), array('json' => new JsonEncoder()));
         $data = array('foo', array(5, 3));
         $result = $this->serializer->encode($data, 'json');
         $this->assertEquals(json_encode($data), $result);
@@ -65,18 +60,9 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
 
     public function testDecode()
     {
-        $this->serializer->setDecoder('json', new JsonEncoder());
+        $this->serializer = new Serializer(array(), array('json' => new JsonEncoder()));
         $data = array('foo', array(5, 3));
         $result = $this->serializer->decode(json_encode($data), 'json');
         $this->assertEquals($data, $result);
-    }
-
-    /**
-     * @expectedException \UnexpectedValueException
-     */
-    public function testNormalizeNoMatchObject()
-    {
-        $this->serializer->addNormalizer($this->getMock('Symfony\Component\Serializer\Normalizer\CustomNormalizer'));
-        $this->serializer->normalizeObject(new \stdClass, 'xml');
     }
 }


### PR DESCRIPTION
@fabpot: ignore for now :)

@schmittjoh: FFS! You don't even implement a separate encoder/decoder map in your SerializerBundle. Of course in your fork of the component your EncoderInterface still also has a decode() method, meaning in your own Bundle its impossible to tell from the outside if an Encoder supports encoding and/or decoding. We split out the DecoderInterface because there is a real world use case for being able to efficiently check of decoding is supported. I do not see a real world use case for the other way around that has any significant impact. So please, lets revert this API explosion.

For the other changes, the main thing I need is a way to check if a decoder is registered via hasDecoder() as well as check if TemplatingAwareInterface is implemented by an encoder via getEncoder(). The others I am exposing for completeness so that the Serializer component can be easily configured at runtime.
