### PR TITLE
[DependencyInjection] Fixed bug where anonymous services could collide

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -44,19 +44,19 @@ class XmlFileLoader extends FileLoader
         $this->container->addResource(new FileResource($path));
 
         // anonymous services
-        $xml = $this->processAnonymousServices($xml, $file);
+        $xml = $this->processAnonymousServices($xml, $path);
 
         // imports
-        $this->parseImports($xml, $file);
+        $this->parseImports($xml, $path);
 
         // parameters
-        $this->parseParameters($xml, $file);
+        $this->parseParameters($xml, $path);
 
         // extensions
         $this->loadFromExtensions($xml);
 
         // services
-        $this->parseDefinitions($xml, $file);
+        $this->parseDefinitions($xml, $path);
     }
 
     /**

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/extension1/services.xml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/extension1/services.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="extension1.foo" class="FooClass1">
+      <argument type="service">
+        <service class="BarClass1">
+        </service>
+      </argument>
+    </service>
+  </services>
+</container>

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/extension2/services.xml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/xml/extension2/services.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <services>
+    <service id="extension2.foo" class="FooClass2">
+      <argument type="service">
+        <service class="BarClass2">
+        </service>
+      </argument>
+    </service>
+  </services>
+</container>

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
@@ -288,4 +288,26 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($loader->supports('foo.xml'), '->supports() returns true if the resource is loadable');
         $this->assertFalse($loader->supports('foo.foo'), '->supports() returns true if the resource is loadable');
     }
+
+    public function testNoNamingConflictsForAnonymousServices()
+    {
+        $container = new ContainerBuilder();
+
+        $loader1 = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml/extension1'));
+        $loader1->load('services.xml');
+        $services = $container->getDefinitions();
+        $this->assertEquals(2, count($services), '->load() attributes unique ids to anonymous services');        
+        $loader2 = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml/extension2'));
+        $loader2->load('services.xml');
+        $services = $container->getDefinitions();
+        $this->assertEquals(4, count($services), '->load() attributes unique ids to anonymous services');
+
+        $services = $container->getDefinitions();
+        $args1 = $services['extension1.foo']->getArguments();
+        $inner1 = $services[(string) $args1[0]];
+        $this->assertEquals('BarClass1', $inner1->getClass(), '->load() uses the same configuration as for the anonymous ones');
+        $args2 = $services['extension2.foo']->getArguments();
+        $inner2 = $services[(string) $args2[0]];
+        $this->assertEquals('BarClass2', $inner2->getClass(), '->load() uses the same configuration as for the anonymous ones');
+    }
 }


### PR DESCRIPTION
I found that if two bundles both have a Resources/config/services.xml-file that they both try to load via a container extension, the anonymous services in these files could be assigned the same id's.

This PR highlights the problem with a test, and fixes it by calculating id's for anonymous services by hashing the full path to the file, not just the file path passed to the FileLocator.
