### PR TITLE
[HttpFoundation] merge Response::isRedirected() with Response::isRedirect

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -79,8 +79,7 @@ class RedirectControllerTest extends TestCase
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
 
-        $this->assertTrue($returnResponse->isRedirect());
-        $this->assertTrue($returnResponse->isRedirected($url));
+        $this->assertTrue($returnResponse->isRedirect($url));
         $this->assertEquals($expectedCode, $returnResponse->getStatusCode());
     }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -729,19 +729,14 @@ class Response
         return 404 === $this->statusCode;
     }
 
-    public function isRedirect()
+    public function isRedirect($location = null)
     {
-        return in_array($this->statusCode, array(201, 301, 302, 303, 307));
+        return in_array($this->statusCode, array(201, 301, 302, 303, 307)) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 
     public function isEmpty()
     {
         return in_array($this->statusCode, array(201, 204, 304));
-    }
-
-    public function isRedirected($location)
-    {
-        return $this->isRedirect() && $location == $this->headers->get('Location');
     }
 
     protected function fixContentType()

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -340,6 +340,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = new Response('', 404);
         $this->assertFalse($response->isRedirection());
         $this->assertFalse($response->isRedirect());
+
+        $response = new Response('', 301, array('Location' => '/good-uri'));
+        $this->assertFalse($response->isRedirect('/bad-uri'));
+        $this->assertTrue($response->isRedirect('/good-uri'));
     }
 
     public function testIsNotFound()


### PR DESCRIPTION
<code>Response::isRedirect()</code> and <code>Response::isRedirected()</code> seems confusing
