### PR TITLE
[Routing] Fixing a bug where the current directory was set too late in th

### DIFF
--- a/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
@@ -35,9 +35,9 @@ class PhpFileLoader extends FileLoader
         $loader = $this;
 
         $path = $this->locator->locate($file);
+        $this->setCurrentDir(dirname($path));
 
         $collection = include $path;
-        $this->setCurrentDir(dirname($path));
         $collection->addResource(new FileResource($path));
 
         return $collection;


### PR DESCRIPTION
Hey guys-

Basically, if you loaded routing with PHP and tried to import a resource from the same dir (e.g. `$collection->addCollection($loader->import("routing_dev.yml"));`), it wouldn't work because the current directory was not yet set.

Thanks!
