### PR TITLE
[FrameworkBundle] Adding two form-related methods to the base controller

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Form\FormTypeInterface;
 
 /**
  * Controller is a simple implementation of a Controller.
@@ -105,6 +106,33 @@ class Controller extends ContainerAware
     public function createNotFoundException($message = 'Not Found', \Exception $previous = null)
     {
         return new NotFoundHttpException($message, $previous);
+    }
+
+    /**
+     * Creates and returns a Form instance from the form type object
+     *
+     * @param FormTypeInterface $type   The built form type object
+     * @param mixed $data               The initial data for the form
+     * @param array $options            Options for the form
+     *
+     * @return Symfony\Component\Form\Form
+     */
+    public function createForm(FormTypeInterface $type, $data = null, array $options = array())
+    {
+        return $this->get('form.factory')->create($type, $data, $options);
+    }
+
+    /**
+     * Creates and returns a form builder instance
+     *
+     * @param mixed $data               The initial data for the form
+     * @param array $options            Options for the form
+     *
+     * @return Symfony\Component\Form\FormBuilder
+     */
+    public function createFormBuilder($data = null, array $options = array())
+    {
+        return $this->get('form.factory')->createBuilder('form', $data, $options);
     }
 
     /**


### PR DESCRIPTION
Hey guys-

Two new additions to the base controller related to forms. I think this makes things more rapid and less difficult for beginners.

Before:

```
$form = $this->get('form.factory')
    ->createBuilder('form', $product)
    ->add('name', 'text')
    ->getForm();
```

After:

```
$form = createFormBuilder($product)
    ->add('name', 'text')
    ->getForm();
```

And for built form type classes, before:

```
$form = $this->get('form.factory')->create(new ProductType(), $product);
```

After:

```
$form = $this->createForm(new ProductType(), $product);
```

Upon acceptance of this PR, I'll update the docs to reflect these changes.

Thanks!
