### PR TITLE
[Form] Fixed single expanded choice type with boolean data

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ScalarToBooleanChoicesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ScalarToBooleanChoicesTransformer.php
@@ -51,6 +51,10 @@ class ScalarToBooleanChoicesTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($value, 'scalar');
         }
 
+        if (is_bool($value) || null === $value) {
+            $value = (int)$value;
+        }
+
         try {
             $choices = $this->choiceList->getChoices();
         } catch (\Exception $e) {
@@ -58,7 +62,7 @@ class ScalarToBooleanChoicesTransformer implements DataTransformerInterface
         }
 
         foreach (array_keys($choices) as $key) {
-            $choices[$key] = $key === $value;
+            $choices[$key] = (string)$key === (string)$value;
         }
 
         return $choices;

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -27,7 +27,7 @@ class FixRadioInputListener implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        $event->setData(empty($data) ? array() : array($data => true));
+        $event->setData(strlen($data) < 1 ? array() : array($data => true));
     }
 
     public static function getSubscribedEvents()

--- a/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
@@ -479,6 +479,28 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testSingleChoiceExpandedWithBooleanValue()
+    {
+        $form = $this->factory->createNamed('choice', 'na&me', true, array(
+            'property_path' => 'name',
+            'choices' => array('1' => 'Choice&A', '0' => 'Choice&B'),
+            'multiple' => false,
+            'expanded' => true,
+        ));
+
+        $this->assertWidgetMatchesXpath($form->createView(), array(),
+'/div
+    [
+        ./input[@type="radio"][@name="na&me"][@id="na&me_1"][@checked]
+        /following-sibling::label[@for="na&me_1"][.="[trans]Choice&A[/trans]"]
+        /following-sibling::input[@type="radio"][@name="na&me"][@id="na&me_0"][not(@checked)]
+        /following-sibling::label[@for="na&me_0"][.="[trans]Choice&B[/trans]"]
+    ]
+    [count(./input)=2]
+'
+        );
+    }
+
     public function testMultipleChoiceExpanded()
     {
         $form = $this->factory->createNamed('choice', 'na&me', array('&a', '&c'), array(

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/FixRadioInputListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/FixRadioInputListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Form\Extension\Core\EventListener;
+
+use Symfony\Component\Form\Event\FilterDataEvent;
+use Symfony\Component\Form\Extension\Core\EventListener\FixRadioInputListener;
+
+class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFixRadio()
+    {
+        $data = '1';
+        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $event = new FilterDataEvent($form, $data);
+
+        $filter = new FixRadioInputListener();
+        $filter->onBindClientData($event);
+
+        $this->assertEquals(array('1' => true), $event->getData());
+    }
+
+    public function testFixZero()
+    {
+        $data = '0';
+        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $event = new FilterDataEvent($form, $data);
+
+        $filter = new FixRadioInputListener();
+        $filter->onBindClientData($event);
+
+        $this->assertEquals(array('0' => true), $event->getData());
+    }
+
+    public function testIgnoreEmptyString()
+    {
+        $data = '';
+        $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+        $event = new FilterDataEvent($form, $data);
+
+        $filter = new FixRadioInputListener();
+        $filter->onBindClientData($event);
+
+        $this->assertEquals(array(), $event->getData());
+    }
+}


### PR DESCRIPTION
Currently, the `ScalarToBooleanChoicesTransformer::transform()` always compare choices and value identically. But the following case, PHP cast boolean keys to integer automatically. 

```
$builder->add('enabled', 'choice', array(
    'multiple' => false,
    'expanded' => true,
    'choices'  => array(true => 'ON', false => 'OFF'),  // casted: array(1 => 'ON', 0 => 'OFF'),
))
```

Therefore, when passed boolean data to there, the transformer always evaluate the all choices not checked.
This commit fixed that problem.
