### PR TITLE
[FrameworkBundle] modified help text for init:bundle command to suggest p

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/InitBundleCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/InitBundleCommand.php
@@ -84,8 +84,8 @@ EOT
         // validate that the namespace is at least one level deep
         if (false === strpos($namespace, '\\')) {
             $msg = array();
-            $msg[] = sprintf('The namespace must contain a vendor namespace (e.g. "VendorName\%s" instead of simply "%s").', $namespace, $namespace);
-            $msg[] = 'If you\'ve specified a vendor namespace, did you forget to surround it with quotes (init:bundle "Acme\BlogBundle")?';
+            $msg[] = sprintf('The namespace must contain a vendor namespace (e.g. "VendorName/%s" instead of simply "%s").', $namespace, $namespace);
+            $msg[] = 'If you\'ve specified a vendor namespace, did you forget to surround it with quotes (init:bundle "Acme/BlogBundle")?';
 
             throw new \InvalidArgumentException(implode("\n\n", $msg));
         }


### PR DESCRIPTION
[FrameworkBundle] modified help text for init:bundle command to suggest preferred syntax of forward slash for separator between vendor name and bundle.

Following on from [discussion](http://groups.google.com/group/symfony-devs/browse_thread/thread/7b2608c3bf82370e) on symfony-devs mailing list, this changes the help text to suggest use of a forward slash between vendor name and bundle (i.e. VendorName/FooBundle, rather than VendorName\FooBundle), as this should work in all contexts and is preferred syntax.
