### PR TITLE
[2.1] Support for New Monolog Insight (FirePHP 1.0) Handler

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/DebugHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/DebugHandler.php
@@ -28,6 +28,9 @@ class DebugHandler extends TestHandler implements DebugLoggerInterface
     public function getLogs()
     {
         $records = array();
+        if (!$this->records) {
+            return $records;
+        }
         foreach ($this->records as $record) {
             $records[] = array(
                 'timestamp' => $record['datetime']->getTimestamp(),

--- a/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/RequestListener.php
@@ -103,7 +103,18 @@ class RequestListener
             $parameters = $this->router->match($request->getPathInfo());
 
             if (null !== $this->logger) {
-                $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
+                if (true === constant('FIREPHP_ACTIVATED')) {
+                    \FirePHP::to('request')
+                            ->console('Request')
+                            ->on('Request')
+                            ->label('Matched route')
+                            ->expand()
+                            ->group('request-route', sprintf('%s', $parameters['_route']))
+                            ->label('Parameters')
+                            ->log($parameters);
+                } else {
+                    $this->logger->info(sprintf('Matched route "%s" (parameters: %s)', $parameters['_route'], $this->parametersToString($parameters)));
+                }
             }
 
             $request->attributes->add($parameters);

--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/MonologExtension.php
@@ -128,6 +128,13 @@ class MonologExtension extends Extension
             $definition->addTag('kernel.listener', array('event' => 'onCoreResponse'));
             break;
 
+        case 'insight':
+            $definition->setArguments(array(
+                $handler['level'],
+                $handler['bubble'],
+            ));
+            break;
+
         case 'rotating_file':
             $definition->setArguments(array(
                 $handler['path'],

--- a/src/Symfony/Bundle/MonologBundle/Resources/config/monolog.xml
+++ b/src/Symfony/Bundle/MonologBundle/Resources/config/monolog.xml
@@ -15,6 +15,7 @@
         <parameter key="monolog.handler.null.class">Monolog\Handler\NullHandler</parameter>
         <parameter key="monolog.handler.test.class">Monolog\Handler\TestHandler</parameter>
         <parameter key="monolog.handler.firephp.class">Symfony\Bridge\Monolog\Handler\FirePHPHandler</parameter>
+        <parameter key="monolog.handler.insight.class">Monolog\Handler\InsightHandler</parameter>
         <parameter key="monolog.handler.debug.class">Symfony\Bridge\Monolog\Handler\DebugHandler</parameter>
         <parameter key="monolog.handler.swift_mailer.class">Monolog\Handler\SwiftMailerHandler</parameter>
         <parameter key="monolog.handler.native_mailer.class">Monolog\Handler\NativeMailerHandler</parameter>

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -71,7 +71,16 @@ class ControllerResolver implements ControllerResolverInterface
         }
 
         if (null !== $this->logger) {
-            $this->logger->info(sprintf('Using controller "%s::%s"', get_class($controller), $method));
+            if (true === constant('FIREPHP_ACTIVATED')) {
+                \FirePHP::to('request')
+                        ->console('Request')
+                        ->on('Request')
+                        ->group('request-route')
+                        ->label('Using controller')
+                        ->log(sprintf('%s::%s', get_class($controller), $method));
+            } else {
+               $this->logger->info(sprintf('Using controller "%s::%s"', get_class($controller), $method));
+            }
         }
 
         return array($controller, $method);


### PR DESCRIPTION
This patch adds support for the new Insight handler for monolog. See: https://github.com/Seldaek/monolog/pull/30

The new `Monolog_Handler_InsightHandler` handler effectively replaces the `Monolog_Handler_FirePHPHandler` handler to log to [FirePHP 1.0](http://reference.developercompanion.com/#/Tools/FirePHPCompanion/Introduction/).

FirePHP 1.0 boasts a new logging API called [Insight](http://reference.developercompanion.com/#/Tools/FirePHPCompanion/API/). I have added a few examples that provide more info than the basic string logging in the patch. These messages can be enabled by:

```
config/config_dev.yml ~ {
  monolog:
      handlers:
          insight:
              type:  insight
              level: info
}
web/app_dev.php ~ {
  // top of file
  define('INSIGHT_IPS', '*');    // <-- CHANGE THIS
  define('INSIGHT_AUTHKEYS', '*');    // <-- CHANGE THIS
  define('INSIGHT_PATHS', dirname(__DIR__));
  define('INSIGHT_SERVER_PATH', '/web/app_dev.php/');
  require_once('FirePHP/Init.php');
  // rest of code
}
```

When inspecting a request with [DeveloperCompanion](http://developercompanion.com/) you can enable/disable logging messages and view them like this:

[http://screencast.com/t/GohZSWOUv](http://screencast.com/t/GohZSWOUv)

Notes:
- The handler should **not** use Symfony's cookie handling code as FirePHP is designed to _wrap_ a framework and then allow the framework to call into FirePHP when processing a request. This allows FirePHP to inspect and troubleshoot the cookie handling code of the framework.
- Logging calls should not use `\FirePHP::to("request")` but rather `Monolog_Handler_InsightHandler::getContext("request")`. Need to check if insight logging is enabled and then load handler class.
- The code currently always logs to the _request_ context (which requires the paid DeveloperCompanion). There should be a config option to log to the _page_ context instead (so messages show up in the firebug console).
- There should be config options to control the `->on()` logging conditions from the server.
- The insight logging calls in the code may become too verbose. They could be abstracted by annotations, code comments or a specialized API for symfony.

I realize that this patch will need some discussion and am hoping to get some feedback and expressions of interest to get this into symfony. Let me know where next steps should best be discussed.

FYI, Monolog is the first logging library to add support for FirePHP 1.0 and I hope that symfony will become the first framework to use it. With some discussion I think we can devise an amazing development workflow for symfony developers and this feedback will influence how FirePHP, the Insight API and DeveloperCompanion evolve.

Looking forward to feedback.

Thanks!
Christoph
