### PR TITLE
[Form] Added missing feature for adding attributes to an field label

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -151,10 +151,15 @@ class FormExtension extends \Twig_Extension
      *
      * @param FormView $view  The view to render the label for
      * @param string   $label Label name
+     * @param array    $variables Additional variables passed to the template
      */
-    public function renderLabel(FormView $view, $label = null)
+    public function renderLabel(FormView $view, $label = null, array $variables = array())
     {
-        return $this->render($view, 'label', null === $label ? array() : array('label' => $label));
+        if ($label !== null) {
+            $variables += array('label' => $label);
+        }
+
+        return $this->render($view, 'label', $variables);
     }
 
     protected function render(FormView $view, $section, array $variables = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_label.html.php
@@ -1,1 +1,1 @@
-<label for="<?php echo $view->escape($id) ?>"><?php echo $view->escape($view['translator']->trans($label)) ?></label>
+<label for="<?php echo $view->escape($id) ?>" <?php echo $view['form']->attributes() ?>><?php echo $view->escape($view['translator']->trans($label)) ?></label>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -86,9 +86,13 @@ class FormHelper extends Helper
         return $this->renderSection($view, 'row', $variables);
     }
 
-    public function label(FormView $view, $label = null)
+    public function label(FormView $view, $label = null, array $variables = array())
     {
-        return $this->renderSection($view, 'label', null === $label ? array() : array('label' => $label));
+        if ($label !== null) {
+            $variables += array('label' => $label);
+        }
+
+        return $this->renderSection($view, 'label', $variables);
     }
 
     public function errors(FormView $view)

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTest.php
@@ -51,9 +51,9 @@ class FormHelperTest extends AbstractDivLayoutTest
         return (string)$this->helper->enctype($view);
     }
 
-    protected function renderLabel(FormView $view, $label = null)
+    protected function renderLabel(FormView $view, $label = null, array $vars = array())
     {
-        return (string)$this->helper->label($view, $label);
+        return (string)$this->helper->label($view, $label, $vars);
     }
 
     protected function renderErrors(FormView $view)
@@ -75,5 +75,4 @@ class FormHelperTest extends AbstractDivLayoutTest
     {
         return (string)$this->helper->rest($view, $vars);
     }
-
 }

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -37,7 +37,7 @@
 
 {% block field_label %}
 {% spaceless %}
-    <label for="{{ id }}">{{ label|trans }}</label>
+    <label for="{{ id }}"{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
 {% endspaceless %}
 {% endblock field_label %}
 

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
@@ -53,9 +53,9 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
         return (string)$this->extension->renderEnctype($view);
     }
 
-    protected function renderLabel(FormView $view, $label = null)
+    protected function renderLabel(FormView $view, $label = null, array $vars = array())
     {
-        return (string)$this->extension->renderLabel($view, $label);
+        return (string)$this->extension->renderLabel($view, $label, $vars);
     }
 
     protected function renderErrors(FormView $view)

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionTableLayoutTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionTableLayoutTest.php
@@ -53,9 +53,9 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
         return (string)$this->extension->renderEnctype($view);
     }
 
-    protected function renderLabel(FormView $view, $label = null)
+    protected function renderLabel(FormView $view, $label = null, array $vars = array())
     {
-        return (string)$this->extension->renderLabel($view, $label);
+        return (string)$this->extension->renderLabel($view, $label, $vars);
     }
 
     protected function renderErrors(FormView $view)

--- a/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
@@ -93,7 +93,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
     abstract protected function renderEnctype(FormView $view);
 
-    abstract protected function renderLabel(FormView $view, $label = null);
+    abstract protected function renderLabel(FormView $view, $label = null, array $vars = array());
 
     abstract protected function renderErrors(FormView $view);
 
@@ -166,6 +166,61 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
         $this->assertMatchesXpath($html,
 '/label
     [@for="na&me"]
+    [.="[trans]Custom label[/trans]"]
+'
+        );
+    }
+
+    public function testLabelWithCustomTextPassedAsOptionAndDirectly()
+    {
+        $form = $this->factory->createNamed('text', 'na&me', null, array(
+            'property_path' => 'name',
+            'label' => 'Custom label',
+        ));
+        $html = $this->renderLabel($form->createView(), 'Overridden label');
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="na&me"]
+    [.="[trans]Overridden label[/trans]"]
+'
+        );
+    }
+
+    public function testLabelWithCustomOptionsPassedDirectly()
+    {
+        $form = $this->factory->createNamed('text', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
+        $html = $this->renderLabel($form->createView(), null, array(
+            'attr' => array(
+                'class' => 'my&class'
+            ),
+        ));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="na&me"]
+    [@class="my&class"]
+'
+        );
+    }
+
+    public function testLabelWithCustomTextAndCustomOptionsPassedDirectly()
+    {
+        $form = $this->factory->createNamed('text', 'na&me', null, array(
+            'property_path' => 'name',
+        ));
+        $html = $this->renderLabel($form->createView(), 'Custom label', array(
+            'attr' => array(
+                'class' => 'my&class'
+            ),
+        ));
+
+        $this->assertMatchesXpath($html,
+'/label
+    [@for="na&me"]
+    [@class="my&class"]
     [.="[trans]Custom label[/trans]"]
 '
         );


### PR DESCRIPTION
With this PR we can setup i.e.:

``` html+jinja
{{ form_label(form.field_name, null, { 'attr': { 'class': 'input_label' } } ) }}
```

Result:

``` html
<label for="field_name" class="input_label">Field name</label>
```
