### PR TITLE
[AsseticBundle] added support for parameter replacement in asset inputs

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/AssetFactory.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\AsseticBundle\Factory;
 
 use Assetic\Factory\AssetFactory as BaseAssetFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -24,31 +25,36 @@ class AssetFactory extends BaseAssetFactory
 {
     private $kernel;
     private $container;
+    private $parameterBag;
 
     /**
      * Constructor.
      *
-     * @param KernelInterface    $kernel    The kernel is used to parse bundle notation
-     * @param ContainerInterface $container The container is used to load the managers lazily, thus avoiding a circular dependency
-     * @param string             $baseDir   The base directory for relative inputs
-     * @param Boolean            $debug     The current debug mode
+     * @param KernelInterface       $kernel       The kernel is used to parse bundle notation
+     * @param ContainerInterface    $container    The container is used to load the managers lazily, thus avoiding a circular dependency
+     * @param ParameterBagInterface $parameterBag The container parameter bag
+     * @param string                $baseDir      The base directory for relative inputs
+     * @param Boolean               $debug        The current debug mode
      */
-    public function __construct(KernelInterface $kernel, ContainerInterface $container, $baseDir, $debug = false)
+    public function __construct(KernelInterface $kernel, ContainerInterface $container, ParameterBagInterface $parameterBag, $baseDir, $debug = false)
     {
         $this->kernel = $kernel;
         $this->container = $container;
+        $this->parameterBag = $parameterBag;
 
         parent::__construct($baseDir, $debug);
     }
 
     /**
-     * Adds support for bundle notation file and glob assets.
+     * Adds support for bundle notation file and glob assets and parameter placeholders.
      *
      * FIXME: This is a naive implementation of globs in that it doesn't
      * attempt to support bundle inheritance within the glob pattern itself.
      */
     protected function parseInput($input, array $options = array())
     {
+        $input = $this->parameterBag->resolveValue($input);
+
         // expand bundle notation
         if ('@' == $input[0] && false !== strpos($input, '/')) {
             // use the bundle path as this asset's root

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -35,6 +35,7 @@
         <service id="assetic.asset_factory" class="%assetic.asset_factory.class%" public="false">
             <argument type="service" id="kernel" />
             <argument type="service" id="service_container" />
+            <argument type="service" id="assetic.parameter_bag" />
             <argument>%assetic.read_from%</argument>
             <argument>%assetic.debug%</argument>
         </service>
@@ -60,5 +61,11 @@
             <argument /> <!-- pattern -->
             <argument /> <!-- filter -->
         </service>
+
+        <service id="assetic.parameter_bag" class="Symfony\Component\DependencyInjection\ParameterBag\ParameterBag" public="false">
+            <argument type="service" id="assetic.parameters" />
+        </service>
+
+        <service id="assetic.parameters" class="stdClass" factory-service="service_container" factory-method="getDefaultParameters" public="false" />
     </services>
 </container>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/AssetFactoryTest.php
@@ -27,7 +27,8 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
 
         $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
         $this->container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
-        $this->factory = new AssetFactory($this->kernel, $this->container, '/path/to/web');
+        $this->parameterBag = $this->getMock('Symfony\\Component\\DependencyInjection\\ParameterBag\\ParameterBagInterface');
+        $this->factory = new AssetFactory($this->kernel, $this->container, $this->parameterBag, '/path/to/web');
     }
 
     public function testBundleNotation()
@@ -35,6 +36,9 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
         $input = '@MyBundle/Resources/css/main.css';
         $bundle = $this->getMock('Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface');
 
+        $this->parameterBag->expects($this->once())
+            ->method('resolveValue')
+            ->will($this->returnCallback(function($v) { return $v; }));
         $this->kernel->expects($this->once())
             ->method('getBundle')
             ->with('MyBundle')
@@ -61,6 +65,9 @@ class AssetFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $bundle = $this->getMock('Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface');
 
+        $this->parameterBag->expects($this->once())
+            ->method('resolveValue')
+            ->will($this->returnCallback(function($v) { return $v; }));
         $this->kernel->expects($this->once())
             ->method('getBundle')
             ->with('MyBundle')


### PR DESCRIPTION
For example:

```
{% javascripts '%kernel.root_dir%/Resources/css/main.css' %}
...
{% endjavascripts %}
```
