### PR TITLE
[AsseticBundle] Add the missing cssmin filter service's schema 

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/cssmin.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/filters/cssmin.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="assetic.filter.cssmin.class">Assetic\Filter\CssMinFilter</parameter>
+    </parameters>
+
+    <services>
+        <service id="assetic.filter.cssmin" class="%assetic.filter.cssmin.class%">
+            <tag name="assetic.filter" alias="cssmin" />
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
I have add and tested cssmin.xml for :

```
filters:
    cssmin: ~
```
