### PR TITLE
Reverse DateTimeToStringTransformer must use format

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -95,10 +95,11 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
 
         try {
             $dateTime = \DateTime::createFromFormat($this->format, $value, new \DateTimeZone($this->outputTimezone));
-            $last_errors = \DateTime::getLastErrors();
-            if($last_errors['warning_count'] > 0 || $last_errors['error_count'] > 0){
-                throw new \Exception('Date is invalid.');
-            }
+            $errors = \DateTime::getLastErrors();
+            if ($errors['warning_count'] > 0 || $errors['error_count'] > 0) {
+                throw new \Exception('Date is invalid. List of warnings: "' . implode(', "',array_values($errors['warnings'])) . '" ' .
+                        'List of errors: "' . implode(', "',array_values($errors['errors'])) . '"');
+            }       
 
             if ($this->inputTimezone !== $this->outputTimezone) {
                 $dateTime->setTimeZone(new \DateTimeZone($this->inputTimezone));

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -94,7 +94,11 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
         }
 
         try {
-            $dateTime = new \DateTime(sprintf("%s %s", $value, $this->outputTimezone));
+            $dateTime = \DateTime::createFromFormat($this->format, $value, new \DateTimeZone($this->outputTimezone));
+            $last_errors = \DateTime::getLastErrors();
+            if($last_errors['warning_count'] > 0 || $last_errors['error_count'] > 0){
+                throw new \Exception('Date is invalid.');
+            }
 
             if ($this->inputTimezone !== $this->outputTimezone) {
                 $dateTime->setTimeZone(new \DateTimeZone($this->inputTimezone));

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -55,6 +55,18 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
 
         $transformer->transform('1234');
     }
+	
+	public function testTransformOtherFormat()
+    {
+        $transformer = new DateTimeToStringTransformer('UTC', 'UTC', 'd/m/Y H:i:s');
+
+        $input = new \DateTime('2010-02-03 04:05:06 UTC');
+        $output = clone $input;
+        $output->setTimezone(new \DateTimeZone('UTC'));
+        $output = $output->format('d/m/Y H:i:s');
+
+        $this->assertEquals($output, $transformer->transform($input));
+    }
 
     public function testReverseTransform()
     {
@@ -100,5 +112,15 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $this->setExpectedException('Symfony\Component\Form\Exception\TransformationFailedException');
 
         $reverseTransformer->reverseTransform('2010-2010-2010', null);
+    }
+	
+	public function testReverseTransformOtherFormat()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer('UTC', 'UTC', 'd/m/Y H:i:s');
+
+        $output = new \DateTime('2010-02-03 04:05:06 UTC');
+        $input = '03/02/2010 04:05:06';
+
+        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -123,4 +123,13 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
 
         $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
+	
+	public function testReverseTransformExpectsDateExists()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer('UTC', 'UTC', 'Y-m-d H:i:s');
+
+        $this->setExpectedException('Symfony\Component\Form\Exception\TransformationFailedException');
+
+        $reverseTransformer->reverseTransform('2011-02-29 04:05:06', null);
+    }
 }


### PR DESCRIPTION
Continuation of pull request https://github.com/symfony/symfony/pull/1134 (I am sorry, the old pull request has been deleted because I deleted one commit which was in a bad branch).

Summary:
Before: In DateTimeToStringTransformer, transform function uses "format" but not "reverseTransform".
If the format is different than "Y-m-d", reverseTransform throws TransformationFailedException.

Now: "reverse" function uses "format". I added "\DateTime::getLastErrors()" because DateTime::createFromFormat doesn't throw exception.
Now, if a bad date (2011-02-29) is given, it is refused.

I added additional tests.
