### PR TITLE
Issue with MonthChoiceList.php on the 1st of every month

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
@@ -46,7 +46,7 @@ class MonthChoiceList extends PaddedChoiceList
 
             foreach ($this->choices as $choice => $value) {
                 // It's important to specify the first day of the month here!
-                $this->choices[$choice] = $this->formatter->format(gmmktime(0, 0, 0, $value, 1));
+                $this->choices[$choice] = $this->formatter->format(mktime(0, 0, 0, $value, 1));
             }
 
             // I'd like to clone the formatter above, but then we get a

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
@@ -46,7 +46,7 @@ class MonthChoiceList extends PaddedChoiceList
 
             foreach ($this->choices as $choice => $value) {
                 // It's important to specify the first day of the month here!
-                $this->choices[$choice] = $this->formatter->format(mktime(0, 0, 0, $value, 1));
+                $this->choices[$choice] = $this->formatter->format(gmmktime(0, 0, 0, $value, 15));
             }
 
             // I'd like to clone the formatter above, but then we get a


### PR DESCRIPTION
Use mktime instead of gmmaketime. On the 1st of every month the following options are generated:

```
<select id="filter_start_date_month" name="filter[start][date][month]">
<option value="1">Dec</option>
<option value="2">Jan</option>
<option value="3">Feb</option>
<option value="4">Mar</option>
<option value="5">Apr</option>
<option value="6" selected="selected">May</option>
<option value="7">Jun</option>
<option value="8">Jul</option>
<option value="9">Aug</option>
<option value="10">Sep</option>
<option value="11">Oct</option>
<option value="12">Nov</option>
</select>
```

I do not totally understand the problem but using mktime instead of gmmktime fixes the issue.
