### PR TITLE
[Console] added mb_detect_encoding (when formatting block)

### DIFF
--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -74,7 +74,7 @@ class FormatterHelper extends Helper
      */
     private function strlen($string)
     {
-        return function_exists('mb_strlen') ? mb_strlen($string) : strlen($string);
+        return function_exists('mb_strlen') ? mb_strlen($string, mb_detect_encoding($string)) : strlen($string);
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Console/Helper/FormatterHelperTest.php
+++ b/tests/Symfony/Tests/Component/Console/Helper/FormatterHelperTest.php
@@ -19,16 +19,44 @@ class FormatterHelperTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = new FormatterHelper();
 
-        $this->assertEquals('<info>[cli]</info> Some text to display', $formatter->formatSection('cli', 'Some text to display'), '::formatSection() formats a message in a section');
+        $this->assertEquals(
+            '<info>[cli]</info> Some text to display',
+            $formatter->formatSection('cli', 'Some text to display'),
+            '::formatSection() formats a message in a section'
+        );
     }
 
     public function testFormatBlock()
     {
         $formatter = new FormatterHelper();
 
-        $this->assertEquals('<error> Some text to display </error>', $formatter->formatBlock('Some text to display', 'error'), '::formatBlock() formats a message in a block');
-        $this->assertEquals("<error> Some text to display </error>\n<error> foo bar              </error>", $formatter->formatBlock(array('Some text to display', 'foo bar'), 'error'), '::formatBlock() formats a message in a block');
+        $this->assertEquals(
+            '<error> Some text to display </error>',
+            $formatter->formatBlock('Some text to display', 'error'),
+            '::formatBlock() formats a message in a block'
+        );
 
-        $this->assertEquals("<error>                        </error>\n<error>  Some text to display  </error>\n<error>                        </error>", $formatter->formatBlock('Some text to display', 'error', true), '::formatBlock() formats a message in a block');
+        $this->assertEquals(
+            '<error> Some text to display </error>' . "\n" .
+            '<error> foo bar              </error>',
+            $formatter->formatBlock(array('Some text to display', 'foo bar'), 'error'),
+            '::formatBlock() formats a message in a block'
+        );
+
+        $this->assertEquals(
+            '<error>                        </error>' . "\n" .
+            '<error>  Some text to display  </error>' . "\n" .
+            '<error>                        </error>',
+            $formatter->formatBlock('Some text to display', 'error', true),
+            '::formatBlock() formats a message in a block'
+        );
+
+        $this->assertEquals(
+            '<error>                       </error>' . "\n" .
+            '<error>  Du texte à afficher  </error>' . "\n" .
+            '<error>                       </error>',
+            $formatter->formatBlock('Du texte à afficher', 'error', true),
+            '::formatBlock() formats a message in a block'
+        );
     }
 }


### PR DESCRIPTION
I added this in order to have the formatting block not rely on mb_internal_encoding.
@fabpot If you don't agree with this PR maybe it would be better to add a warning in app/check.php saying that the preferred encoding (for mb_internal_encoding) is **UTF-8**
