### PR TITLE
[FrameworkBundle][DoctrineBundle] Adding a few shortcut methods

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -109,6 +109,19 @@ class Registry
     }
 
     /**
+     * Shortcut method to return the EntityRepository for an entity.
+     *
+     * @param string $entityName The name of the entity.
+     * @param string $entityManagerNAme The entity manager name (null for the default one)
+     * @return Doctrine\ORM\EntityRepository
+     */
+    public function getRepository($entityName, $entityManagerName)
+    {
+        return $this->getEntityManager($entityManagerName)
+            ->getRespository($entityName);
+    }
+
+    /**
      * Resets a named entity manager.
      *
      * This method is useful when an entity manager has been closed

--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -115,7 +115,7 @@ class Registry
      * @param string $entityManagerNAme The entity manager name (null for the default one)
      * @return Doctrine\ORM\EntityRepository
      */
-    public function getRepository($entityName, $entityManagerName)
+    public function getRepository($entityName, $entityManagerName = null)
     {
         return $this->getEntityManager($entityManagerName)
             ->getRespository($entityName);

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -144,6 +144,10 @@ class Controller extends ContainerAware
      */
     public function getDoctrine()
     {
+        if (!$this->has('doctrine')) {
+            throw new \LogicException('The DoctrineBundle is not installed in your application.');
+        }
+
         return $this->get('doctrine');
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -138,6 +138,16 @@ class Controller extends ContainerAware
     }
 
     /**
+     * Shortcut to return the Doctrine Registry class
+     *
+     * @return Symfony\Bundle\DoctrineBundle\Registry
+     */
+    public function getDoctrine()
+    {
+        return $this->get('doctrine');
+    }
+
+    /**
      * Returns true if the service id is defined.
      *
      * @param  string  $id The service id


### PR DESCRIPTION
Hi guys!

This adds two convience methods, for two separate reasons:
- Controller::getDoctrine() - this will allow method completion on the Registry class to work in IDEs, is slightly shorter, and should feel very "concrete" to beginners
- Registry::getRepository() - the repository is a very convenient thing to need - this allows it to be fetched much more succintly

Overall before:

```
$product = $this->get('doctrine')
    ->getEntityManager()
    ->getRepository('AcmeDemoBundle:Product')
    ->find($id);
```

Overall after (with IDE method auto-completion for `getRepository`):

```
$product = $this->getDoctrine()
    ->getRepository('AcmeDemoBundle:Product')
    ->find($id);
```
