### PR TITLE
[HttpKernel] Fixed the test about the availability of the logger

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -88,7 +88,7 @@ class Profiler
      */
     public function saveProfile(Profile $profile)
     {
-        if (!$ret = $this->storage->write($profile) && null !== $this->logger) {
+        if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
             $this->logger->err('Unable to store the profiler information.');
         }
 


### PR DESCRIPTION
This fixes the test about the availability of the logger. Due to the precedence rules, the variable was set with the value of the `&&` test which leads to calling the logger when it is not set.
