### PR TITLE
[Routing] Adding a failing route generation test

### DIFF
--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -184,6 +184,13 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost/app.php/', $this->getGenerator($routes, array('scheme' => 'https'))->generate('test'));
     }
 
+    public function testNoTrailingSlashForMultipleOptionalParameters()
+    {
+        $routes = $this->getRoutes('test', new Route('/category/{slug1}/{slug2}/{slug3}', array('slug2' => null, 'slug3' => null)));
+
+        $this->assertEquals('/app.php/category/foo', $this->getGenerator($routes)->generate('test', array('slug1' => 'foo')));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array())
     {
         $context = new RequestContext('/app.php');


### PR DESCRIPTION
Hey guys-

I believe there's a small router generation bug where an extra trailing slash is added to a route that looks like this:

```
test:
    pattern: /category/{slug1}/{slug2}/{slug3}
    defaults: { slug2: ~, slug3: ~ }
```

and generating like this:

```
$router->generate('test', array('slug1' => 'foo'));
```

The result has an extra trailing slash (only when only `slug1` is specified).

```
/category/foo/
```

This situation does not occur of `slug2` and `slug3` are set to blank strings instead of null.

I've included only the test because, frankly, the logic in `UrlGenerator` is a bit above my pay grade.

Thanks!
