### PR TITLE
Removed HTML5 attributes from div_layout.html.twig

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -43,7 +43,7 @@
 
 {% block attributes %}
 {% spaceless %}
-    id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
+    id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}
     {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
 {% endspaceless %}
 {% endblock attributes %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout_html5.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout_html5.html.twig
@@ -1,0 +1,8 @@
+{% extends "TwigBundle:Form:div_layout.html.twig" %}
+
+{% block attributes %}
+{% spaceless %}
+    id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
+    {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
+{% endspaceless %}
+{% endblock attributes %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/table_layout_html5.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/table_layout_html5.html.twig
@@ -1,0 +1,8 @@
+{% extends "TwigBundle:Form:table_layout.html.twig" %}
+
+{% block attributes %}
+{% spaceless %}
+    id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
+    {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
+{% endspaceless %}
+{% endblock attributes %}


### PR DESCRIPTION
This is in reference to Issue #1082 and @fabpot preferring HTML5 attributes not be present in the default template.

I experimented with logic like the following, but thought it was unnecessary:

```
{% extends "TwigBundle:Form:div_layout.html.twig" { with: { 'html5_support': true }} %}
```

Instead, I just created a new template with the original attributes and removed HTML5 attributes from the current one.
