### PR TITLE
[Form] A proposal to fix the form rendering

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -242,12 +242,6 @@
 {% endspaceless %}
 {% endblock file_widget %}
 
-{% block collection_widget %}
-{% spaceless %}
-    {{ block('form_widget') }}
-{% endspaceless %}
-{% endblock collection_widget %}
-
 {% block repeated_row %}
 {% spaceless %}
     {{ block('field_rows') }}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/div_layout.html.twig
@@ -1,17 +1,14 @@
-{% block field_rows %}
-{% spaceless %}
-    {{ form_errors(form) }}
-    {% for child in form %}
-        {{ form_row(child) }}
-    {% endfor %}
-{% endspaceless %}
-{% endblock field_rows %}
-
 {% block field_enctype %}
 {% spaceless %}
     {% if multipart %}enctype="multipart/form-data"{% endif %}
 {% endspaceless %}
 {% endblock field_enctype %}
+
+{% block field_label %}
+{% spaceless %}
+    <label for="{{ id }}"{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
+{% endspaceless %}
+{% endblock field_label %}
 
 {% block field_errors %}
 {% spaceless %}
@@ -25,6 +22,15 @@
 {% endspaceless %}
 {% endblock field_errors %}
 
+{% block field_rows %}
+{% spaceless %}
+    {{ form_errors(form) }}
+    {% for child in form %}
+        {{ form_row(child) }}
+    {% endfor %}
+{% endspaceless %}
+{% endblock field_rows %}
+
 {% block field_rest %}
 {% spaceless %}
     {% for child in form %}
@@ -35,12 +41,6 @@
 {% endspaceless %}
 {% endblock field_rest %}
 
-{% block field_label %}
-{% spaceless %}
-    <label for="{{ id }}"{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
-{% endspaceless %}
-{% endblock field_label %}
-
 {% block attributes %}
 {% spaceless %}
     id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
@@ -50,11 +50,20 @@
 
 {% block container_attributes %}
 {% spaceless %}
-    id="{{ id }}" 
+    id="{{ id }}"
     {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
 {% endspaceless %}
 {% endblock container_attributes %}
-    
+
+{% block form_widget %}
+{% spaceless %}
+    <div {{ block('container_attributes') }}>
+        {{ block('field_rows') }}
+        {{ form_rest(form) }}
+    </div>
+{% endspaceless %}
+{% endblock form_widget %}
+
 {% block field_widget %}
 {% spaceless %}
     {% set type = type|default('text') %}
@@ -245,7 +254,6 @@
 {% endspaceless %}
 {% endblock repeated_row %}
 
-
 {% block field_row %}
 {% spaceless %}
     <div>
@@ -255,15 +263,6 @@
     </div>
 {% endspaceless %}
 {% endblock field_row %}
-
-{% block form_widget %}
-{% spaceless %}
-    <div {{ block('container_attributes') }}>
-        {{ block('field_rows') }}
-        {{ form_rest(form) }}
-    </div>
-{% endspaceless %}
-{% endblock form_widget %}
 
 {% block email_widget %}
 {% spaceless %}

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Form/table_layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Form/table_layout.html.twig
@@ -36,12 +36,6 @@
 {% endspaceless %}
 {% endblock hidden_row %}
 
-{% block repeated_errors %}
-{% spaceless %}
-    {{ block('form_errors') }}
-{% endspaceless %}
-{% endblock repeated_errors %}
-
 {% block form_widget %}
 {% spaceless %}
     <table {{ block('container_attributes') }}>

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -112,7 +112,21 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function isRendered()
     {
-        return $this->rendered;
+        if (true === $this->rendered || 0 == count($this->children)) {
+            return $this->rendered;
+        }
+
+        if (count($this->children) > 0) {
+            foreach ($this->children as $child) {
+                if (!$child->isRendered()) {
+                    return false;
+                }
+            }
+
+            return $this->rendered = true;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -258,10 +272,6 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
      */
     public function getIterator()
     {
-        if (count($this->children)) {
-            $this->rendered = true;
-        }
-
         return new \ArrayIterator($this->children);
     }
 


### PR DESCRIPTION
This PR is my proposal to fix the form rendering.

How it works:
- A view is considered rendered when the associated "row" or "widget" section has been rendered,
- if all the children views have been rendered, the view is considered as rendered.

The second bullet causes a change in beviahor: if you have a repeated form and you render the widget individually, `form_rest` would not render the labels any more. The same thing when you have a file form and render all the nested fields individually (that's `file`, `token`, `name` & `originalName`) then the file widget `<div>` would not be rendered.

This new behavior is intended as you should have taken care of the markup (labels, div, ...) when rendering the fields individually.

Some unit test from @stloyd have been reused to improve the coverage. They have been slighty modified to take into account the change in behavior.

The [original tests](https://github.com/stloyd/symfony/commit/66d1a6150eb0cd29b698eeac759958ba8427c4f3#L3R264) were expecting the labels to be rendered for a repeated field. The [modified tests](https://github.com/vicb/symfony/commit/c2b9061559a12adc9ecd5dc92f3b8f9b9034aca1#L0R263) expects them not to be rendered.
