### PR TITLE
[FrameworkBundle] Changing PHPDoc to have opening namespace slash

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -140,7 +140,7 @@ class Controller extends ContainerAware
     /**
      * Shortcut to return the Doctrine Registry class
      *
-     * @return Symfony\Bundle\DoctrineBundle\Registry
+     * @return \Symfony\Bundle\DoctrineBundle\Registry
      */
     public function getDoctrine()
     {


### PR DESCRIPTION
Hey guys-

At least in my IDE (PHPStorm), it expects the `@return` to have the opening slash for a fully-qualified name.

Thanks!
