### PR TITLE
[Assetic] Make AsseticExtension::createDirectoryResourceDefinition public

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
+++ b/src/Symfony/Bundle/AsseticBundle/DependencyInjection/AsseticExtension.php
@@ -186,7 +186,7 @@ class AsseticExtension extends Extension
      *
      * @return Definition A resource definition
      */
-    static protected function createDirectoryResourceDefinition($bundle, $engine, array $dirs)
+    static public function createDirectoryResourceDefinition($bundle, $engine, array $dirs)
     {
         $dirResources = array();
         foreach ($dirs as $dir) {


### PR DESCRIPTION
[Assetic] Make AsseticExtension::createDirectoryResourceDefinition public, so that third party bundles can easilycreate definitions to search for assetic formulae in additional directories. LiipThemeBundle needs this to make the app/Resources/themes and Bundle/Resources/themes folder searchable. Without this change the whole method would need to be copy pasted. Since the method has no side-effects at all (only factory, not pushing into the container) this change is justifyable imho.
