### PR TITLE
[DoctrineBridge] Added possibility to validate entity unicity outside of an entity.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -25,6 +25,7 @@ class UniqueEntity extends Constraint
     public $message = 'This value is already used.';
     public $em = null;
     public $fields = array();
+    public $entity = null;
 
     public function getRequiredOptions()
     {
@@ -54,3 +55,4 @@ class UniqueEntity extends Constraint
         return 'fields';
     }
 }
+


### PR DESCRIPTION
It was not possible to validate the unicity of an Entity outside of it. This patch adds the "entity" option to the UniqueEntity constraint. If this option is provided, the validator will validate the value against this class. 
