### PR TITLE
Fixed vendors.php not working if directory path has space in it

### DIFF
--- a/vendors.php
+++ b/vendors.php
@@ -40,7 +40,7 @@ foreach ($deps as $dep) {
 
     $installDir = $vendorDir.'/'.$name;
     if (!is_dir($installDir)) {
-        system(sprintf('git clone %s %s', $url, $installDir));
+        system(sprintf('git clone %s "%s"', $url, $installDir));
     }
 
     system(sprintf('cd %s && git fetch origin && git reset --hard %s', $installDir, $rev));


### PR DESCRIPTION
If path is not quoted, anything after a space is treated as another parameter.
