### PR TITLE
[DoctrineBundle] fixed MetadataFactory::getMetadataForClass() to always r

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Mapping/MetadataFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Mapping/MetadataFactory.php
@@ -151,6 +151,8 @@ class MetadataFactory
                 return new ClassMetadataCollection(array($metadata));
             }
         }
+
+        return new ClassMetadataCollection(array());
     }
 
     private function getAllMetadata()


### PR DESCRIPTION
[DoctrineBundle] fixed MetadataFactory::getMetadataForClass() to always return a ClassMetadataCollection object instead of NULL.
