### PR TITLE
[Form] text is now the default type when not explicitely set and when no data class is set

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -562,22 +562,10 @@ class FormBuilder
         }
 
         if (null !== $type) {
-            $builder = $this->getFormFactory()->createNamedBuilder(
-                $type,
-                $name,
-                null,
-                $options
-            );
-        } else {
-            $builder = $this->getFormFactory()->createBuilderForProperty(
-                $this->dataClass,
-                $name,
-                null,
-                $options
-            );
+            return $this->getFormFactory()->createNamedBuilder($type, $name, null, $options);
         }
 
-        return $builder;
+        return $this->getFormFactory()->createBuilderForProperty($this->dataClass, $name, null, $options);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -554,11 +554,13 @@ class FormBuilder
      * @param array                     $options The options
      *
      * @return FormBuilder The builder
-     *
-     * @throws FormException if the data class is not set when creating a property builder
      */
     public function create($name, $type = null, array $options = array())
     {
+        if (null === $type && !$this->dataClass) {
+            $type = 'text';
+        }
+
         if (null !== $type) {
             $builder = $this->getFormFactory()->createNamedBuilder(
                 $type,
@@ -567,10 +569,6 @@ class FormBuilder
                 $options
             );
         } else {
-            if (!$this->dataClass) {
-                throw new FormException(sprintf('The "%s" type cannot be guessed as the data class is not set. Provide the type manually (\'text\', \'password\', ...) or set the data class.', $name));
-            }
-
             $builder = $this->getFormFactory()->createBuilderForProperty(
                 $this->dataClass,
                 $name,

--- a/tests/Symfony/Tests/Component/Form/FormBuilderTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormBuilderTest.php
@@ -97,8 +97,12 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testCreateNoTypeNoDataClass()
     {
-        $this->setExpectedException('Symfony\Component\Form\Exception\FormException', 'The data class must be set to automatically create children');
-        $this->builder->create('foo');
+        $this->factory->expects($this->once())
+                ->method('createNamedBuilder')
+                ->with('text', 'foo', null, array())
+        ;
+
+        $builder = $this->builder->create('foo');
     }
 
     public function testGetUnknown()


### PR DESCRIPTION
Looks like a great enhancement to me, especially because the error message is really difficult to understand... and I don't see any drawback. Thoughts?

Just have a look at the first commit to understand the change:

https://github.com/symfony/symfony/commit/fd97dd00599a0220a0750faf3cd04aed1496df70
