### PR TITLE
[Validator] Allow DateTime objects as valid Times

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -25,6 +25,10 @@ class TimeValidator extends ConstraintValidator
             return true;
         }
 
+        if ($value instanceof \DateTime) {
+            return true;
+        }
+
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
             throw new UnexpectedTypeException($value, 'string');
         }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/DateValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/DateValidatorTest.php
@@ -33,6 +33,11 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->isValid('', new Date()));
     }
 
+    public function testDateTimeClassIsValid()
+    {
+        $this->validator->isValid(new \DateTime(), new Date());
+    }
+
     public function testExpectsStringCompatibleType()
     {
         $this->setExpectedException('Symfony\Component\Validator\Exception\UnexpectedTypeException');

--- a/tests/Symfony/Tests/Component/Validator/Constraints/TimeValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/TimeValidatorTest.php
@@ -33,6 +33,11 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->isValid('', new Time()));
     }
 
+    public function testDateTimeClassIsValid()
+    {
+        $this->validator->isValid(new \DateTime(), new Time());
+    }
+
     public function testExpectsStringCompatibleType()
     {
         $this->setExpectedException('Symfony\Component\Validator\Exception\UnexpectedTypeException');


### PR DESCRIPTION
Also added tests for `DateTime` objects as valid on `Date` and `Time` constraints.

I didn't include the test for the `DateTime` constraint, as it's already included in this PR:

https://github.com/symfony/symfony/pull/1085
