### PR TITLE
Added an optimisation for PHP-FPM (FastCGI Process Manager).

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -153,6 +153,10 @@ class Response
     {
         $this->sendHeaders();
         $this->sendContent();
+        
+        if (function_exists('fastcgi_finish_request')) {
+            fastcgi_finish_request();
+        }
     }
 
     /**


### PR DESCRIPTION
As soon as a full Response is dispatched to the browser, the HTTP connection is closed, but the script stays alive on FPM servers.
