### PR TITLE
Fixed vendors.php not working if directory path has space in it (update)

### DIFF
--- a/vendors.php
+++ b/vendors.php
@@ -43,5 +43,5 @@ foreach ($deps as $dep) {
         system(sprintf('git clone %s "%s"', $url, $installDir));
     }
 
-    system(sprintf('cd %s && git fetch origin && git reset --hard %s', $installDir, $rev));
+    system(sprintf('cd "%s" && git fetch origin && git reset --hard %s', $installDir, $rev));
 }


### PR DESCRIPTION
This is an update to the last pulled request.  I missed a system() call that uses a directory path.
