### PR TITLE
Using escapeshellarg() instead of quotes to fix paths with spaces (vendors.php)

### DIFF
--- a/vendors.php
+++ b/vendors.php
@@ -40,8 +40,8 @@ foreach ($deps as $dep) {
 
     $installDir = $vendorDir.'/'.$name;
     if (!is_dir($installDir)) {
-        system(sprintf('git clone %s "%s"', $url, $installDir));
+        system(sprintf('git clone %s %s', $url, escapeshellarg($installDir)));
     }
 
-    system(sprintf('cd "%s" && git fetch origin && git reset --hard %s', $installDir, $rev));
+    system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), $rev));
 }

--- a/vendors.php
+++ b/vendors.php
@@ -40,8 +40,8 @@ foreach ($deps as $dep) {
 
     $installDir = $vendorDir.'/'.$name;
     if (!is_dir($installDir)) {
-        system(sprintf('git clone %s %s', $url, escapeshellarg($installDir)));
+        system(sprintf('git clone %s %s', escapeshellarg($url), escapeshellarg($installDir)));
     }
 
-    system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), $rev));
+    system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));
 }


### PR DESCRIPTION
Changed fix implementation as per https://github.com/symfony/symfony/pull/1272#commitcomment-424840

This is probably more reliable.
