### PR TITLE
multiple headers of the same type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -128,7 +128,7 @@ class Response
         // headers
         foreach ($this->headers->all() as $name => $values) {
             foreach ($values as $value) {
-                header($name.': '.$value);
+                header($name.': '.$value, false);
             }
         }
 


### PR DESCRIPTION
I think this is a bugfix, as the HeaderBag Class offers the possibility to have multiple headers of the same type. But the native php header() function has the optional parameter "replace" set to TRUE. So the actual behaviour replaces those headers. 
