### PR TITLE
[Form] fixed addition of CSRF field

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListener.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Csrf\EventListener;
+
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+/**
+ * Ensures the CSRF field.
+ *
+ * @author Bulat Shakirzyanov <mallluhuct@gmail.com>
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+class EnsureCsrfFieldListener
+{
+    private $factory;
+    private $name;
+    private $intention;
+    private $provider;
+
+    /**
+     * Constructor.
+     *
+     * @param FormFactoryInterface  $factory   The form factory
+     * @param string                $name      A name for the CSRF field
+     * @param string                $intention The intention string
+     * @param CsrfProviderInterface $provider  The CSRF provider
+     */
+    public function __construct(FormFactoryInterface $factory, $name, $intention = null, CsrfProviderInterface $provider = null)
+    {
+        $this->factory = $factory;
+        $this->name = $name;
+        $this->intention = $intention;
+        $this->provider = $provider;
+    }
+
+    /**
+     * Ensures a root form has a CSRF field.
+     *
+     * This method should be connected to both form.pre_set_data and form.pre_bind.
+     */
+    public function ensureCsrfField(DataEvent $event)
+    {
+        $form = $event->getForm();
+
+        $options = array();
+        if ($this->intention) {
+            $options['intention'] = $this->intention;
+        }
+        if ($this->provider) {
+            $options['csrf_provider'] = $this->provider;
+        }
+
+        $form->add($this->factory->createNamed('csrf', $this->name, null, $options));
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/AbstractTableLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractTableLayoutTest.php
@@ -153,8 +153,9 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
     [
         ./tr[./td/input[@type="text"][@value="a"]]
         /following-sibling::tr[./td/input[@type="text"][@value="b"]]
+        /following-sibling::tr[./td/input[@type="hidden"][@id="name__token"]]
     ]
-    [count(./tr[./td/input])=2]
+    [count(./tr[./td/input])=3]
 '
         );
     }

--- a/tests/Symfony/Tests/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListenerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Form\Extension\Csrf\EventListener;
+
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\Form\Extension\Csrf\EventListener\EnsureCsrfFieldListener;
+
+class EnsureCsrfFieldListenerTest extends \PHPUnit_Framework_TestCase
+{
+    private $form;
+    private $formFactory;
+
+    protected function setUp()
+    {
+        $this->formFactory = $this->getMock('Symfony\\Component\\Form\\FormFactoryInterface');
+        $this->form = $this->getMock('Symfony\\Tests\\Component\\Form\\FormInterface');
+        $this->field = $this->getMock('Symfony\\Tests\\Component\\Form\\FormInterface');
+        $this->event = new DataEvent($this->form, array());
+    }
+
+    public function testAddField()
+    {
+        $this->formFactory->expects($this->once())
+            ->method('createNamed')
+            ->with('csrf', '_token', null, array())
+            ->will($this->returnValue($this->field));
+        $this->form->expects($this->once())
+            ->method('add')
+            ->with($this->isInstanceOf('Symfony\\Tests\\Component\\Form\\FormInterface'));
+
+        $listener = new EnsureCsrfFieldListener($this->formFactory, '_token');
+        $listener->ensureCsrfField($this->event);
+    }
+
+    public function testIntention()
+    {
+        $this->formFactory->expects($this->once())
+            ->method('createNamed')
+            ->with('csrf', '_token', null, array('intention' => 'something'))
+            ->will($this->returnValue($this->field));
+        $this->form->expects($this->once())
+            ->method('add')
+            ->with($this->isInstanceOf('Symfony\\Tests\\Component\\Form\\FormInterface'));
+
+        $listener = new EnsureCsrfFieldListener($this->formFactory, '_token', 'something');
+        $listener->ensureCsrfField($this->event);
+    }
+
+    public function testProvider()
+    {
+        $provider = $this->getMock('Symfony\\Component\\Form\\Extension\\Csrf\\CsrfProvider\\CsrfProviderInterface');
+
+        $this->formFactory->expects($this->once())
+            ->method('createNamed')
+            ->with('csrf', '_token', null, array('csrf_provider' => $provider))
+            ->will($this->returnValue($this->field));
+        $this->form->expects($this->once())
+            ->method('add')
+            ->with($this->isInstanceOf('Symfony\\Tests\\Component\\Form\\FormInterface'));
+
+        $listener = new EnsureCsrfFieldListener($this->formFactory, '_token', null, $provider);
+        $listener->ensureCsrfField($this->event);
+    }
+}


### PR DESCRIPTION
I've moved the addition of the CSRF field from the type class to a low-priority listener so it runs after the collection type's resize listener, for instance. /cc @avalanche123
