### PR TITLE
[TwigBundle] Adding an exception message for bad extension service

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -57,6 +57,10 @@ class TwigExtension extends Extension
 
         if (!empty($config['extensions'])) {
             foreach ($config['extensions'] as $id) {
+                if (!$container->hasDefinition($id)) {
+                    throw new \InvalidArgumentException(sprintf('You specified "%s" as a Twig extension, but that service name does not exist.', $id));
+                }
+
                 $container->getDefinition($id)->addTag('twig.extension');
             }
         }


### PR DESCRIPTION
Hey guys-

Simple - just an improved exception message if you put a service name into the twig extensions array that doesn't exist.

Since I believe the only purpose of this option is to "activate" these extension services that are brought in internally by the TwigBundle (i.e. you'd just tag your own service yourself), we might just be better off hardcoding the available extension into the Configuration class and perhaps drop the need to say `twig.extension.text` (just let them say `text`). If that sounds fine, I'll add that to the PR.

Thanks!
