### PR TITLE
[Routing] Optimised the PHP URL matcher dumper 

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -101,6 +101,7 @@ EOF;
 
     private function compileRoute(Route $route, $name, $supportsRedirections, $parentPrefix = null)
     {
+        $code = array();
         $compiledRoute = $route->compile();
         $conditions = array();
         $hasTrailingSlash = false;

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -69,7 +69,7 @@ $code
 EOF;
     }
 
-    private function compileRoutes(RouteCollection $routes, $supportsRedirections)
+    private function compileRoutes(RouteCollection $routes, $supportsRedirections, $parentPrefix = null)
     {
         $code = array();
         foreach ($routes as $name => $route) {
@@ -80,7 +80,7 @@ EOF;
                     $indent = '    ';
                 }
 
-                foreach ($this->compileRoutes($route, $supportsRedirections) as $line) {
+                foreach ($this->compileRoutes($route, $supportsRedirections, $prefix) as $line) {
                     foreach (explode("\n", $line) as $l) {
                         $code[] = $indent.$l;
                     }
@@ -90,7 +90,7 @@ EOF;
                     $code[] = "        }\n";
                 }
             } else {
-                foreach ($this->compileRoute($route, $name, $supportsRedirections) as $line) {
+                foreach ($this->compileRoute($route, $name, $supportsRedirections, $parentPrefix) as $line) {
                     $code[] = $line;
                 }
             }
@@ -99,7 +99,7 @@ EOF;
         return $code;
     }
 
-    private function compileRoute(Route $route, $name, $supportsRedirections)
+    private function compileRoute(Route $route, $name, $supportsRedirections, $parentPrefix = null)
     {
         $compiledRoute = $route->compile();
         $conditions = array();
@@ -113,7 +113,7 @@ EOF;
                 $conditions[] = sprintf("\$pathinfo === '%s'", str_replace('\\', '', $m['url']));
             }
         } else {
-            if ($compiledRoute->getStaticPrefix()) {
+            if ($compiledRoute->getStaticPrefix() && $compiledRoute->getStaticPrefix() != $parentPrefix) {
                 $conditions[] = sprintf("0 === strpos(\$pathinfo, '%s')", $compiledRoute->getStaticPrefix());
             }
 


### PR DESCRIPTION
The cached URL matcher classes contain some unneeded logic. Consider the following example:

```
if (0 === strpos($pathinfo, '/Blog')) {
    // blog_index
    if (0 === strpos($pathinfo, '/Blog') && preg_match('#^/Blog/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {
        return array_merge($this->mergeDefaults($matches, array (  '_action' => 'index',)), array('_route' => 'blog_index'));
    }
}
```

The 2nd strpos is not required, as we have already satisfied this condition in the parent if statement.
My change will produce the following code for the same routing setup::

```
if (0 === strpos($pathinfo, '/Blog')) {
    // blog_index
    if (preg_match('#^/Blog/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {
        return array_merge($this->mergeDefaults($matches, array (  '_action' => 'index',)), array('_route' => 'blog_index'));
    }
}
```

Note: I haven't been able to run this code through the PHPUnit test suite, as I cannot get it to work (see issue #1282)
