### PR TITLE
[Routing] Better nesting for RouteCollections in dumped URL matcher classes

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -72,16 +72,47 @@ EOF;
     private function compileRoutes(RouteCollection $routes, $supportsRedirections, $parentPrefix = null)
     {
         $code = array();
-        foreach ($routes as $name => $route) {
+        
+        $routeIterator = $routes->getIterator();
+        $keys = array_keys($routeIterator->getArrayCopy());
+        
+        $i = 0;
+        
+        foreach ($routeIterator as $name => $route) {
+            $i++;
+            
             if ($route instanceof RouteCollection) {
                 $prefix = $route->getPrefix();
                 $optimizable = $prefix && count($route->all()) > 1 && false === strpos($route->getPrefix(), '{');
                 $indent = '';
                 if ($optimizable) {
+                    for ($j = $i; $j < count($keys); $j++) {
+                        if ($keys[$j] === null) continue;
+                      
+                        $testRoute = $routeIterator->offsetGet($keys[$j]);
+                        $isCollection = ($testRoute instanceof RouteCollection);
+
+                        $testPrefix = $isCollection ? $testRoute->getPrefix() : $testRoute->getPattern();
+
+                        if (0 === strpos($testPrefix, $prefix)) {
+                            $routeIterator->offsetUnset($keys[$j]);
+                        
+                            if ($isCollection) {
+                                $route->addCollection($testRoute);
+                            }
+                            else {
+                                $route->add($keys[$j], $testRoute);
+                            }
+                        
+                            $i++;
+                            $keys[$j] = null;
+                        }
+                    }
+                    
                     $code[] = sprintf("        if (0 === strpos(\$pathinfo, '%s')) {", $prefix);
                     $indent = '    ';
                 }
-
+                
                 foreach ($this->compileRoutes($route, $supportsRedirections, $prefix) as $line) {
                     foreach (explode("\n", $line) as $l) {
                         $code[] = $indent.$l;
@@ -89,6 +120,7 @@ EOF;
                 }
 
                 if ($optimizable) {
+                    $code[] = "            throw 0 < count(\$allow) ? new MethodNotAllowedException(array_unique(\$allow)) : new ResourceNotFoundException();";
                     $code[] = "        }\n";
                 }
             } else {

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -75,6 +75,7 @@ EOF;
         
         $routeIterator = $routes->getIterator();
         $keys = array_keys($routeIterator->getArrayCopy());
+        $keysCount = count($keys);
         
         $i = 0;
         
@@ -86,8 +87,10 @@ EOF;
                 $optimizable = $prefix && count($route->all()) > 1 && false === strpos($route->getPrefix(), '{');
                 $indent = '';
                 if ($optimizable) {
-                    for ($j = $i; $j < count($keys); $j++) {
-                        if ($keys[$j] === null) continue;
+                    for ($j = $i; $j < $keysCount; $j++) {
+                        if ($keys[$j] === null) {
+                          continue;
+                        }
                       
                         $testRoute = $routeIterator->offsetGet($keys[$j]);
                         $isCollection = ($testRoute instanceof RouteCollection);

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -72,16 +72,16 @@ EOF;
     private function compileRoutes(RouteCollection $routes, $supportsRedirections, $parentPrefix = null)
     {
         $code = array();
-        
+
         $routeIterator = $routes->getIterator();
         $keys = array_keys($routeIterator->getArrayCopy());
         $keysCount = count($keys);
-        
+
         $i = 0;
-        
+
         foreach ($routeIterator as $name => $route) {
             $i++;
-            
+
             if ($route instanceof RouteCollection) {
                 $prefix = $route->getPrefix();
                 $optimizable = $prefix && count($route->all()) > 1 && false === strpos($route->getPrefix(), '{');
@@ -91,7 +91,7 @@ EOF;
                         if ($keys[$j] === null) {
                           continue;
                         }
-                      
+
                         $testRoute = $routeIterator->offsetGet($keys[$j]);
                         $isCollection = ($testRoute instanceof RouteCollection);
 
@@ -99,23 +99,22 @@ EOF;
 
                         if (0 === strpos($testPrefix, $prefix)) {
                             $routeIterator->offsetUnset($keys[$j]);
-                        
+
                             if ($isCollection) {
                                 $route->addCollection($testRoute);
-                            }
-                            else {
+                            } else {
                                 $route->add($keys[$j], $testRoute);
                             }
-                        
+
                             $i++;
                             $keys[$j] = null;
                         }
                     }
-                    
+
                     $code[] = sprintf("        if (0 === strpos(\$pathinfo, '%s')) {", $prefix);
                     $indent = '    ';
                 }
-                
+
                 foreach ($this->compileRoutes($route, $supportsRedirections, $prefix) as $line) {
                     foreach (explode("\n", $line) as $l) {
                         $code[] = $indent.$l;


### PR DESCRIPTION
Consider the following routing file:

```
_blog:
    resource: "@AcmeDemoBundle/Resources/config/routing/BlogController.yml"
    prefix:   /blog

_blogger:
    resource: "@AcmeDemoBundle/Resources/config/routing/BloggerController.yml"
    prefix:   /blogger

_bloggeroo:
    resource: "@AcmeDemoBundle/Resources/config/routing/BloggerooController.yml"
    prefix:   /bloggeroo

_blogtest:
    pattern:   /blogtest
    defaults:  { _controller: AcmeDemoBundle:Blog:test }

login:
    pattern:   /login
    defaults:  { _controller: AcmeDemoBundle:Security:login }
```

Note: Each imported file contains two simple blog/blogger/bloggeroo routes (e.g. blog_index & blog_view)
With this change, the cached URL matcher looks something like this:

``` php
<?php
class appprodUrlMatcher
{
  public function match($pathinfo)
  {
      $allow = array();

      if (0 === strpos($pathinfo, '/blog')) {
          // blog_index
          if (preg_match('#^/blog/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {...}

          // blog_view
          if (preg_match('#^/blog/(?P<year>\d{4})/(?P<month>\d{2})/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {...}

          if (0 === strpos($pathinfo, '/blogger')) {
              // blogger_index
              if (preg_match('#^/blogger/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {...}

              // blogger_view
              if (preg_match('#^/blogger/(?P<year>\d{4})/(?P<month>\d{2})/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {...}

              if (0 === strpos($pathinfo, '/bloggeroo')) {
                  // bloggeroo_index
                  if (preg_match('#^/bloggeroo/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {...}

                  // bloggeroo_view
                  if (preg_match('#^/bloggeroo/(?P<year>\d{4})/(?P<month>\d{2})/(?P<slug>[^/]+?)$#x', $pathinfo, $matches)) {...}

                  throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
              }

              throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
          }

          // _blogtest
          if ($pathinfo === '/blogtest') {...}

          throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
      }

      // login
      if ($pathinfo === '/login') {...}

      throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
  }
}
```

As far as I can see, you can throw the 404 earlier (as I've done), as by nesting all these possibilities, there is no chance another route will be matched outside the parent if statement.
