### PR TITLE
[HttpKernel] made WebTestCase methods static

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -9,6 +9,9 @@ timeline closely anyway.
 beta4 to beta5
 --------------
 
+* The `$kernel` property on `WebTestCase` is now static. Change any instances
+  of `$this->kernel` in your functional tests to `self::$kernel`.
+
 * The `extensions` setting for Twig has been removed. There is now only one
   way to register Twig extensions, via the `twig.extension` tag.
 

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpKernel\Test\WebTestCase as BaseWebTestCase;
  */
 abstract class WebTestCase extends BaseWebTestCase
 {
-    protected $kernel;
+    static protected $kernel;
 
     /**
      * Creates a Client.
@@ -34,12 +34,12 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return Client A Client instance
      */
-    public function createClient(array $options = array(), array $server = array())
+    static protected function createClient(array $options = array(), array $server = array())
     {
-        $this->kernel = $this->createKernel($options);
-        $this->kernel->boot();
+        static::$kernel = static::createKernel($options);
+        static::$kernel->boot();
 
-        $client = $this->kernel->getContainer()->get('test.client');
+        $client = static::$kernel->getContainer()->get('test.client');
         $client->setServerParameters($server);
 
         return $client;
@@ -53,13 +53,13 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return string The directory where phpunit.xml(.dist) is stored
      */
-    protected function getPhpUnitXmlDir()
+    static protected function getPhpUnitXmlDir()
     {
         if (!isset($_SERVER['argv']) || false === strpos($_SERVER['argv'][0], 'phpunit')) {
             throw new \RuntimeException('You must override the WebTestCase::createKernel() method.');
         }
 
-        $dir = $this->getPhpUnitCliConfigArgument();
+        $dir = static::getPhpUnitCliConfigArgument();
         if ($dir === null &&
             (file_exists(getcwd().DIRECTORY_SEPARATOR.'phpunit.xml') ||
             file_exists(getcwd().DIRECTORY_SEPARATOR.'phpunit.xml.dist'))) {
@@ -86,7 +86,7 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return string The value of the phpunit cli configuration option
      */
-    private function getPhpUnitCliConfigArgument()
+    static private function getPhpUnitCliConfigArgument()
     {
         $dir = null;
         $reversedArgs = array_reverse($_SERVER['argv']);
@@ -111,9 +111,9 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return string The Kernel class name
      */
-    protected function getKernelClass()
+    static protected function getKernelClass()
     {
-        $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : $this->getPhpUnitXmlDir();
+        $dir = isset($_SERVER['KERNEL_DIR']) ? $_SERVER['KERNEL_DIR'] : static::getPhpUnitXmlDir();
 
         $finder = new Finder();
         $finder->name('*Kernel.php')->in($dir);
@@ -141,9 +141,9 @@ abstract class WebTestCase extends BaseWebTestCase
      *
      * @return HttpKernelInterface A HttpKernelInterface instance
      */
-    protected function createKernel(array $options = array())
+    static protected function createKernel(array $options = array())
     {
-        $class = $this->getKernelClass();
+        $class = static::getKernelClass();
 
         return new $class(
             isset($options['environment']) ? $options['environment'] : 'test',
@@ -156,8 +156,8 @@ abstract class WebTestCase extends BaseWebTestCase
      */
     protected function tearDown()
     {
-        if (null !== $this->kernel) {
-            $this->kernel->shutdown();
+        if (null !== static::$kernel) {
+            static::$kernel->shutdown();
         }
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
@@ -41,16 +41,16 @@ class WebTestCase extends BaseWebTestCase
         $fs->remove($dir);
     }
 
-    protected function getKernelClass()
+    static protected function getKernelClass()
     {
         require_once __DIR__.'/app/AppKernel.php';
 
         return 'Symfony\Bundle\SecurityBundle\Tests\Functional\AppKernel';
     }
 
-    protected function createKernel(array $options = array())
+    static protected function createKernel(array $options = array())
     {
-        $class = $this->getKernelClass();
+        $class = self::getKernelClass();
 
         if (!isset($options['test_case'])) {
             throw new \InvalidArgumentException('The option "test_case" must be set.');

--- a/src/Symfony/Component/HttpKernel/Test/WebTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Test/WebTestCase.php
@@ -29,5 +29,5 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
      *
      * @return Client A Client instance
      */
-    abstract public function createClient(array $options = array(), array $server = array());
+    abstract static protected function createClient(array $options = array(), array $server = array());
 }


### PR DESCRIPTION
This makes it possible to load fixture data in `::setUpBeforeClass()` which makes tests run much faster.

Also, `createClient()` is not protected instead of public; I'm not sure why it was public in the first place.
