### PR TITLE
[AsseticBundle] fixed ScopeWideningInjectionExc in prod env using php tpl

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/templating_php.xml
@@ -17,7 +17,7 @@
             <argument type="service" id="assetic.asset_factory" />
         </service>
 
-        <service id="assetic.helper.static" class="%assetic.helper.static.class%">
+        <service id="assetic.helper.static" class="%assetic.helper.static.class%" scope="request">
             <tag name="assetic.templating.php" />
             <argument type="service" id="templating.helper.assets" />
             <argument type="service" id="assetic.asset_factory" />


### PR DESCRIPTION
The definition "assetic.helper.static" references the service "templating.helper.assets" which belongs to a narrower scope. Generally, it is safer to either move "assetic.helper.static" to scope "request" or alternatively rely on the provider pattern by injecting the container itself, and requesting the service "templating.helper.assets" each time it is needed. In rare, special cases however that might not be necessary, then you can set the reference to strict=false to get rid of this error.
