### PR TITLE
[Form] Fix rendering using twig

### DIFF
--- a/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
@@ -48,6 +48,51 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
         $this->extension->initRuntime($environment);
     }
 
+    public function testThemeBlockInheritance()
+    {
+        $view = $this->factory
+            ->createNamed('email', 'name')
+            ->createView()
+        ;
+
+        $this->extension->setTheme($view, array('theme.html.twig'));
+
+        $this->assertMatchesXpath(
+            $this->renderWidget($view),
+            '/input[@type="email"][@rel="theme"]'
+        );
+    }
+
+    public function testThemeBlockInheritanceUsingUse()
+    {
+        $view = $this->factory
+            ->createNamed('email', 'name')
+            ->createView()
+        ;
+
+        $this->extension->setTheme($view, array('theme_use.html.twig'));
+
+        $this->assertMatchesXpath(
+            $this->renderWidget($view),
+            '/input[@type="email"][@rel="theme"]'
+        );
+    }
+
+    public function testThemeBlockInheritanceUsingExtend()
+    {
+        $view = $this->factory
+            ->createNamed('email', 'name')
+            ->createView()
+        ;
+
+        $this->extension->setTheme($view, array('theme_extends.html.twig'));
+
+        $this->assertMatchesXpath(
+            $this->renderWidget($view),
+            '/input[@type="email"][@rel="theme"]'
+        );
+    }
+
     public function testThemeInheritance()
     {
         $child = $this->factory->createNamedBuilder('form', 'child')

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/theme.html.twig
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/theme.html.twig
@@ -1,0 +1,6 @@
+{% block field_widget %}
+{% spaceless %}
+    {% set type = type|default('text') %}
+    <input type="{{ type }}" {{ block('attributes') }} value="{{ value }}" rel="theme" />
+{% endspaceless %}
+{% endblock field_widget %}

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/theme_extends.html.twig
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/theme_extends.html.twig
@@ -1,0 +1,8 @@
+{% extends 'div_layout.html.twig' %}
+
+{% block field_widget %}
+{% spaceless %}
+    {% set type = type|default('text') %}
+    <input type="{{ type }}" {{ block('attributes') }} value="{{ value }}" rel="theme" />
+{% endspaceless %}
+{% endblock field_widget %}

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/theme_use.html.twig
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/theme_use.html.twig
@@ -1,0 +1,8 @@
+{% use 'div_layout.html.twig' %}
+
+{% block field_widget %}
+{% spaceless %}
+    {% set type = type|default('text') %}
+    <input type="{{ type }}" {{ block('attributes') }} value="{{ value }}" rel="theme" />
+{% endspaceless %}
+{% endblock field_widget %}


### PR DESCRIPTION
The issue being fixed is described here:
https://github.com/symfony/symfony/pull/1188

The [first commit](https://github.com/vicb/symfony/commit/8677aa3dce03e3633d272054e9c5d153aee9cf86) is the one fixing the issue. The main idea is to first compute the list the blocks that should be used to render a particular view and pass the list of block when [rendering the block from the twig template](https://github.com/vicb/symfony/commit/8677aa3dce03e3633d272054e9c5d153aee9cf86#L0R236).

Notes:
- Blocks are looked in this order: themes from the current view, themes from the parent view up to the root view and then extension resources;
- there is no more need to `extends` or `use` a base template in a theme - the docs should be updated accordingly if this PR gets merged;
- any template can be used to call `renderBlock` as the only thing who cares is the list of blocks.

The [second commit](https://github.com/vicb/symfony/commit/9135f963db9d59d0785808a9cf7c22d2cfd4384d) is an attempt to optimize the cache layer by making `getTemplates()` recursive. The previous cache was only helpful while rendering different section (label, widget, errors) of a single view. 

The [third commit](https://github.com/vicb/symfony/commit/b19052f8797d13a0ca6700c7c7f057dfb7fe0585) further improves the cache by caching blocks rather than templates.
