### PR TITLE
[TwigBundle] Optimize the FilesystemLoader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
@@ -90,6 +90,6 @@ class ExceptionController extends ContainerAware
         // default to a generic HTML exception
         $this->container->get('request')->setRequestFormat('html');
 
-        return sprintf('FrameworkBundle:Exception:%s.html.twig');
+        return sprintf('FrameworkBundle:Exception:%s.html.twig', $name);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ExceptionController.php
@@ -75,14 +75,14 @@ class ExceptionController extends ContainerAware
 
         // when not in debug, try to find a template for the specific HTTP status code and format
         if (!$debug) {
-            $template = new TemplateReference('FrameworkBundle', 'Exception', $name.$code, $format, 'twig');
+            $template = sprintf('FrameworkBundle:Exception:%s%s.%s.twig', $name, $code, $format);
             if ($templating->exists($template)) {
                 return $template;
             }
         }
 
         // try to find a template for the given format
-        $template = new TemplateReference('FrameworkBundle', 'Exception', $name, $format, 'twig');
+        $template = sprintf('FrameworkBundle:Exception:%s.%s.twig', $name, $format);
         if ($templating->exists($template)) {
             return $template;
         }
@@ -90,6 +90,6 @@ class ExceptionController extends ContainerAware
         // default to a generic HTML exception
         $this->container->get('request')->setRequestFormat('html');
 
-        return new TemplateReference('FrameworkBundle', 'Exception', $name, 'html', 'twig');
+        return sprintf('FrameworkBundle:Exception:%s.html.twig');
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\TwigBundle\Loader;
 
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Component\Templating\TemplateReferenceInterface;
 
 /**
  * FilesystemLoader extends the default Twig filesystem loader
@@ -25,7 +24,6 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
 {
     protected $locator;
     protected $parser;
-    protected $cache;
 
     /**
      * Constructor.
@@ -41,36 +39,47 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
     }
 
     /**
-     * Returns the path to the template file
+     * Returns the path to the template file.
      *
-     * @param $name The template logical name
+     * The file locator is used to locate the template when the naming convention
+     * is the symfony one (i.e. the name can be parsed).
+     * Otherwise the template is located using the locator from the twig library.
+     *
+     * @param string|TemplateReferenceInterface $template The template
      *
      * @return string The path to the template file
+     *
+     * @throws \Twig_Error_Loader if the template could not be found
      */
-    protected function findTemplate($name)
+    protected function findTemplate($template)
     {
-        try {
-            $tpl = $this->parser->parse($name);
-        } catch (\Exception $e) {
-            return parent::findTemplate($name);
-        }
+        $logicalName = (string) $template;
 
-        if (isset($this->cache[$key = $tpl->getLogicalName()])) {
-            return $this->cache[$key];
+        if (isset($this->cache[$logicalName])) {
+            return $this->cache[$logicalName];
         }
 
         $file = null;
         $previous = null;
         try {
-            $file = $this->locator->locate($tpl);
-        } catch (\InvalidArgumentException $e) {
-            $previous = $e;
+            $template = $this->parser->parse($template);
+            try {
+                $file = $this->locator->locate($template);
+            } catch (\InvalidArgumentException $e) {
+                $previous = $e;
+            }
+        } catch (\Exception $e) {
+            try {
+                $file = parent::findTemplate($template);
+            } catch (\Twig_Error_Loader $e) {
+                $previous = $e;
+            }
         }
 
         if (false === $file || null === $file) {
-            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', $tpl), -1, null, $previous);
+            throw new \Twig_Error_Loader(sprintf('Unable to find template "%s".', $logicalName), -1, null, $previous);
         }
 
-        return $this->cache[$key] = $file;
+        return $this->cache[$logicalName] = $file;
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -37,8 +37,8 @@ class FilesystemLoaderTest extends TestCase
 
         $this->parser->expects($this->once())
                 ->method('parse')
-                ->with('name.engine.format')
-                ->will($this->returnValue(new TemplateReference('', '', 'name', 'engine', 'format')))
+                ->with('name.format.engine')
+                ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
         ;
     }
 
@@ -50,7 +50,7 @@ class FilesystemLoaderTest extends TestCase
                       ->method('locate')
                       ->will($this->throwException($invalidException));
 
-        $this->loader->getCacheKey('name.engine.format');
+        $this->loader->getCacheKey('name.format.engine');
     }
 
     public function testTwigErrorIfLocatorReturnsFalse()
@@ -60,6 +60,6 @@ class FilesystemLoaderTest extends TestCase
                       ->method('locate')
                       ->will($this->returnValue(false));
 
-        $this->loader->getCacheKey('name.engine.format');
+        $this->loader->getCacheKey('name.format.engine');
     }
 }


### PR DESCRIPTION
-  `findTemplate()` will most likely be called with the template logical name. In such a case this is a waste of time to call `parse()` and `getLogicalName()`;
- use `$cache[]` from the base `\Twig_Loader_Filesystem`.
