### PR TITLE
Fix array access

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -74,7 +74,7 @@ class UniqueEntityValidator extends ConstraintValidator
         if (count($result) > 0 && $result[0] !== $entity) {
             $oldPath = $this->context->getPropertyPath();
             $this->context->setPropertyPath( empty($oldPath) ? $fields[0] : $oldPath . "." . $fields[0]);
-            $this->context->addViolation($constraint->message, array(), $criteria[$constraint->fields[0]]);
+            $this->context->addViolation($constraint->message, array(), $criteria[$fields[0]]);
             $this->context->setPropertyPath($oldPath);
         }
 


### PR DESCRIPTION
If you provide only one field as string you're not able to access the $constraint->fields as an array. Use $fields instead.
