### PR TITLE
[AsseticBundle] changed file resource string value to logical template name

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Factory/Resource/FileResource.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/Resource/FileResource.php
@@ -56,7 +56,7 @@ class FileResource implements ResourceInterface
 
     public function __toString()
     {
-        return $this->path;
+        return (string) $this->getTemplate();
     }
 
     protected function getTemplate()


### PR DESCRIPTION
This fixes an obscure route not found exception when the `{% filter %}` tag is used.

Please merge ASAP.
