### PR TITLE
[AsseticBundle] fixed directory coalescing

### DIFF
--- a/src/Symfony/Bundle/AsseticBundle/Factory/Resource/CoalescingDirectoryResource.php
+++ b/src/Symfony/Bundle/AsseticBundle/Factory/Resource/CoalescingDirectoryResource.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Factory\Resource;
+
+use Assetic\Factory\Resource\CoalescingDirectoryResource as BaseCoalescingDirectoryResource;
+use Assetic\Factory\Resource\ResourceInterface;
+
+/**
+ * Coalesces multiple directories together into one merged resource.
+ *
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+class CoalescingDirectoryResource extends BaseCoalescingDirectoryResource
+{
+    protected function getRelativeName(ResourceInterface $file, ResourceInterface $directory)
+    {
+        $name = (string) $file;
+
+        return substr($name, strpos($name, ':'));
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
+++ b/src/Symfony/Bundle/AsseticBundle/Resources/config/assetic.xml
@@ -12,7 +12,7 @@
         <parameter key="assetic.config_cache.class">Assetic\Cache\ConfigCache</parameter>
         <parameter key="assetic.config_loader.class">Symfony\Bundle\AsseticBundle\Factory\Loader\ConfigurationLoader</parameter>
         <parameter key="assetic.config_resource.class">Symfony\Bundle\AsseticBundle\Factory\Resource\ConfigurationResource</parameter>
-        <parameter key="assetic.coalescing_directory_resource.class">Assetic\Factory\Resource\CoalescingDirectoryResource</parameter>
+        <parameter key="assetic.coalescing_directory_resource.class">Symfony\Bundle\AsseticBundle\Factory\Resource\CoalescingDirectoryResource</parameter>
         <parameter key="assetic.directory_resource.class">Symfony\Bundle\AsseticBundle\Factory\Resource\DirectoryResource</parameter>
         <parameter key="assetic.filter_manager.class">Symfony\Bundle\AsseticBundle\FilterManager</parameter>
         <parameter key="assetic.worker.ensure_filter.class">Assetic\Factory\Worker\EnsureFilterWorker</parameter>

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/Resource/CoalescingDirectoryResourceTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/Resource/CoalescingDirectoryResourceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Factory\Resource;
+
+use Symfony\Bundle\AsseticBundle\Factory\Resource\CoalescingDirectoryResource;
+
+class CoalescingDirectoryResourceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFiltering()
+    {
+        $dir1 = $this->getMock('Assetic\\Factory\\Resource\\IteratorResourceInterface');
+        $file1a = $this->getMock('Assetic\\Factory\\Resource\\ResourceInterface');
+        $file1b = $this->getMock('Assetic\\Factory\\Resource\\ResourceInterface');
+
+        $dir2 = $this->getMock('Assetic\\Factory\\Resource\\IteratorResourceInterface');
+        $file2a = $this->getMock('Assetic\\Factory\\Resource\\ResourceInterface');
+        $file2c = $this->getMock('Assetic\\Factory\\Resource\\ResourceInterface');
+
+        $dir1->expects($this->any())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($file1a, $file1b))));
+        $file1a->expects($this->any())
+            ->method('__toString')
+            ->will($this->returnValue('FooBundle:Foo:file1.foo.bar'));
+        $file1b->expects($this->any())
+            ->method('__toString')
+            ->will($this->returnValue('FooBundle:Foo:file2.foo.bar'));
+
+        $dir2->expects($this->any())
+            ->method('getIterator')
+            ->will($this->returnValue(new \ArrayIterator(array($file2a, $file2c))));
+        $file2a->expects($this->any())
+            ->method('__toString')
+            ->will($this->returnValue('BarBundle:Foo:file1.foo.bar'));
+        $file2c->expects($this->any())
+            ->method('__toString')
+            ->will($this->returnValue('BarBundle:Foo:file3.foo.bar'));
+
+        $resource = new CoalescingDirectoryResource(array($dir1, $dir2));
+
+        $actual = array();
+        foreach ($resource as $file) {
+            $actual[] = (string) $file;
+        }
+
+        $expected = array(
+            'FooBundle:Foo:file1.foo.bar',
+            'FooBundle:Foo:file2.foo.bar',
+            'BarBundle:Foo:file3.foo.bar',
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/src/Symfony/Bundle/AsseticBundle/Tests/Factory/Resource/FileResourceTest.php
+++ b/src/Symfony/Bundle/AsseticBundle/Tests/Factory/Resource/FileResourceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\AsseticBundle\Tests\Factory\Resource;
+
+use Symfony\Bundle\AsseticBundle\Factory\Resource\FileResource;
+
+class FileResourceTest extends \PHPUnit_Framework_TestCase
+{
+    private $loader;
+
+    protected function setUp()
+    {
+        $this->loader = $this->getMock('Symfony\\Component\\Templating\\Loader\\LoaderInterface');
+    }
+
+    public function testCastAsString()
+    {
+        $baseDir = '/path/to/MyBundle/Resources/views/';
+        $resource = new FileResource($this->loader, 'MyBundle', $baseDir, $baseDir.'Section/template.html.twig');
+        $this->assertEquals('MyBundle:Section:template.html.twig', (string) $resource);
+    }
+}


### PR DESCRIPTION
This fixes an issue my earlier commit introduced. Directory coalescing now works with template logical names instead of a filesystem path.
