### PR TITLE
[Form] Make the prototype view child of the collection view

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -226,7 +226,7 @@ class FormExtension extends \Twig_Extension
 
         $blocks = $this->getBlocks($view);
         $types = $view->get('types');
-        array_unshift($types, '_'.$view->get('id'));
+        array_unshift($types, '_'.$view->get('proto_id', $view->get('id')));
 
         foreach ($types as $type) {
             $block = $type.'_'.$section;

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -226,12 +226,12 @@ class FormExtension extends \Twig_Extension
 
         $blocks = $this->getBlocks($view);
         $types = $view->get('types');
-        array_unshift($types, '_'.$view->get('proto_id', $view->get('id')));
+        $types[] = '_'.$view->get('proto_id', $view->get('id'));
 
-        foreach ($types as &$block) {
-            $block = $block.'_'.$section;
+        for ($i = count($types) - 1; $i >= 0; $i--) {
+            $types[$i] .= '_'.$section;
 
-            if (isset($blocks[$block])) {
+            if (isset($blocks[$types[$i]])) {
 
                 $this->varStack[$view] = array_replace(
                     $view->all(),
@@ -239,7 +239,7 @@ class FormExtension extends \Twig_Extension
                     $variables
                 );
 
-                $html = $this->template->renderBlock($block, $this->varStack[$view], $blocks);
+                $html = $this->template->renderBlock($types[$i], $this->varStack[$view], $blocks);
 
                 if ($mainTemplate) {
                     $view->setRendered();

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -228,8 +228,8 @@ class FormExtension extends \Twig_Extension
         $types = $view->get('types');
         array_unshift($types, '_'.$view->get('proto_id', $view->get('id')));
 
-        foreach ($types as $type) {
-            $block = $type.'_'.$section;
+        foreach ($types as &$block) {
+            $block = $block.'_'.$section;
 
             if (isset($blocks[$block])) {
 
@@ -251,7 +251,7 @@ class FormExtension extends \Twig_Extension
             }
         }
 
-        throw new FormException(sprintf('Unable to render form as none of the following blocks exist: "%s".', implode('", "', $blocks)));
+        throw new FormException(sprintf('Unable to render form as none of the following blocks exist: "%s".', implode('", "', $types)));
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/div_layout.html.twig
@@ -260,11 +260,8 @@
 {% endspaceless %}
 {% endblock email_widget %}
 
-{% block collection_widget %}
+{% block prototype_row %}
 {% spaceless %}
-    {{ block('form_widget') }}
-    {% if prototype is defined %}
-    <script type="text/html" id="{{ id }}_prototype">{{ form_row(prototype) }}</script>
-    {% endif %}
+    <script type="text/html" id="{{ proto_id }}">{{ block('field_row') }}</script>
 {% endspaceless %}
-{% endblock collection_widget %}
+{% endblock prototype_row %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/collection_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/collection_widget.html.php
@@ -1,5 +1,0 @@
-<?php echo $view->render('FrameworkBundle:Form:form_widget.html.php', array('form' => $form)) ?>
-
-<?php if (isset($prototype)): ?>
-<script type="text/html" id="<?php echo $view->escape($id) ?>_prototype"><?php echo $view['form']->row($prototype) ?></script>
-<?php endif; ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/prototype_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/prototype_row.html.php
@@ -1,0 +1,3 @@
+<script type="text/html" id="<?php echo $view->escape($proto_id) ?>">
+    <?php echo $view->render('FrameworkBundle:Form:field_row.html.php', array('form' => $form)) ?>
+</script>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -202,29 +202,25 @@ class FormHelper extends Helper
         }
 
         $template = null;
-        $blocks = $view->get('types');
-        array_unshift($blocks, '_'.$view->get('proto_id', $view->get('id')));
+        $types = $view->get('types');
+        $types[] = '_'.$view->get('proto_id', $view->get('id'));
 
-        foreach ($blocks as &$block) {
-            $block = $block.'_'.$section;
-            $template = $this->lookupTemplate($block);
+        for ($i = count($types) - 1; $i >= 0; $i--) {
+            $types[$i] .= '_'.$section;
+            $template = $this->lookupTemplate($types[$i]);
 
             if ($template) {
-                break;
+                $html = $this->render($view, $template, $variables);
+
+                if ($mainTemplate) {
+                    $view->setRendered();
+                }
+
+                return $html;
             }
         }
 
-        if (!$template) {
-            throw new FormException(sprintf('Unable to render form as none of the following blocks exist: "%s".', implode('", "', $blocks)));
-        }
-
-        $html = $this->render($view, $template, $variables);
-
-        if ($mainTemplate) {
-            $view->setRendered();
-        }
-
-        return $html;
+        throw new FormException(sprintf('Unable to render form as none of the following blocks exist: "%s".', implode('", "', $types)));
     }
 
     public function render(FormView $view, $template, array $variables = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -203,7 +203,7 @@ class FormHelper extends Helper
 
         $template = null;
         $blocks = $view->get('types');
-        array_unshift($blocks, '_'.$view->get('id'));
+        array_unshift($blocks, '_'.$view->get('proto_id', $view->get('id')));
 
         foreach ($blocks as &$block) {
             $block = $block.'_'.$section;

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -26,7 +26,7 @@ class CollectionType extends AbstractType
     {
         if ($options['allow_add'] && $options['prototype']) {
             $prototype = $builder->create('$$name$$', $options['type'], $options['options']);
-            $builder->setAttribute('prototype', $prototype->getForm());
+            $builder->setAttribute('prototype', $prototype);
         }
 
         $listener = new ResizeFormListener(
@@ -55,7 +55,7 @@ class CollectionType extends AbstractType
         ;
 
         if ($form->hasAttribute('prototype')) {
-            $view->set('prototype', $form->getAttribute('prototype')->createView());
+            $view->set('prototype', $form->getAttribute('prototype'));
         }
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -75,6 +75,11 @@ class FieldType extends AbstractType
             $fullName = $name;
         }
 
+        $types = array();
+        foreach ($form->getTypes() as $type) {
+            $types[] = $type->getName();
+        }
+
         $view
             ->set('form', $view)
             ->set('id', $id)
@@ -90,7 +95,7 @@ class FieldType extends AbstractType
             ->set('label', $form->getAttribute('label'))
             ->set('multipart', false)
             ->set('attr', array())
-            ->set('types', array_map(function ($type) { return $type->getName(); }, $form->getTypes()))
+            ->set('types', $types)
         ;
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -75,11 +75,6 @@ class FieldType extends AbstractType
             $fullName = $name;
         }
 
-        $types = array();
-        foreach (array_reverse((array) $form->getTypes()) as $type) {
-            $types[] = $type->getName();
-        }
-
         $view
             ->set('form', $view)
             ->set('id', $id)
@@ -95,7 +90,7 @@ class FieldType extends AbstractType
             ->set('label', $form->getAttribute('label'))
             ->set('multipart', false)
             ->set('attr', array())
-            ->set('types', $types)
+            ->set('types', array_map(function ($type) { return $type->getName(); }, $form->getTypes()))
         ;
     }
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -921,7 +921,7 @@ class Form implements \IteratorAggregate, FormInterface
         if (null !== $prototype = $view->get('prototype')) {
             $protoView = $prototype->getForm()->createView($view);
             $protoTypes = $protoView->get('types');
-            array_unshift($protoTypes, 'prototype');
+            $protoTypes[] = 'prototype';
             $childViews[$prototype->getName()] = $protoView
                 ->set('types', $protoTypes)
                 ->set('proto_id', $view->get('id').'_prototype');

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -922,11 +922,10 @@ class Form implements \IteratorAggregate, FormInterface
             $protoView = $prototype->getForm()->createView($view);
             $protoTypes = $protoView->get('types');
             array_unshift($protoTypes, 'prototype');
-            $protoView
+            $childViews[$prototype->getName()] = $protoView
                 ->set('types', $protoTypes)
-                ->set('proto_id', $protoView->getParent()->get('id').'_prototype');
+                ->set('proto_id', $view->get('id').'_prototype');
             ;
-            $childViews[$prototype->getName()] = $protoView;
         }
 
         $view->setChildren($childViews);

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -907,7 +907,6 @@ class Form implements \IteratorAggregate, FormInterface
         $view->setParent($parent);
 
         $types = (array) $this->types;
-        $childViews = array();
 
         foreach ($types as $type) {
             $type->buildView($view, $this);
@@ -917,9 +916,7 @@ class Form implements \IteratorAggregate, FormInterface
             }
         }
 
-        foreach ($this->children as $key => $child) {
-            $childViews[$key] = $child->createView($view);
-        }
+        $childViews = array_map(function ($child) use ($view) { return $child->createView($view); }, $this->children);
 
         if (null !== $prototype = $view->get('prototype')) {
             $protoView = $prototype->getForm()->createView($view);

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -921,6 +921,17 @@ class Form implements \IteratorAggregate, FormInterface
             $childViews[$key] = $child->createView($view);
         }
 
+        if (null !== $prototype = $view->get('prototype')) {
+            $protoView = $prototype->getForm()->createView($view);
+            $protoTypes = $protoView->get('types');
+            array_unshift($protoTypes, 'prototype');
+            $protoView
+                ->set('types', $protoTypes)
+                ->set('proto_id', $protoView->getParent()->get('id').'_prototype');
+            ;
+            $childViews[$prototype->getName()] = $protoView;
+        }
+
         $view->setChildren($childViews);
 
         foreach ($types as $type) {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -916,7 +916,11 @@ class Form implements \IteratorAggregate, FormInterface
             }
         }
 
-        $childViews = array_map(function ($child) use ($view) { return $child->createView($view); }, $this->children);
+        $childViews = array();
+
+        foreach ($this->children as $key => $child) {
+            $childViews[$key] = $child->createView($view);
+        }
 
         if (null !== $prototype = $view->get('prototype')) {
             $protoView = $prototype->getForm()->createView($view);

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CollectionTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CollectionTypeTest.php
@@ -121,11 +121,24 @@ class CollectionFormTest extends TypeTestCase
     public function testAllowAddButNoPrototype()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'field',
+            'type'      => 'field',
             'allow_add' => true,
             'prototype' => false,
         ));
 
         $this->assertFalse($form->has('$$name$$'));
+    }
+
+    public function testPrototypeMultipartPropagation()
+    {
+        $form = $this->factory
+            ->create('collection', null, array(
+                'type'      => 'file',
+                'allow_add' => true,
+                'prototype' => true,
+            ))
+        ;
+
+        $this->assertTrue($form->createView()->get('multipart'));
     }
 }


### PR DESCRIPTION
This PR should be a base for discussion.

The [current implementation](https://github.com/symfony/symfony/pull/1188) has some drawbacks because the prototype view is not a child of the collection view:
- The 'multipart' attribute is not propagated from the prototype to the collection,
- The prototype view do not use the theme from the collection.

Those 2 points are fixed by the proposed implementation and one more benefit is that the template markup might be easier to work with:

before:

``` html
<div id="form_emails">
  <div>
    <label for="form_emails_0">0</label>
    <input type="email" id="form_emails_0" name="form[emails][0]" value="a@b.com">
  </div>
  <script type="text/html" id="form_emails_prototype">
    <div>
      <label for="$$name$$">$$name$$</label>
      <input type="email" id="$$name$$" name="$$name$$" value="" />
    </div>
  </script>
</div>
```

after:

``` html
<div id="form_emails">
  <div>
    <label for="form_emails_0">0</label>
    <input type="email" id="form_emails_0" name="form[emails][0]" value="a@b.com">
  </div>
  <script type="text/html" id="form_emails_prototype">
    <div>
      <label for="form_emails_$$name$$">$$name$$</label>
      <input type="email" id="form_emails_$$name$$" name="form[emails][$$name$$]" value="" />
    </div>
  </script>
</div>
```

@kriswallsmith I'd like to get your feedback on this PR. thanks.
