### PR TITLE
[Form] Configured timezone restored after transform

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -93,6 +93,14 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         if (intl_get_error_code() != 0) {
             throw new TransformationFailedException(intl_get_error_message());
         }
+        
+        if ('UTC' !== $this->inputTimezone) {
+            try {
+                $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
+            } catch (\Exception $e) {
+                throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+            }
+        }
 
         return $value;
     }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -122,6 +122,17 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
         $this->assertEquals($dateTime->format('d.m.Y H:i'), $transformer->transform($input));
     }
+    
+    public function testTransform_dontChangeReference()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('Europe/Paris');
+        
+        $input = new \DateTime('2010-02-03 00:00:00 Europe/Paris');
+        
+        $transformer->transform($input);
+        
+        $this->assertEquals(new \DateTime('2010-02-03 00:00:00 Europe/Paris'), $input);
+    }
 
     /**
      * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException


### PR DESCRIPTION
`DateTimeToLocalizedStringTransformer::transform` changes the timezone
of the `DateTime` object passed by reference. This could change the
date of a property's object attached to a `DateType` field... And each
time field is submitted date could decrease by 1 day.

For exemple, when `timedate.timezone` is set to `Europe/Paris` and
input `DateTime` is `2010-02-03T00:00:00+01:00` (`Europe\Paris`
timezone by default) after transform input becomes
`2010-02-02T23:00:00+00:00`.
