### PR TITLE
[FrameworkBundle] fixed TemplateRefence::getPath() when using namespaced 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
@@ -41,6 +41,12 @@ class TemplateReference extends BaseTemplateReference
     public function getPath()
     {
         $controller = $this->get('controller');
+
+        // Fix for namespaced controllers
+        if (!empty($controller) && false !== strpos($controller, '\\')) {
+            $controller = str_replace('\\', '/', $controller);
+        }
+
         $path = (empty($controller) ? '' : $controller.'/').$this->get('name').'.'.$this->get('format').'.'.$this->get('engine');
 
         return empty($this->parameters['bundle']) ? 'views/'.$path : '@'.$this->get('bundle').'/Resources/views/'.$path;

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
@@ -40,12 +40,7 @@ class TemplateReference extends BaseTemplateReference
      */
     public function getPath()
     {
-        $controller = $this->get('controller');
-
-        // Fix for namespaced controllers
-        if (!empty($controller) && false !== strpos($controller, '\\')) {
-            $controller = str_replace('\\', '/', $controller);
-        }
+        $controller = str_replace('\\', '/', $this->get('controller'));
 
         $path = (empty($controller) ? '' : $controller.'/').$this->get('name').'.'.$this->get('format').'.'.$this->get('engine');
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateReferenceTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateReferenceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
+
+class TemplateReferenceTest extends TestCase
+{
+    public function testGetPathWorksWithNamespacedControllers()
+    {
+        $reference = new TemplateReference('AcmeBlogBundle', 'Admin\Post', 'index', 'html', 'twig');
+
+        $this->assertSame(
+            '@AcmeBlogBundle/Resources/views/Admin/Post/index.html.twig',
+            $reference->getPath()
+        );
+    }
+}


### PR DESCRIPTION
[FrameworkBundle] fixed TemplateRefence::getPath() when using namespaced controllers (i.e: AcmeBlogBundle\Controller\Admin\PostController)
