### PR TITLE
[Tests] Sync vendors.php with last Symfony2

### DIFF
--- a/vendors.php
+++ b/vendors.php
@@ -24,9 +24,8 @@ if (!is_dir($vendorDir = dirname(__FILE__).'/vendor')) {
 }
 
 $deps = array(
-    array('assetic', 'http://github.com/kriswallsmith/assetic.git', 'origin/HEAD'),
-    array('doctrine', 'http://github.com/doctrine/doctrine2.git', '2.0.5'),
-    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', '2.0.5'),
+    array('doctrine', 'http://github.com/doctrine/doctrine2.git', 'origin/2.0.x'),
+    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', 'origin/2.0.x'),
     array('doctrine-common', 'http://github.com/doctrine/common.git', 'origin/3.0.x'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', 'origin/HEAD'),
     array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'origin/4.1'),


### PR DESCRIPTION
Sync `vendors.php` with last Symfony2 changes (removing `Assetic` and `AsseticBundle` and changes in `YamlParser`)
