### PR TITLE
Doctrine mapping types

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/ConnectionFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/ConnectionFactory.php
@@ -43,14 +43,23 @@ class ConnectionFactory
      *
      * @return Doctrine\DBAL\Connection
      */
-    public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null)
+    public function createConnection(array $params, Configuration $config = null, EventManager $eventManager = null, array $mappingTypes = array())
     {
         if (!$this->initialized) {
             $this->initializeTypes();
             $this->initialized = true;
         }
 
-        return DriverManager::getConnection($params, $config, $eventManager);
+        $connection = DriverManager::getConnection($params, $config, $eventManager);
+
+        if (!empty($mappingTypes)) {
+            $platform = $connection->getDatabasePlatform();
+            foreach ($mappingTypes as $dbType => $doctrineType) {
+                $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
+            }
+        }
+
+        return $connection;
     }
 
     private function initializeTypes()

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -77,7 +77,8 @@ class Configuration implements ConfigurationInterface
                             'wrapper_class',
                             'platform_service',
                             'charset',
-                            'logging'
+                            'logging',
+                            'mapping_types',
                         ) as $key) {
                             if (array_key_exists($key, $v)) {
                                 $connection[$key] = $v[$key];
@@ -115,6 +116,7 @@ class Configuration implements ConfigurationInterface
             ->requiresAtLeastOneElement()
             ->useAttributeAsKey('name')
             ->prototype('array')
+                ->fixXmlConfig('mapping_type')
                 ->children()
                     ->scalarNode('dbname')->end()
                     ->scalarNode('host')->defaultValue('localhost')->end()
@@ -132,6 +134,10 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('wrapper_class')->end()
                     ->arrayNode('options')
                         ->useAttributeAsKey('key')
+                        ->prototype('scalar')->end()
+                    ->end()
+                    ->arrayNode('mapping_types')
+                        ->useAttributeAsKey('name')
                         ->prototype('scalar')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -127,6 +127,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
                 $options,
                 new Reference(sprintf('doctrine.dbal.%s_connection.configuration', $name)),
                 new Reference(sprintf('doctrine.dbal.%s_connection.event_manager', $name)),
+                $connection['mapping_types'],
             ))
         ;
     }
@@ -139,6 +140,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
             $options['platform'] = new Reference($options['platform_service']);
             unset($options['platform_service']);
         }
+        unset($options['mapping_types']);
 
         foreach (array(
             'options' => 'driverOptions',

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/schema/doctrine-1.0.xsd
@@ -22,7 +22,6 @@
         <xsd:attribute name="password" type="xsd:string" />
         <xsd:attribute name="driver" type="xsd:string" />
         <xsd:attribute name="driver-class" type="xsd:string" />
-        <xsd:attribute name="options" type="xsd:string" />
         <xsd:attribute name="path" type="xsd:string" />
         <xsd:attribute name="unix-socket" type="xsd:string" />
         <xsd:attribute name="memory" type="xsd:boolean" />
@@ -36,10 +35,28 @@
         <xsd:choice minOccurs="0" maxOccurs="unbounded">
             <xsd:element name="connection" type="connection" />
             <xsd:element name="type" type="type" />
+            <xsd:element name="option" type="option" />
+            <xsd:element name="mapping-type" type="mapping-type" />
         </xsd:choice>
 
         <xsd:attribute name="default-connection" type="xsd:string" />
         <xsd:attributeGroup ref="connection-config" />
+    </xsd:complexType>
+
+    <xsd:complexType name="option">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="key" type="xsd:string" use="required" />
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:complexType name="mapping-type">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:extension>
+        </xsd:simpleContent>
     </xsd:complexType>
 
     <xsd:complexType name="type">
@@ -51,6 +68,10 @@
     </xsd:complexType>
 
     <xsd:complexType name="connection">
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="option" type="option" />
+            <xsd:element name="mapping-type" type="mapping-type" />
+        </xsd:choice>
         <xsd:attribute name="name" type="xsd:string" use="required" />
         <xsd:attributeGroup ref="connection-config" />
     </xsd:complexType>

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -226,7 +226,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'driverOptions' => array(),
             ),
             new Reference('doctrine.dbal.default_connection.configuration'),
-            new Reference('doctrine.dbal.default_connection.event_manager')
+            new Reference('doctrine.dbal.default_connection.event_manager'),
+            array(),
         ));
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');
@@ -265,7 +266,8 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
                 'logging' => false,
             ),
             new Reference('doctrine.dbal.default_connection.configuration'),
-            new Reference('doctrine.dbal.default_connection.event_manager')
+            new Reference('doctrine.dbal.default_connection.event_manager'),
+            array(),
         ));
 
         $definition = $container->getDefinition('doctrine.orm.default_entity_manager');


### PR DESCRIPTION
This adds the full support of Doctrine mapping type, allowing to use them in the SchemaTool. It closes #1349
