### PR TITLE
If no sids have been loaded, return false from isSidLoaded

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -234,7 +234,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     public function isSidLoaded($sids)
     {
         if (!$this->loadedSids) {
-            return true;
+            return false;
         }
 
         if (!is_array($sids)) {


### PR DESCRIPTION
If no sids have been loaded, return false. If this wasn't just a simple typo, what's the reasoning behind this method returning true always if there haven't been any loaded sids?
