### PR TITLE
[Console] fixed formatter if content has line breaks

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -125,7 +125,7 @@ class OutputFormatter implements OutputFormatterInterface
      */
     public function format($message)
     {
-        return preg_replace_callback('#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#i', array($this, 'replaceStyle'), $message);
+        return preg_replace_callback('#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#is', array($this, 'replaceStyle'), $message);
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
@@ -129,4 +129,55 @@ class FormatterStyleTest extends \PHPUnit_Framework_TestCase
             "\033[30;46msome question\033[0m", $formatter->format('<question>some question</question>')
         );
     }
+
+    public function testContentWithLineBreaks()
+    {
+        $formatter = new OutputFormatter(true);
+
+        $this->assertEquals(<<<EOF
+\033[32m
+some text\033[0m
+EOF
+            , $formatter->format(<<<EOF
+<info>
+some text</info>
+EOF
+        ));
+
+        $this->assertEquals(<<<EOF
+\033[32msome text
+\033[0m
+EOF
+            , $formatter->format(<<<EOF
+<info>some text
+</info>
+EOF
+        ));
+
+        $this->assertEquals(<<<EOF
+\033[32m
+some text
+\033[0m
+EOF
+            , $formatter->format(<<<EOF
+<info>
+some text
+</info>
+EOF
+        ));
+
+        $this->assertEquals(<<<EOF
+\033[32m
+some text
+more text
+\033[0m
+EOF
+            , $formatter->format(<<<EOF
+<info>
+some text
+more text
+</info>
+EOF
+        ));
+    }
 }


### PR DESCRIPTION
Fixes the Symfony2 ASCII art in shell.
