### PR TITLE
Improoved request method management.

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -573,14 +573,14 @@ class Form implements \IteratorAggregate, FormInterface
     {
         // Store the bound data in case of a post request
         switch ($request->getMethod()) {
-            case 'POST':
-            case 'PUT':
+            case Request::METHOD_POST:
+            case Request::METHOD_PUT:
                 $data = array_replace_recursive(
                     $request->request->get($this->getName(), array()),
                     $request->files->get($this->getName(), array())
                 );
                 break;
-            case 'GET':
+            case Request::METHOD_GET:
                 $data = $request->query->get($this->getName(), array());
                 break;
             default:

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -20,6 +20,12 @@ use Symfony\Component\HttpFoundation\SessionStorage\NativeSessionStorage;
  */
 class Request
 {
+    const METHOD_GET = 'GET';
+    const METHOD_POST = 'POST';
+    const METHOD_PUT = 'PUT';
+    const METHOD_DELETE = 'DELETE';
+    const METHOD_HEAD = 'HEAD';
+    
     /**
      * @var \Symfony\Component\HttpFoundation\ParameterBag
      */
@@ -130,7 +136,7 @@ class Request
         $request = new static($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER);
 
         if (0 === strpos($request->server->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
-            && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE'))
+            && in_array(strtoupper($request->server->get('REQUEST_METHOD', self::METHOD_GET)), array(self::METHOD_PUT, self::METHOD_DELETE))
         ) {
             parse_str($request->getContent(), $data);
             $request->request = new ParameterBag($data);
@@ -152,7 +158,7 @@ class Request
      *
      * @return Request A Request instance
      */
-    static public function create($uri, $method = 'GET', $parameters = array(), $cookies = array(), $files = array(), $server = array(), $content = null)
+    static public function create($uri, $method = self::METHOD_GET, $parameters = array(), $cookies = array(), $files = array(), $server = array(), $content = null)
     {
         $defaults = array(
             'SERVER_NAME'          => 'localhost',
@@ -186,7 +192,7 @@ class Request
             $defaults['HTTP_HOST'] = $defaults['HTTP_HOST'].':'.$components['port'];
         }
 
-        if (in_array(strtoupper($method), array('POST', 'PUT', 'DELETE'))) {
+        if (in_array(strtoupper($method), array(self::METHOD_POST, self::METHOD_PUT, self::METHOD_DELETE))) {
             $request = $parameters;
             $query = array();
             $defaults['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
@@ -620,7 +626,7 @@ class Request
     }
 
     /**
-     * Sets the request method.
+     * Sets the request method. 
      *
      * @param string $method
      */
@@ -640,13 +646,63 @@ class Request
     public function getMethod()
     {
         if (null === $this->method) {
-            $this->method = strtoupper($this->server->get('REQUEST_METHOD', 'GET'));
-            if ('POST' === $this->method) {
-                $this->method = strtoupper($this->server->get('X-HTTP-METHOD-OVERRIDE', $this->request->get('_method', 'POST')));
+            $this->method = strtoupper($this->server->get('REQUEST_METHOD', self::METHOD_GET));
+            if (self::METHOD_POST === $this->method) {
+                $this->method = strtoupper($this->server->get('X-HTTP-METHOD-OVERRIDE', $this->request->get('_method', self::METHOD_POST)));
             }
         }
 
         return $this->method;
+    }
+    
+    /**
+     * Checks if method is GET.
+     *
+     * @return boolean
+     */
+    public function isMethodGet()
+    {
+        return self::METHOD_GET === $this->getMethod();
+    }
+    
+    /**
+     * Checks if method is POST.
+     *
+     * @return boolean
+     */
+    public function isMethodPost()
+    {
+        return self::METHOD_POST === $this->getMethod();
+    }
+    
+    /**
+     * Checks if method is PUT.
+     *
+     * @return boolean
+     */
+    public function isMethodPut()
+    {
+        return self::METHOD_PUT === $this->getMethod();
+    }
+    
+    /**
+     * Checks if method is DELETE.
+     *
+     * @return boolean
+     */
+    public function isMethodDelete()
+    {
+        return self::METHOD_DELETE === $this->getMethod();
+    }
+    
+    /**
+     * Checks if method is HEAD.
+     *
+     * @return boolean
+     */
+    public function isMethodHead()
+    {
+        return self::METHOD_HEAD === $this->getMethod();
     }
 
     /**
@@ -740,7 +796,7 @@ class Request
      */
     public function isMethodSafe()
     {
-        return in_array($this->getMethod(), array('GET', 'HEAD'));
+        return in_array($this->getMethod(), array(self::METHOD_GET, self::METHOD_HEAD));
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -810,8 +810,8 @@ class FormTest extends \PHPUnit_Framework_TestCase
     public function requestMethodProvider()
     {
         return array(
-            array('POST'),
-            array('PUT'),
+            array(Request::METHOD_POST),
+            array(Request::METHOD_PUT),
         );
     }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -103,7 +103,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($request->isSecure());
 
         $json = '{"jsonrpc":"2.0","method":"echo","id":7,"params":["Hello World"]}';
-        $request = Request::create('http://example.com/jsonrpc', 'POST', array(), array(), array(), array(), $json);
+        $request = Request::create('http://example.com/jsonrpc', Request::METHOD_POST, array(), array(), array(), array(), $json);
         $this->assertEquals($json, $request->getContent());
         $this->assertFalse($request->isSecure());
     }
@@ -448,29 +448,58 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
 
-        $this->assertEquals('GET', $request->getMethod(), '->getMethod() returns GET if no method is defined');
+        $this->assertEquals(Request::METHOD_GET, $request->getMethod(), '->getMethod() returns GET if no method is defined');
 
         $request->setMethod('get');
-        $this->assertEquals('GET', $request->getMethod(), '->getMethod() returns an uppercased string');
+        $this->assertEquals(Request::METHOD_GET, $request->getMethod(), '->getMethod() returns an uppercased string');
 
         $request->setMethod('PURGE');
         $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returns the method even if it is not a standard one');
 
-        $request->setMethod('POST');
-        $this->assertEquals('POST', $request->getMethod(), '->getMethod() returns the method POST if no _method is defined');
+        $request->setMethod(Request::METHOD_POST);
+        $this->assertEquals(Request::METHOD_POST, $request->getMethod(), '->getMethod() returns the method POST if no _method is defined');
 
-        $request->setMethod('POST');
+        $request->setMethod(Request::METHOD_POST);
         $request->request->set('_method', 'purge');
         $this->assertEquals('PURGE', $request->getMethod(), '->getMethod() returns the method from _method if defined and POST');
 
-        $request->setMethod('POST');
+        $request->setMethod(Request::METHOD_POST);
         $request->server->set('X-HTTP-METHOD-OVERRIDE', 'delete');
-        $this->assertEquals('DELETE', $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override even though _method is set if defined and POST');
+        $this->assertEquals(Request::METHOD_DELETE, $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override even though _method is set if defined and POST');
 
         $request = new Request();
-        $request->setMethod('POST');
+        $request->setMethod(Request::METHOD_POST);
         $request->server->set('X-HTTP-METHOD-OVERRIDE', 'delete');
-        $this->assertEquals('DELETE', $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override if defined and POST');
+        $this->assertEquals(Request::METHOD_DELETE, $request->getMethod(), '->getMethod() returns the method from X-HTTP-Method-Override if defined and POST');
+    }
+    
+    /**
+     * @covers Symfony\Component\HttpFoundation\Request::isMethodGet
+     * @covers Symfony\Component\HttpFoundation\Request::isMethodPost
+     * @covers Symfony\Component\HttpFoundation\Request::isMethodPut
+     * @covers Symfony\Component\HttpFoundation\Request::isMethodDelete
+     * @covers Symfony\Component\HttpFoundation\Request::isMethodHead
+     */
+    public function testIsMethodType()
+    {
+        $request = new Request();
+
+        $this->assertTrue($request->isMethodGet(), '->isMethodGet() returns true if no method is defined');
+
+        $request->setMethod(Request::METHOD_POST);
+        $this->assertTrue($request->isMethodPost(), '->isMethodPost() returns true if method is POST');
+        
+        $request->setMethod(Request::METHOD_GET);
+        $this->assertTrue($request->isMethodGet(), '->isMethodGet() returns true if method is GET');
+        
+        $request->setMethod(Request::METHOD_PUT);
+        $this->assertTrue($request->isMethodPut(), '->isMethodPut() returns true if method is PUT');
+        
+        $request->setMethod(Request::METHOD_DELETE);
+        $this->assertTrue($request->isMethodDelete(), '->isMethodDelete() returns true if method is DELETE');
+        
+        $request->setMethod(Request::METHOD_HEAD);
+        $this->assertTrue($request->isMethodHead(), '->isMethodHead() returns true if method is HEAD');        
     }
 
     /**


### PR DESCRIPTION
Request methods (GET, POST, PUT...) moved to constants in Request class. Added isMethod*() methods for easy checking request method.

Use case - when handling forms we usually have this line repeated:

<pre>
if ('POST' == $request->getMethod())
</pre>


after this fix it can be written like:

<pre>
if ($request->isMethodPost())
</pre>


so we will not hard-code strings across projects and Symfony framework itself + it is more handy and prevent possible typos.
