### PR TITLE
[Process] Sets the append mode for the stderr descriptor

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -105,13 +105,9 @@ class Process
         };
 
         // Workaround for http://bugs.php.net/bug.php?id=51800
-        if (strstr(PHP_OS, 'WIN')) {
-            $stderrPipeMode = 'a';
-        } else {
-            $stderrPipeMode = 'w';
-        }
-
-        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', $stderrPipeMode));
+        // Set stderr in append mode.
+        // This bug causes freezing in Windows machines and empty files in GNU/Linux
+        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
 
         $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -105,9 +105,14 @@ class Process
         };
 
         // Workaround for http://bugs.php.net/bug.php?id=51800
-        // Set stderr in append mode.
+        // Set stderr in append mode for Windows and GNU/Linux.
         // This bug causes freezing in Windows machines and empty files in GNU/Linux
-        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'a'));
+        if (PHP_OS === 'Linux' || strstr(PHP_OS, 'WIN')) {
+            $stderrPipeMode = 'a';
+        } else {
+            $stderrPipeMode = 'w';
+        }
+        $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', $stderrPipeMode));
 
         $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 


### PR DESCRIPTION
This bug was already reported in https://github.com/symfony/symfony/pull/919 as causing a deadlock in Windows based systems. However in GNU/Linux systems caused empty files being generated for files larger than 16KB.

To reproduce you could set up a jquery asset in twig, for example, and then try to apply the Google Closure filter.
