### PR TITLE
[HttpFoundation] Small optimization of Session flash handling

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -66,7 +66,7 @@ class Session implements \Serializable
             $this->setPhpDefaultLocale($this->locale);
 
             // flag current flash messages to be removed at shutdown
-            $this->oldFlashes = array_flip(array_keys($this->flashes));
+            $this->oldFlashes = $this->flashes;
         }
 
         $this->started = true;


### PR DESCRIPTION
Due to copy-on-write, this is faster and takes less memory unless the flashes are changed during the request, but that's not very likely as typically you set flashes, redirect, then show them, and at that point you do not modify them again.
