### PR TITLE
[Form] Some refactoring of the rendering

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -35,7 +35,7 @@ class FormExtension extends \Twig_Extension
     public function __construct(array $resources = array())
     {
         $this->themes = new \SplObjectStorage();
-        $this->varStack = new \SplObjectStorage();
+        $this->varStack = array();
         $this->blocks = new \SplObjectStorage();
         $this->rendering = array();
 
@@ -125,6 +125,15 @@ class FormExtension extends \Twig_Extension
      */
     public function renderRow(FormView $view, array $variables = array())
     {
+        $variables = array_replace_recursive(
+            array(
+                'label'     => array(),
+                'widget'    => array(),
+                'attr'      => array(),
+            ),
+            $variables
+        );
+        
         return $this->render($view, 'row', $variables);
     }
 
@@ -241,18 +250,18 @@ class FormExtension extends \Twig_Extension
 
                 $this->rendering[$rendering] = $i;
 
-                $this->varStack[$view] = array_replace(
-                    isset($this->varStack[$view]) ? $this->varStack[$view] : $view->all(),
+                $this->varStack[$rendering] = array_replace_recursive(
+                    isset($this->varStack[$rendering]) ? $this->varStack[$rendering] : $view->all(),
                     $variables
                 );
 
-                $html = $this->template->renderBlock($block, $this->varStack[$view], $blocks);
+                $html = $this->template->renderBlock($block, $this->varStack[$rendering], $blocks);
 
                 if ($mainTemplate) {
                     $view->setRendered();
                 }
 
-                unset($this->varStack[$view], $this->rendering[$rendering]);
+                unset($this->varStack[$rendering], $this->rendering[$rendering]);
 
                 return $html;
             }
@@ -270,7 +279,7 @@ class FormExtension extends \Twig_Extension
     {
         return 'form';
     }
-    
+
     /**
      * Returns the blocks used to render the view.
      *

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -251,13 +251,13 @@ class FormExtension extends \Twig_Extension
         }
 
         do {
-            $block = $types[$typeIndex].'_'.$section;
+            $types[$typeIndex] .= '_'.$section;
 
-            if (isset($blocks[$block])) {
+            if (isset($blocks[$types[$typeIndex]])) {
 
                 $this->varStack[$rendering]['typeIndex'] = $typeIndex;
 
-                $html = $this->template->renderBlock($block, $this->varStack[$rendering]['variables'], $blocks);
+                $html = $this->template->renderBlock($types[$typeIndex], $this->varStack[$rendering]['variables'], $blocks);
 
                 if ($mainTemplate) {
                     $view->setRendered();
@@ -269,7 +269,10 @@ class FormExtension extends \Twig_Extension
             }
         } while (--$typeIndex >= 0);
 
-        throw new FormException(sprintf('Unable to render form as none of the following blocks exist: "%s".', implode('", "', $types)));
+        throw new FormException(sprintf(
+            'Unable to render the form as none of the following blocks exist: "%s".',
+            implode('", "', array_reverse($types))
+        ));
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -122,15 +122,6 @@ class FormExtension extends \Twig_Extension
      */
     public function renderRow(FormView $view, array $variables = array())
     {
-        $variables = array_replace_recursive(
-            array(
-                'label'     => array(),
-                'widget'    => array(),
-                'attr'      => array(),
-            ),
-            $variables
-        );
-
         return $this->render($view, 'row', $variables);
     }
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -1,65 +1,4 @@
-{% block field_enctype %}
-{% spaceless %}
-    {% if multipart %}enctype="multipart/form-data"{% endif %}
-{% endspaceless %}
-{% endblock field_enctype %}
-
-{% block field_label %}
-{% spaceless %}
-    <label for="{{ id }}"{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
-{% endspaceless %}
-{% endblock field_label %}
-
-{% block form_label %}
-{% spaceless %}
-    <label {% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
-{% endspaceless %}
-{% endblock form_label %}
-
-{% block field_errors %}
-{% spaceless %}
-    {% if errors|length > 0 %}
-    <ul>
-        {% for error in errors %}
-            <li>{{ error.messageTemplate|trans(error.messageParameters, 'validators') }}</li>
-        {% endfor %}
-    </ul>
-    {% endif %}
-{% endspaceless %}
-{% endblock field_errors %}
-
-{% block field_rows %}
-{% spaceless %}
-    {{ form_errors(form) }}
-    {% for child in form %}
-        {{ form_row(child) }}
-    {% endfor %}
-{% endspaceless %}
-{% endblock field_rows %}
-
-{% block field_rest %}
-{% spaceless %}
-    {% for child in form %}
-        {% if not child.rendered %}
-            {{ form_row(child) }}
-        {% endif %}
-    {% endfor %}
-{% endspaceless %}
-{% endblock field_rest %}
-
-{% block widget_attributes %}
-{% spaceless %}
-    id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
-    {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
-{% endspaceless %}
-{% endblock widget_attributes %}
-
-{% block widget_container_attributes %}
-{% spaceless %}
-    id="{{ id }}"
-    {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
-{% endspaceless %}
-{% endblock widget_container_attributes %}
+{# Widgets #}
 
 {% block form_widget %}
 {% spaceless %}
@@ -69,36 +8,6 @@
     </div>
 {% endspaceless %}
 {% endblock form_widget %}
-
-{% block field_widget %}
-{% spaceless %}
-    {% set type = type|default('text') %}
-    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" />
-{% endspaceless %}
-{% endblock field_widget %}
-
-{% block text_widget %}
-{% spaceless %}
-    {% set type = type|default('text') %}
-    {{ block('field_widget') }}
-{% endspaceless %}
-{% endblock text_widget %}
-
-{% block password_widget %}
-{% spaceless %}
-    {% set type = type|default('password') %}
-    {{ block('field_widget') }}
-{% endspaceless %}
-{% endblock password_widget %}
-
-{% block hidden_widget %}
-    {% set type = type|default('hidden') %}
-    {{ block('field_widget') }}
-{% endblock hidden_widget %}
-
-{% block hidden_row %}
-    {{ form_widget(form) }}
-{% endblock hidden_row %}
 
 {% block textarea_widget %}
 {% spaceless %}
@@ -126,7 +35,7 @@
 {% spaceless %}
     {% if expanded %}
         <div {{ block('widget_container_attributes') }}>
-        {% for choice, child in form %}
+        {% for child in form %}
             {{ form_widget(child) }}
             {{ form_label(child) }}
         {% endfor %}
@@ -174,13 +83,13 @@
 {% block date_widget %}
 {% spaceless %}
     {% if widget == 'single_text' %}
-        {{ block('text_widget') }}
+        {{ form_widget(form) }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {{ date_pattern|replace({
-                '{{ year }}': form_widget(form.year),
+                '{{ year }}':  form_widget(form.year),
                 '{{ month }}': form_widget(form.month),
-                '{{ day }}': form_widget(form.day),
+                '{{ day }}':   form_widget(form.day),
             })|raw }}
         </div>
     {% endif %}
@@ -198,44 +107,78 @@
 {% block number_widget %}
 {% spaceless %}
     {# type="number" doesn't work with floats #}
-    {% set type = type|default('text') %}
-    {{ block('field_widget') }}
+    {{ form_widget(form, {"type": type|default('text')}) }}
 {% endspaceless %}
 {% endblock number_widget %}
 
 {% block integer_widget %}
 {% spaceless %}
-    {% set type = type|default('number') %}
-    {{ block('field_widget') }}
+    {{ form_widget(form, {"type": type|default('number')}) }}
 {% endspaceless %}
 {% endblock integer_widget %}
 
 {% block money_widget %}
 {% spaceless %}
-    {{ money_pattern|replace({ '{{ widget }}': block('field_widget') })|raw }}
+    {{ money_pattern|replace({ '{{ widget }}': form_widget(form) })|raw }}
 {% endspaceless %}
 {% endblock money_widget %}
 
 {% block url_widget %}
 {% spaceless %}
-    {% set type = type|default('url') %}
-    {{ block('field_widget') }}
+    {{ form_widget(form, {"type": type|default('url')}) }}
 {% endspaceless %}
 {% endblock url_widget %}
 
 {% block search_widget %}
 {% spaceless %}
-    {% set type = type|default('search') %}
-    {{ block('field_widget') }}
+    {{ form_widget(form, {"type": type|default('search')}) }}
 {% endspaceless %}
 {% endblock search_widget %}
 
 {% block percent_widget %}
 {% spaceless %}
-    {% set type = type|default('text') %}
-    {{ block('field_widget') }} %
+    {{ form_widget(form, {"type": type|default('text')}) }} %
 {% endspaceless %}
 {% endblock percent_widget %}
+
+{% block field_widget %}
+{% spaceless %}
+    {% set type = type|default('text') %}
+    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" />
+{% endspaceless %}
+{% endblock field_widget %}
+
+{% block password_widget %}
+{% spaceless %}
+    {{ form_widget(form, {"type": type|default('password')}) }}
+{% endspaceless %}
+{% endblock password_widget %}
+
+{% block hidden_widget %}
+    {{ form_widget(form, {"type": type|default('hidden')}) }}
+{% endblock hidden_widget %}
+
+{% block email_widget %}
+{% spaceless %}
+    {{ form_widget(form, {"type": type|default('email')}) }}
+{% endspaceless %}
+{% endblock email_widget %}
+
+{# Labels #}
+
+{% block field_label %}
+{% spaceless %}
+    <label for="{{ id }}"{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
+{% endspaceless %}
+{% endblock field_label %}
+
+{% block form_label %}
+{% spaceless %}
+    <label {% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
+{% endspaceless %}
+{% endblock form_label %}
+
+{# Rows #}
 
 {% block repeated_row %}
 {% spaceless %}
@@ -253,15 +196,67 @@
 {% endspaceless %}
 {% endblock field_row %}
 
-{% block email_widget %}
-{% spaceless %}
-    {% set type = type|default('email') %}
-    {{ block('field_widget') }}
-{% endspaceless %}
-{% endblock email_widget %}
-
 {% block prototype_row %}
 {% spaceless %}
-    <script type="text/html" id="{{ proto_id }}">{{ block('field_row') }}</script>
+    <script type="text/html" id="{{ proto_id }}">{{ form_row(form) }}</script>
 {% endspaceless %}
 {% endblock prototype_row %}
+
+{% block hidden_row %}
+    {{ form_widget(form) }}
+{% endblock hidden_row %}
+
+{# Misc #}
+
+{% block field_enctype %}
+{% spaceless %}
+    {% if multipart %}enctype="multipart/form-data"{% endif %}
+{% endspaceless %}
+{% endblock field_enctype %}
+
+{% block field_errors %}
+{% spaceless %}
+    {% if errors|length > 0 %}
+    <ul>
+        {% for error in errors %}
+            <li>{{ error.messageTemplate|trans(error.messageParameters, 'validators') }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+{% endspaceless %}
+{% endblock field_errors %}
+
+{% block field_rest %}
+{% spaceless %}
+    {% for child in form %}
+        {% if not child.rendered %}
+            {{ form_row(child) }}
+        {% endif %}
+    {% endfor %}
+{% endspaceless %}
+{% endblock field_rest %}
+
+{# Support #}
+
+{% block field_rows %}
+{% spaceless %}
+    {{ form_errors(form) }}
+    {% for child in form %}
+        {{ form_row(child) }}
+    {% endfor %}
+{% endspaceless %}
+{% endblock field_rows %}
+
+{% block widget_attributes %}
+{% spaceless %}
+    id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
+    {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
+{% endspaceless %}
+{% endblock widget_attributes %}
+
+{% block widget_container_attributes %}
+{% spaceless %}
+    id="{{ id }}"
+    {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
+{% endspaceless %}
+{% endblock widget_container_attributes %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -83,7 +83,7 @@
 {% block date_widget %}
 {% spaceless %}
     {% if widget == 'single_text' %}
-        {{ form_widget(form) }}
+        {{ block('field_widget') }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {{ date_pattern|replace({
@@ -107,37 +107,42 @@
 {% block number_widget %}
 {% spaceless %}
     {# type="number" doesn't work with floats #}
-    {{ form_widget(form, {"type": type|default('text')}) }}
+    {% set type = type|default('text') %}
+    {{ block('field_widget') }}
 {% endspaceless %}
 {% endblock number_widget %}
 
 {% block integer_widget %}
 {% spaceless %}
-    {{ form_widget(form, {"type": type|default('number')}) }}
+    {% set type = type|default('number') %}
+    {{ block('field_widget') }}
 {% endspaceless %}
 {% endblock integer_widget %}
 
 {% block money_widget %}
 {% spaceless %}
-    {{ money_pattern|replace({ '{{ widget }}': form_widget(form) })|raw }}
+    {{ money_pattern|replace({ '{{ widget }}': block('field_widget') })|raw }}
 {% endspaceless %}
 {% endblock money_widget %}
 
 {% block url_widget %}
 {% spaceless %}
-    {{ form_widget(form, {"type": type|default('url')}) }}
+    {% set type = type|default('url') %}
+    {{ block('field_widget') }}
 {% endspaceless %}
 {% endblock url_widget %}
 
 {% block search_widget %}
 {% spaceless %}
-    {{ form_widget(form, {"type": type|default('search')}) }}
+    {% set type = type|default('search') %}
+    {{ block('field_widget') }}
 {% endspaceless %}
 {% endblock search_widget %}
 
 {% block percent_widget %}
 {% spaceless %}
-    {{ form_widget(form, {"type": type|default('text')}) }} %
+    {% set type = type|default('text') %}
+    {{ block('field_widget') }} %
 {% endspaceless %}
 {% endblock percent_widget %}
 
@@ -150,17 +155,20 @@
 
 {% block password_widget %}
 {% spaceless %}
-    {{ form_widget(form, {"type": type|default('password')}) }}
+    {% set type = type|default('password') %}
+    {{ block('field_widget') }}
 {% endspaceless %}
 {% endblock password_widget %}
 
 {% block hidden_widget %}
-    {{ form_widget(form, {"type": type|default('hidden')}) }}
+    {% set type = type|default('hidden') %}
+    {{ block('field_widget') }}
 {% endblock hidden_widget %}
 
 {% block email_widget %}
 {% spaceless %}
-    {{ form_widget(form, {"type": type|default('email')}) }}
+    {% set type = type|default('email') %}
+    {{ block('field_widget') }}
 {% endspaceless %}
 {% endblock email_widget %}
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -188,10 +188,10 @@
 
 {% block field_row %}
 {% spaceless %}
-    <div>
-        {{ form_label(form) }}
+    <div {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}>
+        {{ form_label(form, null, label) }}
         {{ form_errors(form) }}
-        {{ form_widget(form) }}
+        {{ form_widget(form, widget) }}
     </div>
 {% endspaceless %}
 {% endblock field_row %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -196,10 +196,10 @@
 
 {% block field_row %}
 {% spaceless %}
-    <div {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}>
-        {{ form_label(form, null, label) }}
+    <div>
+        {{ form_label(form, label|default(null)) }}
         {{ form_errors(form) }}
-        {{ form_widget(form, widget) }}
+        {{ form_widget(form) }}
     </div>
 {% endspaceless %}
 {% endblock field_row %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -2,13 +2,13 @@
 
 {% block field_row %}
 {% spaceless %}
-    <tr>
+    <tr {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}>
         <td>
-            {{ form_label(form) }}
+            {{ form_label(form, null, label) }}
         </td>
         <td>
             {{ form_errors(form) }}
-            {{ form_widget(form) }}
+            {{ form_widget(form, widget) }}
         </td>
     </tr>
 {% endspaceless %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -2,13 +2,13 @@
 
 {% block field_row %}
 {% spaceless %}
-    <tr {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}>
+    <tr>
         <td>
-            {{ form_label(form, null, label) }}
+            {{ form_label(form, label|default(null)) }}
         </td>
         <td>
             {{ form_errors(form) }}
-            {{ form_widget(form, widget) }}
+            {{ form_widget(form) }}
         </td>
     </tr>
 {% endspaceless %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/attributes.html.php
@@ -1,0 +1,8 @@
+id="<?php echo $view->escape($id) ?>"
+name="<?php echo $view->escape($full_name) ?>"
+<?php if ($read_only): ?>disabled="disabled" <?php endif ?>
+<?php if ($required): ?>required="required" <?php endif ?>
+<?php if ($max_length): ?>maxlength="<?php echo $view->escape($max_length) ?>" <?php endif ?>
+<?php if ($pattern): ?>pattern="<?php echo $view->escape($pattern) ?>" <?php endif ?>
+<?php foreach($attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>
+

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/checkbox_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/checkbox_widget.html.php
@@ -1,8 +1,5 @@
 <input type="checkbox"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    <?php if ($value): ?>value="<?php echo $view->escape($value) ?>"<?php endif ?>
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-    <?php if ($checked): ?>checked="checked"<?php endif ?>
+    <?php echo $view['form']->renderBlock('attributes') ?>
+    <?php if ($value): ?> value="<?php echo $view->escape($value) ?>"<?php endif ?>
+    <?php if ($checked): ?> checked="checked"<?php endif ?>
 />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget.html.php
@@ -1,15 +1,13 @@
 <?php if ($expanded): ?>
-    <div<?php echo $view['form']->attributes() ?>>
-    <?php foreach ($form as $choice => $child): ?>
+    <div <?php echo $view['form']->renderBlock('container_attributes') ?>>
+    <?php foreach ($form as $child): ?>
         <?php echo $view['form']->widget($child) ?>
         <?php echo $view['form']->label($child) ?>
     <?php endforeach ?>
     </div>
 <?php else: ?>
     <select
-        <?php echo $view['form']->attributes() ?>
-        name="<?php echo $view->escape($full_name) ?>"
-        <?php if ($read_only): ?> disabled="disabled"<?php endif ?>
+        <?php echo $view['form']->renderBlock('attributes') ?>
         <?php if ($multiple): ?> multiple="multiple"<?php endif ?>
     >
         <?php if (null !== $empty_value): ?><option value=""><?php echo $view->escape($view['translator']->trans($empty_value)) ?></option><?php endif; ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/container_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/container_attributes.html.php
@@ -1,0 +1,2 @@
+id="<?php echo $view->escape($id) ?>"
+<?php foreach($attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
@@ -1,14 +1,7 @@
 <?php if ($widget == 'single_text'): ?>
-    <input type="text"
-        <?php echo $view['form']->attributes() ?>
-        name="<?php echo $view->escape($full_name) ?>"
-        value="<?php echo $view->escape($value) ?>"
-        <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-        <?php if ($required): ?>required="required"<?php endif ?>
-        <?php if ($max_length): ?>maxlength="<?php echo $max_length ?>"<?php endif ?>
-    />
+    <?php echo $view['form']->widget($form); ?>
 <?php else: ?>
-    <div<?php echo $view['form']->attributes() ?>>
+    <div <?php echo $view['form']->renderBlock('container_attributes') ?>>
         <?php echo str_replace(array('{{ year }}', '{{ month }}', '{{ day }}'), array(
             $view['form']->widget($form['year']),
             $view['form']->widget($form['month']),

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/date_widget.html.php
@@ -1,5 +1,5 @@
 <?php if ($widget == 'single_text'): ?>
-    <?php echo $view['form']->widget($form); ?>
+    <?php echo $view['form']->renderBlock('field_widget'); ?>
 <?php else: ?>
     <div <?php echo $view['form']->renderBlock('container_attributes') ?>>
         <?php echo str_replace(array('{{ year }}', '{{ month }}', '{{ day }}'), array(

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/datetime_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/datetime_widget.html.php
@@ -1,4 +1,4 @@
-<div<?php echo $view['form']->attributes() ?>>
+<div <?php echo $view['form']->renderBlock('container_attributes') ?>>
     <?php echo $view['form']->widget($form['date'])
         . ' '
         . $view['form']->widget($form['time']) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/email_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/email_widget.html.php
@@ -1,8 +1,1 @@
-<input type="email"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($max_length): ?>maxlength="<?php echo $view->escape($max_length) ?>"<?php endif ?>
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-/>
+<?php echo $view['form']->widget($form, array('type' => isset($type) ? $type : 'email')) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/email_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/email_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form, array('type' => isset($type) ? $type : 'email')) ?>
+<?php echo $view['form']->renderBlock('field_widget', array('type' => isset($type) ? $type : 'email')) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_label.html.php
@@ -1,1 +1,1 @@
-<label for="<?php echo $view->escape($id) ?>" <?php echo $view['form']->attributes(false) ?>><?php echo $view->escape($view['translator']->trans($label)) ?></label>
+<label for="<?php echo $view->escape($id) ?>" <?php foreach($attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label)) ?></label>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_row.html.php
@@ -1,5 +1,5 @@
-<div>
-    <?php echo $view['form']->label($form) ?>
+<div <?php foreach($attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>>
+    <?php echo $view['form']->label($form, null, $label) ?>
     <?php echo $view['form']->errors($form) ?>
-    <?php echo $view['form']->widget($form) ?>
+    <?php echo $view['form']->widget($form, $widget) ?>
 </div>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_row.html.php
@@ -1,5 +1,5 @@
-<div <?php foreach($attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>>
-    <?php echo $view['form']->label($form, null, $label) ?>
+<div>
+    <?php echo $view['form']->label($form, isset($label) ? $label : null) ?>
     <?php echo $view['form']->errors($form) ?>
-    <?php echo $view['form']->widget($form, $widget) ?>
+    <?php echo $view['form']->widget($form) ?>
 </div>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_rows.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_rows.html.php
@@ -1,0 +1,4 @@
+<?php echo $view['form']->errors($form) ?>
+<?php foreach ($form as $child) : ?>
+    <?php echo $view['form']->row($child) ?>
+<?php endforeach; ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_widget.html.php
@@ -1,7 +1,5 @@
 <input
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
+    type="<?php echo isset($type) ? $view->escape($type) : "text" ?>"
     value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
+    <?php echo $view['form']->renderBlock('attributes') ?>
 />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/file_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/file_widget.html.php
@@ -1,7 +1,0 @@
-<input type="file"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-/>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -1,1 +1,1 @@
-<label <?php echo $view['form']->attributes(false) ?>><?php echo $view->escape($view['translator']->trans($label)) ?></label>
+<label <?php foreach($attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label)) ?></label>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_widget.html.php
@@ -1,8 +1,5 @@
-<div<?php echo $view['form']->attributes() ?>>
-    <?php echo $view['form']->errors($form); ?>
-    <?php foreach ($form as $child): ?>
-        <?php echo $view['form']->row($child); ?>
-    <?php endforeach; ?>
+<div <?php echo $view['form']->renderBlock('container_attributes') ?>>
+    <?php echo $view['form']->renderBlock('field_rows') ?>
     <?php echo $view['form']->rest($form) ?>
 </div>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/hidden_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/hidden_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form, array('type' => isset($type) ? $type : "hidden")) ?>
+<?php echo $view['form']->renderBlock('field_widget', array('type' => isset($type) ? $type : "hidden")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/hidden_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/hidden_widget.html.php
@@ -1,6 +1,1 @@
-<input type="hidden"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-/>
+<?php echo $view['form']->widget($form, array('type' => isset($type) ? $type : "hidden")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/integer_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/integer_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form, array('type' => isset($type) ? $type : "number")) ?>
+<?php echo $view['form']->renderBlock('field_widget', array('type' => isset($type) ? $type : "number")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/integer_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/integer_widget.html.php
@@ -1,7 +1,1 @@
-<input type="number"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-/>
+<?php echo $view['form']->widget($form, array('type' => isset($type) ? $type : "number")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/money_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/money_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo str_replace('{{ widget }}', $view['form']->widget($form), $money_pattern) ?>
+<?php echo str_replace('{{ widget }}', $view['form']->renderBlock('field_widget'), $money_pattern) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/money_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/money_widget.html.php
@@ -1,4 +1,1 @@
-<?php echo str_replace('{{ widget }}',
-    $view['form']->render($form, 'FrameworkBundle:Form:number_widget.html.php'),
-    $money_pattern
-) ?>
+<?php echo str_replace('{{ widget }}', $view['form']->widget($form), $money_pattern) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/number_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/number_widget.html.php
@@ -1,9 +1,1 @@
-<input type="text"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-    <?php if ($max_length): ?>maxlength="<?php echo $max_length ?>"<?php endif ?>
-    <?php if ($pattern): ?>pattern="<?php echo $pattern ?>"<?php endif ?>
-/>
+<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "text")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/number_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/number_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "text")) ?>
+<?php echo $view['form']->renderBlock('field_widget',  array('type' => isset($type) ? $type : "text")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_widget.html.php
@@ -1,9 +1,1 @@
-<input type="password"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-    <?php if ($max_length): ?>maxlength="<?php echo $max_length ?>"<?php endif ?>
-    <?php if ($pattern): ?>pattern="<?php echo $pattern ?>"<?php endif ?>
-/>
+<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "password")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/password_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "password")) ?>
+<?php echo $view['form']->renderBlock('field_widget',  array('type' => isset($type) ? $type : "password")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->render($form, 'FrameworkBundle:Form:number_widget.html.php') ?> %
+<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "text")) ?> %

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/percent_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "text")) ?> %
+<?php echo $view['form']->renderBlock('field_widget',  array('type' => isset($type) ? $type : "text")) ?> %

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/prototype_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/prototype_row.html.php
@@ -1,3 +1,3 @@
 <script type="text/html" id="<?php echo $view->escape($proto_id) ?>">
-    <?php echo $view->render('FrameworkBundle:Form:field_row.html.php', array('form' => $form)) ?>
+    <?php echo $view['form']->row($form) ?>
 </script>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/radio_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/radio_widget.html.php
@@ -1,8 +1,5 @@
 <input type="radio"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
+    <?php echo $view['form']->renderBlock('attributes') ?>
     value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-    <?php if ($checked): ?>checked="checked"<?php endif ?>
+    <?php if ($checked): ?> checked="checked"<?php endif ?>
 />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/repeated_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/repeated_row.html.php
@@ -1,5 +1,1 @@
-<?php echo $view['form']->errors($form) ?>
-
-<?php foreach ($form as $child): ?>
-    <?php echo $view['form']->row($child); ?>
-<?php endforeach; ?>
+<?php echo $view['form']->renderBlock('field_rows') ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/search_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/search_widget.html.php
@@ -1,8 +1,1 @@
-<input type="search"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-    <?php if ($max_length): ?>maxlength="<?php echo $max_length ?>"<?php endif ?>
-/>
+<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "search")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/search_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/search_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "search")) ?>
+<?php echo $view['form']->renderBlock('field_widget',  array('type' => isset($type) ? $type : "search")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/text_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/text_widget.html.php
@@ -1,9 +1,0 @@
-<input type="text"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-    <?php if ($max_length): ?>maxlength="<?php echo $max_length ?>"<?php endif ?>
-    <?php if ($pattern): ?>pattern="<?php echo $pattern ?>"<?php endif ?>
-/>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/textarea_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/textarea_widget.html.php
@@ -1,6 +1,1 @@
-<textarea
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-><?php echo $view->escape($value) ?></textarea>
+<textarea <?php echo $view['form']->renderBlock('attributes') ?>><?php echo $view->escape($value) ?></textarea>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/time_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/time_widget.html.php
@@ -1,4 +1,4 @@
-<div<?php echo $view['form']->attributes() ?>>
+<div <?php echo $view['form']->renderBlock('container_attributes') ?>>
     <?php
         // There should be no spaces between the colons and the widgets, that's why
         // this block is written in a single PHP tag

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/url_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/url_widget.html.php
@@ -1,7 +1,1 @@
-<input type="url"
-    <?php echo $view['form']->attributes() ?>
-    name="<?php echo $view->escape($full_name) ?>"
-    value="<?php echo $view->escape($value) ?>"
-    <?php if ($read_only): ?>disabled="disabled"<?php endif ?>
-    <?php if ($required): ?>required="required"<?php endif ?>
-/>
+<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "url")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/url_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/url_widget.html.php
@@ -1,1 +1,1 @@
-<?php echo $view['form']->widget($form,  array('type' => isset($type) ? $type : "url")) ?>
+<?php echo $view['form']->renderBlock('field_widget',  array('type' => isset($type) ? $type : "url")) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -199,8 +199,8 @@ class FormHelper extends Helper
         }
 
         do {
-            $block = $types[$typeIndex].'_'.$section;
-            $template = $this->lookupTemplate($block);
+            $types[$typeIndex] .= '_'.$section;
+            $template = $this->lookupTemplate($types[$typeIndex]);
 
             if ($template) {
 
@@ -221,7 +221,10 @@ class FormHelper extends Helper
             }
         }  while (--$typeIndex >= 0);
 
-        throw new FormException(sprintf('Unable to render the form as none of the following blocks exist: "%s".', implode('", "', $types)));
+        throw new FormException(sprintf(
+            'Unable to render the form as none of the following blocks exist: "%s".',
+            implode('", "', array_reverse($types))
+        ));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -99,15 +99,6 @@ class FormHelper extends Helper
      */
     public function row(FormView $view, array $variables = array())
     {
-        $variables = array_replace_recursive(
-            array(
-                'label'     => array(),
-                'widget'    => array(),
-                'attr'      => array()
-            ),
-            $variables
-        );
-
         return $this->renderSection($view, 'row', $variables);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -38,8 +38,7 @@ class FormHelper extends Helper
     public function __construct(EngineInterface $engine)
     {
         $this->engine = $engine;
-        $this->varStack = new \SplObjectStorage();
-        $this->viewStack = array();
+        $this->varStack = array();
         $this->rendering = array();
         $this->context = array();
     }
@@ -103,6 +102,15 @@ class FormHelper extends Helper
      */
     public function row(FormView $view, array $variables = array())
     {
+        $variables = array_replace_recursive(
+            array(
+                'label'     => array(),
+                'widget'    => array(),
+                'attr'      => array()
+            ),
+            $variables
+        );
+        
         return $this->renderSection($view, 'row', $variables);
     }
 
@@ -191,18 +199,17 @@ class FormHelper extends Helper
 
                 $this->rendering[$rendering] = $i;
 
-                $this->varStack[$view] = array_replace(
-                    $view->all(),
-                    isset($this->varStack[$view]) ? $this->varStack[$view] : array(),
+                $this->varStack[$rendering] = array_replace_recursive(
+                    isset($this->varStack[$rendering]) ? $this->varStack[$rendering] : $view->all(),
                     $variables
                 );
 
-                $this->context[] = $this->varStack[$view];
+                $this->context[] = $this->varStack[$rendering];
 
-                $html = $this->engine->render($template, $this->varStack[$view]);
+                $html = $this->engine->render($template, $this->varStack[$rendering]);
 
                 array_pop($this->context);
-                unset($this->varStack[$view], $this->rendering[$rendering]);
+                unset($this->varStack[$rendering], $this->rendering[$rendering]);
 
                 if ($mainTemplate) {
                     $view->setRendered();

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -31,12 +31,17 @@ class FormHelper extends Helper
 
     protected $varStack;
 
-    protected $viewStack = array();
+    protected $rendering;
+
+    protected $context;
 
     public function __construct(EngineInterface $engine)
     {
         $this->engine = $engine;
         $this->varStack = new \SplObjectStorage();
+        $this->viewStack = array();
+        $this->rendering = array();
+        $this->context = array();
     }
 
     public function isChoiceGroup($label)
@@ -47,38 +52,6 @@ class FormHelper extends Helper
     public function isChoiceSelected(FormView $view, $choice)
     {
         return FormUtil::isChoiceSelected($choice, $view->get('value'));
-    }
-
-    /**
-     * Renders the attributes for the current view.
-     *
-     * @param Boolean $includeId Whether to render the id attribute
-     *
-     * @return string The HTML markup
-     */
-    public function attributes($includeId = true)
-    {
-        $html = '';
-        $attr = array();
-
-        if (count($this->viewStack) > 0) {
-            $view = end($this->viewStack);
-            $vars = $this->varStack[$view];
-
-            if (isset($vars['attr'])) {
-                $attr = $vars['attr'];
-            }
-
-            if (true === $includeId && isset($vars['id'])) {
-                $attr['id'] = $vars['id'];
-            }
-        }
-
-        foreach ($attr as $k => $v) {
-            $html .= ' '.$this->engine->escape($k).'="'.$this->engine->escape($v).'"';
-        }
-
-        return $html;
     }
 
     /**
@@ -202,15 +175,34 @@ class FormHelper extends Helper
         }
 
         $template = null;
-        $types = $view->get('types');
-        $types[] = '_'.$view->get('proto_id', $view->get('id'));
 
-        for ($i = count($types) - 1; $i >= 0; $i--) {
-            $types[$i] .= '_'.$section;
-            $template = $this->lookupTemplate($types[$i]);
+        $custom = '_'.$view->get('proto_id', $view->get('id'));
+        $types = $view->get('types');
+        $types[] = $custom;
+        $rendering = $custom.$section;
+
+        $i = isset($this->rendering[$rendering]) ? $this->rendering[$rendering] - 1 : count ($types) - 1;
+
+        do {
+            $block = $types[$i].'_'.$section;
+            $template = $this->lookupTemplate($block);
 
             if ($template) {
-                $html = $this->render($view, $template, $variables);
+
+                $this->rendering[$rendering] = $i;
+
+                $this->varStack[$view] = array_replace(
+                    $view->all(),
+                    isset($this->varStack[$view]) ? $this->varStack[$view] : array(),
+                    $variables
+                );
+
+                $this->context[] = $this->varStack[$view];
+
+                $html = $this->engine->render($template, $this->varStack[$view]);
+
+                array_pop($this->context);
+                unset($this->varStack[$view], $this->rendering[$rendering]);
 
                 if ($mainTemplate) {
                     $view->setRendered();
@@ -218,27 +210,35 @@ class FormHelper extends Helper
 
                 return $html;
             }
-        }
+        }  while (--$i >= 0);
 
-        throw new FormException(sprintf('Unable to render form as none of the following blocks exist: "%s".', implode('", "', $types)));
+        throw new FormException(sprintf('Unable to render the form as none of the following blocks exist: "%s".', implode('", "', $types)));
     }
 
-    public function render(FormView $view, $template, array $variables = array())
+    /**
+     * Render a block from a form element.
+     *
+     * @param string $name
+     * @param array  $variables Additional variables (those would override the current context)
+     *
+     * @throws FormException if the block is not found
+     * @throws FormException if the method is called out of a form element (no context)
+     */
+    public function renderBlock($name, $variables = array())
     {
-        $this->varStack[$view] = array_replace(
-            $view->all(),
-            isset($this->varStack[$view]) ? $this->varStack[$view] : array(),
-            $variables
-        );
+        if (0 == count($this->context)) {
+            throw new FormException(sprintf('This method should only be called while rendering a form element.', $name));
+        }
 
-        $this->viewStack[] = $view;
+        $template = $this->lookupTemplate($name);
 
-        $html = $this->engine->render($template, $this->varStack[$view]);
+        if (false === $template) {
+            throw new FormException(sprintf('No block "%s" found while rendering the form.', $name));
+        }
 
-        array_pop($this->viewStack);
-        unset($this->varStack[$view]);
+        $variables = array_replace_recursive(end($this->context), $variables);
 
-        return $html;
+        return $this->engine->render($template, $variables);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/_text_id_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/Resources/_text_id_widget.html.php
@@ -1,3 +1,3 @@
 <div id="container">
-    <?php echo $view['form']->render($form, 'FrameworkBundle:Form:text_widget.html.php') ?>
+    <?php echo $view['form']->widget($form) ?>
 </div>

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/custom_widgets.html.twig
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/custom_widgets.html.twig
@@ -1,6 +1,5 @@
 {% block _text_id_widget %}
 <div id="container">
-    {# TODO find a smarter way to render the parent type #}
-    <input type="text" id="{{ id }}" value="{{ value }}" />
+    {{ form_widget(form) }}
 </div>
 {% endblock _text_id_widget %}

--- a/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
@@ -409,20 +409,4 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 '
         );
     }
-
-    public function testFileLabelAccessibility()
-    {
-        $form = $this->factory->createNamed('file', 'name');
-        $html = $this->renderRow($form->createView());
-
-        $this->assertMatchesXpath($html,
-'/div
-    [
-        ./label[@for="name"]
-        /following-sibling::input[@id="name"][@type="file"]
-    ]
-'
-        );
-    }
-
 }

--- a/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
@@ -38,18 +38,13 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testRowOverrideVariables()
     {
         $view = $this->factory->createNamed('text', 'name')->createView();
-        $html = $this->renderRow($view, array(
-            'label'  => array('label' => 'foo&bar', 'attr' => array('class ' => 'label&class')),
-            'widget' => array('attr' => array('class' => 'widget&class')),
-            'attr'   => array('class' => 'row&class')
-
-        ));
+        $html = $this->renderRow($view, array('label' => 'foo&bar'));
 
         $this->assertMatchesXpath($html,
-'/div[@class="row&class"]
+'/div
     [
-        ./label[@for="name"][.="[trans]foo&bar[/trans]"][@class="label&class"]
-        /following-sibling::input[@id="name"][@class="widget&class"]
+        ./label[@for="name"][.="[trans]foo&bar[/trans]"]
+        /following-sibling::input[@id="name"]
     ]
 '
         );

--- a/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractDivLayoutTest.php
@@ -35,16 +35,21 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
         );
     }
 
-    public function testRowForwardsVariables()
+    public function testRowOverrideVariables()
     {
         $view = $this->factory->createNamed('text', 'name')->createView();
-        $html = $this->renderRow($view, array('label' => 'foo&bar'));
+        $html = $this->renderRow($view, array(
+            'label'  => array('label' => 'foo&bar', 'attr' => array('class ' => 'label&class')),
+            'widget' => array('attr' => array('class' => 'widget&class')),
+            'attr'   => array('class' => 'row&class')
+
+        ));
 
         $this->assertMatchesXpath($html,
-'/div
+'/div[@class="row&class"]
     [
-        ./label[@for="name"][.="[trans]foo&bar[/trans]"]
-        /following-sibling::input[@id="name"]
+        ./label[@for="name"][.="[trans]foo&bar[/trans]"][@class="label&class"]
+        /following-sibling::input[@id="name"][@class="widget&class"]
     ]
 '
         );


### PR DESCRIPTION
# First two commits
## FormExtension::render() can now be called recursively.

The main use case is theming support in for collections. Let's consider that you have a collection of `CustomType`, the type hierarchy while rendering the proto would be `field < form < custom < prototype`. Before this change any theme applied to your custom type (i.e. a `custom_row` block) would not have been taken into account while rendering the prototype because of the structure of the `prototype_row` block:

``` html
{% block prototype_row %}
{% spaceless %}
    <script type="text/html" id="{{ proto_id }}">{{ block('field_row') }}</script>
{% endspaceless %}
{% endblock prototype_row %}
```

which skip the `custom_row` block rendering to fallback to the `field_row` block rendering.

With this PR `prototype_row` recursively calls `FormExtension::render()`

``` html
{% block prototype_row %}
{% spaceless %}
    <script type="text/html" id="{{ proto_id }}">{{ form_row(form) }}</script>
{% endspaceless %}
{% endblock prototype_row %}
```

this has for effect to render the block for the parent type (i.e. `custom_row`)
## FormHelper

The `FormHelper` has been updated to more closely match the `FormExtension` architecture and the templates have been modified accordingly. `echo $view['form']->renderBlock(<block name>)` is the php equivalent of `{{ block(<block name>) }}`.

The attributes are now rendered using a template rather than by the `FormHelper::attributes()` method.

Several templates have been fixed.
# Third commit

The `$varStack` property was used to forward options to the label and the widget when rendering a row. The implementation was not working as expected. The proposed way to override label and widget options is to pass these options in the `label` and `widget` keys while callinf `render_row`.

That would be:
`{{ form_row(form.field, {"attr": {<row attributes>}, "label" : {"label": <text>, "attr": {<label attr>}}, "widget" : { "attr" : {<widget attributes}} } }}`

So there is now the ability to set attributes for the row (`<div>` or `<tr>`).

This has been discussed on [the mailing list](http://groups.google.com/group/symfony-devs/browse_thread/thread/17754128ba480545). **I would like to find a compromise with @Seldaek before this gets merged**

The `$varStack` property is now only used when recursively calling `FormExtension::render()`
# Notes

I have preferred to submit several commits in order to ease review and to keep some history.
