### PR TITLE
Allow the user to use a failure handler and follow the default workflow

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -189,7 +189,10 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
         $this->securityContext->setToken(null);
 
         if (null !== $this->failureHandler) {
-            return $this->failureHandler->onAuthenticationFailure($request, $failed);
+            $response = $this->failureHandler->onAuthenticationFailure($request, $failed);
+            if ($response !== null) {
+                return $response;
+            }
         }
 
         if (null === $this->options['failure_path']) {

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -190,7 +190,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
 
         if (null !== $this->failureHandler) {
             $response = $this->failureHandler->onAuthenticationFailure($request, $failed);
-            if ($response !== null) {
+            if (null !== $response) {
                 return $response;
             }
         }


### PR DESCRIPTION
Allow the user to use a failure handler and follow the default workflow if it handler don't send a response
