### PR TITLE
Make the security.access.decision_manager service public

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -71,7 +71,7 @@
 
 
         <!-- Authorization related services -->
-        <service id="security.access.decision_manager" class="%security.access.decision_manager.class%" public="false">
+        <service id="security.access.decision_manager" class="%security.access.decision_manager.class%" public="true">
             <argument type="collection"></argument>
         </service>
 


### PR DESCRIPTION
This allows checking credentials of users that are not authenticated.
For example:

```
// determine if $user is granted ROLE_BACKEND
$token = new UsernamePasswordToken($user->getUsername(), '', $providerKey, $user->getRoles());
$decisionManager = $container->get('security.access.decision_manager');
$decisionManager->decide($token, array('ROLE_BACKEND'));
```

This is not possible actually because the decision manager service is private.
