### PR TITLE
[HttpFoundation] Ensure response body is string, fixes #1378

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -165,6 +165,9 @@ class Response
      */
     public function setContent($content)
     {
+        if (!is_string($content)) {
+            throw new \UnexpectedValueException('The Response content must be a string, "'.gettype($content).'" given.');
+        }
         $this->content = $content;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -161,12 +161,14 @@ class Response
     /**
      * Sets the response content
      *
-     * @param string $content
+     * Valid types are strings, numbers, and objects that implement a __toString() method.
+     *
+     * @param mixed $content
      */
     public function setContent($content)
     {
-        if (!is_string($content)) {
-            throw new \UnexpectedValueException('The Response content must be a string, "'.gettype($content).'" given.');
+        if (!is_string($content) && !is_numeric($content) && !is_callable(array($content, '__toString'))) {
+            throw new \UnexpectedValueException('The Response content must be a string or object implementing __toString(), "'.gettype($content).'" given.');
         }
         $this->content = $content;
     }

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -424,6 +424,44 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($response->headers->get('Etag'), '->setEtag() removes Etags when call with null');
     }
 
+    /**
+     * @dataProvider validContentProvider
+     */
+    public function testSetContent($content)
+    {
+        $response = new Response();
+        $response->setContent($content);
+        $this->assertEquals($content, $response->getContent());
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     * @dataProvider invalidContentProvider
+     */
+    public function testSetContentInvalid($content)
+    {
+        $response = new Response();
+        $response->setContent($content);
+    }
+
+    public function validContentProvider()
+    {
+        return array(
+            'obj'    => array(new StringableObject),
+            'string' => array('Foo'),
+            'int'    => array(2),
+        );
+    }
+
+    public function invalidContentProvider()
+    {
+        return array(
+            'obj'   => array(new \stdClass),
+            'array' => array(array()),
+            'bool'   => array(true, '1'),
+        );
+    }
+
     protected function createDateTimeOneHourAgo()
     {
         $date = new \DateTime();
@@ -441,5 +479,13 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     protected function createDateTimeNow()
     {
         return new \DateTime();
+    }
+}
+
+class StringableObject
+{
+    public function __toString()
+    {
+        return 'Foo';
     }
 }


### PR DESCRIPTION
The issue in #1378 is clearly just a misuse of the class due but the error it triggers is confusing. This hopes to fix that.
