### PR TITLE
Non-blocking WDT & prevents garbage to slip in the page

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -11,7 +11,7 @@
         xhr.open('GET', '{{ path("_wdt", { "token": token }) }}', true);
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
         xhr.onreadystatechange = function(state) {
-            if (4 === xhr.readyState && 200 === xhr.status) {
+            if (4 === xhr.readyState && 200 === xhr.status && '<!-- START' === xhr.responseText.substring(0, 10)) {
                 wdt.innerHTML = xhr.responseText;
                 wdt.style.display = 'block';
             }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -8,10 +8,14 @@
         } else {
             xhr = new ActiveXObject('Microsoft.XMLHTTP');
         }
-        xhr.open('GET', '{{ path("_wdt", { "token": token }) }}', false);
+        xhr.open('GET', '{{ path("_wdt", { "token": token }) }}', true);
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+        xhr.onreadystatechange = function(state) {
+            if (4 === xhr.readyState && 200 === xhr.status) {
+                wdt.innerHTML = xhr.responseText;
+                wdt.style.display = 'block';
+            }
+        };
         xhr.send('');
-        wdt.innerHTML = xhr.responseText;
-        wdt.style.display = 'block';
     })();
 /*]]>*/</script>


### PR DESCRIPTION
I made the loading non-blocking so that it's not preventing normal operation of the page when the WDT takes a bit long to come up (happens sometimes when the machine is busy).

The second commit also checks that the response looks correct, to prevent stack traces and such to appear in the page if there was a problem. The main issue is not really stack traces though it's mostly with security and intercept_redirect enabled, if you look at a fully secured site you get twice the redirect intercept message to the login page.

Tested in IE7/9/FF4/Opera11
