### PR TITLE
[WebProfilerBundle] Fixes toolbar content check

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -11,7 +11,7 @@
         xhr.open('GET', '{{ path("_wdt", { "token": token }) }}', true);
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
         xhr.onreadystatechange = function(state) {
-            if (4 === xhr.readyState && 200 === xhr.status && '<!-- START' === xhr.responseText.substring(0, 10)) {
+            if (4 === xhr.readyState && 200 === xhr.status && -1 !== xhr.responseText.indexOf('sf-toolbarreset')) {
                 wdt.innerHTML = xhr.responseText;
                 wdt.style.display = 'block';
             }


### PR DESCRIPTION
It appears that some html optimizers trim the comments, therefore the old check was not working. This is more robust.

Fixes the issue reported in 8541a5bcbc97f965f4c53fc3ece790cdc4a922bf
