### PR TITLE
[DomCrawler] Fixed handling of relative query strings as links

### DIFF
--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -89,9 +89,21 @@ class Link
             return $this->currentUri;
         }
 
-        // only an anchor or a query string
-        if (in_array($uri[0], array('?', '#'))) {
+        // only an anchor
+        if ('#' ===  $uri[0]) {
             return $this->currentUri.$uri;
+        }
+
+        // only a query string
+        if ('?' === $uri[0] ) {
+            $baseUri = $this->currentUri;
+
+            // remove the query string from the current uri
+            if (false !== ($pos = strpos($this->currentUri, '?'))) {
+                $baseUri = substr($this->currentUri, 0, strpos($this->currentUri, '?'));
+            }
+
+            return $baseUri.$uri;
         }
 
         // absolute path

--- a/tests/Symfony/Tests/Component/DomCrawler/LinkTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/LinkTest.php
@@ -88,6 +88,11 @@ class LinkTest extends \PHPUnit_Framework_TestCase
             array('?a=b', 'http://localhost/bar/', 'http://localhost/bar/?a=b'),
 
             array('http://login.foo.com/foo', 'http://localhost/bar/', 'http://login.foo.com/foo'),
+
+            array('?foo=2', 'http://localhost?foo=1', 'http://localhost?foo=2'),
+            array('?foo=2', 'http://localhost/?foo=1', 'http://localhost/?foo=2'),
+            array('?foo=2', 'http://localhost/bar?foo=1', 'http://localhost/bar?foo=2'),
+            array('?foo=2', 'http://localhost/bar/?foo=1', 'http://localhost/bar/?foo=2'),
         );
     }
 }


### PR DESCRIPTION
The link object concatenates links containing only a query string to the current URI. This shouldn't happen if the current URI already contains a query string.

This PR fixes the incorrect behavior (tests included).
