### PR TITLE
[Console] Expose the OutputFormatter's regular expression

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -20,6 +20,11 @@ namespace Symfony\Component\Console\Formatter;
  */
 class OutputFormatter implements OutputFormatterInterface
 {
+    /**
+     * The pattern to phrase the format.
+     */
+    const FORMAT_PATTERN = '#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#is';
+
     private $decorated;
     private $styles = array();
 
@@ -125,7 +130,7 @@ class OutputFormatter implements OutputFormatterInterface
      */
     public function format($message)
     {
-        return preg_replace_callback(OutputFormatterInterface::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
+        return preg_replace_callback(self::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -125,7 +125,7 @@ class OutputFormatter implements OutputFormatterInterface
      */
     public function format($message)
     {
-        return preg_replace_callback(OutputFormatterStyleInterface::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
+        return preg_replace_callback(OutputFormatterInterface::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -125,7 +125,7 @@ class OutputFormatter implements OutputFormatterInterface
      */
     public function format($message)
     {
-        return preg_replace_callback('#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#is', array($this, 'replaceStyle'), $message);
+        return preg_replace_callback(OutputFormatterStyleInterface::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -20,7 +20,6 @@ namespace Symfony\Component\Console\Formatter;
  */
 interface OutputFormatterInterface
 {
-
     /**
      * Sets the decorated flag.
      *

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -20,10 +20,6 @@ namespace Symfony\Component\Console\Formatter;
  */
 interface OutputFormatterInterface
 {
-    /**
-     * The pattern to phrase the format.
-     */
-    const FORMAT_PATTERN = '#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#is';
 
     /**
      * Sets the decorated flag.

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -21,6 +21,11 @@ namespace Symfony\Component\Console\Formatter;
 interface OutputFormatterInterface
 {
     /**
+     * The pattern to phrase the format.
+     */
+    const FORMAT_PATTERN = '#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#is';
+
+    /**
      * Sets the decorated flag.
      *
      * @param Boolean $decorated Whether to decorated the messages or not


### PR DESCRIPTION
In my ConsoleBundle(https://github.com/CoreSphere/ConsoleBundle) I needed to decorate the OutputFormatter to enable html escaping while allow to apply styles.

For that I need to reuse the regular expression used in the original OutputFormatter. I think it would be cleaner exposing it than duplicating it.
(https://github.com/CoreSphere/ConsoleBundle/blob/master/Formatter/HtmlOutputFormatterDecorator.php#L64)
