### PR TITLE
[HttpFoundation] Add REQUEST_TIME by default

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -166,6 +166,7 @@ class Request
             'SCRIPT_NAME'          => '',
             'SCRIPT_FILENAME'      => '',
             'SERVER_PROTOCOL'      => 'HTTP/1.1',
+            'REQUEST_TIME'         => time(),
         );
 
         $components = parse_url($uri);


### PR DESCRIPTION
Without this the getting the REQUEST_TIME from the Request in tests is breaking.
