### PR TITLE
[HttpFoundation] Test response's ->setStatusCode() method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -233,6 +233,26 @@ class Response
     }
 
     /**
+     * Sets response status text
+     *
+     * @param string $text HTTP status text
+     */
+    public function setStatusText($text)
+    {
+        $this->statusText = $text;
+    }
+
+    /**
+     * Retrieves the status text for the current web response.
+     *
+     * @return string Status text
+     */
+    public function getStatusText()
+    {
+        return $this->statusText;
+    }
+
+    /**
      * Sets response charset.
      *
      * @param string $charset Character set

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -15,6 +15,21 @@ use Symfony\Component\HttpFoundation\Response;
 
 class ResponseTest extends \PHPUnit_Framework_TestCase
 {
+    public function testSetStatusCode()
+    {
+        $response = new Response();
+        $response->setStatusCode(200);
+        $this->assertEquals('OK', $response->getStatusText(), '->setStatusCode() with no text argument sets the status text corresponding to the code');
+
+        $response = new Response();
+        $response->setStatusCode(200, false);
+        $this->assertEquals('', $response->getStatusText(), '->setStatusCode() with FALSE as text sets an empty string as status text');
+
+        $response = new Response();
+        $response->setStatusCode(200, 'The status text');
+        $this->assertEquals('The status text', $response->getStatusText(), '->setStatusCode() with a text argument overrides the default status text');
+    }
+
     public function testIsValidateable()
     {
         $response = new Response('', 200, array('Last-Modified' => $this->createDateTimeOneHourAgo()->format(DATE_RFC2822)));


### PR DESCRIPTION
Adds [gs]etStatusText methods to the response and test the ->setStatusCode() method's behavior.
