### PR TITLE
Cache warmup problem [issue #1431]

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -92,6 +92,12 @@ EOF
             file_put_contents(preg_replace('/__.*__/', '', $file), $content);
             unlink($file);
         }
+        // This fix the appdevUrlMatcher.php.meta and appdevUrlGenerator.php.meta
+        foreach ($finder->files()->name('*.php.meta')->in($warmupDir) as $file) {
+            $content = file_get_contents($file);
+            $content = preg_replace('/C:'.  strlen($kernel->getName()).':"'.$kernel->getName().'"/', 'C:9:"AppKernel"', $content);
+            file_put_contents($file, $content);
+        }
     }
 
     protected function getTempKernel(KernelInterface $parent, $warmupDir)
@@ -127,6 +133,10 @@ namespace $namespace
         protected function getContainerClass()
         {
             return parent::getContainerClass().'__{$rand}__';
+        }
+        public function getName()
+        {
+            return 'AppKernel{$rand}';
         }
     }
 }


### PR DESCRIPTION
This is about the issue #1431
When you use app/console cache:clear, we get a error like "Warning: Class __PHP_Incomplete_Class has no unserializer in /home/nginx/kernel/app/bootstrap.php.cache line 3024"
The error is in the serialized content of appdevUrlMatcher.php.meta and appdevUrlGenerator.php.meta that has a part like 'C:22:"AppKernel4e06e362030ff"' when should be 'C:9:"AppKernel"'.
I know that should be a better solution for this problem, but this pull request is only for you to understand what's happening.
Thank you and sorry about my bad english.
