### PR TITLE
[Form] Replace $$name$$ by --name-- in collection type

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -25,7 +25,7 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototype = $builder->create('$$name$$', $options['type'], $options['options']);
+            $prototype = $builder->create('--name--', $options['type'], $options['options']);
             $builder->setAttribute('prototype', $prototype);
         }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CollectionTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CollectionTypeTest.php
@@ -126,7 +126,7 @@ class CollectionFormTest extends TypeTestCase
             'prototype' => false,
         ));
 
-        $this->assertFalse($form->has('$$name$$'));
+        $this->assertFalse($form->has('--name--'));
     }
 
     public function testPrototypeMultipartPropagation()


### PR DESCRIPTION
The collection type creates a field with $$name$$ in the id and name attributes.

The problems :
- In XHTML and HTML 4, "$" is not a valid character for the id and name attributes : http://www.w3.org/TR/html4/types.html#h-6.2
- The $$name$$ is usually replaced in Javascript by something else. But the $ character must be escaped in regular expression : field.id.replace(/\$\$name\$\$/, newId)
- With some libraries like jQuery, the $ character must be escaped too : $('#field_\$\$name\$\$').clone()

Replacing $$name$$ by --name-- solves all these issues.
