### PR TITLE
[2.1] Added a new option 'forward_data' to pass 'data' value to form children in a CollectionType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -52,6 +52,12 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     private $allowDelete;
 
+    /**
+     * Whether children will receive 'data' from the parent
+     * @var Boolean
+     */
+    private $forwardData;
+
     public function __construct(FormFactoryInterface $factory, $type, array $options = array(), $allowAdd = false, $allowDelete = false)
     {
         $this->factory = $factory;
@@ -59,6 +65,7 @@ class ResizeFormListener implements EventSubscriberInterface
         $this->allowAdd = $allowAdd;
         $this->allowDelete = $allowDelete;
         $this->options = $options;
+        $this->forwardData = false;
     }
 
     static public function getSubscribedEvents()
@@ -88,8 +95,18 @@ class ResizeFormListener implements EventSubscriberInterface
             $form->remove($name);
         }
 
+        if (isset($this->options['forward_data'])) {
+            $this->forwardData = $this->options['forward_data'];
+            unset($this->options['forward_data']);
+        }
+
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
+            if ($this->forwardData) {
+                // Forward 'data' value in each row
+                $this->options['data'] = $value;
+            }
+
             $form->add($this->factory->createNamed($this->type, $name, null, array_replace(array(
                 'property_path' => '['.$name.']',
             ), $this->options)));

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -238,4 +238,64 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array(), $event->getData());
     }
+
+    public function testPreSetDataWithForwardOption()
+    {
+        $this->form->add($this->getForm('0'));
+        $this->form->add($this->getForm('1'));
+
+        $this->factory->expects($this->at(0))
+            ->method('createNamed')
+            ->with('collection', 1, null, array('data' => 'string', 'property_path' => '[1]'))
+            ->will($this->returnValue($this->getForm('1')));
+        $this->factory->expects($this->at(1))
+            ->method('createNamed')
+            ->with('collection', 2, null, array('data' => 'string', 'property_path' => '[2]'))
+            ->will($this->returnValue($this->getForm('2')));
+
+        $data = array(1 => 'string', 2 => 'string');
+        $event = new DataEvent($this->form, $data);
+        $listener = new ResizeFormListener($this->factory, 'collection', array('forward_data' => true), false, false);
+        $listener->preSetData($event);
+    }
+
+    public function testPreSetDataWithoutForwardOption()
+    {
+        $this->form->add($this->getForm('0'));
+        $this->form->add($this->getForm('1'));
+
+        $this->factory->expects($this->at(0))
+            ->method('createNamed')
+            ->with('collection', 1, null, array('property_path' => '[1]'))
+            ->will($this->returnValue($this->getForm('1')));
+        $this->factory->expects($this->at(1))
+            ->method('createNamed')
+            ->with('collection', 2, null, array('property_path' => '[2]'))
+            ->will($this->returnValue($this->getForm('2')));
+
+        $data = array(1 => 'string', 2 => 'string');
+        $event = new DataEvent($this->form, $data);
+        $listener = new ResizeFormListener($this->factory, 'collection', array(), false, false);
+        $listener->preSetData($event);
+    }
+
+    public function testPreSetDataWithFalseForwardData()
+    {
+        $this->form->add($this->getForm('0'));
+        $this->form->add($this->getForm('1'));
+
+        $this->factory->expects($this->at(0))
+            ->method('createNamed')
+            ->with('collection', 1, null, array('property_path' => '[1]'))
+            ->will($this->returnValue($this->getForm('1')));
+        $this->factory->expects($this->at(1))
+            ->method('createNamed')
+            ->with('collection', 2, null, array('property_path' => '[2]'))
+            ->will($this->returnValue($this->getForm('2')));
+
+        $data = array(1 => 'string', 2 => 'string');
+        $event = new DataEvent($this->form, $data);
+        $listener = new ResizeFormListener($this->factory, 'collection', array('forward_data' => false), false, false);
+        $listener->preSetData($event);
+    }
 }


### PR DESCRIPTION
Hi,

To populate a custom type used in a CollectionType, we need to pass data from this CollectionType to the custom type.

Example:

Assuming we have a `Poll` class with a set of questions and each question has a set of answers.

``` php
<?php
// PollFormType.php

$builder->add('questions', 'collection', array(
    'type'          => new \Acme\DemoBundle\Form\QuestionType(),
    'allow_add'     => false,
    'allow_delete'  => false,
    'options'         => array(
        'forward_data' => true
    )
));
```

``` php
<?php
// QuestionType.php

$builder->add('answers', 'choice', array(
    'choices' => $options['data']->getAnswers();
));
```

Regards,
William.
