### PR TITLE
[HttpKernel] Added AutoloadExtension

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -88,9 +88,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
             }
         }
 
-        if ($this->extension) {
-            return $this->extension;
-        }
+        return $this->extension;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Bundle;
 
+use Symfony\Component\HttpKernel\DependencyInjection\AutoloadExtension;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Container;
@@ -84,7 +85,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
 
                 $this->extension = $extension;
             } else {
-                $this->extension = false;
+                $this->extension = new AutoloadExtension($this, Container::underscore($basename));
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AutoloadExtension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AutoloadExtension.php
@@ -5,8 +5,6 @@ namespace Symfony\Component\HttpKernel\DependencyInjection;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 
 /*
  * This file is part of the Symfony framework.
@@ -49,12 +47,19 @@ class AutoloadExtension extends Extension
             }
         }
 
-        if (file_exists($this->path.'/Resources/config/services.yml')) {
-            $loader = new YamlFileLoader($container, new FileLocator($this->path.'/Resources/config'));
-            $loader->load('services.yml');
-        } elseif (file_exists($this->path.'/Resources/config/services.xml')) {
-            $loader = new XmlFileLoader($container, new FileLocator($this->path.'/Resources/config'));
-            $loader->load('services.xml');
+        $formats = array(
+            'yml' => 'Yaml',
+            'xml' => 'Xml',
+            'php' => 'Php',
+            'ini' => 'Ini',
+        );
+        foreach ($formats as $format => $class) {
+            if (file_exists($this->path.'/Resources/config/services.'.$format)) {
+                $class = 'Symfony\Component\DependencyInjection\Loader\\'.$class.'FileLoader';
+                $loader = new $class($container, new FileLocator($this->path.'/Resources/config'));
+                $loader->load('services.'.$format);
+                break;
+            }
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AutoloadExtension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AutoloadExtension.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\DependencyInjection;
+
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Provides automatic loading of services.yml/xml files for Bundles with no Extension.
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class AutoloadExtension extends Extension
+{
+    private $alias;
+    private $path;
+
+    /**
+     * @param BundleInterface $bundle Bundle that owns this extension instance
+     * @param string $alias The extension alias for this extension instance
+     */
+    public function __construct(BundleInterface $bundle, $alias)
+    {
+        $this->alias = $alias;
+        $reflClass = new \ReflectionClass($bundle);
+        $this->path = dirname($reflClass->getFileName());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        foreach ($configs as $config) {
+            if ($config) {
+                throw new \UnexpectedValueException('The '.$this->alias.' extension accepts no configuration.');
+            }
+        }
+
+        if (file_exists($this->path.'/Resources/config/services.yml')) {
+            $loader = new YamlFileLoader($container, new FileLocator($this->path.'/Resources/config'));
+            $loader->load('services.yml');
+        } elseif (file_exists($this->path.'/Resources/config/services.xml')) {
+            $loader = new XmlFileLoader($container, new FileLocator($this->path.'/Resources/config'));
+            $loader->load('services.xml');
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAlias()
+    {
+        return $this->alias;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/AutoloadExtension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/AutoloadExtension.php
@@ -51,7 +51,6 @@ class AutoloadExtension extends Extension
             'yml' => 'Yaml',
             'xml' => 'Xml',
             'php' => 'Php',
-            'ini' => 'Ini',
         );
         foreach ($formats as $format => $class) {
             if (file_exists($this->path.'/Resources/config/services.'.$format)) {

--- a/tests/Symfony/Tests/Component/HttpKernel/DependencyInjection/AutoloadExtensionTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/DependencyInjection/AutoloadExtensionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpKernel\DependencyInjection;
+
+use Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionAbsentWithConfigBundle\ExtensionAbsentWithConfigBundle;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AutoloadExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetAlias()
+    {
+        $bundle = new ExtensionAbsentWithConfigBundle();
+        $ext = $bundle->getContainerExtension();
+        $this->assertEquals('extension_absent_with_config', $ext->getAlias());
+    }
+
+    /**
+     * @dataProvider extensionProvider
+     */
+    public function testAutoloadExtension($class, $expected)
+    {
+        $bundle = new $class;
+        $ext = $bundle->getContainerExtension();
+        $this->assertInstanceOf('Symfony\Component\HttpKernel\DependencyInjection\AutoloadExtension', $ext);
+
+        $builder = new ContainerBuilder;
+        $ext->load(array(array(), array()), $builder);
+        $this->assertEquals($expected, $builder->hasDefinition('foo'));
+    }
+
+    public function extensionProvider()
+    {
+        return array(
+            'with file must import'     => array(
+                'Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionAbsentWithConfigBundle\ExtensionAbsentWithConfigBundle',
+                true
+            ),
+            'without file must ignore'  => array(
+                'Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionAbsentBundle\ExtensionAbsentBundle',
+                false
+            ),
+        );
+    }
+}

--- a/tests/Symfony/Tests/Component/HttpKernel/Fixtures/ExtensionAbsentWithConfigBundle/ExtensionAbsentWithConfigBundle.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Fixtures/ExtensionAbsentWithConfigBundle/ExtensionAbsentWithConfigBundle.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpKernel\Fixtures\ExtensionAbsentWithConfigBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class ExtensionAbsentWithConfigBundle extends Bundle
+{
+}

--- a/tests/Symfony/Tests/Component/HttpKernel/Fixtures/ExtensionAbsentWithConfigBundle/Resources/config/services.yml
+++ b/tests/Symfony/Tests/Component/HttpKernel/Fixtures/ExtensionAbsentWithConfigBundle/Resources/config/services.yml
@@ -1,0 +1,3 @@
+services:
+    foo:
+        class: Foo


### PR DESCRIPTION
This extension is instanciated by default for Bundles that don't have an Extension class.
It automatically loads Resources/config/services.(yml|xml) service definitions into the Container if they exist.

The idea came from @lsmith77 - many people don't get the concept of extensions, and the best way for them is to smash service definitions in their app config, or put it in the bundle and include it from the app config, but that ends up creating issues apparently (I'll let Lukas explain if needed). So the idea here is that by default the GeneratorBundle should create a services.yml or xml, and people can drop their services in there. That way we can skip the subject of extensions entirely for people that don't write reusable bundles. 

Also it standardizes the name a bit, instead of having a ton of different names as we have right now. It could be a good thing to rename the core files to follow this convention, except for FrameworkBundle and SecurityBundle (and any other?) that have many files.
