### PR TITLE
Correct prefix from nothing to ORM\ for annotations

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -99,6 +99,7 @@ EOT
         $repoGenerator = new EntityRepositoryGenerator();
         foreach ($metadata->getMetadata() as $m) {
             $output->writeln(sprintf('  > generating <comment>%s</comment>', $m->name));
+            $generator->setAnnotationPrefix('ORM\\');
             $generator->generate(array($m), $metadata->getPath());
 
             if ($m->customRepositoryClassName && false !== strpos($m->customRepositoryClassName, $metadata->getNamespace())) {


### PR DESCRIPTION
For yml et xml mapping, the commands generate:doctrine:entities and doctrine:generate:entities, don't prefixed the annotations, specially for the listenners methods (prepersist, preupdate...).
