### PR TITLE
Added missing cache-warmer attributes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -65,6 +65,7 @@
     </xsd:complexType>
 
     <xsd:complexType name="router">
+        <xsd:attribute name="cache-warmer" type="xsd:boolean" />
         <xsd:attribute name="resource" type="xsd:string" />
         <xsd:attribute name="type" type="xsd:string" />
         <xsd:attribute name="http-port" type="xsd:string" />
@@ -96,6 +97,7 @@
         <xsd:attribute name="assets-version" type="xsd:string" />
         <xsd:attribute name="assets-version-format" type="xsd:string" />
         <xsd:attribute name="cache" type="xsd:string" />
+        <xsd:attribute name="cache-warmer" type="xsd:boolean" />
     </xsd:complexType>
 
     <xsd:complexType name="form-resources">


### PR DESCRIPTION
Validating Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml against this DTD generated 2 errors about missing cache-warmer attributes.
