### PR TITLE
[CssSelector] Fatal error on invalid selector expression

### DIFF
--- a/src/Symfony/Component/CssSelector/Tokenizer.php
+++ b/src/Symfony/Component/CssSelector/Tokenizer.php
@@ -189,7 +189,7 @@ class Tokenizer
         $matchStart = $match[0][1];
 
         if ($matchStart == $pos) {
-            throw new ParseException(sprintf('Unexpected symbol: %s at %s', $s[$pos], $pos));
+            throw new Exception\ParseException(sprintf('Unexpected symbol: %s at %s', $s[$pos], $pos));
         }
 
         $result = substr($s, $start, $matchStart - $start);

--- a/tests/Symfony/Tests/Component/CssSelector/TokenizerTest.php
+++ b/tests/Symfony/Tests/Component/CssSelector/TokenizerTest.php
@@ -36,6 +36,14 @@ class TokenizerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("foo[class=foo Abar     ]", $this->tokensToString($this->tokenizer->tokenize('foo[class="foo \\65 bar"]')), '->tokenize() lexes an input string and returns an array of tokens');
     }
 
+    /**
+     * @expectedException Symfony\Component\CssSelector\Exception\ParseException
+     */
+    public function testTokenizeInvalidString()
+    {
+        $this->tokensToString($this->tokenizer->tokenize('/invalid'));
+    }
+
     public function getCssSelectors()
     {
         return array(


### PR DESCRIPTION
The following usage in a WebTestCase leads to a fatal error and ends phpunit:

```
$client = $this->createClient();
$crawler = $client->request('GET', '/');
$this->assertTrue($crawler->filter('/invalid')->count() > 0);
```

2 commits made, first one is the UnitTest to check on correct exception throwing, second one to fix the wrong namespace.
