### PR TITLE
[HttpFoundation] fixed zero-lifetime session bug

### DIFF
--- a/src/Symfony/Component/HttpFoundation/SessionStorage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/NativeSessionStorage.php
@@ -80,6 +80,11 @@ class NativeSessionStorage implements SessionStorageInterface
 
         session_start();
 
+        // set zero-lifetime (till browser closed) cookie properly
+        if (0 === $this->options['lifetime']) {
+            setcookie(session_name(), session_id(), 0);
+        }
+
         self::$sessionStarted = true;
     }
 


### PR DESCRIPTION
We set session cookie parameters with `session_set_cookie_params()` call in `NativeSessionStorage`. But there's actually a problem with this method. It doesn't work correctly with zero-lifetime session cookies (Symfony2 defaults).

Documentation says, that for **cookie_lifetime**, _The value 0 means "until the browser is closed."_ and that's how `setcookie()` works, but not `session_set_cookie_params()`:
http://www.php.net/manual/en/function.session-set-cookie-params.php#100657
`session_set_cookie_params()` instead sets actual cookie lifetime to zero, making it expire right after it was set :-) This causes default authorization mechanism (without `lifetime: ...` setting) to always fail.

I've added extra _zero-value_ check and proper `setcookie()` call, that does nothing more than just setting proper cookie lifetime.
