### PR TITLE
[Form] Fix choice field validation

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -53,7 +53,7 @@ class ChoiceValidator extends ConstraintValidator
 
         if ($constraint->multiple) {
             foreach ($value as $_value) {
-                if (!in_array($_value, $choices, true)) {
+                if (!array_key_exists($_value, $choices)) {
                     $this->setMessage($constraint->multipleMessage, array('{{ value }}' => $_value));
 
                     return false;
@@ -73,7 +73,7 @@ class ChoiceValidator extends ConstraintValidator
 
                 return false;
             }
-        } elseif (!in_array($value, $choices, true)) {
+        } elseif (!array_key_exists($value, $choices)) {
             $this->setMessage($constraint->message, array('{{ value }}' => $value));
 
             return false;


### PR DESCRIPTION
To validate a choice field, we use an array of allowed values. It can be guessed from Choice constraint or specified when calling add() on the FormBuilder.

The validation is currently done using values of the given array. With this pull request, we validate with the keys of the array which makes much more sense as this is what is transfered in the POST request.

Without this patch, guessing is useless (validation always fails), and we're forced to give the list of allowed values (array_keys on what's given to Choice constraint) when calling add() on the FormBuilder.

This commit fixes issues #1405 and #1406.
