### PR TITLE
[Config] tweaked exception message when a resource can't be loaded. The n

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -36,7 +36,7 @@ class FileLoaderLoadException extends \Exception
         if ('@' === $resource[0]) {
             $parts = explode(DIRECTORY_SEPARATOR, $resource);
             $bundle = substr($parts[0], 1);
-            $message .= ' '. sprintf('Make sure the "%s" bundle is correctly registered and loaded in the application kernel class.', $bundle);
+            $message .= ' '.sprintf('Make sure the "%s" bundle is correctly registered and loaded in the application kernel class.', $bundle);
         }
 
         parent::__construct($message, $code, $previous);

--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -32,6 +32,13 @@ class FileLoaderLoadException extends \Exception
             $message = sprintf('Cannot import resource "%s" from "%s".', $this->varToString($resource), $this->varToString($sourceResource));
         }
 
+        // Is the resource located inside a bundle?
+        if ('@' === $resource[0]) {
+            $parts = explode(DIRECTORY_SEPARATOR, $resource);
+            $bundle = substr($parts[0], 1);
+            $message .= ' '. sprintf('Make sure the "%s" bundle is correctly registered and loaded in the application kernel class.', $bundle);
+        }
+
         parent::__construct($message, $code, $previous);
     }
 


### PR DESCRIPTION
[Config] tweaked exception message when a resource can't be loaded. The new exception message reminds to check if the bundle is correctly loaded in the kernel class when trying to load a resource coming from a bundle.
