### PR TITLE
Annotation autoloading

### DIFF
--- a/UPDATE.md
+++ b/UPDATE.md
@@ -10,6 +10,22 @@ RC3 to RC4
 ----------
 * Annotation classes must be annotated with @Annotation 
   (see the validator constraints for examples)
+* Annotations are not using the PHP autoloading but their own mechanism. This allows much more control
+  about possible failure states. To make your code work you have to add the following lines to your
+  autoload.php:
+
+    AnnotationRegistry::registerLoader(function($class) use ($loader) {
+        $loader->loadClass($class);
+        return class_exists($class, false);
+    });
+    AnnotationRegistry::registerFile(
+        __DIR__.'/../vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php'
+    );
+
+  The `$loader` variable is an instance of the UniversalClassLoader. Additionally you might have to adjust
+  the ORM path to the DoctrineAnnotations.php. If you are not using the UniversalClassLoader see the
+  [Doctrine Annotations documentation](http://www.doctrine-project.org/docs/common/2.1/en/reference/annotations.html) 
+  for more details on how to register annotations.
 
 beta5 to RC1
 ------------

--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -3,6 +3,7 @@
 require_once __DIR__.'/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
 
 use Symfony\Component\ClassLoader\UniversalClassLoader;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = new UniversalClassLoader();
 $loader->registerNamespaces(array(
@@ -20,6 +21,12 @@ $loader->registerPrefixFallbacks(array(
     __DIR__.'/src/Symfony/Component/Locale/Resources/stubs',
 ));
 $loader->register();
+
+AnnotationRegistry::registerLoader(function($class) use ($loader) {
+    $loader->loadClass($class);
+    return class_exists($class, false);
+});
+AnnotationRegistry::registerFile(__DIR__.'/vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
 
 if (is_file(__DIR__.'/vendor/swiftmailer/lib/classes/Swift.php')) {
     require_once __DIR__.'/vendor/swiftmailer/lib/classes/Swift.php';

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -11,9 +11,7 @@
     </parameters>
 
     <services>
-        <service id="annotations.reader" class="%annotations.reader.class%" public="false">
-            <call method="setAutoloadAnnotations"><argument>true</argument></call>
-        </service>
+        <service id="annotations.reader" class="%annotations.reader.class%" public="false" />
 
         <service id="annotations.cached_reader" class="%annotations.cached_reader.class%" public="false">
             <argument type="service" id="annotations.reader" />

--- a/tests/Symfony/Tests/Component/Validator/Mapping/Loader/AnnotationLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Mapping/Loader/AnnotationLoaderTest.php
@@ -36,7 +36,6 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassMetadataReturnsTrueIfSuccessful()
     {
         $reader = new AnnotationReader();
-        $reader->setAutoloadAnnotations(true);
         $loader = new AnnotationLoader($reader);
         $metadata = new ClassMetadata('Symfony\Tests\Component\Validator\Fixtures\Entity');
 


### PR DESCRIPTION
This pull request disables the annotation autoloading through the DIC. PHP Autoloading is now removed from the AnnotationReader and replaced with its own autoloading mechanism that offers much more control over possible error states.
