### PR TITLE
[Session] Call session_name() only if user gave an new one

### DIFF
--- a/src/Symfony/Component/HttpFoundation/SessionStorage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/NativeSessionStorage.php
@@ -26,8 +26,8 @@ class NativeSessionStorage implements SessionStorageInterface
     /**
      * Available options:
      *
-     *  * name:     The cookie name (_SESS by default)
-     *  * id:       The session id (null by default)
+     *  * name:     The cookie name (null [ommited] by default)
+     *  * id:       The session id (null [ommited] by default)
      *  * lifetime: Cookie lifetime
      *  * path:     Cookie path
      *  * domain:   Cookie domain
@@ -43,15 +43,18 @@ class NativeSessionStorage implements SessionStorageInterface
         $cookieDefaults = session_get_cookie_params();
 
         $this->options = array_merge(array(
-            'name'          => '_SESS',
-            'lifetime'      => $cookieDefaults['lifetime'],
-            'path'          => $cookieDefaults['path'],
-            'domain'        => $cookieDefaults['domain'],
-            'secure'        => $cookieDefaults['secure'],
-            'httponly'      => isset($cookieDefaults['httponly']) ? $cookieDefaults['httponly'] : false,
+            'name'     => null,
+            'lifetime' => $cookieDefaults['lifetime'],
+            'path'     => $cookieDefaults['path'],
+            'domain'   => $cookieDefaults['domain'],
+            'secure'   => $cookieDefaults['secure'],
+            'httponly' => isset($cookieDefaults['httponly']) ? $cookieDefaults['httponly'] : false,
         ), $options);
 
-        session_name($this->options['name']);
+        // Skip setting new session name if user don't wan't it
+        if (isset($this->options['name'])) {
+            session_name($this->options['name']);
+        }
     }
 
     /**


### PR DESCRIPTION
Call `session_name()` only if user gave an new one, by default will use an "php.ini" option. Also added some phpdoc.

Closes #1418.
