### PR TITLE
[Bridge/Twig] Add required class to labels that match required fields

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -184,6 +184,9 @@
 
 {% block field_label %}
 {% spaceless %}
+    {% if required %}
+        {% set attr = attr|merge({'class': attr.class|default('') ~ ' required'}) %}
+    {% endif %}
     <label for="{{ id }}"{% for attrname,attrvalue in attr %} {{attrname}}="{{attrvalue}}"{% endfor %}>{{ label|trans }}</label>
 {% endspaceless %}
 {% endblock field_label %}

--- a/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
@@ -209,7 +209,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
         $this->assertMatchesXpath($html,
 '/label
     [@for="na&me"]
-    [@class="my&class"]
+    [@class="my&class required"]
 '
         );
     }
@@ -228,7 +228,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
         $this->assertMatchesXpath($html,
 '/label
     [@for="na&me"]
-    [@class="my&class"]
+    [@class="my&class required"]
     [.="[trans]Custom label[/trans]"]
 '
         );


### PR DESCRIPTION
I have used this to simply style labels that are required with a red star behind them using this CSS:

``` css
label.required::after {
    content: " *";
    color: #c00;
}
```

The problem is that you can't use `input[required] + label::after` as a selector since the label is typically rendered before the input. There is no way to check for an element that is _followed by_ another, only elements _following_.

Of course this CSS in particular won't work except in the latest browsers, but you could still use the `label.required` selector to add a background image and so on. I think this is a very common use case and therefore I think it'd benefit the core framework.
