### PR TITLE
[console] Incorrect help text

### DIFF
--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -44,11 +44,11 @@ class HelpCommand extends Command
             ->setHelp(<<<EOF
 The <info>help</info> command displays help for a given command:
 
-  <info>./symfony help list</info>
+  <info>php app/console help list</info>
 
 You can also output the help as XML by using the <comment>--xml</comment> option:
 
-  <info>./symfony help --xml list</info>
+  <info>php app/console help --xml list</info>
 EOF
             );
     }

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -44,11 +44,11 @@ class HelpCommand extends Command
             ->setHelp(<<<EOF
 The <info>help</info> command displays help for a given command:
 
-  <info>php app/console help list</info>
+  <info>./app/console help list</info>
 
 You can also output the help as XML by using the <comment>--xml</comment> option:
 
-  <info>php app/console help --xml list</info>
+  <info>./app/console help --xml list</info>
 EOF
             );
     }

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -40,15 +40,15 @@ class ListCommand extends Command
             ->setHelp(<<<EOF
 The <info>list</info> command lists all commands:
 
-  <info>./symfony list</info>
+  <info>php app/console list</info>
 
 You can also display the commands for a specific namespace:
 
-  <info>./symfony list test</info>
+  <info>php app/console list test</info>
 
 You can also output the information as XML by using the <comment>--xml</comment> option:
 
-  <info>./symfony list --xml</info>
+  <info>php app/console list --xml</info>
 EOF
             );
     }

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -40,15 +40,15 @@ class ListCommand extends Command
             ->setHelp(<<<EOF
 The <info>list</info> command lists all commands:
 
-  <info>php app/console list</info>
+  <info>./app/console list</info>
 
 You can also display the commands for a specific namespace:
 
-  <info>php app/console list test</info>
+  <info>./app/console list test</info>
 
 You can also output the information as XML by using the <comment>--xml</comment> option:
 
-  <info>php app/console list --xml</info>
+  <info>./app/console list --xml</info>
 EOF
             );
     }


### PR DESCRIPTION
When executing 'php app/console help', example commands starting with './symfony ' are shown. 
I've made it consistent with the help text shown for generate:bundle; './app/console '
