### PR TITLE
EOF triggers infinite loop in console dialog helper

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -35,9 +35,12 @@ class DialogHelper extends Helper
     {
         $output->write($question);
 
-        $ret = trim(fgets(null === $this->inputStream ? STDIN : $this->inputStream));
+        if (false === $ret = fgets(null === $this->inputStream ? STDIN : $this->inputStream)) {
+            throw new \Exception('Aborted');
+        }
+        $ret = trim($ret);
 
-        return $ret ? $ret : $default;
+        return strlen($ret) > 0 ? $ret : $default;
     }
 
     /**


### PR DESCRIPTION
- fix by throwing an exception when fgets() fails
- Also fixes "0" returning a default answer instead of "0"
