### PR TITLE
[Form] Fix the default validator

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Validator/DefaultValidator.php
+++ b/src/Symfony/Component/Form/Extension/Core/Validator/DefaultValidator.php
@@ -31,18 +31,20 @@ class DefaultValidator implements FormValidatorInterface
             $length = (int) $_SERVER['CONTENT_LENGTH'];
             $max = trim(ini_get('post_max_size'));
 
-            switch (strtolower(substr($max, -1))) {
-                // The 'G' modifier is available since PHP 5.1.0
-                case 'g':
-                    $max *= 1024;
-                case 'm':
-                    $max *= 1024;
-                case 'k':
-                    $max *= 1024;
-            }
+            if ('' !== $max) {
+                switch (strtolower(substr($max, -1))) {
+                    // The 'G' modifier is available since PHP 5.1.0
+                    case 'g':
+                        $max *= 1024;
+                    case 'm':
+                        $max *= 1024;
+                    case 'k':
+                        $max *= 1024;
+                }
 
-            if ($length > $max) {
-                $form->addError(new FormError('The uploaded file was too large. Please try to upload a smaller file'));
+                if ($length > $max) {
+                    $form->addError(new FormError('The uploaded file was too large. Please try to upload a smaller file'));
+                }
             }
         }
     }


### PR DESCRIPTION
When php.ini has an empty value for post_max_size
`post_max_size =`

see http://fr2.php.net/manual/en/function.ini-get.php

post_max_size can not be false as it has a default value
