### PR TITLE
Authorize the creation of an empty array of choices.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -31,7 +31,7 @@ class ChoiceType extends AbstractType
      */
     public function buildForm(FormBuilder $builder, array $options)
     {
-        if (!$options['choices'] && !$options['choice_list']) {
+        if (!isset($options['choices']) && !$options['choice_list']) {
             throw new FormException('Either the option "choices" or "choice_list" is required');
         }
 


### PR DESCRIPTION
Authorize the creation of an empty array of choices. (nldr. For autocomplete ajax by example)
As example:

```
    $builder->add('toComplete', 'choice', array(
                'choices' => array(),
                'multiple' => true,
                'required' => false
            ))
```
