### PR TITLE
[HttpFoundation] set Content-Length header to the length of content

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -172,6 +172,7 @@ class Response
         }
 
         $this->content = (string) $content;
+        $this->headers->set('Content-Length', strlen($this->content));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
@@ -40,7 +40,7 @@ class ResponseListener
         $response = $event->getResponse();
 
         if ('HEAD' === $request->getMethod()) {
-            // cf. RFC2611 14.13
+            // cf. RFC2616 14.13
             $length = $response->headers->get('Content-Length');
             $response->setContent('');
             if ($length) {


### PR DESCRIPTION
I can't think of why this could be bad but if somebody knows please chime in.

The good thing is that with this change keepalive will work out of the box.
