### PR TITLE
[Console] definitions printing fix

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -408,10 +408,15 @@ class InputDefinition
         // find the largest option or argument name
         $max = 0;
         foreach ($this->getOptions() as $option) {
-            $max = strlen($option->getName()) + 2 > $max ? strlen($option->getName()) + 2 : $max;
+            $nameLength = strlen($option->getName()) + 2;
+            if ($option->getShortcut()) {
+                $nameLength += strlen($option->getShortcut()) + 3;
+            }
+
+            $max = max($max, $nameLength);
         }
         foreach ($this->getArguments() as $argument) {
-            $max = strlen($argument->getName()) > $max ? strlen($argument->getName()) : $max;
+            $max = max($max, strlen($argument->getName()));
         }
         ++$max;
 
@@ -426,7 +431,9 @@ class InputDefinition
                     $default = '';
                 }
 
-                $text[] = sprintf(" <info>%-${max}s</info> %s%s", $argument->getName(), $argument->getDescription(), $default);
+                $description = str_replace("\n", "\n".str_pad('', $max + 2, ' '), $argument->getDescription());
+
+                $text[] = sprintf(" <info>%-${max}s</info> %s%s", $argument->getName(), $description, $default);
             }
 
             $text[] = '';
@@ -443,7 +450,16 @@ class InputDefinition
                 }
 
                 $multiple = $option->isArray() ? '<comment> (multiple values allowed)</comment>' : '';
-                $text[] = sprintf(' %-'.$max.'s %s%s%s%s', '<info>--'.$option->getName().'</info>', $option->getShortcut() ? sprintf('(-%s) ', $option->getShortcut()) : '', $option->getDescription(), $default, $multiple);
+                $description = str_replace("\n", "\n".str_pad('', $max + 2, ' '), $option->getDescription());
+
+                $optionMax = $max - strlen($option->getName()) - 2;
+                $text[] = sprintf(" <info>%s</info> %-${optionMax}s%s%s%s",
+                    '--'.$option->getName(),
+                    $option->getShortcut() ? sprintf('(-%s) ', $option->getShortcut()) : '',
+                    $description,
+                    $default,
+                    $multiple
+                );
             }
 
             $text[] = '';

--- a/tests/Symfony/Tests/Component/Console/Fixtures/application_run2.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/application_run2.txt
@@ -2,17 +2,17 @@ Usage:
  help [--xml] [command_name]
 
 Arguments:
- command           The command to execute
- command_name      The command name (default: help)
+ command               The command to execute
+ command_name          The command name (default: help)
 
 Options:
- --xml To output help as XML
- --help (-h) Display this help message.
- --quiet (-q) Do not output any message.
- --verbose (-v) Increase verbosity of messages.
- --version (-V) Display this program version.
- --ansi Force ANSI output.
- --no-ansi Disable ANSI output.
+ --xml                 To output help as XML
+ --help (-h)           Display this help message.
+ --quiet (-q)          Do not output any message.
+ --verbose (-v)        Increase verbosity of messages.
+ --version (-V)        Display this program version.
+ --ansi                Force ANSI output.
+ --no-ansi             Disable ANSI output.
  --no-interaction (-n) Do not ask any interactive question.
 
 Help:

--- a/tests/Symfony/Tests/Component/Console/Fixtures/application_run3.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/application_run3.txt
@@ -5,7 +5,7 @@ Arguments:
  namespace  The namespace name
 
 Options:
- --xml To output help as XML
+ --xml      To output help as XML
 
 Help:
  The list command lists all commands:

--- a/tests/Symfony/Tests/Component/Console/Fixtures/command_astext.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/command_astext.txt
@@ -3,15 +3,15 @@
 
 <comment>Aliases:</comment> <info>name</info>
 <comment>Arguments:</comment>
- <info>command          </info> The command to execute
+ <info>command              </info> The command to execute
 
 <comment>Options:</comment>
- <info>--help</info> (-h) Display this help message.
- <info>--quiet</info> (-q) Do not output any message.
- <info>--verbose</info> (-v) Increase verbosity of messages.
- <info>--version</info> (-V) Display this program version.
- <info>--ansi</info> Force ANSI output.
- <info>--no-ansi</info> Disable ANSI output.
+ <info>--help</info> (-h)           Display this help message.
+ <info>--quiet</info> (-q)          Do not output any message.
+ <info>--verbose</info> (-v)        Increase verbosity of messages.
+ <info>--version</info> (-V)        Display this program version.
+ <info>--ansi</info>                Force ANSI output.
+ <info>--no-ansi</info>             Disable ANSI output.
  <info>--no-interaction</info> (-n) Do not ask any interactive question.
 
 <comment>Help:</comment>

--- a/tests/Symfony/Tests/Component/Console/Fixtures/definition_astext.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/definition_astext.txt
@@ -1,6 +1,6 @@
 <comment>Arguments:</comment>
- <info>foo   </info> The bar argument
- <info>bar   </info> The foo argument<comment> (default: array (  0 => 'bar',))</comment>
+ <info>foo       </info> The bar argument
+ <info>bar       </info> The foo argument<comment> (default: array (  0 => 'bar',))</comment>
 
 <comment>Options:</comment>
  <info>--foo</info> (-f) The foo option


### PR DESCRIPTION
Before this change, console component printed definitions as:

``` bash
Arguments:
 features        Feature(s) to run. Could be a dir (features/), 
a feature (*.feature) or a scenario at specific line 
(*.feature:10).

Options:
 --config (-c) Specify external configuration file to load. behat.yml or config/behat.yml will be used by default.
 --profile (-p) Specify configuration profile to use. Define profiles in config file (--config).
 --init Create features directory structure.

 --format (-f) How to format features. pretty is default. Available formats are 
- pretty
- progress
- html
- junit
 --out Write formatter output to a file/directory instead of STDOUT (output_path).
 --colors Force Behat to use ANSI color in the output.
 --no-colors Do not use ANSI color in the output.
 --no-time Hide time in output.
 --lang Print formatter output in particular language.
 --no-paths Do not print the definition path with the steps.
 --no-snippets Do not print snippets for undefined steps.
 --no-multiline No multiline arguments in output.
 --expand Expand Scenario Outline Tables in output.

 --story-syntax Print *.feature example in specified language (--lang).
 --definitions Print available step definitions in specified language (--lang).

 --name Only execute the feature elements (features or scenarios) which match part of the given name or regex.
```

As you might see, indentation is totally broken (also notice how it prints multiline descriptions in argument and --format option).

This PR makes output looks like this:

``` bash
Arguments:
 features        Feature(s) to run. Could be a dir (features/), 
                 a feature (*.feature) or a scenario at specific line 
                 (*.feature:10).

Options:
 --config (-c)   Specify external configuration file to load. behat.yml or config/behat.yml will be used by default.
 --profile (-p)  Specify configuration profile to use. Define profiles in config file (--config).
 --init          Create features directory structure.

 --format (-f)   How to format features. pretty is default. Available formats are 
                 - pretty
                 - progress
                 - html
                 - junit
 --out           Write formatter output to a file/directory instead of STDOUT (output_path).
 --colors        Force Behat to use ANSI color in the output.
 --no-colors     Do not use ANSI color in the output.
 --no-time       Hide time in output.
 --lang          Print formatter output in particular language.
 --no-paths      Do not print the definition path with the steps.
 --no-snippets   Do not print snippets for undefined steps.
 --no-multiline  No multiline arguments in output.
 --expand        Expand Scenario Outline Tables in output.

 --story-syntax  Print *.feature example in specified language (--lang).
 --definitions   Print available step definitions in specified language (--lang).

 --name          Only execute the feature elements (features or scenarios) which match part of the given name or regex.
```
