### PR TITLE
[HttpFoundation] Redirect response is missing a HTML body

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -33,7 +33,7 @@ class RedirectResponse extends Response
         }
 
         parent::__construct(
-            sprintf('<html><head><meta http-equiv="refresh" content="1;url=%s"/></head></html>', htmlspecialchars($url, ENT_QUOTES)),
+            sprintf('<html><head><meta http-equiv="refresh" content="1;url=%s"/></head><body>Redirect to <a href="%1$s">%1$s</a>.</body></html>', htmlspecialchars($url, ENT_QUOTES)),
             $status,
             array('Location' => $url)
         );


### PR DESCRIPTION
HTTP 1.1 / RFC 2616 - Make Redirect response HTTP body having a HTML body as "...the entity of the response SHOULD contain a short hypertext note with a hyperlink to the new URI(s)." (unless HEAD request, see response codes 301, 302, 303 and 307).

See [10.3 Redirection 3xx _in_ Hypertext Transfer Protocol -- HTTP/1.1 (RFC 2616 Fielding, et al.)](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3) and [9.3 Redirection 3xx _in_ Hypertext Transfer Protocol -- HTTP/1.0](http://tools.ietf.org/html/rfc1945#section-9.3).
