### PR TITLE
[Form] Make CSRF error message configurable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -87,6 +87,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('enabled')->defaultTrue()->end()
                         ->scalarNode('field_name')->defaultValue('_token')->end()
+                        ->scalarNode('error_message')->defaultValue('The CSRF token is invalid. Please try to resubmit the form')->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -155,6 +155,7 @@ class FrameworkExtension extends Extension
             }
             $loader->load('form_csrf.xml');
 
+            $container->setParameter('form.type.csrf.error_message', $config['csrf_protection']['error_message']);
             $container->setParameter('form.type_extension.csrf.enabled', $config['csrf_protection']['enabled']);
             $container->setParameter('form.type_extension.csrf.field_name', $config['csrf_protection']['field_name']);
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form_csrf.xml
@@ -17,6 +17,7 @@
         <service id="form.type.csrf" class="Symfony\Component\Form\Extension\Csrf\Type\CsrfType">
             <tag name="form.type" alias="csrf" />
             <argument type="service" id="form.csrf_provider" />
+            <argument>%form.type.csrf.error_message%</argument>
         </service>
         <service id="form.type_extension.csrf" class="Symfony\Component\Form\Extension\Csrf\Type\FormTypeCsrfExtension">
             <tag name="form.type_extension" alias="form" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -35,6 +35,7 @@
     <xsd:complexType name="csrf_protection">
         <xsd:attribute name="enabled" type="xsd:boolean" />
         <xsd:attribute name="field-name" type="xsd:string" />
+        <xsd:attribute name="error-message" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="esi">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -4,8 +4,9 @@ $container->loadFromExtension('framework', array(
     'secret' => 's3cr3t',
     'form' => null,
     'csrf_protection' => array(
-        'enabled'    => true,
-        'field_name' => '_csrf',
+        'enabled'       => true,
+        'field_name'    => '_csrf',
+        'error_message' => 'csrf_error',
     ),
     'esi' => array(
         'enabled' => true,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -7,7 +7,7 @@
                         http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
 
     <framework:config secret="s3cr3t">
-        <framework:csrf-protection enabled="true" field-name="_csrf" />
+        <framework:csrf-protection enabled="true" field-name="_csrf" error-message="csrf_error" />
         <framework:form />
         <framework:esi enabled="true" />
         <framework:profiler only-exceptions="true" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -2,8 +2,9 @@ framework:
     secret: s3cr3t
     form: ~
     csrf_protection:
-        enabled:    true
-        field_name: _csrf
+        enabled:       true
+        field_name:    _csrf
+        error_message: csrf_error
     esi:
         enabled: true
     profiler:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -24,6 +24,12 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('full');
 
+        $def = $container->getDefinition('form.type.csrf');
+
+        $this->assertEquals('form.csrf_provider', (string) $def->getArgument(0));
+        $this->assertEquals('csrf_error', $container->getParameter('form.type.csrf.error_message'));
+        $this->assertEquals('%form.type.csrf.error_message%', $def->getArgument(1));
+
         $def = $container->getDefinition('form.type_extension.csrf');
 
         $this->assertTrue($container->getParameter('form.type_extension.csrf.enabled'));

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListener.php
@@ -27,21 +27,24 @@ class EnsureCsrfFieldListener
     private $name;
     private $intention;
     private $provider;
+    private $errorMessage;
 
     /**
      * Constructor.
      *
-     * @param FormFactoryInterface  $factory   The form factory
-     * @param string                $name      A name for the CSRF field
-     * @param string                $intention The intention string
-     * @param CsrfProviderInterface $provider  The CSRF provider
+     * @param FormFactoryInterface  $factory      The form factory
+     * @param string                $name         A name for the CSRF field
+     * @param string                $intention    The intention string
+     * @param CsrfProviderInterface $provider     The CSRF provider
+     * @param string                $errorMessage The error message for an invalid CSRF token
      */
-    public function __construct(FormFactoryInterface $factory, $name, $intention = null, CsrfProviderInterface $provider = null)
+    public function __construct(FormFactoryInterface $factory, $name, $intention = null, CsrfProviderInterface $provider = null, $errorMessage = null)
     {
         $this->factory = $factory;
         $this->name = $name;
         $this->intention = $intention;
         $this->provider = $provider;
+        $this->errorMessage = $errorMessage;
     }
 
     /**
@@ -59,6 +62,9 @@ class EnsureCsrfFieldListener
         }
         if ($this->provider) {
             $options['csrf_provider'] = $this->provider;
+        }
+        if ($this->errorMessage) {
+            $options['error_message'] = $this->errorMessage;
         }
 
         $form->add($this->factory->createNamed('csrf', $this->name, null, $options));

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -45,7 +45,8 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
             $builder->getFormFactory(),
             $options['csrf_field_name'],
             $options['intention'],
-            $options['csrf_provider']
+            $options['csrf_provider'],
+            $options['csrf_error_message']
         );
 
         // use a low priority so higher priority listeners don't remove the field
@@ -79,10 +80,11 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     public function getDefaultOptions(array $options)
     {
         return array(
-            'csrf_protection'   => $this->enabled,
-            'csrf_field_name'   => $this->fieldName,
-            'csrf_provider'     => null,
-            'intention'         => 'unknown',
+            'csrf_protection'    => $this->enabled,
+            'csrf_error_message' => null,
+            'csrf_field_name'    => $this->fieldName,
+            'csrf_provider'      => null,
+            'intention'          => 'unknown',
         );
     }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Csrf/EventListener/EnsureCsrfFieldListenerTest.php
@@ -80,4 +80,20 @@ class EnsureCsrfFieldListenerTest extends \PHPUnit_Framework_TestCase
         $listener = new EnsureCsrfFieldListener($this->formFactory, '_token', null, $provider);
         $listener->ensureCsrfField($this->event);
     }
+
+    public function testErrorMessage()
+    {
+        $errorMessage = 'An error occurred.';
+
+        $this->formFactory->expects($this->once())
+            ->method('createNamed')
+            ->with('csrf', '_token', null, array('error_message' => $errorMessage))
+            ->will($this->returnValue($this->field));
+        $this->form->expects($this->once())
+            ->method('add')
+            ->with($this->isInstanceOf('Symfony\\Tests\\Component\\Form\\FormInterface'));
+
+        $listener = new EnsureCsrfFieldListener($this->formFactory, '_token', null, null, $errorMessage);
+        $listener->ensureCsrfField($this->event);
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Csrf/Type/CsrfTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Csrf/Type/CsrfTypeTest.php
@@ -54,6 +54,41 @@ class CsrfTypeTest extends TypeTestCase
         $this->assertEquals('token', $form->getData());
     }
 
+    public function testInvalidTokenCustomErrorMessage()
+    {
+        $this->provider->expects($this->once())
+            ->method('isCsrfTokenValid')
+            ->with('%INTENTION%', 'token')
+            ->will($this->returnValue(false));
+
+        $form = $this->factory->create('csrf', null, array(
+            'csrf_provider' => $this->provider,
+            'intention' => '%INTENTION%',
+            'error_message' => 'An error occurred.',
+        ));
+        $form->bind('token');
+
+        $formErrors = $form->getErrors();
+        $this->assertEquals('An error occurred.', $formErrors[0]->getMessageTemplate());
+    }
+
+    public function testInvalidTokenDefaultErrorMessage()
+    {
+        $this->provider->expects($this->once())
+            ->method('isCsrfTokenValid')
+            ->with('%INTENTION%', 'token')
+            ->will($this->returnValue(false));
+
+        $form = $this->factory->create('csrf', null, array(
+            'csrf_provider' => $this->provider,
+            'intention' => '%INTENTION%',
+        ));
+        $form->bind('token');
+
+        $formErrors = $form->getErrors();
+        $this->assertEquals('The CSRF token is invalid. Please try to resubmit the form', $formErrors[0]->getMessageTemplate());
+    }
+
     public function testValidateTokenOnBind()
     {
         $this->provider->expects($this->once())


### PR DESCRIPTION
We've had ongoing problems with non-technical users of our site being confused by the default CSRF error message. While it was originally configurable via the messages XML files (way back when), that's no longer the case.

This PR turns the hard-coded CSRF validation error message in `CsrfType` into a configurable constructor argument, form option, and app configuration option. I attempted to follow the example of the CSRF's field name, whose default value appears in both `FormTypeCsrfExtension` and FrameworkBundle's configuration class.

The FrameworkBundle test fixtures were updated to provide examples for all three formats.

I didn't touch `CsrfExtension`, which I believe is intended for folks using the Form component on its own. It appears to be missing multiple configuration options that FrameworkBundle handles for `FormTypeCsrfExtension`, so I imagine the absence of a configurable error message is forgivable. Still, that's something to think about for the maintainer of that class.
