### PR TITLE
[HttpKernel] Fix for #1571, which escapes dots in ESI controller parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/internal.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/internal.xml
@@ -6,5 +6,6 @@
 
   <route id="_internal" pattern="/{controller}/{path}.{_format}">
     <default key="_controller">FrameworkBundle:Internal:index</default>
+    <requirement key="path">.+?</requirement>
   </route>
 </routes>


### PR DESCRIPTION
Fix for #1571.

http_build_query doesn't urlencode dots. This creates an issue whenever an ESI controller parameter has a dot in it, since the applicable route parameter is "[^/.]+?".

This is fixed by replacing all dots in the parameters with the URL-encoded counterpart %2E.
