### PR TITLE
Fix RedirectResponse HTML indentation and constructor phpDoc

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -24,7 +24,7 @@ class RedirectResponse extends Response
      * @param string  $url    The URL to redirect to
      * @param integer $status The status code (302 by default)
      *
-     * @see http://tools.ietf.org/html/rfc2616#section-10.3.5
+     * @see http://tools.ietf.org/html/rfc2616#section-10.3
      */
     public function __construct($url, $status = 302)
     {
@@ -34,14 +34,14 @@ class RedirectResponse extends Response
 
         parent::__construct(
             sprintf('<html>
-                <head>
-                    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-                    <meta http-equiv="refresh" content="1;url=%1$s" />
-                </head>
-                <body>
-                    Redirecting to <a href="%1$s">%1$s</a>.
-                </body>
-            </html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8')),
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="refresh" content="1;url=%1$s" />
+    </head>
+    <body>
+        Redirecting to <a href="%1$s">%1$s</a>.
+    </body>
+</html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8')),
             $status,
             array('Location' => $url)
         );


### PR DESCRIPTION
Removes extra indents from the redirection response content.
