### PR TITLE
[DoctrineBundle] Fixed the Registry::getEntityManagerForObject method

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -237,7 +237,7 @@ class Registry implements RegistryInterface
         foreach ($this->entityManagers as $id) {
             $em = $this->container->get($id);
 
-            if ($em->getConfiguration()->getMetadataDriverImpl()->isTransient($class)) {
+            if (!$em->getConfiguration()->getMetadataDriverImpl()->isTransient($class)) {
                 return $em;
             }
         }

--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -16,6 +16,7 @@ use Symfony\Bridge\Doctrine\RegistryInterface;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\ORMException;
+use Doctrine\ORM\Proxy\Proxy;
 
 /**
  * References all Doctrine connections and entity managers in a given Container.
@@ -226,10 +227,17 @@ class Registry implements RegistryInterface
      */
     public function getEntityManagerForObject($object)
     {
+        if ($object instanceof Proxy) {
+            $proxyClass = new \ReflectionClass($object);
+            $class = $proxyClass->getParentClass()->getName();
+        } else {
+            $class = get_class($object);
+        }
+
         foreach ($this->entityManagers as $id) {
             $em = $this->container->get($id);
 
-            if ($em->getConfiguration()->getMetadataDriverImpl()->isTransient($object)) {
+            if ($em->getConfiguration()->getMetadataDriverImpl()->isTransient($class)) {
                 return $em;
             }
         }


### PR DESCRIPTION
This fixes the Registry::getEntityManagerForObject implementation. Doctrine expects the entity class name, not the object. The current code throw a Fatal Error.
