### PR TITLE
[FrameworkBundle] Updated Russian translations for validators.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ru.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ru.xliff
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="3">
                 <source>This value should be of type {{ type }}</source>
-                <target>Значение должно быть типа {{ type }}</target>
+                <target>Тип значения должен быть {{ type }}</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>This value should be blank</source>
@@ -31,104 +31,104 @@
                 <target>Вы должны выбрать не более чем {{ limit }} вариантов</target>
             </trans-unit>
             <trans-unit id="8">
+                <source>One or more of the given values is invalid</source>
+                <target>Одно или несколько заданных значений недопустимо</target>
+            </trans-unit>
+            <trans-unit id="9">
                 <source>The fields {{ fields }} were not expected</source>
                 <target>Поля {{ fields }} не ожидались</target>
             </trans-unit>
-            <trans-unit id="9">
+            <trans-unit id="10">
                 <source>The fields {{ fields }} are missing</source>
                 <target>Поля {{ fields }} осутствуют</target>
             </trans-unit>
-            <trans-unit id="10">
+            <trans-unit id="11">
                 <source>This value is not a valid date</source>
                 <target>Значение не является правильной датой</target>
             </trans-unit>
-            <trans-unit id="11">
+            <trans-unit id="12">
                 <source>This value is not a valid datetime</source>
                 <target>Значение даты и времени недопустимо</target>
             </trans-unit>
-            <trans-unit id="12">
+            <trans-unit id="13">
                 <source>This value is not a valid email address</source>
                 <target>Значение адреса электронной почты недопустимо</target>
             </trans-unit>
-            <trans-unit id="13">
+            <trans-unit id="14">
                 <source>The file could not be found</source>
                 <target>Файл не может быть найден</target>
             </trans-unit>
-            <trans-unit id="14">
+            <trans-unit id="15">
                 <source>The file is not readable</source>
                 <target>Файл не может быть прочитан</target>
             </trans-unit>
-            <trans-unit id="15">
+            <trans-unit id="16">
                 <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}</source>
                 <target>Файл слишком большой ({{ size }}). Максимальный допустимый размер {{ limit }}</target>
             </trans-unit>
-            <trans-unit id="16">
+            <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}</source>
                 <target>MIME-тип файла недопустим ({{ type }}). Допустимы MIME-типы файлов {{ types }}</target>
             </trans-unit>
-            <trans-unit id="17">
+            <trans-unit id="18">
                 <source>This value should be {{ limit }} or less</source>
                 <target>Значение должно быть {{ limit }} или меньше</target>
             </trans-unit>
-            <trans-unit id="18">
+            <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} characters or less</source>
                 <target>Значение слишком длинное. Должно быть {{ limit }} символов или меньше</target>
             </trans-unit>
-            <trans-unit id="19">
+            <trans-unit id="20">
                 <source>This value should be {{ limit }} or more</source>
                 <target>Значение должно быть {{ limit }} или больше</target>
             </trans-unit>
-            <trans-unit id="20">
+            <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} characters or more</source>
                 <target>Значение слишком короткое. Должно быть {{ limit }} символов или больше</target>
             </trans-unit>
-            <trans-unit id="21">
+            <trans-unit id="22">
                 <source>This value should not be blank</source>
                 <target>Значение не должно быть пустым</target>
             </trans-unit>
-            <trans-unit id="22">
+            <trans-unit id="23">
                 <source>This value should not be null</source>
                 <target>Значение не должно быть null</target>
             </trans-unit>
-            <trans-unit id="23">
+            <trans-unit id="24">
                 <source>This value should be null</source>
                 <target>Значение должно быть null</target>
             </trans-unit>
-            <trans-unit id="24">
+            <trans-unit id="25">
                 <source>This value is not valid</source>
                 <target>Значение недопустимо</target>
             </trans-unit>
-            <trans-unit id="25">
+            <trans-unit id="26">
                 <source>This value is not a valid time</source>
                 <target>Значение времени недопустимо</target>
             </trans-unit>
-            <trans-unit id="26">
+            <trans-unit id="27">
                 <source>This value is not a valid URL</source>
                 <target>Значение URL недопустимо</target>
             </trans-unit>
-            <trans-unit id="27">
-                <source>This value should be instance of class {{ class }}</source>
-                <target>Значение должно быть экземпляром класса {{ class }}</target>
-            </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
-                <target>Эта группа полей не должна иметь дополнительных полей</target>
+                <source>The CSRF token is invalid. Please try to resubmit the form</source>
+                <target>CSRF значение недопустимо. Пожалуйста, попробуйте повторить отправку формы</target>
             </trans-unit>
             <trans-unit id="29">
-                <source>The uploaded file was too large. Please try to upload a smaller file</source>
-                <target>Загружённый файл слишком большой. Пожалуйста, попробуйте загрузить файл меньше</target>
-            </trans-unit>
-            <trans-unit id="30">
-                <source>The CSRF token is invalid</source>
-                <target>CSRF значение недопустимо</target>
-            </trans-unit>
-            <trans-unit id="31">
                 <source>The two values should be equal</source>
                 <target>Оба значения должны быть одинаковыми</target>
             </trans-unit>
+            <trans-unit id="30">
+                <source>The file is too large. Allowed maximum size is {{ limit }}</source>
+                <target>Файл слишком большой. Максимальный допустимый размер {{ limit }}</target>
+            </trans-unit>
+            <trans-unit id="31">
+                <source>The file is too large</source>
+                <target>Файл слишком большой</target>
+            </trans-unit>
             <trans-unit id="32">
-                <source>One or more of the given values is invalid</source>
-                <target>Одно или несколько заданных значений недопустимо</target>
+                <source>The file could not be uploaded</source>
+                <target>Файл не может быть загружен</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Sync translations with the actual validator constraints.

Removed some translations (they are not found among the constraints):
- `This value should be instance of class {{ class }}`
- `This field group should not contain extra fields`
- `The uploaded file was too large. Please try to upload a smaller file`
