### PR TITLE
Session instantiation breaks with Fatal error if intl module is not installed.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -355,10 +355,14 @@ class Session implements \Serializable
 
     private function setPhpDefaultLocale($locale)
     {
+        // if either the class Locale doesn't exist, or an exception is thrown when
+        // setting the default locale, the intl module is not installed, and
+        // the call can be ignored:
         try {
-            \Locale::setDefault($this->locale);
+            if (class_exists('Locale', false)) {
+                \Locale::setDefault($locale);
+            }
         } catch (\Exception $e) {
-            // means that intl is not installed.
         }
     }
 }


### PR DESCRIPTION
A check for class_exists in setPhpDefaultLocale() fixes this, though I got the feeling it should be resolved with a proxy or subscriber object; setPhpDefaultLocale feels like a hack now.
