### PR TITLE
[Form] Translation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ca.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ca.xliff
@@ -111,7 +111,7 @@
                 <target>Aquest valor hauria de ser una instància de la classe {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Aquest grup de camps no hauria de contenir camps addicionals</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xliff
@@ -111,7 +111,7 @@
                 <target>Tato hodnota musí být instancí třídy {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Tato skupina polí nesmí obsahovat další pole</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.da.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.da.xliff
@@ -111,7 +111,7 @@
                 <target>Værdien skal være instans af klassen {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Feltgruppen må ikke indeholde ekstra felter</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.de.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.de.xliff
@@ -111,7 +111,7 @@
                 <target>Dieser Wert sollte eine Instanz der Klasse {{ class }} sein</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Diese Feldgruppe sollte keine zusätzlichen Felder enthalten</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.es.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.es.xliff
@@ -111,7 +111,7 @@
                 <target>Este valor debería ser una instancia de la clase {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Este grupo de campos no debería contener campos adicionales</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.et.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.et.xliff
@@ -111,7 +111,7 @@
                 <target>Väärtus peaks olema klassi {{ class }} isend</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Väljade grupp ei tohiks sisalda lisaväljasid</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
@@ -111,8 +111,8 @@
                 <target>Cette valeur doit être une instance de la classe {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
-                <target>Ce groupe de champs ne doit pas contenir des champs supplémentaires</target>
+                <source>This form should not contain extra fields</source>
+                <target>Ce formulaire ne doit pas contenir des champs supplémentaires</target>
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.he.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.he.xliff
@@ -111,7 +111,7 @@
                 <target>הערך צריך להיות מסוג {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>קבוצה השדה לא יכילו שדות נוספת</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hu.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hu.xliff
@@ -111,7 +111,7 @@
                 <target>Ennek az értéknek a(z) {{ class }} osztály példányának kell lennie</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Ez a mezőcsoport nem tartalmazhat extra mezőket</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.id.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.id.xliff
@@ -111,7 +111,7 @@
                 <target>Nilai ini harus turunan dari kelas {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Gabungan kolom tidak boleh mengandung kolom tambahan</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.it.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.it.xliff
@@ -111,7 +111,7 @@
                 <target>Deve essere istanza della classe {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Questo gruppo di campi non deve contenete nessun campo extra</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ja_JP.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ja_JP.xliff
@@ -111,7 +111,7 @@
                 <target>値は{{ class }}のインスタンスでなければなりません</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>フィールドグループに追加のフィールドを含んではなりません</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lb.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lb.xliff
@@ -111,7 +111,7 @@
                 <target>Dëse Wäert sollt eine Instanz vun der Klass {{ class }} sinn</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Dës Feldergrupp sollt keng zousätzlech Felder enthalen</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xliff
@@ -111,7 +111,7 @@
                 <target>Deze waarde moet een instantie van de klasse {{ class }} zijn</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Deze veldgroep mag geen extra velden bevatten</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pl.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pl.xliff
@@ -111,7 +111,7 @@
                 <target>Ta wartość powinna być instancją klasy {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Ta grupa pól nie powinna zawierać dodatkowych pól</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_BR.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_BR.xliff
@@ -111,7 +111,7 @@
                 <target>Este valor deveria ser uma instância da classe {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Este grupo de campos não deveria conter campos adicionais</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_PT.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_PT.xliff
@@ -111,7 +111,7 @@
                 <target>Este valor deveria ser uma instância da classe {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Este grupo de campos não deveria conter campos adicionais</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ro.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ro.xliff
@@ -111,7 +111,7 @@
                 <target>Această valoare trebuie să fie o instanță a clasei {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Aceast  grup de câmpuri nu trebuie să conțină câmpuri suplimentare</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sk.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sk.xliff
@@ -111,7 +111,7 @@
                 <target>Táto hodnota by mala byť inštancia triedy {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Polia by nemali obsahovať ďalšie prvky</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sl.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sl.xliff
@@ -111,7 +111,7 @@
                 <target>Vrednost bi morala biti instanca razreda {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>To področje ne sme vsebovati dodatnih polj</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr.xliff
@@ -111,7 +111,7 @@
                 <target>Вредност треба да буде инстанца класе {{ class }}</target>
             </trans-unit>
             <trans-unit id="28">
-                <source>This field group should not contain extra fields</source>
+                <source>This form should not contain extra fields</source>
                 <target>Група поља не треба да садржи додатна поља</target>
             </trans-unit>
             <trans-unit id="29">

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -54,6 +54,8 @@ class FieldType extends AbstractType
             ->setAttribute('pattern', $options['pattern'])
             ->setAttribute('label', $options['label'] ?: $this->humanize($builder->getName()))
             ->setAttribute('attr', $options['attr'] ?: array())
+            ->setAttribute('invalid_message_template', $options['invalid_message_template'])
+            ->setAttribute('invalid_message_parameters', $options['invalid_message_parameters'])
             ->setData($options['data'])
             ->addValidator(new DefaultValidator())
         ;
@@ -123,6 +125,8 @@ class FieldType extends AbstractType
             'error_mapping'     => array(),
             'label'             => null,
             'attr'              => array(),
+            'invalid_message_template'   => 'This value is not valid',
+            'invalid_message_parameters' => array(),
         );
 
         $class = isset($options['data_class']) ? $options['data_class'] : null;

--- a/src/Symfony/Component/Form/Extension/Core/Validator/DefaultValidator.php
+++ b/src/Symfony/Component/Form/Extension/Core/Validator/DefaultValidator.php
@@ -20,7 +20,10 @@ class DefaultValidator implements FormValidatorInterface
     public function validate(FormInterface $form)
     {
         if (!$form->isSynchronized()) {
-            $form->addError(new FormError(sprintf('The value for "%s" is invalid', $form->getName())));
+            $form->addError(new FormError(
+                $form->getAttribute('invalid_message_template'),
+                $form->getAttribute('invalid_message_parameters')
+            ));
         }
 
         if (count($form->getExtraData()) > 0) {


### PR DESCRIPTION
The first commit adds the ability to customize the default message when the form is invalid:
- Make it an option in the form builder,
- Allow placeholders in the message,
- The default value `This value is not valid` exists in the translation files.

The second commit updates a source string in the XLIFF files to make it translatable. All translations should be updated accordingly. The source string is from the [default validator](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/Validator/DefaultValidator.php#L27).

This PR should fix The issue #997.
