### PR TITLE
Added a AccessDeniedHttpException to wrap the AccessDeniedException.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * NotFoundHttpException.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class AccessDeniedHttpException extends HttpException
+{
+    /**
+     * Constructor.
+     *
+     * @param string    $message  The internal exception message
+     * @param Exception $previous The previous exception
+     * @param integer   $code     The internal exception code
+     */
+    public function __construct($message = null, \Exception $previous = null, $code = 0)
+    {
+        parent::__construct(403, $message, $previous, array(), $code);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/AccessDeniedHttpException.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\HttpKernel\Exception;
 
 /**
- * NotFoundHttpException.
+ * AccessDeniedHttpException.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Christophe Coevoet <stof@notk.org>

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -26,6 +26,7 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -113,16 +114,16 @@ class ExceptionListener
                         if (!$response instanceof Response) {
                             return;
                         }
-                    } else {
-                        if (null === $this->errorPage) {
-                            return;
-                        }
-
+                    } elseif (null !== $this->errorPage) {
                         $subRequest = $this->httpUtils->createRequest($request, $this->errorPage);
                         $subRequest->attributes->set(SecurityContextInterface::ACCESS_DENIED_ERROR, $exception);
 
                         $response = $event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
                         $response->setStatusCode(403);
+                    } else {
+                        $event->setException(new AccessDeniedHttpException($exception->getMessage(), $exception));
+
+                        return;
                     }
                 } catch (\Exception $e) {
                     if (null !== $this->logger) {


### PR DESCRIPTION
This is a proposal to fix #1631

It wraps the AccessDeniedException in an AccessDeniedHttpException when the firewall is not able to handle it itself. This allows getting a 403 response using the standard exception listener in this case.

Note that the app should not throw the AccessDeniedHttpException itself but keep using the AccessDeniedException to let the Security component check if the user is already fully authenticated or if it should give a chance to authenticate.
