### PR TITLE
[Routing] Allow multiple `@Route` annotations with a default name

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -59,6 +59,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
 {
     protected $reader;
     protected $routeAnnotationClass  = 'Symfony\\Component\\Routing\\Annotation\\Route';
+    protected $defaultRouteIndex;
 
     /**
      * Constructor.
@@ -126,6 +127,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $collection->addResource(new FileResource($class->getFileName()));
 
         foreach ($class->getMethods() as $method) {
+            $this->defaultRouteIndex = 0;
             foreach ($this->reader->getMethodAnnotations($method) as $annot) {
                 if ($annot instanceof $this->routeAnnotationClass) {
                     $this->addRoute($collection, $annot, $globals, $class, $method);
@@ -194,7 +196,13 @@ abstract class AnnotationClassLoader implements LoaderInterface
      */
     protected function getDefaultRouteName(\ReflectionClass $class, \ReflectionMethod $method)
     {
-        return strtolower(str_replace('\\', '_', $class->getName()).'_'.$method->getName());
+        $name = strtolower(str_replace('\\', '_', $class->getName()).'_'.$method->getName());
+        if ($this->defaultRouteIndex > 0) {
+            $name .= '_'.$this->defaultRouteIndex;
+        }
+        $this->defaultRouteIndex++;
+
+        return $name;
     }
 
     abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot);


### PR DESCRIPTION
[Routing] Allow multiple `@Route` annotations with a default name on a single method (fixes #1647)

Before this change, the default name would be the same for multiple `@Route` with a default name on the same method. Then only the last declared route is active.

The defaults names are (for consecutive `@Route`s):
- former_default,
- former_default_1,
- former_name,
- former_default_2,
- ...

The FrameworkExtraBundle needs to be updated in sync with this PR: https://github.com/sensio/SensioFrameworkExtraBundle/pull/50
