### PR TITLE
Made the cache namespace for the Doctrine cache extension unique to each environment

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/DoctrineExtension.php
@@ -389,7 +389,7 @@ class DoctrineExtension extends AbstractDoctrineExtension
 
         $cacheDef->setPublic(false);
         // generate a unique namespace for the given application
-        $namespace = 'sf2orm_'.$entityManager['name'].'_'.md5($container->getParameter('kernel.root_dir'));
+        $namespace = 'sf2orm_'.$entityManager['name'].'_'.md5($container->getParameter('kernel.root_dir').$container->getParameter('kernel.environment'));
         $cacheDef->addMethodCall('setNamespace', array($namespace));
 
         return $cacheDef;


### PR DESCRIPTION
The current cache namespace for the Doctrine adapters is unique on an entity manager and the kernel root directory; however, it causes problems as settings for entity managers can differ between environments, so the addition of the environment into the namespace would address the issue.

```
    $namespace = 'sf2orm_'.$entityManager['name'].'_'.md5($container->getParameter('kernel.root_dir'));
```

Solves issues with the cache not being valid for the DBAL ACL provider using D2 as the cache and switching environments.

```
    An exception has been thrown during the rendering of a template ("Warning: Illegal offset type in isset or  empty in ../vendor/symfony/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php line 404")
```
