### PR TITLE
Allow matching of format extensions on routes in a route collection

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -73,8 +73,14 @@ class Route
     {
         $this->pattern = trim($pattern);
 
-        // a route must start with a slash
-        if (empty($this->pattern) || '/' !== $this->pattern[0]) {
+        // A route must start with a slash
+        //
+        // Also ensure that we are able to use prefixes with route collections
+        // and still be able to refer to the prefix as a url resource.
+        //
+        // Prefix /articles with route .{_format} defined as a route part
+        // of the collection should match as /articles.json not /articles/.json
+        if (empty($this->pattern) || '/' !== $this->pattern[0] && '.' !== $this->pattern[0]) {
             $this->pattern = '/'.$this->pattern;
         }
 

--- a/tests/Symfony/Tests/Component/Routing/RouteTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteTest.php
@@ -31,6 +31,8 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/{bar}', $route->getPattern(), '->setPattern() sets the pattern');
         $route->setPattern('');
         $this->assertEquals('/', $route->getPattern(), '->setPattern() adds a / at the beginning of the pattern if needed');
+        $route->setPattern('.{_format}');
+        $this->assertEquals('.{_format}', $route->getPattern(), '->setPattern() does not add a / at the beginning of the pattern for patterns starting with .');
         $route->setPattern('bar');
         $this->assertEquals('/bar', $route->getPattern(), '->setPattern() adds a / at the beginning of the pattern if needed');
         $this->assertEquals($route, $route->setPattern(''), '->setPattern() implements a fluent interface');


### PR DESCRIPTION
Currently Symfony2 does not allow the matching of a URL such as /menus.json if /menus is assigned as a prefix to a route collection. As a route included in the route collection, we are unable to match .{_format} because a route must start with a /.

The issue is demonstrated below as the route is /menus/.json without the patch. With the patch, we are able to match it properly as /menus.json

```
<?xml version="1.0" ?>
<routes>
    <import resource="@FooBundle/Controller/MenusController.php"  type="annotation" prefix="/menus" />
</routes>

class MenusController extends Controller
{
    /**
     * @Route(".{_format}", name="backend_menus", defaults = { "_format" = "html" })
     */
    public function listAction()
    {}
}
```
