### PR TITLE
fixes #1538

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * A SecurityIdentity implementation for roles
@@ -31,7 +31,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function __construct($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
 


### PR DESCRIPTION
## Constructor of  Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity 

currently it check if the argument is instance of Symfony\Component\Security\Core\Role\Role by

`if ($role instanceof Role)`

Maybe it should be changed to

`if ($role instanceof RoleInterface)`

Because if we use another Role class which implements RoleInterface

it dosen't work when we check access, it will throw a _NoAceFoundException_ when vote
