### PR TITLE
[DependencyInjection] Add DIC Pass to remove *.class parameters, fixes #1684

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -66,6 +66,7 @@ class PassConfig
                 new RemoveUnusedDefinitionsPass(),
             )),
             new CheckExceptionOnInvalidReferenceBehaviorPass(),
+            new RemoveClassParametersPass(),
         );
     }
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveClassParametersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveClassParametersPass.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Definition;
+
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Removes foo.class parameters and replace their values inline
+ *
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class RemoveClassParametersPass implements CompilerPassInterface
+{
+    private $container;
+    private $aggressive;
+
+    /**
+     * @param Boolean $aggressive If true, all *.class parameters are removed,
+     *                            otherwise only those that are used in the DIC are.
+     */
+    public function __construct($aggressive = true)
+    {
+        $this->aggressive = $aggressive;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        $this->container = $container;
+
+        $classes = array();
+
+        if (false === $this->aggressive) {
+            foreach ($container->getDefinitions() as $definition) {
+                $classes[$definition->getClass()] = true;
+            }
+        }
+
+        $classParams = array();
+        foreach ($container->getParameterBag()->all() as $param => $value) {
+            if ('.class' === substr($param, -6) && (true === $this->aggressive || isset($classes[$value]))) {
+                $classParams[] = $param;
+            }
+        }
+        $container->getParameterBag()->remove($classParams);
+    }
+}

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -57,6 +57,18 @@ class ParameterBag implements ParameterBagInterface
     }
 
     /**
+     * Removes parameters from the service container parameters.
+     *
+     * @param array $parameters An array of parameters
+     */
+    public function remove(array $parameters)
+    {
+        foreach ($parameters as $parameter) {
+            unset($this->parameters[strtolower($parameter)]);
+        }
+    }
+
+    /**
      * Gets the service container parameters.
      *
      * @return array An array of parameters

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -33,6 +33,13 @@ interface ParameterBagInterface
     function add(array $parameters);
 
     /**
+     * Removes parameters from the service container parameters.
+     *
+     * @param array $parameters An array of parameters
+     */
+    function remove(array $parameters);
+
+    /**
      * Gets the service container parameters.
      *
      * @return array An array of parameters


### PR DESCRIPTION
Just had a stab at trying to fix #1684. I realize it's not perfect, especially with the aggressive mode on. But just as a note, my compiled DIC went from 105KB to 99KB with `$aggressive` `false`, and then to 92KB with `true`. 

Whether we want to optimize to hell at the risk of creating issues for some (of course we should document it), I don't know.
