### PR TITLE
[Yaml] Wrap numeric strings in quotes when dumping

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -87,7 +87,7 @@ class Inline
             case ctype_digit($value):
                 return is_string($value) ? "'$value'" : (int) $value;
             case is_numeric($value):
-                return is_infinite($value) ? str_ireplace('INF', '.Inf', strval($value)) : (is_string($value) ? "'$value'" : $value);
+                return is_string($value) ? "'$value'" : (is_infinite($value) ? str_ireplace('INF', '.Inf', strval($value)) : $value);
             case Escaper::requiresDoubleQuoting($value):
                 return Escaper::escapeWithDoubleQuotes($value);
             case Escaper::requiresSingleQuoting($value):

--- a/tests/Symfony/Tests/Component/Yaml/InlineTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/InlineTest.php
@@ -48,6 +48,13 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testHashStringsResemblingExponentialNumericsShouldNotBeChangedToINF()
+    {
+        $value = '686e444';
+
+        $this->assertSame($value, Inline::parse(Inline::dump($value)));
+    }
+
     protected function getTestsForParse()
     {
         return array(
@@ -63,6 +70,8 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             '02333' => 02333,
             '.Inf' => -log(0),
             '-.Inf' => log(0),
+            "'686e444'" => '686e444',
+            '686e444' => 646e444,
             '123456789123456789' => '123456789123456789',
             '"foo\r\nbar"' => "foo\r\nbar",
             "'foo#bar'" => 'foo#bar',
@@ -121,6 +130,8 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             '1243' => 02333,
             '.Inf' => -log(0),
             '-.Inf' => log(0),
+            "'686e444'" => '686e444',
+            '.Inf' => 646e444,
             '"foo\r\nbar"' => "foo\r\nbar",
             "'foo#bar'" => 'foo#bar',
             "'foo # bar'" => 'foo # bar',


### PR DESCRIPTION
This addresses an obscure case where a hash string (actually a commit-ish, "686e444") was dumped to YAML as an unquoted string value. It was later parsed from YAML as an exponential numeric and changed to ".Inf".

This commit should not change the existing behavior when dumping non-string numerics. It also doesn't appear to disturb any of the other test cases. I realize it's a huge edge case, so I'm open to discussion.

The alternative to this fix was an ugly `preg_replace()` to apply quoting around the commit-ish after dumping. I would look forward to removing that :)
