### PR TITLE
[Yaml] Do not skip consistency checks in InlineTest::testDump()

### DIFF
--- a/tests/Symfony/Tests/Component/Yaml/InlineTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/InlineTest.php
@@ -32,18 +32,10 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         }
 
         foreach ($this->getTestsForParse() as $yaml => $value) {
-            if ($value == 1230) {
-                continue;
-            }
-
             $this->assertEquals($value, Inline::parse(Inline::dump($value)), 'check consistency');
         }
 
         foreach ($testsForDump as $yaml => $value) {
-            if ($value == 1230) {
-                continue;
-            }
-
             $this->assertEquals($value, Inline::parse(Inline::dump($value)), 'check consistency');
         }
     }


### PR DESCRIPTION
These conditionals were excluding 12.30e+02 from being checked. Removing the conditionals does not break any tests.

I investigated the conditionals with git blame, but that stops at previous commits for code formatting changes. These appear to be very old. Perhaps they were added for test failures on certain platforms? I don't spot any failures on Linux.
