### PR TITLE
[HttpFoundation] Problem with RequestMatcher if PHP is compiled with the option "disable-ipv6" 

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -154,6 +154,10 @@ class RequestMatcher implements RequestMatcherInterface
      */
     protected function checkIp6($requestIp, $ip)
     {
+        if (!defined('AF_INET6')) {
+            throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
+        }
+
         list($address, $netmask) = explode('/', $ip);
 
         $bytes_addr = unpack("n*", inet_pton($address));

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestMatcherTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestMatcherTest.php
@@ -21,9 +21,9 @@ use Symfony\Component\HttpFoundation\Request;
 class RequestMatcherTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @dataProvider testIpProvider
+     * @dataProvider testIpv4Provider
      */
-    public function testIp($matches, $remoteAddr, $cidr)
+    public function testIpv4($matches, $remoteAddr, $cidr)
     {
         $request = Request::create('', 'get', array(), array(), array(), array('REMOTE_ADDR' => $remoteAddr));
 
@@ -33,7 +33,7 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($matches, $matcher->matches($request));
     }
 
-    public function testIpProvider()
+    public function testIpv4Provider()
     {
         return array(
             array(true, '192.168.1.1', '192.168.1.1'),
@@ -41,9 +41,52 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
             array(true, '192.168.1.1', '192.168.1.0/24'),
             array(false, '192.168.1.1', '1.2.3.4/1'),
             array(false, '192.168.1.1', '192.168.1/33'),
+        );
+    }
+
+    /**
+     * @dataProvider testIpv6Provider
+     */
+    public function testIpv6($matches, $remoteAddr, $cidr)
+    {
+        if (!defined('AF_INET6')) {
+            $this->markTestSkipped('Only works when PHP is compiled without the option "disable-ipv6".');
+        }
+
+        $request = Request::create('', 'get', array(), array(), array(), array('REMOTE_ADDR' => $remoteAddr));
+
+        $matcher = new RequestMatcher();
+        $matcher->matchIp($cidr);
+
+        $this->assertEquals($matches, $matcher->matches($request));
+    }
+
+    public function testIpv6Provider()
+    {
+        return array(
             array(true, '2a01:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65'),
             array(false, '2a00:198:603:0:396e:4789:8e99:890f', '2a01:198:603:0::/65'),
         );
+    }
+
+    public function testAnIpv6WithOptionDisabledIpv6()
+    {
+        if (defined('AF_INET6')) {
+            $this->markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
+        }
+
+        $request = Request::create('', 'get', array(), array(), array(), array('REMOTE_ADDR' => '2a01:198:603:0:396e:4789:8e99:890f'));
+
+        $matcher = new RequestMatcher();
+        $matcher->matchIp('2a01:198:603:0::/65');
+
+        try {
+            $matcher->matches($request);
+
+            $this->fail('An expected RuntimeException has not been raised.');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\RuntimeException', $e);
+        }
     }
 
     public function testMethod()
@@ -135,4 +178,3 @@ class RequestMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($matcher->matches($request));
     }
 }
-


### PR DESCRIPTION
Thrown a \RuntimeException in RequestMatcher::checkIp6() if PHP is compiled with the option "disable-ipv6".
