### PR TITLE
[FrameworkBundle] Enable annotation reader to parse php imports

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/annotations.xml
@@ -11,7 +11,11 @@
     </parameters>
 
     <services>
-        <service id="annotations.reader" class="%annotations.reader.class%" public="false" />
+        <service id="annotations.reader" class="%annotations.reader.class%" public="false">
+            <call method="setEnableParsePhpImports">
+                 <argument>true</argument>
+            </call>
+        </service>
 
         <service id="annotations.cached_reader" class="%annotations.cached_reader.class%" public="false">
             <argument type="service" id="annotations.reader" />


### PR DESCRIPTION
This enables things like:

``` php
<?php

use Sensio\Bundle\FrameworkExtraBundle\Configuration as Extra;

/**
 * @Extra\Route("/blog")
 * @Extra\Cache(expires="tomorrow")
 */
class AnnotController extends Controller
{
```

Which is IMHO much nicer than adding dozen (SensioExtra, DiExtra, SecurityExtra together are quite a lot) use statements at the top of the file, and another file and so on....
