### PR TITLE
fixes a bug where the cookie was wrongly considered expired

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -282,6 +282,6 @@ class Cookie
      */
     public function isExpired()
     {
-        return (null !== $this->expires) && $this->expires < time();
+        return null !== $this->expires && 0 !== $this->expires && $this->expires < time();
     }
 }

--- a/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
@@ -136,5 +136,8 @@ class CookieTest extends \PHPUnit_Framework_TestCase
 
         $cookie = new Cookie('foo', 'bar', time() - 86400);
         $this->assertTrue($cookie->isExpired(), '->isExpired() returns true when the cookie is expired');
+
+        $cookie = new Cookie('foo', 'bar', 0);
+        $this->assertFalse($cookie->isExpired());
     }
 }


### PR DESCRIPTION
On a related note, what do you think about adding some more functional tests here? Not only phpunit, but I would also suggest to add behat tests since there are a lot of things which are not picked up by the in process request emulation, but only by a real client.

@fabpot, @everzet, what do you think?
