### PR TITLE
[Console] Detect EOF when reading input stream

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DialogHelper extends Helper
 {
-    private $inputStream;
+    private $inputStream = STDIN;
 
     /**
      * Asks a question to the user.
@@ -35,7 +35,8 @@ class DialogHelper extends Helper
     {
         $output->write($question);
 
-        if (false === $ret = stream_get_line(null === $this->inputStream ? STDIN : $this->inputStream, 4096, "\n")) {
+        $ret = fgets($this->inputStream, 4096);
+        if (false === $ret) {
             throw new \RuntimeException('Aborted');
         }
         $ret = trim($ret);


### PR DESCRIPTION
This is related to commits 511a9a1fd75a89146056 and 3a5d508766f0480c3f1b.

First of them introduced abort-on-EOF and the second regressed the functionality.
Problem is stream_get_line() doesn't return false on EOF. So it needs call to feof() to
detect the situation.

Still, it's not ideal. With fgets() it worked fine, but with stream_get_line() one has to press
CTRL+D twice to get out. I presume this could be bug in PHP itself.

But better than nothing. Please consider.
