### PR TITLE
[DoctrineBundle] Allowed to configure dql functions using the single EM syntax

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Configuration.php
@@ -163,7 +163,7 @@ class Configuration implements ConfigurationInterface
                                 'query_cache_driver', 'query-cache-driver',
                                 'auto_mapping', 'auto-mapping',
                                 'mappings', 'mapping',
-                                'connection'
+                                'connection', 'dql'
                             ) as $key) {
                                 if (array_key_exists($key, $v)) {
                                     $entityManager[$key] = $v[$key];

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/AbstractDoctrineExtensionTest.php
@@ -661,6 +661,19 @@ abstract class AbstractDoctrineExtensionTest extends TestCase
         $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomDatetimeFunction', array('test_datetime', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestDatetimeFunction'));
     }
 
+    public function testSingleEMSetCustomFunctions()
+    {
+        $container = $this->getContainer(array('YamlBundle'));
+
+        $loader = new DoctrineExtension();
+        $container->registerExtension($loader);
+        $this->loadFromFile($container, 'orm_single_em_dql_functions');
+        $this->compileContainer($container);
+
+        $definition = $container->getDefinition('doctrine.orm.default_configuration');
+        $this->assertDICDefinitionMethodCallOnce($definition, 'addCustomStringFunction', array('test_string', 'Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction'));
+    }
+
     public function testAddCustomHydrationMode()
     {
         $container = $this->getContainer(array('YamlBundle'));

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_dql_functions.yml
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/DependencyInjection/Fixtures/config/yml/orm_single_em_dql_functions.yml
@@ -1,0 +1,12 @@
+doctrine:
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                dbname: db
+
+    orm:
+        dql:
+            string_functions: 
+                test_string: Symfony\Bundle\DoctrineBundle\Tests\DependencyInjection\TestStringFunction
+


### PR DESCRIPTION
[DoctrineBundle] Allowed to configure dql functions without using the multiple entity managers syntax
