### PR TITLE
Improved performance when assetic's use_controller is enabled

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateReference.php
@@ -52,6 +52,6 @@ class TemplateReference extends BaseTemplateReference
      */
     public function getLogicalName()
     {
-        return sprintf('%s:%s:%s.%s.%s', $this->get('bundle'), $this->get('controller'), $this->get('name'), $this->get('format'), $this->get('engine'));
+        return sprintf('%s:%s:%s.%s.%s', $this->parameters['bundle'], $this->parameters['controller'], $this->parameters['name'], $this->parameters['format'], $this->parameters['engine']);
     }
 }


### PR DESCRIPTION
When assetic's use_controller is enabled, assetic has to loop through all the templates and create TemplateReferences through the assetic FileResource. This in turn causes a lot of calls to getLogicalName() leading to 5x the calls to the TemplateReference's get() (16k in my case). By accessing the protected field directly compared to using get() we achieve better performance during development (33% in my case).
