### PR TITLE
[DoctrineBridge] Optimized the mapping drivers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Mapping/Driver/XmlDriver.php
+++ b/src/Symfony/Bridge/Doctrine/Mapping/Driver/XmlDriver.php
@@ -48,7 +48,22 @@ class XmlDriver extends BaseXmlDriver
 
     public function isTransient($className)
     {
-        return !in_array($className, $this->getAllClassNames());
+        if (null === $this->_classCache) {
+            $this->initialize();
+        }
+
+        // The mapping is defined in the global mapping file
+        if (isset($this->_classCache[$className])) {
+            return false;
+        }
+
+        try {
+            $this->_findMappingFile($className);
+
+            return false;
+        } catch (MappingException $e) {
+            return true;
+        }
     }
 
     public function getAllClassNames()

--- a/src/Symfony/Bridge/Doctrine/Mapping/Driver/YamlDriver.php
+++ b/src/Symfony/Bridge/Doctrine/Mapping/Driver/YamlDriver.php
@@ -48,7 +48,22 @@ class YamlDriver extends BaseYamlDriver
 
     public function isTransient($className)
     {
-        return !in_array($className, $this->getAllClassNames());
+        if (null === $this->_classCache) {
+            $this->initialize();
+        }
+
+        // The mapping is defined in the global mapping file
+        if (isset($this->_classCache[$className])) {
+            return false;
+        }
+
+        try {
+            $this->_findMappingFile($className);
+
+            return false;
+        } catch (MappingException $e) {
+            return true;
+        }
     }
 
     public function getAllClassNames()


### PR DESCRIPTION
This avoids loading all mappings when calling `isTransient` as it adds an overhead.
