### PR TITLE
[HttpFoundation] Fixed creation of requests without a path.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -188,6 +188,10 @@ class Request
             $defaults['SERVER_PORT'] = $components['port'];
             $defaults['HTTP_HOST'] = $defaults['HTTP_HOST'].':'.$components['port'];
         }
+        
+        if (!isset($components['path'])) {
+            $components['path'] = '';
+        }
 
         if (in_array(strtoupper($method), array('POST', 'PUT', 'DELETE'))) {
             $request = $parameters;

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -111,6 +111,23 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('http://example.com/jsonrpc', 'POST', array(), array(), array(), array(), $json);
         $this->assertEquals($json, $request->getContent());
         $this->assertFalse($request->isSecure());
+        
+        $request = Request::create('http://test.com');
+        $this->assertEquals('http://test.com/', $request->getUri());
+        $this->assertEquals('/', $request->getPathInfo());
+        $this->assertEquals('', $request->getQueryString());
+        $this->assertEquals(80, $request->getPort());
+        $this->assertEquals('test.com', $request->getHttpHost());
+        $this->assertFalse($request->isSecure());
+        
+        $request = Request::create('http://test.com:90/?test=1');
+        $this->assertEquals('http://test.com:90/?test=1', $request->getUri());
+        $this->assertEquals('/', $request->getPathInfo());
+        $this->assertEquals('test=1', $request->getQueryString());
+        $this->assertEquals(90, $request->getPort());
+        $this->assertEquals('test.com:90', $request->getHttpHost());
+        $this->assertFalse($request->isSecure());
+        
     }
 
     /**


### PR DESCRIPTION
Providing urls with no path led to php warning that the index 'path' is
not set. This patch initializes 'path' if no path is set.
