### PR TITLE
Disable libxml errors and allow user to fetch error information as needed

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -114,7 +114,9 @@ class Crawler extends \SplObjectStorage
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
 
-        @$dom->loadHTML($content);
+        libxml_use_internal_errors(true);
+        $dom->loadHTML('...');
+        libxml_clear_errors();
         $this->addDocument($dom);
 
         $base = $this->filter('base')->extract(array('href'));


### PR DESCRIPTION
With this change my behat/mink test run through. Before i got several errors due to html5 tags ("nav",...) and facebook tags ("<fb:like...").

Filed an issue yesterday: https://github.com/symfony/symfony/issues/1733

On stackoverflow they suggest to use this code for suppressing html5 parsing errors or to use another library for html5 parsing:

http://stackoverflow.com/questions/6090667/php-domdocument-errors-warnings-on-html5-tags
