### PR TITLE
[FrameworkBundle] fixed handling of null-values in attribute- and query-arrays

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -177,7 +177,7 @@ class HttpKernel extends BaseHttpKernel
         $path = http_build_query($attributes);
         $uri = $this->container->get('router')->generate('_internal', array(
             'controller' => $controller,
-            'path'       => $path ? $path : 'none',
+            'path'       => $path ?: 'none',
             '_format'    => $this->container->get('request')->getRequestFormat(),
         ));
 

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -182,7 +182,7 @@ class HttpKernel extends BaseHttpKernel
         ));
 
         if ($queryString = http_build_query($query)) {
-            $uri = $uri.'?'.$queryString;
+            $uri .= '?'.$queryString;
         }
 
         return $uri;

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -174,14 +174,15 @@ class HttpKernel extends BaseHttpKernel
             return $controller;
         }
 
+        $path = http_build_query($attributes);
         $uri = $this->container->get('router')->generate('_internal', array(
             'controller' => $controller,
-            'path'       => $attributes ? http_build_query($attributes) : 'none',
+            'path'       => $path ? $path : 'none',
             '_format'    => $this->container->get('request')->getRequestFormat(),
         ));
 
-        if ($query) {
-            $uri = $uri.'?'.http_build_query($query);
+        if ($queryString = http_build_query($query)) {
+            $uri = $uri.'?'.$queryString;
         }
 
         return $uri;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/HttpKernelTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/HttpKernelTest.php
@@ -119,6 +119,47 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGenerateInternalUriHandlesNullValues()
+    {
+        $request = new Request();
+
+        $router = $this->getMock('Symfony\\Component\\Routing\\RouterInterface');
+        $container = $this->getMock('Symfony\\Component\\DependencyInjection\\ContainerInterface');
+        $container
+            ->expects($this->at(0))
+            ->method('get')
+            ->with($this->equalTo('router'))
+            ->will($this->returnValue($router))
+        ;
+        $container
+            ->expects($this->at('1'))
+            ->method('get')
+            ->with($this->equalTo('request'))
+            ->will($this->returnValue($request))
+        ;
+
+        $controller = 'AController';
+        $attributes = array('anAttribute' => null);
+        $query = array('aQueryParam' => null);
+
+        $expectedPath = 'none';
+
+        $routeParameters = array('controller' => $controller, 'path' => $expectedPath, '_format' => 'html');
+        $router
+            ->expects($this->once())
+            ->method('generate')
+            ->with($this->equalTo('_internal'), $this->equalTo($routeParameters))
+            ->will($this->returnValue('GENERATED_URI'))
+        ;
+
+        $dispatcher = new EventDispatcher();
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
+        $kernel = new HttpKernel($dispatcher, $container, $resolver);
+
+        $uri = $kernel->generateInternalUri($controller, $attributes, $query);
+        $this->assertEquals('GENERATED_URI', $uri);
+    }
+
     public function getProviderTypes()
     {
         return array(


### PR DESCRIPTION
when esi is enabled and internal uris are generated for esi-tags, an
attribute-array consisting entirely of null-values isn't handled correctly.

The reason is that php's `http_build_query()`-method outputs an empty string
for such arrays:

```
http_build_query(array('foo' => '')) == 'foo='
http_build_query(array('foo' => null)) == ''
```

In the latter case, the generation of an URI in [`HttpKernel::generateInternalUri()`](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php#L179)
generates an URI that could not be matched by the corresponding route (ex.
`_internal/Controller/.html` opposed to `_internal/Controller/none.html` which
should be expected).

This commit adds a possible solution as well as a simple test for this issue.
