### PR TITLE
Optionally loosen restriction for property injection

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -693,8 +693,17 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         $properties = $this->resolveServices($this->getParameterBag()->resolveValue($definition->getProperties()));
+        $outsideClass = new \ReflectionClass($service);
         foreach ($properties as $name => $value) {
-            $service->$name = $value;
+            $class = $outsideClass;
+            do {
+                if ($class->hasProperty($name)) {
+                    $property = $class->getProperty($name);
+                    $property->setAccessible(true);
+                    $property->setValue($service, $value);
+                    continue 2;
+                }
+            } while (false !== $class = $class->getParentClass());
         }
 
         if ($callable = $definition->getConfigurator()) {

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -688,6 +688,8 @@ EOF;
      */
     private function addFrozenConstructor()
     {
+        $defaultParameters = $this->container->getParameters() ? '$this->getDefaultParameters()' : 'array()';
+
         $code = <<<EOF
 
     /**
@@ -695,7 +697,7 @@ EOF;
      */
     public function __construct()
     {
-        \$this->parameters = \$this->getDefaultParameters();
+        \$this->parameters = $defaultParameters;
 
         \$this->services =
         \$this->scopedServices =

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -883,6 +883,15 @@ EOF;
             } else if ($argument instanceof Reference) {
                 $id = (string) $argument;
 
+                $refDef = $this->container->findDefinition($id);
+                if ($factoryId = $refDef->getFactoryService()) {
+                    if (isset($calls[$factoryId])) {
+                        $calls[$factoryId] = 0;
+                    }
+                    $calls[$factoryId] += 1;
+                    $behavior[$factoryId] = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
+                }
+
                 if (!isset($calls[$id])) {
                     $calls[$id] = 0;
                 }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -71,8 +71,9 @@ class PhpDumper extends Dumper
     public function dump(array $options = array())
     {
         $options = array_merge(array(
-            'class'      => 'ProjectServiceContainer',
-            'base_class' => 'Container',
+            'class'                      => 'ProjectServiceContainer',
+            'base_class'                 => 'Container',
+            'limited_property_injection' => true,
         ), $options);
 
         $code = $this->startClass($options['class'], $options['base_class']);
@@ -374,12 +375,26 @@ class PhpDumper extends Dumper
     {
         $code = '';
         foreach ($definition->getProperties() as $name => $value) {
-            $code .= sprintf("        \$%s = new \ReflectionProperty(\$%s, %s);\n", $refName = $this->getNextVariableName(), $variableName, var_export($name, true));
+            $declaringClass = $this->getReflectionProperty($definition->getClass(), $name)->getDeclaringClass()->getName();
+            $code .= sprintf("        \$%s = new \ReflectionProperty(%s, %s);\n", $refName = $this->getNextVariableName(), var_export($declaringClass, true), var_export($name, true));
             $code .= sprintf("        \$%s->setAccessible(true);\n", $refName);
             $code .= sprintf("        \$%s->setValue(\$%s, %s);\n", $refName, $variableName, $this->dumpValue($value));
         }
 
         return $code;
+    }
+
+    private function getReflectionProperty($className, $name)
+    {
+        $class = new \ReflectionClass($className);
+
+        do {
+            if ($class->hasProperty($name)) {
+                return $class->getProperty($name);
+            }
+        } while (false !== $class = $class->getParentClass());
+
+        throw new \RuntimeException(sprintf('The class "%s", and none of its parent classes have a property named "%s".', $className, $name));
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -374,7 +374,9 @@ class PhpDumper extends Dumper
     {
         $code = '';
         foreach ($definition->getProperties() as $name => $value) {
-            $code .= sprintf("        \$%s->%s = %s;\n", $variableName, $name, $this->dumpValue($value));
+            $code .= sprintf("        \$%s = new \ReflectionProperty(\$%s, %s);\n", $refName = $this->getNextVariableName(), $variableName, var_export($name, true));
+            $code .= sprintf("        \$%s->setAccessible(true);\n", $refName);
+            $code .= sprintf("        \$%s->setValue(\$%s, %s);\n", $refName, $variableName, $this->dumpValue($value));
         }
 
         return $code;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Dumper/PhpDumperTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Dumper/PhpDumperTest.php
@@ -56,7 +56,7 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
     {
         $container = include self::$fixturesPath.'/containers/container9.php';
         $dumper = new PhpDumper($container);
-        $this->assertEquals(str_replace('%path%', str_replace('\\','\\\\',self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR), file_get_contents(self::$fixturesPath.'/php/services9.php')), $dumper->dump(), '->dump() dumps services');
+        $this->assertEquals(str_replace('%path%', str_replace('\\','\\\\',self::$fixturesPath.DIRECTORY_SEPARATOR.'includes'.DIRECTORY_SEPARATOR), file_get_contents(self::$fixturesPath.'/php/services9.php')), $dumper->dump(array('limited_property_injection' => false)), '->dump() dumps services');
 
         $dumper = new PhpDumper($container = new ContainerBuilder());
         $container->register('foo', 'FooClass')->addArgument(new \stdClass());

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/classes.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/classes.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once __DIR__.'/foo.php';
+
 function sc_configure($instance)
 {
     $instance->configure();

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/foo.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/includes/foo.php
@@ -2,7 +2,7 @@
 
 class FooClass
 {
-    public $foo, $moo;
+    private $foo, $moo;
 
     public $bar = null, $initialized = false, $configured = false, $called = false, $arguments = array();
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
@@ -66,10 +66,10 @@ class ProjectServiceContainer extends Container
 
         $instance->setBar($this->get('bar'));
         $instance->initialize();
-        $b = new \ReflectionProperty($instance, 'foo');
+        $b = new \ReflectionProperty('FooClass', 'foo');
         $b->setAccessible(true);
         $b->setValue($instance, 'bar');
-        $c = new \ReflectionProperty($instance, 'moo');
+        $c = new \ReflectionProperty('FooClass', 'moo');
         $c->setAccessible(true);
         $c->setValue($instance, $a);
         sc_configure($instance);

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
@@ -66,8 +66,12 @@ class ProjectServiceContainer extends Container
 
         $instance->setBar($this->get('bar'));
         $instance->initialize();
-        $instance->foo = 'bar';
-        $instance->moo = $a;
+        $b = new \ReflectionProperty($instance, 'foo');
+        $b->setAccessible(true);
+        $b->setValue($instance, 'bar');
+        $c = new \ReflectionProperty($instance, 'moo');
+        $c->setAccessible(true);
+        $c->setValue($instance, $a);
         sc_configure($instance);
 
         return $instance;


### PR DESCRIPTION
This allows the PHP dumper to optionally dump code which supports injection into private and protected properties (disabled by default).

Also see https://github.com/sensio/SensioFrameworkExtraBundle/pull/51 for some discussion
