### PR TITLE
Fix for issue #1753

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -142,6 +142,10 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
             ));
         }
 
+        if (false === checkdate($value['month'], $value['day'], $value['year'])) {
+            throw new TransformationFailedException('This is an invalid date');
+        }
+
         try {
             $dateTime = new \DateTime(sprintf(
                 '%s-%s-%s %s:%s:%s %s',


### PR DESCRIPTION
Patched src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php to throw an exception when an invalid date is passed for transformation (e.g. 31st February)
