### PR TITLE
[Router] annotationLoader: add option 'prefix' to overwrite class prefix

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -152,8 +152,10 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $defaults = array_merge($globals['defaults'], $annot->getDefaults());
         $requirements = array_merge($globals['requirements'], $annot->getRequirements());
         $options = array_merge($globals['options'], $annot->getOptions());
+        $prefix = isset($options['prefix'])? $options['prefix'] : $globals['pattern'];
+        unset($options['prefix']);
 
-        $route = new Route($globals['pattern'].$annot->getPattern(), $defaults, $requirements, $options);
+        $route = new Route($prefix.$annot->getPattern(), $defaults, $requirements, $options);
 
         $this->configureRoute($route, $class, $method, $annot);
 


### PR DESCRIPTION
hi,
I add an option 'prefix' to overwrite class annotation prefix for one or more route

``` php
<?php
/**
 * @author jaugustin
 * @Route("/prefix-global")
 */
class MyController extends Controller
{
    /**
     * @Route("/a-route")
     *
     */
    public function myAction() {}

   /**
    * @Route("/another-route-with-prefix-overwriten", options={"prefix"="/another-prefix"})
    */
    public function anotherAction() {}

}
```
