### PR TITLE
UrlGenerator no longer appends '?' if query string is empty

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -134,8 +134,9 @@ class UrlGenerator implements UrlGeneratorInterface
         }
 
         // add a query string if needed
-        if ($extra = array_diff_key($originParameters, $variables, $defaults)) {
-            $url .= '?'.http_build_query($extra);
+        $extra = array_diff_key($originParameters, $variables, $defaults);
+        if ($extra && $query = http_build_query($extra)) {
+            $url .= '?'.$query;
         }
 
         $url = $this->context->getBaseUrl().$url;

--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -106,6 +106,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost/app.php/testing?foo=bar', $url);
     }
 
+    public function testUrlWithNullExtraParameters()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing'));
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => null), true);
+
+        $this->assertEquals('http://localhost/app.php/testing', $url);
+    }
+
     public function testUrlWithExtraParametersFromGlobals()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));


### PR DESCRIPTION
If you generate a URL using null parameters (`array('foo' => null, 'bar' => null')`), `http_build_query` returns an empty string, resulting in a trailing `?` at the end of the generated URL.

This fixes that so that, if there are `$extra` params & `http_build_query` is empty, the URL is no longer appended.
