### PR TITLE
[Console] Fixed tests that rely on undecorated Application/Command-output

### DIFF
--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -208,12 +208,12 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester = new ApplicationTester($application);
 
         $application->setCatchExceptions(true);
-        $tester->run(array('command' => 'foo'));
+        $tester->run(array('command' => 'foo'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $this->normalize($tester->getDisplay()), '->setCatchExceptions() sets the catch exception flag');
 
         $application->setCatchExceptions(false);
         try {
-            $tester->run(array('command' => 'foo'));
+            $tester->run(array('command' => 'foo'), array('decorated' => false));
             $this->fail('->setCatchExceptions() sets the catch exception flag');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\Exception', $e, '->setCatchExceptions() sets the catch exception flag');
@@ -243,18 +243,18 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->setAutoExit(false);
         $tester = new ApplicationTester($application);
 
-        $tester->run(array('command' => 'foo'));
+        $tester->run(array('command' => 'foo'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception1.txt', $this->normalize($tester->getDisplay()), '->renderException() renders a pretty exception');
 
-        $tester->run(array('command' => 'foo'), array('verbosity' => Output::VERBOSITY_VERBOSE));
+        $tester->run(array('command' => 'foo'), array('decorated' => false, 'verbosity' => Output::VERBOSITY_VERBOSE));
         $this->assertRegExp('/Exception trace/', $this->normalize($tester->getDisplay()), '->renderException() renders a pretty exception with a stack trace when verbosity is verbose');
 
-        $tester->run(array('command' => 'list', '--foo' => true));
+        $tester->run(array('command' => 'list', '--foo' => true), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception2.txt', $this->normalize($tester->getDisplay()), '->renderException() renders the command synopsis when an exception occurs in the context of a command');
 
         $application->add(new \Foo3Command);
         $tester = new ApplicationTester($application);
-        $tester->run(array('command' => 'foo3:bar'));
+        $tester->run(array('command' => 'foo3:bar'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $this->normalize($tester->getDisplay()), '->renderException() renders a pretty exceptions with previous exceptions');
 
     }
@@ -278,23 +278,23 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
         $tester = new ApplicationTester($application);
-        $tester->run(array());
+        $tester->run(array(), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run1.txt', $this->normalize($tester->getDisplay()), '->run() runs the list command if no argument is passed');
 
-        $tester->run(array('--help' => true));
+        $tester->run(array('--help' => true), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run2.txt', $this->normalize($tester->getDisplay()), '->run() runs the help command if --help is passed');
 
-        $tester->run(array('-h' => true));
+        $tester->run(array('-h' => true), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run2.txt', $this->normalize($tester->getDisplay()), '->run() runs the help command if -h is passed');
 
         $application = new Application();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
         $tester = new ApplicationTester($application);
-        $tester->run(array('command' => 'list', '--help' => true));
+        $tester->run(array('command' => 'list', '--help' => true), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run3.txt', $this->normalize($tester->getDisplay()), '->run() displays the help if --help is passed');
 
-        $tester->run(array('command' => 'list', '-h' => true));
+        $tester->run(array('command' => 'list', '-h' => true), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run3.txt', $this->normalize($tester->getDisplay()), '->run() displays the help if -h is passed');
 
         $application = new Application();
@@ -311,10 +311,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
         $tester = new ApplicationTester($application);
-        $tester->run(array('--version' => true));
+        $tester->run(array('--version' => true), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run4.txt', $this->normalize($tester->getDisplay()), '->run() displays the program version if --version is passed');
 
-        $tester->run(array('-V' => true));
+        $tester->run(array('-V' => true), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_run4.txt', $this->normalize($tester->getDisplay()), '->run() displays the program version if -v is passed');
 
         $application = new Application();
@@ -342,10 +342,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $application->setCatchExceptions(false);
         $application->add(new \FooCommand());
         $tester = new ApplicationTester($application);
-        $tester->run(array('command' => 'foo:bar', '--no-interaction' => true));
+        $tester->run(array('command' => 'foo:bar', '--no-interaction' => true), array('decorated' => false));
         $this->assertEquals("called\n", $this->normalize($tester->getDisplay()), '->run() does not called interact() if --no-interaction is passed');
 
-        $tester->run(array('command' => 'foo:bar', '-n' => true));
+        $tester->run(array('command' => 'foo:bar', '-n' => true), array('decorated' => false));
         $this->assertEquals("called\n", $this->normalize($tester->getDisplay()), '->run() does not called interact() if -n is passed');
     }
 }

--- a/tests/Symfony/Tests/Component/Console/Command/ListCommandTest.php
+++ b/tests/Symfony/Tests/Component/Console/Command/ListCommandTest.php
@@ -21,7 +21,7 @@ class ListCommandTest extends \PHPUnit_Framework_TestCase
         $application = new Application();
 
         $commandTester = new CommandTester($command = $application->get('list'));
-        $commandTester->execute(array('command' => $command->getName()));
+        $commandTester->execute(array('command' => $command->getName()), array('decorated' => false));
         $this->assertRegExp('/help   Displays help for a command/', $commandTester->getDisplay(), '->execute() returns a list of available commands');
 
         $commandTester->execute(array('command' => $command->getName(), '--xml' => true));


### PR DESCRIPTION
Some tests compare the output of an `Application`/`Command` run to a fixed string. The output is decorated however (at least) when run on a Windows box with Ansicon installed. 
This PR fixes these failing tests by forcing the `Application`/`Command`-output to be undecorated.
