### PR TITLE
[HttpFoundation] Fixed incorrect test when 'fileinfo' extension is not enabled

### DIFF
--- a/tests/Symfony/Tests/Component/HttpFoundation/File/MimeType/MimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/MimeType/MimeTypeTest.php
@@ -33,13 +33,9 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
 
     public function testGuessImageWithDirectory()
     {
-        if (extension_loaded('fileinfo')) {
-            $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException');
+        $this->setExpectedException('Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException');
 
-            $this->assertEquals('image/gif', MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/directory'));
-        } else {
-            $this->assertNull(MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/directory'));
-        }
+        MimeTypeGuesser::getInstance()->guess(__DIR__.'/../Fixtures/directory');
     }
 
     public function testGuessImageWithContentTypeMimeTypeGuesser()


### PR DESCRIPTION
This test failed on my box with `fileinfo` disabled. The `FileNotFoundException` is thrown also when the `fileinfo`-extension is not enabled, so it should be expected.
