### PR TITLE
[Form] Skip tests that are incompatible with the installed ICU (intl) library

### DIFF
--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -96,6 +96,10 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
     public function testTransformFullTime()
     {
+        if ($this->isLowerThanIcuVersion(3.8)) {
+            $this->markTestSkipped('Please upgrade ICU version to 3.8+');
+        }
+
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
 
         $this->assertEquals('03.02.2010 04:05:06 GMT+00:00', $transformer->transform($this->dateTime));
@@ -207,6 +211,10 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
     public function testReverseTransformFullTime()
     {
+        if ($this->isLowerThanIcuVersion(3.8)) {
+            $this->markTestSkipped('Please upgrade ICU version to 3.8+');
+        }
+
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
 
         $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06 GMT+00:00', null));

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/LocalizedTestCase.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/LocalizedTestCase.php
@@ -13,12 +13,58 @@ namespace Symfony\Tests\Component\Form\Extension\Core\DataTransformer;
 
 class LocalizedTestCase extends \PHPUnit_Framework_TestCase
 {
+    protected static $icuVersion = null;
+
     protected function setUp()
     {
         parent::setUp();
 
-        if (!extension_loaded('intl')) {
+        if (!$this->isIntlExtensionLoaded()) {
             $this->markTestSkipped('The "intl" extension is not available');
         }
+    }
+
+    protected function isIntlExtensionLoaded()
+    {
+        return extension_loaded('intl');
+    }
+
+    protected function isLowerThanIcuVersion($version)
+    {
+        $version = $this->normalizeIcuVersion($version);
+        $icuVersion = $this->normalizeIcuVersion($this->getIntlExtensionIcuVersion());
+
+        return $icuVersion < $version;
+    }
+
+    protected function normalizeIcuVersion($version)
+    {
+        return ((float) $version) * 100;
+    }
+
+    protected function getIntlExtensionIcuVersion()
+    {
+        if (isset(self::$icuVersion)) {
+            return self::$icuVersion;
+        }
+
+        if (!$this->isIntlExtensionLoaded()) {
+            throw new \RuntimeException('The intl extension is not available');
+        }
+
+        if (defined('INTL_ICU_VERSION')) {
+            return INTL_ICU_VERSION;
+        }
+
+        $reflector = new \ReflectionExtension('intl');
+
+        ob_start();
+        $reflector->info();
+        $output = ob_get_clean();
+
+        preg_match('/^ICU version => (.*)$/m', $output, $matches);
+        self::$icuVersion = $matches[1];
+
+        return self::$icuVersion;
     }
 }


### PR DESCRIPTION
Two tests for the `DateTimeToLocalizedStringTransformer` depend on a datetime-format that has only been added in version 3.8 of the ICU library (used by `intl`), see http://bugs.icu-project.org/trac/changeset/21815#file60. Some PHP-versions still ship with ICU 3.6 however.

This PR skips these tests when an incompatible version of the ICU library is detected. Unfortunately I had to copy-paste some code from `Symfony\Tests\Component\Locale\TestCase`, but I don't see any other way without creating a strange dependency between the tests for the Form and Locale components.
