### PR TITLE
[2.1] [HttpKernel] MongoDb storage for Profiler

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -196,6 +196,7 @@ class FrameworkExtension extends Extension
         $supported = array(
             'sqlite' => 'Symfony\Component\HttpKernel\Profiler\SqliteProfilerStorage',
             'mysql'  => 'Symfony\Component\HttpKernel\Profiler\MysqlProfilerStorage',
+            'mongodb'  => 'Symfony\Component\HttpKernel\Profiler\MongoDbProfilerStorage',
         );
         list($class, ) = explode(':', $config['dsn']);
         if (!isset($supported[$class])) {

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -80,11 +80,11 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     public function write(Profile $profile)
     {
         return $this->getMongo()->insert(array(
-                                          'token' => $profile->getToken(),
-                                          'ip' => $profile->getIp(),
-                                          'url' => $profile->getUrl() === null ? '' : $profile->getUrl(),
-                                          'profile' => serialize($profile)
-                                      ));
+            'token' => $profile->getToken(),
+            'ip' => $profile->getIp(),
+            'url' => $profile->getUrl() === null ? '' : $profile->getUrl(),
+            'profile' => serialize($profile)
+        ));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Profiler;
+
+class MongoDbProfilerStorage implements ProfilerStorageInterface
+{
+    protected $dsn;
+    protected $mongo;
+
+    /**
+     * Constructor.
+     *
+     * @param string  $dsn        A data source name
+     * @param string  $database   The name of the database
+     * @param string  $collection The collection inside the database
+     * @param string  $username   The username for the database
+     * @param string  $password   The password for the database
+     * @param integer $lifetime   The lifetime to use for the purge
+     */
+    public function __construct($dsn)
+    {
+        $this->dsn = $dsn;
+    }
+
+    /**
+     * Internal convenience method that returns the instance of the 
+     */
+    protected function mongo()
+    {
+        if ($this->mongo === null) {
+            $mongo = new \Mongo($this->dsn);
+            list($database, $collection,) = explode('/', substr(parse_url($this->dsn, PHP_URL_PATH), 1));
+            $this->mongo = $mongo->selectCollection($database, $collection);
+        }
+        return $this->mongo;
+    }
+
+    /**
+     * Finds profiler tokens for the given criteria.
+     *
+     * @param string $ip    The IP
+     * @param string $url   The URL
+     * @param string $limit The maximum number of tokens to return
+     *
+     * @return array An array of tokens
+     */
+    function find($ip, $url, $limit)
+    {
+        $cursor = $this->mongo()->find(array('ip' => $ip, 'url' => $url))->limit($limit);
+        $return = array();
+        foreach ($cursor as $profile) {
+            $return[] = $profile['token'];
+        }
+        return $return;
+    }
+
+    /**
+     * Purges all data from the database.
+     */
+    function purge()
+    {
+        $this->mongo()->remove(array());
+    }
+
+    /**
+     * Reads data associated with the given token.
+     *
+     * The method returns false if the token does not exists in the storage.
+     *
+     * @param string $token A token
+     *
+     * @return Profile The profile associated with token
+     */
+    function read($token)
+    {
+        $profile = $this->mongo()->findOne(array('token' => $token));
+        return $profile !== null ? $profile['profile'] : null;
+    }
+
+    /**
+     * Write data associated with the given token.
+     *
+     * @param Profile $profile A Profile instance
+     *
+     * @return Boolean Write operation successful
+     */
+    function write(Profile $profile)
+    {
+        return $this->mongo()->insert(array(
+                                          'token' => $profile->getToken(),
+                                          'ip' => $profile->getIp(),
+                                          'url' => $profile->getUrl() === null ? '' : $profile->getUrl(),
+                                          'profile' => serialize($profile)
+                                      ));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -20,11 +20,6 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
      * Constructor.
      *
      * @param string  $dsn        A data source name
-     * @param string  $database   The name of the database
-     * @param string  $collection The collection inside the database
-     * @param string  $username   The username for the database
-     * @param string  $password   The password for the database
-     * @param integer $lifetime   The lifetime to use for the purge
      */
     public function __construct($dsn)
     {
@@ -32,7 +27,9 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     }
 
     /**
-     * Internal convenience method that returns the instance of the 
+     * Internal convenience method that returns the instance of the MongoDB Collection
+     *
+     * @return \MongoCollection
      */
     protected function mongo()
     {
@@ -83,7 +80,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     function read($token)
     {
         $profile = $this->mongo()->findOne(array('token' => $token));
-        return $profile !== null ? $profile['profile'] : null;
+        return $profile !== null ? unserialize($profile['profile']) : null;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpKernel\Profiler;
+
+use Symfony\Component\HttpKernel\Profiler\MongoDbProfilerStorage;
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $storage;
+
+    protected function setUp()
+    {
+        if (extension_loaded('mongo')) {
+            self::$storage = new MongoDbProfilerStorage('mongodb://localhost/symfony_tests/profiler_data');
+            self::$storage->purge();
+        } else {
+            $this->markTestSkipped('MongoDbProfilerStorageTest requires that the extension mongo is loaded');
+        }
+    }
+
+    public function testStore()
+    {
+        for ($i = 0; $i < 10; $i ++) {
+            $profile = new Profile('token_'.$i);
+            $profile->setIp('127.0.0.1');
+            $profile->setUrl('http://foo.bar');
+            self::$storage->write($profile);
+        }
+        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar', 20)), 10, '->write() stores data in the database');
+        self::$storage->purge();
+    }
+
+    public function testStoreSpecialCharsInUrl()
+    {
+        // The storage accepts special characters in URLs (Even though URLs are not
+        // supposed to contain them)
+        $profile = new Profile('simple_quote');
+        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
+        self::$storage->write($profile);
+        $this->assertTrue(false !== self::$storage->read('simple_quote'), '->write() accepts single quotes in URL');
+
+        $profile = new Profile('double_quote');
+        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
+        self::$storage->write($profile);
+        $this->assertTrue(false !== self::$storage->read('double_quote'), '->write() accepts double quotes in URL');
+
+        $profile = new Profile('backslash');
+        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
+        self::$storage->write($profile);
+        $this->assertTrue(false !== self::$storage->read('backslash'), '->write() accpets backslash in URL');
+
+        self::$storage->purge();
+    }
+    
+    public function testRetrieveByIp()
+    {
+        $profile = new Profile('token');
+        $profile->setIp('127.0.0.1');
+
+        self::$storage->write($profile);
+
+        $this->assertEquals(count(self::$storage->find('127.0.0.1', '', 10)), 1, '->find() retrieve a record by IP');
+        $this->assertEquals(count(self::$storage->find('127.0.%.1', '', 10)), 0, '->find() does not interpret a "%" as a wildcard in the IP');
+        $this->assertEquals(count(self::$storage->find('127.0._.1', '', 10)), 0, '->find() does not interpret a "_" as a wildcard in the IP');
+
+        self::$storage->purge();
+    }
+
+    public function testRetrieveByUrl()
+    {
+        $profile = new Profile('simple_quote');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/\'');
+        self::$storage->write($profile);
+
+        $profile = new Profile('double_quote');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/"');
+        self::$storage->write($profile);
+
+        $profile = new Profile('backslash');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo\\bar/');
+        self::$storage->write($profile);
+
+        $profile = new Profile('percent');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/%');
+        self::$storage->write($profile);
+
+        $profile = new Profile('underscore');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/_');
+        self::$storage->write($profile);
+
+        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10)), 1, '->find() accepts single quotes in URLs');
+        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10)), 1, '->find() accepts double quotes in URLs');
+        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10)), 1, '->find() accepts backslash in URLs');
+        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10)), 1, '->find() does not interpret a "%" as a wildcard in the URL');
+        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10)), 1, '->find() does not interpret a "_" as a wildcard in the URL');
+
+        self::$storage->purge();
+    }
+}

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the Symfony package.
  *
@@ -14,6 +13,12 @@ namespace Symfony\Tests\Component\HttpKernel\Profiler;
 use Symfony\Component\HttpKernel\Profiler\MongoDbProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
+class DummyMongoDbProfilerStorage extends MongoDbProfilerStorage {
+    public function getMongo() {
+        return parent::getMongo();
+    }
+}
+
 class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
 {
     protected static $storage;
@@ -21,7 +26,12 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (extension_loaded('mongo')) {
-            self::$storage = new MongoDbProfilerStorage('mongodb://localhost/symfony_tests/profiler_data');
+            self::$storage = new DummyMongoDbProfilerStorage('mongodb://localhost/symfony_tests/profiler_data');
+            try {
+                self::$storage->getMongo();
+            } catch(\MongoConnectionException $e) {
+                $this->markTestSkipped('MongoDbProfilerStorageTest requires that there is a MongoDB server present on localhost');
+            }
             self::$storage->purge();
         } else {
             $this->markTestSkipped('MongoDbProfilerStorageTest requires that the extension mongo is loaded');


### PR DESCRIPTION
As a documentbased database like MongoDB is [supposedly fantastic in logging](http://blog.mongodb.org/post/172254834/mongodb-is-fantastic-for-logging) I implemented a storage engine for the profiler that should enable us to use this database as storage for this.

Activate it using this way:

```
framework:
    profiler:
        dsn:     mongodb://user:pass@location/database/collection
```
