### PR TITLE
[BrowserKit] Fixed incorrect temp dir when running insulated functional tests in Windows

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -286,8 +286,8 @@ abstract class Client
      */
     protected function doRequestInProcess($request)
     {
-        // We set the TMPDIR because on Macs, the temp directory changes based on the user.
-        $process = new PhpProcess($this->getScript($request), null, array('TMPDIR' => sys_get_temp_dir()));
+        // We set the TMPDIR (for Macs) and TEMP (for Windows), because on these platforms the temp directory changes based on the user.
+        $process = new PhpProcess($this->getScript($request), null, array('TMPDIR' => sys_get_temp_dir(), 'TEMP' => sys_get_temp_dir()));
         $process->run();
 
         if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {


### PR DESCRIPTION
The `Client` class in the `BrowserKit`-component does not pass on a temporary directory environment variable recognized by Windows. This can lead to an incorrect temp dir being used when using an insulated `Client` in a functional test. A fix for Mac was already present, I extended this to also work on Windows.
