### PR TITLE
[FrameworkBundle] Log calls to event listereners _before_ calling them

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
@@ -71,8 +71,6 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
     protected function doDispatch($listeners, $eventName, Event $event)
     {
         foreach ($listeners as $listener) {
-            call_user_func($listener, $event);
-
             $info = $this->getListenerInfo($listener, $eventName);
 
             if (null !== $this->logger) {
@@ -80,6 +78,8 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
             }
 
             $this->called[$eventName.'.'.$info['pretty']] = $info;
+
+            call_user_func($listener, $event);
 
             if ($event->isPropagationStopped()) {
                 if (null !== $this->logger) {


### PR DESCRIPTION
The current implementation of `TraceableEventDispatcher` logs calls to event listeners _after_ actually calling them. This leads to strange logs when an event listener triggers another event.

For example, if I attach some `LoginListener` to the `security.interactive_login`-event, the log will look something like this:

<pre>
...
User "myusername" has been authenticated successfully
Notified event "security.interactive_login" to listener "MyVendor\MyBundle\EventListener\LoginListener::onSecurityInteractiveLogin".
Notified event "kernel.request" to listener "Symfony\Component\Security\Http\Firewall::onKernelRequest". 
...
</pre>

From the logs it looks like the `kernel.request` event was fired after the user was authenticated, whereas it was actually the listener to `kernel.request` that caused the user to be authenticated.

By logging the call to the event listener _before_ calling it, the logs will look like this:

<pre>
...
Notified event "kernel.request" to listener "Symfony\Component\Security\Http\Firewall::onKernelRequest".
Notified event "security.interactive_login" to listener "MyVendor\MyBundle\EventListener\LoginListener::onSecurityInteractiveLogin". 
User "myusername" has been authenticated successfully
...
</pre>

In my opinion this makes the causal relationship between the events clearer.
