### PR TITLE
Using the $status parameter instead of fixed value

### DIFF
--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -54,7 +54,7 @@ class HttpUtils
             $path = $this->generateUrl($path, true);
         }
 
-        return new RedirectResponse($path, 302);
+        return new RedirectResponse($path, $status);
     }
 
     /**


### PR DESCRIPTION
I checked the usages and the optional `$status` parameter is never used, so maybe another option would be to remove the parameter completely...
