### PR TITLE
Making the Response class more extendable (e.g. for streamed responses)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -235,7 +235,7 @@ class Response
      */
     protected function getContentLength()
     {
-    	return strlen($this->content);
+        return strlen($this->content);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -143,7 +143,7 @@ class Response
         if ($this->headers->has('Transfer-Encoding')) {
             $this->headers->remove('Content-Length');
         } elseif (!$this->headers->has('Content-Length')) {
-            $this->headers->set('Content-Length', strlen($this->content));
+            $this->headers->set('Content-Length', $this->getContentLength());
         }
     }
 
@@ -226,6 +226,16 @@ class Response
     public function getContent()
     {
         return $this->content;
+    }
+    
+    /**
+     * Gets the length of the content
+     * 
+     * @return int
+     */
+    protected function getContentLength()
+    {
+    	return strlen($this->content);
     }
 
     /**


### PR DESCRIPTION
I added a special method to get the response content length to make it more extendable (e.g. for responses that need to stream file contents). At the moment, the strlen($this->content) in prepare() makes this impossible.

Simple example:

```
class FileResponse extends Response
{
    private $file;

    public function __construct(File $file)
    {
        parent::__construct('', 200, array('content-type' => $file->getMimeType()));

        $this->file = $file;
    }

    public function sendContent()
    {
        readfile($this->file->getRealPath());
    }

    protected function getContentLength()
    {
        return $this->file->getSize();
    }
}
```
