### PR TITLE
Change private variables and functions to protected ones

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -46,15 +46,15 @@ use Symfony\Component\Console\Helper\DialogHelper;
  */
 class Application
 {
-    private $commands;
-    private $wantHelps = false;
-    private $runningCommand;
-    private $name;
-    private $version;
-    private $catchExceptions;
-    private $autoExit;
-    private $definition;
-    private $helperSet;
+    protected $commands;
+    protected $wantHelps = false;
+    protected $runningCommand;
+    protected $name;
+    protected $version;
+    protected $catchExceptions;
+    protected $autoExit;
+    protected $definition;
+    protected $helperSet;
 
     /**
      * Constructor.
@@ -797,7 +797,7 @@ class Application
      *
      * @return array A sorted array of commands
      */
-    private function sortCommands($commands)
+    protected function sortCommands($commands)
     {
         $namespacedCommands = array();
         foreach ($commands as $name => $command) {
@@ -824,12 +824,12 @@ class Application
      *
      * @return string A formatted string of abbreviated suggestions
      */
-    private function getAbbreviationSuggestions($abbrevs)
+    protected function getAbbreviationSuggestions($abbrevs)
     {
         return sprintf('%s, %s%s', $abbrevs[0], $abbrevs[1], count($abbrevs) > 2 ? sprintf(' and %d more', count($abbrevs) - 2) : '');
     }
 
-    private function extractNamespace($name, $limit = null)
+    protected function extractNamespace($name, $limit = null)
     {
         $parts = explode(':', $name);
         array_pop($parts);

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -28,17 +28,17 @@ use Symfony\Component\Console\Helper\HelperSet;
  */
 class Command
 {
-    private $application;
-    private $name;
-    private $aliases;
-    private $definition;
-    private $help;
-    private $description;
-    private $ignoreValidationErrors;
-    private $applicationDefinitionMerged;
-    private $code;
-    private $synopsis;
-    private $helperSet;
+    protected $application;
+    protected $name;
+    protected $aliases;
+    protected $definition;
+    protected $help;
+    protected $description;
+    protected $ignoreValidationErrors;
+    protected $applicationDefinitionMerged;
+    protected $code;
+    protected $synopsis;
+    protected $helperSet;
 
     /**
      * Constructor.
@@ -238,7 +238,7 @@ class Command
     /**
      * Merges the application definition with the command definition.
      */
-    private function mergeApplicationDefinition()
+    protected function mergeApplicationDefinition()
     {
         if (null === $this->application || true === $this->applicationDefinitionMerged) {
             return;
@@ -569,7 +569,7 @@ class Command
         return $asDom ? $dom : $dom->saveXml();
     }
 
-    private function validateName($name)
+    protected function validateName($name)
     {
         if (!preg_match('/^[^\:]+(\:[^\:]+)*$/', $name)) {
             throw new \InvalidArgumentException(sprintf('Command name "%s" is invalid.', $name));

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -25,7 +25,7 @@ use Symfony\Component\Console\Command\Command;
  */
 class HelpCommand extends Command
 {
-    private $command;
+    protected $command;
 
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -25,8 +25,8 @@ class OutputFormatter implements OutputFormatterInterface
      */
     const FORMAT_PATTERN = '#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#is';
 
-    private $decorated;
-    private $styles = array();
+    protected $decorated;
+    protected $styles = array();
 
     /**
      * Initializes console output formatter.
@@ -140,7 +140,7 @@ class OutputFormatter implements OutputFormatterInterface
      *
      * @return string The replaced style
      */
-    private function replaceStyle($match)
+    protected function replaceStyle($match)
     {
         if (!$this->isDecorated()) {
             return $match[2];
@@ -166,7 +166,7 @@ class OutputFormatter implements OutputFormatterInterface
      *
      * @return  Symfony\Component\Console\Format\FormatterStyle|Boolean false if string is not format string
      */
-    private function createStyleFromString($string)
+    protected function createStyleFromString($string)
     {
         if (!preg_match_all('/([^=]+)=([^;]+)(;|$)/', strtolower($string), $matches, PREG_SET_ORDER)) {
             return false;

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Console\Formatter;
  */
 class OutputFormatterStyle implements OutputFormatterStyleInterface
 {
-    static private $availableForegroundColors = array(
+    static protected $availableForegroundColors = array(
         'black'     => 30,
         'red'       => 31,
         'green'     => 32,
@@ -30,7 +30,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'cyan'      => 36,
         'white'     => 37
     );
-    static private $availableBackgroundColors = array(
+    static protected $availableBackgroundColors = array(
         'black'     => 40,
         'red'       => 41,
         'green'     => 42,
@@ -40,7 +40,7 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'cyan'      => 46,
         'white'     => 47
     );
-    static private $availableOptions = array(
+    static protected $availableOptions = array(
         'bold'          => 1,
         'underscore'    => 4,
         'blink'         => 5,
@@ -48,9 +48,9 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         'conceal'       => 8
     );
 
-    private $foreground;
-    private $background;
-    private $options = array();
+    protected $foreground;
+    protected $background;
+    protected $options = array();
 
     /**
      * Initializes output formatter style.

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DialogHelper extends Helper
 {
-    private $inputStream;
+    protected $inputStream;
 
     /**
      * Asks a question to the user.

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -72,7 +72,7 @@ class FormatterHelper extends Helper
      *
      * @return integer The length of the string
      */
-    private function strlen($string)
+    protected function strlen($string)
     {
         return function_exists('mb_strlen') ? mb_strlen($string, mb_detect_encoding($string)) : strlen($string);
     }

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -20,8 +20,8 @@ use Symfony\Component\Console\Command\Command;
  */
 class HelperSet
 {
-    private $helpers;
-    private $command;
+    protected $helpers;
+    protected $command;
 
     /**
      * @param Helper[] $helpers An array of helper.

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -40,8 +40,8 @@ namespace Symfony\Component\Console\Input;
  */
 class ArgvInput extends Input
 {
-    private $tokens;
-    private $parsed;
+    protected $tokens;
+    protected $parsed;
 
     /**
      * Constructor.
@@ -92,7 +92,7 @@ class ArgvInput extends Input
      *
      * @param string $token The current token.
      */
-    private function parseShortOption($token)
+    protected function parseShortOption($token)
     {
         $name = substr($token, 1);
 
@@ -115,7 +115,7 @@ class ArgvInput extends Input
      *
      * @throws \RuntimeException When option given doesn't exist
      */
-    private function parseShortOptionSet($name)
+    protected function parseShortOptionSet($name)
     {
         $len = strlen($name);
         for ($i = 0; $i < $len; $i++) {
@@ -139,7 +139,7 @@ class ArgvInput extends Input
      *
      * @param string $token The current token
      */
-    private function parseLongOption($token)
+    protected function parseLongOption($token)
     {
         $name = substr($token, 2);
 
@@ -157,7 +157,7 @@ class ArgvInput extends Input
      *
      * @throws \RuntimeException When too many arguments are given
      */
-    private function parseArgument($token)
+    protected function parseArgument($token)
     {
         $c = count($this->arguments);
 
@@ -185,7 +185,7 @@ class ArgvInput extends Input
      *
      * @throws \RuntimeException When option given doesn't exist
      */
-    private function addShortOption($shortcut, $value)
+    protected function addShortOption($shortcut, $value)
     {
         if (!$this->definition->hasShortcut($shortcut)) {
             throw new \RuntimeException(sprintf('The "-%s" option does not exist.', $shortcut));
@@ -202,7 +202,7 @@ class ArgvInput extends Input
      *
      * @throws \RuntimeException When option given doesn't exist
      */
-    private function addLongOption($name, $value)
+    protected function addLongOption($name, $value)
     {
         if (!$this->definition->hasOption($name)) {
             throw new \RuntimeException(sprintf('The "--%s" option does not exist.', $name));

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -24,7 +24,7 @@ namespace Symfony\Component\Console\Input;
  */
 class ArrayInput extends Input
 {
-    private $parameters;
+    protected $parameters;
 
     /**
      * Constructor.
@@ -134,7 +134,7 @@ class ArrayInput extends Input
      *
      * @throws \RuntimeException When option given doesn't exist
      */
-    private function addShortOption($shortcut, $value)
+    protected function addShortOption($shortcut, $value)
     {
         if (!$this->definition->hasShortcut($shortcut)) {
             throw new \InvalidArgumentException(sprintf('The "-%s" option does not exist.', $shortcut));
@@ -152,7 +152,7 @@ class ArrayInput extends Input
      * @throws \InvalidArgumentException When option given doesn't exist
      * @throws \InvalidArgumentException When a required value is missing
      */
-    private function addLongOption($name, $value)
+    protected function addLongOption($name, $value)
     {
         if (!$this->definition->hasOption($name)) {
             throw new \InvalidArgumentException(sprintf('The "--%s" option does not exist.', $name));
@@ -179,7 +179,7 @@ class ArrayInput extends Input
      *
      * @throws \InvalidArgumentException When argument given doesn't exist
      */
-    private function addArgument($name, $value)
+    protected function addArgument($name, $value)
     {
         if (!$this->definition->hasArgument($name)) {
             throw new \InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -24,10 +24,10 @@ class InputArgument
     const OPTIONAL = 2;
     const IS_ARRAY = 4;
 
-    private $name;
-    private $mode;
-    private $default;
-    private $description;
+    protected $name;
+    protected $mode;
+    protected $default;
+    protected $description;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -27,12 +27,12 @@ namespace Symfony\Component\Console\Input;
  */
 class InputDefinition
 {
-    private $arguments;
-    private $requiredCount;
-    private $hasAnArrayArgument = false;
-    private $hasOptional;
-    private $options;
-    private $shortcuts;
+    protected $arguments;
+    protected $requiredCount;
+    protected $hasAnArrayArgument = false;
+    protected $hasOptional;
+    protected $options;
+    protected $shortcuts;
 
     /**
      * Constructor.
@@ -365,7 +365,7 @@ class InputDefinition
      *
      * @throws \InvalidArgumentException When option given does not exist
      */
-    private function shortcutToName($shortcut)
+    protected function shortcutToName($shortcut)
     {
         if (!isset($this->shortcuts[$shortcut])) {
             throw new \InvalidArgumentException(sprintf('The "-%s" option does not exist.', $shortcut));

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -25,11 +25,11 @@ class InputOption
     const VALUE_OPTIONAL = 4;
     const VALUE_IS_ARRAY = 8;
 
-    private $name;
-    private $shortcut;
-    private $mode;
-    private $default;
-    private $description;
+    protected $name;
+    protected $shortcut;
+    protected $mode;
+    protected $default;
+    protected $description;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Input/StringInput.php
+++ b/src/Symfony/Component/Console/Input/StringInput.php
@@ -48,7 +48,7 @@ class StringInput extends ArgvInput
      * @param string $input The input to tokenize
      * @throws \InvalidArgumentException When unable to parse input (should never happen)
      */
-    private function tokenize($input)
+    protected function tokenize($input)
     {
         $input = preg_replace('/(\r\n|\r|\n|\t)/', ' ', $input);
 

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -29,8 +29,8 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
  */
 abstract class Output implements OutputInterface
 {
-    private $verbosity;
-    private $formatter;
+    protected $verbosity;
+    protected $formatter;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
  */
 class StreamOutput extends Output
 {
-    private $stream;
+    protected $stream;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -25,9 +25,9 @@ use Symfony\Component\Console\Output\ConsoleOutput;
  */
 class Shell
 {
-    private $application;
-    private $history;
-    private $output;
+    protected $application;
+    protected $history;
+    protected $output;
 
     /**
      * Constructor.
@@ -86,7 +86,7 @@ class Shell
      * @param string  $text     The last segment of the entered text
      * @param integer $position The current position
      */
-    private function autocompleter($text, $position)
+    protected function autocompleter($text, $position)
     {
         $info = readline_info();
         $text = substr($info['line_buffer'], 0, $info['end']);

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -20,9 +20,9 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class ApplicationTester
 {
-    private $application;
-    private $input;
-    private $output;
+    protected $application;
+    protected $input;
+    protected $output;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -20,9 +20,9 @@ use Symfony\Component\Console\Output\StreamOutput;
  */
 class CommandTester
 {
-    private $command;
-    private $input;
-    private $output;
+    protected $command;
+    protected $input;
+    protected $output;
 
     /**
      * Constructor.


### PR DESCRIPTION
Hey guys,

I've been using Symfony's [Console](https://github.com/symfony/Console) component for a few side projects recently and have found myself writing extra code that I wouldn't otherwise need to if we switched the `private` class properties and methods to `protected` ones.

For example:

```
use Symfony\Component\Console;

class MyApp extends Console\Application {

   public function __construct($name, $version)
   {
       $this->name = $name;
       $this->definition = new Console\Input\InputDefinition();
   }
}

$app = new MyApp('myapp');
var_dump($app->getName(), get_class($app->getDefinition()));
```

Outputs:

```
NULL
bool(false)
```

While changing the visibility from `private` to `protected` allows for the expected output of:

```
string(5) "myapp"
string(47) "Symfony\Component\Console\Input\InputDefinition"
```

I really think this is a much better approach, especially for a _component_ that's released as a stand-alone PEAR package.

Considering @fabpot's [blog post](http://fabien.potencier.org/article/47/pragmatism-over-theory-protected-vs-private), I may have gone overboard in assuming that _all_ these properties/methods should be declared `protected`, but so far this solution has made working with the [Console](https://github.com/symfony/Console) component a lot easier.

Let me know what you guys think.
