### PR TITLE
Changed exception wording

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -81,7 +81,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
                     throw new \LogicException(sprintf(
                         'The extension alias for the default extension of a '.
                         'bundle must be the underscored version of the '.
-                        'bundle name ("%s" vs "%s")',
+                        'bundle name ("%s" instead of "%s")',
                         $expectedAlias, $extension->getAlias()
                     ));
                 }


### PR DESCRIPTION
Changed the wording of the exception thrown when Bundle::getAlias() returns something different to the Container::underscore version, fixes #1768
