### PR TITLE
Trans locale

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -63,14 +63,14 @@ class TranslationExtension extends \Twig_Extension
         );
     }
 
-    public function trans($message, array $arguments = array(), $domain = "messages")
+    public function trans($message, array $arguments = array(), $domain = "messages", $locale = null)
     {
-        return $this->translator->trans($message, $arguments, $domain);
+        return $this->translator->trans($message, $arguments, $domain, $locale);
     }
 
-    public function transchoice($message, $count, array $arguments = array(), $domain = "messages")
+    public function transchoice($message, $count, array $arguments = array(), $domain = "messages", $locale = null)
     {
-        return $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain);
+        return $this->translator->transChoice($message, $count, array_merge(array('%count%' => $count), $arguments), $domain, $locale);
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -18,9 +18,9 @@ namespace Symfony\Bridge\Twig\Node;
  */
 class TransNode extends \Twig_Node
 {
-    public function __construct(\Twig_NodeInterface $body, \Twig_NodeInterface $domain, \Twig_Node_Expression $count = null, \Twig_Node_Expression $vars = null, $lineno = 0, $tag = null)
+    public function __construct(\Twig_NodeInterface $body, \Twig_NodeInterface $domain, \Twig_Node_Expression $count = null, \Twig_Node_Expression $vars = null, \Twig_Node_Expression $locale = null, $lineno = 0, $tag = null)
     {
-        parent::__construct(array('count' => $count, 'body' => $body, 'domain' => $domain, 'vars' => $vars), array(), $lineno, $tag);
+        parent::__construct(array('count' => $count, 'body' => $body, 'domain' => $domain, 'vars' => $vars, 'locale' => $locale), array(), $lineno, $tag);
     }
 
     /**
@@ -71,8 +71,14 @@ class TransNode extends \Twig_Node
         $compiler
             ->raw(', ')
             ->subcompile($this->getNode('domain'))
-            ->raw(");\n")
         ;
+        if (null !== $this->getNode('locale')) {
+            $compiler
+                ->raw(', ')
+                ->subcompile($this->getNode('locale'))
+            ;
+        }
+        $compiler->raw(");\n");
     }
 
     protected function compileDefaults(\Twig_Compiler $compiler, \Twig_Node_Expression_Array $defaults)

--- a/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransChoiceTokenParser.php
@@ -37,6 +37,7 @@ class TransChoiceTokenParser extends TransTokenParser
         $count = $this->parser->getExpressionParser()->parseExpression();
 
         $domain = new \Twig_Node_Expression_Constant('messages', $lineno);
+        $locale = null;
 
         if ($stream->test('with')) {
             // {% transchoice count with vars %}
@@ -50,6 +51,12 @@ class TransChoiceTokenParser extends TransTokenParser
             $domain = $this->parser->getExpressionParser()->parseExpression();
         }
 
+        if ($stream->test('into')) {
+            // {% transchoice count into "fr" %}
+            $stream->next();
+            $locale =  $this->parser->getExpressionParser()->parseExpression();
+        }
+
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
         $body = $this->parser->subparse(array($this, 'decideTransChoiceFork'), true);
@@ -60,7 +67,7 @@ class TransChoiceTokenParser extends TransTokenParser
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        return new TransNode($body, $domain, $count, $vars, $lineno, $this->getTag());
+        return new TransNode($body, $domain, $count, $vars, $locale, $lineno, $this->getTag());
     }
 
     public function decideTransChoiceFork($token)

--- a/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/TransTokenParser.php
@@ -34,6 +34,7 @@ class TransTokenParser extends \Twig_TokenParser
 
         $vars = new \Twig_Node_Expression_Array(array(), $lineno);
         $domain = new \Twig_Node_Expression_Constant('messages', $lineno);
+        $locale = null;
         if (!$stream->test(\Twig_Token::BLOCK_END_TYPE)) {
             if ($stream->test('with')) {
                 // {% trans with vars %}
@@ -45,6 +46,12 @@ class TransTokenParser extends \Twig_TokenParser
                 // {% trans from "messages" %}
                 $stream->next();
                 $domain = $this->parser->getExpressionParser()->parseExpression();
+            }
+
+            if ($stream->test('into')) {
+                // {% trans into "fr" %}
+                $stream->next();
+                $locale =  $this->parser->getExpressionParser()->parseExpression();
             } elseif (!$stream->test(\Twig_Token::BLOCK_END_TYPE)) {
                 throw new \Twig_Error_Syntax('Unexpected token. Twig was looking for the "with" or "from" keyword.');
             }
@@ -60,7 +67,7 @@ class TransTokenParser extends \Twig_TokenParser
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        return new TransNode($body, $domain, null, $vars, $lineno, $this->getTag());
+        return new TransNode($body, $domain, null, $vars, $locale, $lineno, $this->getTag());
     }
 
     public function decideTransFork($token)

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/TranslationExtensionTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/TranslationExtensionTest.php
@@ -63,6 +63,8 @@ class TranslationExtensionTest extends TestCase
             array('{% trans with { \'%name%\': \'Symfony2\' } %}Hello %name%{% endtrans %}', 'Hello Symfony2'),
             array('{% set vars = { \'%name%\': \'Symfony2\' } %}{% trans with vars %}Hello %name%{% endtrans %}', 'Hello Symfony2'),
 
+            array('{% trans into "fr"%}Hello{% endtrans %}', 'Hello'),
+
             // transchoice
             array('{% transchoice count from "messages" %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
                 'There is no apples', array('count' => 0)),
@@ -72,6 +74,8 @@ class TranslationExtensionTest extends TestCase
                 'There is 5 apples (Symfony2)', array('count' => 5, 'name' => 'Symfony2')),
             array('{% transchoice count with { \'%name%\': \'Symfony2\' } %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
                 'There is 5 apples (Symfony2)', array('count' => 5)),
+            array('{% transchoice count into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
+                'There is no apples', array('count' => 0)),
 
             // trans filter
             array('{{ "Hello"|trans }}', 'Hello'),

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/TranslationExtensionTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/TranslationExtensionTest.php
@@ -78,10 +78,12 @@ class TranslationExtensionTest extends TestCase
             array('{{ name|trans }}', 'Symfony2', array('name' => 'Symfony2')),
             array('{{ hello|trans({ \'%name%\': \'Symfony2\' }) }}', 'Hello Symfony2', array('hello' => 'Hello %name%')),
             array('{% set vars = { \'%name%\': \'Symfony2\' } %}{{ hello|trans(vars) }}', 'Hello Symfony2', array('hello' => 'Hello %name%')),
+            array('{{ "Hello"|trans({}, "messages", "fr") }}', 'Hello'),
 
             // transchoice filter
             array('{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|transchoice(count) }}', 'There is 5 apples', array('count' => 5)),
             array('{{ text|transchoice(5, {\'%name%\': \'Symfony2\'}) }}', 'There is 5 apples (Symfony2)', array('text' => '{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%)')),
+            array('{{ "{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples"|transchoice(count, {}, "messages", "fr") }}', 'There is 5 apples', array('count' => 5)),
         );
     }
 


### PR DESCRIPTION
This allows setting the locale when translating in a Twig template. This was already allowed in the Translator and in the PHP templates
