### PR TITLE
support for variables without separator in routing pattern

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -32,7 +32,8 @@ class RouteCompiler implements RouteCompilerInterface
         $tokens = array();
         $variables = array();
         $pos = 0;
-        preg_match_all('#.\{([\w\d_]+)\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        preg_match_all('#.?\{([\w\d_]+)\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+
         foreach ($matches as $match) {
             if ($text = substr($pattern, $pos, $match[0][1] - $pos)) {
                 $tokens[] = array('text', $text);
@@ -50,7 +51,12 @@ class RouteCompiler implements RouteCompilerInterface
                 $regexp = sprintf('[^%s]+?', preg_quote(implode('', array_unique($seps)), '#'));
             }
 
-            $tokens[] = array('variable', $match[0][0][0], $regexp, $var);
+            if ($match[0][0][0] !== '{') {
+                $prefix = $match[0][0][0];
+            } else {
+                $prefix = '';
+            }
+            $tokens[] = array('variable', $prefix, $regexp, $var);
             $variables[] = $var;
         }
 

--- a/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
@@ -96,6 +96,15 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                 '', '#^/(?:(?P<bar>(foo|bar)))?$#x', array('bar'), array(
                     array('variable', '/', '(foo|bar)', 'bar'),
                 )),
+
+            array(
+                'Route with several variables without separator but with requirements',
+                array('/foo/{bar}{foobar}', array(), array('bar'=> 'foo|bar', 'foobar' => '\d+')),
+                '/foo', '#^/foo/(?P<bar>foo|bar)(?P<foobar>\d+)$#x', array('bar', 'foobar'), array(
+                    array('variable', '', '\d+', 'foobar'),
+                    array('variable', '/', 'foo|bar', 'bar'),
+                    array('text', '/foo'),
+                )),
         );
     }
 }


### PR DESCRIPTION
Bring back support for routing patterns like this one:

```
pattern:  /foobar/{foo}{bar}
```

This was possible in symfony 1 using "segment_separators" option.

Of course, it only makes sense if requirements are specified for {foo} and {bar}

BTW: I agree that it's probably a bad ided to use that kind of URL. But sometimes you have no choice but to maintain compatibility with existing URL.
