### PR TITLE
issue #1823, adding support to retrieve PEAR-installed classes within the UniversalClassLoader

### DIFF
--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -242,7 +242,7 @@ class UniversalClassLoader
             foreach ($this->prefixes as $prefix => $dirs) {
                 foreach ($dirs as $dir) {
                     if (0 === strpos($class, $prefix)) {
-                        $file = $dir.DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $class).'.php';
+                        $file = $dir. DIRECTORY_SEPARATOR. $this->convertPearClassNameToPath($class);
                         if (file_exists($file)) {
                             return $file;
                         }
@@ -251,11 +251,27 @@ class UniversalClassLoader
             }
 
             foreach ($this->prefixFallbacks as $dir) {
-                $file = $dir.DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $class).'.php';
+                $file = $dir. DIRECTORY_SEPARATOR . $this->convertPearClassNameToPath($class);
                 if (file_exists($file)) {
                     return $file;
                 }
             }
+
+            $file = stream_resolve_include_path($this->convertPearClassNameToPath($class));
+            if (file_exists($file)) {
+              return $file;
+            }
         }
+    }
+    
+    /**
+     * Converts a PEAR-style class name to a filesystem relative path.
+     *
+     * @param   string $className The name of the class to load
+     * @return  string the relative path to that class
+     */
+    protected function convertPearClassNameToPath($className)
+    {
+      return str_replace('_', DIRECTORY_SEPARATOR, $className).'.php';
     }
 }

--- a/tests/Symfony/Tests/Component/ClassLoader/UniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/UniversalClassLoaderTest.php
@@ -37,6 +37,13 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testLoadingClassesInstalledViaPear()
+    {
+        $loader = new UniversalClassLoader();
+        $className = 'PEAR';
+        $this->assertTrue((bool) $loader->findFile($className), '->findFile() finds classes installed via PEAR');
+    }
+
     /**
      * @dataProvider getLoadClassFromFallbackTests
      */


### PR DESCRIPTION
As discussed here https://github.com/symfony/symfony/issues/1823 it would be cool, as a final fallback, to try include classes with stream_resolve_include_path, to, for example, autoload classes installed via PEAR.

I wrote a small patch, including a protected method in the UniversalClassLoader, which formats a PEAR-style class name in a FS relative path (this snippet was used 2 times, with this patch 3 times, so I refactored) and added a test.
Since I can't check class_exists('PEAR'), because PHP would say "yes" using the include path but the universal class loader would, however, not load it, I checked if the findFile() method finds the PEAR class, which should be installed in _almost_ every PC running the tests: I don't know if there is a better way to test it.
