### PR TITLE
[ClassLoader] Improve exception messages of the debug class loader

### DIFF
--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -55,7 +55,13 @@ class DebugUniversalClassLoader extends UniversalClassLoader
             require $file;
 
             if (!class_exists($class, false) && !interface_exists($class, false)) {
-                throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". You probably have a typo in the namespace or the class name.', $class, $file));
+                if (!file_exists($file)) {
+                    throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". You probably have a typo in the namespace or the class name.', $class, $file));
+                }
+                if (!is_readable($file)) {
+                    throw new \RuntimeException(sprintf('The autoloader could not load "%s" from "%s", the file is not readable by this PHP process.', $class, $file));
+                }
+                throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but not the class, the class name is probably incorrectly defined.', $class, $file));
             }
         }
     }

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -65,15 +65,16 @@ class DebugUniversalClassLoader extends UniversalClassLoader
      */
     public function findFile($class)
     {
-      $file = parent::findFile($class);
-      
-      if (!$file) {
-          throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". You probably have a typo in the namespace or the class name.', $class, $file));
-      }
-      elseif (!is_readable($file)) {
-          throw new \RuntimeException(sprintf('The autoloader could not load "%s" from "%s", the file is not readable by this PHP process.', $class, $file));
-      }
-      
-      return $file;
+        $file = parent::findFile($class);
+
+        if (!$file) {
+            throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". You probably have a typo in the namespace or the class name.', $class, $file));
+        }
+        
+        if (!is_readable($file)) {
+            throw new \RuntimeException(sprintf('The autoloader could not load "%s" from "%s", the file is not readable by this PHP process.', $class, $file));
+        }
+
+        return $file;
     }
 }

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -55,14 +55,25 @@ class DebugUniversalClassLoader extends UniversalClassLoader
             require $file;
 
             if (!class_exists($class, false) && !interface_exists($class, false)) {
-                if (!file_exists($file)) {
-                    throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". You probably have a typo in the namespace or the class name.', $class, $file));
-                }
-                if (!is_readable($file)) {
-                    throw new \RuntimeException(sprintf('The autoloader could not load "%s" from "%s", the file is not readable by this PHP process.', $class, $file));
-                }
                 throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but not the class, the class name is probably incorrectly defined.', $class, $file));
             }
         }
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function findFile($class)
+    {
+      $file = parent::findFile($class);
+      
+      if (!$file) {
+          throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". You probably have a typo in the namespace or the class name.', $class, $file));
+      }
+      elseif (!is_readable($file)) {
+          throw new \RuntimeException(sprintf('The autoloader could not load "%s" from "%s", the file is not readable by this PHP process.', $class, $file));
+      }
+      
+      return $file;
     }
 }

--- a/tests/Symfony/Tests/Component/ClassLoader/DebugUniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/DebugUniversalClassLoaderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\ClassLoader;
+
+use Symfony\Component\ClassLoader\DebugUniversalClassLoader;
+
+class DebugUniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAClassNotFoundThrowsAnExplicitHelpException()
+    {
+        $loader = new DebugUniversalClassLoader();
+        
+        try {
+            $loader->findFile('NonExistingClass');
+        }
+        catch (\RuntimeException $e) {
+            $message = 'The autoloader expected class "NonExistingClass" to be defined in file "". You probably have a typo in the namespace or the class name.';
+            $this->assertEquals($message, $e->getMessage());
+        }
+    }
+    
+    public function testAnUnreadableFileContainingTheClassToAutoloadThrowsAnExplicitHelpException()
+    {      
+        $fixtureDir     = __DIR__.DIRECTORY_SEPARATOR.'Fixtures';
+        $unreadableFile = $fixtureDir.DIRECTORY_SEPARATOR.'Namespaced'.DIRECTORY_SEPARATOR.'Unreadable.php';
+        $loader         = new DebugUniversalClassLoader();
+        $loader->registerNamespace('Namespaced', $fixtureDir);
+        touch($unreadableFile);
+        chmod($unreadableFile, 0333);
+        
+        try {
+            $loader->findFile('\\Namespaced\Unreadable');
+            $this->fail('The autoloader should raise an explicit exception when unable to load a file due to its permissions.');
+        }
+        catch (\RuntimeException $e) {
+            $message = 'The autoloader could not load "\Namespaced\Unreadable" from "'.__DIR__.'/Fixtures/Namespaced/Unreadable.php", the file is not readable by this PHP process.';
+            $this->assertEquals($message, $e->getMessage());
+        }
+        
+        unlink($unreadableFile);
+    }
+}


### PR DESCRIPTION
Hi guys,

this is basically a JOrdi's idea, that I refactored starting from issue #1825
https://github.com/symfony/symfony/pull/1825

I modified the Debug autoloader: when a class is not readable or could not be found you have some useful error messages ( most part of the job, like messages, has been done by Jordi ).

I integrated a test (the debug autoloader seemed not to be tested), which looks at the exception messages that are thrown away.
I was tempted to use ->setExpectedException, but, as the exceptions for file not found/unreadable file/file exists but class is not declared there are the same (RuntimeException), I preferred to inspect the error message.

is this good, @fabpot?
