### PR TITLE
[Routing] Add class global prefix support for the AnnotationClassLoader

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -99,6 +99,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
         $globals = array(
             'pattern'      => '',
+            'name'         => '',
             'requirements' => array(),
             'options'      => array(),
             'defaults'     => array(),
@@ -125,6 +126,10 @@ abstract class AnnotationClassLoader implements LoaderInterface
             if (null !== $annot->getDefaults()) {
                 $globals['defaults'] = $annot->getDefaults();
             }
+
+            if (null !== $annot->getName()) {
+                $globals['name'] = $annot->getName();
+            }
         }
 
         $collection = new RouteCollection();
@@ -146,7 +151,13 @@ abstract class AnnotationClassLoader implements LoaderInterface
     {
         $name = $annot->getName();
         if (null === $name) {
-            $name = $this->getDefaultRouteName($class, $method);
+            if ($globals['name']) {
+                $name = $this->getDefaultMethodRouteName($globals['name'], $method);
+            } else {
+                $name = $this->getDefaultRouteName($class, $method);
+            }
+
+            $annot->setName($name);
         }
 
         $defaults = array_merge($globals['defaults'], $annot->getDefaults());
@@ -208,6 +219,19 @@ abstract class AnnotationClassLoader implements LoaderInterface
         $this->defaultRouteIndex++;
 
         return $name;
+    }
+
+    /**
+     * Appends the default method name when a global prefix is specified
+     *
+     * @param string $prefix
+     * @param \ReflectionMethod $method
+     *
+     * @return string
+     */    
+    protected function getDefaultMethodRouteName($prefix, \ReflectionMethod $method) 
+    {
+        return strtolower($prefix . '_' . $method->getName()); 
     }
 
     abstract protected function configureRoute(Route $route, \ReflectionClass $class, \ReflectionMethod $method, $annot);


### PR DESCRIPTION
This request will add the capability to specify a class wide routing prefix default when using the annotation loader
There is a related pull request for SensioFrameworkExtraBundle that removes the action suffix from the route name
This is fully BC

For example:

```
/**
 * Users controller.
 *
 * @Route("/site/users", name="users")
 */
class UsersController {

    /**
     * @Route("/list")
     */
    public function list() {

    }

    /**
     * @Route("/search")
     */
    public function searchAction() {

    }    
    /**
     * @Route("/custom", name="custom_route_name")
     */
    public function custom() {

    }
}
```

will generate the routes:

```
users_list                         ANY /site/users/list
users_searchaction           ANY /site/users/search
custom_route_name          ANY /site/users/search
```

See #PR53 https://github.com/sensio/SensioFrameworkExtraBundle/pull/53 for the related cleanup of the action keyword
