### PR TITLE
[SwiftmailerBundle] Allow non-file spools

### DIFF
--- a/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/DependencyInjection/SwiftmailerExtension.php
@@ -86,6 +86,9 @@ class SwiftmailerExtension extends Extension
             $type = $config['spool']['type'];
 
             $loader->load('spool.xml');
+            if ($type === 'file') {
+                $loader->load('spool_file.xml');
+            }
             $container->setAlias('swiftmailer.transport.real', $transport);
             $container->setAlias('swiftmailer.transport', 'swiftmailer.transport.spool');
             $container->setAlias('swiftmailer.spool', 'swiftmailer.spool.'.$type);

--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/spool.xml
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/spool.xml
@@ -5,8 +5,6 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="swiftmailer.spool.file.class">Swift_FileSpool</parameter>
-
         <parameter key="swiftmailer.plugin.redirecting.class">Swift_Plugins_RedirectingPlugin</parameter>
         <parameter key="swiftmailer.plugin.blackhole.class">Swift_Plugins_BlackholePlugin</parameter>
     </parameters>
@@ -16,11 +14,5 @@
             <argument type="service" id="swiftmailer.transport.eventdispatcher" />
             <argument type="service" id="swiftmailer.spool" />
         </service>
-
-        <service id="swiftmailer.spool.file" class="%swiftmailer.spool.file.class%" public="false">
-            <argument>%swiftmailer.spool.file.path%</argument>
-        </service>
-
-        <service id="swiftmailer.spool" alias="swiftmailer.spool.file" public="false" />
     </services>
 </container>

--- a/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/spool_file.xml
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Resources/config/spool_file.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="swiftmailer.spool.file.class">Swift_FileSpool</parameter>
+    </parameters>
+
+    <services>
+        <service id="swiftmailer.spool.file" class="%swiftmailer.spool.file.class%" public="false">
+            <argument>%swiftmailer.spool.file.path%</argument>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Actually if I have the following configuration:

```
swiftmailer:
    spool:
        type:   not_file
        path:   some_path
```

The DIC compiler will complain:

```
'The service "swiftmailer.spool.file" has a dependency on
a non-existent parameter "swiftmailer.spool.file.path"
```

Because the file spool service is declared no matter the spool type configured.
And it requires the file.path, which is not available.

This patch aims to load the file spooler only if required by the
configuration.
