### PR TITLE
[Console] Initialize array class properties as arrays by default

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -46,7 +46,7 @@ use Symfony\Component\Console\Helper\DialogHelper;
  */
 class Application
 {
-    private $commands;
+    private $commands = array();
     private $wantHelps = false;
     private $runningCommand;
     private $name;
@@ -70,7 +70,6 @@ class Application
         $this->version = $version;
         $this->catchExceptions = true;
         $this->autoExit = true;
-        $this->commands = array();
         $this->helperSet = new HelperSet(array(
             new FormatterHelper(),
             new DialogHelper(),

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -30,7 +30,7 @@ class Command
 {
     private $application;
     private $name;
-    private $aliases;
+    private $aliases = array();
     private $definition;
     private $help;
     private $description;
@@ -54,7 +54,6 @@ class Command
         $this->definition = new InputDefinition();
         $this->ignoreValidationErrors = false;
         $this->applicationDefinitionMerged = false;
-        $this->aliases = array();
 
         if (null !== $name) {
             $this->setName($name);


### PR DESCRIPTION
I found myself having to call the `Application::__construct()` from my own class extension simply to initialize the `Application::$commands` variable as an array.

The same thing goes for `Command\Command::$aliases`. I just believe these should be defined as arrays by default, and not initialized in their respective `__constructor` methods.

This PR simply removes initialization from the `__constructor` and defines the two properties as arrays by default.
