### PR TITLE
[Security] Remove VoterInterface::supports{Attribute,Class}

### DIFF
--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -50,11 +50,6 @@ class AclVoter implements VoterInterface
         $this->allowIfObjectIdentityUnavailable = $allowIfObjectIdentityUnavailable;
     }
 
-    public function supportsAttribute($attribute)
-    {
-        return $this->permissionMap->contains($attribute);
-    }
-
     public function vote(TokenInterface $token, $object, array $attributes)
     {
         foreach ($attributes as $attribute) {
@@ -125,18 +120,5 @@ class AclVoter implements VoterInterface
 
         // no attribute was supported
         return self::ACCESS_ABSTAIN;
-    }
-
-    /**
-     * You can override this method when writing a voter for a specific domain
-     * class.
-     *
-     * @param string $class The class name
-     *
-     * @return Boolean
-     */
-    public function supportsClass($class)
-    {
-        return true;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -56,34 +56,6 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function supportsAttribute($attribute)
-    {
-        foreach ($this->voters as $voter) {
-            if ($voter->supportsAttribute($attribute)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsClass($class)
-    {
-        foreach ($this->voters as $voter) {
-            if ($voter->supportsClass($class)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
      * Grants access if any voter returns an affirmative response.
      *
      * If all voters abstained from voting, the decision will be based on the

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -30,22 +30,4 @@ interface AccessDecisionManagerInterface
      * @return Boolean true if the access is granted, false otherwise
      */
     function decide(TokenInterface $token, array $attributes, $object = null);
-
-    /**
-     * Checks if the access decision manager supports the given attribute.
-     *
-     * @param string $attribute An attribute
-     *
-     * @return Boolean true if this decision manager supports the attribute, false otherwise
-     */
-    function supportsAttribute($attribute);
-
-    /**
-     * Checks if the access decision manager supports the given class.
-     *
-     * @param string $class A class name
-     *
-     * @return true if this decision manager can process the class
-     */
-    function supportsClass($class);
 }

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/AuthenticatedVoter.php
@@ -43,20 +43,9 @@ class AuthenticatedVoter implements VoterInterface
         $this->authenticationTrustResolver = $authenticationTrustResolver;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsAttribute($attribute)
+    private function supportsAttribute($attribute)
     {
         return null !== $attribute && (self::IS_AUTHENTICATED_FULLY === $attribute || self::IS_AUTHENTICATED_REMEMBERED === $attribute || self::IS_AUTHENTICATED_ANONYMOUSLY === $attribute);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsClass($class)
-    {
-        return true;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/RoleVoter.php
@@ -32,20 +32,9 @@ class RoleVoter implements VoterInterface
         $this->prefix = $prefix;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsAttribute($attribute)
+    private function supportsAttribute($attribute)
     {
         return 0 === strpos($attribute, $this->prefix);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function supportsClass($class)
-    {
-        return true;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -25,24 +25,6 @@ interface VoterInterface
     const ACCESS_DENIED  = -1;
 
     /**
-     * Checks if the voter supports the given attribute.
-     *
-     * @param string $attribute An attribute
-     *
-     * @return Boolean true if this Voter supports the attribute, false otherwise
-     */
-    function supportsAttribute($attribute);
-
-    /**
-     * Checks if the voter supports the given class.
-     *
-     * @param string $class A class name
-     *
-     * @return true if this Voter can process the class
-     */
-    function supportsClass($class);
-
-    /**
      * Returns the vote for the given parameters.
      *
      * This method must return one of the following constant:

--- a/tests/Symfony/Tests/Component/Security/Acl/Voter/AclVoterTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Voter/AclVoterTest.php
@@ -22,50 +22,6 @@ use Symfony\Component\Security\Acl\Voter\AclVoter;
 
 class AclVoterTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @dataProvider getSupportsAttributeTests
-     */
-    public function testSupportsAttribute($attribute, $supported)
-    {
-        list($voter,, $permissionMap,,) = $this->getVoter();
-
-        $permissionMap
-            ->expects($this->once())
-            ->method('contains')
-            ->with($this->identicalTo($attribute))
-            ->will($this->returnValue($supported))
-        ;
-
-        $this->assertSame($supported, $voter->supportsAttribute($attribute));
-    }
-
-    public function getSupportsAttributeTests()
-    {
-        return array(
-            array('foo', true),
-            array('foo', false),
-        );
-    }
-
-    /**
-     * @dataProvider getSupportsClassTests
-     */
-    public function testSupportsClass($class)
-    {
-        list($voter,,,,) = $this->getVoter();
-
-        $this->assertTrue($voter->supportsClass($class));
-    }
-
-    public function getSupportsClassTests()
-    {
-        return array(
-            array('foo'),
-            array('bar'),
-            array('moo'),
-        );
-    }
-
     public function testVote()
     {
         list($voter,, $permissionMap,,) = $this->getVoter();

--- a/tests/Symfony/Tests/Component/Security/Core/Authorization/AccessDecisionManagerTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/Authorization/AccessDecisionManagerTest.php
@@ -16,36 +16,6 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
 {
-    public function testSupportsClass()
-    {
-        $manager = new AccessDecisionManager(array(
-            $this->getVoterSupportsClass(true),
-            $this->getVoterSupportsClass(false),
-        ));
-        $this->assertTrue($manager->supportsClass('FooClass'));
-
-        $manager = new AccessDecisionManager(array(
-            $this->getVoterSupportsClass(false),
-            $this->getVoterSupportsClass(false),
-        ));
-        $this->assertFalse($manager->supportsClass('FooClass'));
-    }
-
-    public function testSupportsAttribute()
-    {
-        $manager = new AccessDecisionManager(array(
-            $this->getVoterSupportsAttribute(true),
-            $this->getVoterSupportsAttribute(false),
-        ));
-        $this->assertTrue($manager->supportsAttribute('foo'));
-
-        $manager = new AccessDecisionManager(array(
-            $this->getVoterSupportsAttribute(false),
-            $this->getVoterSupportsAttribute(false),
-        ));
-        $this->assertFalse($manager->supportsAttribute('foo'));
-    }
-
     /**
      * @expectedException InvalidArgumentException
      */
@@ -122,28 +92,6 @@ class AccessDecisionManagerTest extends \PHPUnit_Framework_TestCase
         $voter->expects($this->any())
               ->method('vote')
               ->will($this->returnValue($vote));
-        ;
-
-        return $voter;
-    }
-
-    protected function getVoterSupportsClass($ret)
-    {
-        $voter = $this->getMock('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface');
-        $voter->expects($this->any())
-              ->method('supportsClass')
-              ->will($this->returnValue($ret));
-        ;
-
-        return $voter;
-    }
-
-    protected function getVoterSupportsAttribute($ret)
-    {
-        $voter = $this->getMock('Symfony\Component\Security\Core\Authorization\Voter\VoterInterface');
-        $voter->expects($this->any())
-              ->method('supportsAttribute')
-              ->will($this->returnValue($ret));
         ;
 
         return $voter;


### PR DESCRIPTION
These methods are never used by Symfony. So there is no point in making
them part of the VoterInterface. Plus it is confusing to the developer who
implements it.

In fact these methods appear once in
AccessDecisionManager::suports{Attribute,Class}. But again, these
methods are never called, so I removed them to.
