### PR TITLE
$node->hasAttribute('disabled') sf2 should not create disagreement betwee

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -281,7 +281,7 @@ class Form extends Link implements \ArrayAccess
         $xpath = new \DOMXPath($document);
 
         foreach ($xpath->query('descendant::input | descendant::textarea | descendant::select', $root) as $node) {
-            if ($node->hasAttribute('disabled') || !$node->hasAttribute('name')) {
+            if (!$node->hasAttribute('name')) {
                 continue;
             }
 


### PR DESCRIPTION
$node->hasAttribute('disabled') sf2 should not create disagreement between implementation and practice for a crawler. If sahi real browser can find an element that is disabled, then sf2 should too. 
https://github.com/Behat/Mink/pull/58#issuecomment-1712459
