### PR TITLE
[FrameworkBundle] Functional tests, to test functional test simulated file uploads

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AppKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/AppKernel.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Component\HttpKernel\Util\Filesystem;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class AppKernel extends Kernel
+{
+    private $config;
+
+    public function __construct($config)
+    {
+        parent::__construct('test', true);
+
+        $fs = new Filesystem();
+        if (!$fs->isAbsolutePath($config)) {
+            $config = __DIR__.'/config/'.$config;
+        }
+
+        if (!file_exists($config)) {
+            throw new \RuntimeException(sprintf('The config file "%s" does not exist.', $config));
+        }
+
+        $this->config = $config;
+    }
+
+    public function registerBundles()
+    {
+        return array(
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Symfony\Bundle\TwigBundle\TwigBundle(),
+            new \Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\FileUploadBundle\FileUploadBundle(),
+        );
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load($this->config);
+    }
+
+    public function getCacheDir()
+    {
+        return sys_get_temp_dir().'/FrameworkBundle';
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Controller/DefaultController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Controller/DefaultController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\FileUploadBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+
+class DefaultController extends Controller
+{
+    
+    public function indexAction()
+    {
+        $files = $this->get('request')->files->all();
+        
+        return $this->render('FileUploadBundle:Default:index.html.twig', array('files' => count($files)));
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/FileUploadBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/FileUploadBundle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\FileUploadBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class FileUploadBundle extends Bundle
+{
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Resources/config/routing.yml
@@ -1,0 +1,3 @@
+FileUploadBundle_homepage:
+    pattern:  /submit
+    defaults: { _controller: FileUploadBundle:Default:index }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Resources/views/Default/index.html.twig
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Resources/views/Default/index.html.twig
@@ -1,0 +1,1 @@
+{{ files }} File

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Tests/Controller/DefaultControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/FileUploadBundle/Tests/Controller/DefaultControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\FileUploadBundle\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class DefaultControllerTest extends WebTestCase
+{
+    public function testIndex()
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', '/hello/Fabien');
+
+        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UploadTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/UploadTestCase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class UploadTestCase extends WebTestCase
+{
+    static protected function createKernel(array $options = array())
+    {
+        return new AppKernel(
+            isset($options['config']) ? $options['config'] : 'default.yml'
+        );
+    }
+
+    /**
+     * The point of this is to send this file to the upload file
+     *
+     * The route should respond with the number of files sent to it. In this case 1.
+     *
+     * @return void
+     */
+    public function testUploadFile()
+    {
+        $client = $this->createClient();
+        $crawler = $client->request(
+                         'POST',
+                         '/submit',
+                         array('name' => 'Fabien'),
+                         array('photo' => __FILE__)
+                         );
+        $this->assertEquals("1 File", $crawler->text());
+        $this->assertEquals(1, count($client->getRequest()->files->all()));
+    }
+
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/default.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/default.yml
@@ -1,0 +1,3 @@
+imports:
+    - { resource: framework.yml }
+    - { resource: twig.yml }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/framework.yml
@@ -1,0 +1,12 @@
+framework:
+    secret: test
+    test: ~
+    session:
+        storage_id: session.storage.filesystem
+    form:            true
+    csrf_protection: true
+    validation:       
+        enabled: true
+        enable_annotations: true
+    router:
+        resource: "%kernel.root_dir%/config/routing.yml"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/routing.yml
@@ -1,0 +1,2 @@
+_food_risc_account_admin:
+    resource: "@FileUploadBundle/Resources/config/routing.yml"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/twig.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/config/twig.yml
@@ -1,0 +1,7 @@
+framework:
+    templating:
+        engines: [twig, php]
+
+twig:
+    debug:            %kernel.debug%
+    strict_variables: %kernel.debug%


### PR DESCRIPTION
I have been having great difficulty testing file uploads in a Symfony app. The app code works but I can't write tests to confirm it.

The documentation states the following should work:

```
$client->request('POST', '/submit', array('name' => 'Fabien'), array('photo' => '/path/to/photo'));
```

So I've created a Functional test for the framework to test this. All I have modified is the photo path to be the test file it's self. This way I know the file exists and it removes this doubt.

I am unsure if this is even the right location for this test or if its even appropriate. But this seemed the best way to test if things are working or not.

I hope it's not a problem between keyboard and chair as it's taken me about 7 hours of chasing code down to decide to put this pull request together.
