### PR TITLE
[2.1] [TwigBundle] Allow option to avoid auto-escaping of translations.

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -23,10 +23,12 @@ use Symfony\Component\Translation\TranslatorInterface;
 class TranslationExtension extends \Twig_Extension
 {
     private $translator;
+    private $trusted;
 
-    public function __construct(TranslatorInterface $translator)
+    public function __construct(TranslatorInterface $translator, $trusted = false)
     {
         $this->translator = $translator;
+        $this->trusted = $trusted;
     }
 
     public function getTranslator()
@@ -39,9 +41,10 @@ class TranslationExtension extends \Twig_Extension
      */
     public function getFilters()
     {
+        $opts = $this->trusted ? array('is_safe' => array('html')) : array();
         return array(
-            'trans' => new \Twig_Filter_Method($this, 'trans'),
-            'transchoice' => new \Twig_Filter_Method($this, 'transchoice'),
+            'trans' => new \Twig_Filter_Method($this, 'trans', $opts),
+            'transchoice' => new \Twig_Filter_Method($this, 'transchoice', $opts),
         );
     }
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('exception_controller')->defaultValue('Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController::showAction')->end()
+                ->booleanNode('trust_translations')->defaultValue(false)->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -40,6 +40,7 @@ class TwigExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $container->setParameter('twig.exception_listener.controller', $config['exception_controller']);
+        $container->setParameter('twig.trust_translations', $config['trust_translations']);
 
         $container->setParameter('twig.form.resources', $config['form']['resources']);
         $container->getDefinition('twig.loader')->addMethodCall('addPath', array(__DIR__.'/../../../Bridge/Twig/Resources/views/Form'));
@@ -58,7 +59,8 @@ class TwigExtension extends Extension
         unset(
             $config['form'],
             $config['globals'],
-            $config['extensions']
+            $config['extensions'],
+            $config['trust_translations']
         );
 
         $container->setParameter('twig.options', $config);

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -45,6 +45,7 @@
         <service id="twig.extension.trans" class="%twig.extension.trans.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="translator" />
+            <argument>%twig.trust_translations%</argument>
         </service>
 
         <service id="twig.extension.assets" class="%twig.extension.assets.class%" public="false">


### PR DESCRIPTION
This adds a `twig.trust_translations` option. If set to true. The trans and transchoice filters don't auto-escape anymore. I like to put HTML in my translation strings, and it's pretty annoying to have to mark them all as `|raw`.

Note: This is incomplete, the trans tag should be updated as well, but I wanted feedback first.
