### PR TITLE
The option date_format was ignored when widget is single_text.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -33,8 +33,10 @@ class DateTimeType extends AbstractType
         $parts = array('year', 'month', 'day', 'hour', 'minute');
         $timeParts = array('hour', 'minute');
 
-        $format = 'Y-m-d H:i:00';
-        if ($options['with_seconds']) {
+        $format = ($options['date_format']) ? $options['date_format'] : 'Y-m-d H:i:00';
+        
+        //Only used when date_format is default
+        if ($options['with_seconds'] && is_null($options['date_format'])) {
             $format = 'Y-m-d H:i:s';
 
             $parts[] = 'second';

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -33,7 +33,7 @@ class DateTimeType extends AbstractType
         $parts = array('year', 'month', 'day', 'hour', 'minute');
         $timeParts = array('hour', 'minute');
 
-        $format = $options['date_format']?: 'Y-m-d H:i:00';
+        $format = $options['date_format'] ?: 'Y-m-d H:i:00';
         
         //Only used when date_format is default
         if ($options['with_seconds'] && $options['date_format']) { 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -33,10 +33,10 @@ class DateTimeType extends AbstractType
         $parts = array('year', 'month', 'day', 'hour', 'minute');
         $timeParts = array('hour', 'minute');
 
-        $format = ($options['date_format']) ? $options['date_format'] : 'Y-m-d H:i:00';
+        $format = $options['date_format']?: 'Y-m-d H:i:00';
         
         //Only used when date_format is default
-        if ($options['with_seconds'] && is_null($options['date_format'])) {
+        if ($options['with_seconds'] && $options['date_format']) { 
             $format = 'Y-m-d H:i:s';
 
             $parts[] = 'second';


### PR DESCRIPTION
The option date_format was ignored when widget is single_text. The option 'with_seconds' is ignored if date_format is specified.
