### PR TITLE
[Validator] change 'self::' to 'static::' for PATTERN constant overridable in child classes

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -48,7 +48,7 @@ class TimeValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (!preg_match(self::PATTERN, $value)) {
+        if (!preg_match(static::PATTERN, $value)) {
             $this->setMessage($constraint->message, array('{{ value }}' => $value));
 
             return false;

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -57,7 +57,7 @@ class UrlValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        $pattern = sprintf(self::PATTERN, implode('|', $constraint->protocols));
+        $pattern = sprintf(static::PATTERN, implode('|', $constraint->protocols));
 
         if (!preg_match($pattern, $value)) {
             $this->setMessage($constraint->message, array('{{ value }}' => $value));


### PR DESCRIPTION
In TimeValidator and UrlValidator, PATTERN constant is not used with late static bind(static::) while DateValidator supports it.
