### PR TITLE
[Form] choices ids are malformed

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -70,8 +70,7 @@ class FieldType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form)
     {
-        $name = $form->getName();
-        $name = $this->robotize($name);
+        $name = $this->robotize($form->getName());
 
         if ($view->hasParent()) {
             $parentId = $view->getParent()->get('id');

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -71,6 +71,7 @@ class FieldType extends AbstractType
     public function buildView(FormView $view, FormInterface $form)
     {
         $name = $form->getName();
+        $name = $this->robotize($name);
 
         if ($view->hasParent()) {
             $parentId = $view->getParent()->get('id');
@@ -175,5 +176,22 @@ class FieldType extends AbstractType
     private function humanize($text)
     {
         return ucfirst(strtolower(str_replace('_', ' ', $text)));
+    }
+
+    private function robotize($str, $delimiter = '-')
+    {
+        $clean = iconv('UTF-8', 'ASCII//TRANSLIT', $str);
+        $clean = preg_replace("/[^a-zA-Z0-9\/_|+ -]/", '', $clean);
+        $clean = strtolower(trim($clean, '-'));
+        $clean = preg_replace("/[\/_|+ -]+/", $delimiter, $clean);
+
+        // this is used to keep the 1st underscore for _token
+        // but i guess it would be better to name it "-token" to keep things
+        // consistent
+        if ($clean{0} === '-') {
+            $clean{0} = '_';
+        }
+
+        return $clean;
     }
 }


### PR DESCRIPTION
Choices ids are not malformed, they should be normalized (slugged)

When using this...

``` php
<?php

$builder
    ->add('color', 'choice', array(
        'choices' => array(
            ($k = 'The color #1') => $k,
            ($k = 'The color #2') => $k,
            ($k = 'The color #3') => $k,
        ),
        'expanded' => true,
    ))
;
```

I get this...

``` html
<div id="form_color">
    <input type="radio" id="form_color_The color #1" name="form[color]" required="required" value="The color #1">
    <label for="form_color_The color #1" class="required">The color #1</label>

    <input type="radio" id="form_color_The color #2" name="form[color]" required="required" value="The color #2">
    <label for="form_color_The color #2" class="required">The color #2</label>

    <input type="radio" id="form_color_The color #3" name="form[color]" required="required" value="The color #3">
    <label for="form_color_The color #3" class="required">The color #3</label>
</div>
```

Instead of this...

``` html
<div id="form_color">
    <input type="radio" id="form_color_the-color-1" name="form[color]" required="required" value="The color #1">
    <label for="form_color_the-color-1" class="required">The color #1</label>

    <input type="radio" id="form_color_the-color-2" name="form[color]" required="required" value="The color #2">
    <label for="form_color_the-color-2" class="required">The color #2</label>

    <input type="radio" id="form_color_the-color-3" name="form[color]" required="required" value="The color #3">
    <label for="form_color_the-color-3" class="required">The color #3</label>
</div>
```

NB: Things would be easier to implement/test with a new standalone Inflector Component (with dasheize, pluralize, humanize ... functions)
