### PR TITLE
[DoctrineBundle] Adding a message in doctrine:generate:entities to notify

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -102,9 +102,16 @@ EOT
         }
 
         $generator = $this->getEntityGenerator();
-        $generator->setBackupExisting(!$input->getOption('no-backup'));
+
+        $backupExisting = !$input->getOption('no-backup');
+        $generator->setBackupExisting($backupExisting);
+
         $repoGenerator = new EntityRepositoryGenerator();
         foreach ($metadata->getMetadata() as $m) {
+            if ($backupExisting) {
+                $basename = substr($m->name, strrpos($m->name, '\\') + 1);
+                $output->writeln(sprintf('  > backing up <comment>%s.php</comment> to <comment>%s.php~</comment>', $basename, $basename));
+            }
             $output->writeln(sprintf('  > generating <comment>%s</comment>', $m->name));
             $generator->generate(array($m), $metadata->getPath());
 


### PR DESCRIPTION
Hey guys!

This adds a message to the doctrine:generate:entities command when a backup file is created. This is because the backup file causes confusion in some cases (where did it come from?) and in rare cases - for reasons I don't know yet - the backup file causes "Cannot redeclare class ..." errors.

This is a not a BC-break, but of course could potentially cause an issue if there's some edge case that line 112 doesn't consider. For that reason, I'm pulling against master instead of 2.0.

Thanks!
