### PR TITLE
[FrameworkBundle] Adding information about env being cleared

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -61,6 +61,9 @@ EOF
             throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $realCacheDir));
         }
 
+        $kernel = $this->getContainer()->get('kernel');
+        $output->writeln(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
         if ($input->getOption('no-warmup')) {
             rename($realCacheDir, $oldCacheDir);
         } else {


### PR DESCRIPTION
Hey guys!

I think the `cache:clear` confuses some people - they're expecting it to wipe out any and all cache (not just the cache for a specific env+debug mode). So, this adds details on _what_ is being cleared, which should at least help.

I'll also put more information into the docs.

Thanks!
