### PR TITLE
[DomCrawler] fix finding charset in addContent

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -92,6 +92,9 @@ class Crawler extends \SplObjectStorage
         $charset = 'ISO-8859-1';
         if (false !== $pos = strpos($type, 'charset=')) {
             $charset = substr($type, $pos + 8);
+            if (false !== $pos = strpos($charset, ';')) {
+                $charset = substr($charset, 0, $pos);
+            }
         }
 
         if ('x' === $matches[1]) {

--- a/tests/Symfony/Tests/Component/DomCrawler/CrawlerTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/CrawlerTest.php
@@ -90,6 +90,10 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $crawler->filter('div')->attr('class'), '->addContent() adds nodes from an HTML string');
 
         $crawler = new Crawler();
+        $crawler->addContent('<html><div class="foo"></html>', 'text/html; charset=UTF-8; dir=RTL');
+        $this->assertEquals('foo', $crawler->filter('div')->attr('class'), '->addContent() adds nodes from an HTML string with extended content type');
+
+        $crawler = new Crawler();
         $crawler->addContent('<html><div class="foo"></html>');
         $this->assertEquals('foo', $crawler->filter('div')->attr('class'), '->addContent() uses text/html as the default type');
 


### PR DESCRIPTION
According to http://www.ietf.org/rfc/rfc2045.txt content type can include other field after charset. So they should be cut.
