### PR TITLE
[Route] Treat defaults enclosed between % as parameters from dic

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -50,8 +50,32 @@ class Router extends BaseRouter
     {
         if (null === $this->collection) {
             $this->collection = $this->container->get('routing.loader')->load($this->resource, $this->options['resource_type']);
+            $this->applyParameters($this->collection);
         }
 
         return $this->collection;
+    }
+
+    /**
+     * Apply parameters from dic as defaults for a routes
+     *
+     * @param $collection
+     * @return void
+     */
+    private function applyParameters($collection)
+    {
+        foreach ($collection as &$route) {
+            if (is_array($route) || $route instanceof \Traversable ) {
+                $this->applyParameters($route);
+            } else {
+                $defaults = $route->getDefaults();
+                foreach ($defaults as $name => $value) {
+                    if (preg_match('#^%(.+)%$#', $value, $matches)) {
+                        $route->setDefault($name, $this->container->getParameter($matches[1]));
+                    }
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
This allows as to define default like this

foo:
    pattern:  /{_locale}/login
    defaults:
        _controller: my_login_controller:loginAction
        _locale: %session.default_locale%
