### PR TITLE
[Validator] UniqueEntityValidator should convert any DateTime object to string with the right format or else the PDOStatement will fail.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -17,6 +17,8 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 use Symfony\Component\Validator\ConstraintValidator;
 
+use Doctrine\DBAL\Types\Type;
+
 /**
  * Unique Entity Validator checks if one or a set of fields contain unique values.
  *
@@ -69,6 +71,14 @@ class UniqueEntityValidator extends ConstraintValidator
 
             if ($criteria[$fieldName] === null) {
                 return true;
+            }
+
+            $fieldType = $class->getTypeOfField($fieldName);
+
+            if (in_array($fieldType, array(Type::DATETIME, Type::DATETIMETZ, Type::DATE, Type::TIME))) {
+                $platform = $em->getConnection()->getDatabasePlatform();
+                $getFormatString = 'get'.Type::getType($fieldType).'FormatString';
+                $criteria[$fieldName] = $criteria[$fieldName]->format($platform->$getFormatString());
             }
         }
 


### PR DESCRIPTION
If you use the Doctrine assert `UniqueEntity` on a date type field every validation attempt will fail because the `DateTime` object is sent _as is_ to the PDOStatement.

A correctly formatted string with the database platform's field type format should be used instead.
