### PR TITLE
[HttpFoundation] Saving session data in __destroy() has a side effect on functional tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -29,6 +29,7 @@ class Session implements \Serializable
     protected $oldFlashes;
     protected $locale;
     protected $defaultLocale;
+    protected $saved;
 
     /**
      * Constructor.
@@ -46,6 +47,7 @@ class Session implements \Serializable
         $this->attributes = array();
         $this->setPhpDefaultLocale($this->defaultLocale);
         $this->started = false;
+        $this->saved = false;
     }
 
     /**
@@ -356,11 +358,12 @@ class Session implements \Serializable
             'flashes'    => $this->flashes,
             'locale'     => $this->locale,
         ));
+        $this->saved = true;
     }
 
     public function __destruct()
     {
-        if (true === $this->started) {
+        if (true === $this->started && !$this->saved) {
             $this->save();
         }
     }


### PR DESCRIPTION
Having functional test with several non-insulated requests, TestSessionListener invokes session saving at the end of every request. But instance of Session remains in memory until it's collected by garbage collector which saves the same data again in __destroy() method. The problem is that session object can get collected after other requests changed session data (e. g. user logged in) resulting in former data overwriting the latter.
