### PR TITLE
[ClassLoader] Optimization: conditions that do not belong in some loops

### DIFF
--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -220,8 +220,8 @@ class UniversalClassLoader
             // namespaced class name
             $namespace = substr($class, 0, $pos);
             foreach ($this->namespaces as $ns => $dirs) {
-                foreach ($dirs as $dir) {
-                    if (0 === strpos($namespace, $ns)) {
+                if (0 === strpos($namespace, $ns)) {
+                    foreach ($dirs as $dir) {
                         $className = substr($class, $pos + 1);
                         $file = $dir.DIRECTORY_SEPARATOR.str_replace('\\', DIRECTORY_SEPARATOR, $namespace).DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $className).'.php';
                         if (file_exists($file)) {
@@ -240,8 +240,8 @@ class UniversalClassLoader
         } else {
             // PEAR-like class name
             foreach ($this->prefixes as $prefix => $dirs) {
-                foreach ($dirs as $dir) {
-                    if (0 === strpos($class, $prefix)) {
+                if (0 === strpos($class, $prefix)) {
+                    foreach ($dirs as $dir) {
                         $file = $dir.DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $class).'.php';
                         if (file_exists($file)) {
                             return $file;


### PR DESCRIPTION
Why are these foreachs outside the condition of verification of the namespace?

Should not it be better that the conditions are outside of these foreachs, since these conditions will always return the same result for any item covered by these foreachs?

Cheers
