### PR TITLE
[2.2] [Form] Added form type "entity_identifier" (#1946)

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/OneEntityToIdTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/OneEntityToIdTransformer.php
@@ -28,12 +28,13 @@ class OneEntityToIdTransformer implements DataTransformerInterface
 
     public function __construct(EntityManager $em, $class, $queryBuilder)
     {
-        if (!(null === $queryBuilder || $queryBuilder instanceof \Closure)) {
+        if (null !== $queryBuilder && ! $queryBuilder instanceof \Closure) {
             throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder or \Closure');
         } 
 
-        if (null == $class)
+        if (null === $class) {
             throw new UnexpectedTypeException($class, 'string');
+        }
 
         $this->em = $em;
         $this->class = $class;
@@ -45,13 +46,15 @@ class OneEntityToIdTransformer implements DataTransformerInterface
      */
     public function transform($data)
     {
-        if (null === $data)
+        if (null === $data) {
             return null;
+        }
 
         $meta = $this->em->getClassMetadata($this->class);
 
-        if (!$meta->getReflectionClass()->isInstance($data))
+        if (!$meta->getReflectionClass()->isInstance($data)) {
             throw new TransformationFailedException('Invalid data, must be an instance of '.$this->class);
+        }
 
         $identifierField = $meta->getSingleIdentifierFieldName();
         $id = $meta->getReflectionProperty($identifierField)->getValue($data);
@@ -69,8 +72,7 @@ class OneEntityToIdTransformer implements DataTransformerInterface
         }
 
         $em = $this->em;
-        $class = $this->class;
-        $repository = $em->getRepository($class);
+        $repository = $em->getRepository($this->class);
 
         if ($qb = $this->queryBuilder) {
             // If a closure was passed, call id with the repository and the id
@@ -88,8 +90,9 @@ class OneEntityToIdTransformer implements DataTransformerInterface
             $result = $repository->find($data);
         }
 
-        if (!$result)
+        if (!$result) {
             throw new TransformationFailedException('Can not find entity');
+        }
 
         return $result;
     }

--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/OneEntityToIdTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/OneEntityToIdTransformer.php
@@ -34,7 +34,7 @@ class OneEntityToIdTransformer implements DataTransformerInterface
     public function __construct(EntityManager $em, $class, $property, $queryBuilder)
     {
         if (null !== $queryBuilder && ! $queryBuilder instanceof \Closure) {
-            throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder or \Closure');
+            throw new UnexpectedTypeException($queryBuilder, '\Closure');
         } 
 
         if (null === $class) {
@@ -84,10 +84,8 @@ class OneEntityToIdTransformer implements DataTransformerInterface
         $repository = $em->getRepository($this->class);
 
         if ($qb = $this->queryBuilder) {
-            // If a closure was passed, call id with the repository and the id
-            if ($qb instanceof \Closure) {
-                $qb = $qb($repository, $data);
-            }
+            // Call the closure with the repository and the id
+            $qb = $qb($repository, $data);
 
             try {
                 $result = $qb->getQuery()->getSingleResult();

--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/OneEntityToIdTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/OneEntityToIdTransformer.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Form\DataTransformer;
+
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\NoResultException;
+
+class OneEntityToIdTransformer implements DataTransformerInterface
+{
+    private $em;
+    private $class;
+    private $queryBuilder;
+
+    public function __construct(EntityManager $em, $class, $queryBuilder)
+    {
+        if (!(null === $queryBuilder || $queryBuilder instanceof \Closure)) {
+            throw new UnexpectedTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder or \Closure');
+        } 
+
+        if (null == $class)
+            throw new UnexpectedTypeException($class, 'string');
+
+        $this->em = $em;
+        $this->class = $class;
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    /**
+     * Fetch the id of the entity to populate the form
+     */
+    public function transform($data)
+    {
+        if (null === $data)
+            return null;
+
+        $meta = $this->em->getClassMetadata($this->class);
+
+        if (!$meta->getReflectionClass()->isInstance($data))
+            throw new TransformationFailedException('Invalid data, must be an instance of '.$this->class);
+
+        $identifierField = $meta->getSingleIdentifierFieldName();
+        $id = $meta->getReflectionProperty($identifierField)->getValue($data);
+
+        return $id;
+    }
+
+    /**
+     * Try to fetch the entity from its id in the database
+     */
+    public function reverseTransform($data)
+    {
+        if (!$data) {
+            return null;
+        }
+
+        $em = $this->em;
+        $class = $this->class;
+        $repository = $em->getRepository($class);
+
+        if ($qb = $this->queryBuilder) {
+            // If a closure was passed, call id with the repository and the id
+            if ($qb instanceof \Closure) {
+                $qb = $qb($repository, $data);
+            }
+
+            try {
+                $result = $qb->getQuery()->getSingleResult();
+            } catch (NoResultException $e) {
+                $result = null;
+            }
+        } else {
+            // Defaults to find()
+            $result = $repository->find($data);
+        }
+
+        if (!$result)
+            throw new TransformationFailedException('Can not find entity');
+
+        return $result;
+    }
+}
+

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
@@ -18,18 +18,20 @@ use Symfony\Component\Form\AbstractType;
 
 class EntityIdType extends AbstractType
 {
-    protected $em;
+    protected $registry;
 
     public function __construct(RegistryInterface $registry)
     {
-        $this->em = $registry->getEntityManager();
+        $this->registry = $registry;
     }
 
     public function buildForm(FormBuilder $builder, array $options)
     {
-        $em = $options['em'] ?: $this->em;
-
-        $builder->prependClientTransformer(new OneEntityToIdTransformer($em, $options['class'], $options['query_builder']));
+        $builder->prependClientTransformer(new OneEntityToIdTransformer(
+            $this->registry->getEntityManager($options['em']),
+            $options['class'], 
+            $options['query_builder']
+        ));
     }
 
     public function getDefaultOptions(array $options)

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
@@ -48,6 +48,10 @@ class EntityIdType extends AbstractType
 
         $options = array_replace($defaultOptions, $options);
 
+        if (null === $options['class']) {
+            throw new \RunTimeException('You must provide a class option for the entity_id field');
+        }  
+
         return $defaultOptions;
     }
 

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Form\Type;
+
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Bridge\Doctrine\RegistryInterface;
+use Symfony\Bridge\Doctrine\Form\DataTransformer\OneEntityToIdTransformer;
+use Symfony\Component\Form\AbstractType;
+
+class EntityIdType extends AbstractType
+{
+    protected $em;
+
+    public function __construct(RegistryInterface $registry)
+    {
+        $this->em = $registry->getEntityManager();
+    }
+
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $em = $options['em'] ?: $this->em;
+
+        $builder->prependClientTransformer(new OneEntityToIdTransformer($em, $options['class'], $options['query_builder']));
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        $defaultOptions = array(
+            'required'          => true,
+            'em'                => null,
+            'class'             => null,
+            'query_builder'     => null,
+            'hidden'            => true
+        );
+
+        $options = array_replace($defaultOptions, $options);
+
+        return $defaultOptions;
+    }
+
+    public function getParent(array $options)
+    {
+        return $options['hidden'] ? 'hidden' : 'field';
+    }
+
+    public function getName()
+    {
+        return 'entity_id';
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormBuilder;
 use Symfony\Bridge\Doctrine\RegistryInterface;
 use Symfony\Bridge\Doctrine\Form\DataTransformer\OneEntityToIdTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Exception\FormException;
 
 class EntityIdType extends AbstractType
 {
@@ -49,7 +50,7 @@ class EntityIdType extends AbstractType
         $options = array_replace($defaultOptions, $options);
 
         if (null === $options['class']) {
-            throw new \RunTimeException('You must provide a class option for the entity_id field');
+            throw new FormException('You must provide a class option for the entity_id field');
         }  
 
         return $defaultOptions;

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdType.php
@@ -30,6 +30,7 @@ class EntityIdType extends AbstractType
         $builder->prependClientTransformer(new OneEntityToIdTransformer(
             $this->registry->getEntityManager($options['em']),
             $options['class'], 
+            $options['property'],
             $options['query_builder']
         ));
     }
@@ -41,6 +42,7 @@ class EntityIdType extends AbstractType
             'em'                => null,
             'class'             => null,
             'query_builder'     => null,
+            'property'          => null,
             'hidden'            => true
         );
 

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdentifierType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityIdentifierType.php
@@ -17,7 +17,7 @@ use Symfony\Bridge\Doctrine\Form\DataTransformer\OneEntityToIdTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Exception\FormException;
 
-class EntityIdType extends AbstractType
+class EntityIdentifierType extends AbstractType
 {
     protected $registry;
 
@@ -50,7 +50,7 @@ class EntityIdType extends AbstractType
         $options = array_replace($defaultOptions, $options);
 
         if (null === $options['class']) {
-            throw new FormException('You must provide a class option for the entity_id field');
+            throw new FormException('You must provide a class option for the entity_identifier field');
         }  
 
         return $defaultOptions;
@@ -63,6 +63,6 @@ class EntityIdType extends AbstractType
 
     public function getName()
     {
-        return 'entity_id';
+        return 'entity_identifier';
     }
 }

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -58,6 +58,11 @@
             <argument type="service" id="doctrine" />
         </service>
 
+        <service id="form.type.entity_id" class="Symfony\Bridge\Doctrine\Form\Type\EntityIdType">
+            <tag name="form.type" alias="entity_id" />
+            <argument type="service" id="doctrine" />
+        </service>
+
         <service id="doctrine.orm.configuration" class="%doctrine.orm.configuration.class%" abstract="true" public="false" />
 
         <service id="doctrine.orm.entity_manager.abstract" class="%doctrine.orm.entity_manager.class%" factory-class="%doctrine.orm.entity_manager.class%" factory-method="create" abstract="true" />

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -58,8 +58,8 @@
             <argument type="service" id="doctrine" />
         </service>
 
-        <service id="form.type.entity_id" class="Symfony\Bridge\Doctrine\Form\Type\EntityIdType">
-            <tag name="form.type" alias="entity_id" />
+        <service id="form.type.entity_identifier" class="Symfony\Bridge\Doctrine\Form\Type\EntityIdentifierType">
+            <tag name="form.type" alias="entity_identifier" />
             <argument type="service" id="doctrine" />
         </service>
 


### PR DESCRIPTION
(You can have a look at the issue #1946)

The "entity_id" type allow you to do things such:

``` javascript
        $builder->add('city', 'entity_id', array(
            'query_builder' => function($repository, $id) {
                return $repository->createQueryBuilder('c')
                    ->where('c.id = :id AND c.available = 1')
                    ->setParameter('id', $id);
            },  
            'class' => 'Gregwar\TestBundle\Entity\City',
            'required' => false,
            'hidden' => true
        )); 
```

So, with some JS logics and UI, you can fill the field directly using the entity id.

If you pass hidden => false, a text input will be rendered, which can allow an user to provide the id manually.

If you don't pass a query_builder closure, ->find() will be used.
