### PR TITLE
[Security] Fixed incorrect merge of two modifications to AclVoter

### DIFF
--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -82,14 +82,13 @@ class AclVoter implements VoterInterface
                     $this->logger->debug(sprintf('Object identity unavailable. Voting to %s', $this->allowIfObjectIdentityUnavailable? 'grant access' : 'abstain'));
                 }
 
-                if (!$this->supportsClass($oid->getType())) {
-                    return self::ACCESS_ABSTAIN;
-                }
-
-                $sids = $this->securityIdentityRetrievalStrategy->getSecurityIdentities($token);
-
                 return $this->allowIfObjectIdentityUnavailable ? self::ACCESS_GRANTED : self::ACCESS_ABSTAIN;
             }
+
+            if (!$this->supportsClass($oid->getType())) {
+                return self::ACCESS_ABSTAIN;
+            }
+
             $sids = $this->securityIdentityRetrievalStrategy->getSecurityIdentities($token);
 
             try {


### PR DESCRIPTION
It seems two modifications to `AclVoter` (53f5c23c and 85199677) have been merged incorrectly, leading to a method call on an object that is known to be `null` and a fatal error when running the tests
