### PR TITLE
Chain user provider doesn't search in all user providers

### DIFF
--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -60,15 +60,16 @@ class ChainUserProvider implements UserProviderInterface
             } catch (UnsupportedUserException $unsupported) {
                 // try next one
             } catch (UsernameNotFoundException $notFound) {
-                // try next one
                 $supportedUserFound = true;
+                // try next one
             }
         }
         
-        if ($supportedUserFound)
+        if ($supportedUserFound) {
             throw new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
-        else
+        } else {
             throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -52,15 +52,23 @@ class ChainUserProvider implements UserProviderInterface
      */
     public function refreshUser(UserInterface $user)
     {
+        $supportedUserFound = false;
+
         foreach ($this->providers as $provider) {
             try {
                 return $provider->refreshUser($user);
             } catch (UnsupportedUserException $unsupported) {
                 // try next one
+            } catch (UsernameNotFoundException $notFound) {
+                // try next one
+                $supportedUserFound = true;
             }
         }
-
-        throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
+        
+        if ($supportedUserFound)
+            throw new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
+        else
+            throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
     }
 
     /**


### PR DESCRIPTION
I commit these changes because Chain user provider doesn't search in all user providers.

Example with the Acme/DemoBundle:

```
// security.yml
...
    providers:
        chain_provider:
            providers: [in_memory, in_memory_extend]
        in_memory_extend:
            users:
                admin2: { password: adminpass2, roles: [ 'ROLE_ADMIN' ] }
        in_memory:
            users:
                user:  { password: userpass, roles: [ 'ROLE_USER' ] }
...
    firewalls:
...
        secured_area:
            pattern:    ^/demo/secured/
            provider: chain_provider OR in_memory_extend
...
```

We can see these logs :

```
security.INFO: User "admin2" has been authenticated successfully [] []
security.DEBUG: Write SecurityContext in the session [] []
security.DEBUG: Read SecurityContext from the session [] []
security.DEBUG: Reloading user from user provider. [] []
security.WARNING: Username "admin2" could not be found. [] []
```

The new code search in others user providers when a user is not found in the first user provider and throws the right exception.
