### PR TITLE
NotBlank constraint should be using the `empty` language construct

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -31,7 +31,7 @@ class NotBlankValidator extends ConstraintValidator
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (empty($value) && 0 !== $value && 0.0 !== $value && '0' !== $value) {
+        if (false === $value || (empty($value) && '0' != $value)) {
             $this->setMessage($constraint->message);
 
             return false;

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -31,7 +31,7 @@ class NotBlankValidator extends ConstraintValidator
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (empty($value)) {
+        if (empty($value) && 0 !== $value && '0' !== $value) {
             $this->setMessage($constraint->message);
 
             return false;

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -31,7 +31,7 @@ class NotBlankValidator extends ConstraintValidator
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value || '' === $value) {
+        if (empty($value)) {
             $this->setMessage($constraint->message);
 
             return false;

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -31,7 +31,7 @@ class NotBlankValidator extends ConstraintValidator
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (empty($value) && 0 !== $value && '0' !== $value) {
+        if (empty($value) && 0 !== $value && 0.0 !== $value && '0' !== $value) {
             $this->setMessage($constraint->message);
 
             return false;

--- a/tests/Symfony/Tests/Component/Validator/Constraints/NotBlankValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/NotBlankValidatorTest.php
@@ -41,7 +41,8 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
         return array(
             array('foobar'),
             array(0),
-            array(false),
+            array(0.0),
+            array('0'),
             array(1234),
         );
     }
@@ -56,6 +57,16 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->validator->isValid('', new NotBlank()));
     }
 
+    public function testFalseIsInvalid()
+    {
+        $this->assertFalse($this->validator->isValid(false, new NotBlank()));
+    }
+
+    public function testEmptyArrayIsInvalid()
+    {
+        $this->assertFalse($this->validator->isValid(array(), new NotBlank()));
+    }
+
     public function testSetMessage()
     {
         $constraint = new NotBlank(array(
@@ -67,3 +78,4 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->validator->getMessageParameters(), array());
     }
 }
+

--- a/tests/Symfony/Tests/Component/Validator/Constraints/NotBlankValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/NotBlankValidatorTest.php
@@ -29,14 +29,14 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getInvalidValues
+     * @dataProvider getValidValues
      */
-    public function testInvalidValues($date)
+    public function testValidValues($date)
     {
         $this->assertTrue($this->validator->isValid($date, new NotBlank()));
     }
 
-    public function getInvalidValues()
+    public function getValidValues()
     {
         return array(
             array('foobar'),


### PR DESCRIPTION
Per the [documentation](http://symfony.com/doc/2.0/reference/constraints/NotBlank.html), the **NotBlank** constraint should be using the `empty` language construct, otherwise it will not trigger on, for example, a boolean false from an unchecked checkbox field.

This becomes necessary since a checkbox _defaults_ to a boolean true (checked) or false (unchecked), but can also be set to a non-boolean string value when checked.
