### PR TITLE
[DoctrineBundle] Tries to auto-generate the missing proxy files on the autoloaded

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -42,12 +42,37 @@ class DoctrineBundle extends Bundle
         if ($this->container->hasParameter('doctrine.orm.proxy_namespace')) {
             $namespace = $this->container->getParameter('doctrine.orm.proxy_namespace');
             $dir = $this->container->getParameter('doctrine.orm.proxy_dir');
+            $doctrine = $this->container->get('doctrine');
 
-            spl_autoload_register(function($class) use ($namespace, $dir) {
+            spl_autoload_register(function($class) use ($namespace, $dir, $doctrine) {
                 if (0 === strpos($class, $namespace)) {
                     $className = substr($class, strlen($namespace) +1);
                     $file = $dir.DIRECTORY_SEPARATOR.$className.'.php';
 
+                    if (!file_exists($file)) {
+                        // Tries to auto-generate the proxy file
+                        if (preg_match('/^(.+)\\\\([a-z0-9_]+)Proxy$/i', $class, $matches)) {
+                            $className = $matches[2];
+
+                            foreach ($doctrine->getEntityManagers() as $em) {
+                                $em = $doctrine->getEntityManager();
+
+                                if ($em->getConfiguration()->getAutoGenerateProxyClasses()) {
+
+                                    $classes = $em->getMetadataFactory()->getAllMetadata();
+                                    foreach ($classes as $class) 
+                                    {
+                                        $name = str_replace('\\', '', $class->name);
+
+                                        if ($name == $className) {
+                                            $em->getProxyFactory()->generateProxyClasses(array($class));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    
                     if (!file_exists($file)) {
                         throw new \RuntimeException(sprintf('The proxy file "%s" does not exist. If you still have objects serialized in the session, you need to clear the session manually.', $file));
                     }

--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -57,10 +57,9 @@ class DoctrineBundle extends Bundle
                         foreach ($registry->getEntityManagers() as $em) {
 
                             if ($em->getConfiguration()->getAutoGenerateProxyClasses()) {
-
                                 $classes = $em->getMetadataFactory()->getAllMetadata();
-                                foreach ($classes as $class) 
-                                {
+
+                                foreach ($classes as $class) {
                                     $name = str_replace('\\', '', $class->name);
 
                                     if ($name == $originalClassName) {


### PR DESCRIPTION
See:
https://github.com/symfony/symfony/issues/1965
https://github.com/symfony/symfony/issues/1535

This fix is not really clean and there's maybe a factorizing work to do on it, but this work and avoid me spending my day deleting session cookies each time I clear cache.
