### PR TITLE
Extend email validation according to RFC 5322

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -22,4 +22,5 @@ class Email extends Constraint
 {
     public $message = 'This value is not a valid email address';
     public $checkMX = false;
+    public $multiple = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -21,6 +21,7 @@ use Symfony\Component\Validator\Constraint;
 class Email extends Constraint
 {
     public $message = 'This value is not a valid email address';
+    public $messageMultiple = 'This value is not a list of valid email addresses.';
     public $checkMX = false;
     public $multiple = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -23,5 +23,6 @@ class Email extends Constraint
     public $message = 'This value is not a valid email address';
     public $messageMultiple = 'This value is not a list of valid email addresses.';
     public $checkMX = false;
+    public $separator = ',';
     public $multiple = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -61,7 +61,11 @@ class EmailValidator extends ConstraintValidator
         }
 
         if (!$valid) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            if ($constraint->multiple) {
+                $this->setMessage($constraint->messageMultiple, array('{{ value }}' => $value));
+            } else {
+                $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            }
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @api
@@ -43,8 +44,14 @@ class EmailValidator extends ConstraintValidator
         $value = (string) $value;
 
         if ($constraint->multiple) {
+            // Check the separator.
+            if (null === $constraint->separator || '' === $constraint->separator) {
+                throw new ConstraintDefinitionException('The separator must neither be null nor an empty string.');
+            }
+            $separator = trim(strval($constraint->separator));
+            
             // Split into pieces and validate each part.
-            $parts = explode(',', $value);
+            $parts = explode($separator, $value);
             $valid = true;
             foreach ($parts as $part) {
                 $part = trim($part);

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -43,18 +43,20 @@ class EmailValidator extends ConstraintValidator
         $value = (string) $value;
 
         if ($constraint->multiple) {
+            // Split into pieces and validate each part.
             $parts = explode(',', $value);
             $valid = true;
             foreach ($parts as $part) {
+                $part = trim($part);
+
                 if ('' === $part) {
                     $valid = false;
-                }
-                else {
+                } else {
                     $valid = $valid && $this->checkAddress($part, $constraint);
                 }
             }
-        }
-        else {
+        } else {
+            // Validate a single address.
             $valid = $this->checkAddress($value, $constraint);
         }
 
@@ -107,4 +109,5 @@ class EmailValidator extends ConstraintValidator
     {
         return checkdnsrr($host, 'MX');
     }
+
 }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -41,6 +41,42 @@ class EmailValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
+
+        if ($constraint->multiple) {
+            $parts = explode(',', $value);
+            $valid = true;
+            foreach ($parts as $part) {
+                if ('' === $part) {
+                    $valid = false;
+                }
+                else {
+                    $valid = $valid && $this->checkAddress($part, $constraint);
+                }
+            }
+        }
+        else {
+            $valid = $this->checkAddress($value, $constraint);
+        }
+
+        if (!$valid) {
+            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check a single address for validity.
+     *
+     * @param mixed      $value      The address that should be checked
+     * @param Constraint $constraint The constraint for the validation
+     *
+     * @return Boolean Whether or not the address is valid
+     */
+    private function checkAddress($value, Constraint $constraint)
+    {
         $valid = filter_var($value, FILTER_VALIDATE_EMAIL);
 
         if ($valid) {
@@ -57,13 +93,7 @@ class EmailValidator extends ConstraintValidator
             }
         }
 
-        if (!$valid) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
-
-            return false;
-        }
-
-        return true;
+        return $valid;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
@@ -78,6 +78,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
             array('example@localhost'),
             array('example@example.com@example.com'),
             array('fabien@symfony.com,example@example.co.uk'),
+            array('fabien@symfony.com,example'),
         );
     }
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
@@ -46,14 +46,14 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getValidEmails
+     * @dataProvider getValidEmailsSingle
      */
-    public function testValidEmails($email)
+    public function testValidEmailsSingle($email)
     {
         $this->assertTrue($this->validator->isValid($email, new Email()));
     }
 
-    public function getValidEmails()
+    public function getValidEmailsSingle()
     {
         return array(
             array('fabien@symfony.com'),
@@ -63,20 +63,68 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider getInvalidEmails
+     * @dataProvider getInvalidEmailsSingle
      */
-    public function testInvalidEmails($email)
+    public function testInvalidEmailsSingle($email)
     {
         $this->assertFalse($this->validator->isValid($email, new Email()));
     }
 
-    public function getInvalidEmails()
+    public function getInvalidEmailsSingle()
     {
         return array(
             array('example'),
             array('example@'),
             array('example@localhost'),
             array('example@example.com@example.com'),
+            array('fabien@symfony.com,example@example.co.uk'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidEmailsMultiple
+     */
+    public function testValidEmailsMultiple($email)
+    {
+        $constraint = new Email(array(
+            'multiple' => true,
+        ));
+        $this->assertTrue($this->validator->isValid($email, $constraint));
+    }
+
+    public function getValidEmailsMultiple()
+    {
+        return array(
+            array('fabien@symfony.com'),
+            array('example@example.co.uk'),
+            array('fabien_potencier@example.fr'),
+            array('fabien@symfony.com,fabien_potencier@example.fr'),
+            array('example@example.co.uk,fabien@symfony.com'),
+            array('fabien_potencier@example.fr,example@example.co.uk'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidEmailsMultiple
+     */
+    public function testInvalidEmailsMultiple($email)
+    {
+        $constraint = new Email(array(
+            'multiple' => true,
+        ));
+        $this->assertFalse($this->validator->isValid($email, $constraint));
+    }
+
+    public function getInvalidEmailsMultiple()
+    {
+        return array(
+            array('example'),
+            array('example@'),
+            array('example@localhost'),
+            array('example@localhost,example@example.co.uk'),
+            array('example@example.com@example.com'),
+            array('fabien@symfony.com,example'),
+            array('fabien_potencier@example.fr,example@example.co.uk,'),
         );
     }
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/EmailValidatorTest.php
@@ -85,10 +85,11 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getValidEmailsMultiple
      */
-    public function testValidEmailsMultiple($email)
+    public function testValidEmailsMultiple($separator, $email)
     {
         $constraint = new Email(array(
             'multiple' => true,
+            'separator' => $separator,
         ));
         $this->assertTrue($this->validator->isValid($email, $constraint));
     }
@@ -96,22 +97,23 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
     public function getValidEmailsMultiple()
     {
         return array(
-            array('fabien@symfony.com'),
-            array('example@example.co.uk'),
-            array('fabien_potencier@example.fr'),
-            array('fabien@symfony.com,fabien_potencier@example.fr'),
-            array('example@example.co.uk,fabien@symfony.com'),
-            array('fabien_potencier@example.fr,example@example.co.uk'),
+            array(',', 'fabien@symfony.com'),
+            array(';', 'fabien_potencier@example.fr'),
+            array('|', 'example@example.co.uk'),
+            array(',', 'fabien@symfony.com,fabien_potencier@example.fr'),
+            array(';', 'example@example.co.uk; fabien@symfony.com'),
+            array(' | ', 'fabien_potencier@example.fr |example@example.co.uk'),
         );
     }
 
     /**
      * @dataProvider getInvalidEmailsMultiple
      */
-    public function testInvalidEmailsMultiple($email)
+    public function testInvalidEmailsMultiple($separator, $email)
     {
         $constraint = new Email(array(
             'multiple' => true,
+            'separator' => $separator,
         ));
         $this->assertFalse($this->validator->isValid($email, $constraint));
     }
@@ -119,14 +121,26 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
     public function getInvalidEmailsMultiple()
     {
         return array(
-            array('example'),
-            array('example@'),
-            array('example@localhost'),
-            array('example@localhost,example@example.co.uk'),
-            array('example@example.com@example.com'),
-            array('fabien@symfony.com,example'),
-            array('fabien_potencier@example.fr,example@example.co.uk,'),
+            array(',', 'example'),
+            array(',', 'example@'),
+            array(',', 'example@localhost'),
+            array(';', 'example@localhost;example@example.co.uk'),
+            array(';', 'example@example.com@example.com'),
+            array('|', 'fabien@symfony.com|example'),
+            array(',', 'fabien_potencier@example.fr,example@example.co.uk,'),
+            array(',', 'fabien_potencier@example.fr|example@example.co.uk'),
         );
+    }
+
+    public function testExpectsNotEmptySeparator()
+    {
+        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+
+        $constraint = new Email(array(
+            'multiple' => true,
+            'separator' => null,
+        ));
+        $this->validator->isValid('example@example.co.uk,fabien@symfony.com', $constraint);
     }
 
     public function testMessageIsSet()


### PR DESCRIPTION
Make it possible to validate a list of email addresses as specified in RFC 5322, section 3.4 (i.e. have multiple email addresses separated by comma).
