### PR TITLE
[Fix] Email() constraints now guess as 'email' field type

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -144,7 +144,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 );
             case 'Symfony\Component\Validator\Constraints\Email':
                 return new TypeGuess(
-                    'text',
+                    'email',
                     array(),
                     Guess::HIGH_CONFIDENCE
                 );


### PR DESCRIPTION
I don't know what this was set to "text"
