### PR TITLE
[HttpKernel] Simplify test code

### DIFF
--- a/tests/Symfony/Tests/Component/HttpKernel/ClientTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/ClientTest.php
@@ -89,7 +89,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->request('POST', '/', array(), array(new UploadedFile($source, 'original', 'mime/original', 123, UPLOAD_ERR_OK)));
 
-        $files = $kernel->request->files->all();
+        $files = $client->getRequest()->files->all();
 
         $this->assertEquals(1, count($files));
 
@@ -127,7 +127,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->request('POST', '/', array(), array($file));
 
-        $files = $kernel->request->files->all();
+        $files = $client->getRequest()->files->all();
 
         $this->assertEquals(1, count($files));
 

--- a/tests/Symfony/Tests/Component/HttpKernel/TestHttpKernel.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/TestHttpKernel.php
@@ -19,8 +19,6 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
 {
-    public $request;
-
     public function __construct()
     {
         parent::__construct(new EventDispatcher(), $this);
@@ -38,8 +36,6 @@ class TestHttpKernel extends HttpKernel implements ControllerResolverInterface
 
     public function callController(Request $request)
     {
-        $this->request = $request;
-
         return new Response('Request: '.$request->getRequestUri());
     }
 }


### PR DESCRIPTION
Get the `$request` from the client (removes a hack in test kernel)
