### PR TITLE
[SecurityBundle] Fix autoloading in tests

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/AppKernel.php
@@ -17,6 +17,11 @@ $lastDir = null;
 while ($dir !== $lastDir) {
     $lastDir = $dir;
 
+    if (file_exists($dir.'/autoload.php')) {
+        require_once $dir.'/autoload.php';
+        break;
+    }
+
     if (file_exists($dir.'/autoload.php.dist')) {
         require_once $dir.'/autoload.php.dist';
         break;


### PR DESCRIPTION
autoload.php should override autoload.php.dist when it exists
