### PR TITLE
[autoload] Use variable for vendor folder in dist file

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -5,17 +5,18 @@ require_once __DIR__.'/src/Symfony/Component/ClassLoader/UniversalClassLoader.ph
 use Symfony\Component\ClassLoader\UniversalClassLoader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
+$vendorDir = __DIR__.'/vendor';
 $loader = new UniversalClassLoader();
 $loader->registerNamespaces(array(
     'Symfony\\Tests'   => __DIR__.'/tests',
     'Symfony'          => __DIR__.'/src',
-    'Doctrine\\Common' => __DIR__.'/vendor/doctrine-common/lib',
-    'Doctrine\\DBAL'   => __DIR__.'/vendor/doctrine-dbal/lib',
-    'Doctrine'         => __DIR__.'/vendor/doctrine/lib',
-    'Monolog'          => __DIR__.'/vendor/monolog/src',
+    'Doctrine\\Common' => $vendorDir.'/doctrine-common/lib',
+    'Doctrine\\DBAL'   => $vendorDir.'/doctrine-dbal/lib',
+    'Doctrine'         => $vendorDir.'/doctrine/lib',
+    'Monolog'          => $vendorDir.'/monolog/src',
 ));
 $loader->registerPrefixes(array(
-    'Twig_' => __DIR__.'/vendor/twig/lib',
+    'Twig_' => $vendorDir.'/twig/lib',
 ));
 if (!function_exists('intl_get_error_code')) {
     require_once __DIR__.'/src/Symfony/Component/Locale/Resources/stubs/functions.php';
@@ -24,13 +25,13 @@ if (!function_exists('intl_get_error_code')) {
 }
 $loader->register();
 
-AnnotationRegistry::registerLoader(function($class) use ($loader) {
+AnnotationRegistry::registerLoader(function ($class) use ($loader) {
     $loader->loadClass($class);
     return class_exists($class, false);
 });
-AnnotationRegistry::registerFile(__DIR__.'/vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
+AnnotationRegistry::registerFile($vendorDir.'/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
 
-if (is_file(__DIR__.'/vendor/swiftmailer/lib/classes/Swift.php')) {
-    require_once __DIR__.'/vendor/swiftmailer/lib/classes/Swift.php';
-    Swift::registerAutoload(__DIR__.'/vendor/swiftmailer/lib/swift_init.php');
+if (is_file($vendorDir.'/swiftmailer/lib/classes/Swift.php')) {
+    require_once $vendorDir.'/swiftmailer/lib/classes/Swift.php';
+    Swift::registerAutoload($vendorDir.'/swiftmailer/lib/swift_init.php');
 }


### PR DESCRIPTION
In my projects I place vendor libraries not under `symfony/vendor` as proposed by framework. After having to edit autoload.php for the 3rd time (don't ask), I figured it should be a bit more comfortable - 1 LOC to change instead of 9.
