### PR TITLE
[FrameworkBundle] Set HttpKernel::render ignore_errors default value to false

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -154,6 +154,8 @@ class HttpKernel extends BaseHttpKernel
             if (!$options['ignore_errors']) {
                 throw $e;
             }
+            
+            return '';
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -95,7 +95,7 @@ class HttpKernel extends BaseHttpKernel
         $options = array_merge(array(
             'attributes'    => array(),
             'query'         => array(),
-            'ignore_errors' => !$this->container->getParameter('kernel.debug'),
+            'ignore_errors' => false,
             'alt'           => array(),
             'standalone'    => false,
             'comment'       => '',


### PR DESCRIPTION
I just recently discovered the `ignore_errors` attribute of `Symfony\Bundle\FrameworkBundle\HttpKernel::render()` and thought the default value seemed odd.

The default behavior if a sub request throws an uncaught exception is:
- In debug mode, re-throw the exception, which is caught by the parent kernel, and eventually handled by the `ExceptionListener` and `ExceptionController`.
- In non-debug mode, return null (no return statement exists for this situation)

Any time HttpKernel is catching an exception, it means the application itself has moved into an "exceptional" state from which there really is no recovery except to show a stack trace in debug mode or a friendly error message in non-debug mode (which is done by the `ExceptionController`).  Why short circuit this in non-debug mode simply because the request is a sub request?

To me there's no difference from the point of of view of the final, master response, between 1 master request that renders 5 "things" or 1 master request which uses 5 sub requests to each render 1 "thing" and combine them.  In both situations, an exception making it to `HttpKernel` is bad news bears and shouldn't selectively mask that fact.

Now, having the `ignore_errors` option available is fine by me.  Really I'm just taking issue with the default value which is coupled to the debug mode.

Thoughts?
