### PR TITLE
[RoutingGenerator] Throwing an exception when $name is not a string

### DIFF
--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -80,6 +80,10 @@ EOF
 
     public function generate(\$name, \$parameters = array(), \$absolute = false)
     {
+        if (!is_string(\$name)) {
+            throw new RouteNotFoundException(sprintf('Route name should be a string (%s given)', gettype(\$name)));
+        } 
+
         if (!isset(self::\$declaredRouteNames[\$name])) {
             throw new RouteNotFoundException(sprintf('Route "%s" does not exist.', \$name));
         }


### PR DESCRIPTION
When you do the mistake of forgetting the route name, just passing the route parameters, you currently get an error like :

```
Warning: Illegal offset type in isset or empty in /data/webs/web145/app/cache/dev/appdevUrlGenerator.php line 139
500 Internal Server Error - ErrorException 
```

Which is a PHP error, since you can't index an array with another array.
