### PR TITLE
[Form] Fixing a bug where setting empty_value to false caused a variable 

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -67,7 +67,7 @@ class ChoiceType extends AbstractType
             $emptyValue = null;
         } elseif (false === $options['empty_value']) {
             // an empty value should be added but the user decided otherwise
-            $options['empty_value'] = null;
+            $emptyValue = null;
         } elseif (null === $options['empty_value']) {
             // user did not made a decision, so we put a blank empty value
             $emptyValue = $options['required'] ? null : '';


### PR DESCRIPTION
Hey guys!

I think was an edge case that was overlooked. In this one case, the `$emptyValue` variable is never set. It causes warnings, but there should be no behavior change since the missing variable is being set to `null`.

Thanks!
