### PR TITLE
[Tests] Update vendors script to get lastest versions

### DIFF
--- a/vendors.php
+++ b/vendors.php
@@ -28,8 +28,8 @@ $deps = array(
     array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', '2.1.0'),
     array('doctrine-common', 'http://github.com/doctrine/common.git', '2.1.0'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', '1.0.0'),
-    array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.0'),
-    array('twig', 'http://github.com/fabpot/Twig.git', 'v1.1.1'),
+    array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.1'),
+    array('twig', 'http://github.com/fabpot/Twig.git', 'v1.1.2'),
 );
 
 foreach ($deps as $dep) {


### PR DESCRIPTION
Update `vendors.php` script to get latest versions (sync with Symfony2 SE). Updating only Twig to latest version speed up testing around ~10s on my Ubuntu.
