### PR TITLE
Removed check for NULL value in TypeValidator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -31,10 +31,6 @@ class TypeValidator extends ConstraintValidator
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value) {
-            return true;
-        }
-
         $type = $constraint->type == 'boolean' ? 'bool' : $constraint->type;
         $function = 'is_'.$type;
 


### PR DESCRIPTION
Removed check for NULL value. Otherwise $validator->isValid(null, new Type('type' => 'integer')) fails.
