### PR TITLE
[WebProfiler] Use proper `Response` function

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -82,7 +82,7 @@ class WebDebugToolbarListener
 
         if (self::DISABLED === $this->mode
             || !$response->headers->has('X-Debug-Token')
-            || '3' === substr($response->getStatusCode(), 0, 1)
+            || $response->isRedirection()
             || ($response->headers->has('Content-Type') && false === strpos($response->headers->get('Content-Type'), 'html'))
             || 'html' !== $request->getRequestFormat()
         ) {


### PR DESCRIPTION
Use proper `Response::isRedirection()` function to check is it an redirection.
