### PR TITLE
[EventDispatcher] Remove static declaration for getSubscribedEvents()

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeCollectionListener.php
@@ -25,7 +25,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class MergeCollectionListener implements EventSubscriberInterface
 {
-    static public function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array(FormEvents::BIND_NORM_DATA => 'onBindNormData');
     }

--- a/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventSubscriberInterface.php
@@ -45,5 +45,5 @@ interface EventSubscriberInterface
      *
      * @api
      */
-    static function getSubscribedEvents();
+    function getSubscribedEvents();
 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -30,7 +30,7 @@ class FixRadioInputListener implements EventSubscriberInterface
         $event->setData(strlen($data) < 1 ? array() : array($data => true));
     }
 
-    static public function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array(FormEvents::BIND_CLIENT_DATA => 'onBindClientData');
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -38,7 +38,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         }
     }
 
-    static public function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array(FormEvents::BIND_NORM_DATA => 'onBindNormData');
     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -61,7 +61,7 @@ class ResizeFormListener implements EventSubscriberInterface
         $this->options = $options;
     }
 
-    static public function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array(
             FormEvents::PRE_SET_DATA => 'preSetData',

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
@@ -31,7 +31,7 @@ class TrimListener implements EventSubscriberInterface
         }
     }
 
-    static public function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array(FormEvents::BIND_CLIENT_DATA => 'onBindClientData');
     }

--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -222,7 +222,7 @@ class TestEventListener
 
 class TestEventSubscriber implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array('pre.foo' => 'preFoo', 'post.foo' => 'postFoo');
     }
@@ -230,7 +230,7 @@ class TestEventSubscriber implements EventSubscriberInterface
 
 class TestEventSubscriberWithPriorities implements EventSubscriberInterface
 {
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array('pre.foo' => array('preFoo', 10));
     }

--- a/tests/Symfony/Tests/Component/Form/Fixtures/FixedFilterListener.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/FixedFilterListener.php
@@ -46,7 +46,7 @@ class FixedFilterListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public function getSubscribedEvents()
     {
         return array(
             FormEvents::BIND_CLIENT_DATA => 'onBindClientData',


### PR DESCRIPTION
[EventDispatcher] Remove static declaration for EventSubscriberInterface::getSubscribedEvents()

Existing code never invokes this subscriber method statically and the Doctrine interface upon which it's based is also not static. Changing it to a normal method will also allow the interface to be mocked easily, in contrast to requiring stub classes (see EventDispatcherTest).
