### PR TITLE
[EventDispatcher] Fix removeSubscriber() to work with priority syntax

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -127,8 +127,8 @@ class EventDispatcher implements EventDispatcherInterface
      */
     public function removeSubscriber(EventSubscriberInterface $subscriber)
     {
-        foreach ($subscriber->getSubscribedEvents() as $eventName => $method) {
-            $this->removeListener($eventName, array($subscriber, $method));
+        foreach ($subscriber->getSubscribedEvents() as $eventName => $params) {
+            $this->removeListener($eventName, array($subscriber, is_string($params) ? $params : $params[0]));
         }
     }
 

--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -198,6 +198,15 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->dispatcher->hasListeners(self::preFoo));
         $this->assertFalse($this->dispatcher->hasListeners(self::postFoo));
     }
+
+    public function testRemoveSubscriberWithPriorities()
+    {
+        $eventSubscriber = new TestEventSubscriberWithPriorities();
+        $this->dispatcher->addSubscriber($eventSubscriber);
+        $this->assertTrue($this->dispatcher->hasListeners(self::preFoo));
+        $this->dispatcher->removeSubscriber($eventSubscriber);
+        $this->assertFalse($this->dispatcher->hasListeners(self::preFoo));
+    }
 }
 
 class TestEventListener


### PR DESCRIPTION
Previously only addSubscriber() was being tested with priority syntax. This adds a unit test for removeSubscriber() and fixes a bug that would have caused it to fail.
