### PR TITLE
[Form] Fix "pattern" option for date field type

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -139,7 +139,7 @@ class DateType extends AbstractType
         if ($view->hasChildren()) {
             $pattern = $form->getAttribute('pattern');
 
-            if(is_null($pattern)) {
+            if (null === $pattern) {
                 $pattern = $form->getAttribute('formatter')->getPattern();
 
                 // set right order with respect to locale (e.g.: de_DE=dd.MM.yy; en_US=M/d/yy)

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -125,7 +125,8 @@ class DateType extends AbstractType
 
         $builder
             ->setAttribute('formatter', $formatter)
-            ->setAttribute('widget', $options['widget']);
+            ->setAttribute('widget', $options['widget'])
+            ->setAttribute('pattern', $options['pattern']);
     }
 
     /**
@@ -136,15 +137,19 @@ class DateType extends AbstractType
         $view->set('widget', $form->getAttribute('widget'));
 
         if ($view->hasChildren()) {
-            $pattern = $form->getAttribute('formatter')->getPattern();
+            $pattern = $form->getAttribute('pattern');
 
-            // set right order with respect to locale (e.g.: de_DE=dd.MM.yy; en_US=M/d/yy)
-            // lookup various formats at http://userguide.icu-project.org/formatparse/datetime
-            if (preg_match('/^([yMd]+).+([yMd]+).+([yMd]+)$/', $pattern)) {
-                $pattern = preg_replace(array('/y+/', '/M+/', '/d+/'), array('{{ year }}', '{{ month }}', '{{ day }}'), $pattern);
-            } else {
-                // default fallback
-                $pattern = '{{ year }}-{{ month }}-{{ day }}';
+            if(is_null($pattern)) {
+                $pattern = $form->getAttribute('formatter')->getPattern();
+
+                // set right order with respect to locale (e.g.: de_DE=dd.MM.yy; en_US=M/d/yy)
+                // lookup various formats at http://userguide.icu-project.org/formatparse/datetime
+                if (preg_match('/^([yMd]+).+([yMd]+).+([yMd]+)$/', $pattern)) {
+                    $pattern = preg_replace(array('/y+/', '/M+/', '/d+/'), array('{{ year }}', '{{ month }}', '{{ day }}'), $pattern);
+                } else {
+                    // default fallback
+                    $pattern = '{{ year }}-{{ month }}-{{ day }}';
+                }
             }
 
             $view->set('date_pattern', $pattern);


### PR DESCRIPTION
This pull request adds the "pattern" option to the date field type. It was documented (http://symfony.com/doc/current/reference/forms/types/date.html) but apparently not implemented. The value was simply ignored and replaced with an automatically generated value that matched the locale.

As far as I can see this fixes both #1730 and #1967.

The behaviour should now be exactly as documented here: http://symfony.com/doc/current/reference/forms/types/date.html#pattern
