### PR TITLE
[FrameworkBundle] Avoid listener key conflicts in ContainerAwareEventDispatcher

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/ContainerAwareEventDispatcher.php
@@ -86,7 +86,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
                 list($serviceId, $method, $priority) = $args;
                 $listener = $this->container->get($serviceId);
 
-                $key = $serviceId.$method;
+                $key = $serviceId.'.'.$method;
                 if (!isset($this->listeners[$eventName][$key])) {
                     $this->addListener($eventName, array($listener, $method), $priority);
                 } elseif ($listener !== $this->listeners[$eventName][$key]) {


### PR DESCRIPTION
Since the key was previously concatenating service ID and method without a separator, it's possible that two different listeners could conflict (e.g. service/method pairs: foo/bar and fo/obar).
