### PR TITLE
Fixed FileSystem->mirror() argument

### DIFF
--- a/src/Symfony/Component/HttpKernel/Util/Filesystem.php
+++ b/src/Symfony/Component/HttpKernel/Util/Filesystem.php
@@ -175,11 +175,11 @@ class Filesystem
      * @param string $originDir      The origin directory
      * @param string $targetDir      The target directory
      * @param \Traversable $iterator A Traversable instance
-     * @param array  $options        An array of options (see copy())
+     * @param boolean $override      Whether to override an existing file or not (see copy())
      *
      * @throws \RuntimeException When file type is unknown
      */
-    public function mirror($originDir, $targetDir, \Traversable $iterator = null, $options = array())
+    public function mirror($originDir, $targetDir, \Traversable $iterator = null, $override = false)
     {
         if (null === $iterator) {
             $iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($originDir, \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);

--- a/src/Symfony/Component/HttpKernel/Util/Filesystem.php
+++ b/src/Symfony/Component/HttpKernel/Util/Filesystem.php
@@ -199,7 +199,7 @@ class Filesystem
             if (is_dir($file)) {
                 $this->mkdir($target);
             } else if (is_file($file)) {
-                $this->copy($file, $target, $options);
+                $this->copy($file, $target, $override);
             } else if (is_link($file)) {
                 $this->symlink($file, $target);
             } else {


### PR DESCRIPTION
The fourth argument of `mirror()` doesn't reflect the third optional `$override` argument of `copy()`.
