### PR TITLE
[Form] ScalarToChoiceTransformer and FormUtil changes

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformer.php
@@ -13,16 +13,25 @@ namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class ScalarToChoiceTransformer implements DataTransformerInterface
 {
     public function transform($value)
     {
+        if (null !== $value && !is_scalar($value)) {
+            throw new UnexpectedTypeException($value, 'scalar');
+        }
+
         return FormUtil::toArrayKey($value);
     }
 
     public function reverseTransform($value)
     {
+        if (null !== $value && !is_scalar($value)) {
+            throw new UnexpectedTypeException($value, 'scalar');
+        }
+
         return $value;
     }
 }

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -15,11 +15,7 @@ abstract class FormUtil
 {
     static public function toArrayKey($value)
     {
-        if ((string) (int) $value === (string) $value) {
-            return (int) $value;
-        }
-
-        if (is_bool($value)) {
+        if (is_bool($value) || (string) (int) $value === (string) $value) {
             return (int) $value;
         }
 
@@ -52,7 +48,7 @@ abstract class FormUtil
      */
     static public function isChoiceSelected($choice, $value)
     {
-        $choice = FormUtil::toArrayKey($choice);
+        $choice = static::toArrayKey($choice);
 
         // The value should already have been converted by value transformers,
         // otherwise we had to do the conversion on every call of this method

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformerTest.php
@@ -62,4 +62,20 @@ class ScalarToChoiceTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame($out, $this->transformer->transform($in));
     }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testTransformExpectsScalar()
+    {
+        $this->transformer->transform(array());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testReverseTransformExpectsScalar()
+    {
+        $this->transformer->reverseTransform(array());
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Util/FormUtilTest.php
+++ b/tests/Symfony/Tests/Component/Form/Util/FormUtilTest.php
@@ -50,4 +50,56 @@ class FormUtilTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($out, FormUtil::toArrayKeys($in));
     }
+
+    public function isChoiceGroupProvider()
+    {
+        return array(
+            array(false, 0),
+            array(false, '0'),
+            array(false, '1'),
+            array(false, 1),
+            array(false, ''),
+            array(false, null),
+            array(false, true),
+
+            array(true, array()),
+            array(true, new \SplFixedArray(1)),
+        );
+    }
+
+    /**
+     * @dataProvider isChoiceGroupProvider
+     */
+    public function testIsChoiceGroup($expected, $value)
+    {
+        $this->assertSame($expected, FormUtil::isChoiceGroup($value));
+    }
+
+    public function isChoiceSelectedProvider()
+    {
+        return array(
+            array(true, 0, 0),
+            array(true, '0', 0),
+            array(true, '1', 1),
+            array(true, false, 0),
+            array(true, true, 1),
+            array(true, '', ''),
+            array(true, null, ''),
+            array(true, '1.23', '1.23'),
+            array(true, 'foo', 'foo'),
+            array(true, 'foo10', 'foo10'),
+            array(true, 'foo', array(1, 'foo', 'foo10')),
+
+            array(false, 10, array(1, 'foo', 'foo10')),
+            array(false, 0, array(1, 'foo', 'foo10')),
+        );
+    }
+
+    /**
+     * @dataProvider isChoiceSelectedProvider
+     */
+    public function testIsChoiceSelected($expected, $choice, $value)
+    {
+        $this->assertSame($expected, FormUtil::isChoiceSelected($choice, $value));
+    }
 }


### PR DESCRIPTION
Hey, 

I just added simply check into `ScalarToChoiceTransformer` (now accepts **only** scalars, hint in #1962), also I changed a bit `FormUtil` and extended tests for it.
