### PR TITLE
[Security] [ACL] Allows ObjectIdentity and UserSecurityIdentity to work with proxies

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/ClassIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ClassIdentity.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Acl\Domain;
+
+/**
+ * An helper class with a getClass method aware of proxies
+ *
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
+ */
+class ClassIdentity
+{
+    /**
+     * @var array An array of proxies interfaces for which
+     *            we want to retrieve the parent class
+     */
+    protected static $interfaces = array(
+        'Doctrine\ORM\Proxy\Proxy',
+        'Doctrine\ODM\MongoDB\Proxy\Proxy',
+        'Doctrine\ODM\CouchDB\Proxy\Proxy',
+        'Doctrine\ODM\PHPCR\Proxy\Proxy',
+        'Doctrine\OXM\Proxy\Proxy',
+    );
+
+    /**
+     * Returns the class of the domain object $object
+     *
+     * If $object is a proxy instance, gets its real class.
+     *
+     * @param object $object The object we want to know the real class of
+     * @return string The class of the domain object
+     */
+    public static function getClass($object)
+    {
+        if (!is_object($object)) {
+            throw new \InvalidArgumentException('$object must be an object.');
+        }
+
+        foreach (static::$interfaces as $interface) {
+            if ($object instanceof $interface) {
+                return get_parent_class($object);
+            }
+        }
+
+        return get_class($object);
+    }
+}

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
  * ObjectIdentity implementation
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
  */
 final class ObjectIdentity implements ObjectIdentityInterface
 {
@@ -60,9 +61,9 @@ final class ObjectIdentity implements ObjectIdentityInterface
 
         try {
             if ($domainObject instanceof DomainObjectInterface) {
-                return new self($domainObject->getObjectIdentifier(), get_class($domainObject));
+                return new self($domainObject->getObjectIdentifier(), ClassIdentity::getClass($domainObject));
             } else if (method_exists($domainObject, 'getId')) {
-                return new self($domainObject->getId(), get_class($domainObject));
+                return new self($domainObject->getId(), ClassIdentity::getClass($domainObject));
             }
         } catch (\InvalidArgumentException $invalid) {
             throw new InvalidDomainObjectException($invalid->getMessage(), 0, $invalid);

--- a/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
@@ -19,6 +19,7 @@ use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
  * A SecurityIdentity implementation used for actual users
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
  */
 final class UserSecurityIdentity implements SecurityIdentityInterface
 {
@@ -52,7 +53,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
      */
     static public function fromAccount(UserInterface $user)
     {
-        return new self($user->getUsername(), get_class($user));
+        return new self($user->getUsername(), ClassIdentity::getClass($user));
     }
 
     /**
@@ -69,7 +70,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
             return self::fromAccount($user);
         }
 
-        return new self((string) $user, is_object($user)? get_class($user) : get_class($token));
+        return new self((string) $user, is_object($user) ? ClassIdentity::getClass($user) : ClassIdentity::getClass($token));
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/ClassIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/ClassIdentityTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Security\Acl\Domain;
+
+use Symfony\Component\Security\Acl\Domain\ClassIdentity;
+use Doctrine\ORM\Proxy\Proxy;
+
+class ClassIdentityTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getCompareData
+     */
+    public function testEquals($cls1, $cls2)
+    {
+        $this->assertEquals($cls1, $cls2);
+    }
+
+    public function getCompareData()
+    {
+        return array(
+            array('Symfony\Tests\Component\Security\Acl\Domain\TestObjectClassIdentity', ClassIdentity::getClass(new TestObjectClassIdentity())),
+            array('Symfony\Tests\Component\Security\Acl\Domain\TestObjectClassIdentity', ClassIdentity::getClass(new TestObjectClassIdentityProxy())),
+        );
+    }
+
+    public function setUp()
+    {
+        if (!interface_exists('Doctrine\ORM\Proxy\Proxy')) {
+            $this->markTestSkipped('The Doctrine2 ORM is required for this test');
+        }
+    }
+}
+
+class TestObjectClassIdentity { }
+
+class TestObjectClassIdentityProxy extends TestObjectClassIdentity implements Proxy { }


### PR DESCRIPTION
Right now, ACL doesn't really work with Doctrine (either ORM, ODM, etc.) because it tries to retrieve the actual class of the objects. We can still create new ObjectIdentity and UserSecurityIdentity with the constructors but most people just use the static methods, which are easier to use.

This PR is far from perfect but it is IMO the only thing we can do in the 2.0 branch without too many modifications.

For 2.1, I suggest creating a new service able to retrieve an ObjectIdentityInterface from a given object.
This service would be given a list of other services (with a given DIC tag), and would iterate on this list until one gives a valid Identity. At last, we would call a default one (the actual implementation).

Bundles like Doctrine ORM, ODM, etc. would then each have to create a new service correctly tagged which would check if the given object is supported, etc.

This would maybe also allows for instance Doctrine to retrieve an object identity even if the primary key is not retrieved through `getId()` (since the EntityManager knows what identifier identifies which object).
