### PR TITLE
[Translation] Add compatibility to PCRE 6.6 for explicit interval plurali

### DIFF
--- a/src/Symfony/Component/Translation/Interval.php
+++ b/src/Symfony/Component/Translation/Interval.php
@@ -80,13 +80,13 @@ class Interval
 
             |
 
-        (?<left_delimiter>[\[\]])
+        (?P<left_delimiter>[\[\]])
             \s*
-            (?<left>-Inf|\-?\d+)
+            (?P<left>-Inf|\-?\d+)
             \s*,\s*
-            (?<right>\+?Inf|\-?\d+)
+            (?P<right>\+?Inf|\-?\d+)
             \s*
-        (?<right_delimiter>[\[\]])
+        (?P<right_delimiter>[\[\]])
 EOF;
     }
 

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -54,7 +54,7 @@ class MessageSelector
         foreach ($parts as $part) {
             $part = trim($part);
 
-            if (preg_match('/^(?<interval>'.Interval::getIntervalRegexp().')\s+(?<message>.+?)$/x', $part, $matches)) {
+            if (preg_match('/^(?P<interval>'.Interval::getIntervalRegexp().')\s+(?P<message>.+?)$/x', $part, $matches)) {
                 $explicitRules[$matches['interval']] = $matches['message'];
             } elseif (preg_match('/^\w+\: +(.+)$/', $part, $matches)) {
                 $standardRules[] = $matches[1];


### PR DESCRIPTION
[Translation] Add compatibility to PCRE 6.6.0 for explicit interval pluralization

A lot of distros still come with PCRE 6.6.0 that is not compatible with named groups. And there is no check for version in check.php or is detailed as a requirement.

So if you try to use explicit pluralizations with 6.6 it throws:

````Warning: preg_match(): Compilation failed: unrecognized character after (?< at offset 4 in /root/test.php on line 3

```

Initial issue in: https://github.com/symfony/symfony-standard/issues/183
thanks to stealth35
```
