### PR TITLE
[FrameworkBundle] Remove `session_id('')` call

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
@@ -50,8 +50,6 @@ class TestSessionListener
         $cookies = $event->getRequest()->cookies;
         if ($cookies->has(session_name())) {
             session_id($cookies->get(session_name()));
-        } else {
-            session_id('');
         }
     }
 


### PR DESCRIPTION
Remove useless and causing errors `session_id('')` call (closes #1984).
