### PR TITLE
"Compatibility Fix" for PHP_CodeCoverage 1.1

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,10 @@
         </testsuite>
     </testsuites>
 
+    <php>
+        <const name="SYMFONY_TESTSUITE" value="true"/>
+    </php>
+
     <groups>
         <exclude>
             <group>benchmark</group>


### PR DESCRIPTION
Set SYMFONY_TESTSUITE flag that tells PHP_CodeCoverage 1.1 (and later) to not exclude Symfony's source files from code coverage.

PHPUnit uses Symfony's YAML component so by default PHP_CodeCoverage adds the component's source files to the default blacklist for code coverage reporting. This is, of course, not desired when running Symfony's own test suite.
