### PR TITLE
[2.1] Add dumpers for translation catalogs

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -11,6 +11,9 @@
         <parameter key="translation.loader.php.class">Symfony\Component\Translation\Loader\PhpFileLoader</parameter>
         <parameter key="translation.loader.yml.class">Symfony\Component\Translation\Loader\YamlFileLoader</parameter>
         <parameter key="translation.loader.xliff.class">Symfony\Component\Translation\Loader\XliffFileLoader</parameter>
+        <parameter key="translation.dumper.php.class">Symfony\Component\Translation\Dumper\PhpDumper</parameter>
+        <parameter key="translation.dumper.xliff.class">Symfony\Component\Translation\Dumper\XliffDumper</parameter>
+        <parameter key="translation.dumper.yml.class">Symfony\Component\Translation\Dumper\YamlDumper</parameter>
     </parameters>
 
     <services>
@@ -41,6 +44,18 @@
 
         <service id="translation.loader.xliff" class="%translation.loader.xliff.class%">
             <tag name="translation.loader" alias="xliff" />
+        </service>
+
+        <service id="translation.dumper.php" class="%translation.dumper.php.class%">
+            <tag name="translation.dumper" alias="php" />
+        </service>
+
+        <service id="tranlsation.dumper.xliff" class="%translation.dumper.xliff.class%">
+            <tag name="translation.dumper" alias="xliff" />
+        </service>
+
+        <service id="translation.dumper.yml" class="%translation.dumper.yml.class%">
+            <tag name="translation.dumper" alias="yml" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/Translation/Dumper/DumperInterface.php
+++ b/src/Symfony/Component/Translation/Dumper/DumperInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Dumper;
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * DumperInterface is the interface implemented by all translation dumpers.
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ */
+interface DumperInterface
+{
+    /**
+     * Generates a string representation of the message catalogue
+     *
+     * @param MessageCatalogue $messages The message catalogue
+     * @param string           $domain   The domain to dump
+     *
+     * @return string                    The string representation
+     */
+    function dump(MessageCatalogue $messages, $domain = 'messages');
+}

--- a/src/Symfony/Component/Translation/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/PhpDumper.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Dumper;
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * PhpDumper generates a php formated string representation of a message catalogue
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ */
+class PhpDumper implements DumperInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function dump(MessageCatalogue $messages, $domain = 'messages')
+    {
+        $output = "<?php\n\nreturn ".var_export($messages->all($domain), true).";\n";
+
+        return $output;
+    }
+}

--- a/src/Symfony/Component/Translation/Dumper/XliffDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/XliffDumper.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Dumper;
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+/**
+ * XliffDumper generates a xliff formated string representation of a message catalogue
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ */
+class XliffDumper implements DumperInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function dump(MessageCatalogue $messages, $domain = 'messages')
+    {
+        $dom = new \DOMDocument('1.0', 'utf-8');
+        $dom->formatOutput = true;
+        $xliff = $dom->appendChild($dom->createElement('xliff'));
+        $xliff->setAttribute('version', '1.2');
+        $xliff->setAttribute('xmlns', 'urn:oasis:names:tc:xliff:document:1.2');
+        $xliffFile = $xliff->appendChild($dom->createElement('file'));
+        $xliffFile->setAttribute('source-language', $messages->getLocale());
+        $xliffFile->setAttribute('datatype', 'plaintext');
+        $xliffFile->setAttribute('original', 'file.ext');
+        $xliffBody = $xliffFile->appendChild($dom->createElement('body'));
+        $id = 1;
+        foreach ($messages->all($domain) as $source => $target) {
+            $trans = $dom->createElement('trans-unit');
+            $trans->setAttribute('id', $id);
+            $s = $trans->appendChild($dom->createElement('source'));
+            $s->appendChild($dom->createTextNode($source));
+            $t = $trans->appendChild($dom->createElement('target'));
+            $t->appendChild($dom->createTextNode($target));
+            $xliffBody->appendChild($trans);
+            $id++;
+        }
+
+        return $dom->saveXML();
+    }
+}

--- a/src/Symfony/Component/Translation/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlDumper.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Dumper;
+
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * YamlDumper generates a yaml formated string representation of a message catalogue
+ *
+ * @author Michel Salib <michelsalib@hotmail.com>
+ */
+class YamlDumper implements DumperInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function dump(MessageCatalogue $messages, $domain = 'messages')
+    {
+         return Yaml::dump($messages->all($domain));
+    }
+}

--- a/tests/Symfony/Tests/Component/Translation/Dumper/PhpFileDumperTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Dumper/PhpFileDumperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Translation\Dumper;
+
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Dumper\PhpDumper;
+
+class PhpFileDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDump()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->add(array('foo' => 'bar'));
+        
+        $dumper = new PhpDumper();
+        $dumperString = $dumper->dump($catalogue);
+        
+        $resource = __DIR__.'/../fixtures/resources.php';
+        $file = new \SplFileObject($resource);
+        $fileString = '';
+        while(!$file->eof()) {
+            $fileString .= $file->fgets();
+        }
+        
+        $this->assertEquals($fileString, $dumperString);
+    }
+}

--- a/tests/Symfony/Tests/Component/Translation/Dumper/XliffFileDumperTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Dumper/XliffFileDumperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Translation\Dumper;
+
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Dumper\XliffDumper;
+
+class XliffFileDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDump()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->add(array('foo' => 'bar'));
+        
+        $dumper = new XliffDumper();
+        $dumperString = $dumper->dump($catalogue);
+        
+        $resource = __DIR__.'/../fixtures/resources.xliff';
+        $file = new \SplFileObject($resource);
+        $fileString = '';
+        while(!$file->eof()) {
+            $fileString .= $file->fgets();
+        }
+        
+        $this->assertEquals($fileString, $dumperString);
+    }
+}

--- a/tests/Symfony/Tests/Component/Translation/Dumper/YamlFileDumperTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Dumper/YamlFileDumperTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Translation\Dumper;
+
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Dumper\YamlDumper;
+
+class YamlFileDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDump()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->add(array('foo' => 'bar'));
+        
+        $dumper = new YamlDumper();
+        $dumperString = $dumper->dump($catalogue);
+        
+        $resource = __DIR__.'/../fixtures/resources.yml';
+        $file = new \SplFileObject($resource);
+        $fileString = '';
+        while(!$file->eof()) {
+            $fileString .= $file->fgets();
+        }
+        
+        $this->assertEquals($fileString, $dumperString);
+    }
+}

--- a/tests/Symfony/Tests/Component/Translation/fixtures/resources.php
+++ b/tests/Symfony/Tests/Component/Translation/fixtures/resources.php
@@ -1,5 +1,5 @@
 <?php
 
-return array(
-    'foo' => 'bar',
+return array (
+  'foo' => 'bar',
 );

--- a/tests/Symfony/Tests/Component/Translation/fixtures/resources.xliff
+++ b/tests/Symfony/Tests/Component/Translation/fixtures/resources.xliff
@@ -1,11 +1,11 @@
-<?xml version="1.0"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
-        <body>
-            <trans-unit id="1">
-                <source>foo</source>
-                <target>bar</target>
-            </trans-unit>
-        </body>
-    </file>
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="1">
+        <source>foo</source>
+        <target>bar</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>


### PR DESCRIPTION
As seen here #1283, I push just the translation catalogs dumpers. It involved renaming and some essentially.

I also included a Pot dumper/loader that have been provided here : https://github.com/michelsalib/BCCExtraToolsBundle/pull/12.
