### PR TITLE
[Translation] Add compatibility to PCRE 6.6.0 for explicit interval pluralization

### DIFF
--- a/src/Symfony/Component/Translation/Interval.php
+++ b/src/Symfony/Component/Translation/Interval.php
@@ -80,13 +80,13 @@ class Interval
 
             |
 
-        (?<left_delimiter>[\[\]])
+        (?P<left_delimiter>[\[\]])
             \s*
-            (?<left>-Inf|\-?\d+)
+            (?P<left>-Inf|\-?\d+)
             \s*,\s*
-            (?<right>\+?Inf|\-?\d+)
+            (?P<right>\+?Inf|\-?\d+)
             \s*
-        (?<right_delimiter>[\[\]])
+        (?P<right_delimiter>[\[\]])
 EOF;
     }
 

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -54,7 +54,7 @@ class MessageSelector
         foreach ($parts as $part) {
             $part = trim($part);
 
-            if (preg_match('/^(?<interval>'.Interval::getIntervalRegexp().')\s+(?<message>.+?)$/x', $part, $matches)) {
+            if (preg_match('/^(?P<interval>'.Interval::getIntervalRegexp().')\s+(?P<message>.+?)$/x', $part, $matches)) {
                 $explicitRules[$matches['interval']] = $matches['message'];
             } elseif (preg_match('/^\w+\: +(.+)$/', $part, $matches)) {
                 $standardRules[] = $matches[1];


### PR DESCRIPTION
[Translation] Add compatibility to PCRE 6.6.0 for explicit interval pluralization

Corrected branches: From 2.0 to 2.0

more info: https://github.com/symfony/symfony/pull/2038
