### PR TITLE
[Acl] [ObjectIdentity] Getting parent class on proxies

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -59,10 +59,16 @@ final class ObjectIdentity implements ObjectIdentityInterface
         }
 
         try {
+            if ($domainObject instanceof \Doctrine\ORM\Proxy\Proxy) {
+                $class = get_parent_class($domainObject);
+            } else {
+                $class = get_class($domainObject);
+            }  
+
             if ($domainObject instanceof DomainObjectInterface) {
-                return new self($domainObject->getObjectIdentifier(), get_class($domainObject));
+                return new self($domainObject->getObjectIdentifier(), $class);
             } else if (method_exists($domainObject, 'getId')) {
-                return new self($domainObject->getId(), get_class($domainObject));
+                return new self($domainObject->getId(), $class);
             }
         } catch (\InvalidArgumentException $invalid) {
             throw new InvalidDomainObjectException($invalid->getMessage(), 0, $invalid);


### PR DESCRIPTION
As raised here:
https://groups.google.com/d/topic/symfony2/bhk8AiSfloM/discussion

The ObjectIdentity behavior on proxies can be improved.

Maybe this could be done in a cleaned way, but this works and the Security component can be still used standalone with this.
