### PR TITLE
[Routing] Naming conflict of the goto generated by url matcher dumper

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -173,7 +173,7 @@ EOF;
 
         $conditions = implode(' && ', $conditions);
 
-        $gotoname = 'not_'.preg_replace('/[^A-Za-z0-9_]/', '', $name);
+        $gotoname = preg_replace('/[^A-Za-z0-9_]/', '', '_'.($parentPrefix ? str_replace('/', '_', substr($parentPrefix, 1)).'_' : '').'not_'.$name);
 
         $code[] = <<<EOF
         // $name

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher3.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher3.php
@@ -1,0 +1,50 @@
+<?php
+
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * ProjectUrlMatcher
+ *
+ * This class has been auto-generated
+ * by the Symfony Routing Component.
+ */
+class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function match($pathinfo)
+    {
+        $allow = array();
+        $pathinfo = urldecode($pathinfo);
+
+        // index
+        if ($pathinfo === '/child1/actions/') {
+            if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                $allow = array_merge($allow, array('GET', 'HEAD'));
+                goto _child1_actions_not_index;
+            }
+            return array('_route' => 'index');
+        }
+        _child1_actions_not_index:
+
+        // index
+        if ($pathinfo === '/child2/index') {
+            if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                $allow = array_merge($allow, array('GET', 'HEAD'));
+                goto _child2_not_index;
+            }
+            return array('_route' => 'index');
+        }
+        _child2_not_index:
+
+        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+    }
+}

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -128,6 +128,27 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(__DIR__.'/../../Fixtures/dumper/url_matcher2.php', $dumper->dump(array('base_class' => 'Symfony\Tests\Component\Routing\Fixtures\RedirectableUrlMatcher')), '->dump() dumps basic routes to the correct PHP file.');
     }
 
+    public function testDumpTreeWithSameRouteNames()
+    {
+        // tree of routes with same route names
+        $collectionRoot = new RouteCollection(); 
+        
+        $collectionChild1 = new RouteCollection(); 
+        $collectionChild1Actions = new RouteCollection(); 
+        $collectionChild1Actions->add('index', new Route('/', array(), array('_method' => 'GET|HEAD')));
+        $collectionChild1->addCollection($collectionChild1Actions, '/actions');
+        
+        $collectionChild2 = new RouteCollection(); 
+        $collectionChild2->add('index', new Route('/index', array(), array('_method' => 'GET|HEAD')));
+        
+        $collectionRoot->addCollection($collectionChild1, '/child1'); 
+        $collectionRoot->addCollection($collectionChild2, '/child2'); 
+
+        $dumper = new PhpMatcherDumper($collectionRoot, new RequestContext());
+        
+        $this->assertStringEqualsFile(__DIR__.'/../../Fixtures/dumper/url_matcher3.php', $dumper->dump(), '->dump() dumps tree of routes to the correct PHP file.');
+    }
+    
     /**
      * @expectedException \LogicException
      */


### PR DESCRIPTION
Naming conflict of the goto occurs if you've defined two same route names 
within two different collections. See unit test for details how to reproduce this bug. 

Additionally, my proposal for the bug-fix. 
