### PR TITLE
[2.1] [Security] [ACL] New service security.acl.identity_resolver

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/Acl/DomainObjectIdentityRetrievalStrategy.php
+++ b/src/Symfony/Bridge/Doctrine/Security/Acl/DomainObjectIdentityRetrievalStrategy.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\Security\Acl;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Symfony\Component\Security\Acl\Model\DomainObjectIdentityRetrievalStrategyInterface;
+use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
+
+use Doctrine\ORM\Proxy\Proxy;
+
+/**
+ * The Doctrine implementation for DomainObjectIdentityRetrievalStrategyInterface
+ *
+ * This class is aware of Doctrine proxies and entities real identifiers
+ *
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
+ */
+class DomainObjectIdentityRetrievalStrategy implements DomainObjectIdentityRetrievalStrategyInterface
+{
+    private $registry;
+
+    public function __construct(RegistryInterface $registry)
+    {
+        $this->registry = $registry;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDomainObjectIdentity($domainObject)
+    {
+        // Check if this object is managed by Doctrine ORM
+        if (null === $em = $this->registry->getEntityManagerForClass($domainObject)) {
+            return null;
+        }
+
+        // We want the user to be able to override the identifier
+        if ($domainObject instanceof DomainObjectInterface) {
+            return new ObjectIdentity((string) $domainObject->getObjectIdentifier(), $this->getEntityClass($domainObject));
+        }
+
+        // We don't want to load the object
+        $ids = $em->getUnitOfWork()->getEntityIdentifier($domainObject);
+        $identifier = (1 === count($ids)) ? (string) $ids[0] : serialize($ids);
+
+        return new ObjectIdentity($identifier, $this->getEntityClass($domainObject));
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function getDomainUserSecurityIdentityFromAccount(UserInterface $user)
+    {
+        // Check if this object is managed by Doctrine ORM
+        if (null === $this->registry->getEntityManagerForClass($user)) {
+            return null;
+        }
+
+        return new UserSecurityIdentity($user->getUsername(), $this->getEntityClass($user));
+    }
+
+    /**
+    * {@inheritDoc}
+    */
+    public function getDomainUserSecurityIdentityFromToken(TokenInterface $token)
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof UserInterface) {
+            return null;
+        }
+
+        return $this->getDomainUserSecurityIdentityFromAccount($user);
+    }
+
+    /**
+     * Returns the real class of this domain object.
+     * Never returns a proxy class.
+     *
+     * @param object $object
+     */
+    private function getEntityClass($object)
+    {
+        if ($object instanceof Proxy) {
+            return get_parent_class($object);
+        }
+
+        return get_class($object);
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -35,6 +35,9 @@
         <!-- validator -->
         <parameter key="doctrine.orm.validator.unique.class">Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator</parameter>
         <parameter key="doctrine.orm.validator_initializer.class">Symfony\Bridge\Doctrine\Validator\EntityInitializer</parameter>
+
+        <!-- object identity resolver -->
+        <parameter key="doctrine.orm.object_identity_resolver.class">Symfony\Bridge\Doctrine\Security\Acl\DomainObjectIdentityRetrievalStrategy</parameter>
     </parameters>
 
     <services>
@@ -70,6 +73,12 @@
 
         <service id="doctrine.orm.validator_initializer" class="%doctrine.orm.validator_initializer.class%">
             <tag name="validator.initializer" />
+            <argument type="service" id="doctrine" />
+        </service>
+
+        <!-- object identity resolver -->
+        <service id="doctrine.orm.object_identity_resolver" class="%doctrine.orm.object_identity_resolver.class%" public="false">
+            <tag name="security.identity_resolver" />
             <argument type="service" id="doctrine" />
         </service>
     </services>

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddIdentityResolversPass.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Compiler/AddIdentityResolversPass.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Adds all configured identity resolvers to the DomainObjectIdentityRetrievalStrategy
+ *
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
+ */
+class AddIdentityResolversPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('security.acl.identity_resolver')) {
+            return;
+        }
+
+        $identityResolvers = array();
+        foreach ($container->findTaggedServiceIds('security.identity_resolver') as $id => $attributes) {
+            $identityResolvers[] = new Reference($id);
+        }
+
+        $container->getDefinition('security.acl.identity_resolver')->replaceArgument(0, $identityResolvers);
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl.xml
@@ -13,17 +13,26 @@
         <parameter key="security.acl.object_identity_retrieval_strategy.class">Symfony\Component\Security\Acl\Domain\ObjectIdentityRetrievalStrategy</parameter>
         <parameter key="security.acl.security_identity_retrieval_strategy.class">Symfony\Component\Security\Acl\Domain\SecurityIdentityRetrievalStrategy</parameter>
 
+        <parameter key="security.acl.identity_resolver.class">Symfony\Component\Security\Acl\Domain\DomainObjectIdentityRetrievalStrategy</parameter>
+
         <parameter key="security.acl.cache.doctrine.class">Symfony\Component\Security\Acl\Domain\DoctrineAclCache</parameter>
 
         <parameter key="security.acl.collection_cache.class">Symfony\Component\Security\Acl\Domain\AclCollectionCache</parameter>
     </parameters>
 
     <services>
-        <service id="security.acl.object_identity_retrieval_strategy" class="%security.acl.object_identity_retrieval_strategy.class%" public="false"></service>
+        <service id="security.acl.object_identity_retrieval_strategy" class="%security.acl.object_identity_retrieval_strategy.class%" public="false">
+            <argument type="service" id="security.acl.identity_resolver" />            
+        </service>
 
         <service id="security.acl.security_identity_retrieval_strategy" class="%security.acl.security_identity_retrieval_strategy.class%" public="false">
             <argument type="service" id="security.role_hierarchy" />
             <argument type="service" id="security.authentication.trust_resolver" />
+            <argument type="service" id="security.acl.identity_resolver" />
+        </service>
+
+        <service id="security.acl.identity_resolver" class="%security.acl.identity_resolver.class%">
+            <argument type="collection" />
         </service>
 
         <service id="security.acl.permission_granting_strategy" class="%security.acl.permission_granting_strategy.class%" public="false">

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddIdentityResolversPass;
 
 /**
  * Bundle.
@@ -27,5 +28,6 @@ class SecurityBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new AddSecurityVotersPass());
+        $container->addCompilerPass(new AddIdentityResolversPass());
     }
 }

--- a/src/Symfony/Component/Security/Acl/Domain/DomainObjectIdentityRetrievalStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/DomainObjectIdentityRetrievalStrategy.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Acl\Domain;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Symfony\Component\Security\Acl\Model\DomainObjectIdentityRetrievalStrategyInterface;
+
+/**
+ * The default implementation for DomainObjectIdentityRetrievalStrategyInterface
+ *
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
+ */
+class DomainObjectIdentityRetrievalStrategy implements DomainObjectIdentityRetrievalStrategyInterface
+{
+    private $identityResolvers;
+
+    /**
+     * Constructor
+     *
+     * @param array $identityResolvers
+     */
+    public function __construct(array $identityResolvers = array())
+    {
+        $this->identityResolvers = $identityResolvers;
+
+        foreach ($this->identityResolvers as $identityResolver) {
+            if (!$identityResolver instanceof DomainObjectIdentityRetrievalStrategyInterface) {
+                throw new \InvalidArgumentException('Identity resolvers must implement Symfony\Component\Security\Acl\Model\DomainObjectIdentityRetrievalStrategyInterface');
+            }
+        }
+    }
+
+    /**
+     * Loops over all registered identity resolvers and fall
+     * back to the default implementation if none supports this
+     * domain object
+     *
+     * {@inheritDoc}
+     */
+    public function getDomainObjectIdentity($domainObject)
+    {
+        foreach ($this->identityResolvers as $identityResolver) {
+            if (null !== $objectIdentity = $identityResolver->getDomainObjectIdentity($domainObject)) {
+                return $objectIdentity;
+            }
+        }
+
+        return ObjectIdentity::fromDomainObject($domainObject);
+    }
+
+    /**
+     * Loops over all registered identity resolvers and fall
+     * back to the default implementation if none supports this
+     * user
+     *
+     * {@inheritDoc}
+     */
+    public function getDomainUserSecurityIdentityFromAccount(UserInterface $user)
+    {
+        foreach ($this->identityResolvers as $identityResolver) {
+            if (null !== $securityIdentity = $identityResolver->getDomainUserSecurityIdentityFromAccount($user)) {
+                return $securityIdentity;
+            }
+        }
+
+        return UserSecurityIdentity::fromAccount($user);
+    }
+
+    /**
+     * Loops over all registered identity resolvers and fall
+     * back to the default implementation if none supports this
+     * token
+     *
+     * {@inheritDoc}
+     */
+    public function getDomainUserSecurityIdentityFromToken(TokenInterface $token)
+    {
+        foreach ($this->identityResolvers as $identityResolver) {
+            if (null !== $securityIdentity = $identityResolver->getDomainUserSecurityIdentityFromToken($token)) {
+                return $securityIdentity;
+            }
+        }
+
+        return UserSecurityIdentity::fromToken($token);
+    }
+}

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentityRetrievalStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentityRetrievalStrategy.php
@@ -12,22 +12,36 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Exception\InvalidDomainObjectException;
+use Symfony\Component\Security\Acl\Model\DomainObjectIdentityRetrievalStrategyInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityRetrievalStrategyInterface;
 
 /**
  * Strategy to be used for retrieving object identities from domain objects
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
  */
 class ObjectIdentityRetrievalStrategy implements ObjectIdentityRetrievalStrategyInterface
 {
+    private $identityResolver;
+
+    /**
+    * Constructor
+    *
+    * @param DomainObjectIdentityRetrievalStrategyInterface $identityResolver
+    */
+    public function __construct(DomainObjectIdentityRetrievalStrategyInterface $identityResolver)
+    {
+        $this->identityResolver = $identityResolver;
+    }
+
     /**
      * {@inheritDoc}
      */
     public function getObjectIdentity($domainObject)
     {
         try {
-            return ObjectIdentity::fromDomainObject($domainObject);
+            return $this->identityResolver->getDomainObjectIdentity($domainObject);
         } catch (InvalidDomainObjectException $failed) {
             return null;
         }

--- a/src/Symfony/Component/Security/Acl/Model/DomainObjectIdentityRetrievalStrategyInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/DomainObjectIdentityRetrievalStrategyInterface.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Acl\Model;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+/**
+ * This interface can be implemented by services able to retrieve a ObjectIdentityInterface
+ * or a UserSecurityIdentityInterface for particular objects.
+ *
+ * @author Jordan Alliot <jordan.alliot@gmail.com>
+ */
+interface DomainObjectIdentityRetrievalStrategyInterface
+{
+    /**
+     * Returns the ObjectIdentityInterface for this domain object
+     * or null if the object is not supported.
+     *
+     * @param object $domainObject
+     * @return ObjectIdentityInterface|null
+     */
+    function getDomainObjectIdentity($domainObject);
+
+    /**
+     * Returns the SecurityIdentityInterface for this domain user account
+     * or null if the object is not supported.
+     *
+     * @param UserInterface $user
+     * @return SecurityIdentityInterface|null
+     */
+    function getDomainUserSecurityIdentityFromAccount(UserInterface $user);
+
+    /**
+     * Returns the SecurityIdentityInterface for this domain user token
+     * or null if the object is not supported.
+     *
+     * @param TokenInterface $token
+     * @return SecurityIdentityInterface|null
+     */
+    function getDomainUserSecurityIdentityFromToken(TokenInterface $token);
+}


### PR DESCRIPTION
This PR follows #2035 and is a first try for a better implementation for 2.1.

I opened it to discuss it. I haven't even tested it yet!

With this implementation, the example from the [cookbook](http://symfony.com/doc/current/cookbook/security/acl.html#creating-an-acl-and-adding-an-ace) would have to be changed to: https://gist.github.com/1180537
Also, every bundle similar to the DoctrineBundle (i.e. every Doctrine*****Bundle having proxy objects or lazy-loaded domain objects) would have to create a new service tagged with `security.identity_resolver` and implementing interface `Symfony\Component\Security\Acl\Model\DomainObjectIdentityRetrievalStrategyInterface`.

The names of interfaces/classes/tag/service id are not really great so don't hesitate to propose better ones.

This implementation, although maybe not perfect, seems really cleaner than solution in #2035 (although I don't think this can be merged in 2.0) because we don't have to hard-code anything (like every proxy interfaces in #2035).

@schmittjoh @fabpot @stof What do you think?
