### PR TITLE
Fatal Error in autoload.php.dist

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -24,11 +24,13 @@ if (!function_exists('intl_get_error_code')) {
 }
 $loader->register();
 
-AnnotationRegistry::registerLoader(function($class) use ($loader) {
-    $loader->loadClass($class);
-    return class_exists($class, false);
-});
-AnnotationRegistry::registerFile(__DIR__.'/vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
+if (class_exists('AnnotationRegistry')) {
+    AnnotationRegistry::registerLoader(function($class) use ($loader) {
+        $loader->loadClass($class);
+        return class_exists($class, false);
+    });
+    AnnotationRegistry::registerFile(__DIR__.'/vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
+}
 
 if (is_file(__DIR__.'/vendor/swiftmailer/lib/classes/Swift.php')) {
     require_once __DIR__.'/vendor/swiftmailer/lib/classes/Swift.php';


### PR DESCRIPTION
autoload.php.dist from master expects classes to exist which do not, namely:

> Doctrine\Common\Annotations\AnnotationRegistry

Resulting in a fatal error:

```
Fatal error:  Class 'Doctrine\Common\Annotations\AnnotationRegistry' not found in /symfony/autoload.php.dist on line 27
```

I ran into the fatal error while I wanted to execute test cases.

Then I realized that the vendor directory is not there.

I could fix the issue for me by just checking if the class exists and then conditionally using it (or not).

After fixing `/symfony/autoload.php.dist` I could successfully run the testcase.

Related: #1327
