### PR TITLE
Fix for ticket #2063 - Race condition in Kernel.php

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
+++ b/src/Symfony/Bridge/Doctrine/CacheWarmer/ProxyCacheWarmer.php
@@ -51,7 +51,7 @@ class ProxyCacheWarmer implements CacheWarmerInterface
         foreach ($this->registry->getEntityManagers() as $em) {
             // we need the directory no matter the proxy cache generation strategy
             if (!is_dir($proxyCacheDir = $em->getConfiguration()->getProxyDir())) {
-                if (false === @mkdir($proxyCacheDir, 0777, true)) {
+                if (false === @mkdir($proxyCacheDir, 0777, true) && !is_dir($proxyCacheDir)) {
                     throw new \RuntimeException(sprintf('Unable to create the Doctrine Proxy directory "%s".', dirname($proxyCacheDir)));
                 }
             } elseif (!is_writable($proxyCacheDir)) {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -578,7 +578,7 @@ class FrameworkExtension extends Extension
 
         if ('file' === $config['cache']) {
             $cacheDir = $container->getParameterBag()->resolveValue($config['file_cache_dir']);
-            if (!is_dir($cacheDir) && false === @mkdir($cacheDir, 0777, true)) {
+            if (!is_dir($cacheDir) && false === @mkdir($cacheDir, 0777, true) && !is_dir($cacheDir)) {
                 throw new \RuntimeException(sprintf('Could not create cache directory "%s".', $cacheDir));
             }
 

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -92,7 +92,7 @@ class ConfigCache
     {
         $dir = dirname($this->file);
         if (!is_dir($dir)) {
-            if (false === @mkdir($dir, 0777, true)) {
+            if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
                 throw new \RuntimeException(sprintf('Unable to create the %s directory', $dir));
             }
         } elseif (!is_writable($dir)) {

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -523,7 +523,7 @@ class File extends \SplFileInfo
     public function move($directory, $name = null)
     {
         if (!is_dir($directory)) {
-            if (false === @mkdir($directory, 0777, true)) {
+            if (false === @mkdir($directory, 0777, true) && !is_dir($directory)) {
                 throw new FileException(sprintf('Unable to create the "%s" directory', $directory));
             }
         } elseif (!is_writable($directory)) {

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -614,7 +614,7 @@ abstract class Kernel implements KernelInterface
     {
         foreach (array('cache' => $this->getCacheDir(), 'logs' => $this->getLogDir()) as $name => $dir) {
             if (!is_dir($dir)) {
-                if (false === @mkdir($dir, 0777, true)) {
+                if (false === @mkdir($dir, 0777, true) && !is_dir($dir)) {
                     throw new \RuntimeException(sprintf("Unable to create the %s directory (%s)\n", $name, dirname($dir)));
                 }
             } elseif (!is_writable($dir)) {

--- a/src/Symfony/Component/HttpKernel/Util/Filesystem.php
+++ b/src/Symfony/Component/HttpKernel/Util/Filesystem.php
@@ -61,7 +61,7 @@ class Filesystem
                 continue;
             }
 
-            $ret = @mkdir($dir, $mode, true) && $ret;
+            $ret = (@mkdir($dir, $mode, true) || is_dir($dir)) && $ret;
         }
 
         return $ret;


### PR DESCRIPTION
Please see ticket #2063 for a full description of the problem.

This should fix the race condition that exists when doing multiple mkdir calls from multiple different processes simultaneously.

This problem would manifest itself as RuntimeExceptions during creation of cache directories (after the cache has been blown away for whatever reason).

---

The problem in production is that mkdir, if called from multiple different processes simultaneously for those that are 2nd, 3rd, or later in line will fail.  However the directory actually turned out to be created, just not by the 2nd or 3rd or later call.

Hence it behooves to do one last is_dir check before returning false, or throwing an exception
