### PR TITLE
[Translation] Unique Entity message

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -23,7 +23,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  */
 class UniqueEntity extends Constraint
 {
-    public $message = 'This value is already used.';
+    public $message = 'This value is already used';
     public $em = null;
     public $fields = array();
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
@@ -162,6 +162,10 @@
                 <source>This value is not a valid country</source>
                 <target>Ce pays n'est pas valide</target>
             </trans-unit>
+            <trans-unit id="41">
+                <source>This value is already used</source>
+                <target>Cette valeur est déjà utilisée</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
@@ -142,6 +142,26 @@
                 <source>This value should be a valid number</source>
                 <target>Cette valeur doit être un nombre</target>
             </trans-unit>
+            <trans-unit id="36">
+                <source>This file is not a valid image</source>
+                <target>Ce fichier n'est pas une image valide</target>
+            </trans-unit>
+            <trans-unit id="37">
+                <source>This is not a valid IP address</source>
+                <target>Cette adresse IP n'est pas valide</target>
+            </trans-unit>
+            <trans-unit id="38">
+                <source>This value is not a valid language</source>
+                <target>Cette langue n'est pas valide</target>
+            </trans-unit>
+            <trans-unit id="39">
+                <source>This value is not a valid locale</source>
+                <target>Ce paramètre régional n'est pas valide</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country</source>
+                <target>Ce pays n'est pas valide</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
I've added the translation of uniqueEntity validation message, I've used `trans-unit id="41"` which seems to be unused
