### PR TITLE
Fix Method ContainerAwareEventDispatcher::hasListeners

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ContainerAwareEventDispatcherTest.php
@@ -122,6 +122,50 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
 
         $dispatcher->dispatch('onEvent');
     }
+
+    public function testHasListenersOnLazyLoad()
+    {
+        $event = new Event();
+
+        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+
+        $service
+            ->expects($this->once())
+            ->method('onEvent')
+            ->with($event)
+        ;
+
+        $container = new Container();
+        $container->set('service.listener', $service);
+
+        $dispatcher = new ContainerAwareEventDispatcher($container);
+        $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'));
+
+        $this->assertTrue($dispatcher->hasListeners());
+
+        if ($dispatcher->hasListeners('onEvent')) {
+            $dispatcher->dispatch('onEvent');
+        }
+    }
+
+    public function testGetListenersOnLazyLoad()
+    {
+        $event = new Event();
+
+        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+
+        $container = new Container();
+        $container->set('service.listener', $service);
+
+        $dispatcher = new ContainerAwareEventDispatcher($container);
+        $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'));
+
+        $listeners = $dispatcher->getListeners();
+
+        $this->assertTrue(isset($listeners['onEvent']));
+
+        $this->assertEquals(1, count($dispatcher->getListeners('onEvent')));
+    }
 }
 
 class Service


### PR DESCRIPTION
Related to #1903.

This is the squashed on 2.0 branch version of the PR #1903

---

Fix Method ContainerAwareEventDispatcher::hasListeners

Fix the fact that Method ContainerAwareEventDispatcher::hasListeners return false if my service is not lazyLoaded
