### PR TITLE
[HttpKernel] Tweaked SQLite to speed up SqliteProfilerStorage

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
@@ -41,6 +41,7 @@ class SqliteProfilerStorage extends PdoProfilerStorage
                 throw new \RuntimeException('You need to enable either the SQLite3 or PDO_SQLite extension for the profiler to run properly.');
             }
 
+            $db->exec('PRAGMA temp_store=MEMORY; PRAGMA journal_mode=MEMORY;');
             $db->exec('CREATE TABLE IF NOT EXISTS sf_profiler_data (token STRING, data STRING, ip STRING, url STRING, time INTEGER, parent STRING, created_at INTEGER)');
             $db->exec('CREATE INDEX IF NOT EXISTS data_created_at ON sf_profiler_data (created_at)');
             $db->exec('CREATE INDEX IF NOT EXISTS data_ip ON sf_profiler_data (ip)');


### PR DESCRIPTION
See: http://stackoverflow.com/questions/6108602/avoiding-locked-sqlite-database-timeouts-with-php-pdo

This is the PR rebased for symfony/2.0 (the old PR was #1864)

---

Hi,

Here is a PR as discussed in issue #1856.
It solves a "fatal error" in the `SqliteProfilerStorage`.
I tested it all day long for real and it works fine.

Regards,
William
