### PR TITLE
Allow kernel parameters to be overriden by extensions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -20,12 +20,18 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class MergeExtensionConfigurationPass implements CompilerPassInterface
 {
+    private $configParams;
+
+    public function __construct(array $configParams)
+    {
+        $this->configParams = $configParams;
+    }
+
     /**
      * {@inheritDoc}
      */
     public function process(ContainerBuilder $container)
     {
-        $parameters = $container->getParameterBag()->all();
         $definitions = $container->getDefinitions();
         $aliases = $container->getAliases();
 
@@ -46,6 +52,6 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
 
         $container->addDefinitions($definitions);
         $container->addAliases($aliases);
-        $container->getParameterBag()->add($parameters);
+        $container->getParameterBag()->add($this->configParams);
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -22,6 +22,12 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
 {
     private $configParams;
 
+    /**
+     * To make sure that the main configuration's parameters are not overridable by extensions
+     * you should pass them to the constructor.
+     *
+     * @param array $configParams Configuration parameters that will take precedence over extensions
+     */
     public function __construct(array $configParams)
     {
         $this->configParams = $configParams;

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -40,7 +40,7 @@ class PassConfig
      */
     public function __construct()
     {
-        $this->mergePass = new MergeExtensionConfigurationPass();
+        $this->mergePass = new MergeExtensionConfigurationPass(array());
 
         $this->afterRemovingPasses = array();
         $this->beforeOptimizationPasses = array();

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPass.php
@@ -23,9 +23,10 @@ class MergeExtensionConfigurationPass extends BaseMergeExtensionConfigurationPas
 {
     private $extensions;
 
-    public function __construct(array $extensions)
+    public function __construct(array $configParams, array $extensions)
     {
         $this->extensions = $extensions;
+        parent::__construct($configParams);
     }
 
     public function process(ContainerBuilder $container)

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -622,7 +622,11 @@ abstract class Kernel implements KernelInterface
             }
         }
 
-        $container = new ContainerBuilder(new ParameterBag($this->getKernelParameters()));
+        $kernelParams = $this->getKernelParameters();
+        $container = new ContainerBuilder(new ParameterBag($kernelParams));
+        $container->addObjectResource($this);
+
+        // ensure these extensions are implicitly loaded
         $extensions = array();
         foreach ($this->bundles as $bundle) {
             $bundle->build($container);
@@ -636,14 +640,20 @@ abstract class Kernel implements KernelInterface
                 $container->addObjectResource($bundle);
             }
         }
-        $container->addObjectResource($this);
-
-        // ensure these extensions are implicitly loaded
-        $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($extensions));
 
         if (null !== $cont = $this->registerContainerConfiguration($this->getContainerLoader($container))) {
             $container->merge($cont);
         }
+
+        // ensure kernel parameters are overridable by extensions
+        $params = $container->getParameterBag()->all();
+        foreach ($params as $key => $val) {
+            if (isset($kernelParams[$key]) && $kernelParams[$key] === $val) {
+                unset($params[$key]);
+            }
+        }
+
+        $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($params, $extensions));
 
         $container->addCompilerPass(new AddClassesToCachePass($this));
         $container->compile();

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/XmlFileLoaderTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
 
 class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -204,6 +205,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         // extension without an XSD
         $loader->load('extensions/services1.xml');
+        $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($container->getParameterBag()->all()));
         $container->compile();
         $services = $container->getDefinitions();
         $parameters = $container->getParameterBag()->all();
@@ -220,6 +222,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $container->registerExtension(new \ProjectWithXsdExtension());
         $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
         $loader->load('extensions/services2.xml');
+        $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($container->getParameterBag()->all()));
         $container->compile();
         $services = $container->getDefinitions();
         $parameters = $container->getParameterBag()->all();

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
@@ -20,6 +20,7 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Compiler\MergeExtensionConfigurationPass;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -132,6 +133,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $container->registerExtension(new \ProjectExtension());
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services10.yml');
+        $container->getCompilerPassConfig()->setMergePass(new MergeExtensionConfigurationPass($container->getParameterBag()->all()));
         $container->compile();
         $services = $container->getDefinitions();
         $parameters = $container->getParameterBag()->all();

--- a/tests/Symfony/Tests/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPassTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/DependencyInjection/MergeExtensionConfigurationPassTest.php
@@ -48,7 +48,7 @@ class MergeExtensionConfigurationPassTest extends \PHPUnit_Framework_TestCase
             ->method('getExtensions')
             ->will($this->returnValue(array()));
 
-        $configPass = new MergeExtensionConfigurationPass(array('loaded', 'notloaded'));
+        $configPass = new MergeExtensionConfigurationPass(array(), array('loaded', 'notloaded'));
         $configPass->process($container);
     }
 }


### PR DESCRIPTION
This just cost me a few hours, I'll try to explain carefully.

The ContainerBuilder receives kernel parameters first, because they are needed for the application config. Then the application config is loaded, and after that the extensions are loaded.

All the parameters/services/aliases defined _before_ the extensions are loaded are saved, and restored after the extensions got loaded, because anything you define in the config should take precedence over everything else. That is good. But the problem is that kernel params are added before the app config, and those are also protected by this behavior. 

For example `framework.charset` is broken at the moment because in the FrameworkExtension it sets the `kernel.charset` value, and it is then reset to UTF-8 after the extension is merged.

What the patch does is load the kernel params, load the app config, diff the two to be sure we have only the app config, and pass that to the compiler pass that merges extensions, so it can restore only those parameters that were added by the app config. We unfortunately can't just ignore kernel.\* params because those could be defined by users in the app config.
