### PR TITLE
Impossible to use ACL provider cache

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
@@ -27,7 +27,7 @@
         <service id="security.acl.provider" alias="security.acl.dbal.provider" />
 
         <service id="security.acl.cache.doctrine" class="%security.acl.cache.doctrine.class%" public="false">
-            <argument type="service" id="security.acl.cache.doctrine_cache_impl" />
+            <argument type="service" id="security.acl.cache.doctrine.cache_impl" />
             <argument type="service" id="security.acl.permission_granting_strategy" />
         </service>
 


### PR DESCRIPTION
Using ACL provider cache is impossible. It's due to a typo in the configuration file (an undescore in place of a dot). My PR fixes this. Maybe add some tests to validate the ACL cache feature?
