### PR TITLE
[Validator] FileValidator allow MIME with wildcard

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -109,10 +109,28 @@ class FileValidator extends ConstraintValidator
                 $value = new FileObject($value);
             }
 
-            if (!in_array($value->getMimeType(), (array) $constraint->mimeTypes)) {
+            $mimeTypes = (array) $constraint->mimeTypes;
+            $mime = $value->getMimeType();
+            $valid = false;
+
+            foreach ($mimeTypes as $mimeType) {
+                if ($mimeType === $mime) {
+                    $valid = true;
+                    break;
+                }
+
+                if ($discrete = strstr($mimeType, '/*', true)) {
+                    if (strstr($mime, '/', true) === $discrete) {
+                        $valid = true;
+                        break;
+                    }
+                }                
+            }
+
+            if (false === $valid) {
                 $this->setMessage($constraint->mimeTypesMessage, array(
-                    '{{ type }}'    => '"'.$value->getMimeType().'"',
-                    '{{ types }}'   => '"'.implode('", "', (array) $constraint->mimeTypes).'"',
+                    '{{ type }}'    => '"'.$mime.'"',
+                    '{{ types }}'   => '"'.implode('", "', $mimeTypes) .'"',
                     '{{ file }}'    => $path,
                 ));
 

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -127,7 +127,7 @@ class FileValidator extends ConstraintValidator
                 }                
             }
 
-            if (false === $valid) {
+            if (!$valid) {
                 $this->setMessage($constraint->mimeTypesMessage, array(
                     '{{ type }}'    => '"'.$mime.'"',
                     '{{ types }}'   => '"'.implode('", "', $mimeTypes) .'"',

--- a/src/Symfony/Component/Validator/Constraints/Image.php
+++ b/src/Symfony/Component/Validator/Constraints/Image.php
@@ -18,13 +18,7 @@ namespace Symfony\Component\Validator\Constraints;
  */
 class Image extends File
 {
-    public $mimeTypes = array(
-        'image/png',
-        'image/jpg',
-        'image/jpeg',
-        'image/pjpeg',
-        'image/gif',
-    );
+    public $mimeTypes = 'image/*';
     public $mimeTypesMessage = 'This file is not a valid image';
 
     /**

--- a/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorTest.php
@@ -171,6 +171,31 @@ class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->isValid($file, $constraint));
     }
 
+    public function testValidWildcardMimeType()
+    {
+        $file = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getPathname')
+            ->will($this->returnValue($this->path))
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getMimeType')
+            ->will($this->returnValue('image/jpg'))
+        ;
+
+        $constraint = new File(array(
+            'mimeTypes' => array('image/*'),
+        ));
+
+        $this->assertTrue($this->validator->isValid($file, $constraint));
+    }
+
     public function testInvalidMimeType()
     {
         $file = $this
@@ -184,7 +209,7 @@ class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->path))
         ;
         $file
-            ->expects($this->exactly(2))
+            ->expects($this->once())
             ->method('getMimeType')
             ->will($this->returnValue('application/pdf'))
         ;
@@ -199,6 +224,38 @@ class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->validator->getMessageParameters(), array(
             '{{ type }}'    => '"application/pdf"',
             '{{ types }}'   => '"image/png", "image/jpg"',
+            '{{ file }}'    => $this->path,
+        ));
+    }
+
+    public function testInvalidWildcardMimeType()
+    {
+        $file = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getPathname')
+            ->will($this->returnValue($this->path))
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getMimeType')
+            ->will($this->returnValue('application/pdf'))
+        ;
+
+        $constraint = new File(array(
+            'mimeTypes' => array('image/*', 'image/jpg'),
+            'mimeTypesMessage' => 'myMessage',
+        ));
+
+        $this->assertFalse($this->validator->isValid($file, $constraint));
+        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
+        $this->assertEquals($this->validator->getMessageParameters(), array(
+            '{{ type }}'    => '"application/pdf"',
+            '{{ types }}'   => '"image/*", "image/jpg"',
             '{{ file }}'    => $this->path,
         ));
     }


### PR DESCRIPTION
- Allow MIME with wildcard like `image/*`
- Image constraint use wildcard mime

(squash failed sorry #2068)
