### PR TITLE
[2.1][FrameworkBundle] sanitize target arg in asset:install command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -60,7 +60,9 @@ EOT
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!is_dir($input->getArgument('target'))) {
+        $targetArg = rtrim($input->getArgument('target'), '/');
+
+        if (!is_dir($targetArg)) {
             throw new \InvalidArgumentException(sprintf('The target directory "%s" does not exist.', $input->getArgument('target')));
         }
 
@@ -71,11 +73,11 @@ EOT
         $filesystem = $this->getContainer()->get('filesystem');
 
         // Create the bundles directory otherwise symlink will fail.
-        $filesystem->mkdir($input->getArgument('target').'/bundles/', 0777);
+        $filesystem->mkdir($targetArg.'/bundles/', 0777);
 
         foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
             if (is_dir($originDir = $bundle->getPath().'/Resources/public')) {
-                $targetDir = $input->getArgument('target').'/bundles/'.preg_replace('/bundle$/', '', strtolower($bundle->getName()));
+                $targetDir = $targetArg.'/bundles/'.preg_replace('/bundle$/', '', strtolower($bundle->getName()));
 
                 $output->writeln(sprintf('Installing assets for <comment>%s</comment> into <comment>%s</comment>', $bundle->getNamespace(), $targetDir));
 


### PR DESCRIPTION
`php app/console assets:install web/` 

(removed tailing /)

 before 
`Installing assets for Symfony\Bundle\FrameworkBundle into web//bundles/framework`  
after
`Installing assets for Symfony\Bundle\FrameworkBundle into web/bundles/framework`
