### PR TITLE
few optimisations for XliffFileLoader and XmlFileLoader

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -326,10 +326,10 @@ class XmlFileLoader extends FileLoader
         $imports = '';
         foreach ($schemaLocations as $namespace => $location) {
             $parts = explode('/', $location);
-            if (preg_match('#^phar://#i', $location)) {
+            if (0 === stripos($location, 'phar://')) {
                 $tmpfile = tempnam(sys_get_temp_dir(), 'sf2');
                 if ($tmpfile) {
-                    file_put_contents($tmpfile, file_get_contents($location));
+                    copy($location, $tmpfile);
                     $tmpfiles[] = $tmpfile;
                     $parts = explode('/', str_replace('\\', '/', $tmpfile));
                 }

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -58,11 +58,10 @@ class XliffFileLoader implements LoaderInterface
 
         $location = str_replace('\\', '/', __DIR__).'/schema/dic/xliff-core/xml.xsd';
         $parts = explode('/', $location);
-        if (preg_match('#^phar://#i', $location)) {
+        if (0 === stripos($location, 'phar://')) {
             $tmpfile = tempnam(sys_get_temp_dir(), 'sf2');
             if ($tmpfile) {
-                file_put_contents($tmpfile, file_get_contents($location));
-                $tmpfiles[] = $tmpfile;
+                copy($location, $tmpfile);
                 $parts = explode('/', str_replace('\\', '/', $tmpfile));
             }
         }


### PR DESCRIPTION
- file_put_contents + file_get_contents -> copy
- use stripos insteed preg_match
- removed useless `$tmpfiles` in XliffFileLoader
