### PR TITLE
Added RSS HTTP request format

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1220,6 +1220,7 @@ class Request
             'xml'  => array('text/xml', 'application/xml', 'application/x-xml'),
             'rdf'  => array('application/rdf+xml'),
             'atom' => array('application/atom+xml'),
+            'rss'  => array('application/rss+xml'),
         );
     }
 }


### PR DESCRIPTION
Hi,

We have added RSS HTTP request format to `initializeFormats()` function in HttpFoundation Request class, to enable specifying `_format: rss` in routing files.

We couldn't find a reason for not having the rss format specified, and even the [cookbook refers](http://symfony.com/doc/2.0/book/routing.html#advanced-routing-example) to using of `_format: rss` .

Thanks,
Bait.sk
