### PR TITLE
Added missing method to HTTP Digest entry point

### DIFF
--- a/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
@@ -61,4 +61,14 @@ class DigestAuthenticationEntryPoint implements AuthenticationEntryPointInterfac
 
         return $response;
     }
+
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function getRealmName()
+    {
+        return $this->realmName;
+    }
 }


### PR DESCRIPTION
I added getKey() and getRealmName() to DigestAuthenticationEntryPoint because of this error:
Fatal error: Call to undefined method Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint::getKey() in /.../vendor/symfony/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php on line 79
