### PR TITLE
ClassLoader support for traits (PHP >= 5.4)

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -84,7 +84,7 @@ class ClassCollectionLoader
         $files = array();
         $content = '';
         foreach ($classes as $class) {
-            if (!self::isLoadable($class)) {
+            if (!self::isLoaded($class)) {
                 throw new \InvalidArgumentException(sprintf('Unable to load class "%s"', $class));
             }
 
@@ -224,20 +224,19 @@ class ClassCollectionLoader
      * Checks if $class is either an existing class, interface or trait.
      *
      * @param string $class
+     * @param bool   $autoload
+     *
      * @return bool
      */
-    static private function isLoadable($class)
+    static private function isLoaded($class)
     {
-        if (class_exists($class)) {
-            return true;
-        }
-        
-        if (interface_exists($class)) {
+        // Check for class or interface
+        if (class_exists($class) || interface_exists($class)) {
             return true;
         }
 
-        $traitsAvailable = function_exists('trait_exists');
-        if ($traitsAvailable && trait_exists($class)) {
+        // Check for traits only if available (PHP >= 5.4)
+        if (function_exists('trait_exists') && trait_exists($class)) {
             return true;
         }
 

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -84,7 +84,7 @@ class ClassCollectionLoader
         $files = array();
         $content = '';
         foreach ($classes as $class) {
-            if (!class_exists($class) && !interface_exists($class)) {
+            if (!self::isLoadable($class)) {
                 throw new \InvalidArgumentException(sprintf('Unable to load class "%s"', $class));
             }
 
@@ -218,5 +218,29 @@ class ClassCollectionLoader
         $output = preg_replace(array('/\s+$/Sm', '/\n+/S'), "\n", $output);
 
         return $output;
+    }
+
+    /**
+     * Checks if $class is either an existing class, interface or trait.
+     *
+     * @param string $class
+     * @return bool
+     */
+    static private function isLoadable($class)
+    {
+        if (class_exists($class)) {
+            return true;
+        }
+        
+        if (interface_exists($class)) {
+            return true;
+        }
+
+        $traitsAvailable = function_exists('trait_exists');
+        if ($traitsAvailable && trait_exists($class)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -224,7 +224,6 @@ class ClassCollectionLoader
      * Checks if $class is either an existing class, interface or trait.
      *
      * @param string $class
-     * @param bool   $autoload
      *
      * @return bool
      */

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -65,7 +65,6 @@ class DebugUniversalClassLoader extends UniversalClassLoader
      * Checks if $class is either an existing class, interface or trait.
      *
      * @param string $class
-     * @param bool   $autoload
      *
      * @return bool
      */

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -55,12 +55,8 @@ class DebugUniversalClassLoader extends UniversalClassLoader
         if ($file = $this->findFile($class)) {
             require $file;
 
-            if (!$this->isLoadable($class)) {
-                throw new \RuntimeException(sprintf(
-                    'The autoloader expected class "%s" to be defined in file "%s". '.
-                    'The file was found but the class was not in it, the class name or namespace probably has a typo.',
-                    $class, $file
-                ));
+            if (!$this->isLoaded($class)) {
+                throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but the class was not in it, the class name or namespace probably has a typo.', $class, $file));
             }
         }
     }
@@ -69,20 +65,19 @@ class DebugUniversalClassLoader extends UniversalClassLoader
      * Checks if $class is either an existing class, interface or trait.
      *
      * @param string $class
+     * @param bool   $autoload
+     *
      * @return bool
      */
-    private function isLoadable($class)
+    private function isLoaded($class)
     {
-        if (class_exists($class)) {
+        // Check for class or interface
+        if (class_exists($class, false) || interface_exists($class, false)) {
             return true;
         }
 
-        if (interface_exists($class)) {
-            return true;
-        }
-
-        $traitsAvailable = function_exists('trait_exists');
-        if ($traitsAvailable && trait_exists($class)) {
+        // Check for traits only if available (PHP >= 5.4)
+        if (function_exists('trait_exists') && trait_exists($class, false)) {
             return true;
         }
 

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -55,9 +55,37 @@ class DebugUniversalClassLoader extends UniversalClassLoader
         if ($file = $this->findFile($class)) {
             require $file;
 
-            if (!class_exists($class, false) && !interface_exists($class, false)) {
-                throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but the class was not in it, the class name or namespace probably has a typo.', $class, $file));
+            if (!$this->isLoadable($class)) {
+                throw new \RuntimeException(sprintf(
+                    'The autoloader expected class "%s" to be defined in file "%s". '.
+                    'The file was found but the class was not in it, the class name or namespace probably has a typo.',
+                    $class, $file
+                ));
             }
         }
+    }
+
+    /**
+     * Checks if $class is either an existing class, interface or trait.
+     *
+     * @param string $class
+     * @return bool
+     */
+    private function isLoadable($class)
+    {
+        if (class_exists($class)) {
+            return true;
+        }
+
+        if (interface_exists($class)) {
+            return true;
+        }
+
+        $traitsAvailable = function_exists('trait_exists');
+        if ($traitsAvailable && trait_exists($class)) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Added support for traits while not breaking older php versions.

Hurts a little bit to duplicate `isLoadable()`. Any chance to put this into a common place for all loaders?
