### PR TITLE
[Form] Empty data option handles an empty string as NULL

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -142,7 +142,7 @@ class FieldType extends AbstractType
                 return new $class();
             };
         } else {
-            $defaultOptions['empty_data'] = '';
+            $defaultOptions['empty_data'] = null;
         }
 
         return $defaultOptions;

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1004,7 +1004,7 @@ class Form implements \IteratorAggregate, FormInterface
     private function clientToNorm($value)
     {
         if (!$this->clientTransformers) {
-            return '' === $value ? null : $value;
+            return $value;
         }
 
         for ($i = count($this->clientTransformers) - 1; $i >= 0; --$i) {

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -109,7 +109,7 @@ class FormBuilder
      * Data used for the client data when no value is bound
      * @var mixed
      */
-    private $emptyData = '';
+    private $emptyData = null;
 
     private $currentLoadingType;
 

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -1003,6 +1003,18 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($parent, $view->getParent());
     }
 
+    public function testEmptyStringData()
+    {
+        $test = $this;
+        $form = $this->getBuilder()
+            ->setEmptyData('')
+            ->getForm();
+
+        $form->bind(null);
+
+        $this->assertTrue('' === $form->getData());
+    }
+
     protected function getBuilder($name = 'name', EventDispatcherInterface $dispatcher = null)
     {
         return new FormBuilder($name, $this->factory, $dispatcher ?: $this->dispatcher);


### PR DESCRIPTION
If the specified empty data to builder is an empty string and the inputted value is empty, form returns NULL as data.

The following is the minimum reproduce code:

```
use Symfony\Component\Form\FormBuilder;
use Symfony\Component\Form\FormFactory;
use Symfony\Component\EventDispatcher\EventDispatcher;

$builder = new FormBuilder('field', new FormFactory(array()), new EventDispatcher());
$form = $builder->setEmptyData('')->getForm();

$form->bind(null);
var_dump($form->getData());  // output "NULL"
```

I don't think this result is not good. In this situation, $form->getData() must return an empty string.

I'm in trouble with this behavior. My case is:
1. Create an entity for Doctrine ORM which has a non-nullable text field. That "non-nullable" restriction is just a performance reason. It accepts an empty string as empty value
2. Create a form for binding user data to the entity. Set {'required' : false, 'empty_data' : ''} options to a form field which is for the non-nullable text field of the entity
3. User leaves blank for the field
4. The form sets NULL to the field of the entity
5. DBMS deny that NULL value

It is avoidable by casting to string value in all setters for such fields. But I can't see a valid reason of ignoring setEmptyData('')

I have a patch to fix this problem. A concept of my patch is:
- A default value of the empty data option must be NULL
- In user inputted data, form doesn't make distinction between NULL and an empty string
- In binding empty data, form makes distinction between NULL and an empty string
- After the binding user inputted data (or empty data), form makes distinction between NULL and an empty string
