### PR TITLE
Checking if the passthru function exists

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -28,7 +28,7 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
      */
     static public function isSupported()
     {
-        return !strstr(PHP_OS, 'WIN');
+        return !strstr(PHP_OS, 'WIN') && function_exists('passthru');
     }
     /**
      * Guesses the mime type of the file with the given path


### PR DESCRIPTION
In a server I'm using this the passthru function is disabled for security reasons, so I added a check to see if it exists before adding the FileBinaryMimeTypeGuesser as a supported MimeTypeGuesser.
