### PR TITLE
Session locale

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -68,11 +68,14 @@ class Session implements \Serializable
         if (isset($attributes['attributes'])) {
             $this->attributes = $attributes['attributes'];
             $this->flashes = $attributes['flashes'];
-            $this->locale = $attributes['locale'];
-            $this->setPhpDefaultLocale($this->locale);
 
             // flag current flash messages to be removed at shutdown
             $this->oldFlashes = $this->flashes;
+        }
+
+        if (isset($attributes['locale'])) {
+            $this->locale = $attributes['locale'];
+            $this->setPhpDefaultLocale($this->locale);
         }
 
         $this->started = true;


### PR DESCRIPTION
Hi,

I've encountered an error with session storage, which had no locale parameter set.

The current code would overwrite the Session::locale even with an empty locale attribute from the storage, erasing the default_locale option set in configuration during the Session::start() execution. My commit resolves this issue, verifying if the locale attribute is set in storage.
