### PR TITLE
Changed the behavior of Session::regenerate to destroy the old session when invalidates it.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -194,7 +194,7 @@ class Session implements \Serializable
     public function invalidate()
     {
         $this->clear();
-        $this->storage->regenerate();
+        $this->storage->regenerate(true);
     }
 
     /**


### PR DESCRIPTION
When invalidating a session, I've yet to find a reason for the storage not to destroy the old session.

If the intent of the method is to invalidate the session, there's no reason at all to keep the old session around in storage, since it's supposed to be invalid.
