### PR TITLE
Added missing translation for Swedish

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sv.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sv.xliff
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid</source>
-                <target>One or more of the given values is invalid</target>
+                <target>Ett eller fler av de valda värdena är ogiltigt</target>
             </trans-unit>
             <trans-unit id="9">
                 <source>The fields {{ fields }} were not expected</source>


### PR DESCRIPTION
A missing Swedish translation for "One or more of the given values is invalid" was added.

(New PR with changed base from #2177)
