### PR TITLE
[Validator] Fixed UniqueEntityValidator to properly handle association fields

### DIFF
--- a/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/CompositeRelationOriginEntity.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/CompositeRelationOriginEntity.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Tests\Bridge\Doctrine\Form\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Doctrine\ORM\Mapping\JoinColumns;
+use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\CompositeIdentEntity;
+
+/** @Entity */
+class CompositeRelationOriginEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+    
+    /**
+     * @OneToOne(targetEntity="CompositeIdentEntity")
+     * @JoinColumns({
+     *  @JoinColumn(name="composite_ident_id1", referencedColumnName="id1"),
+     *  @JoinColumn(name="composite_ident_id2", referencedColumnName="id2")
+     * })
+     */    
+    protected $composite_ident;
+    
+    public function __construct($id, CompositeIdentEntity $composite_ident) {
+        $this->id = $id;
+        $this->composite_ident = $composite_ident;
+    }
+}

--- a/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/RelationOriginEntity.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/RelationOriginEntity.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Symfony\Tests\Bridge\Doctrine\Form\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+use Doctrine\ORM\Mapping\OneToOne;
+use Doctrine\ORM\Mapping\JoinColumn;
+use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\SingleIdentEntity;
+
+/** @Entity */
+class RelationOriginEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /**
+     * @OneToOne(targetEntity="SingleIdentEntity")
+     * @JoinColumn(name="single_ident_id", referencedColumnName="id")
+     */
+    protected $single_ident;
+
+    public function __construct($id, SingleIdentEntity $single_ident) {
+        $this->id = $id;
+        $this->single_ident = $single_ident;
+    }
+}


### PR DESCRIPTION
Issue #1635
If one of the fields in a UniqueEntity constraint is actually an association field, use the value of the associated entity related field to perform the validation for uniqueness.
This patch doesn't fix the case where the association field is a composite primary key entity. This will be fixed inside Doctrine in the future.
