### PR TITLE
[Validator] Validate object with it's own entity manager by default

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -54,7 +54,11 @@ class UniqueEntityValidator extends ConstraintValidator
             throw new ConstraintDefinitionException("At least one field has to be specified.");
         }
 
-        $em = $this->registry->getEntityManager($constraint->em);
+        if ($constraint->em) {
+            $em = $this->registry->getEntityManager($constraint->em);
+        } else {
+            $em = $this->registry->getEntityManagerForClass(get_class($entity));
+        }
 
         $className = $this->context->getCurrentClass();
         $class = $em->getClassMetadata($className);


### PR DESCRIPTION
While working with multiple object managers the default validation uses default entity manager, requiring the dev to create own validation services for each entity using other entity managers. This commit causes entity to be validated (by default) by it's own entity manager, while still preserving a possiblity to specifiy $constraint->em.

This is was a pull request to 2.0, changed to master according to stof's suggestion.
