### PR TITLE
[FrameworkBundle] Allow definition of extra app.* Twig globals from the configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -21,10 +21,43 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class GlobalVariables
 {
     protected $container;
+    protected $additionalGlobals = array();
 
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
+    }
+
+    /**
+     * Stores an array of extra globals available through this class
+     *
+     * @param array $globals
+     */
+    public function setAdditionalGlobals(array $globals)
+    {
+        $this->additionalGlobals = $globals;
+    }
+
+    /**
+     * Checks if an additional global exists
+     *
+     * @param string $var var name
+     * @return Boolean
+     */
+    public function __isset($var)
+    {
+        return array_key_exists($var, $this->additionalGlobals);
+    }
+
+    /**
+     * Returns an additional global
+     *
+     * @param string $var var name
+     * @return mixed
+     */
+    public function __get($var)
+    {
+        return $this->additionalGlobals[$var];
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -40,6 +40,10 @@ class TwigEngine implements EngineInterface
         $this->parser = $parser;
 
         if (null !== $globals) {
+            $origGlobals = $environment->getGlobals();
+            if (isset($origGlobals['app'])) {
+                $globals->setAdditionalGlobals($origGlobals['app']);
+            }
             $environment->addGlobal('app', $globals);
         }
     }


### PR DESCRIPTION
This may be too hackish to make it in core, but I think it's a pretty cool feature so I suggest it anyway.

Basically it allows to add data into the "app" globals from config.yml like:

``` yaml
twig:
    globals:
        app:
            foo: bar
```

`{{ app.foo }}` is now working in the templates.
