### PR TITLE
Twig error on transchoice

### DIFF
--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -148,6 +148,9 @@ class Translator implements TranslatorInterface
         if (!$this->catalogues[$locale]->defines($id, $domain)) {
             // we will use the locale fallback
             foreach ($this->computeFallbackLocales($locale) as $fallback) {
+                if(!isset($this->catalogues[$fallback])){
+                    $this->loadCatalogue($fallback);
+                }
                 if ($this->catalogues[$fallback]->defines($id, $domain)) {
                     $locale = $fallback;
                     break;


### PR DESCRIPTION
With the last commit to add support for more than one fallback locale, i get this error when i try to use {%transchoice%} in Twig:

'An exception has been thrown during the rendering of a template ("Notice: Undefined index: pt in /home/nginx/sf2-sandbox/vendor/symfony/src/Symfony/Component/Translation/Translator.php line 151")'

In this case, my locale fallback is set to "pt_BR".

Thank you!
Fernando
