### PR TITLE
[WebProfilerBundle] Propose to open debug toolbar request in an error occ

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -3,6 +3,7 @@
     (function () {
         var wdt, xhr;
         var url = '{{ path("_wdt", { "token": token }) }}';
+        var urlPanel = '{{ path("_profiler", { "token": token }) }}';
         wdt = document.getElementById('sfwdt{{ token }}');
         if (window.XMLHttpRequest) {
             xhr = new XMLHttpRequest();
@@ -16,7 +17,7 @@
                 wdt.innerHTML = xhr.responseText;
                 wdt.style.display = 'block';
             } else if (4 === xhr.readyState && xhr.status != 200) {
-                confirm('An error occured while loading the debug toolbar ('+xhr.status+': '+xhr.statusText.') .\n\nDo you want to open the page ?') && (window.location = url);
+                confirm('An error occured while loading the debug toolbar ('+xhr.status+': '+xhr.statusText+') .\n\nDo you want to open the page ?') && (window.location = urlPanel);
             }
         };
         xhr.send('');

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -16,7 +16,7 @@
                 wdt.innerHTML = xhr.responseText;
                 wdt.style.display = 'block';
             } else if (4 === xhr.readyState && xhr.status != 200) {
-                    confirm('An error occured while loading the debug toolbar ('+xhr.status+': '+xhr.statusText.') .\n\nDo you want to open the page ?') && (window.location = url);
+                confirm('An error occured while loading the debug toolbar ('+xhr.status+': '+xhr.statusText.') .\n\nDo you want to open the page ?') && (window.location = url);
             }
         };
         xhr.send('');

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -2,22 +2,20 @@
 <script type="text/javascript">/*<![CDATA[*/
     (function () {
         var wdt, xhr;
-        var url = '{{ path("_wdt", { "token": token }) }}';
-        var urlPanel = '{{ path("_profiler", { "token": token }) }}';
         wdt = document.getElementById('sfwdt{{ token }}');
         if (window.XMLHttpRequest) {
             xhr = new XMLHttpRequest();
         } else {
             xhr = new ActiveXObject('Microsoft.XMLHTTP');
         }
-        xhr.open('GET', url, true);
+        xhr.open('GET', '{{ path("_wdt", { "token": token }) }}', true);
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
         xhr.onreadystatechange = function(state) {
             if (4 === xhr.readyState && 200 === xhr.status && -1 !== xhr.responseText.indexOf('sf-toolbarreset')) {
                 wdt.innerHTML = xhr.responseText;
                 wdt.style.display = 'block';
             } else if (4 === xhr.readyState && xhr.status != 200) {
-                confirm('An error occured while loading the debug toolbar ('+xhr.status+': '+xhr.statusText+') .\n\nDo you want to open the page ?') && (window.location = urlPanel);
+                confirm('An error occured while loading the debug toolbar ('+xhr.status+': '+xhr.statusText+') .\n\nDo you want to open the page ?') && (window.location = '{{ path("_profiler", { "token": token }) }}');
             }
         };
         xhr.send('');

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -2,18 +2,21 @@
 <script type="text/javascript">/*<![CDATA[*/
     (function () {
         var wdt, xhr;
+        var url = '{{ path("_wdt", { "token": token }) }}';
         wdt = document.getElementById('sfwdt{{ token }}');
         if (window.XMLHttpRequest) {
             xhr = new XMLHttpRequest();
         } else {
             xhr = new ActiveXObject('Microsoft.XMLHTTP');
         }
-        xhr.open('GET', '{{ path("_wdt", { "token": token }) }}', true);
+        xhr.open('GET', url, true);
         xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
         xhr.onreadystatechange = function(state) {
             if (4 === xhr.readyState && 200 === xhr.status && -1 !== xhr.responseText.indexOf('sf-toolbarreset')) {
                 wdt.innerHTML = xhr.responseText;
                 wdt.style.display = 'block';
+            } else if (4 === xhr.readyState && xhr.status != 200) {
+                    confirm('An error occured while loading the debug toolbar ('+xhr.status+': '+xhr.statusText.') .\n\nDo you want to open the page ?') && (window.location = url);
             }
         };
         xhr.send('');


### PR DESCRIPTION
[WebProfilerBundle] Propose to open debug toolbar request in an error occured.

This is very useful when creating data collectors and an error occurs
when redering the toolbar via XHR.

The only problem is that the exception page renders the toolbar via JS, too.
