### PR TITLE
Added basic support for custom (sub)domains in routes (#1762)

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -175,7 +175,7 @@ class UrlGenerator implements UrlGeneratorInterface
             } elseif (isset($defaults['response_host'])) {
                 $url = $defaults['response_host'].$url;
             }
-        } elseif (isset($defaults['response_host'])) {die('no abs');
+        } elseif (isset($defaults['response_host'])) {
             $url = $defaults['response_host'].$url;
         }
 

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -167,8 +167,16 @@ class UrlGenerator implements UrlGeneratorInterface
                     $port = ':'.$this->context->getHttpsPort();
                 }
 
-                $url = $scheme.'://'.$this->context->getHost().$port.$url;
+                if (false === isset($defaults['response_host'])) {
+                    $url = $scheme.'://'.$this->context->getHost().$port.$url;
+                } else {
+                    $url = $scheme.'://'.$defaults['response_host'].$port.$url;
+                }
+            } elseif (isset($defaults['response_host'])) {
+                $url = $defaults['response_host'].$url;
             }
+        } elseif (isset($defaults['response_host'])) {die('no abs');
+            $url = $defaults['response_host'].$url;
         }
 
         return $url;

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -167,10 +167,10 @@ class UrlGenerator implements UrlGeneratorInterface
                     $port = ':'.$this->context->getHttpsPort();
                 }
 
-                if (false === isset($defaults['response_host'])) {
-                    $url = $scheme.'://'.$this->context->getHost().$port.$url;
-                } else {
+                if (isset($defaults['response_host'])) {
                     $url = $scheme.'://'.$defaults['response_host'].$port.$url;
+                } else {
+                    $url = $scheme.'://'.$this->context->getHost().$port.$url;
                 }
             } elseif (isset($defaults['response_host'])) {
                 $url = $defaults['response_host'].$url;

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -171,6 +171,10 @@ EOF;
             $matches = true;
         }
 
+        if (null !== $route->getOption('request_host')) {
+            $conditions[] = sprintf("preg_match(%s, \$this->context->getHost())", var_export("#" . $route->getOption('request_host') . "#ix", true));
+        }
+
         $conditions = implode(' && ', $conditions);
 
         $gotoname = 'not_'.preg_replace('/[^A-Za-z0-9_]/', '', $name);

--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -206,6 +206,13 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/app.php/foo', $this->getGenerator($routes)->generate('test', array('default' => 'foo')));
     }
 
+    public function testWithFullResponseHostValue()
+    {
+        $routes = $this->getRoutes('test', new Route('/', array('response_host' => 'www.acme.com')));
+
+        $this->assertEquals('www.acme.com/app.php/', $this->getGenerator($routes)->generate('test', array('response_host' => 'www.acme.com')));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array())
     {
         $context = new RequestContext('/app.php');


### PR DESCRIPTION
This PR attempts to address the need of defining custom routes for adding subdomains and external domain names compatibility to defining routes.

It can be done like:

``` yml
_welcome:
    pattern:  /
    defaults: { _controller: AcmeDemoBundle:Welcome:index, response_host: www.symfony.com }
```

and the route that will be displayed will be like this: `www.symfony.com/`

Also I've added support for filtering incoming requests for specific subdomains and domains, it can be done like this:

``` yml
_welcome:
    pattern:  /
    defaults: { _controller: AcmeDemoBundle:Welcome:index }
    options:
        request_host:  ^(www\.)?symfony.com$
```

And it will accept all incoming requests for either `www.symfony.com` or `symfony.com`. 
As you can see, this option accepts regular expressions and it will allow for a very interesting use, defining multiple routes for the same request path, like this:

``` yml
_welcome:
    pattern:  /
    defaults: { _controller: AcmeDemoBundle:Welcome:index }
    options:
        request_host:  ^(www\.)?symfony.com$

_welcome_back:
    pattern:  /
    defaults: { _controller: AcmeDemoBundle:Welcome:back }
    options:
        request_host:  ^back.symfony.com$
```

I've only added a test due to the lack of time and should anyone find this at least part useful feel free to add to it. Also let me know what I can do better in this PR so it can be included into Symfony2.

Regards.

NOTE:
I've only tested this with YML routes as those are the only routes I use and the request domain filtering only works with PHP routes as those are the only one I use. I don't know how to do the dumper for Apache routes to work so any help on that is welcomed.
