### PR TITLE
Fixed the creation of the subrequests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -124,7 +124,7 @@ class HttpKernel extends BaseHttpKernel
 
         // controller or URI?
         if (0 === strpos($controller, '/')) {
-            $subRequest = Request::create($controller, 'get', array(), $request->cookies->all(), array(), $request->server->all());
+            $subRequest = Request::create($request->getUriForPath($controller), 'get', array(), $request->cookies->all(), array(), $request->server->all());
             $subRequest->setSession($request->getSession());
         } else {
             $options['attributes']['_controller'] = $controller;

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -71,6 +71,9 @@ class HttpUtils
             $this->resetLocale($request);
             $path = $this->generateUrl($path, true);
         }
+        if (0 !== strpos($path, 'http')) {
+            $path = $request->getUriForPath($path);
+        }
 
         $newRequest = Request::create($path, 'get', array(), $request->cookies->all(), array(), $request->server->all());
         if ($session = $request->getSession()) {


### PR DESCRIPTION
The subrequest must be created using an absolute path to keep the
informations about the host and the base path.
Closes #2168
