### PR TITLE
[FrameworkBundle] Assets templating helper does not need request scope

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -34,7 +34,7 @@
             <tag name="templating.helper" alias="slots" />
         </service>
 
-        <service id="templating.helper.assets" class="%templating.helper.assets.class%" scope="request">
+        <service id="templating.helper.assets" class="%templating.helper.assets.class%">
             <tag name="templating.helper" alias="assets" />
             <argument /> <!-- default package -->
             <argument type="collection" /> <!-- named packages -->


### PR DESCRIPTION
I traced this request scope addition back to [an old commit](https://github.com/symfony/symfony/commit/d9f5c99fabc649b7067daf6f2f69bdd86f6f715b#commitcomment-597654) from @kriswallsmith.

No other helpers have request scope and the assets helper's parameters don't appear to depend on the request in any way, so this appears to be unnecessary. As-is, request scope here prevents use of the assets helper from a console command that may need to internally render a template.
