### PR TITLE
ResizeDataListener::presetData and ::preBind don't pass data to recreated row

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -90,7 +90,7 @@ class ResizeFormListener implements EventSubscriberInterface
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
-            $form->add($this->factory->createNamed($this->type, $name, null, array_replace(array(
+            $form->add($this->factory->createNamed($this->type, $name, $value, array_replace(array(
                 'property_path' => '['.$name.']',
             ), $this->options)));
         }
@@ -122,7 +122,7 @@ class ResizeFormListener implements EventSubscriberInterface
         if ($this->allowAdd) {
             foreach ($data as $name => $value) {
                 if (!$form->has($name)) {
-                    $form->add($this->factory->createNamed($this->type, $name, null, array_replace(array(
+                    $form->add($this->factory->createNamed($this->type, $name, $value, array_replace(array(
                         'property_path' => '['.$name.']',
                     ), $this->options)));
                 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -58,14 +58,14 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->at(0))
             ->method('createNamed')
-            ->with('text', 1, null, array('property_path' => '[1]', 'max_length' => 10))
+            ->with('text', 1, 'string1', array('property_path' => '[1]', 'max_length' => 10))
             ->will($this->returnValue($this->getForm('1')));
         $this->factory->expects($this->at(1))
             ->method('createNamed')
-            ->with('text', 2, null, array('property_path' => '[2]', 'max_length' => 10))
+            ->with('text', 2, 'string2', array('property_path' => '[2]', 'max_length' => 10))
             ->will($this->returnValue($this->getForm('2')));
 
-        $data = array(1 => 'string', 2 => 'string');
+        $data = array(1 => 'string1', 2 => 'string2');
         $event = new DataEvent($this->form, $data);
         $listener = new ResizeFormListener($this->factory, 'text', array('max_length' => '10'), false, false);
         $listener->preSetData($event);
@@ -102,10 +102,10 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->factory->expects($this->once())
             ->method('createNamed')
-            ->with('text', 1, null, array('property_path' => '[1]', 'max_length' => 10))
+            ->with('text', 1, 'string2', array('property_path' => '[1]', 'max_length' => 10))
             ->will($this->returnValue($this->getForm('1')));
 
-        $data = array(0 => 'string', 1 => 'string');
+        $data = array(0 => 'string1', 1 => 'string2');
         $event = new DataEvent($this->form, $data);
         $listener = new ResizeFormListener($this->factory, 'text', array('max_length' => 10), true, false);
         $listener->preBind($event);


### PR DESCRIPTION
ResizeDataListener::presetData and ::preBind could/should pass data to $this->factory->createNamed(...) when recreating rows. This makes the data object available in the $options['data'] variable in the form class.

The 'createNamed' function was introduced in:
https://github.com/symfony/symfony/commit/a97366fbcb75d96bc53916732580c4b88784cad2#diff-0

Is there a special reason why the value isn't passed as data? I figured it's a bug.

This commits addresses the issue and updates the tests.
