### PR TITLE
change function getPreferredLanguage to better select the preffered language

### DIFF
--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -724,6 +724,46 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en; q=0.6');
         $this->assertEquals('en', $request->getPreferredLanguage(array('fr', 'en')));
+        
+        $request = new Request();
+        $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en; q=0.6');
+        $this->assertEquals('en', $request->getPreferredLanguage(array('de', 'cs', 'en')));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en; q=0.6');
+        $this->assertEquals('en', $request->getPreferredLanguage(array('de_DE', 'cs_CS', 'en')));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en; q=0.6');
+        $this->assertEquals('en', $request->getPreferredLanguage(array('de_DE', 'cs_CS', 'en_GB')));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en-gb; q=0.6');
+        $this->assertEquals('en', $request->getPreferredLanguage(array('de', 'cs', 'en')));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en-gb; q=0.6');
+        $this->assertEquals('en_GB', $request->getPreferredLanguage(array('de', 'cs', 'en_GB', 'en')));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en-gb; q=0.6');
+        $this->assertEquals('en', $request->getPreferredLanguage(array('de', 'cs', 'en')));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'sk');
+        $this->assertEquals('cs', $request->getPreferredLanguage(array('fr', 'en', 'cs'), array(array('ru', 'be'), array('sk', 'cs'))));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'sk-SK, sk; q=0.8, cs; q=0.6, en-US; q=0.4, en; q=0.2');
+        $this->assertEquals('cs', $request->getPreferredLanguage(array('fr', 'en', 'cs'), array(array('ru', 'be'), array('sk', 'cs'))));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'sk');
+        $this->assertEquals('cs', $request->getPreferredLanguage(array('fr', 'en', 'cs'), array(array('ru', 'be'), array('sk', 'cs'))));
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'sk');
+        $this->assertEquals('en', $request->getPreferredLanguage(array('en', 'fr'), array(array('ru', 'be'), array('sk', 'cs'))));        
     }
 
     public function testIsXmlHttpRequest()


### PR DESCRIPTION
- support similar languages - if project suports czech and english language and the visitor is from Slovakia (speaks Slovak), the preffered language for him should be slovak and not english because czech and slovak languages are very similar to each other. The visitor would be happier if he would see the page in language he understand. I thnik that there are some other similar languages for which will be this feature good too (russian, belarussian etc.).
- if supported locales are 'de_DE', 'cs_CS', 'en_GB' and the user will come with language settings: 'zh, en-us; q=0.8, en; q=0.6', the function should return preferred locale "en", not "de_DE".
- if supported locales are 'de_DE', 'cs_CS', 'en_GB', 'en' and the user will come with language settings: 'zh, en-us; q=0.8, en-gb; q=0.6', the function should return preferred locale "en_GB", not "de_DE".

This changed function is slower than the original function, but should return preffered language better.
