### PR TITLE
[Security] Make saving target_path extendible

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -157,11 +157,16 @@ class ExceptionListener
             $this->logger->debug('Calling Authentication entry point');
         }
 
+        $this->setTargetPath($request);
+
+        return $this->authenticationEntryPoint->start($request, $authException);
+    }
+
+    protected function setTargetPath(Request $request)
+    {
         // session isn't required when using http basic authentication mechanism for example
         if ($request->hasSession()) {
             $request->getSession()->set('_security.target_path', $request->getUri());
         }
-
-        return $this->authenticationEntryPoint->start($request, $authException);
     }
 }


### PR DESCRIPTION
The problem lies in how Security component handles `target_path` - the latest request URI is always stored. This can lead to problems in following scenarios:
a) The response type of the request is not HTML (think JSON, XML ..)
b) The URI matches a route that does not listen to HTTP GET

I opened a [PR](https://github.com/symfony/symfony/pull/604) months ago, to partly solve scenario A, which did not make it. Now I am proposing a different solution - user can extend `ExceptionListener` and override the logic behind setting the `target_path` to match his precise needs.

In my simplified scenario, I would be using:

```
protected function setTargetPath(Request $request)
{
    if ($request->isXmlHttpRequest() || 'GET' !== $request->getMethod()) {
        return;
    }

    $request->getSession()->set('_security.target_path', $request->getUri());
}
```

@Seldaek, @schmittjoh, @lsmith77, thoughts?
