### PR TITLE
[SecurityBundle] added a validator for the user password

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -40,6 +40,8 @@
         <parameter key="security.role_hierarchy.class">Symfony\Component\Security\Core\Role\RoleHierarchy</parameter>
 
         <parameter key="security.http_utils.class">Symfony\Component\Security\Http\HttpUtils</parameter>
+
+        <parameter key="security.validator.user_password.class">Symfony\Bundle\SecurityBundle\Validator\Constraint\UserPasswordValidator</parameter>
     </parameters>
 
     <services>
@@ -128,6 +130,13 @@
 
         <service id="security.http_utils" class="%security.http_utils.class%" public="false">
             <argument type="service" id="router" on-invalid="null" />
+        </service>
+
+        <!-- Validator -->
+        <service id="security.validator.user_password" class="%security.validator.user_password.class%">
+            <tag name="validator.constraint_validator" alias="security.validator.user_password" />
+            <argument type="service" id="security.context" />
+            <argument type="service" id="security.encoder_factory" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPassword.php
+++ b/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPassword.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Validator\Constraint;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class UserPassword extends Constraint
+{
+    public $message = 'This value should be the user current password';
+
+    public function validatedBy()
+    {
+        return 'security.validator.user_password';
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Validator\Constraint;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+class UserPasswordValidator extends ConstraintValidator
+{
+    private $securityContext;
+    private $encoderFactory;
+
+    public function __construct(SecurityContextInterface $securityContext, EncoderFactoryInterface $encoderFactory)
+    {
+        $this->securityContext = $securityContext;
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function isValid($password, Constraint $constraint)
+    {
+        $user = $this->securityContext->getToken()->getUser();
+
+        if (!$user instanceof UserInterface) {
+            throw new ConstraintDefinitionException('The User must extend UserInterface');
+        }
+
+        $encoder = $this->encoderFactory->getEncoder($user);
+
+        if (!$encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt())) {
+            $this->setMessage($constraint->message);
+
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
This validator is useful when you want to validate that an input value
is equal to the user current password (in a form where the user can change
his password for instance).

Note that this should not be used to validate a login form as this is
done automatically by the built-in security mechanism.
