### PR TITLE
Changed Yaml Dumper nested collection indentation

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -44,7 +44,7 @@ class Dumper
                     $prefix,
                     $isAHash ? Inline::dump($key).':' : '-',
                     $willBeInlined ? ' ' : "\n",
-                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + 2)
+                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + 4)
                 ).($willBeInlined ? "\n" : '');
             }
         }


### PR DESCRIPTION
This PR changes the dumpers nested collection indentation from 2 to 4 which seems to be the standard.
