### PR TITLE
[Doctrine] added a default implementation of the ManagerRegistry

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -20,7 +20,7 @@ use Doctrine\Common\Persistence\AbstractManagerRegistry;
  *
  * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class ManagerRegistry extends AbstractManagerRegistry implements ContainerAwareInterface
+abstract class ManagerRegistry extends AbstractManagerRegistry implements ContainerAwareInterface
 {
     /**
      * @var ContainerInterface

--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine;
+
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Doctrine\Common\ManagerRegistry as BaseManagerRegistry;
+
+/**
+ * References Doctrine connections and entity/document managers.
+ *
+ * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
+ */
+class ManagerRegistry extends BaseManagerRegistry implements ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @inheritdoc
+     */
+    protected function getService($name)
+    {
+        return $this->container->get($name);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function resetService($name)
+    {
+        $this->container->set($name, null);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
+++ b/src/Symfony/Bridge/Doctrine/ManagerRegistry.php
@@ -13,14 +13,14 @@ namespace Symfony\Bridge\Doctrine;
 
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Doctrine\Common\ManagerRegistry as BaseManagerRegistry;
+use Doctrine\Common\Persistence\AbstractManagerRegistry;
 
 /**
  * References Doctrine connections and entity/document managers.
  *
  * @author  Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class ManagerRegistry extends BaseManagerRegistry implements ContainerAwareInterface
+class ManagerRegistry extends AbstractManagerRegistry implements ContainerAwareInterface
 {
     /**
      * @var ContainerInterface

--- a/src/Symfony/Bridge/Doctrine/RegistryInterface.php
+++ b/src/Symfony/Bridge/Doctrine/RegistryInterface.php
@@ -15,43 +15,15 @@ use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\ORMException;
 
+use Doctrine\Common\Persistence\ConnectionRegistry as ConnectionRegistryInterface;
+
 /**
  * References Doctrine connections and entity managers.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface RegistryInterface
+interface RegistryInterface extends ConnectionRegistryInterface
 {
-    /**
-     * Gets the default connection name.
-     *
-     * @return string The default connection name
-     */
-    function getDefaultConnectionName();
-
-    /**
-     * Gets the named connection.
-     *
-     * @param string $name The connection name (null for the default one)
-     *
-     * @return Connection
-     */
-    function getConnection($name = null);
-
-    /**
-     * Gets an array of all registered connections
-     *
-     * @return array An array of Connection instances
-     */
-    function getConnections();
-
-    /**
-     * Gets all connection names.
-     *
-     * @return array An array of connection names
-     */
-    function getConnectionNames();
-
     /**
      * Gets the default entity manager name.
      *
@@ -113,16 +85,6 @@ interface RegistryInterface
      * @return array An array of connection names
      */
     function getEntityManagerNames();
-
-    /**
-     * Gets the EntityRepository for an entity.
-     *
-     * @param string $entityName        The name of the entity.
-     * @param string $entityManagerNAme The entity manager name (null for the default one)
-     *
-     * @return Doctrine\ORM\EntityRepository
-     */
-    function getRepository($entityName, $entityManagerName = null);
 
     /**
      * Gets the entity manager associated with a given class.

--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -100,12 +100,33 @@ class Registry extends ManagerRegistry implements RegistryInterface
      * @param string $alias The alias
      *
      * @return string The full namespace
-     *
-     * @see Configuration::getEntityNamespace
      */
     public function getEntityNamespace($alias)
     {
-        return $this->getObjectNamespace();
+        return $this->getAliasNamespace($alias);
+    }
+
+    /**
+     * Resolves a registered namespace alias to the full namespace.
+     *
+     * This method looks for the alias in all registered entity managers.
+     *
+     * @param string $alias The alias
+     *
+     * @return string The full namespace
+     *
+     * @see Configuration::getEntityNamespace
+     */
+    public function getAliasNamespace($alias)
+    {
+        foreach (array_keys($this->getManagers()) as $name) {
+            try {
+                return $this->getManager($name)->getConfiguration()->getEntityNamespace($alias);
+            } catch (ORMException $e) {
+            }
+        }
+
+        throw ORMException::unknownEntityNamespace($alias);
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineBundle/Registry.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Registry.php
@@ -105,14 +105,7 @@ class Registry extends ManagerRegistry implements RegistryInterface
      */
     public function getEntityNamespace($alias)
     {
-        foreach (array_keys($this->getManagers()) as $name) {
-            try {
-                return $this->getManager($name)->getConfiguration()->getEntityNamespace($alias);
-            } catch (ORMException $e) {
-            }
-        }
-
-        throw ORMException::unknownEntityNamespace($alias);
+        return $this->getObjectNamespace();
     }
 
     /**

--- a/src/Symfony/Bundle/DoctrineBundle/Tests/RegistryTest.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Tests/RegistryTest.php
@@ -64,7 +64,7 @@ class RegistryTest extends TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->setExpectedException('InvalidArgumentException', 'Doctrine Connection named "default" does not exist.');
+        $this->setExpectedException('InvalidArgumentException', 'Doctrine ORM Connection named "default" does not exist.');
         $registry->getConnection('default');
     }
 
@@ -109,7 +109,7 @@ class RegistryTest extends TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->setExpectedException('InvalidArgumentException', 'Doctrine EntityManager named "default" does not exist.');
+        $this->setExpectedException('InvalidArgumentException', 'Doctrine ORM Manager named "default" does not exist.');
         $registry->getEntityManager('default');
     }
 
@@ -140,7 +140,7 @@ class RegistryTest extends TestCase
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
         $registry = new Registry($container, array(), array(), 'default', 'default');
 
-        $this->setExpectedException('InvalidArgumentException', 'Doctrine EntityManager named "default" does not exist.');
+        $this->setExpectedException('InvalidArgumentException', 'Doctrine ORM Manager named "default" does not exist.');
         $registry->resetEntityManager('default');
     }
 }

--- a/vendors.php
+++ b/vendors.php
@@ -26,7 +26,7 @@ if (!is_dir($vendorDir = dirname(__FILE__).'/vendor')) {
 $deps = array(
     array('doctrine', 'http://github.com/doctrine/doctrine2.git', 'origin/2.1.x'),
     array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', 'origin/2.1.x'),
-    array('doctrine-common', 'http://github.com/lsmith77/common.git', 'origin/ManagerRegistry'),
+    array('doctrine-common', 'http://github.com/doctrine/common.git', 'origin/master'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', '1.0.1'),
     array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.2'),
     array('twig', 'http://github.com/fabpot/Twig.git', 'v1.2.0'),

--- a/vendors.php
+++ b/vendors.php
@@ -26,7 +26,7 @@ if (!is_dir($vendorDir = dirname(__FILE__).'/vendor')) {
 $deps = array(
     array('doctrine', 'http://github.com/doctrine/doctrine2.git', 'origin/2.1.x'),
     array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', 'origin/2.1.x'),
-    array('doctrine-common', 'http://github.com/doctrine/common.git', 'origin/2.1.x'),
+    array('doctrine-common', 'http://github.com/lsmith77/common.git', 'origin/ManagerRegistry'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', '1.0.1'),
     array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.2'),
     array('twig', 'http://github.com/fabpot/Twig.git', 'v1.2.0'),

--- a/vendors.php
+++ b/vendors.php
@@ -24,7 +24,7 @@ if (!is_dir($vendorDir = dirname(__FILE__).'/vendor')) {
 }
 
 $deps = array(
-    array('doctrine', 'http://github.com/doctrine/doctrine2.git', 'origin/2.1.x'),
+    array('doctrine', 'http://github.com/doctrine/doctrine2.git', 'origin/master'),
     array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', 'origin/2.1.x'),
     array('doctrine-common', 'http://github.com/doctrine/common.git', 'origin/master'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', '1.0.1'),


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes (minor change in the interface see below)
Symfony2 tests pass: yes
Fixes the following tickets: -

added a default implementation of the ManagerRegistry integrating the container

attempted to maintain BC as good as possible, but RegistryInterface::getRepository() had to be dropped from RegistryInterface. Its still part of the ManagerRegistry, so its only a BC break for people using RegistryInterface to create their own implementation as I ran into https://bugs.php.net/bug.php?id=43200

all implementation (ORM/ODM) will need to match the changes to the ClassMetadataFactory interface

ORM, PHPCR, CouchDB have been upgraded already.
The Bundles also need to be updated. ORM is covered with this PR, I have a PR ready for PHPCR:
https://github.com/symfony-cmf/symfony-cmf/pull/108

also note that before merging the change to vendors.php needs to be fixed to point to the right repo again

For MongoDB it currently does not yet have a registry and I can take care of CouchDB once this is all merged.
