### PR TITLE
[ClassLoader] restored check for non-existent class and interfaces for PHP 5.3

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -84,7 +84,7 @@ class ClassCollectionLoader
         $files = array();
         $content = '';
         foreach ($classes as $class) {
-            if (!class_exists($class) && !interface_exists($class) && function_exists('trait_exists') && !trait_exists($class)) {
+            if (!class_exists($class) && !interface_exists($class) && (!function_exists('trait_exists') || !trait_exists($class))) {
                 throw new \InvalidArgumentException(sprintf('Unable to load class "%s"', $class));
             }
 

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -55,7 +55,7 @@ class DebugUniversalClassLoader extends UniversalClassLoader
         if ($file = $this->findFile($class)) {
             require $file;
 
-            if (!class_exists($class, false) && !interface_exists($class, false) && function_exists('trait_exists') && !trait_exists($class)) {
+            if (!class_exists($class, false) && !interface_exists($class, false) && (!function_exists('trait_exists') || !trait_exists($class))) {
                 throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but the class was not in it, the class name or namespace probably has a typo.', $class, $file));
             }
         }


### PR DESCRIPTION
[ClassLoader] restored check for non-existent class and interfaces for PHP 5.3

The addition of the check for existent traits in PHP 5.4 seemed to break the logic for PHP 5.3, as function_exists('trait_exists') would always be false, therefore the check condition would always be false.  This should restore the logic so that 5.3 is unaffected by the addition of support for traits.
