### PR TITLE
Fix console: list 'namespace' command display all available commands

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -581,7 +581,7 @@ class Application
 
         $commands = array();
         foreach ($this->commands as $name => $command) {
-            if ($namespace === $this->extractNamespace($name)) {
+            if ($namespace === $this->extractNamespace($name, substr_count($namespace, ':') + 1)) {
                 $commands[$name] = $command;
             }
         }


### PR DESCRIPTION
example 1:

```
songoq@songoq:~/mydev/symfony-test$ ./app/console list doctrine
Symfony version 2.1.0-DEV - app/dev/debug
....
Available commands for the "doctrine" namespace:
  doctrine:cache:clear-metadata         Clear all metadata cache for a entity manager
  doctrine:cache:clear-query            Clear all query cache for a entity manager
  doctrine:cache:clear-result           Clear result cache for a entity manager
  doctrine:database:create              Create the configured databases
  doctrine:database:drop                Drop the configured databases
  ...
  doctrine:schema:validate              Validate the doctrine mapping files
```

example 2:

```
songoq@songoq:~/mydev/symfony-test$ ./app/console list doctrine:query
Symfony version 2.1.0-DEV - app/dev/debug
....
Available commands for the "doctrine:query" namespace:
  doctrine:query:dql   Executes arbitrary DQL directly from the command line.
  doctrine:query:sql   Executes arbitrary SQL directly from the command line.
```

example 3:

```
songoq@songoq:~/mydev/symfony-test$ ./app/console list swiftmailer
Symfony version 2.1.0-DEV - app/dev/debug
....
Available commands for the "swiftmailer" namespace:
  swiftmailer:spool:send   Send emails from the spool
```

Fix #1948
