### PR TITLE
Fixed undefined index notice in readProperty() method (PropertyPath)

### DIFF
--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -279,7 +279,9 @@ class PropertyPath implements \IteratorAggregate
                 throw new InvalidPropertyException(sprintf('Index "%s" cannot be read from object of type "%s" because it doesn\'t implement \ArrayAccess', $property, get_class($object)));
             }
 
-            return $object[$property];
+            if (isset($object[$property])) {
+                return $object[$property];
+            }
         } else {
             $camelProp = $this->camelize($property);
             $reflClass = new \ReflectionClass($object);


### PR DESCRIPTION
Hi,

For some reasons, I get `notice` errors on `readProperty()` with Propel:

```
Notice: Undefined index: 0 in /Users/william/projects/Propel/testProjects/symfony2/vendor/symfony/src/Symfony/Component/Form/Util/PropertyPath.php line 284
```

The `PropelObjectCollection` implements `ArrayAccess`, the `readProperty()` method does not check if the given `index` exists so the `notice` error is thrown. I suppose to check whether the index exists or not has to be added.

Regards,
William
