### PR TITLE
[Form] Dates: testing if values of fields are empty or not

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -131,7 +131,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         $emptyFields = array();
 
         foreach ($this->fields as $field) {
-            if (!isset($value[$field])) {
+            if (!isset($value[$field]) || empty($value[$field])) {
                 $emptyFields[] = $field;
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -131,7 +131,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         $emptyFields = array();
 
         foreach ($this->fields as $field) {
-            if (!isset($value[$field]) || empty($value[$field])) {
+            if (empty($value[$field])) {
                 $emptyFields[] = $field;
             }
         }


### PR DESCRIPTION
If I have a form with a date (or a birthday for example), and if I only fill the "day" and "month" fields, the year will be set but empty, and will fallback to 1970 which is a really strange behaviour for end-user

This change will check if the values are empty and the field will result in an error if the sub-fields are incompletely filled
