### PR TITLE
Replace deprecated key_exists alias

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -198,7 +198,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
                     $data[] = $tmp;
                     $data[] = $value;
                 }
-            } elseif (key_exists($key, $data)) {
+            } elseif (array_key_exists($key, $data)) {
                 if ((false === is_array($data[$key]))  || (false === isset($data[$key][0]))) {
                     $data[$key] = array($data[$key]);
                 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

From the PHP manual of array_key_exists:
    For backward compatibility, the following deprecated alias
    may be used: key_exists().

It is the only instance of Symfony2 using key_exists() instead of array_key_exists().
