### PR TITLE
Updated choice_widget to display the preferred_choice separator only if c

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -57,7 +57,7 @@
         {% if preferred_choices|length > 0 %}
             {% set options = preferred_choices %}
             {{ block('widget_choice_options') }}
-            {% if choices|length > 0 %}
+            {% if choices|length > 0 and separator != '' %}
                 <option disabled="disabled">{{ separator }}</option>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Updated choice_widget to display the preferred_choice separator only if choice|length >0 and separator is not blank.
