### PR TITLE
[Validator] Add option to trim input value of MinLength validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/MinLength.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLength.php
@@ -22,6 +22,7 @@ class MinLength extends Constraint
 {
     public $message = 'This value is too short. It should have {{ limit }} characters or more';
     public $limit;
+    public $trimmed = false;
     public $charset = 'UTF-8';
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
@@ -32,6 +32,10 @@ class MinLengthValidator extends ConstraintValidator
      */
     public function isValid($value, Constraint $constraint)
     {
+        if ($constraint->trimmed) {
+            $value = trim($value);
+        }
+    
         if (null === $value || '' === $value) {
             return true;
         }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/MinLengthValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/MinLengthValidatorTest.php
@@ -62,6 +62,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
             array(123456),
             array('123456'),
             array('  34  '),
+            array('      '),
             array('üüüüüü', !function_exists('mb_strlen')),
             array('éééééé', !function_exists('mb_strlen')),
         );
@@ -85,6 +86,51 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
             array('12345'),
             array('üüüüü', !function_exists('mb_strlen')),
             array('ééééé', !function_exists('mb_strlen')),
+        );
+    }
+
+    /**
+     * @dataProvider getValidTrimmedValues
+     */
+    public function testValidTrimmedValues($value, $skip = false)
+    {
+        if (!$skip) {
+            $constraint = new MinLength(array('limit' => 6, 'trimmed' => true));
+            $this->assertTrue($this->validator->isValid($value, $constraint));
+        }
+    }
+
+    public function getValidTrimmedValues()
+    {
+        return array(
+            array(123456),
+            array('123456'),
+            array(' 234  78'),
+            array('1   56  '),
+            array(' üüüüüü ', !function_exists('mb_strlen')),
+            array(' éééééé ', !function_exists('mb_strlen')),
+        );
+    }
+    
+    /**
+     * @dataProvider getInvalidTrimmedValues
+     */
+    public function testInvalidTrimmedValues($value, $skip = false)
+    {
+        if (!$skip) {
+            $constraint = new MinLength(array('limit' => 6, 'trimmed' => true));
+            $this->assertFalse($this->validator->isValid($value, $constraint));
+        }
+    }
+
+    public function getInvalidTrimmedValues()
+    {
+        return array(
+            array(' 234 6'),
+            array('12345 '),
+            array('  34  '),
+            array('üüüüü ', !function_exists('mb_strlen')),
+            array('ééééé ', !function_exists('mb_strlen')),
         );
     }
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/MinLengthValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/MinLengthValidatorTest.php
@@ -61,6 +61,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
         return array(
             array(123456),
             array('123456'),
+            array('  34  '),
             array('üüüüüü', !function_exists('mb_strlen')),
             array('éééééé', !function_exists('mb_strlen')),
         );


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
