### PR TITLE
[Bridge/Monolog] Fix WebProcessor to accept a Request object.

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -21,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class WebProcessor extends BaseWebProcessor
 {
-    public function __construct(RequestInterface $request)
+    public function __construct(Request $request)
     {
         parent::__construct($request->server->all());
     }

--- a/tests/Symfony/Tests/Bridge/Monolog/Processor/WebProcessorTest.php
+++ b/tests/Symfony/Tests/Bridge/Monolog/Processor/WebProcessorTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Bridge\Monolog\Processor;
+
+use Monolog\Logger;
+use Symfony\Bridge\Monolog\Processor\WebProcessor;
+use Symfony\Component\HttpFoundation\Request;
+
+class WebProcessorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUsesRequestServerData()
+    {
+        $server = array(
+            'REQUEST_URI'    => 'A',
+            'REMOTE_ADDR'    => 'B',
+            'REQUEST_METHOD' => 'C',
+        );
+
+        $request = new Request();
+        $request->server->replace($server);
+
+        $processor = new WebProcessor($request);
+        $record = $processor($this->getRecord());
+
+        $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
+        $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
+        $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
+    }
+
+    /**
+     * @return array Record
+     */
+    protected function getRecord($level = Logger::WARNING, $message = 'test')
+    {
+        return array(
+            'message' => $message,
+            'context' => array(),
+            'level' => $level,
+            'level_name' => Logger::getLevelName($level),
+            'channel' => 'test',
+            'datetime' => new \DateTime(),
+            'extra' => array(),
+        );
+    }
+}


### PR DESCRIPTION
WebProcessor.php is type hinting a bad interface. Adds a simple test case.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

Before:

```
1) Symfony\Tests\Bridge\Monolog\Processor\WebProcessorTest::testUsesRequestServerData
Argument 1 passed to Symfony\Bridge\Monolog\Processor\WebProcessor::__construct() must be an instance of Symfony\Bridge\Monolog\Processor\RequestInterface, instance of Symfony\Component\HttpFoundation\Request given, called in ./symfony/vendor/symfony/tests/Symfony/Tests/Bridge/Monolog/Processor/WebProcessorTest.php on line 31 and defined

./symfony/vendor/symfony/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php:24
./symfony/vendor/symfony/tests/Symfony/Tests/Bridge/Monolog/Processor/WebProcessorTest.php:31

FAILURES!
Tests: 1, Assertions: 0, Errors: 1.
```

After:

```
Starting test 'Symfony\Tests\Bridge\Monolog\Processor\WebProcessorTest::testUsesRequestServerData'.
OK (1 test, 3 assertions)
```

Global:

```
OK, but incomplete or skipped tests!
Tests: 4337, Assertions: 10590, Incomplete: 36, Skipped: 23.
```
