### PR TITLE
[Form] Fixed lacking attributes in DateTimeType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -55,6 +55,8 @@ class DateTimeType extends AbstractType
                 'days',
                 'empty_value',
                 'required',
+                'invalid_message',
+                'invalid_message_parameters'
             )));
             $timeOptions = array_intersect_key($options, array_flip(array(
                 'hours',
@@ -63,6 +65,8 @@ class DateTimeType extends AbstractType
                 'with_seconds',
                 'empty_value',
                 'required',
+                'invalid_message',
+                'invalid_message_parameters'
             )));
 
             // If `widget` is set, overwrite widget options from `date` and `time`

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
@@ -16,6 +16,7 @@ require_once __DIR__ . '/LocalizedTestCase.php';
 use Symfony\Component\Form\DateTimeField;
 use Symfony\Component\Form\DateField;
 use Symfony\Component\Form\TimeField;
+use Symfony\Component\Form\FormError;
 
 class DateTimeTypeTest extends LocalizedTestCase
 {
@@ -233,5 +234,28 @@ class DateTimeTypeTest extends LocalizedTestCase
         ));
 
         $this->assertDateTimeEquals($dateTime, $form->getData());
+    }
+
+    public function testSubmit_invalidDateTime()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'invalid_message' => 'Customized invalid message',
+        ));
+
+        $form->bind(array(
+            'date' => array(
+                'day' => '31',
+                'month' => '9',
+                'year' => '2010',
+            ),
+            'time' => array(
+                'hour' => '25',
+                'minute' => '4',
+            ),
+        ));
+
+        $this->assertFalse($form->isValid());
+        $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['date']->getErrors());
+        $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['time']->getErrors());
     }
 }


### PR DESCRIPTION
Added `invalid_message` and `invalid_message_parameters`. (Moved from #2311)
