### PR TITLE
[2.0][Form] Added type check to ScalarToChoiceTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformer.php
@@ -13,16 +13,25 @@ namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 class ScalarToChoiceTransformer implements DataTransformerInterface
 {
     public function transform($value)
     {
+        if (null !== $value && !is_scalar($value)) {
+            throw new UnexpectedTypeException($value, 'scalar');
+        }
+
         return FormUtil::toArrayKey($value);
     }
 
     public function reverseTransform($value)
     {
+        if (null !== $value && !is_scalar($value)) {
+            throw new UnexpectedTypeException($value, 'scalar');
+        }
+
         return $value;
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/ScalarToChoiceTransformerTest.php
@@ -62,4 +62,20 @@ class ScalarToChoiceTransformerTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertSame($out, $this->transformer->transform($in));
     }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testTransformExpectsScalar()
+    {
+        $this->transformer->transform(array());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testReverseTransformExpectsScalar()
+    {
+        $this->transformer->reverseTransform(array());
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
