### PR TITLE
[2.0][Form] Use proper parent (text) for EmailType and TextareaType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/EmailType.php
@@ -20,7 +20,7 @@ class EmailType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return 'field';
+        return 'text';
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -20,7 +20,7 @@ class TextareaType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return 'field';
+        return 'text';
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
