### PR TITLE
[Translation] Security : Loader should only load local files

### DIFF
--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -35,6 +35,10 @@ class CsvFileLoader extends ArrayLoader implements LoaderInterface
     {
         $messages = array();
 
+        if (!stream_is_local($resource)) {
+            throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $resource));
+        }
+
         try {
             $file = new \SplFileObject($resource, 'rb');
         } catch(\RuntimeException $e) {

--- a/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
@@ -29,6 +29,10 @@ class PhpFileLoader extends ArrayLoader implements LoaderInterface
      */
     public function load($resource, $locale, $domain = 'messages')
     {
+        if (!stream_is_local($resource)) {
+            throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $resource));
+        }
+
         $messages = require($resource);
 
         $catalogue = parent::load($messages, $locale, $domain);

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -30,6 +30,10 @@ class XliffFileLoader implements LoaderInterface
      */
     public function load($resource, $locale, $domain = 'messages')
     {
+        if (!stream_is_local($resource)) {
+            throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $resource));
+        }
+
         $xml = $this->parseFile($resource);
         $xml->registerXPathNamespace('xliff', 'urn:oasis:names:tc:xliff:document:1.2');
 

--- a/tests/Symfony/Tests/Component/Translation/Loader/CsvFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Loader/CsvFileLoaderTest.php
@@ -47,4 +47,14 @@ class CsvFileLoaderTest extends \PHPUnit_Framework_TestCase
         $resource = __DIR__.'/../fixtures/not-exists.csv';
         $loader->load($resource, 'en', 'domain1');
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadThrowsAnExceptionIfFileNotLocal()
+    {
+        $loader = new CsvFileLoader();
+        $resource = 'http://example.com/resources.csv';
+        $loader->load($resource, 'en', 'domain1');
+    }
 }

--- a/tests/Symfony/Tests/Component/Translation/Loader/PhpFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Loader/PhpFileLoaderTest.php
@@ -26,4 +26,14 @@ class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadThrowsAnExceptionIfFileNotLocal()
+    {
+        $loader = new PhpFileLoader();
+        $resource = 'http://example.com/resources.php';
+        $loader->load($resource, 'en', 'domain1');
+    }
 }

--- a/tests/Symfony/Tests/Component/Translation/Loader/XliffFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Loader/XliffFileLoaderTest.php
@@ -44,4 +44,14 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new XliffFileLoader();
         $catalogue = $loader->load(__DIR__.'/../fixtures/non-valid.xliff', 'en', 'domain1');
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadThrowsAnExceptionIfFileNotLocal()
+    {
+        $loader = new XliffFileLoader();
+        $resource = 'http://example.com/resources.xliff';
+        $loader->load($resource, 'en', 'domain1');
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
See: #2327
