### PR TITLE
[Bridge][Doctrine] Adding a catch for when a developer uses the EntityTyp

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DataTransformer/EntityToIdTransformer.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DataTransformer/EntityToIdTransformer.php
@@ -15,6 +15,7 @@ use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
+use Doctrine\Common\Collections\Collection;
 
 class EntityToIdTransformer implements DataTransformerInterface
 {
@@ -40,6 +41,10 @@ class EntityToIdTransformer implements DataTransformerInterface
 
         if (!is_object($entity)) {
             throw new UnexpectedTypeException($entity, 'object');
+        }
+
+        if ($entity instanceof Collection) {
+            throw new \InvalidArgumentException('Expected an object, but got a collection. Did you forget to pass "multiple=true" to an entity field?');
         }
 
         if (count($this->choiceList->getIdentifier()) > 1) {


### PR DESCRIPTION
Hey guys!

This prevents a bad error (I've got this, heard one other user on the docs complain of it) when you use the EntityType with multiple=false, but on a "hasMany" relationship.

Without this, the exception is eventually thrown in EntityChoiceList::getIdentifierValues() with a very a message that doesn't really suit the real error: "Entities passed to the choice field must be managed".

The exception message is very specific to this situation - pragmatic, but perhaps too specific.

Thanks!
