### PR TITLE
Added possibility to have a help text associated with every item

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -53,6 +53,7 @@ class FieldType extends AbstractType
             ->setAttribute('max_length', $options['max_length'])
             ->setAttribute('pattern', $options['pattern'])
             ->setAttribute('label', $options['label'] ?: $this->humanize($builder->getName()))
+            ->setAttribute('help_txt', $options['help_txt'] ?: null)
             ->setAttribute('attr', $options['attr'] ?: array())
             ->setAttribute('invalid_message', $options['invalid_message'])
             ->setAttribute('invalid_message_parameters', $options['invalid_message_parameters'])
@@ -102,6 +103,7 @@ class FieldType extends AbstractType
             ->set('label', $form->getAttribute('label'))
             ->set('multipart', false)
             ->set('attr', $form->getAttribute('attr'))
+            ->set('help_txt', $form->getAttribute('help_txt'))
             ->set('types', $types)
         ;
     }
@@ -124,6 +126,7 @@ class FieldType extends AbstractType
             'error_bubbling'    => false,
             'error_mapping'     => array(),
             'label'             => null,
+            'help_txt'          => null,
             'attr'              => array(),
             'invalid_message'   => 'This value is not valid',
             'invalid_message_parameters' => array(),

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -16,6 +16,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     private $vars = array(
         'value' => null,
         'attr'  => array(),
+        'help_txt'  => null,
     );
 
     private $parent;


### PR DESCRIPTION
Hi, 
i am just integrating bootstrap deeply to symfony and i was wondering that i could not associate any additional things with a form item. i needed some kinde of help text to be asssociated to several fields.

So i made this (litte) change to give at least that possibility, which makes at least sense for me.

I could think of more data assicated to a field, but this one really seems for me necessary.
if there is a more generic solution provided, which aim to the same goal i would be happy too.

Cheers phil
