### PR TITLE
[HttpFoundation] fix splitHttpAcceptHeader() parsing of parameters

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1029,7 +1029,7 @@ class Request
             // Cut off any q-value that might come after a semi-colon
             if (preg_match('/;\s*(q=.*$)/', $value, $match)) {
                 $q     = (float) substr(trim($match[1]), 2);
-                $value = trim(substr($value, 0, -1*strlen($match[0])));
+                $value = trim(substr($value, 0, -strlen($match[0])));
             } else {
                 $q = 1;
             }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1027,9 +1027,9 @@ class Request
         $values = array();
         foreach (array_filter(explode(',', $header)) as $value) {
             // Cut off any q-value that might come after a semi-colon
-            if ($pos = strpos($value, ';')) {
-                $q     = (float) trim(substr($value, strpos($value, '=') + 1));
-                $value = trim(substr($value, 0, $pos));
+            if (preg_match('/;\s*(q=.*$)/', $value, $match)) {
+                $q     = (float) substr(trim($match[1]), 2);
+                $value = trim(substr($value, 0, -1*strlen($match[0])));
             } else {
                 $q = 1;
             }

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -838,6 +838,30 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('Accept-Language: zh, en-us; q=0.8, en; q=0.6', $request->__toString());
     }
+
+    /**
+     * @dataProvider splitHttpAcceptHeaderData
+     */
+    public function testSplitHttpAcceptHeader($acceptHeader, $expected)
+    {
+        $request = new Request();
+
+        $this->assertEquals($expected, $request->splitHttpAcceptHeader($acceptHeader));
+    }
+
+    public function splitHttpAcceptHeaderData()
+    {
+        return array(
+            array(null, array()),
+            array('text/html;q=0.8', array('text/html' => 0.8)),
+            array('text/html;foo=bar;q=0.8 ', array('text/html;foo=bar' => 0.8)),
+            array('text/html;charset=utf-8; q=0.8', array('text/html;charset=utf-8' => 0.8)),
+            array('text/html,application/xml;q=0.9,*/*;charset=utf-8; q=0.8', array('text/html' => 1, 'application/xml' => 0.9, '*/*;charset=utf-8' => 0.8)),
+            array('text/html,application/xhtml+xml;q=0.9,*/*;q=0.8; foo=bar', array('text/html' => 1, 'application/xhtml+xml' => 0.9, '*/*' => 0.8)),
+            array('text/html,application/xhtml+xml;charset=utf-8;q=0.9; foo=bar,*/*', array('text/html' => 1, '*/*' => 1, 'application/xhtml+xml;charset=utf-8' => 0.9)),
+            array('text/html,application/xhtml+xml', array('application/xhtml+xml' => 1, 'text/html' => 1)),
+        );
+    }
 }
 
 class RequestContentProxy extends Request


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

anything in front of ;q= is part of the mime type, anything after may be ignored

see http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
