### PR TITLE
Add validation_groups attribute to the FromView

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -966,6 +966,10 @@ class Form implements \IteratorAggregate, FormInterface
                 $typeExtension->buildViewBottomUp($view, $this);
             }
         }
+        
+        if ($this->hasAttribute('validation_groups')) {
+            $view->setAtrribute('validation_groups', $this->getAttribute('validation_groups'));
+        }
 
         return $view;
     }


### PR DESCRIPTION
Is it possible to add the `validation_groups` attribute from one Form to its FormView ?
We can find all the constraints of a form but not the validation groups passed in options when creating the form.

Why?

I create a bundle that performs automatic validations of a form in javascript.
It works fine but a user has to manually add this attribute to the viewForm if he wants to manage validation groups.

Example:

``` php
<?php
public function newAction(Request $request)
{
    $task = new Task();

    $form = $this->createFormBuilder($task, array(
            'validation_groups' => array('registration')))
            ->add('task', 'text')
            ->add('dueDate', 'date')
            ->getForm();

    $formView = $form->createView();

    // Add validation groups to the formView
    if ($form->hasAttribute('validation_groups')) {
        $formView->setAtrribute('validation_groups', $form->getAttribute('validation_groups'));
    }

    return $this->render('AcmeTaskBundle:Default:new.html.twig', array(
        'form' => $formView,
    ));
}
```

Perhaps we can add all attributes of one from to its formView.
