### PR TITLE
[Validator] The Type constraint now accepts the "Boolean" type instead of

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -35,7 +35,8 @@ class TypeValidator extends ConstraintValidator
             return true;
         }
 
-        $type = $constraint->type == 'boolean' ? 'bool' : $constraint->type;
+        $type = strtolower($constraint->type);
+        $type = $type == 'boolean' ? 'bool' : $constraint->type;
         $function = 'is_'.$type;
 
         if (function_exists($function) && call_user_func($function, $value)) {

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
@@ -62,6 +62,8 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
         $file = $this->createFile();
 
         return array(
+            array(true, 'Boolean'),
+            array(false, 'Boolean'),
             array(true, 'boolean'),
             array(false, 'boolean'),
             array(true, 'bool'),


### PR DESCRIPTION
[Validator] The Type constraint now accepts the "Boolean" type instead of "boolean".

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
