### PR TITLE
session data needs to be encoded because it can contain non binary safe characters e.g null. 

### DIFF
--- a/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
@@ -182,7 +182,7 @@ class PdoSessionStorage extends NativeSessionStorage
             $sessionRows = $stmt->fetchAll(\PDO::FETCH_NUM);
 
             if (count($sessionRows) == 1) {
-                return $sessionRows[0][0];
+                return base64_decode($sessionRows[0][0]);
             }
 
             // session does not exist, create it
@@ -218,9 +218,11 @@ class PdoSessionStorage extends NativeSessionStorage
             : "UPDATE $dbTable SET $dbDataCol = :data, $dbTimeCol = :time WHERE $dbIdCol = :id";
 
         try {
+            //session data can contain non binary safe characters so we need to encode it
+            $encoded = base64_encode($data);
             $stmt = $this->db->prepare($sql);
             $stmt->bindParam(':id', $id, \PDO::PARAM_STR);
-            $stmt->bindParam(':data', $data, \PDO::PARAM_STR);
+            $stmt->bindParam(':data', $encoded, \PDO::PARAM_STR);
             $stmt->bindValue(':time', time(), \PDO::PARAM_INT);
             $stmt->execute();
 
@@ -252,9 +254,11 @@ class PdoSessionStorage extends NativeSessionStorage
 
         $sql = "INSERT INTO $dbTable ($dbIdCol, $dbDataCol, $dbTimeCol) VALUES (:id, :data, :time)";
 
+        //session data can contain non binary safe characters so we need to encode it
+        $encoded = base64_encode($data);
         $stmt = $this->db->prepare($sql);
         $stmt->bindParam(':id', $id, \PDO::PARAM_STR);
-        $stmt->bindParam(':data', $data, \PDO::PARAM_STR);
+        $stmt->bindParam(':data', $encoded, \PDO::PARAM_STR);
         $stmt->bindValue(':time', time(), \PDO::PARAM_INT);
         $stmt->execute();
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #2067

I'm marking this as a compatibility break because session table should be cleared and even if not cleared all currently logged in users will be logged out.
