### PR TITLE
session data needs to be encoded because it can contain non binary safe characters e.g null., part 2

### DIFF
--- a/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionStorage.php
+++ b/src/Symfony/Bridge/Doctrine/HttpFoundation/DbalSessionStorage.php
@@ -132,7 +132,7 @@ class DbalSessionStorage extends NativeSessionStorage
             ))->fetchColumn();
 
             if (false !== $data) {
-                return $data;
+                return base64_decode($data);
             }
 
             // session does not exist, create it
@@ -170,7 +170,8 @@ class DbalSessionStorage extends NativeSessionStorage
             $rowCount = $this->con->exec(sprintf(
                 $sql,
                 $this->con->quote($id),
-                $this->con->quote($data),
+                //session data can contain non binary safe characters so we need to encode it
+                $this->con->quote(base64_encode($data)),
                 time()
             ));
 
@@ -196,7 +197,8 @@ class DbalSessionStorage extends NativeSessionStorage
     {
         $this->con->exec(sprintf("INSERT INTO {$this->tableName} (sess_id, sess_data, sess_time) VALUES (%s, %s, %d)",
             $this->con->quote($id),
-            $this->con->quote($data),
+            //session data can contain non binary safe characters so we need to encode it
+            $this->con->quote(base64_encode($data)),
             time()
         ));
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #2067

I'm marking this as a compatibility break because session table should be cleared and even if not cleared all currently logged in users will be logged out.

This is the fix for a same issue in DBAL session storage made against master.
