### PR TITLE
[BrowserKit] Cookie expiry is discared if the attribute name contains a capital letter

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -169,7 +169,7 @@ class Cookie
             }
 
             if (2 === count($elements = explode('=', $part, 2))) {
-                if ('expires' === $elements[0]) {
+                if ('expires' === strtolower($elements[0])) {
                     $elements[1] = self::parseDate($elements[1]);
                 }
 

--- a/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
@@ -63,7 +63,9 @@ class CookieTest extends \PHPUnit_Framework_TestCase
 
     public function testFromStringWithCapitalization()
     {
+        $this->assertEquals('Foo=Bar', (string) Cookie::fromString('Foo=Bar'));
         $this->assertEquals('foo=bar; expires=Fri, 31 Dec 2010 23:59:59 GMT', (string) Cookie::fromString('foo=bar; Expires=Fri, 31 Dec 2010 23:59:59 GMT'));
+        $this->assertEquals('foo=bar; domain=www.example.org; httponly', (string) Cookie::fromString('foo=bar; DOMAIN=www.example.org; HttpOnly'));
     }
 
     public function testFromStringWithUrl()

--- a/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/CookieTest.php
@@ -61,6 +61,11 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testFromStringWithCapitalization()
+    {
+        $this->assertEquals('foo=bar; expires=Fri, 31 Dec 2010 23:59:59 GMT', (string) Cookie::fromString('foo=bar; Expires=Fri, 31 Dec 2010 23:59:59 GMT'));
+    }
+
     public function testFromStringWithUrl()
     {
         $this->assertEquals('foo=bar; domain=www.example.com', (string) Cookie::FromString('foo=bar', 'http://www.example.com/'));


### PR DESCRIPTION
`Cookie::fromString()` discards the expiry time of a cookie where the `expires` attribute contains a capital letter, like `foo=bar; Expires=Fri, 31 Dec 2010 23:59:59 GMT`.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
