### PR TITLE
[2.1] [FrameworkBundle] Error in the searching of placeholders, at router defaults

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -69,7 +69,7 @@ class Router extends BaseRouter
                 $this->resolveParameters($route);
             } else {
                 foreach ($route->getDefaults() as $name => $value) {
-                    if (!$value || '%' !== $value[0] || '%' !== substr($value, -1)) {
+                    if (!$value || !is_string($value) || '%' !== $value[0] || '%' !== substr($value, -1)) {
                         continue;
                     }
 
@@ -80,7 +80,7 @@ class Router extends BaseRouter
                 }
 
                 foreach ($route->getRequirements() as $name => $value) {
-                    if (!$value || '%' !== $value[0] || '%' !== substr($value, -1)) {
+                    if (!$value || !is_string($value) || '%' !== $value[0] || '%' !== substr($value, -1)) {
                         continue;
                     }
 


### PR DESCRIPTION
Bug fix: [yes]
Feature addition: [no]
Backwards compatibility break: [no]
Symfony2 tests pass: [yes]

I got this error if $value is an array: Notice: Undefined offset: 0 in vendor\symfony\src\Symfony\Bundle\FrameworkBundle\Routing\Router.php line 72 

This PR fix this. But can placeholders be inside arrays too?
