### PR TITLE
[FrameworkBundle] Fixed the ckeck for the router class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterApacheDumperCommand.php
@@ -15,9 +15,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Routing\Matcher\Dumper\ApacheMatcherDumper;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * RouterApacheDumperCommand.
@@ -35,7 +34,7 @@ class RouterApacheDumperCommand extends ContainerAwareCommand
             return false;
         }
         $router = $this->getContainer()->get('router');
-        if (!$router instanceof Router) {
+        if (!$router instanceof RouterInterface) {
             return false;
         }
         return parent::isEnabled();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -12,12 +12,9 @@
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\Output;
-use Symfony\Component\Routing\Matcher\Dumper\ApacheMatcherDumper;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * A console command for retrieving information about routes
@@ -35,7 +32,7 @@ class RouterDebugCommand extends ContainerAwareCommand
             return false;
         }
         $router = $this->getContainer()->get('router');
-        if (!$router instanceof Router) {
+        if (!$router instanceof RouterInterface) {
             return false;
         }
         return parent::isEnabled();


### PR DESCRIPTION
The getRouteCollection method is now part of the RouterInterface so the
command should accept any implementation of the interface instead of just
the implementations extending the core one.
