### PR TITLE
[FrameworkBundle] removed "use" statements for unused classes.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -11,11 +11,6 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
