### PR TITLE
[Form] Collection

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -25,8 +25,7 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototypeName = empty($options['prototype_name']) ? '$$name$$' : '$$' . $options['prototype_name'] . '$$';
-            $prototype = $builder->create($prototypeName, $options['type'], $options['options']);
+            $prototype = $builder->create('$$' . $options['prototype_name'] . '$$', $options['type'], $options['options']);
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -25,7 +25,8 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototype = $builder->create('$$name$$', $options['type'], $options['options']);
+            $prototypeId = empty($options['prototype_name']) ? '$$name$$' : '$$' . $options['prototype_name'] . '$$';
+            $prototype = $builder->create($prototypeId, $options['type'], $options['options']);
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 
@@ -75,11 +76,12 @@ class CollectionType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         return array(
-            'allow_add'     => false,
-            'allow_delete'  => false,
-            'prototype'     => true,
-            'type'          => 'text',
-            'options'       => array(),
+            'allow_add'      => false,
+            'allow_delete'   => false,
+            'prototype'      => true,
+            'prototype_name' => 'name',
+            'type'           => 'text',
+            'options'        => array(),
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -25,8 +25,8 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototypeId = empty($options['prototype_name']) ? '$$name$$' : '$$' . $options['prototype_name'] . '$$';
-            $prototype = $builder->create($prototypeId, $options['type'], $options['options']);
+            $prototypeName = empty($options['prototype_name']) ? '$$name$$' : '$$' . $options['prototype_name'] . '$$';
+            $prototype = $builder->create($prototypeName, $options['type'], $options['options']);
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CollectionTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CollectionTypeTest.php
@@ -166,4 +166,24 @@ class CollectionFormTest extends TypeTestCase
         $data = $form->getData();
         $this->assertFalse(isset($data['$$name$$']));
     }
+
+    public function testPrototypeNameOption()
+    {
+        $form = $this->factory->create('collection', null, array(
+            'type'      => 'field',
+            'prototype' => true,
+            'allow_add' => true,
+        ));
+
+        $this->assertSame('$$name$$', $form->getAttribute('prototype')->getName(), '$$name$$ is the default');
+
+        $form = $this->factory->create('collection', null, array(
+            'type'           => 'field',
+            'prototype'      => true,
+            'allow_add'      => true,
+            'prototype_name' => 'test',
+        ));
+
+        $this->assertSame('$$test$$', $form->getAttribute('prototype')->getName());
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: [#1324](https://github.com/symfony/symfony/issues/1324)

add the ability to set the form prototype name in CollectionType. this will aid in handling nested collections in forms
