### PR TITLE
fixing WebTastCase when kernel is not found

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -117,11 +117,12 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
 
         $finder = new Finder();
         $finder->name('*Kernel.php')->depth(0)->in($dir);
-        if (!count($finder)) {
-            throw new \RuntimeException('You must override the WebTestCase::createKernel() method.');
+        $results = iterator_to_array($finder);
+        if (!count($results)) {
+            throw new \RuntimeException('Either set KERNEL_DIR in your phpunit.xml according to http://www.phpunit.de/manual/current/en/appendixes.configuration.html or override the WebTestCase::createKernel() method.');
         }
 
-        $file = current(iterator_to_array($finder));
+        $file = current($results);
         $class = $file->getBasename('.php');
 
         require_once $file;


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

i was using a phpunit.xml in a bundle that did not define KERNEL_DIR. instead of an exception i got a fatal error: 

PHP Fatal error:  Call to a member function getBasename() on a non-object in .../cmf-sandbox/vendor/symfony/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php on line 126

i tried to figure out whats wrong, but it seems something weird with the Finder class

list($key, $val) = each($finder);
var_dump($key, $val);

gives me:
string(37) "Symfony\Component\Finder\Findermode"
int(0)

but then the array from that iterator is empty. maybe there is something weird with my php version but as it can apparently happen, i suggest this pull request.

as this is a place where people will start to see they have a problem, i thought adding something to the exception could help. not sure if you like the url in the message, maybe it should rather point to a cookbook entry explaining the WebTestCase?
