### PR TITLE
Fixed an "Unexpected token" in WebProfilerBundle:Collector:logger.html.twig

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/logger.html.twig
@@ -52,7 +52,8 @@
 
     {% if collector.logs %}
         <ul class="alt">
-            {% for log in collector.logs if log.priority >= priority %}
+            {% for log in collector.logs %}
+            	{% if log.priority >= priority %}
                 <li class="{{ cycle(['odd', 'even'], loop.index) }}{% if 'ERR' == log.priorityName or 'ERROR' == log.priorityName %} error{% endif %}">
                     {{ log.message }}
                     {% if log.context is defined and log.context is not empty %}
@@ -62,6 +63,7 @@
                         </small>
                     {% endif %}
                 </li>
+                {% endif %}
             {% endfor %}
         </ul>
     {% else %}


### PR DESCRIPTION
I ran into the same issue as the original poster in this thread, however the suggested resolution did not resolve the problem: http://forum.symfony-project.org/viewtopic.php?f=23&t=37194

I outlined the symtoms here: https://github.com/workman/symfony/issues/1

Made a very minor change to WebProfilerBundle:Collector:logger.html.twig, separating the for loop and the if conditional that was causing the twig parse error.
