### PR TITLE
Increased the priority of the profiler request listener

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/profiling.xml
@@ -26,7 +26,7 @@
         <service id="profiler_listener" class="%profiler_listener.class%">
             <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" priority="-100" />
             <tag name="kernel.event_listener" event="kernel.exception" method="onKernelException" />
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" />
+            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="1000" />
             <argument type="service" id="profiler" />
             <argument type="service" id="profiler.request_matcher" on-invalid="null" />
             <argument>%profiler_listener.only_exceptions%</argument>


### PR DESCRIPTION
If a request listener returns a response before calling the profiler
listener, the request will not be added in the stack leading to an error
during the handling of the kernel.response event. The profiler listener
should ideally be run first.

The same issue will occur if a previous listener throws an exception btw.
