### PR TITLE
fix a typo in the routing dependency injection configuration

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -64,7 +64,7 @@
                 <argument key="matcher_dumper_class">%router.options.matcher_dumper_class%</argument>
                 <argument key="matcher_cache_class">%router.options.matcher.cache_class%</argument>
             </argument>
-            <argument type="service" id="routing.request_context" on-invalid="ignore" />
+            <argument type="service" id="router.request_context" on-invalid="ignore" />
         </service>
 
         <service id="router" alias="router.default" />


### PR DESCRIPTION
fix a typo in the routing dependency injection configuration. the request_context service is named router.request_context , not routing.request_context 

Bug fix: yes
Feature addition: no
Backwards compatibility break: ? - should not unless somebody relied on the bug
Symfony2 tests pass: yes
Fixes the following tickets: no ticket

i ran
phpunit src/Symfony/Bundle/FrameworkBundle/Tests/
and
phpunit tests/Symfony/Tests/Component/Routing/
