### PR TITLE
define a WarmableInterface and only warm the cache if it implements warmable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
 use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
-use Symfony\Component\Routing\Router;
+use Symfony\Component\Routing\RouterInterface;
 
 /**
  * Generates the router matcher and generator classes.
@@ -28,7 +28,7 @@ class RouterCacheWarmer implements CacheWarmerInterface
      *
      * @param Router $router A Router instance
      */
-    public function __construct(Router $router)
+    public function __construct(RouterInterface $router)
     {
         $this->router = $router;
     }
@@ -40,14 +40,9 @@ class RouterCacheWarmer implements CacheWarmerInterface
      */
     public function warmUp($cacheDir)
     {
-        $currentDir = $this->router->getOption('cache_dir');
-
-        // force cache generation
-        $this->router->setOption('cache_dir', $cacheDir);
-        $this->router->getMatcher();
-        $this->router->getGenerator();
-
-        $this->router->setOption('cache_dir', $currentDir);
+        if ($this->router instanceof WarmableInterface) {
+            $this->router->warmUp($cacheDir);
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/WarmableInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/WarmableInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
+
+/**
+ * Interface for services that support warming their cache.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface WarmableInterface
+{
+    /**
+     * Warms up the cache.
+     *
+     * @param string $cacheDir The cache directory
+     */
+    public function warmUp($cacheDir);
+}

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/WarmableInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/WarmableInterface.php
@@ -23,5 +23,5 @@ interface WarmableInterface
      *
      * @param string $cacheDir The cache directory
      */
-    public function warmUp($cacheDir);
+    function warmUp($cacheDir);
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -15,13 +15,14 @@ use Symfony\Component\Routing\Router as BaseRouter;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Bundle\FrameworkBundle\CacheWarmer\WarmableInterface;
 
 /**
  * This Router only creates the Loader only when the cache is empty.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Router extends BaseRouter
+class Router extends BaseRouter implements WarmableInterface
 {
     private $container;
 
@@ -55,6 +56,21 @@ class Router extends BaseRouter
         }
 
         return $this->collection;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function warmUp($cacheDir)
+    {
+        $currentDir = $this->getOption('cache_dir');
+
+        // force cache generation
+        $this->setOption('cache_dir', $cacheDir);
+        $this->getMatcher();
+        $this->getGenerator();
+
+        $this->setOption('cache_dir', $currentDir);
     }
 
     /**


### PR DESCRIPTION
define a WarmableInterface and only warm the cache if it implements warmable to allow replacing the core router. this fixes #2422. combining routers will only really work when #2450 is merged too.

Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes*
Fixes the following tickets: #2422

(*) tests:
success for 
phpunit src/Symfony/Bundle/FrameworkBundle/Tests/
and
phpunit tests/Symfony/Tests/Component/Routing/

but when running all tests, i have to put gc_disable() into autoload to avoid segmentation fault and then get (after 3000 successful tests):

PHP Fatal error:  Call to undefined method Symfony\Tests\Component\HttpKernel\Debug\StopwatchTest::assertCount() in /home/david/liip/symfony-cmf/cmf-sandbox/vendor/symfony/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchTest.php on line 84
