### PR TITLE
For security, failed login attempts shouldn't specify which credential(us

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -65,7 +65,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
             }
 
             if (!$this->encoderFactory->getEncoder($user)->isPasswordValid($user->getPassword(), $presentedPassword, $user->getSalt())) {
-                throw new BadCredentialsException('The presented password is invalid.');
+                throw new BadCredentialsException('The login credentals are invalid.');
             }
         }
     }


### PR DESCRIPTION
For security, failed login attempts shouldn't specify which credential(username or password) was incorrect.
