### PR TITLE
[WIP][SecurityBundle] Added a way to extend the providers section of the config

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -30,6 +30,32 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 ### SecurityBundle
 
+ * refactored the user provider configuration. The configuration changed for the chain provider and the memory provider:
+
+   Before:
+
+        security:
+            providers:
+                my_chain_provider:
+                    providers: [my_memory_provider, my_doctrine_provider]
+                my_memory_provider:
+                    users:
+                        toto: { password: foobar, roles: [ROLE_USER] }
+                        foo: { password: bar, roles: [ROLE_USER, ROLE_ADMIN] }
+
+   After:
+
+        security:
+            providers:
+                my_chain_provider:
+                    chain:
+                        providers: [my_memory_provider, my_doctrine_provider]
+                my_memory_provider:
+                    memory:
+                        users:
+                            toto: { password: foobar, roles: [ROLE_USER] }
+                            foo: { password: bar, roles: [ROLE_USER, ROLE_ADMIN] }
+
  * added a validator for the user password
 
 ### WebProfilerBundle

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * HttpBasicFactory creates services for HTTP basic authentication.
+ * EntityFactory creates services for Doctrine user provider.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Christophe Coevoet <stof@notk.org>

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -29,7 +29,7 @@ class EntityFactory implements UserProviderFactoryInterface
     public function create(ContainerBuilder $container, $id, $config)
     {
         $container
-            ->setDefinition($id, new DefinitionDecorator('security.user.provider.entity'))
+            ->setDefinition($id, new DefinitionDecorator('doctrine.orm.security.user.provider'))
             ->addArgument($config['class'])
             ->addArgument($config['property'])
         ;

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\DoctrineBundle\DependencyInjection\Security\UserProvider;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * HttpBasicFactory creates services for HTTP basic authentication.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class EntityFactory implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, $id, $config)
+    {
+        $container
+            ->setDefinition($id, new DefinitionDecorator('security.user.provider.entity'))
+            ->addArgument($config['class'])
+            ->addArgument($config['property'])
+        ;
+    }
+
+    public function getKey()
+    {
+        return 'entity';
+    }
+
+    public function getFixableKey()
+    {
+        return null;
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->children()
+                ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('property')->defaultNull()->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -40,11 +40,6 @@ class EntityFactory implements UserProviderFactoryInterface
         return 'entity';
     }
 
-    public function getFixableKey()
-    {
-        return null;
-    }
-
     public function addConfiguration(NodeDefinition $node)
     {
         $node

--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\DoctrineBundle;
 
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
+use Symfony\Bundle\DoctrineBundle\DependencyInjection\Security\UserProvider\EntityFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,6 +30,9 @@ class DoctrineBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+        if ($container->hasExtension('security')) {
+            $container->getExtension('security')->addUserProviderFactory(new EntityFactory());
+        }
     }
 
     public function boot()

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -34,6 +34,9 @@
         <!-- validator -->
         <parameter key="doctrine.orm.validator.unique.class">Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntityValidator</parameter>
         <parameter key="doctrine.orm.validator_initializer.class">Symfony\Bridge\Doctrine\Validator\DoctrineInitializer</parameter>
+
+        <!-- security -->
+        <parameter key="doctrine.orm.security.user.provider.class">Symfony\Bridge\Doctrine\Security\User\EntityUserProvider</parameter>
     </parameters>
 
     <services>
@@ -68,6 +71,11 @@
         <service id="doctrine.orm.validator_initializer" class="%doctrine.orm.validator_initializer.class%">
             <tag name="validator.initializer" />
             <argument type="service" id="doctrine" />
+        </service>
+
+        <!-- security -->
+        <service id="doctrine.orm.security.user.provider" class="%doctrine.orm.security.user.provider.class%" abstract="true" public="false">
+            <argument type="service" id="doctrine.orm.entity_manager" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -301,29 +301,26 @@ class MainConfiguration implements ConfigurationInterface
                     ->prototype('array')
         ;
 
-        /** @var $providerNodeBuilder \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition */
         $providerNodeBuilder
             ->children()
                 ->scalarNode('id')->end()
-            ->end()
-            ->fixXmlConfig('provider')
-            ->children()
-                ->arrayNode('providers')
-                    ->beforeNormalization()
-                        ->ifString()
-                        ->then(function($v) { return preg_split('/\s*,\s*/', $v); })
+                ->arrayNode('chain')
+                    ->fixXmlConfig('provider')
+                    ->children()
+                        ->arrayNode('providers')
+                            ->beforeNormalization()
+                                ->ifString()
+                                ->then(function($v) { return preg_split('/\s*,\s*/', $v); })
+                            ->end()
+                            ->prototype('scalar')->end()
+                        ->end()
                     ->end()
-                    ->prototype('scalar')->end()
                 ->end()
             ->end()
         ;
 
-        /** @var $factory \Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface */
         foreach ($this->userProviderFactories as $factory) {
             $name = str_replace('-', '_', $factory->getKey());
-            if (null !== $factory->getFixableKey()) {
-                $providerNodeBuilder->fixXmlConfig($factory->getFixableKey(), $name);
-            }
             $factoryNode = $providerNodeBuilder->children()->arrayNode($name)->canBeUnset();
 
             $factory->addConfiguration($factoryNode);

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -325,8 +325,7 @@ class MainConfiguration implements ConfigurationInterface
 
             $factory->addConfiguration($factoryNode);
         }
-/*
- * TODO find a way to do the validation. Issue appears because of prototyped nodes
+
         $providerNodeBuilder
             ->validate()
                 ->ifTrue(function($v){return count($v) > 1;})
@@ -337,7 +336,6 @@ class MainConfiguration implements ConfigurationInterface
                 ->thenInvalid('You must set a provider definition for the provider.')
             ->end()
         ;
-*/
     }
 
     private function addEncodersSection(ArrayNodeDefinition $rootNode)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -31,15 +31,18 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 class MainConfiguration implements ConfigurationInterface
 {
     private $factories;
+    private $userProviderFactories;
 
     /**
      * Constructor.
      *
      * @param array $factories
+     * @param array $userProviderFactories
      */
-    public function __construct(array $factories)
+    public function __construct(array $factories, array $userProviderFactories)
     {
         $this->factories = $factories;
+        $this->userProviderFactories = $userProviderFactories;
     }
 
     /**
@@ -287,7 +290,7 @@ class MainConfiguration implements ConfigurationInterface
 
     private function addProvidersSection(ArrayNodeDefinition $rootNode)
     {
-        $rootNode
+        $providerNodeBuilder = $rootNode
             ->fixXmlConfig('provider')
             ->children()
                 ->arrayNode('providers')
@@ -296,44 +299,48 @@ class MainConfiguration implements ConfigurationInterface
                     ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
-                        ->children()
-                            ->scalarNode('id')->end()
-                            ->arrayNode('entity')
-                                ->children()
-                                    ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
-                                    ->scalarNode('property')->defaultNull()->end()
-                                ->end()
-                            ->end()
-                        ->end()
-                        ->fixXmlConfig('provider')
-                        ->children()
-                            ->arrayNode('providers')
-                                ->beforeNormalization()
-                                    ->ifString()
-                                    ->then(function($v) { return preg_split('/\s*,\s*/', $v); })
-                                ->end()
-                                ->prototype('scalar')->end()
-                            ->end()
-                        ->end()
-                        ->fixXmlConfig('user')
-                        ->children()
-                            ->arrayNode('users')
-                                ->useAttributeAsKey('name')
-                                ->prototype('array')
-                                    ->children()
-                                        ->scalarNode('password')->defaultValue(uniqid())->end()
-                                        ->arrayNode('roles')
-                                            ->beforeNormalization()->ifString()->then(function($v) { return preg_split('/\s*,\s*/', $v); })->end()
-                                            ->prototype('scalar')->end()
-                                        ->end()
-                                    ->end()
-                                ->end()
-                            ->end()
-                        ->end()
+        ;
+
+        /** @var $providerNodeBuilder \Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition */
+        $providerNodeBuilder
+            ->children()
+                ->scalarNode('id')->end()
+            ->end()
+            ->fixXmlConfig('provider')
+            ->children()
+                ->arrayNode('providers')
+                    ->beforeNormalization()
+                        ->ifString()
+                        ->then(function($v) { return preg_split('/\s*,\s*/', $v); })
                     ->end()
+                    ->prototype('scalar')->end()
                 ->end()
             ->end()
         ;
+
+        /** @var $factory \Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface */
+        foreach ($this->userProviderFactories as $factory) {
+            $name = str_replace('-', '_', $factory->getKey());
+            if (null !== $factory->getFixableKey()) {
+                $providerNodeBuilder->fixXmlConfig($factory->getFixableKey(), $name);
+            }
+            $factoryNode = $providerNodeBuilder->children()->arrayNode($name)->canBeUnset();
+
+            $factory->addConfiguration($factoryNode);
+        }
+/*
+ * TODO find a way to do the validation. Issue appears because of prototyped nodes
+        $providerNodeBuilder
+            ->validate()
+                ->ifTrue(function($v){return count($v) > 1;})
+                ->thenInvalid('You cannot set multiple provider types for the same provider')
+            ->end()
+            ->validate()
+                ->ifTrue(function($v){return count($v) === 0;})
+                ->thenInvalid('You must set a provider definition for the provider.')
+            ->end()
+        ;
+*/
     }
 
     private function addEncodersSection(ArrayNodeDefinition $rootNode)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
@@ -29,8 +29,7 @@ class InMemoryFactory implements UserProviderFactoryInterface
     {
         $definition = $container->setDefinition($id, new DefinitionDecorator('security.user.provider.in_memory'));
 
-
-        foreach ($config as $username => $user) {
+        foreach ($config['users'] as $username => $user) {
             $userId = $id.'_'.$username;
 
             $container
@@ -44,24 +43,24 @@ class InMemoryFactory implements UserProviderFactoryInterface
 
     public function getKey()
     {
-        return 'users';
-    }
-
-    public function getFixableKey()
-    {
-        return 'user';
+        return 'memory';
     }
 
     public function addConfiguration(NodeDefinition $node)
     {
         $node
-            ->useAttributeAsKey('name')
-            ->prototype('array')
-                ->children()
-                    ->scalarNode('password')->defaultValue(uniqid())->end()
-                    ->arrayNode('roles')
-                        ->beforeNormalization()->ifString()->then(function($v) { return preg_split('/\s*,\s*/', $v); })->end()
-                        ->prototype('scalar')->end()
+            ->fixXmlConfig('user')
+            ->children()
+                ->arrayNode('users')
+                    ->useAttributeAsKey('name')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('password')->defaultValue(uniqid())->end()
+                            ->arrayNode('roles')
+                                ->beforeNormalization()->ifString()->then(function($v) { return preg_split('/\s*,\s*/', $v); })->end()
+                                ->prototype('scalar')->end()
+                            ->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * HttpBasicFactory creates services for HTTP basic authentication.
+ * InMemoryFactory creates services for the memory provider.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Christophe Coevoet <stof@notk.org>

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/InMemoryFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * HttpBasicFactory creates services for HTTP basic authentication.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class InMemoryFactory implements UserProviderFactoryInterface
+{
+    public function create(ContainerBuilder $container, $id, $config)
+    {
+        $definition = $container->setDefinition($id, new DefinitionDecorator('security.user.provider.in_memory'));
+
+
+        foreach ($config as $username => $user) {
+            $userId = $id.'_'.$username;
+
+            $container
+                ->setDefinition($userId, new DefinitionDecorator('security.user.provider.in_memory.user'))
+                ->setArguments(array($username, (string) $user['password'], $user['roles']))
+            ;
+
+            $definition->addMethodCall('createUser', array(new Reference($userId)));
+        }
+    }
+
+    public function getKey()
+    {
+        return 'users';
+    }
+
+    public function getFixableKey()
+    {
+        return 'user';
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->useAttributeAsKey('name')
+            ->prototype('array')
+                ->children()
+                    ->scalarNode('password')->defaultValue(uniqid())->end()
+                    ->arrayNode('roles')
+                        ->beforeNormalization()->ifString()->then(function($v) { return preg_split('/\s*,\s*/', $v); })->end()
+                        ->prototype('scalar')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/UserProviderFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/UserProviderFactoryInterface.php
@@ -26,7 +26,5 @@ interface UserProviderFactoryInterface
 
     function getKey();
 
-    function getFixableKey();
-
     function addConfiguration(NodeDefinition $builder);
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/UserProviderFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/UserProviderFactoryInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider;
+
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * SecurityFactoryInterface is the interface for all security authentication listener.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+interface UserProviderFactoryInterface
+{
+    function create(ContainerBuilder $container, $id, $config);
+
+    function getKey();
+
+    function getFixableKey();
+
+    function addConfiguration(NodeDefinition $builder);
+}

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/UserProviderFactoryInterface.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/UserProvider/UserProviderFactoryInterface.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
- * SecurityFactoryInterface is the interface for all security authentication listener.
+ * UserProviderFactoryInterface is the interface for all user provider factories.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Christophe Coevoet <stof@notk.org>

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -472,9 +472,9 @@ class SecurityExtension extends Extension
         }
 
         // Chain provider
-        if ($provider['providers']) {
+        if (isset($provider['chain'])) {
             $providers = array();
-            foreach ($provider['providers'] as $providerName) {
+            foreach ($provider['chain']['providers'] as $providerName) {
                 $providers[] = new Reference($this->getUserProviderId(strtolower($providerName)));
             }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\DependencyInjection;
 
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -36,6 +37,7 @@ class SecurityExtension extends Extension
     private $contextListeners = array();
     private $listenerPositions = array('pre_auth', 'form', 'http', 'remember_me');
     private $factories;
+    private $userProviderFactories = array();
 
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -49,7 +51,7 @@ class SecurityExtension extends Extension
         $factories = $this->createListenerFactories($container, $config);
 
         // normalize and merge the actual configuration
-        $mainConfig = new MainConfiguration($factories);
+        $mainConfig = new MainConfiguration($factories, $this->userProviderFactories);
         $config = $this->processConfiguration($mainConfig, $configs);
 
         // load services
@@ -452,6 +454,16 @@ class SecurityExtension extends Extension
     {
         $name = $this->getUserProviderId(strtolower($name));
 
+        foreach ($this->userProviderFactories as $factory) {
+            $key = str_replace('-', '_', $factory->getKey());
+
+            if (!empty($provider[$key])) {
+                $factory->create($container, $name, $provider[$key]);
+
+                return $name;
+            }
+        }
+
         // Existing DAO service provider
         if (isset($provider['id'])) {
             $container->setAlias($name, new Alias($provider['id'], false));
@@ -472,30 +484,6 @@ class SecurityExtension extends Extension
             ;
 
             return $name;
-        }
-
-        // Doctrine Entity DAO provider
-        if (isset($provider['entity'])) {
-            $container
-                ->setDefinition($name, new DefinitionDecorator('security.user.provider.entity'))
-                ->addArgument($provider['entity']['class'])
-                ->addArgument($provider['entity']['property'])
-            ;
-
-            return $name;
-        }
-
-        // In-memory DAO provider
-        $definition = $container->setDefinition($name, new DefinitionDecorator('security.user.provider.in_memory'));
-        foreach ($provider['users'] as $username => $user) {
-            $userId = $name.'_'.$username;
-
-            $container
-                ->setDefinition($userId, new DefinitionDecorator('security.user.provider.in_memory.user'))
-                ->setArguments(array($username, (string)$user['password'], $user['roles']))
-            ;
-
-            $definition->addMethodCall('createUser', array(new Reference($userId)));
         }
 
         return $name;
@@ -600,6 +588,10 @@ class SecurityExtension extends Extension
         return $this->factories = $factories;
     }
 
+    public function addUserProviderFactory(UserProviderFactoryInterface $factory)
+    {
+        $this->userProviderFactories[] = $factory;
+    }
 
     /**
      * Returns the base path for the XSD files.

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -13,7 +13,6 @@
         <parameter key="security.encoder.digest.class">Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder</parameter>
         <parameter key="security.encoder.plain.class">Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder</parameter>
 
-        <parameter key="security.user.provider.entity.class">Symfony\Bridge\Doctrine\Security\User\EntityUserProvider</parameter>
         <parameter key="security.user.provider.in_memory.class">Symfony\Component\Security\Core\User\InMemoryUserProvider</parameter>
         <parameter key="security.user.provider.in_memory.user.class">Symfony\Component\Security\Core\User\User</parameter>
         <parameter key="security.user.provider.chain.class">Symfony\Component\Security\Core\User\ChainUserProvider</parameter>
@@ -118,11 +117,6 @@
         </service>
 
         <!-- Provisioning -->
-        <service id="security.user.provider.entity" class="%security.user.provider.entity.class%" abstract="true" public="false">
-            <argument type="service" id="security.user.entity_manager" />
-        </service>
-        <service id="security.user.entity_manager" alias="doctrine.orm.entity_manager" public="false" />
-
         <service id="security.user.provider.in_memory" class="%security.user.provider.in_memory.class%" abstract="true" public="false" />
         <service id="security.user.provider.in_memory.user" class="%security.user.provider.in_memory.user.class%" abstract="true" public="false" />
 

--- a/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
+++ b/src/Symfony/Bundle/SecurityBundle/SecurityBundle.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\SecurityBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Compiler\AddSecurityVotersPass;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\InMemoryFactory;
 
 /**
  * Bundle.
@@ -26,6 +27,7 @@ class SecurityBundle extends Bundle
     {
         parent::build($container);
 
+        $container->getExtension('security')->addUserProviderFactory(new InMemoryFactory());
         $container->addCompilerPass(new AddSecurityVotersPass());
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -24,7 +24,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
      */
     protected static $minimalConfig = array(
         'providers' => array(
-            'stub' => array(),
+            'stub' => array(
+                'id' => 'foo',
+            ),
         ),
         'firewalls' => array(
             'stub' => array(),
@@ -48,5 +50,40 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse(array_key_exists('factory', $config), 'The factory key is silently removed without an exception');
         $this->assertEquals(array(), $config['factories'], 'The factories key is just an empty array');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testNoConfigForProvider()
+    {
+        $config = array(
+            'providers' => array(
+                'stub' => array(),
+            ),
+        );
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration(array(), array());
+        $config = $processor->processConfiguration($configuration, array($config));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testManyConfigForProvider()
+    {
+        $config = array(
+            'providers' => array(
+                'stub' => array(
+                    'id' => 'foo',
+                    'chain' => array(),
+                ),
+            ),
+        );
+
+        $processor = new Processor();
+        $configuration = new MainConfiguration(array(), array());
+        $config = $processor->processConfiguration($configuration, array($config));
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -43,7 +43,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         ));
 
         $processor = new Processor();
-        $configuration = new MainConfiguration(array());
+        $configuration = new MainConfiguration(array(), array());
         $config = $processor->processConfiguration($configuration, array($config));
 
         $this->assertFalse(array_key_exists('factory', $config), 'The factory key is silently removed without an exception');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -33,14 +33,11 @@ $container->loadFromExtension('security', array(
                 'bar' => array('password' => '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'roles' => array('ROLE_USER', 'ROLE_ADMIN')),
             ),
         ),
-        'doctrine' => array(
-            'entity' => array('class' => 'SecurityBundle:User', 'property' => 'username')
-        ),
         'service' => array(
             'id' => 'user.manager',
         ),
         'chain' => array(
-            'providers' => array('service', 'doctrine', 'basic'),
+            'providers' => array('service', 'basic'),
         ),
     ),
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -18,26 +18,34 @@ $container->loadFromExtension('security', array(
     ),
     'providers' => array(
         'default' => array(
-            'users' => array(
-                'foo' => array('password' => 'foo', 'roles' => 'ROLE_USER'),
+            'memory' => array(
+                'users' => array(
+                    'foo' => array('password' => 'foo', 'roles' => 'ROLE_USER'),
+                ),
             ),
         ),
         'digest' => array(
-            'users' => array(
-                'foo' => array('password' => 'foo', 'roles' => 'ROLE_USER, ROLE_ADMIN'),
+            'memory' => array(
+                'users' => array(
+                    'foo' => array('password' => 'foo', 'roles' => 'ROLE_USER, ROLE_ADMIN'),
+                ),
             ),
         ),
         'basic' => array(
-            'users' => array(
-                'foo' => array('password' => '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'roles' => 'ROLE_SUPER_ADMIN'),
-                'bar' => array('password' => '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'roles' => array('ROLE_USER', 'ROLE_ADMIN')),
+            'memory' => array(
+                'users' => array(
+                    'foo' => array('password' => '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'roles' => 'ROLE_SUPER_ADMIN'),
+                    'bar' => array('password' => '0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33', 'roles' => array('ROLE_USER', 'ROLE_ADMIN')),
+                ),
             ),
         ),
         'service' => array(
             'id' => 'user.manager',
         ),
         'chain' => array(
-            'providers' => array('service', 'basic'),
+            'chain' => array(
+                'providers' => array('service', 'basic'),
+            ),
         ),
     ),
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -17,21 +17,29 @@
         <encoder class="JMS\FooBundle\Entity\User4" id="security.encoder.foo" />
 
         <provider name="default">
-            <user name="foo" password="foo" roles="ROLE_USER" />
+            <memory>
+                <user name="foo" password="foo" roles="ROLE_USER" />
+            </memory>
         </provider>
 
         <provider name="digest">
-            <user name="foo" password="foo" roles="ROLE_USER, ROLE_ADMIN" />
+            <memory>
+                <user name="foo" password="foo" roles="ROLE_USER, ROLE_ADMIN" />
+            </memory>
         </provider>
 
         <provider name="basic">
-            <user name="foo" password="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" roles="ROLE_SUPER_ADMIN" />
-            <user name="bar" password="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" roles="ROLE_USER, ROLE_ADMIN" />
+            <memory>
+                <user name="foo" password="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" roles="ROLE_SUPER_ADMIN" />
+                <user name="bar" password="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" roles="ROLE_USER, ROLE_ADMIN" />
+            </memory>
         </provider>
 
         <provider name="service" id="user.manager" />
 
-        <provider name="chain" providers="service, basic" />
+        <provider name="chain">
+            <chain providers="service, basic" />
+        </provider>
 
         <firewall name="simple" pattern="/login" security="false" />
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -29,13 +29,9 @@
             <user name="bar" password="0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33" roles="ROLE_USER, ROLE_ADMIN" />
         </provider>
 
-        <provider name="doctrine">
-            <entity class="SecurityBundle:User" property="username" />
-        </provider>
-
         <provider name="service" id="user.manager" />
 
-        <provider name="chain" providers="service, doctrine, basic" />
+        <provider name="chain" providers="service, basic" />
 
         <firewall name="simple" pattern="/login" security="false" />
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -13,19 +13,23 @@ security:
 
     providers:
         default:
-            users:
-                foo: { password: foo, roles: ROLE_USER }
+            memory:
+                users:
+                    foo: { password: foo, roles: ROLE_USER }
         digest:
-            users:
-                foo: { password: foo, roles: 'ROLE_USER, ROLE_ADMIN' }
+            memory:
+                users:
+                    foo: { password: foo, roles: 'ROLE_USER, ROLE_ADMIN' }
         basic:
-            users:
-                foo: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: ROLE_SUPER_ADMIN }
-                bar: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: [ROLE_USER, ROLE_ADMIN] }
+            memory:
+                users:
+                    foo: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: ROLE_SUPER_ADMIN }
+                    bar: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: [ROLE_USER, ROLE_ADMIN] }
         service:
             id: user.manager
         chain:
-            providers: [service, basic]
+            chain:
+                providers: [service, basic]
 
 
     firewalls:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -22,12 +22,10 @@ security:
             users:
                 foo: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: ROLE_SUPER_ADMIN }
                 bar: { password: 0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33, roles: [ROLE_USER, ROLE_ADMIN] }
-        doctrine:
-            entity: { class: SecurityBundle:User, property: username }
         service:
             id: user.manager
         chain:
-            providers: [service, doctrine, basic]
+            providers: [service, basic]
 
 
     firewalls:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension;
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\InMemoryFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
@@ -46,7 +47,6 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
             'security.user.provider.concrete.basic',
             'security.user.provider.concrete.basic_foo',
             'security.user.provider.concrete.basic_bar',
-            'security.user.provider.concrete.doctrine',
             'security.user.provider.concrete.service',
             'security.user.provider.concrete.chain',
         );
@@ -57,7 +57,6 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
         // chain provider
         $this->assertEquals(array(array(
             new Reference('security.user.provider.concrete.service'),
-            new Reference('security.user.provider.concrete.doctrine'),
             new Reference('security.user.provider.concrete.basic'),
         )), $container->getDefinition('security.user.provider.concrete.chain')->getArguments());
     }
@@ -170,6 +169,7 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $container = new ContainerBuilder();
         $security = new SecurityExtension();
+        $security->addUserProviderFactory(new InMemoryFactory());
         $container->registerExtension($security);
         $this->loadFromFile($container, $file);
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
BC break: <del>no (for now)</del> yes
Tests pass: yes

This adds a way to extend the `providers` section of the security config so that other bundles can hook their stuff into it. An example is available in DoctrineBundle which is now responsible to handle the entity provider (<del>needs some cleanup as the service definition is still in SecurityBundle currently</del>). This will allow PropelBundle to provide a `propel:` provider for instance.

In order to keep BC with the existing configuration for the in-memory and the chain providers, I had to allow using a prototyped node instead of forcing using an array node with childrens. This introduces some issues:
- impossible to validate easily that a provider uses only one setup as prototyped node always have a default value (the empty array)
- the `getFixableKey` method is needed in the interface to support the XML format by pluralizing the name.

Here is my non-BC proposal for the configuration to clean this:

``` yaml
security:
    providers:
        first:
            memory: # BC break here by adding a level before the users
                users:
                     joe: { password: foobar, roles: ROLE_USER }
                     john: { password: foobarbaz, roles: ROLE_USER }
        second:
            entity: # this one is BC
                class: Acme\DemoBundle\Entity\User
        third:
            id: my_custom_provider # also BC
        fourth:
            chain: # BC break by adding a level before the providers
                 providers: [first, second, third]
```

What do you think about it ? Do we need to keep the BC in the config of the bundle or no ?

Btw note that the way to register the factories used by the firewall section should be refactored using the new way to provide extension points in the extensions (as done here) instead of relying on the end user to register factories, which would probably mean a BC break anyway.
