### PR TITLE
[WebProfilerBundle] Adding "sf-toolbar" class to toolbar wrapper to make it possible to check

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -1,4 +1,4 @@
-<div id="sfwdt{{ token }}" style="display: none"></div>
+<div id="sfwdt{{ token }}" class="sf-toolbar" style="display: none"></div>
 <script type="text/javascript">/*<![CDATA[*/
     (function () {
         var wdt, xhr;


### PR DESCRIPTION
Adding "sf-toolbar" class to toolbar wrapper to make it possible to check for its existance prior to js instantiation (in order to change page layout when profiler toolbar is enabled)
