### PR TITLE
[Doctrine] [Form] EntityType+EntityChoiceList supports grouping choices

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -160,17 +160,13 @@ class EntityChoiceList extends ArrayChoiceList
         $grouped = array();
 
         foreach ($entities as $entity) {
-            if ($groupBy instanceof \Closure) {
-                // Get group name from Closure
-                $group = $groupBy($entity);
-            } else {
-                // Get group name from property path
-                try {
-                    $path   = new PropertyPath($groupBy);
-                    $group  = (string) $path->getValue($entity);
-                } catch (UnexpectedTypeException $e) {
-                    // PropertyPath cannot traverse entity
-                }
+            // Get group name from property path
+            try {
+                $path   = new PropertyPath($groupBy);
+                $group  = (string) $path->getValue($entity);
+            } catch (UnexpectedTypeException $e) {
+                // PropertyPath cannot traverse entity
+                $group = null;
             }
 
             if (empty($group)) {

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -167,7 +167,7 @@ class EntityChoiceList extends ArrayChoiceList
                 // Get group name from property path
                 try {
                     $path   = new PropertyPath($groupBy);
-                    $group  = (String) $path->getValue($entity);
+                    $group  = (string) $path->getValue($entity);
                 } catch (UnexpectedTypeException $e) {
                     // PropertyPath cannot traverse entity
                 }

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -49,6 +49,7 @@ class EntityType extends AbstractType
             'property'          => null,
             'query_builder'     => null,
             'choices'           => array(),
+            'group_by'          => null,
         );
 
         $options = array_replace($defaultOptions, $options);
@@ -59,7 +60,8 @@ class EntityType extends AbstractType
                 $options['class'],
                 $options['property'],
                 $options['query_builder'],
-                $options['choices']
+                $options['choices'],
+                $options['group_by']
             );
         }
 

--- a/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/ItemGroupEntity.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/ItemGroupEntity.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Tests\Bridge\Doctrine\Form\Fixtures;
+
+use Doctrine\ORM\Mapping\Id;
+use Doctrine\ORM\Mapping\Column;
+use Doctrine\ORM\Mapping\Entity;
+
+/** @Entity */
+class ItemGroupEntity
+{
+    /** @Id @Column(type="integer") */
+    protected $id;
+
+    /** @Column(type="string", nullable=true) */
+    public $name;
+
+    /** @Column(type="string", nullable=true) */
+    public $group_name;
+
+    public function __construct($id, $name, $group_name) {
+        $this->id = $id;
+        $this->name = $name;
+        $this->group_name = $group_name;
+    }
+}

--- a/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/ItemGroupEntity.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/ItemGroupEntity.php
@@ -16,11 +16,12 @@ class ItemGroupEntity
     public $name;
 
     /** @Column(type="string", nullable=true) */
-    public $group_name;
+    public $groupName;
 
-    public function __construct($id, $name, $group_name) {
+    public function __construct($id, $name, $groupName)
+    {
         $this->id = $id;
         $this->name = $name;
-        $this->group_name = $group_name;
+        $this->groupName = $groupName;
     }
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -150,4 +150,30 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
             '4' => 'Boo!'
         ), $choiceList->getChoices('choices'));
     }
+
+    public function testGroupByInvalidPropertyPathReturnsFlatChoices()
+    {
+        $item1 = new ItemGroupEntity(1, 'Foo', 'Group1');
+        $item2 = new ItemGroupEntity(2, 'Bar', 'Group1');
+
+        $this->em->persist($item1);
+        $this->em->persist($item2);
+
+        $choiceList = new EntityChoiceList(
+            $this->em,
+            self::ITEM_GROUP_CLASS,
+            'name',
+            null,
+            array(
+                $item1,
+                $item2,
+            ),
+            'group_name.child.that.does.not.exist'
+        );
+
+        $this->assertEquals(array(
+            1 => 'Foo',
+            2 => 'Bar'
+        ), $choiceList->getChoices('choices'));
+    }
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -150,36 +150,4 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
             '4' => 'Boo!'
         ), $choiceList->getChoices('choices'));
     }
-
-    public function testGroupBySupportsClosure()
-    {
-        $item1 = new ItemGroupEntity(1, 'Foo', 'Group1');
-        $item2 = new ItemGroupEntity(2, 'Bar', 'Group2');
-        $item3 = new ItemGroupEntity(3, 'Baz', null);
-
-        $this->em->persist($item1);
-        $this->em->persist($item2);
-        $this->em->persist($item3);
-
-        $choiceList = new EntityChoiceList(
-            $this->em,
-            self::ITEM_GROUP_CLASS,
-            'name',
-            null,
-            array(
-                $item1,
-                $item2,
-                $item3,
-            ),
-            function($entity) {
-                return $entity->group_name;
-            }
-        );
-
-        $this->assertEquals(array(
-            'Group1' => array(1 => 'Foo'),
-            'Group2' => array(2 => 'Bar'),
-            '3' => 'Baz'
-        ), $choiceList->getChoices('choices'));
-    }
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -141,7 +141,7 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
                 $item3,
                 $item4,
             ),
-            'group_name'
+            'groupName'
         );
 
         $this->assertEquals(array(
@@ -168,7 +168,7 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
                 $item1,
                 $item2,
             ),
-            'group_name.child.that.does.not.exist'
+            'groupName.child.that.does.not.exist'
         );
 
         $this->assertEquals(array(

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -12,14 +12,18 @@
 namespace Symfony\Tests\Bridge\Doctrine\Form\ChoiceList;
 
 require_once __DIR__.'/../DoctrineOrmTestCase.php';
+require_once __DIR__.'/../../Fixtures/ItemGroupEntity.php';
 require_once __DIR__.'/../../Fixtures/SingleIdentEntity.php';
 
 use Symfony\Tests\Bridge\Doctrine\Form\DoctrineOrmTestCase;
+use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\ItemGroupEntity;
 use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\SingleIdentEntity;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
 
 class EntityChoiceListTest extends DoctrineOrmTestCase
 {
+    const ITEM_GROUP_CLASS = 'Symfony\Tests\Bridge\Doctrine\Form\Fixtures\ItemGroupEntity';
+
     const SINGLE_IDENT_CLASS = 'Symfony\Tests\Bridge\Doctrine\Form\Fixtures\SingleIdentEntity';
 
     const COMPOSITE_IDENT_CLASS = 'Symfony\Tests\Bridge\Doctrine\Form\Fixtures\CompositeIdentEntity';
@@ -112,5 +116,70 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
             'group1' => array(1 => 'Foo'),
             'group2' => array(2 => 'Bar')
         ), $choiceList->getChoices());
+    }
+
+    public function testGroupBySupportsString()
+    {
+        $item1 = new ItemGroupEntity(1, 'Foo', 'Group1');
+        $item2 = new ItemGroupEntity(2, 'Bar', 'Group1');
+        $item3 = new ItemGroupEntity(3, 'Baz', 'Group2');
+        $item4 = new ItemGroupEntity(4, 'Boo!', null);
+
+        $this->em->persist($item1);
+        $this->em->persist($item2);
+        $this->em->persist($item3);
+        $this->em->persist($item4);
+
+        $choiceList = new EntityChoiceList(
+            $this->em,
+            self::ITEM_GROUP_CLASS,
+            'name',
+            null,
+            array(
+                $item1,
+                $item2,
+                $item3,
+                $item4,
+            ),
+            'group_name'
+        );
+
+        $this->assertEquals(array(
+            'Group1' => array(1 => 'Foo', '2' => 'Bar'),
+            'Group2' => array(3 => 'Baz'),
+            '4' => 'Boo!'
+        ), $choiceList->getChoices('choices'));
+    }
+
+    public function testGroupBySupportsClosure()
+    {
+        $item1 = new ItemGroupEntity(1, 'Foo', 'Group1');
+        $item2 = new ItemGroupEntity(2, 'Bar', 'Group2');
+        $item3 = new ItemGroupEntity(3, 'Baz', null);
+
+        $this->em->persist($item1);
+        $this->em->persist($item2);
+        $this->em->persist($item3);
+
+        $choiceList = new EntityChoiceList(
+            $this->em,
+            self::ITEM_GROUP_CLASS,
+            'name',
+            null,
+            array(
+                $item1,
+                $item2,
+                $item3,
+            ),
+            function($entity) {
+                return $entity->group_name;
+            }
+        );
+
+        $this->assertEquals(array(
+            'Group1' => array(1 => 'Foo'),
+            'Group2' => array(2 => 'Bar'),
+            '3' => 'Baz'
+        ), $choiceList->getChoices('choices'));
     }
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/Type/EntityTypeTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/Type/EntityTypeTest.php
@@ -479,7 +479,7 @@ class EntityTypeTest extends TypeTestCase
             'class' => self::ITEM_GROUP_CLASS,
             'choices' => array($item1, $item2, $item3, $item4),
             'property' => 'name',
-            'group_by' => 'group_name',
+            'group_by' => 'groupName',
         ));
 
         $field->bind('2');

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/Type/EntityTypeTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/Type/EntityTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Tests\Bridge\Doctrine\Form\Type;
 
 require_once __DIR__.'/../DoctrineOrmTestCase.php';
+require_once __DIR__.'/../../Fixtures/ItemGroupEntity.php';
 require_once __DIR__.'/../../Fixtures/SingleIdentEntity.php';
 require_once __DIR__.'/../../Fixtures/SingleStringIdentEntity.php';
 require_once __DIR__.'/../../Fixtures/CompositeIdentEntity.php';
@@ -20,6 +21,7 @@ require_once __DIR__.'/../../Fixtures/CompositeStringIdentEntity.php';
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Tests\Component\Form\Extension\Core\Type\TypeTestCase;
 use Symfony\Tests\Bridge\Doctrine\Form\DoctrineOrmTestCase;
+use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\ItemGroupEntity;
 use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\SingleIdentEntity;
 use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\SingleStringIdentEntity;
 use Symfony\Tests\Bridge\Doctrine\Form\Fixtures\CompositeIdentEntity;
@@ -31,6 +33,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 
 class EntityTypeTest extends TypeTestCase
 {
+    const ITEM_GROUP_CLASS = 'Symfony\Tests\Bridge\Doctrine\Form\Fixtures\ItemGroupEntity';
     const SINGLE_IDENT_CLASS = 'Symfony\Tests\Bridge\Doctrine\Form\Fixtures\SingleIdentEntity';
     const SINGLE_STRING_IDENT_CLASS = 'Symfony\Tests\Bridge\Doctrine\Form\Fixtures\SingleStringIdentEntity';
     const COMPOSITE_IDENT_CLASS = 'Symfony\Tests\Bridge\Doctrine\Form\Fixtures\CompositeIdentEntity';
@@ -50,6 +53,7 @@ class EntityTypeTest extends TypeTestCase
 
         $schemaTool = new SchemaTool($this->em);
         $classes = array(
+            $this->em->getClassMetadata(self::ITEM_GROUP_CLASS),
             $this->em->getClassMetadata(self::SINGLE_IDENT_CLASS),
             $this->em->getClassMetadata(self::SINGLE_STRING_IDENT_CLASS),
             $this->em->getClassMetadata(self::COMPOSITE_IDENT_CLASS),
@@ -459,6 +463,33 @@ class EntityTypeTest extends TypeTestCase
         $this->assertTrue($field->isSynchronized());
         $this->assertEquals($entity2, $field->getData());
         $this->assertEquals(2, $field->getClientData());
+    }
+
+    public function testGroupByChoices()
+    {
+        $item1 = new ItemGroupEntity(1, 'Foo', 'Group1');
+        $item2 = new ItemGroupEntity(2, 'Bar', 'Group1');
+        $item3 = new ItemGroupEntity(3, 'Baz', 'Group2');
+        $item4 = new ItemGroupEntity(4, 'Boo!', null);
+
+        $this->persist(array($item1, $item2, $item3, $item4));
+
+        $field = $this->factory->createNamed('entity', 'name', null, array(
+            'em' => 'default',
+            'class' => self::ITEM_GROUP_CLASS,
+            'choices' => array($item1, $item2, $item3, $item4),
+            'property' => 'name',
+            'group_by' => 'group_name',
+        ));
+
+        $field->bind('2');
+
+        $this->assertEquals(2, $field->getClientData());
+        $this->assertEquals(array(
+            'Group1' => array(1 => 'Foo', '2' => 'Bar'),
+            'Group2' => array(3 => 'Baz'),
+            '4' => 'Boo!'
+        ), $field->createView()->get('choices'));
     }
 
     public function testDisallowChoicesThatAreNotIncluded_choicesSingleIdentifier()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #1735

Per the discussion in #1735, `EntityType` does not immediately support grouping options, though I updated support for it in `EntityChoiceList` in fb9d951b1d220a3a84a0228ca2fee7c7b8883bd5.

This PR accomplishes the following:
- Adds optional `group_by` property to `EntityType` that supports either a `PropertyPath` or a `\Closure` that is evaluated on the entity choices
- Support for groups is added via the constructor in `EntityChoiceList`
- Groups are created prior to `EntityChoiceList#loadEntities` via a new `groupEntities` function
- Added tests for `EntityChoiceList`
- Added test for `EntityType` `group_by` support

_There is an alternative version that only modifies `EntityType`, but that requires the addition of `EntityType#buildView(...)`, which is messy, IMO: https://github.com/ericclemmons/symfony/compare/master...1735-entity_type_group_by_
