### PR TITLE
[HttpKernel] Updated mirror method to check for symlinks before dirs and files

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -42,6 +42,12 @@ class FirePHPHandler extends BaseFirePHPHandler
             return;
         }
 
+        if (!preg_match('{\bFirePHP/\d+\.\d+\b}', $event->getRequest()->headers->get('User-Agent'))) {
+            $this->sendHeaders = false;
+            $this->headers = array();
+            return;
+        }
+
         $this->response = $event->getResponse();
         foreach ($this->headers as $header => $content) {
             $this->response->headers->set($header, $content);
@@ -54,10 +60,22 @@ class FirePHPHandler extends BaseFirePHPHandler
      */
     protected function sendHeader($header, $content)
     {
+        if (!$this->sendHeaders) {
+            return;
+        }
+
         if ($this->response) {
             $this->response->headers->set($header, $content);
         } else {
             $this->headers[$header] = $content;
         }
+    }
+
+    /**
+     * Override default behavior since we check the user agent in onKernelResponse
+     */
+    protected function headersAccepted()
+    {
+        return true;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -96,7 +96,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $this->assertTrue($container->hasDefinition('templating.name_parser'), '->registerTemplatingConfiguration() loads templating.xml');
 
-        $this->assertEquals('request', $container->getDefinition('templating.helper.assets')->getScope(), '->registerTemplatingConfiguration() sets request scope on assets helper if one or more packages are request-scopes');
+        $this->assertEquals('request', $container->getDefinition('templating.helper.assets')->getScope(), '->registerTemplatingConfiguration() sets request scope on assets helper if one or more packages are request-scoped');
 
         // default package should have one http base url and path package ssl url
         $this->assertTrue($container->hasDefinition('templating.asset.default_package.http'));
@@ -131,7 +131,7 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         $container = $this->createContainerFromFile('templating_url_package');
 
-        $this->assertNotEquals('request', $container->getDefinition('templating.helper.assets')->getScope(), '->registerTemplatingConfiguration() does not set request scope on assets helper if no packages are request-scopes');
+        $this->assertNotEquals('request', $container->getDefinition('templating.helper.assets')->getScope(), '->registerTemplatingConfiguration() does not set request scope on assets helper if no packages are request-scoped');
     }
 
     public function testTranslator()

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -1022,7 +1022,7 @@ EOF;
                 $code = str_replace('%%', '%', preg_replace_callback('/(?<!%)(%)([^%]+)\1/', $replaceParameters, var_export($value, true)));
 
                 // optimize string
-                $code = preg_replace(array("/^''\./", "/\.''$/", "/'\.'/", "/\.''\./"), array('', '', '', '.'), $code);
+                $code = preg_replace(array("/^''\./", "/\.''$/", "/(\w+)(?:'\.')/", "/(.+)(?:\.''\.)/"), array('', '', '$1', '$1.'), $code);
 
                 return $code;
             }

--- a/src/Symfony/Component/HttpKernel/Util/Filesystem.php
+++ b/src/Symfony/Component/HttpKernel/Util/Filesystem.php
@@ -204,12 +204,12 @@ class Filesystem
         foreach ($iterator as $file) {
             $target = $targetDir.'/'.str_replace($originDir.DIRECTORY_SEPARATOR, '', $file->getPathname());
 
-            if (is_dir($file)) {
+            if (is_link($file)) {
+                $this->symlink($file, $target);
+            } else if (is_dir($file)) {
                 $this->mkdir($target);
             } else if (is_file($file) || ($copyOnWindows && is_link($file))) {
                 $this->copy($file, $target, isset($options['override']) ? $options['override'] : false);
-            } else if (is_link($file)) {
-                $this->symlink($file, $target);
             } else {
                 throw new \RuntimeException(sprintf('Unable to guess "%s" file type.', $file));
             }

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -44,7 +44,6 @@ class RouteCollection implements \IteratorAggregate
 
     public function __clone()
     {
-        $parent = $this;
         foreach ($this->routes as $name => $route) {
             $this->routes[$name] = clone $route;
             if ($route instanceof RouteCollection) {

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services10.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services10.php
@@ -1,0 +1,101 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * ProjectServiceContainer
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class ProjectServiceContainer extends Container
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->parameters = $this->getDefaultParameters();
+
+        $this->services =
+        $this->scopedServices =
+        $this->scopeStacks = array();
+
+        $this->set('service_container', $this);
+
+        $this->scopes = array();
+        $this->scopeChildren = array();
+    }
+
+    /**
+     * Gets the 'test' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return stdClass A stdClass instance.
+     */
+    protected function getTestService()
+    {
+        return $this->services['test'] = new \stdClass(array('only dot' => '.', 'concatenation as value' => '.\'\'.', 'concatenation from the start value' => '\'\'.', '.' => 'dot as a key', '.\'\'.' => 'concatenation as a key', '\'\'.' => 'concatenation from the start key', 'optimize concatenation' => 'string1-string2', 'optimize concatenation with empty string' => 'string1string2', 'optimize concatenation from the start' => 'start', 'optimize concatenation at the end' => 'end'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParameter($name)
+    {
+        $name = strtolower($name);
+
+        if (!array_key_exists($name, $this->parameters)) {
+            throw new \InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
+        }
+
+        return $this->parameters[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasParameter($name)
+    {
+        return array_key_exists(strtolower($name), $this->parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParameter($name, $value)
+    {
+        throw new \LogicException('Impossible to call set() on a frozen ParameterBag.');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getParameterBag()
+    {
+        if (null === $this->parameterBag) {
+            $this->parameterBag = new FrozenParameterBag($this->parameters);
+        }
+
+        return $this->parameterBag;
+    }
+    /**
+     * Gets the default parameters.
+     *
+     * @return array An array of the default parameters
+     */
+    protected function getDefaultParameters()
+    {
+        return array(
+            'empty_value' => '',
+            'some_string' => '-',
+        );
+    }
+}


### PR DESCRIPTION
[HttpKernel] [Filesystem::mirror] Updated to check for symbolic links before directories and files

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2436
