### PR TITLE
Add a new TwigExtension to enable to extends a template giving the key of a parameter wich is in the container

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Extension/ExtendsByConfigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/ExtendsByConfigExtension.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Extension;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+use Symfony\Bundle\TwigBundle\TokenParser\ExtendsByConfigTokenParser;
+
+/**
+ *
+ * @author Cedric LOMBARDOT <cedric.lombardot@gmail.com>
+ */
+class ExtendsByConfigExtension extends \Twig_Extension
+{
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function getTokenParsers()
+    {
+        return array(
+            //{% extends_by_config 'container.parameter_name' %}
+            new ExtendsByConfigTokenParser($this->container),
+        );
+    }
+
+    public function getName()
+    {
+        return 'extends_by_config';
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -16,6 +16,7 @@
         <parameter key="twig.extension.routing.class">Symfony\Bridge\Twig\Extension\RoutingExtension</parameter>
         <parameter key="twig.extension.yaml.class">Symfony\Bridge\Twig\Extension\YamlExtension</parameter>
         <parameter key="twig.extension.form.class">Symfony\Bridge\Twig\Extension\FormExtension</parameter>
+        <parameter key="twig.extension.extends_by_config.class">Symfony\Bundle\TwigBundle\Extension\ExtendsByConfigExtension</parameter>
         <parameter key="twig.translation.extractor.class">Symfony\Bridge\Twig\Translation\TwigExtractor</parameter>
         <parameter key="twig.exception_listener.class">Symfony\Component\HttpKernel\EventListener\ExceptionListener</parameter>
     </parameters>
@@ -75,6 +76,11 @@
         <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">
             <tag name="twig.extension" />
             <argument>%twig.form.resources%</argument>
+        </service>
+
+        <service id="twig.extension.extends_by_config" class="%twig.extension.extends_by_config.class%" public="false">
+            <tag name="twig.extension" />
+            <argument type="service" id="service_container" />
         </service>
 
         <service id="twig.translation.extractor" class="%twig.translation.extractor.class%">

--- a/src/Symfony/Bundle/TwigBundle/TokenParser/ExtendsByConfigTokenParser.php
+++ b/src/Symfony/Bundle/TwigBundle/TokenParser/ExtendsByConfigTokenParser.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\TwigBundle\TokenParser;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ *
+ * @author Cedric LOMBARDOT <cedric.lombardot@gmail.com>
+ */
+class ExtendsByConfigTokenParser extends \Twig_TokenParser
+{
+    protected $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Parses a token and returns a node.
+     *
+     * @param \Twig_Token $token A \Twig_Token instance
+     *
+     * @return \Twig_NodeInterface A \Twig_NodeInterface instance
+     */
+    public function parse(\Twig_Token $token)
+    {
+        if (null !== $this->parser->getParent()) {
+            throw new \Twig_Error_Syntax('Multiple extends tags are forbidden', $token->getLine());
+        }
+
+        $tpl = $this->container->getParameter($this->parser->getCurrentToken()->getValue());
+
+        $this->parser->getExpressionParser()->parseExpression();
+        $this->parser->setParent(new \Twig_Node_Expression_Constant($tpl,$token->getLine()));
+        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+
+        return null;
+    }
+
+    /**
+     * Gets the tag name associated with this token parser.
+     *
+     * @return string The tag name
+     */
+    public function getTag()
+    {
+        return 'extends_by_config';
+    }
+}


### PR DESCRIPTION
Add the capacity to set :

```
{% extends_by_config 'my_config.parameter_name' %}
```

Will be the same as :

```
{% extends 'DemoBundle::index.html.twig' %}
```

if the container parameter `my_config.parameter_name` value is `DemoBundle::index.html.twig`

---

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: no (i can't segmentation fault for symfony2 & phpunit)
Fixes the following tickets: -
