### PR TITLE
[Console] Added exception on reserved command options/arguments (closes #1949).

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -399,7 +399,7 @@ class Application
                 $command_options['names']
             );
 
-            if (count($common_names) > 0) {
+            if (!empty($common_names)) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following names are reserved: "%s".',
                     implode(', ', $common_names)
@@ -411,7 +411,7 @@ class Application
                 $command_options['shortcuts']
             );
 
-            if (count($common_shortcuts) > 0) {
+            if (!empty($common_shortcuts)) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following shortcuts are reserved: "%s".',
                     implode(', ', $common_shortcuts)

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -391,9 +391,12 @@ class Application
         }
 
         if ($this->definition !== null) {
+            $default_options = $this->definition->getOptionsArray();
+            $command_options = $command->getDefinition()->getOptionsArray();
+
             $common_names = array_intersect(
-                $this->definition->getOptionsArray(),
-                $command->getDefinition()->getOptionsArray()
+                $default_options['names'],
+                $command_options['names']
             );
 
             if (count($common_names) > 0) {
@@ -404,8 +407,8 @@ class Application
             }
 
             $common_shortcuts = array_intersect(
-                $this->definition->getOptionsArray(true),
-                $command->getDefinition()->getOptionsArray(true)
+                $default_options['shortcuts'],
+                $command_options['shortcuts']
             );
 
             if (count($common_shortcuts) > 0) {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -376,6 +376,9 @@ class Application
      *
      * @return Command The registered command
      *
+     * @throws \InvalidArgumentException
+     *      If the command's definition contains reserved options.
+     *
      * @api
      */
     public function add(Command $command)
@@ -385,6 +388,32 @@ class Application
         if (!$command->isEnabled()) {
             $command->setApplication(null);
             return;
+        }
+
+        if ($this->definition !== null) {
+            $common_names = array_intersect(
+                $this->definition->getOptionsArray(),
+                $command->getDefinition()->getOptionsArray()
+            );
+
+            if (count($common_names) > 0) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The following names are reserved: "%s".',
+                    implode(', ', $common_names)
+                ));
+            }
+
+            $common_shortcuts = array_intersect(
+                $this->definition->getOptionsArray(true),
+                $command->getDefinition()->getOptionsArray(true)
+            );
+
+            if (count($common_shortcuts) > 0) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The following shortcuts are reserved: "%s".',
+                    implode(', ', $common_shortcuts)
+                ));
+            }
         }
 
         $this->commands[$command->getName()] = $command;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -394,42 +394,27 @@ class Application
             $defaultOptions = $this->definition->getOptionsArray();
             $commandOptions = $command->getDefinition()->getOptionsArray();
 
-            $commonOptionNames = array_intersect(
+            $commonNames = array_intersect(
                 $defaultOptions['names'],
                 $commandOptions['names']
             );
 
-            if (!empty($commonOptionNames)) {
+            if (!empty($commonNames)) {
                 throw new \InvalidArgumentException(sprintf(
-                    'The following option names are reserved: "%s".',
-                    implode(', ', $commonOptionNames)
+                    'The following names are reserved: "%s".',
+                    implode(', ', $commonNames)
                 ));
             }
 
-            $commonOptionShortcuts = array_intersect(
+            $commonShortcuts = array_intersect(
                 $defaultOptions['shortcuts'],
                 $commandOptions['shortcuts']
             );
 
-            if (!empty($commonOptionShortcuts)) {
+            if (!empty($commonShortcuts)) {
                 throw new \InvalidArgumentException(sprintf(
-                    'The following option shortcuts are reserved: "%s".',
-                    implode(', ', $commonOptionShortcuts)
-                ));
-            }
-
-            $defaultArguments = $this->definition->getArgumentsArray();
-            $commandArguments = $command->getDefinition()->getArgumentsArray();
-
-            $commonArgumentNames = array_intersect(
-                $defaultArguments,
-                $commandArguments
-            );
-
-            if (!empty($commonArgumentNames)) {
-                throw new \InvalidArgumentException(sprintf(
-                    'The following argument names are reserved: "%s".',
-                    implode(', ', $commonArgumentNames)
+                    'The following shortcuts are reserved: "%s".',
+                    implode(', ', $commonShortcuts)
                 ));
             }
         }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -391,30 +391,30 @@ class Application
         }
 
         if ($this->definition !== null) {
-            $default_options = $this->definition->getOptionsArray();
-            $command_options = $command->getDefinition()->getOptionsArray();
+            $defaultOptions = $this->definition->getOptionsArray();
+            $commandOptions = $command->getDefinition()->getOptionsArray();
 
-            $common_names = array_intersect(
-                $default_options['names'],
-                $command_options['names']
+            $commonNames = array_intersect(
+                $defaultOptions['names'],
+                $commandOptions['names']
             );
 
-            if (!empty($common_names)) {
+            if (!empty($commonNames)) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following names are reserved: "%s".',
-                    implode(', ', $common_names)
+                    implode(', ', $commonNames)
                 ));
             }
 
-            $common_shortcuts = array_intersect(
-                $default_options['shortcuts'],
-                $command_options['shortcuts']
+            $commonShortcuts = array_intersect(
+                $defaultOptions['shortcuts'],
+                $commandOptions['shortcuts']
             );
 
-            if (!empty($common_shortcuts)) {
+            if (!empty($commonShortcuts)) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following shortcuts are reserved: "%s".',
-                    implode(', ', $common_shortcuts)
+                    implode(', ', $commonShortcuts)
                 ));
             }
         }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -399,7 +399,7 @@ class Application
                 $command_options['names']
             );
 
-            if (!empty($common_names)) {
+            if (count($common_names) > 0) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following names are reserved: "%s".',
                     implode(', ', $common_names)
@@ -411,7 +411,7 @@ class Application
                 $command_options['shortcuts']
             );
 
-            if (!empty($common_shortcuts)) {
+            if (count($common_shortcuts) > 0) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following shortcuts are reserved: "%s".',
                     implode(', ', $common_shortcuts)

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -377,7 +377,7 @@ class Application
      * @return Command The registered command
      *
      * @throws \InvalidArgumentException
-     *      If the command's definition contains reserved options.
+     *      If the command's definition contains reserved options/arguments.
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -391,30 +391,30 @@ class Application
         }
 
         if ($this->definition !== null) {
-            $defaultOptions = $this->definition->getOptionsArray();
-            $commandOptions = $command->getDefinition()->getOptionsArray();
+            $default_options = $this->definition->getOptionsArray();
+            $command_options = $command->getDefinition()->getOptionsArray();
 
-            $commonNames = array_intersect(
-                $defaultOptions['names'],
-                $commandOptions['names']
+            $common_names = array_intersect(
+                $default_options['names'],
+                $command_options['names']
             );
 
-            if (!empty($commonNames)) {
+            if (!empty($common_names)) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following names are reserved: "%s".',
-                    implode(', ', $commonNames)
+                    implode(', ', $common_names)
                 ));
             }
 
-            $commonShortcuts = array_intersect(
-                $defaultOptions['shortcuts'],
-                $commandOptions['shortcuts']
+            $common_shortcuts = array_intersect(
+                $default_options['shortcuts'],
+                $command_options['shortcuts']
             );
 
-            if (!empty($commonShortcuts)) {
+            if (!empty($common_shortcuts)) {
                 throw new \InvalidArgumentException(sprintf(
                     'The following shortcuts are reserved: "%s".',
-                    implode(', ', $commonShortcuts)
+                    implode(', ', $common_shortcuts)
                 ));
             }
         }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -394,27 +394,42 @@ class Application
             $defaultOptions = $this->definition->getOptionsArray();
             $commandOptions = $command->getDefinition()->getOptionsArray();
 
-            $commonNames = array_intersect(
+            $commonOptionNames = array_intersect(
                 $defaultOptions['names'],
                 $commandOptions['names']
             );
 
-            if (!empty($commonNames)) {
+            if (!empty($commonOptionNames)) {
                 throw new \InvalidArgumentException(sprintf(
-                    'The following names are reserved: "%s".',
-                    implode(', ', $commonNames)
+                    'The following option names are reserved: "%s".',
+                    implode(', ', $commonOptionNames)
                 ));
             }
 
-            $commonShortcuts = array_intersect(
+            $commonOptionShortcuts = array_intersect(
                 $defaultOptions['shortcuts'],
                 $commandOptions['shortcuts']
             );
 
-            if (!empty($commonShortcuts)) {
+            if (!empty($commonOptionShortcuts)) {
                 throw new \InvalidArgumentException(sprintf(
-                    'The following shortcuts are reserved: "%s".',
-                    implode(', ', $commonShortcuts)
+                    'The following option shortcuts are reserved: "%s".',
+                    implode(', ', $commonOptionShortcuts)
+                ));
+            }
+
+            $defaultArguments = $this->definition->getArgumentsArray();
+            $commandArguments = $command->getDefinition()->getArgumentsArray();
+
+            $commonArgumentNames = array_intersect(
+                $defaultArguments,
+                $commandArguments
+            );
+
+            if (!empty($commonArgumentNames)) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The following argument names are reserved: "%s".',
+                    implode(', ', $commonArgumentNames)
                 ));
             }
         }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -377,7 +377,7 @@ class Application
      * @return Command The registered command
      *
      * @throws \InvalidArgumentException
-     *      If the command's definition contains reserved options/arguments.
+     *      If the command's definition contains reserved options.
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -391,12 +391,9 @@ class Application
         }
 
         if ($this->definition !== null) {
-            $default_options = $this->definition->getOptionsArray();
-            $command_options = $command->getDefinition()->getOptionsArray();
-
             $common_names = array_intersect(
-                $default_options['names'],
-                $command_options['names']
+                $this->definition->getOptionsArray(),
+                $command->getDefinition()->getOptionsArray()
             );
 
             if (count($common_names) > 0) {
@@ -407,8 +404,8 @@ class Application
             }
 
             $common_shortcuts = array_intersect(
-                $default_options['shortcuts'],
-                $command_options['shortcuts']
+                $this->definition->getOptionsArray(true),
+                $command->getDefinition()->getOptionsArray(true)
             );
 
             if (count($common_shortcuts) > 0) {

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -322,7 +322,7 @@ class InputDefinition
      *
      * @return array An array containing the names and the shortcuts
      */
-    public function getOptionsArray()
+    public function getOptionsArray($shortcuts = false)
     {
         $options = array(
             'names' => array(),

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -322,7 +322,7 @@ class InputDefinition
      *
      * @return array An array containing the names and the shortcuts
      */
-    public function getOptionsArray($shortcuts = false)
+    public function getOptionsArray()
     {
         $options = array(
             'names' => array(),

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -188,6 +188,22 @@ class InputDefinition
     }
 
     /**
+     * Returns the arguments as an indexed array containing their names.
+     *
+     * @return array An array of argument names
+     */
+    public function getArgumentsArray()
+    {
+        $arguments = array();
+
+        foreach ($this->arguments as $argument) {
+            $arguments[] = $argument->getName();
+        }
+
+        return $arguments;
+    }
+
+    /**
      * Returns the number of InputArguments.
      *
      * @return integer The number of InputArguments

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -188,22 +188,6 @@ class InputDefinition
     }
 
     /**
-     * Returns the arguments as an indexed array containing their names.
-     *
-     * @return array An array of argument names
-     */
-    public function getArgumentsArray()
-    {
-        $arguments = array();
-
-        foreach ($this->arguments as $argument) {
-            $arguments[] = $argument->getName();
-        }
-
-        return $arguments;
-    }
-
-    /**
      * Returns the number of InputArguments.
      *
      * @return integer The number of InputArguments

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -318,6 +318,31 @@ class InputDefinition
     }
 
     /**
+     * Returns the options names/shortcuts as an indexed array.
+     *
+     * @param Boolean $shortcuts Whether to return shortcuts
+     *
+     * @return array An array containing the names/shortcuts
+     */
+    public function getOptionsArray($shortcuts = false)
+    {
+        $options = array();
+
+        foreach ($this->options as $option) {
+            if ($shortcuts) {
+                if ($option->getShortcut() !== null) {
+                    $options[] = $option->getShortcut();
+                }
+            }
+            else {
+                $options[] = $option->getName();
+            }
+        }
+
+        return $options;
+    }
+
+    /**
      * Returns true if an InputOption object exists by shortcut.
      *
      * @param string $name The InputOption shortcut

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -318,24 +318,22 @@ class InputDefinition
     }
 
     /**
-     * Returns the options names/shortcuts as an indexed array.
+     * Returns the options names and shortcuts.
      *
-     * @param Boolean $shortcuts Whether to return shortcuts
-     *
-     * @return array An array containing the names/shortcuts
+     * @return array An array containing the names and the shortcuts
      */
     public function getOptionsArray($shortcuts = false)
     {
-        $options = array();
+        $options = array(
+            'names' => array(),
+            'shortcuts' => array(),
+        );
 
         foreach ($this->options as $option) {
-            if ($shortcuts) {
-                if ($option->getShortcut() !== null) {
-                    $options[] = $option->getShortcut();
-                }
-            }
-            else {
-                $options[] = $option->getName();
+            $options['names'][] = $option->getName();
+
+            if ($option->getShortcut() !== null) {
+                $options['shortcuts'][] = $option->getShortcut();
             }
         }
 

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -318,22 +318,24 @@ class InputDefinition
     }
 
     /**
-     * Returns the options names and shortcuts.
+     * Returns the options names/shortcuts as an indexed array.
      *
-     * @return array An array containing the names and the shortcuts
+     * @param Boolean $shortcuts Whether to return shortcuts
+     *
+     * @return array An array containing the names/shortcuts
      */
     public function getOptionsArray($shortcuts = false)
     {
-        $options = array(
-            'names' => array(),
-            'shortcuts' => array(),
-        );
+        $options = array();
 
         foreach ($this->options as $option) {
-            $options['names'][] = $option->getName();
-
-            if ($option->getShortcut() !== null) {
-                $options['shortcuts'][] = $option->getShortcut();
+            if ($shortcuts) {
+                if ($option->getShortcut() !== null) {
+                    $options[] = $option->getShortcut();
+                }
+            }
+            else {
+                $options[] = $option->getName();
             }
         }
 

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -379,6 +380,23 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $definition = new InputDefinition(array(
             new InputOption('--h-option', '-h'),
             new InputOption('--foo'),
+        ));
+
+        $command = new \FooCommand();
+        $command->setDefinition($definition);
+
+        $application->add($command);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testExceptionOnReservedArgumentNames()
+    {
+        $application = new Application();
+
+        $definition = new InputDefinition(array(
+            new InputArgument('command'),
         ));
 
         $command = new \FooCommand();

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -15,7 +15,6 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -380,23 +379,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $definition = new InputDefinition(array(
             new InputOption('--h-option', '-h'),
             new InputOption('--foo'),
-        ));
-
-        $command = new \FooCommand();
-        $command->setDefinition($definition);
-
-        $application->add($command);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testExceptionOnReservedArgumentNames()
-    {
-        $application = new Application();
-
-        $definition = new InputDefinition(array(
-            new InputArgument('command'),
         ));
 
         $command = new \FooCommand();

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -13,6 +13,8 @@ namespace Symfony\Tests\Component\Console;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\Console\Tester\ApplicationTester;
@@ -347,5 +349,41 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $tester->run(array('command' => 'foo:bar', '-n' => true), array('decorated' => false));
         $this->assertEquals("called\n", $this->normalize($tester->getDisplay()), '->run() does not called interact() if -n is passed');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testExceptionOnReservedOptionNames()
+    {
+        $application = new Application();
+
+        $definition = new InputDefinition(array(
+            new InputOption('--help'),
+            new InputOption('--foo', '-f'),
+        ));
+
+        $command = new \FooCommand();
+        $command->setDefinition($definition);
+
+        $application->add($command);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testExceptionOnReservedOptionShortcuts()
+    {
+        $application = new Application();
+
+        $definition = new InputDefinition(array(
+            new InputOption('--h-option', '-h'),
+            new InputOption('--foo'),
+        ));
+
+        $command = new \FooCommand();
+        $command->setDefinition($definition);
+
+        $application->add($command);
     }
 }

--- a/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
@@ -257,8 +257,10 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
             new InputOption('--bar', '-b'),
         ));
 
-        $this->assertEquals(array('foo', 'bar'), $definition->getOptionsArray());
-        $this->assertEquals(array('f', 'b'), $definition->getOptionsArray(true));
+        $options = $definition->getOptionsArray();
+
+        $this->assertEquals(array('foo', 'bar'), $options['names']);
+        $this->assertEquals(array('f', 'b'), $options['shortcuts']);
     }
 
     public function testHasShortcut()

--- a/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
@@ -126,16 +126,6 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testGetArgumentsArray()
-    {
-        $definition = new InputDefinition(array(
-            new InputArgument('foo'),
-            new InputArgument('bar'),
-        ));
-
-        $this->assertEquals(array('foo', 'bar'), $definition->getArgumentsArray());
-    }
-
     public function testHasArgument()
     {
         $this->initializeArguments();

--- a/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
@@ -257,10 +257,8 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
             new InputOption('--bar', '-b'),
         ));
 
-        $options = $definition->getOptionsArray();
-
-        $this->assertEquals(array('foo', 'bar'), $options['names']);
-        $this->assertEquals(array('f', 'b'), $options['shortcuts']);
+        $this->assertEquals(array('foo', 'bar'), $definition->getOptionsArray());
+        $this->assertEquals(array('f', 'b'), $definition->getOptionsArray(true));
     }
 
     public function testHasShortcut()

--- a/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
@@ -250,6 +250,17 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($definition->hasOption('bar'), '->hasOption() returns false if a InputOption exists for the given name');
     }
 
+    public function testGetOptionsArray()
+    {
+        $definition = new InputDefinition(array(
+            new InputOption('--foo', '-f'),
+            new InputOption('--bar', '-b'),
+        ));
+
+        $this->assertEquals(array('foo', 'bar'), $definition->getOptionsArray());
+        $this->assertEquals(array('f', 'b'), $definition->getOptionsArray(true));
+    }
+
     public function testHasShortcut()
     {
         $this->initializeOptions();

--- a/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
@@ -126,6 +126,16 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGetArgumentsArray()
+    {
+        $definition = new InputDefinition(array(
+            new InputArgument('foo'),
+            new InputArgument('bar'),
+        ));
+
+        $this->assertEquals(array('foo', 'bar'), $definition->getArgumentsArray());
+    }
+
     public function testHasArgument()
     {
         $this->initializeArguments();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #1949

The `Symfony\Component\Console\Application` class now throws an `\InvalidArgumentException` when a command uses an option or an argument contained in the default console definition.
