### PR TITLE
Process pipes windows

### DIFF
--- a/tests/Symfony/Tests/Component/Process/ProcessTest.php
+++ b/tests/Symfony/Tests/Component/Process/ProcessTest.php
@@ -55,6 +55,10 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessPipes($expected, $code)
     {
+        if (strpos(PHP_OS, "WIN") === 0 ) {
+            $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120');
+        }
+
         $p = new Process(sprintf('php -r %s', escapeshellarg($code)));
         $p->setStdin($expected);
         $p->run();

--- a/tests/Symfony/Tests/Component/Process/ProcessTest.php
+++ b/tests/Symfony/Tests/Component/Process/ProcessTest.php
@@ -55,8 +55,8 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessPipes($expected, $code)
     {
-        if (strpos(PHP_OS, "WIN") === 0 ) {
-            $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120');
+        if (strpos(PHP_OS, "WIN") === 0 && version_compare(phpversion(), "5.3.9", "<")) {
+            $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120 fixed in http://svn.php.net/viewvc?view=revision&revision=318366');
         }
 
         $p = new Process(sprintf('php -r %s', escapeshellarg($code)));


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: GH-2287

This fixes the problem that proc_open and pipes hang on inputs larger than 2048 chars, see https://bugs.php.net/bug.php?id=60120

Until then the appropriate test should be skipped to make the testsuite run on Windows.
