### PR TITLE
[2.1] Add way to set bundle dependant on other bundles.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -140,6 +140,16 @@ abstract class Bundle extends ContainerAware implements BundleInterface
     {
         return null;
     }
+    
+    /**
+     * Returns array of required bundles.
+     * 
+     * @return array The array of bundles or null if no dependencies
+     */
+    public function getDependencies()
+    {
+        return null;
+    }
 
     /**
      * Returns the bundle name (the class short name).

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -64,6 +64,13 @@ interface BundleInterface
      * @api
      */
     function getParent();
+    
+    /**
+     * Returns array of required bundles.
+     * 
+     * @return array The array of bundles or null if no dependencies
+     */
+    function getDependencies();
 
     /**
      * Returns the bundle name (the class short name).

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -481,6 +481,14 @@ abstract class Kernel implements KernelInterface
             } else {
                 $topMostBundles[$name] = $bundle;
             }
+            
+            if (null !== $bundle->getDependencies()) {
+                foreach ($bundle->getDependencies() as $dependency) {
+                    if (!isset($this->bundles[$dependency])) {
+                        throw new \LogicException(sprintf('Bundle "%s" requires other bundle "%s" to be registered', $name, $dependency));
+                    }
+                }
+            }
         }
 
         // look for orphans

--- a/tests/Symfony/Tests/Component/HttpKernel/KernelTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/KernelTest.php
@@ -579,6 +579,22 @@ EOF;
         ;
         $kernel->initializeBundles();
     }
+    
+	/**
+     * @expectedException \LogicException
+     */
+    public function testInitializeBundlesThrowsExceptionWhenADepencencyDoesNotExists()
+    {
+        $bundle = $this->getBundle(null, null, 'FooBarBundle', 'BarFooBundle');
+
+        $kernel = $this->getKernel();
+        $kernel
+            ->expects($this->once())
+            ->method('registerBundles')
+            ->will($this->returnValue(array($bundle)))
+        ;
+        $kernel->initializeBundles();
+    }
 
     public function testInitializeBundlesSupportsArbitraryBundleRegistrationOrder()
     {
@@ -652,11 +668,11 @@ EOF;
         $kernel->initializeBundles();
     }
 
-    protected function getBundle($dir = null, $parent = null, $className = null, $bundleName = null)
+    protected function getBundle($dir = null, $parent = null, $className = null, $bundleName = null, array $dependencies = null)
     {
         $bundle = $this
             ->getMockBuilder('Symfony\Tests\Component\HttpKernel\BundleForTest')
-            ->setMethods(array('getPath', 'getParent', 'getName'))
+            ->setMethods(array('getPath', 'getParent', 'getName', 'getDependencies'))
             ->disableOriginalConstructor()
         ;
 
@@ -682,6 +698,12 @@ EOF;
             ->expects($this->any())
             ->method('getParent')
             ->will($this->returnValue($parent))
+        ;
+        
+        $bundle
+            ->expects($this->any())
+            ->method('getDepencencies')
+            ->will($this->returnValue($dependencies))
         ;
 
         return $bundle;


### PR DESCRIPTION
**Bug fix**: no.
**Feature addition**: yes.
**BC break**: no.
**Tests pass**: yes.

Hi,

I am not sure if it will be useful at the moment, but the number of bundles constantly grows.
Some bundles are tied with each other, like my [SyliusThemingBundle](http://github.com/Sylius/SyliusThemingBundle) with the [LiipThemeBundle](http://github.com/liip/LiipThemeBundle).
When I disccussed this integration with @lsmith on IRC, he suggested to set the bundle as parent of my bundle, as there currently is no other way to formalize this dependency.
But this creates some issues, for example with files overriding.
We have **Composer** but i thought about elegant way to do this in the Symfony2 itself.
And here is my pull request, it adds simple method to the base bundle class and a check within the kernel.

PS. I am not sure if I modified the test properly. : (
