### PR TITLE
Fix typo in init:acl command from Security bundle

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -35,7 +35,7 @@ class InitAclCommand extends ContainerAwareCommand
             ->setHelp(<<<EOT
 The <info>init:acl</info> command mounts ACL tables in the database.
 
-<info>php app/console ini:acl</info>
+<info>php app/console init:acl</info>
 
 The name of the DBAL connection must be configured in your <info>app/config/security.yml</info> configuration file in the <info>security.acl.connection</info> variable.
 

--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -29,13 +29,14 @@ class InitAclCommand extends ContainerAwareCommand
      */
     protected function configure()
     {
+        $name = 'init:acl';
         $this
-            ->setName('init:acl')
+            ->setName($name)
             ->setDescription('Mounts ACL tables in the database')
             ->setHelp(<<<EOT
-The <info>init:acl</info> command mounts ACL tables in the database.
+The <info>$name</info> command mounts ACL tables in the database.
 
-<info>php app/console init:acl</info>
+<info>php app/console $name</info>
 
 The name of the DBAL connection must be configured in your <info>app/config/security.yml</info> configuration file in the <info>security.acl.connection</info> variable.
 


### PR DESCRIPTION
and abstract command name to avoid future typos. I broke this into two separate commits in case you only want the first.
