### PR TITLE
Fix fire php handler

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -60,7 +60,7 @@ class FirePHPHandler extends BaseFirePHPHandler
      */
     protected function sendHeader($header, $content)
     {
-        if (!$this->sendHeaders) {
+        if (!isset($this->sendHeaders)) {
             return;
         }
 


### PR DESCRIPTION
There is an error with the test :

ErrorException: Notice: Undefined property: Symfony\Bridge\Monolog\Handler\FirePHPHandler::$sendHeaders in www/vendor/symfony/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php line 63

BR,
Maxime
