### PR TITLE
[Security] Fix typo in init:acl command name

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -35,7 +35,7 @@ class InitAclCommand extends ContainerAwareCommand
             ->setHelp(<<<EOT
 The <info>init:acl</info> command mounts ACL tables in the database.
 
-<info>php app/console ini:acl</info>
+<info>php app/console init:acl</info>
 
 The name of the DBAL connection must be configured in your <info>app/config/security.yml</info> configuration file in the <info>security.acl.connection</info> variable.
 


### PR DESCRIPTION
This fixes a typo in the help/usage message for the "init:acl" command. The documentation was incorrectly displaying "ini:acl" in a command line execution example.
