### PR TITLE
[Form][Validator] Enable dynamic set of validation groups based on callback

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtension.php
@@ -27,9 +27,13 @@ class FieldTypeValidatorExtension extends AbstractTypeExtension
 
     public function buildForm(FormBuilder $builder, array $options)
     {
-        $options['validation_groups'] = empty($options['validation_groups'])
-            ? null
-            : (array)$options['validation_groups'];
+        if (empty($options['validation_groups'])) {
+            $options['validation_groups'] = null;
+        } else {
+            $options['validation_groups'] = is_callable($options['validation_groups'])
+                ? $options['validation_groups']
+                : (array) $options['validation_groups'];
+        }
 
         $builder
             ->setAttribute('validation_groups', $options['validation_groups'])

--- a/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
@@ -133,6 +133,10 @@ class DelegatingValidator implements FormValidatorInterface
 
         if ($form->hasAttribute('validation_groups')) {
             $groups = $form->getAttribute('validation_groups');
+
+            if (is_callable($groups)) {
+                $groups = (array) call_user_func($groups, $form);
+            }
         }
 
         $currentForm = $form;
@@ -141,6 +145,10 @@ class DelegatingValidator implements FormValidatorInterface
 
             if ($currentForm->hasAttribute('validation_groups')) {
                 $groups = $currentForm->getAttribute('validation_groups');
+
+                if (is_callable($groups)) {
+                    $groups = (array) call_user_func($groups, $currentForm);
+                }
             }
         }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtensionTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtensionTest.php
@@ -38,6 +38,24 @@ class FieldTypeValidatorExtensionTest extends TypeTestCase
         $this->assertEquals(array('group1', 'group2'), $form->getAttribute('validation_groups'));
     }
 
+    public function testValidationGroupsCanBeSetToCallback()
+    {
+        $form = $this->factory->create('field', null, array(
+            'validation_groups' => array($this, 'testValidationGroupsCanBeSetToCallback'),
+        ));
+
+        $this->assertTrue(is_callable($form->getAttribute('validation_groups')));
+    }
+
+    public function testValidationGroupsCanBeSetToClosure()
+    {
+        $form = $this->factory->create('field', null, array(
+            'validation_groups' => function($data, $extraData){ return null; },
+        ));
+
+        $this->assertTrue(is_callable($form->getAttribute('validation_groups')));
+    }
+
     public function testBindValidatesData()
     {
         $builder = $this->factory->createBuilder('field', null, array(

--- a/tests/Symfony/Tests/Component/Form/Extension/Validator/Validator/DelegatingValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Validator/Validator/DelegatingValidatorTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Tests\Component\Form\Extension\Validator\Validator;
 
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Util\PropertyPath;
@@ -89,6 +90,16 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
     protected function getMockForm()
     {
         return $this->getMock('Symfony\Tests\Component\Form\FormInterface');
+    }
+
+    /**
+     * Access has to be public, as this method is called via callback array
+     * in {@link testValidateFormDataCanHandleCallbackValidationGroups()}
+     * and {@link testValidateFormDataUsesInheritedCallbackValidationGroup()}
+     */
+    public function getValidationGroups(FormInterface $form)
+    {
+        return array('group1', 'group2');
     }
 
     public function testUseValidateValueWhenValidationConstraintExist()
@@ -598,6 +609,52 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
         DelegatingValidator::validateFormData($form, $context);
     }
 
+    public function testValidateFormDataCanHandleCallbackValidationGroups()
+    {
+        $graphWalker = $this->getMockGraphWalker();
+        $metadataFactory = $this->getMockMetadataFactory();
+        $context = new ExecutionContext('Root', $graphWalker, $metadataFactory);
+        $object = $this->getMock('\stdClass');
+        $form = $this->getBuilder()
+            ->setAttribute('validation_groups', array($this, 'getValidationGroups'))
+            ->getForm();
+
+        $graphWalker->expects($this->at(0))
+            ->method('walkReference')
+            ->with($object, 'group1', 'data', true);
+        $graphWalker->expects($this->at(1))
+            ->method('walkReference')
+            ->with($object, 'group2', 'data', true);
+
+        $form->setData($object);
+
+        DelegatingValidator::validateFormData($form, $context);
+    }
+
+    public function testValidateFormDataCanHandleClosureValidationGroups()
+    {
+        $graphWalker = $this->getMockGraphWalker();
+        $metadataFactory = $this->getMockMetadataFactory();
+        $context = new ExecutionContext('Root', $graphWalker, $metadataFactory);
+        $object = $this->getMock('\stdClass');
+        $form = $this->getBuilder()
+            ->setAttribute('validation_groups', function(FormInterface $form){
+                return array('group1', 'group2');
+            })
+            ->getForm();
+
+        $graphWalker->expects($this->at(0))
+            ->method('walkReference')
+            ->with($object, 'group1', 'data', true);
+        $graphWalker->expects($this->at(1))
+            ->method('walkReference')
+            ->with($object, 'group2', 'data', true);
+
+        $form->setData($object);
+
+        DelegatingValidator::validateFormData($form, $context);
+    }
+
     public function testValidateFormDataUsesInheritedValidationGroup()
     {
         $graphWalker = $this->getMockGraphWalker();
@@ -619,6 +676,64 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
         $graphWalker->expects($this->once())
             ->method('walkReference')
             ->with($object, 'group', 'path.data', true);
+
+        DelegatingValidator::validateFormData($child, $context);
+    }
+
+    public function testValidateFormDataUsesInheritedCallbackValidationGroup()
+    {
+        $graphWalker = $this->getMockGraphWalker();
+        $metadataFactory = $this->getMockMetadataFactory();
+        $context = new ExecutionContext('Root', $graphWalker, $metadataFactory);
+        $context->setPropertyPath('path');
+        $object = $this->getMock('\stdClass');
+
+        $parent = $this->getBuilder()
+            ->setAttribute('validation_groups', array($this, 'getValidationGroups'))
+            ->getForm();
+        $child = $this->getBuilder()
+            ->setAttribute('validation_groups', null)
+            ->getForm();
+        $parent->add($child);
+
+        $child->setData($object);
+
+        $graphWalker->expects($this->at(0))
+            ->method('walkReference')
+            ->with($object, 'group1', 'path.data', true);
+        $graphWalker->expects($this->at(1))
+            ->method('walkReference')
+            ->with($object, 'group2', 'path.data', true);
+
+        DelegatingValidator::validateFormData($child, $context);
+    }
+
+    public function testValidateFormDataUsesInheritedClosureValidationGroup()
+    {
+        $graphWalker = $this->getMockGraphWalker();
+        $metadataFactory = $this->getMockMetadataFactory();
+        $context = new ExecutionContext('Root', $graphWalker, $metadataFactory);
+        $context->setPropertyPath('path');
+        $object = $this->getMock('\stdClass');
+
+        $parent = $this->getBuilder()
+            ->setAttribute('validation_groups', function(FormInterface $form){
+                return array('group1', 'group2');
+            })
+            ->getForm();
+        $child = $this->getBuilder()
+            ->setAttribute('validation_groups', null)
+            ->getForm();
+        $parent->add($child);
+
+        $child->setData($object);
+
+        $graphWalker->expects($this->at(0))
+            ->method('walkReference')
+            ->with($object, 'group1', 'path.data', true);
+        $graphWalker->expects($this->at(1))
+            ->method('walkReference')
+            ->with($object, 'group2', 'path.data', true);
 
         DelegatingValidator::validateFormData($child, $context);
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Symfony2 tests written for new feature: yes
closes tickets: #2498 #1151

This will allow developer to pass a Closure or a callback array as a Validation groups option of a form. Eg:

```
class ClientType extends AbstarctType
{
// ...
    public function getDefaultOptions(array $options)
    {
        return array(
            'validation_groups' => function(FormInterface $form){
                // return array of validation groups based on submitted user data (data is after transform)
                $data = $form->getData();
                if($data->getType() == Entity\Client::TYPE_PERSON)
                    return array('Default', 'person');
                else
                    return array('Default', 'company');
            },
        );
    }
// ...
}
```

```
class ClientType extends AbstarctType
{
// ...
    public function getDefaultOptions(array $options)
    {
        return array(
            'validation_groups' => array(
                'Acme\\AcmeBundle\\Entity\\Client',
                'determineValidationGroups'
            ),
        );
    }
// ...
}
```

This will make developers life easier !
