### PR TITLE
[Doctrine Bridge] EntityType : default choices value

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -127,7 +127,7 @@ class EntityChoiceList extends ArrayChoiceList
     {
         parent::load();
 
-        if ($this->choices === false) {
+        if ($this->choices !== false) {
             $entities = $this->choices;
         } else if ($qb = $this->queryBuilder) {
             $entities = $qb->getQuery()->execute();

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -127,7 +127,7 @@ class EntityChoiceList extends ArrayChoiceList
     {
         parent::load();
 
-        if ($this->choices) {
+        if ($this->choices === false) {
             $entities = $this->choices;
         } else if ($qb = $this->queryBuilder) {
             $entities = $qb->getQuery()->execute();

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -48,7 +48,7 @@ class EntityType extends AbstractType
             'class'             => null,
             'property'          => null,
             'query_builder'     => null,
-            'choices'           => array(),
+            'choices'           => false,
         );
 
         $options = array_replace($defaultOptions, $options);


### PR DESCRIPTION
If the _choices_ property is equal to array(), the EntityChoiceList don't use empty choices and try query_builder or findAll.

We should use **false** as default instead of **array()** to be able to have an empty list if a custom filter give an empty result. With **array()** as default, the EntityType populates choices with findAll even if our result was empty; and it is not expected.
