### PR TITLE
[DependencyInjection] Fix getArgument() for replaced definition arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -147,6 +147,33 @@ class DefinitionDecorator extends Definition
     }
 
     /**
+     * Gets an argument to pass to the service constructor/factory method.
+     *
+     * If replaceArgument() has been used to replace an argument, this method
+     * will return the replacement value.
+     *
+     * @param integer $index
+     *
+     * @return mixed The argument value
+     *
+     * @api
+     */
+    public function getArgument($index)
+    {
+        if (array_key_exists('index_'.$index, $this->arguments)) {
+            return $this->arguments['index_'.$index];
+        }
+
+        $lastIndex = count(array_filter(array_keys($this->arguments), 'is_int')) - 1;
+
+        if ($index < 0 || $index > $lastIndex) {
+            throw new \OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, $lastIndex));
+        }
+
+        return $this->arguments[$index];
+    }
+
+    /**
      * You should always use this method when overwriting existing arguments
      * of the parent definition.
      *

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionDecoratorTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionDecoratorTest.php
@@ -69,4 +69,14 @@ class DefinitionDecoratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($def, $def->replaceArgument(0, 'foo'));
         $this->assertEquals(array('index_0' => 'foo'), $def->getArguments());
     }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testReplaceArgumentShouldRequireIntegerIndex()
+    {
+        $def = new DefinitionDecorator('foo');
+
+        $def->replaceArgument('0', 'foo');
+    }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionDecoratorTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionDecoratorTest.php
@@ -79,4 +79,32 @@ class DefinitionDecoratorTest extends \PHPUnit_Framework_TestCase
 
         $def->replaceArgument('0', 'foo');
     }
+
+    public function testReplaceArgument()
+    {
+        $def = new DefinitionDecorator('foo');
+
+        $def->setArguments(array(0 => 'foo', 1 => 'bar'));
+        $this->assertEquals('foo', $def->getArgument(0));
+        $this->assertEquals('bar', $def->getArgument(1));
+
+        $this->assertSame($def, $def->replaceArgument(1, 'baz'));
+        $this->assertEquals('foo', $def->getArgument(0));
+        $this->assertEquals('baz', $def->getArgument(1));
+
+        $this->assertEquals(array(0 => 'foo', 1 => 'bar', 'index_1' => 'baz'), $def->getArguments());
+    }
+
+    /**
+     * @expectedException OutOfBoundsException
+     */
+    public function testGetArgumentShouldCheckBounds()
+    {
+        $def = new DefinitionDecorator('foo');
+
+        $def->setArguments(array(0 => 'foo'));
+        $def->replaceArgument(0, 'foo');
+
+        $def->getArgument(1);
+    }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
@@ -221,6 +221,28 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('foo', 'bar'), $def->getArguments());
     }
 
+    /**
+     * @expectedException OutOfBoundsException
+     */
+    public function testGetArgumentShouldCheckBounds()
+    {
+        $def = new Definition('stdClass');
+
+        $def->addArgument('foo');
+        $def->getArgument(1);
+    }
+
+    /**
+     * @expectedException OutOfBoundsException
+     */
+    public function testReplaceArgumentShouldCheckBounds()
+    {
+        $def = new Definition('stdClass');
+
+        $def->addArgument('foo');
+        $def->replaceArgument(1, 'bar');
+    }
+
     public function testSetGetProperties()
     {
         $def = new Definition('stdClass');


### PR DESCRIPTION
I was implementing something that worked with DefinitionDecorators before the container was compiled and ran into some missing functionality. While I was tinkering, I also added some additional tests for exceptions in both Definition and DefinitionDecorator.
