### PR TITLE
[Doctrine][Bridge] EntityType : default choices value

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -81,7 +81,7 @@ class EntityChoiceList extends ArrayChoiceList
 
     private $propertyPath;
 
-    public function __construct(EntityManager $em, $class, $property = null, $queryBuilder = null, $choices = array())
+    public function __construct(EntityManager $em, $class, $property = null, $queryBuilder = null, $choices = null)
     {
         // If a query builder was passed, it must be a closure or QueryBuilder
         // instance

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -109,7 +109,11 @@ class EntityChoiceList extends ArrayChoiceList
             $this->propertyPath = new PropertyPath($property);
         }
 
-        parent::__construct($choices);
+        if (!is_array($choices) && !$choices instanceof \Closure && !is_null($choices)) {
+            throw new UnexpectedTypeException($choices, 'array or \Closure or null');
+        }
+
+        $this->choices = $choices;
     }
 
     /**
@@ -127,7 +131,7 @@ class EntityChoiceList extends ArrayChoiceList
     {
         parent::load();
 
-        if ($this->choices !== false) {
+        if (is_array($this->choices)) {
             $entities = $this->choices;
         } else if ($qb = $this->queryBuilder) {
             $entities = $qb->getQuery()->execute();

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -127,7 +127,7 @@ class EntityChoiceList extends ArrayChoiceList
     {
         parent::load();
 
-        if ($this->choices) {
+        if ($this->choices !== false) {
             $entities = $this->choices;
         } else if ($qb = $this->queryBuilder) {
             $entities = $qb->getQuery()->execute();

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -48,7 +48,7 @@ class EntityType extends AbstractType
             'class'             => null,
             'property'          => null,
             'query_builder'     => null,
-            'choices'           => false,
+            'choices'           => null,
         );
 
         $options = array_replace($defaultOptions, $options);

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -48,7 +48,7 @@ class EntityType extends AbstractType
             'class'             => null,
             'property'          => null,
             'query_builder'     => null,
-            'choices'           => array(),
+            'choices'           => false,
         );
 
         $options = array_replace($defaultOptions, $options);

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -88,6 +88,26 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
         $this->assertSame(array(1 => 'Foo', 2 => 'Bar'), $choiceList->getChoices());
     }
 
+    public function testEmptyChoicesAreManaged()
+    {
+        $entity1 = new SingleIdentEntity(1, 'Foo');
+        $entity2 = new SingleIdentEntity(2, 'Bar');
+
+        // Persist for managed state
+        $this->em->persist($entity1);
+        $this->em->persist($entity2);
+
+        $choiceList = new EntityChoiceList(
+            $this->em,
+            self::SINGLE_IDENT_CLASS,
+            'name',
+            null,
+            array()
+        );
+
+        $this->assertSame(array(), $choiceList->getChoices());
+    }
+
     public function testNestedChoicesAreManaged()
     {
         $entity1 = new SingleIdentEntity(1, 'Foo');


### PR DESCRIPTION
If the choices property is equal to array(), the EntityChoiceList don't use empty choices and try query_builder or findAll.

We should use false as default instead of array() to be able to have an empty list if a custom filter gives an empty result. With array() as default, the EntityType populates choices with findAll even if our result was empty; and it is not expected.

(PR created instead of https://github.com/symfony/symfony/pull/2500 to pull it into 2.0 branch)
