### PR TITLE
[Validator] extension constraint for FileValidator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xliff
@@ -194,6 +194,10 @@
                 <source>This value should have exactly {{ limit }} characters</source>
                 <target>Cette chaine doit avoir exactement {{ limit }} caractères</target>
             </trans-unit>
+            <trans-unit id="49">
+                <source>The file extension is invalid ({{ extension }}). Allowed extensions are {{ extensions }}</source>
+                <target>L'extension du fichier est invalide ({{ extension }}). Les extensions autorisés sont {{ extensions }}</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -21,10 +21,12 @@ use Symfony\Component\Validator\Constraint;
 class File extends Constraint
 {
     public $maxSize = null;
+    public $extensions = array();
     public $mimeTypes = array();
     public $notFoundMessage = 'The file could not be found';
     public $notReadableMessage = 'The file is not readable';
     public $maxSizeMessage = 'The file is too large ({{ size }}). Allowed maximum size is {{ limit }}';
+    public $extensionsMessage = 'The file extension is invalid ({{ extension }}). Allowed extensions are {{ extensions }}';
     public $mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}';
 
     public $uploadIniSizeErrorMessage = 'The file is too large. Allowed maximum size is {{ limit }}';

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -104,6 +104,21 @@ class FileValidator extends ConstraintValidator
             }
         }
 
+        if ($constraint->extensions) {
+            $extensions = (array) $constraint->extensions;
+            $extension = $value instanceof FileObject ? $value->getExtension() : pathinfo($value, PATHINFO_EXTENSION);
+
+            if (!in_array($extension, $extensions)) {
+                $this->setMessage($constraint->extensionsMessage, array(
+                    '{{ extension }}'  => '"'.$extension.'"',
+                    '{{ extensions }}' => '"'.implode('", "', $extensions) .'"',
+                    '{{ file }}'       => $path,
+                ));
+
+                return false;
+            }
+        }
+
         if ($constraint->mimeTypes) {
             if (!$value instanceof FileObject) {
                 $value = new FileObject($value);

--- a/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorTest.php
@@ -146,6 +146,63 @@ class FileValidatorTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testValidExtension()
+    {
+        $file = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getPathname')
+           ->will($this->returnValue($this->path))
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getExtension')
+            ->will($this->returnValue('jpg'))
+        ;
+
+        $constraint = new File(array(
+            'extensions' => array('jpg', 'png'),
+        ));
+
+        $this->assertTrue($this->validator->isValid($file, $constraint));
+    }
+
+    public function testInvalidExtension()
+    {
+        $file = $this
+            ->getMockBuilder('Symfony\Component\HttpFoundation\File\File')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getPathname')
+            ->will($this->returnValue($this->path))
+        ;
+        $file
+            ->expects($this->once())
+            ->method('getExtension')
+            ->will($this->returnValue('jpg'))
+        ;
+
+        $constraint = new File(array(
+            'extensions' => array('xml', 'csv'),
+            'extensionsMessage' => 'myMessage',
+        ));
+
+        $this->assertFalse($this->validator->isValid($file, $constraint));
+        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
+        $this->assertEquals($this->validator->getMessageParameters(), array(
+            '{{ extension }}'  => '"jpg"',
+            '{{ extensions }}' => '"xml", "csv"',
+            '{{ file }}'       => $this->path,
+        ));
+    }
+
     public function testValidMimeType()
     {
         $file = $this


### PR DESCRIPTION
```
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
```

Add extension constraint for FileValidator, 

For example :
When your waiting a CSV file the mimetype is `text/plain` not `text/csv`, so it's good to double checking with the extension (`csv`), same thing with an Open Office Calc file who render an `application/xml` (extension `ods`)
