### PR TITLE
1863 improve flash

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -342,6 +342,17 @@ class Session implements \Serializable
         $this->oldFlashes = array('status' => array());
     }
 
+    /**
+     * Adds a generic flash message to the session.
+     *
+     * @param string $type
+     *
+     * @return array
+     */
+    public function addFlash($value) {
+        $this->flashes['status'][] = $value;
+    }
+
     public function save()
     {
         if (false === $this->started) {

--- a/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
@@ -149,7 +149,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->set('foo', 'bar');
 
         $this->session->save();
-        $compare = array('_symfony2' => array('attributes' => array('foo' => 'bar'), 'flashes' => array()));
+        $compare = array('_symfony2' => array('attributes' => array('foo' => 'bar'), 'flashes' => array('status' => array())));
 
         $r = new \ReflectionObject($this->storage);
         $p = $r->getProperty('data');
@@ -179,7 +179,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         
         $expected = array(
             'attributes'=>array('foo'=>'bar'),
-            'flashes'=>array(),
+            'flashes'=>array('status' => array()),
         );
         $saved = $this->storage->read('_symfony2');
         $this->assertSame($expected, $saved);
@@ -195,7 +195,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         
         $expected = array(
             'attributes'=>array('foo'=>'bar'),
-            'flashes'=>array(),
+            'flashes'=>array('status' => array()),
         );
         $saved = $this->storage->read('_symfony2');
         $this->assertSame($expected, $saved);

--- a/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
@@ -59,6 +59,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->session->setFlashes($flashes);
 
         $this->assertSame($flashes, $this->session->getFlashes());
+
+        $this->session->clearFlashes();
+        $this->session->addFlash('foo');
+        $compare = $this->session->getFlashes();
+        $this->assertSame($compare, array(0 => 'foo'));
     }
 
     public function testFlashesAreFlushedWhenNeeded()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 1863

Adds a "type" parameter for flash messages. By default, status messages are placed in the "status" bucket, but type could be 'error', 'warning', etc. An addFlash() method is also added to easily add flash messages without needing to specify a type or a name.
