### PR TITLE
Login redirect

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -273,7 +273,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
             return $targetUrl;
         }
 
-        if ($this->options['use_referer'] && $targetUrl = $request->headers->get('Referer')) {
+        if ($this->options['use_referer'] && ($targetUrl = $request->headers->get('Referer')) && $targetUrl !== $request->getUriForPath($this->options['login_path'])) {
             return $targetUrl;
         }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes

Redirect to default_target_path if use_referer is true and the referer is the login_path.
