### PR TITLE
Set error code when number cannot be parsed in StubNumberFormatter

### DIFF
--- a/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
@@ -32,7 +32,24 @@ class StubNumberFormatter
      * @see StubNumberFormatter::getErrorMessage()
      */
     const U_ZERO_ERROR = 0;
-    const U_ZERO_ERROR_MESSAGE = 'U_ZERO_ERROR';
+    const U_PARSE_ERROR = 9;
+
+    /**
+     * The error messages for each error code
+     *
+     * @var array
+     */
+    protected $errorMessages = array(
+        self::U_ZERO_ERROR => 'U_ZERO_ERROR',
+        self::U_PARSE_ERROR => 'Number parsing failed: U_PARSE_ERROR',
+    );
+
+    /**
+     * The error code from the last operation
+     * 
+     * @var integer
+     */
+    protected $errorCode = self::U_ZERO_ERROR;
 
     /** Format style constants */
     const PATTERN_DECIMAL   = 0;
@@ -346,7 +363,7 @@ class StubNumberFormatter
      */
     public function getErrorCode()
     {
-        return self::U_ZERO_ERROR;
+        return $this->errorCode;
     }
 
     /**
@@ -357,7 +374,7 @@ class StubNumberFormatter
      */
     public function getErrorMessage()
     {
-        return self::U_ZERO_ERROR_MESSAGE;
+        return $this->errorMessages[$this->errorCode];
     }
 
     /**
@@ -458,6 +475,7 @@ class StubNumberFormatter
 
         // Any string before the numeric value causes error in the parsing
         if (isset($matches[1]) && !empty($matches[1])) {
+            $this->errorCode = self::U_PARSE_ERROR;
             return false;
         }
 

--- a/tests/Symfony/Tests/Component/Locale/Stub/StubNumberFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubNumberFormatterTest.php
@@ -616,12 +616,6 @@ class StubNumberFormatterTest extends LocaleTestCase
         $this->assertEquals(StubNumberFormatter::U_ZERO_ERROR, $formatter->getErrorCode());
     }
 
-    public function testGetErrorMessage()
-    {
-        $formatter = $this->getStubFormatterWithDecimalStyle();
-        $this->assertEquals(StubNumberFormatter::U_ZERO_ERROR_MESSAGE, $formatter->getErrorMessage());
-    }
-
     public function testGetLocale()
     {
         $formatter = $this->getStubFormatterWithDecimalStyle();
@@ -672,6 +666,12 @@ class StubNumberFormatterTest extends LocaleTestCase
         $formatter = $this->getStubFormatterWithDecimalStyle();
         $parsedValue = $formatter->parse($value, StubNumberFormatter::TYPE_DOUBLE);
         $this->assertSame($expected, $parsedValue, $message);
+
+        if ($expected === false) {
+            $this->assertSame($formatter::U_PARSE_ERROR, $formatter->getErrorCode());
+        } else {
+            $this->assertEquals($formatter::U_ZERO_ERROR, $formatter->getErrorCode());
+        }
     }
 
     /**
@@ -684,6 +684,12 @@ class StubNumberFormatterTest extends LocaleTestCase
         $formatter = $this->getIntlFormatterWithDecimalStyle();
         $parsedValue = $formatter->parse($value, \NumberFormatter::TYPE_DOUBLE);
         $this->assertSame($expected, $parsedValue, $message);
+
+        if ($expected === false) {
+            $this->assertSame(U_PARSE_ERROR, $formatter->getErrorCode());
+        } else {
+            $this->assertEquals(U_ZERO_ERROR, $formatter->getErrorCode());
+        }
     }
 
     public function parseProvider()


### PR DESCRIPTION
The stub implementation of NumberFormatter never sets an error code and instead always returns the "no-error" code. This causes unexpected results when a transformer gives it bad arguments, such as transforming the input value to boolean false and causing exceptions further down the line, as in #2389.

Instead, it should set an error code when appropriate and return it when requested so that a TransformationFailedException can be raised and the input value left unaltered.

There may be other instances where an error should be set. This covers the common use case of non-numeric input.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2389
