### PR TITLE
[Config] Implemented Serializable on resources

### DIFF
--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class DirectoryResource implements ResourceInterface
+class DirectoryResource implements ResourceInterface, \Serializable
 {
     private $resource;
     private $pattern;
@@ -88,5 +88,15 @@ class DirectoryResource implements ResourceInterface
         }
 
         return $newestMTime < $timestamp;
+    }
+
+    public function serialize()
+    {
+        return serialize(array($this->resource, $this->pattern));
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->resource, $this->pattern) = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class FileResource implements ResourceInterface
+class FileResource implements ResourceInterface, \Serializable
 {
     private $resource;
 
@@ -66,5 +66,15 @@ class FileResource implements ResourceInterface
         }
 
         return filemtime($this->resource) < $timestamp;
+    }
+
+    public function serialize()
+    {
+        return serialize($this->resource);
+    }
+
+    public function unserialize($serialized)
+    {
+        $this->resource = unserialize($serialized);
     }
 }


### PR DESCRIPTION
bug fix: no
feature addition: no
BC break: not really. you simply need to clear your cache in debug mode
test passes: yes

Serializing private variables without implementing Serializable uses far more space as it prepend the fully qualified class name before the name of each property. This change allows keeping the meta file smaller.
