### PR TITLE
[Validators][Type] Added support for ctype_* functions + tests

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -37,9 +37,12 @@ class TypeValidator extends ConstraintValidator
 
         $type = strtolower($constraint->type);
         $type = $type == 'boolean' ? 'bool' : $constraint->type;
-        $function = 'is_'.$type;
+        $isFunction = 'is_'.$type;
+        $ctypeFunction = 'ctype_'.$type;
 
-        if (function_exists($function) && call_user_func($function, $value)) {
+        if (function_exists($isFunction) && call_user_func($isFunction, $value)) {
+            return true;
+        } else if (function_exists($ctypeFunction) && call_user_func($ctypeFunction, $value)) {
             return true;
         } else if ($value instanceof $constraint->type) {
             return true;

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AssertTypeValidatorTest.php
@@ -79,6 +79,17 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
             array($object, 'object'),
             array($object, 'stdClass'),
             array($file, 'resource'),
+            array('12345', 'digit'),
+            array('12a34', 'alnum'),
+            array('abcde', 'alpha'),
+            array("\n\r\t", 'cntrl'),
+            array('arf12', 'graph'),
+            array('abcde', 'lower'),
+            array('ABCDE', 'upper'),
+            array('arf12', 'print'),
+            array('*&$()', 'punct'),
+            array("\n\r\t", 'space'),
+            array('AB10BC99', 'xdigit'),
         );
     }
 
@@ -131,6 +142,17 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
             array($file, 'float'),
             array($file, 'string'),
             array($file, 'object'),
+            array('12a34', 'digit'),
+            array('1a#23', 'alnum'),
+            array('abcd1', 'alpha'),
+            array("\nabc", 'cntrl'),
+            array("abc\n", 'graph'),
+            array('abCDE', 'lower'),
+            array('ABcde', 'upper'),
+            array("\nabc", 'print'),
+            array('abc&$!', 'punct'),
+            array("\nabc", 'space'),
+            array('AR1012', 'xdigit'),
         );
     }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -

Not sure if the ctype_\* functions support should be included in the AssertTypeValidator or in a dedicated one.
What do you think ?
