### PR TITLE
[Form] Enhanced error messages

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -249,11 +249,11 @@ class FormFactory implements FormFactoryInterface
         $diff = array_diff($passedOptions, $knownOptions);
 
         if (count($diff) > 1) {
-            throw new CreationException(sprintf('The options "%s" do not exist', implode('", "', $diff)));
+            throw new CreationException(sprintf('The options "%s" do not exist. Known options are: "%s"', implode('", "', $diff), implode('", "', $knownOptions)));
         }
 
         if (count($diff) > 0) {
-            throw new CreationException(sprintf('The option "%s" does not exist', current($diff)));
+            throw new CreationException(sprintf('The option "%s" does not exist. Known options are: "%s"', current($diff), implode('", "', $knownOptions)));
         }
 
         foreach ($optionValues as $option => $allowedValues) {

--- a/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
@@ -475,6 +475,36 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('builderInstance', $builder);
     }
 
+    public function testUnknownOptions()
+    {
+        $type = new \Symfony\Component\Form\Extension\Core\Type\TextType();
+
+        $factory = new FormFactory(array(new \Symfony\Component\Form\Extension\Core\CoreExtension()));
+
+        $this->setExpectedException('Symfony\Component\Form\Exception\CreationException',
+            'The options "invalid", "unknown" do not exist. Known options are: "data", "data_class", ' .
+            '"trim", "required", "read_only", "max_length", "pattern", "property_path", "by_reference", ' .
+            '"error_bubbling", "error_mapping", "label", "attr", "invalid_message", "invalid_message_parameters", ' .
+            '"translation_domain", "empty_data"'
+        );
+        $factory->createNamedBuilder($type, "text", "value", array("invalid" => "opt", "unknown" => "opt"));
+    }
+
+    public function testUnknownOption()
+    {
+        $type = new \Symfony\Component\Form\Extension\Core\Type\TextType();
+
+        $factory = new FormFactory(array(new \Symfony\Component\Form\Extension\Core\CoreExtension()));
+
+        $this->setExpectedException('Symfony\Component\Form\Exception\CreationException',
+            'The option "unknown" does not exist. Known options are: "data", "data_class", ' .
+            '"trim", "required", "read_only", "max_length", "pattern", "property_path", "by_reference", ' .
+            '"error_bubbling", "error_mapping", "label", "attr", "invalid_message", "invalid_message_parameters", ' .
+            '"translation_domain", "empty_data"'
+        );
+        $factory->createNamedBuilder($type, "text", "value", array("unknown" => "opt"));
+    }
+
     private function createMockFactory(array $methods = array())
     {
         return $this->getMockBuilder('Symfony\Component\Form\FormFactory')


### PR DESCRIPTION
With this patch its much easier to see what went wrong with a form type and what the possible options are.

Also added tests for this error conditions.
