### PR TITLE
[WIP] Validation on a Doctrine Manager Basis

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/DoctrineValidationPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/DoctrineValidationPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\Config\Resource\FileResource;
 
 /**
  * Registers additional validators
@@ -36,8 +37,8 @@ class DoctrineValidationPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $this->updateValidatorMappingFiles($container, 'xml');
-        $this->updateValidatorMappingFiles($container, 'yaml');
+        $this->updateValidatorMappingFiles($container, 'xml', 'xml');
+        $this->updateValidatorMappingFiles($container, 'yaml', 'yml');
     }
 
     /**
@@ -47,13 +48,13 @@ class DoctrineValidationPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param type $extension
      */
-    private function updateValidatorMappingFiles(ContainerBuilder $container, $extension)
+    private function updateValidatorMappingFiles(ContainerBuilder $container, $mapping, $extension)
     {
-        if ( ! $container->hasParameter('validator.mapping.loader.' . $extension . '_files_loader.mapping_files')) {
+        if ( ! $container->hasParameter('validator.mapping.loader.' . $mapping . '_files_loader.mapping_files')) {
             return;
         }
 
-        $files = $container->getParameter('validator.mapping.loader.' . $extension . '_files_loader.mapping_files');
+        $files = $container->getParameter('validator.mapping.loader.' . $mapping . '_files_loader.mapping_files');
         $validationPath = 'Resources/config/validation.' . $this->managerType . '.' . $extension;
 
         foreach ($container->getParameter('kernel.bundles') as $bundle) {
@@ -64,6 +65,6 @@ class DoctrineValidationPass implements CompilerPassInterface
             }
         }
 
-        $container->setParameter('validator.mapping.loader.' . $extension . '_files_loader.mapping_files', $files);
+        $container->setParameter('validator.mapping.loader.' . $mapping . '_files_loader.mapping_files', $files);
     }
 }

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/DoctrineValidationPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/DoctrineValidationPass.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Registers additional validators
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
+class DoctrineValidationPass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    private $managerType;
+
+    public function __construct($managerType)
+    {
+        $this->managerType = $managerType;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $this->updateValidatorMappingFiles($container, 'xml');
+        $this->updateValidatorMappingFiles($container, 'yaml');
+    }
+
+    /**
+     * Gets the validation mapping files for the format and extends them with
+     * files matching a doctrine search pattern (Resources/config/validation.orm.xml)
+     *
+     * @param ContainerBuilder $container
+     * @param type $extension
+     */
+    private function updateValidatorMappingFiles(ContainerBuilder $container, $extension)
+    {
+        if ( ! $container->hasParameter('validator.mapping.loader.' . $extension . '_files_loader.mapping_files')) {
+            return;
+        }
+
+        $files = $container->getParameter('validator.mapping.loader.' . $extension . '_files_loader.mapping_files');
+        $validationPath = 'Resources/config/validation.' . $this->managerType . '.' . $extension;
+
+        foreach ($container->getParameter('kernel.bundles') as $bundle) {
+            $reflection = new \ReflectionClass($bundle);
+            if (is_file($file = dirname($reflection->getFilename()) . '/' . $validationPath)) {
+                $files[] = realpath($file);
+                $container->addResource(new FileResource($file));
+            }
+        }
+
+        $container->setParameter('validator.mapping.loader.' . $extension . '_files_loader.mapping_files', $files);
+    }
+}

--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -12,9 +12,10 @@
 namespace Symfony\Bundle\DoctrineBundle;
 
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
-use Symfony\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
+use Symfony\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
 
 /**
  * Bundle.
@@ -29,6 +30,7 @@ class DoctrineBundle extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
+        $container->addCompilerPass(new DoctrineValidationPass('orm'));
     }
 
     public function boot()


### PR DESCRIPTION
Hello,

we have had problems before with validation that is "persistence" related. Unique-validators or any other validation that is based on services that depend on persistence.

The problem is two-fold:
1. In annotations you cannot define validators for all persistence layers you support, because then users need them all installed.
2. In XML/YAML the same is true, since there is only one validation.xml or validation.yml file looked for.

Now one solution is to have three model classes that extend from a base class to get around this (like FOSUserBundle does) but that is cumbersome. This PR provides a new solution that is Doctrine specific (and takes the responsibility out of the Core).

Each Doctrine Bundle (ORM, CouchDB, MongoDB, PHPCR) can add this compiler pass with a manager type name:

```
$container->addCompilerPass(new DoctrineValidationPass('orm'));
```

This leads to the compiler pass searching for additional validation files "Resources/config/validation.orm.yml" and "Resources/configvalidation.orm.xml".

My first idea was to put this into the Resources/config/doctrine folder as well, but then it is detected as mapping file of course.

Regarding tests, this is not easily testable without a full fledged bundle setup, i tested this inside Acme Demo Bundle, however for a good unit-test we probably need a filesystem abstraction testing layer. Has anyone a good idea how to test this without having to setup another test-bundle? I can't use the one from DoctrineBundle since this code is in the Bridge.
