### PR TITLE
fixing WebTastCase when kernel is not found and improving exception message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -116,11 +116,12 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
 
         $finder = new Finder();
         $finder->name('*Kernel.php')->depth(0)->in($dir);
-        if (!count($finder)) {
-            throw new \RuntimeException('You must override the WebTestCase::createKernel() method.');
+        $results = iterator_to_array($finder);
+        if (!count($results)) {
+            throw new \RuntimeException('Either set KERNEL_DIR in your phpunit.xml according to http://symfony.com/doc/current/book/testing.html#your-first-functional-test or override the WebTestCase::createKernel() method.');
         }
 
-        $file = current(iterator_to_array($finder));
+        $file = current($results);
         $class = $file->getBasename('.php');
 
         require_once $file;


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

this time against 2.0 and with the link to the symfony book. replaces #2418

(i hope you merge 2.0 into master as well?)
