### PR TITLE
Fix routing exception doc

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -74,15 +74,7 @@ class UrlGenerator implements UrlGeneratorInterface
     }
 
     /**
-     * Generates a URL from the given parameters.
-     *
-     * @param  string  $name       The name of the route
-     * @param  mixed   $parameters An array of parameters
-     * @param  Boolean $absolute   Whether to generate an absolute URL
-     *
-     * @return string The generated URL
-     *
-     * @throws Symfony\Component\Routing\Exception\RouteNotFoundException When route doesn't exist
+     * {@inheritDoc}
      *
      * @api
      */
@@ -100,8 +92,8 @@ class UrlGenerator implements UrlGeneratorInterface
     }
 
     /**
-     * @throws Symfony\Component\Routing\Exception\MissingMandatoryParametersException When route has some missing mandatory parameters
-     * @throws Symfony\Component\Routing\Exception\InvalidParameterException When a parameter value is not correct
+     * @throws MissingMandatoryParametersException When route has some missing mandatory parameters
+     * @throws InvalidParameterException When a parameter value is not correct
      */
     protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $absolute)
     {

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -12,9 +12,10 @@
 namespace Symfony\Component\Routing\Generator;
 
 use Symfony\Component\Routing\RequestContextAwareInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
- * UrlGeneratorInterface is the interface that all URL generator classes must implements.
+ * UrlGeneratorInterface is the interface that all URL generator classes must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
@@ -25,11 +26,16 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
     /**
      * Generates a URL from the given parameters.
      *
+     * If the generator is not able to generate the url, it must throw the RouteNotFoundException
+     * as documented below.
+     *
      * @param string  $name       The name of the route
      * @param mixed   $parameters An array of parameters
      * @param Boolean $absolute   Whether to generate an absolute URL
      *
      * @return string The generated URL
+     *
+     * @throws RouteNotFoundException if route doesn't exist
      *
      * @api
      */

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -68,14 +68,7 @@ class UrlMatcher implements UrlMatcherInterface
     }
 
     /**
-     * Tries to match a URL with a set of routes.
-     *
-     * @param  string $pathinfo The path info to be parsed
-     *
-     * @return array An array of parameters
-     *
-     * @throws ResourceNotFoundException If the resource could not be found
-     * @throws MethodNotAllowedException If the resource was found but the request method is not allowed
+     * {@inheritDoc}
      *
      * @api
      */

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Routing\Matcher;
 
 use Symfony\Component\Routing\RequestContextAwareInterface;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 /**
  * UrlMatcherInterface is the interface that all URL matcher classes must implement.
@@ -24,6 +26,9 @@ interface UrlMatcherInterface extends RequestContextAwareInterface
 {
     /**
      * Tries to match a URL with a set of routes.
+     *
+     * If the matcher can not find information, it must throw one of the exceptions documented
+     * below.
      *
      * @param  string $pathinfo The path info to be parsed
      *


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

This is only documentation cleanup for the url matcher and generator interfaces as they did not properly reflect the exceptions that are expected to be thrown. when the exceptions are not respected, unexpected behaviour can happen.
