### PR TITLE
[DependencyInjection] Fix a problem that a parameter cannot be used as the value of a factory-method definition

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -728,7 +728,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
                 throw new \RuntimeException('Cannot create service from factory method without a factory service or factory class.');
             }
 
-            $service = call_user_func_array(array($factory, $definition->getFactoryMethod()), $arguments);
+            $service = call_user_func_array(array($factory, $this->getParameterBag()->resolveValue($definition->getFactoryMethod())), $arguments);
         } else {
             $r = new \ReflectionClass($this->getParameterBag()->resolveValue($definition->getClass()));
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ContainerBuilderTest.php
@@ -268,6 +268,20 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
      */
+    public function testCreateServiceFactoryMethodWithParameter()
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('bar', 'stdClass');
+        $builder->register('foo1', 'FooClass')->setFactoryClass('FooClass')->setFactoryMethod('%method%')->addArgument(array('foo' => '%value%', '%value%' => 'foo', new Reference('bar')));
+        $builder->setParameter('value', 'bar');
+        $builder->setParameter('method', 'getInstance');
+        $this->assertTrue($builder->get('foo1')->called, '->createService() calls the parametrized factory method to create the service instance');
+        $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo', $builder->get('bar')), $builder->get('foo1')->arguments, '->createService() passes the arguments to the factory method');
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
+     */
     public function testCreateServiceFactoryService()
     {
         $builder = new ContainerBuilder();


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

All definitions except the factory-method are resolved by $this->getParameterBag()->resolveValue() method in the createService() method, but the factory-method is not resolved by the same way. Thus a parameter cannot be used as the value of a factory-method definition. This PR fixes the problem unless it is the expected behavior.
