### PR TITLE
[EventDispatcher] Add reference to the EventDispatcher on the Event

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/ContainerAwareEventDispatcherTest.php
@@ -151,17 +151,19 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
 
         $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
 
-        $service
-            ->expects($this->once())
-            ->method('onEvent')
-            ->with($event)
-        ;
-
         $container = new Container();
         $container->set('service.listener', $service);
 
         $dispatcher = new ContainerAwareEventDispatcher($container);
         $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'));
+
+        $event->setDispatcher($dispatcher);
+
+        $service
+            ->expects($this->once())
+            ->method('onEvent')
+            ->with($event)
+        ;
 
         $this->assertTrue($dispatcher->hasListeners());
 

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -38,6 +38,11 @@ class Event
     private $propagationStopped = false;
 
     /**
+     * @var EventDispatcher Dispatcher that dispatched this event
+     */
+    private $dispatcher;
+
+    /**
      * Returns whether further event listeners should be triggered.
      *
      * @see Event::stopPropagation
@@ -62,5 +67,29 @@ class Event
     public function stopPropagation()
     {
         $this->propagationStopped = true;
+    }
+
+    /**
+     * Stores the EventDispatcher that dispatches this Event
+     *
+     * @param EventDispatcher $dispatcher
+     *
+     * @api
+     */
+    public function setDispatcher(EventDispatcher $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * Returns the EventDispatcher that dispatches this Event
+     *
+     * @return EventDispatcher
+     *
+     * @api
+     */
+    public function getDispatcher()
+    {
+        return $this->dispatcher;
     }
 }

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -47,6 +47,8 @@ class EventDispatcher implements EventDispatcherInterface
             $event = new Event();
         }
 
+        $event->setDispatcher($this);
+
         $this->doDispatch($this->getListeners($eventName), $eventName, $event);
     }
 

--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -228,6 +228,16 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->dispatcher->removeSubscriber($eventSubscriber);
         $this->assertFalse($this->dispatcher->hasListeners(self::preFoo));
     }
+
+    public function testEventReceivesTheDispatcherInstance()
+    {
+        $test = $this;
+        $this->dispatcher->addListener('test', function ($event) use (&$dispatcher) {
+            $dispatcher = $event->getDispatcher();
+        });
+        $this->dispatcher->dispatch('test');
+        $this->assertSame($this->dispatcher, $dispatcher);
+    }
 }
 
 class TestEventListener


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

I don't like registering event listeners unless they are really used, it seems wasteful. So I tend to register listeners for the response event in other listeners, only when they will be required. @stof has [brought to my attention](https://github.com/nelmio/NelmioCorsBundle/commit/fb243ace83c55280d8a7841a0fbaf22a4e947600#commitcomment-696467) that this may cause issues in Silex or any other situation where event listeners are not lazy loaded, since it creates a circular reference in that case.

With this PR, avoiding the circular reference is possible, without bloating the response listener with unnecessary "do I need to do anything?" code.
