### PR TITLE
[Serializer] `normalize` should use supported normalizer before Traversable

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -199,7 +199,7 @@ class Serializer implements SerializerInterface
      * @param object $object Object to test for normalization support
      * @param string $format Format name, needed for normalizers to pivot on
      */
-    protected function supportsNormalization($object, $format)
+    private function supportsNormalization($object, $format)
     {
         $class = get_class($object);
 

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -96,6 +96,9 @@ class Serializer implements SerializerInterface
         if (null === $data || is_scalar($data)) {
             return $data;
         }
+        if (is_object($data) && $this->supportsNormalization($data, $format)) {
+            return $this->normalizeObject($data, $format);
+        }
         if ($data instanceof \Traversable) {
             $normalized = array();
             foreach ($data as $key => $val) {

--- a/tests/Symfony/Tests/Component/Serializer/Fixtures/NormalizableTraversableDummy.php
+++ b/tests/Symfony/Tests/Component/Serializer/Fixtures/NormalizableTraversableDummy.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Tests\Component\Serializer\Fixtures;
+
+use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+
+class NormalizableTraversableDummy extends TraversableDummy implements NormalizableInterface
+{
+    public function normalize(SerializerInterface $serializer, $format = null)
+    {
+        return array(
+            'foo' => 'normalizedFoo',
+            'bar' => 'normalizedBar',
+        );
+    }
+
+    public function denormalize(SerializerInterface $serializer, $data, $format = null)
+    {
+        return array(
+            'foo' => 'denormalizedFoo',
+            'bar' => 'denormalizedBar',
+        );
+    }
+}

--- a/tests/Symfony/Tests/Component/Serializer/Fixtures/TraversableDummy.php
+++ b/tests/Symfony/Tests/Component/Serializer/Fixtures/TraversableDummy.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Symfony\Tests\Component\Serializer\Fixtures;
+
+class TraversableDummy implements \IteratorAggregate
+{
+    public $foo = 'foo';
+    public $bar = 'bar';
+
+    public function getIterator()
+    {
+        return new \ArrayIterator(get_object_vars($this));
+    }
+}

--- a/tests/Symfony/Tests/Component/Serializer/SerializerTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/SerializerTest.php
@@ -4,6 +4,9 @@ namespace Symfony\Tests\Component\Serializer;
 
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
+use Symfony\Tests\Component\Serializer\Fixtures\TraversableDummy;
+use Symfony\Tests\Component\Serializer\Fixtures\NormalizableTraversableDummy;
 
 /*
  * This file is part of the Symfony framework.
@@ -23,6 +26,20 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
     {
         $this->serializer = new Serializer(array($this->getMock('Symfony\Component\Serializer\Normalizer\CustomNormalizer')));
         $this->serializer->normalize(new \stdClass, 'xml');
+    }
+
+    public function testNormalizeTraversable()
+    {
+        $this->serializer = new Serializer(array(), array('json' => new JsonEncoder()));
+        $result = $this->serializer->serialize(new TraversableDummy, 'json');
+        $this->assertEquals('{"foo":"foo","bar":"bar"}', $result);
+    }
+
+    public function testNormalizeGivesPriorityToInterfaceOverTraversable()
+    {
+        $this->serializer = new Serializer(array(new CustomNormalizer), array('json' => new JsonEncoder()));
+        $result = $this->serializer->serialize(new NormalizableTraversableDummy, 'json');
+        $this->assertEquals('{"foo":"normalizedFoo","bar":"normalizedBar"}', $result);
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no (discussion needed)
Symfony2 tests pass: yes
Fixes the following tickets: #2295

**Same as PR #2539, except rebased onto `2.0`**

Should I abstract out a `supportsDenormalization` function just for symmetry? 
