### PR TITLE
[TwigBundle] Fix trace to not show 'in at line' when file/line are empty.

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/trace.html.twig
@@ -5,10 +5,10 @@
         {{ trace.type ~ trace.function }}
     </strong>
     ({{ trace.args|format_args }})
-    <br />
 {% endif %}
 
-{% if trace.file is defined and trace.line is defined %}
+{% if trace.file is defined and trace.file and trace.line is defined and trace.line %}
+    {{ trace.function ? '<br />' : '' }}
     in {{ trace.file|format_file(trace.line) }}&nbsp;
     {% spaceless %}
     <a href="#" onclick="toggle('trace_{{ prefix ~ '_' ~ i }}'); switchIcons('icon_{{ prefix ~ '_' ~ i }}_open', 'icon_{{ prefix ~ '_' ~ i }}_close'); return false;">


### PR DESCRIPTION
Occasionally I saw call stacks where file/line are empty in the raw exception object, but the trace.html.twig file was still showing 'in at line' with empty values. I believe this fixes that.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
