### PR TITLE
Fix for issue 2589

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/logs.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/logs.html.twig
@@ -1,4 +1,4 @@
-<ol class="traces">
+<ol class="traces logs">
     {% for log in logs %}
         <li{% if log.priorityName in ['EMERG', 'ERR', 'CRIT', 'ALERT', 'ERROR', 'CRITICAL'] %} class="error"{% endif %}>
             {{ log.message }}


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2589

Added a class to the logs ol element to prevent hiding it when toggling an exception.
