### PR TITLE
[Yaml][Tests] Fixed missing locale string for Windows platforms

### DIFF
--- a/tests/Symfony/Tests/Component/Yaml/InlineTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/InlineTest.php
@@ -47,10 +47,10 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Your platform does not support locales.');
         }
 
-        setlocale(LC_ALL, 'fr_FR.UTF-8', 'fr_FR.UTF8', 'fr_FR.utf-8', 'fr_FR.utf8');
+        setlocale(LC_ALL, 'fr_FR.UTF-8', 'fr_FR.UTF8', 'fr_FR.utf-8', 'fr_FR.utf8', 'French_France.1252');
 
         $this->assertEquals('1.2', Inline::dump(1.2));
-        $this->assertContains('fr', setlocale(LC_NUMERIC, 0));
+        $this->assertContains('fr', strtolower(setlocale(LC_NUMERIC, 0)));
 
         setlocale(LC_ALL, $locale);
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

On Windows all the locale formats supplied in the test do not work, causing the test to fail. The added locale string works correctly on (at least) Windows 7.
