### PR TITLE
Fixed rendering of FileType

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -168,7 +168,7 @@
 {% block field_widget %}
 {% spaceless %}
     {% set type = type|default('text') %}
-    <input type="{{ type }}" {{ block('widget_attributes') }} value="{{ value }}" />
+    <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
 {% endspaceless %}
 {% endblock field_widget %}
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/field_widget.html.php
@@ -1,5 +1,5 @@
 <input
     type="<?php echo isset($type) ? $view->escape($type) : "text" ?>"
-    value="<?php echo $view->escape($value) ?>"
+    <?php if (!empty($value)): ?>value="<?php echo $view->escape($value) ?>"<?php endif ?>
     <?php echo $view['form']->renderBlock('attributes') ?>
 />

--- a/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
@@ -1386,7 +1386,6 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 '/input
     [@type="password"]
     [@name="na&me"]
-    [@value=""]
 '
         );
     }
@@ -1419,7 +1418,6 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 '/input
     [@type="password"]
     [@name="na&me"]
-    [@value=""]
     [@maxlength="123"]
 '
         );


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

According to the W3C validator, `value` is not a valid attribute for `input[type=file]`.
