### PR TITLE
Added check for array fields to be integers in reverseTransform method. ...

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -141,6 +141,10 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
                 sprintf('The fields "%s" should not be empty', implode('", "', $emptyFields)
             ));
         }
+        
+        if (preg_match( '/^\d*$/', $value['month'] . $value['day'] . $value['year']) === 0) {
+            throw new TransformationFailedException('This is an invalid date');
+        }
 
         if (!empty($value['month']) && !empty($value['day']) && !empty($value['year']) && false === checkdate($value['month'], $value['day'], $value['year'])) {
             throw new TransformationFailedException('This is an invalid date');


### PR DESCRIPTION
...This prevents checkdate from getting strings as arguments and throwing incorrect ErrorException when submitting form with malformed (string) data in, for example, Date field. #2609
