### PR TITLE
[TwigBundle] Do not clean output buffering below initial level

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -41,8 +41,9 @@ class ExceptionController extends ContainerAware
         // some Windows configurations where ob_get_level()
         // never reaches 0
         $count = 100;
+        $startObLevel = $this->container->get('kernel')->getStartObLevel();
         $currentContent = '';
-        while (ob_get_level() && --$count) {
+        while (ob_get_level() > $startObLevel && --$count) {
             $currentContent .= ob_get_clean();
         }
 

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -37,15 +37,7 @@ class ExceptionController extends ContainerAware
     {
         $this->container->get('request')->setRequestFormat($format);
 
-        // the count variable avoids an infinite loop on
-        // some Windows configurations where ob_get_level()
-        // never reaches 0
-        $count = 100;
-        $startObLevel = $this->container->get('kernel')->getStartObLevel();
-        $currentContent = '';
-        while (ob_get_level() > $startObLevel && --$count) {
-            $currentContent .= ob_get_clean();
-        }
+        $currentContent = $this->getAndCleanOutputBuffering();
 
         $templating = $this->container->get('templating');
         $code = $exception->getStatusCode();
@@ -65,6 +57,21 @@ class ExceptionController extends ContainerAware
         $response->headers->replace($exception->getHeaders());
 
         return $response;
+    }
+
+    protected function getAndCleanOutputBuffering()
+    {
+        // the count variable avoids an infinite loop on
+        // some Windows configurations where ob_get_level()
+        // never reaches 0
+        $count = 100;
+        $startObLevel = $this->container->get('kernel')->getStartObLevel();
+        $currentContent = '';
+        while (ob_get_level() > $startObLevel && --$count) {
+            $currentContent .= ob_get_clean();
+        }
+
+        return $currentContent;
     }
 
     protected function findTemplate($templating, $format, $code, $debug)

--- a/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Controller/ExceptionControllerTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\TwigBundle\Tests\Controller;
+
+use Symfony\Bundle\TwigBundle\Tests\TestCase;
+
+use Symfony\Bundle\TwigBundle\Controller\ExceptionController;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Scope;
+use Symfony\Component\DependencyInjection\Definition;
+
+class ExceptionControllerTest extends TestCase
+{
+    protected $controller;
+    protected $container;
+    protected $flatten;
+    protected $templating;
+    protected $kernel;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->flatten = $this->getMock('Symfony\Component\HttpKernel\Exception\FlattenException');
+        $this->flatten
+            ->expects($this->once())
+            ->method('getStatusCode')
+            ->will($this->returnValue(404));
+        $this->flatten
+            ->expects($this->once())
+            ->method('getHeaders')
+            ->will($this->returnValue(array()));
+        $this->controller = new ExceptionController();
+        $this->kernel = $this->getMock('Symfony\\Component\\HttpKernel\\KernelInterface');
+        $this->templating = $this->getMockBuilder('Symfony\\Bundle\\TwigBundle\\TwigEngine')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->templating
+            ->expects($this->any())
+            ->method('renderResponse')
+            ->will($this->returnValue($this->getMock('Symfony\Component\HttpFoundation\Response')));
+        $this->container = $this->getContainer();
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->controller = null;
+        $this->container = null;
+        $this->flatten = null;
+        $this->templating = null;
+        $this->kernel = null;
+    }
+
+    public function testOnlyClearOwnOutputBuffers()
+    {
+        $this->container->enterScope('request');
+
+        $this->kernel
+            ->expects($this->once())
+            ->method('getStartObLevel')
+            ->will($this->returnValue(1));
+
+        $this->controller->setContainer($this->container);
+        $this->controller->showAction($this->flatten);
+    }
+
+    private function getContainer()
+    {
+        $container = new ContainerBuilder();
+        $container->addScope(new Scope('request'));
+        $container->register('request', 'Symfony\\Component\\HttpFoundation\\Request')->setScope('request');
+        $container->set('templating', $this->templating);
+        $container->setParameter('kernel.bundles', array());
+        $container->setParameter('kernel.cache_dir', __DIR__);
+        $container->setParameter('kernel.root_dir', __DIR__);
+        $container->set('kernel', $this->kernel);
+
+        return $container;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -55,6 +55,7 @@ abstract class Kernel implements KernelInterface
     protected $booted;
     protected $name;
     protected $startTime;
+    protected $startObLevel;
     protected $classes;
 
     const VERSION = '2.0.6-DEV';
@@ -119,6 +120,8 @@ abstract class Kernel implements KernelInterface
         if (true === $this->booted) {
             return;
         }
+
+        $this->startObLevel = ob_get_level();
 
         // init bundles
         $this->initializeBundles();
@@ -419,6 +422,16 @@ abstract class Kernel implements KernelInterface
     public function getStartTime()
     {
         return $this->debug ? $this->startTime : -INF;
+    }
+
+    /**
+     * Gets the ob_level at the start of the request
+     *
+     * @return integer The request start ob_level
+     */
+    public function getStartObLevel()
+    {
+        return $this->startObLevel;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -180,6 +180,13 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     function getStartTime();
 
     /**
+     * Gets the ob_level at the start of the request
+     *
+     * @return integer The request start ob_level
+     */
+    function getStartObLevel();
+
+    /**
      * Gets the cache directory.
      *
      * @return string The cache directory


### PR DESCRIPTION
This resulted in issues with PHPUnit 3.6, which will buffer all output and clean them in the end. Since
we cleaned their buffer, the subsequent clean would raise a warning. This is documented in [issue 390](https://github.com/sebastianbergmann/phpunit/issues/390) of
the PHPUnit tracker.

Closes #2531.

This also affects FOSRestBundle's ExceptionController /cc @lsmith.
