### PR TITLE
Also identify FirePHP by the X-FirePHP-Version header

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -42,7 +42,9 @@ class FirePHPHandler extends BaseFirePHPHandler
             return;
         }
 
-        if (!preg_match('{\bFirePHP/\d+\.\d+\b}', $event->getRequest()->headers->get('User-Agent'))) {
+        if (!preg_match('{\bFirePHP/\d+\.\d+\b}', $event->getRequest()->headers->get('User-Agent'))
+            && !$event->getRequest()->headers->has('X-FirePHP-Version')) {
+            
             $this->sendHeaders = false;
             $this->headers = array();
 


### PR DESCRIPTION
ZF also received this update a while back.
The Chrome FirePHP extension, for example, sets this header instead of altering the user agent.
