### PR TITLE
[Form] DateTimeToArrayTransformer fix

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -143,15 +143,15 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         }
 
         if (isset($value['month']) && !ctype_digit($value['month'])) {
-            throw new TransformationFailedException('This month an invalid');
+            throw new TransformationFailedException('This month is invalid');
         }
 
         if (isset($value['day']) && !ctype_digit($value['day'])) {
-            throw new TransformationFailedException('This day an invalid');
+            throw new TransformationFailedException('This day is invalid');
         }
 
         if (isset($value['year']) && !ctype_digit($value['year'])) {
-            throw new TransformationFailedException('This year an invalid');
+            throw new TransformationFailedException('This year is invalid');
         }
 
         if (!empty($value['month']) && !empty($value['day']) && !empty($value['year']) && false === checkdate($value['month'], $value['day'], $value['year'])) {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -142,15 +142,15 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
             ));
         }
 
-        if (isset($value['month']) && !ctype_digit($value['month'])) {
+        if (isset($value['month']) && !ctype_digit($value['month']) && !is_int($value['month'])) {
             throw new TransformationFailedException('This month is invalid');
         }
 
-        if (isset($value['day']) && !ctype_digit($value['day'])) {
+        if (isset($value['day']) && !ctype_digit($value['day']) && !is_int($value['day'])) {
             throw new TransformationFailedException('This day is invalid');
         }
 
-        if (isset($value['year']) && !ctype_digit($value['year'])) {
+        if (isset($value['year']) && !ctype_digit($value['year']) && !is_int($value['year'])) {
             throw new TransformationFailedException('This year is invalid');
         }
 


### PR DESCRIPTION
Bug fix: yes
 Feature addition: no
 Backwards compatibility break: no
 Symfony2 tests pass: yes
 Fixes the following tickets: -
 Todo: -

0427b126c15a0a27cd7033375e30371ae6a4e516 throws an `TransformationFailedException` if you're using integers. In other words: 

`array('year' => '2011', 'month' => '11', 'day' => '12') = valid`
`array('year' => 2011, 'month' => 11, 'day' => 12) = invalid`
