### PR TITLE
Missing current class in GraphWalker::walkMember() execution context

### DIFF
--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -130,6 +130,7 @@ class GraphWalker
 
     protected function walkMember(MemberMetadata $metadata, $value, $group, $propertyPath, $propagatedGroup = null)
     {
+        $this->context->setCurrentClass($metadata->getClassName());
         $this->context->setCurrentProperty($metadata->getPropertyName());
 
         foreach ($metadata->findConstraints($group) as $constraint) {


### PR DESCRIPTION
When performing Validator::validateProperty(), the current property is set in the execution context but the current class isn't. So there's no way to get the current validated class in a validator.
