### PR TITLE
[DoctrineBundle] added missing default parameters for DBAL

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/dbal.xml
@@ -14,6 +14,8 @@
         <parameter key="doctrine.dbal.events.mysql_session_init.class">Doctrine\DBAL\Event\Listeners\MysqlSessionInit</parameter>
         <parameter key="doctrine.dbal.events.oracle_session_init.class">Doctrine\DBAL\Event\Listeners\OracleSessionInit</parameter>
         <parameter key="doctrine.class">Symfony\Bundle\DoctrineBundle\Registry</parameter>
+        <parameter key="doctrine.entity_managers" type="collection"></parameter>
+        <parameter key="doctrine.default_entity_manager"></parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
Without this change, user can't use DBAL without ORM. When user configures only DBAL - he'll get:

```
[Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException]                     
The service "doctrine" has a dependency on a non-existent parameter "doctrine.entity_managers".
```
