### PR TITLE
Fixes a small php doc issue of Symfony\Component\Console\Command\Command::setDefinition()

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -257,7 +257,7 @@ class Command
     /**
      * Sets an array of argument and option instances.
      *
-     * @param array|Definition $definition An array of argument and option instances or a definition instance
+     * @param array|InputDefinition $definition An array of argument and option instances or a definition instance
      *
      * @return Command The current instance
      *


### PR DESCRIPTION
Have setDefinition() accept InputDefinition instead of Definition.
