### PR TITLE
handle the data-placeholder attribute, which needs to be translated

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -283,7 +283,7 @@
     id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
     {% for attrname,attrvalue in attr %}
         {% if attrname == 'data-placeholder' %}
-            {{attrname}}="{{attrvalue|trans}}"
+            {{attrname}}="{{attrvalue|trans({}, translation_domain)}}"
         {% else %}
             {{attrname}}="{{attrvalue}}"
         {% endif %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -281,7 +281,13 @@
 {% block widget_attributes %}
 {% spaceless %}
     id="{{ id }}" name="{{ full_name }}"{% if read_only %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
-    {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
+    {% for attrname,attrvalue in attr %}
+        {% if attrname == 'data-placeholder' %}
+            {{attrname}}="{{attrvalue|trans}}"
+        {% else %}
+            {{attrname}}="{{attrvalue}}"
+        {% endif %}
+    {% endfor %}
 {% endspaceless %}
 {% endblock widget_attributes %}
 


### PR DESCRIPTION
This attribute is used in HTML5 to display a default text for an input. There is no need for javascript anymore.
