### PR TITLE
Skipped tests when PDO is not available

### DIFF
--- a/tests/Symfony/Tests/Bridge/Doctrine/DoctrineOrmTestCase.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DoctrineOrmTestCase.php
@@ -30,6 +30,9 @@ abstract class DoctrineOrmTestCase extends \PHPUnit_Framework_TestCase
      */
     static public function createTestEntityManager($paths = array())
     {
+        if (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers())) {
+            self::markTestSkipped('This test requires SQLite support in your environment');
+        }
         $config = new \Doctrine\ORM\Configuration();
         $config->setAutoGenerateProxyClasses(true);
         $config->setProxyDir(\sys_get_temp_dir());

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/ProfilerTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/ProfilerTest.php
@@ -21,6 +21,10 @@ class ProfilerTest extends \PHPUnit_Framework_TestCase
 {
     public function testCollect()
     {
+        if (!class_exists('SQLite3') && (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers()))) {
+            $this->markTestSkipped('This test requires SQLite support in your environment');
+        }
+
         $request = new Request();
         $request->query->set('foo', 'bar');
         $response = new Response();

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/SqliteProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/SqliteProfilerStorageTest.php
@@ -35,6 +35,9 @@ class SqliteProfilerStorageTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        if (!class_exists('SQLite3') && (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers()))) {
+            $this->markTestSkipped('This test requires SQLite support in your environment');
+        }
         self::$storage->purge();
     }
 

--- a/tests/Symfony/Tests/Component/Security/Acl/Dbal/AclProviderBenchmarkTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Dbal/AclProviderBenchmarkTest.php
@@ -22,6 +22,7 @@ use Doctrine\DBAL\DriverManager;
  */
 class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var \Doctrine\DBAL\Connection */
     protected $con;
     protected $insertClassStmt;
     protected $insertSidStmt;
@@ -31,12 +32,17 @@ class AclProviderBenchmarkTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->con = DriverManager::getConnection(array(
-            'driver' => 'pdo_mysql',
-            'host' => 'localhost',
-            'user' => 'root',
-            'dbname' => 'testdb',
-        ));
+        try {
+            $this->con = DriverManager::getConnection(array(
+                'driver' => 'pdo_mysql',
+                'host' => 'localhost',
+                'user' => 'root',
+                'dbname' => 'testdb',
+            ));
+            $this->con->connect();
+        } catch (\Exception $e) {
+            $this->markTestSkipped('Unable to connect to the database: '.$e->getMessage());
+        }
     }
 
     protected function tearDown()

--- a/tests/Symfony/Tests/Component/Security/Acl/Dbal/AclProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Dbal/AclProviderTest.php
@@ -127,6 +127,10 @@ class AclProviderTest extends \PHPUnit_Framework_TestCase
         if (!class_exists('Doctrine\DBAL\DriverManager')) {
             $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
         }
+        if (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers())) {
+            self::markTestSkipped('This test requires SQLite support in your environment');
+        }
+
         $this->con = DriverManager::getConnection(array(
             'driver' => 'pdo_sqlite',
             'memory' => true,

--- a/tests/Symfony/Tests/Component/Security/Acl/Dbal/MutableAclProviderTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Dbal/MutableAclProviderTest.php
@@ -432,6 +432,10 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         if (!class_exists('Doctrine\DBAL\DriverManager')) {
             $this->markTestSkipped('The Doctrine2 DBAL is required for this test');
         }
+        if (!class_exists('PDO') || !in_array('sqlite', \PDO::getAvailableDrivers())) {
+            self::markTestSkipped('This test requires SQLite support in your environment');
+        }
+
         $this->con = DriverManager::getConnection(array(
             'driver' => 'pdo_sqlite',
             'memory' => true,


### PR DESCRIPTION
Some tests are failing with an exception when PDO SQLite is not available. This skips them instead.
