### PR TITLE
Fixed typo in exception message

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -111,7 +111,7 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
         }
 
         if (!$this->guessers) {
-            throw new \LogicException('Unable to guess the mime type as no guesser are available.');
+            throw new \LogicException('Unable to guess the mime type as no guessers are available.');
         }
 
         foreach ($this->guessers as $guesser) {


### PR DESCRIPTION
Fixed a small typo in the exception message which was added in d67fbe9e
