### PR TITLE
Doctrine info mapping exception

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/InfoDoctrineCommand.php
@@ -71,8 +71,14 @@ EOT
                 $cm = $entityManager->getClassMetadata($entityClassName);
                 $output->writeln(sprintf("<info>[OK]</info>   %s", $entityClassName));
             } catch (MappingException $e) {
+                $message = $e->getMessage();
+                while ($e->getPrevious()) {
+                    $e = $e->getPrevious();
+                    $message .= "\n" . $e->getMessage();
+                }
+
                 $output->writeln("<error>[FAIL]</error> ".$entityClassName);
-                $output->writeln(sprintf("<comment>%s</comment>", $e->getMessage()));
+                $output->writeln(sprintf("<comment>%s</comment>", $message));
                 $output->writeln('');
             }
         }


### PR DESCRIPTION
Better error handling when nested exceptions occur (which is commonly possible with reflection errors).
