### PR TITLE
[Form] fixed checkbox view

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CheckboxType.php
@@ -37,7 +37,7 @@ class CheckboxType extends AbstractType
     {
         $view
             ->set('value', $form->getAttribute('value'))
-            ->set('checked', (Boolean) $form->getData())
+            ->set('checked', (Boolean) $form->getClientData())
         ;
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RadioType.php
@@ -37,7 +37,7 @@ class RadioType extends AbstractType
     {
         $view
             ->set('value', $form->getAttribute('value'))
-            ->set('checked', (Boolean) $form->getData())
+            ->set('checked', (Boolean) $form->getClientData())
         ;
 
         if ($view->hasParent()) {

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CheckboxTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/CheckboxTypeTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Tests\Component\Form\Extension\Core\Type;
 
+use Symfony\Component\Form\CallbackTransformer;
+
 class CheckboxTypeTest extends TypeTestCase
 {
     public function testPassValueToView()
@@ -37,5 +39,40 @@ class CheckboxTypeTest extends TypeTestCase
         $view = $form->createView();
 
         $this->assertFalse($view->get('checked'));
+    }
+
+    /**
+     * @dataProvider proviceTransformedData
+     */
+    public function testTransformedData($data, $expected)
+    {
+        // present a binary status field as a checkbox
+        $transformer = new CallbackTransformer(
+            function ($value)
+            {
+                return 'expedited' == $value;
+            },
+            function ($value)
+            {
+                return $value ? 'expedited' : 'standard';
+            }
+        );
+
+        $form = $this->builder
+            ->create('expedited_shipping', 'checkbox')
+            ->prependClientTransformer($transformer)
+            ->getForm();
+        $form->setData($data);
+        $view = $form->createView();
+
+        $this->assertEquals($expected, $view->get('checked'));
+    }
+
+    public function proviceTransformedData()
+    {
+        return array(
+            array('expedited', true),
+            array('standard', false),
+        );
     }
 }


### PR DESCRIPTION
The checkbox view was being built based on app data, not client data. This fixes it.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
