### PR TITLE
[tests]Fix closure declaration in validation groups tests

### DIFF
--- a/tests/Symfony/Tests/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtensionTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtensionTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Tests\Component\Form\Extension\Validator\Type;
 
+use Symfony\Component\Form\FormInterface;
+
 class FieldTypeValidatorExtensionTest extends TypeTestCase
 {
     public function testValidationGroupNullByDefault()
@@ -50,7 +52,7 @@ class FieldTypeValidatorExtensionTest extends TypeTestCase
     public function testValidationGroupsCanBeSetToClosure()
     {
         $form = $this->factory->create('field', null, array(
-            'validation_groups' => function($data, $extraData){ return null; },
+            'validation_groups' => function(FormInterface $form){ return null; },
         ));
 
         $this->assertTrue(is_callable($form->getAttribute('validation_groups')));


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

This is just small fix for `Closure` declaration in `FieldTypeValidatorExtensionTest`, this is not bug, but if someone will look at this declaration in test, it may lead to misunderstanding.
