### PR TITLE
travis-ci.org integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: php
+
+php: 
+  - 5.3
+  - 5.4
+
+before_script: php vendors.php

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 README
 ======
 
+[![Build Status](https://secure.travis-ci.org/pborreli/symfony.png)](http://travis-ci.org/pborreli/symfony)
+
+
 What is Symfony2?
 -----------------
 


### PR DESCRIPTION
Travis CI is an open, distributed build system for the open source community.

Here the blog post for the PHP support announcement : http://about.travis-ci.org/blog/first_class_php_support_on_travis_ci/

Each commit in the repo will trigger travis-ci.org hook and will launch phpunit against multiple version of PHP (5.3.8, 5.4.0RC1 and soon 5.3.2, 5.3-snapshot and 5.4-snapshot)

For now we noticed almost no false-positive or downtime.

An icon to show the status of the repo (or a specific build) is included in my PR (change pborreli by symfony).

http://about.travis-ci.org/docs/user/languages/php/

This doesn't replace our jenkins platform in any case. it's another way to bulletproof our code and a great way for a contributor to check his Symfony fork before to submit any PR, like that : 

[![Build Status](https://secure.travis-ci.org/pborreli/symfony.png?branch=travis)](http://travis-ci.org/pborreli/symfony)
