### PR TITLE
[BC Break][Security] Renamed equals to isSameUser in the UserInterface

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -36,6 +36,9 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 ### SecurityBundle
 
+ * [BC BREAK] The `equals` method of the `Symfony\Component\Security\Core\User\UserInterface` has been renamed
+   to `isSameUser` to make the name clearer and avoid naming collisions.
+
  * [BC BREAK] The Firewall listener is now registered after the Router one.
    It means that specific Firewall URLs (like /login_check and /logout must now have proper
    route defined in your routing configuration)

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -87,7 +87,7 @@ abstract class AbstractToken implements TokenInterface
             if (!$user instanceof UserInterface) {
                 $changed = true;
             } else {
-                $changed = !$this->user->equals($user);
+                $changed = !$this->user->isSameUser($user);
             }
         } else if ($user instanceof UserInterface) {
             $changed = true;

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -116,7 +116,7 @@ final class User implements AdvancedUserInterface
     /**
      * {@inheritDoc}
      */
-    public function equals(UserInterface $user)
+    public function isSameUser(UserInterface $user)
     {
         if (!$user instanceof User) {
             return false;

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -52,6 +52,11 @@ interface UserInterface
     function eraseCredentials();
 
     /**
+     * Whether the object represents the same user than the other object.
+     *
+     * If this returns false, the user will not be considered authenticated anymore
+     * and will have to re-authenticate before accessing secured areas.
+     *
      * The equality comparison should neither be done by referential equality
      * nor by comparing identities (i.e. getId() === getId()).
      *
@@ -61,5 +66,5 @@ interface UserInterface
      * @param UserInterface $user
      * @return Boolean
      */
-    function equals(UserInterface $user);
+    function isSameUser(UserInterface $user);
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/CompositeIdentEntity.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/CompositeIdentEntity.php
@@ -46,7 +46,7 @@ class CompositeIdentEntity implements UserInterface
     {
     }
 
-    public function equals(UserInterface $user)
+    public function isSameUser(UserInterface $user)
     {
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Core/Authentication/Token/AbstractTokenTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/Authentication/Token/AbstractTokenTest.php
@@ -146,7 +146,7 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $user
             ->expects($this->any())
-            ->method('equals')
+            ->method('isSameUser')
             ->will($this->returnValue(true))
         ;
 
@@ -178,7 +178,7 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
         $user
             ->expects($this->any())
-            ->method('equals')
+            ->method('isSameUser')
             ->will($this->returnValue(false))
         ;
 

--- a/tests/Symfony/Tests/Component/Security/Core/User/UserTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/User/UserTest.php
@@ -129,8 +129,8 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $user1 = new User('fabien', 'superpass', array('ROLE_USER'));
         $user2 = clone $user1;
 
-        $this->assertTrue($user1->equals($user2));
-        $this->assertTrue($user2->equals($user1));
+        $this->assertTrue($user1->isSameUser($user2));
+        $this->assertTrue($user2->isSameUser($user1));
     }
 
     public function testUsersAreNotEqual()
@@ -138,7 +138,7 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $user1 = new User('fabien', 'superpass', array('ROLE_USER'));
         $user2 = new User('fabien', 'superpass', array('ROLE_USER'), false);
 
-        $this->assertFalse($user1->equals($user2));
-        $this->assertFalse($user2->equals($user1));
+        $this->assertFalse($user1->isSameUser($user2));
+        $this->assertFalse($user2->isSameUser($user1));
     }
 }


### PR DESCRIPTION
As discussed today during the IRC meeting, here is the PR changing the name of the method to what was preferred by most people that were there.

All: suggest better names if you have some.
