### PR TITLE
[BugFix][Form]Throw exception on form name circulal ref

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -220,6 +220,10 @@ class FormFactory implements FormFactoryInterface
 
         while (null !== $type) {
             if ($type instanceof FormTypeInterface) {
+                if ($type->getName() == $type->getParent($options)) {
+                    throw new FormException(sprintf('The "%s" form type name ("%s") is not valid. It contains circullar reference to parent type name ("%s")', get_class($type), $type->getName(), $type->getParent($options)));
+                }
+
                 $this->addType($type);
             } else {
                 $type = $this->getType($type);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Closes: #2673

When FormType method `getName()` returns the same value as `getParent()` we're asking about trouble, and land into infinite loop.
