### PR TITLE
[Form] Fixed textarea_widget (W3C standards)

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextareaType.php
@@ -12,9 +12,19 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\FormInterface;
 
 class TextareaType extends AbstractType
 {
+    /**
+     * {@inheritdoc}
+     */
+    public function buildView(FormView $view, FormInterface $form)
+    {
+        $view->set('pattern', null);
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Textarea widget included the "pattern" attribute but is not valid by W3C standards.

(See PR 2666 - New PR because rebase inside the 2.0 branch)
