### PR TITLE
[Security] Implementation of a "failed login" event, replaces: PR #1307

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -74,6 +74,9 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
  * added a validator for the user password
  * added 'erase_credentials' as a configuration key (true by default)
+ * added new events: `security.authentication.success` and `security.authentication.failure`
+   fired on authentication success/failure, regardless of authentication method,
+   events are defined in new event class: `Symfony\Component\Security\Core\AuthenticationEvents`.
 
 ### SwiftmailerBundle
 

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -54,6 +54,9 @@
         <service id="security.authentication.manager" class="%security.authentication.manager.class%" public="false">
             <argument type="collection" />
             <argument>%security.authentication.manager.erase_credentials%</argument>
+            <call method="setEventDispatcher">
+                <argument type="service" id="event_dispatcher" />
+            </call>
         </service>
 
         <service id="security.authentication.trust_resolver" class="%security.authentication.trust_resolver.class%" public="false">

--- a/src/Symfony/Component/Security/Core/AuthenticationEvents.php
+++ b/src/Symfony/Component/Security/Core/AuthenticationEvents.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core;
+
+final class AuthenticationEvents
+{
+    const AUTHENTICATION_SUCCESS = 'security.authentication.success';
+
+    const AUTHENTICATION_FAILURE = 'security.authentication.failure';
+}

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Event;
+
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * This is a general purpose authentication event.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class AuthenticationEvent extends Event
+{
+    private $authenticationToken;
+
+    public function __construct(TokenInterface $token)
+    {
+        $this->authenticationToken = $token;
+    }
+
+    public function getAuthenticationToken()
+    {
+        return $this->authenticationToken;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Event/AuthenticationFailureEvent.php
+++ b/src/Symfony/Component/Security/Core/Event/AuthenticationFailureEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Event;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
+/**
+ * This event is dispatched on authentication failure.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class AuthenticationFailureEvent extends AuthenticationEvent
+{
+    private $authenticationException;
+
+    public function __construct(TokenInterface $token, AuthenticationException $ex)
+    {
+        parent::__construct($token);
+
+        $this->authenticationException = $ex;
+    }
+
+    public function getAuthenticationException()
+    {
+        return $this->authenticationException;
+    }
+}


### PR DESCRIPTION
As I have to use this feature I have completed its implementation.

Bugfix: no
Feature addition: yes
Symfopny2 tests pass: yes
Replaces/closes PR: #1307
