### PR TITLE
[HttpFoundation] Wildcard implementation for ParameterBag & Session

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -144,6 +144,45 @@ class ParameterBag
 
         return $value;
     }
+    
+    /**
+     * Returns values by key wilcard like user.*.param?
+     *
+     * @param string  $pattern Filtering pattern
+     *
+     * @api
+     */
+    public function wildcard($pattern)
+    {
+        //see https://github.com/andrewtch/phpwildcard/blob/master/wildcard_match.php for details
+        //convert pattern to regex
+        $pattern = preg_split('/((?<!\\\)\*)|((?<!\\\)\?)/', $pattern, null,
+              PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
+
+        foreach($pattern as $key => $part) {
+            if($part == '?') {
+                $pattern[$key] = '.';
+            } elseif ($part == '*') {
+                $pattern[$key] = '.*';
+            } else {
+                $pattern[$key] = preg_quote($part);
+            }
+        }
+
+        $pattern = implode('', $pattern);
+
+        $pattern = '/^'.$pattern.'$/';
+      
+        $return = array();
+        
+        foreach($this->parameters as $key => $val) {
+            if(preg_match($pattern, $key)) {
+                $return[$key] = $val;
+            }
+        }
+        
+        return $return;
+    }
 
     /**
      * Sets a parameter by name.

--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -98,6 +98,45 @@ class Session implements \Serializable
     {
         return array_key_exists($name, $this->attributes) ? $this->attributes[$name] : $default;
     }
+    
+    /**
+     * Returns values by key wilcard like user.*.param?
+     *
+     * @param string  $pattern Filtering pattern
+     *
+     * @api
+     */
+    public function wildcard($pattern)
+    {
+        //see https://github.com/andrewtch/phpwildcard/blob/master/wildcard_match.php for details
+        //convert pattern to regex
+        $pattern = preg_split('/((?<!\\\)\*)|((?<!\\\)\?)/', $pattern, null,
+              PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
+
+        foreach($pattern as $key => $part) {
+            if($part == '?') {
+                $pattern[$key] = '.';
+            } elseif ($part == '*') {
+                $pattern[$key] = '.*';
+            } else {
+                $pattern[$key] = preg_quote($part);
+            }
+        }
+
+        $pattern = implode('', $pattern);
+
+        $pattern = '/^'.$pattern.'$/';
+      
+        $return = array();
+        
+        foreach($this->attributes as $key => $val) {
+            if(preg_match($pattern, $key)) {
+                $return[$key] = $val;
+            }
+        }
+        
+        return $return;
+    }
 
     /**
      * Sets an attribute.

--- a/tests/Symfony/Tests/Component/HttpFoundation/ParameterBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ParameterBagTest.php
@@ -202,4 +202,22 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
 
     }
+    
+    public function testWildcard()
+    {
+        $bag = new ParameterBag(array('user.name' => 'John Doe',
+            'user.email' => 'address@example.com',
+            'user.params.param1' => 'boo',
+            'user.params.param25' => 'foo',
+            'other.data' => 'bar'));
+        
+        $this->assertEquals($bag->wildcard('user.*'), array('user.name' => 'John Doe',
+            'user.email' => 'address@example.com',
+            'user.params.param1' => 'boo',
+            'user.params.param25' => 'foo'));
+        
+        $this->assertEquals($bag->wildcard('user.*.param?'), array('user.params.param1' => 'boo'));
+        
+        $this->assertEquals($bag->wildcard('user.*.param??'), array('user.params.param25' => 'foo'));
+    }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
@@ -224,6 +224,25 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($this->storage->read('foo'));
     }
+    
+    public function testWildcards()
+    {
+        $session = $this->getSession();
+        $session->set('user.name', 'John Doe');
+        $session->set('user.email', 'address@example.com');
+        $session->set('user.params.param1', 'boo');
+        $session->set('user.params.param25', 'foo');
+        $session->set('other.data', 'bar');
+        
+        $this->assertEquals($session->wildcard('user.*'), array('user.name' => 'John Doe',
+            'user.email' => 'address@example.com',
+            'user.params.param1' => 'boo',
+            'user.params.param25' => 'foo'));
+        
+        $this->assertEquals($session->wildcard('user.*.param?'), array('user.params.param1' => 'boo'));
+        
+        $this->assertEquals($session->wildcard('user.*.param??'), array('user.params.param25' => 'foo'));
+    }
 
     protected function getSession()
     {


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

Implemented wildcard function for Session and ParameterBag; since there's no namespace support like in 1.4 in session this could be handy.

This is mostly regex matching for attribute/parameter keys and work like this:

``` php
$session->set('user.name', 'John Doe');
$session->set('user.email', 'user@example.com');
$session->wildcard('user.*') //returns array('user.name' => 'John Doe', 'user.email' => 'user@example.com')
```

single character matching (user??.\* for user12., user32. but not for user1.) also available.

Yes, I know about ParameterBag->get array support, but this is more generic solution - as proposed in pull request symfony/symfony#2541
