### PR TITLE
[HttpKernel] ControllerResolver arguments reflection for Closure object.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -96,8 +96,12 @@ class ControllerResolver implements ControllerResolverInterface
         if (is_array($controller)) {
             $r = new \ReflectionMethod($controller[0], $controller[1]);
         } elseif (is_object($controller)) {
-            $r = new \ReflectionObject($controller);
-            $r = $r->getMethod('__invoke');
+            if ($controller instanceof \Closure) {
+                $r = new \ReflectionFunction($controller);
+            } else {
+                $r = new \ReflectionObject($controller);
+                $r = $r->getMethod('__invoke');
+            }
         } else {
             $r = new \ReflectionFunction($controller);
         }


### PR DESCRIPTION
When controller is a `Closure` `ControllerResolver::getArguments` tries to make a `ReflectionMethod` of the `__invoke` method. But because it's an internal function, the parameters method `isDefaultValueAvailable` will return always false, even if `isOptional` return true.
