### PR TITLE
fixed issue 2691

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -118,14 +118,14 @@ class MessageCatalogue implements MessageCatalogueInterface
      *
      * @api
      */
-    public function get($id, $domain = 'messages')
+    public function get($id, $domain = 'messages', $fallbackChecked = false)
     {
         if (isset($this->messages[$domain][$id])) {
             return $this->messages[$domain][$id];
         }
 
-        if (null !== $this->fallbackCatalogue) {
-            return $this->fallbackCatalogue->get($id, $domain);
+        if (null !== $this->fallbackCatalogue && !$fallbackChecked) {
+            return $this->fallbackCatalogue->get($id, $domain, true);
         }
 
         return $id;


### PR DESCRIPTION
if translation checks fallback already then don't try to check fallback a second time and return $id.
