### PR TITLE
[HttpFoundation] Cookie values should not be restricted

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -48,10 +48,6 @@ class Cookie
             throw new \InvalidArgumentException(sprintf('The cookie name "%s" contains invalid characters.', $name));
         }
 
-        if (preg_match("/[,; \t\r\n\013\014]/", $value)) {
-            throw new \InvalidArgumentException(sprintf('The cookie value "%s" contains invalid characters.', $value));
-        }
-
         if (empty($name)) {
             throw new \InvalidArgumentException('The cookie name cannot be empty.');
         }

--- a/tests/Symfony/Tests/Component/HttpFoundation/CookieTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/CookieTest.php
@@ -36,20 +36,6 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function invalidValues()
-    {
-        return array(
-            array(",MyValue"),
-            array(";MyValue"),
-            array(" MyValue"),
-            array("\tMyValue"),
-            array("\rMyValue"),
-            array("\nMyValue"),
-            array("\013MyValue"),
-            array("\014MyValue"),
-        );
-    }
-
     /**
      * @dataProvider invalidNames
      * @expectedException InvalidArgumentException
@@ -58,16 +44,6 @@ class CookieTest extends \PHPUnit_Framework_TestCase
     public function testInstantiationThrowsExceptionIfCookieNameContainsInvalidCharacters($name)
     {
         new Cookie($name);
-    }
-
-    /**
-     * @dataProvider invalidValues
-     * @expectedException InvalidArgumentException
-     * @covers Symfony\Component\HttpFoundation\Cookie::__construct
-     */
-    public function testInstantiationThrowsExceptionIfCookieValueContainsInvalidCharacters($value)
-    {
-        new Cookie('MyCookie', $value);
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

The restriction I removed makes no sense IMO because we do not use setrawcookie() to send cookies. setrawcookie() does throw a warning when the cookie value contains incorrect characters, but not setcookie(). The latter will just urlencode() the value so it becomes valid. This is also what is done by `Cookie::__toString`, so this could be used in combination with header() to just send raw cookies that are valid, even with values that are invalid in their decoded form.

PHP urldecodes cookies on input, so it all works fine.
