### PR TITLE
Oracle 10 issues

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -15,6 +15,7 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Security\Acl\Dbal\Schema;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Doctrine\DBAL\DriverManager;
 
 /**
  * Installs the tables required by the ACL system
@@ -34,7 +35,7 @@ class InitAclCommand extends ContainerAwareCommand
             ->setHelp(<<<EOT
 The <info>init:acl</info> command mounts ACL tables in the database.
 
-<info>php app/console init:acl</info>
+<info>php app/console ini:acl</info>
 
 The name of the DBAL connection must be configured in your <info>app/config/security.yml</info> configuration file in the <info>security.acl.connection</info> variable.
 
@@ -68,8 +69,8 @@ EOT
                 return;
             }
         }
-
-        $schema = new Schema($tables);
+		
+        $schema = new Schema($tables, null, $sm->createSchemaConfig());
         foreach ($schema->toSql($connection->getDatabasePlatform()) as $sql) {
             $connection->exec($sql);
         }

--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -35,7 +35,7 @@ class InitAclCommand extends ContainerAwareCommand
             ->setHelp(<<<EOT
 The <info>init:acl</info> command mounts ACL tables in the database.
 
-<info>php app/console ini:acl</info>
+<info>php app/console init:acl</info>
 
 The name of the DBAL connection must be configured in your <info>app/config/security.yml</info> configuration file in the <info>security.acl.connection</info> variable.
 

--- a/src/Symfony/Component/Security/Acl/Dbal/Schema.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/Schema.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Dbal;
 
 use Doctrine\DBAL\Schema\Schema as BaseSchema;
-use Doctrine\DBAL\Schema\SchemaConfig as SchemaConfig;
+use Doctrine\DBAL\Schema\SchemaConfig;
 
 /**
  * The schema used for the ACL system.
@@ -27,7 +27,6 @@ final class Schema extends BaseSchema
      * Constructor
      *
      * @param array $options the names for tables
-     * @return void
      */
     public function __construct(array $options, $unused=null, SchemaConfig $schemaConfig=null)
     {
@@ -44,8 +43,6 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the class table to the schema
-     *
-     * @return void
      */
     protected function addClassTable()
     {
@@ -58,8 +55,6 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the entry table to the schema
-     *
-     * @return void
      */
     protected function addEntryTable()
     {
@@ -88,8 +83,6 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the object identity table to the schema
-     *
-     * @return void
      */
     protected function addObjectIdentitiesTable()
     {
@@ -110,8 +103,6 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the object identity relation table to the schema
-     *
-     * @return void
      */
     protected function addObjectIdentityAncestorsTable()
     {
@@ -129,8 +120,6 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the security identity table to the schema
-     *
-     * @return void
      */
     protected function addSecurityIdentitiesTable()
     {

--- a/src/Symfony/Component/Security/Acl/Dbal/Schema.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/Schema.php
@@ -82,7 +82,7 @@ final class Schema extends BaseSchema
     }
 
     /**
-     * Adds the object identity table to the schema
+     * Adds the object identity table to the schema 
      */
     protected function addObjectIdentitiesTable()
     {

--- a/src/Symfony/Component/Security/Acl/Dbal/Schema.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/Schema.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Security\Acl\Dbal;
 
 use Doctrine\DBAL\Schema\Schema as BaseSchema;
+use Doctrine\DBAL\Schema\SchemaConfig as SchemaConfig;
 
 /**
  * The schema used for the ACL system.
@@ -26,10 +27,11 @@ final class Schema extends BaseSchema
      * Constructor
      *
      * @param array $options the names for tables
+     * @return void
      */
-    public function __construct(array $options)
+    public function __construct(array $options, $unused=null, SchemaConfig $schemaConfig=null)
     {
-        parent::__construct();
+        parent::__construct(array(), array(), $schemaConfig);
 
         $this->options = $options;
 
@@ -42,6 +44,8 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the class table to the schema
+     *
+     * @return void
      */
     protected function addClassTable()
     {
@@ -54,6 +58,8 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the entry table to the schema
+     *
+     * @return void
      */
     protected function addEntryTable()
     {
@@ -82,6 +88,8 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the object identity table to the schema
+     *
+     * @return void
      */
     protected function addObjectIdentitiesTable()
     {
@@ -97,11 +105,13 @@ final class Schema extends BaseSchema
         $table->addUniqueIndex(array('object_identifier', 'class_id'));
         $table->addIndex(array('parent_object_identity_id'));
 
-        $table->addForeignKeyConstraint($table, array('parent_object_identity_id'), array('id'), array('onDelete' => 'RESTRICT', 'onUpdate' => 'RESTRICT'));
+        $table->addForeignKeyConstraint($table, array('parent_object_identity_id'), array('id'));
     }
 
     /**
      * Adds the object identity relation table to the schema
+     *
+     * @return void
      */
     protected function addObjectIdentityAncestorsTable()
     {
@@ -119,6 +129,8 @@ final class Schema extends BaseSchema
 
     /**
      * Adds the security identity table to the schema
+     *
+     * @return void
      */
     protected function addSecurityIdentitiesTable()
     {


### PR DESCRIPTION
I've changed Schema.php to not use Restrict on delete/update since
oracle report it as missing keyword. Both restrict and no action on
oracle seems to be redundant and used by default. So the output query
can't use it. I've also changed Schema construct to accept a
SchemaConfig parameter. InitAcl was changed to pass on new Schema a
SchemaConfig generated by SchemaManager, I did that because acl command
was generating names with more than 30 characters and Oracle doesn't
accept, this seems to solve the problem and init:acl works properly.
