### PR TITLE
[Form] Possibility to set readOnly and attributes

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -295,6 +295,20 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * Set read only form status
+     *
+     * @param Boolean read only status
+     *
+     * @return Form The current form
+     */
+    public function setReadOnly($readOnly = true)
+    {
+        $this->readOnly = (Boolean) $readOnly;
+
+        return $this;
+    }
+
+    /**
      * Sets the parent form.
      *
      * @param FormInterface $parent The parent form
@@ -368,6 +382,21 @@ class Form implements \IteratorAggregate, FormInterface
     public function getAttribute($name)
     {
         return $this->attributes[$name];
+    }
+
+    /**
+     * Sets the value of the attributes with the given name.
+     *
+     * @param string $name The name of the attribute
+     * @param mixed $value The value of the attribute
+     *
+     * @return Form The current form
+     */
+    public function setAttribute($name, $value)
+    {
+        $this->attributes[$name] = $value;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Digging more inside Form Event Subscribers i found very useful to set a form field as read only and then, based on the data, reverse the read only condition. Without this methods, i am forced to delete the child, create it again with the formFactory and add it to the main form, as the readOnly property is a private one. Same for attributes.

Before:

``` php
        if ($data->getId()) {
            $form->add($this->factory->createNamed('text', 'name', null, array('read_only' => false)));
        }
```

After:

``` php
        if ($data->getId()) {
            $form->get('name')->setReadOnly(false);
        }
```
