### PR TITLE
Adjust composer files to strictly require known to work packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "doctrine/common": "2.2.*",
+        "monolog/monolog": "1.0.*",
+        "swiftmailer/swiftmailer": ">=4.1.2,<4.2-dev",
+        "twig/twig": ">=1.1,<1.5-dev"
     },
     "replace": {
         "symfony/doctrine-bridge": "self.version",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "doctrine/common": "2.2.*"
     },
     "recommend": {
         "doctrine/dbal": ">=2.1",

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "swiftmailer/swiftmailer": ">=4.1"
+        "swiftmailer/swiftmailer": ">=4.1.2,<4.2-dev"
     },
     "suggest": {
         "symfony/http-kernel": "self.version"

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "twig/twig": ">=1.1"
+        "twig/twig": ">=1.1,<1.5-dev"
     },
     "suggest": {
         "symfony/form": "self.version",

--- a/src/Symfony/Bundle/DoctrineBundle/composer.json
+++ b/src/Symfony/Bundle/DoctrineBundle/composer.json
@@ -18,12 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/doctrine-bridge": "2.*",
-        "symfony/doctrine-abstract-bundle": "2.*"
-    },
-    "recommend": {
-        "doctrine/dbal": "2.*",
-        "doctrine/orm": "2.*"
+        "symfony/doctrine-bridge": "self.version"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\DoctrineBundle": "" }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/routing": "self.version",
         "symfony/templating": "self.version",
         "symfony/translator": "self.version",
-        "doctrine/common": ">=2.1.0"
+        "doctrine/common": "2.2.*"
     },
     "recommend": {
         "symfony/console": "self.version",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/routing": "self.version",
         "symfony/templating": "self.version",
         "symfony/translator": "self.version",
-        "doctrine/common": "2.2.*"
+        "doctrine/common": ">=2.1,<2.3-dev"
     },
     "recommend": {
         "symfony/console": "self.version",

--- a/src/Symfony/Bundle/MonologBundle/composer.json
+++ b/src/Symfony/Bundle/MonologBundle/composer.json
@@ -18,7 +18,6 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "monolog/monolog": ">=1.0",
         "symfony/monolog-bridge": "self.version"
     },
     "autoload": {

--- a/src/Symfony/Bundle/SwiftmailerBundle/composer.json
+++ b/src/Symfony/Bundle/SwiftmailerBundle/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "swiftmailer/swiftmailer": ">=4.1.2"
+        "symfony/swiftmailer-bridge": "self.version"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\SwiftmailerBundle": "" }

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -18,7 +18,6 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "twig/twig": ">=1.1",
         "symfony/twig-bridge": "self.version"
     },
     "autoload": {


### PR DESCRIPTION
I also bumped doctrine common to 2.2, because it seems 2.1 doesn't have the AbstractManagerRegistry stuff that is used by symfony 2.1. Please someone correct me if this is wrong.
