### PR TITLE
[DomCrawler] Fixed GH-2720 - Fix disabled atrribute handling for radio form elements

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -95,13 +95,9 @@ class ControllerResolver implements ControllerResolverInterface
     {
         if (is_array($controller)) {
             $r = new \ReflectionMethod($controller[0], $controller[1]);
-        } elseif (is_object($controller)) {
-            if ($controller instanceof \Closure) {
-                $r = new \ReflectionFunction($controller);
-            } else {
-                $r = new \ReflectionObject($controller);
-                $r = $r->getMethod('__invoke');
-            }
+        } elseif (is_object($controller) && !$controller instanceof \Closure) {
+            $r = new \ReflectionObject($controller);
+            $r = $r->getMethod('__invoke');
         } else {
             $r = new \ReflectionFunction($controller);
         }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -96,8 +96,12 @@ class ControllerResolver implements ControllerResolverInterface
         if (is_array($controller)) {
             $r = new \ReflectionMethod($controller[0], $controller[1]);
         } elseif (is_object($controller)) {
-            $r = new \ReflectionObject($controller);
-            $r = $r->getMethod('__invoke');
+            if ($controller instanceof \Closure) {
+                $r = new \ReflectionFunction($controller);
+            } else {
+                $r = new \ReflectionObject($controller);
+                $r = $r->getMethod('__invoke');
+            }
         } else {
             $r = new \ReflectionFunction($controller);
         }

--- a/tests/Symfony/Tests/Component/DomCrawler/Field/ChoiceFormFieldTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/Field/ChoiceFormFieldTest.php
@@ -168,6 +168,22 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         }
     }
 
+    public function testRadioButtonIsDisabled()
+    {
+        $node = $this->createNode('input', '', array('type' => 'radio', 'name' => 'name', 'value' => 'foo', 'disabled' => 'disabled'));
+        $field = new ChoiceFormField($node);
+        $node = $this->createNode('input', '', array('type' => 'radio', 'name' => 'name', 'value' => 'bar'));
+        $field->addChoice($node);
+
+        $field->select('foo');
+        $this->assertEquals('foo', $field->getValue(), '->getValue() returns the value attribute of the selected radio button');
+        $this->assertTrue($field->isDisabled());
+
+        $field->select('bar');
+        $this->assertEquals('bar', $field->getValue(), '->getValue() returns the value attribute of the selected radio button');
+        $this->assertFalse($field->isDisabled());
+    }
+    
     public function testCheckboxes()
     {
         $node = $this->createNode('input', '', array('type' => 'checkbox', 'name' => 'name'));

--- a/tests/Symfony/Tests/Component/HttpKernel/Controller/ControllerResolverTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Controller/ControllerResolverTest.php
@@ -104,6 +104,18 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::create('/');
         $request->attributes->set('foo', 'foo');
+        $controller = function ($foo, $bar = 'bar') {};
+        $this->assertEquals(array('foo', 'bar'), $resolver->getArguments($request, $controller));
+
+        $request = Request::create('/');
+        $request->attributes->set('foo', 'foo');
+        $controller = new self();
+        $this->assertEquals(array('foo', null), $resolver->getArguments($request, $controller));
+        $request->attributes->set('bar', 'bar');
+        $this->assertEquals(array('foo', 'bar'), $resolver->getArguments($request, $controller));
+
+        $request = Request::create('/');
+        $request->attributes->set('foo', 'foo');
         $request->attributes->set('foobar', 'foobar');
         $controller = array(new self(), 'controllerMethod3');
 
@@ -119,7 +131,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($request), $resolver->getArguments($request, $controller), '->getArguments() injects the request');
     }
 
-    public function __invoke()
+    public function __invoke($foo, $bar = null)
     {
     }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: - GH-2720

I wasn't really sure about the correct approach. This one is very minimalistic and following the existing concept of not duplicating nodes of the same name, but only storing multiple values for the same node. If you think that should be changed, let me know. Hints appreciated. 

Thanks
