### PR TITLE
[DoctrineBridge] Generalize EntityValidator to work with any validation ...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -22,6 +22,7 @@ use Symfony\Component\Validator\Constraint;
 class UniqueEntity extends Constraint
 {
     public $message = 'This value is already used';
+    public $service = 'doctrine.orm.validator.unique';
     public $em = null;
     public $fields = array();
 
@@ -37,7 +38,7 @@ class UniqueEntity extends Constraint
      */
     public function validatedBy()
     {
-        return 'doctrine.orm.validator.unique';
+        return $this->service;
     }
 
     /**


### PR DESCRIPTION
...service and against any Common ClassMetadata provider. Also decoupled the Bridge from its implicit dependency on the "doctrine.orm.vaildator.unique" service.

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: no
