### PR TITLE
Stateless authentication broken

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -92,6 +92,10 @@ class ContextListener implements ListenerInterface
         if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
             return;
         }
+        
+        if (!$event->getRequest()->hasSession()) {
+            return;
+        }
 
         if (null === $token = $this->context->getToken()) {
             return;


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes (all except for intl are passing, this is a problem with my local environment)
Fixes the following tickets: -
Todo: -

I made this patch many months ago for a project I am working on. We have been successfully using this patch to allow us to do stateless authentication (no sessions) on a API built using Symfony2.

When disabling sessions support inside config.yml, the Symfony/Component/Security/Http/Firewall/ContextListener does not properly check if a session is available before trying to save to the session inside onKernelResponse. Adding the check for the session resolves this problem.

My apologies for not following the proper procedures on the commit message. I am unsure of how to edit it since I made this commit many months ago.
