### PR TITLE
Fixed #2545 - ChoiceType flattens grouped Choices when expanded

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -41,7 +41,19 @@ class ChoiceType extends AbstractType
 
         if ($options['expanded']) {
             // Load choices already if expanded
-            $options['choices'] = $options['choice_list']->getChoices();
+            $choices = $options['choice_list']->getChoices();
+
+            // Flatten choices
+            $flattened = array();
+            foreach ($choices as $value => $choice) {
+                if (is_array($choice)) {
+                    $flattened = array_replace($flattened, $choice);
+                } else {
+                    $flattened[$value] = $choice;
+                }
+            }
+
+            $options['choices'] = $flattened;
 
             foreach ($options['choices'] as $choice => $value) {
                 if ($options['multiple']) {

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/ChoiceTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/ChoiceTypeTest.php
@@ -71,6 +71,35 @@ class ChoiceTypeTest extends TypeTestCase
         ));
     }
 
+    public function testExpandedChoicesOptionsTurnIntoFields()
+    {
+        $form = $this->factory->create('choice', null, array(
+            'expanded'  => true,
+            'choices'   => $this->choices,
+        ));
+
+        $this->assertEquals(count($this->choices), $form->count(), 'Each choice should become a new field');
+    }
+
+    public function testExpandedChoicesOptionsAreFlattened()
+    {
+        $form = $this->factory->create('choice', null, array(
+            'expanded'  => true,
+            'choices'   => $this->groupedChoices,
+        ));
+
+        $flattened = array();
+        foreach ($this->groupedChoices as $choices) {
+            $flattened = array_replace($flattened, $choices);
+        }
+
+        $this->assertEquals(count($flattened), $form->count(), 'Each nested choice should become a new field, not the groups');
+
+        foreach ($flattened as $value => $choice) {
+            $this->assertTrue($form->has($value), 'Flattened choice is named after it\'s value');
+        }
+    }
+
     public function testExpandedCheckboxesAreNeverRequired()
     {
         $form = $this->factory->create('choice', null, array(


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2545

**Problem**: With PR #2464, a bug was discovered when nested choices threw a exception during rendering.

**Solution**: Nested choices are flattened prior to creating checkbox/radio fields.
