### PR TITLE
[HttpKernel] Fixed failing Stopwatch tests on Windows

### DIFF
--- a/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchEventTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchEventTest.php
@@ -69,7 +69,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         usleep(10000);
         $event->stop();
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 10 && $total <= 20);
+        $this->assertTrue($total >= 9 && $total <= 20);
 
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
@@ -79,7 +79,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         usleep(10000);
         $event->stop();
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 20 && $total <= 30);
+        $this->assertTrue($total >= 18 && $total <= 30);
     }
 
     /**
@@ -101,7 +101,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         usleep(10000);
         $event->ensureStopped();
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 30 && $total <= 40);
+        $this->assertTrue($total >= 27 && $total <= 40);
     }
 
     public function testStartTime()
@@ -139,6 +139,6 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         usleep(10000);
         $event->stop();
         $end = $event->getEndTime();
-        $this->assertTrue($end >= 20 && $end <= 30);
+        $this->assertTrue($end >= 18 && $end <= 30);
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchTest.php
@@ -38,7 +38,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\HttpKernel\Debug\StopwatchEvent', $event);
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 10 && $total <= 20);
+        $this->assertTrue($total >= 9 && $total <= 20);
     }
 
     public function testLap()
@@ -52,7 +52,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\HttpKernel\Debug\StopwatchEvent', $event);
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 20 && $total <= 30);
+        $this->assertTrue($total >= 18 && $total <= 30);
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Due to the system clock resolution on Windows platforms calls to `usleep()` might take less time than expected/requested, causing the Stopwatch tests to fail. Lowering the lower bounds in these tests by 10% makes the tests pass consistently on my platform.
