### PR TITLE
[DoctrineBridge] Fixed attempt to serialize non-serializable values

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -89,36 +89,44 @@ class DoctrineDataCollector extends DataCollector
     {
         foreach ($queries as $i => $query) {
             foreach ($query['params'] as $j => $param) {
-                $queries[$i]['params'][$j] = $this->sanitizeParameter($param);
+                $queries[$i]['params'][$j] = $this->varToString($param);
             }
         }
 
         return $queries;
     }
 
-    private function sanitizeParameter($param)
+    private function varToString($var)
     {
-        if (is_array($param)) {
-            foreach ($param as $key => $value) {
-                $param[$key] = $this->sanitizeParameter($value);
+        if (is_object($var)) {
+            return sprintf('Object(%s)', get_class($var));
+        }
+
+        if (is_array($var)) {
+            $a = array();
+            foreach ($var as $k => $v) {
+                $a[] = sprintf('%s => %s', $k, $this->varToString($v));
             }
 
-            return $param;
+            return sprintf("Array(%s)", implode(', ', $a));
         }
 
-        if (is_resource($param)) {
-            return sprintf('Resource(%s)', get_resource_type($param));
+        if (is_resource($var)) {
+            return sprintf('Resource(%s)', get_resource_type($var));
         }
 
-        if (is_object($param) && $this->isNotSerializable($param)) {
-            return sprintf('Object(%s)', get_class($param));
+        if (null === $var) {
+            return 'null';
         }
 
-        return $param;
-    }
+        if (false === $var) {
+            return 'false';
+        }
 
-    private function isNotSerializable($object)
-    {
-        return $object instanceof \SplFileInfo;
+        if (true === $var) {
+            return 'true';
+        }
+
+        return (string) $var;
     }
 }

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/views/Collector/db.html.twig
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/views/Collector/db.html.twig
@@ -36,7 +36,7 @@
                         <code>{{ query.sql }}</code>
                     </div>
                     <small>
-                        <strong>Parameters</strong>: {{ query.params|yaml_encode }}<br />
+                        <strong>Parameters</strong>: {{ query.params }}<br />
                         <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
                     </small>
                 </li>

--- a/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Bridge\Doctrine\DataCollector;
+
+use Symfony\Bridge\Doctrine\DataCollector\DoctrineDataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCollectConnections()
+    {
+        $c = $this->createCollector(array());
+        $c->collect(new Request(), new Response());
+        $this->assertEquals(array('default' => 'doctrine.dbal.default_connection'), $c->getConnections());
+    }
+
+    public function testCollectManagers()
+    {
+        $c = $this->createCollector(array());
+        $c->collect(new Request(), new Response());
+        $this->assertEquals(array('default' => 'doctrine.orm.default_entity_manager'), $c->getManagers());
+    }
+
+    public function testCollectQueryCount()
+    {
+        $c = $this->createCollector(array());
+        $c->collect(new Request(), new Response());
+        $this->assertEquals(0, $c->getQueryCount());
+
+        $queries = array(
+            array('sql' => "SELECT * FROM table1", 'params' => array(), 'types' => array(), 'executionMS' => 0)
+        );
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $this->assertEquals(1, $c->getQueryCount());
+    }
+
+    public function testCollectTime()
+    {
+        $c = $this->createCollector(array());
+        $c->collect(new Request(), new Response());
+        $this->assertEquals(0, $c->getTime());
+
+        $queries = array(
+            array('sql' => "SELECT * FROM table1", 'params' => array(), 'types' => array(), 'executionMS' => 1)
+        );
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $this->assertEquals(1, $c->getTime());
+
+        $queries = array(
+            array('sql' => "SELECT * FROM table1", 'params' => array(), 'types' => array(), 'executionMS' => 1),
+            array('sql' => "SELECT * FROM table2", 'params' => array(), 'types' => array(), 'executionMS' => 2)
+        );
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $this->assertEquals(3, $c->getTime());
+    }
+
+    /**
+     * @dataProvider paramProvider
+     */
+    public function testCollectQueries($param, $expected)
+    {
+        $queries = array(
+            array('sql' => "SELECT * FROM table1 WHERE field1 = ?1", 'params' => array($param), 'types' => array(), 'executionMS' => 1)
+        );
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+
+        $collected_queries = $c->getQueries();
+        $this->assertEquals($expected, $collected_queries[0]['params'][0]);
+    }
+
+    /**
+     * @dataProvider paramProvider
+     */
+    public function testSerialization($param, $expected)
+    {
+        $queries = array(
+            array('sql' => "SELECT * FROM table1 WHERE field1 = ?1", 'params' => array($param), 'types' => array(), 'executionMS' => 1)
+        );
+        $c = $this->createCollector($queries);
+        $c->collect(new Request(), new Response());
+        $c = unserialize(serialize($c));
+
+        $collected_queries = $c->getQueries();
+        $this->assertEquals($expected, $collected_queries[0]['params'][0]);
+    }
+
+    public function paramProvider()
+    {
+        return array(
+            array('some value', 'some value'),
+            array(1, 1),
+            array(true, true),
+            array(null, null),
+            array(new \stdClass(), new \stdClass()),
+            array(fopen(__FILE__, 'r'), 'Resource(stream)'),
+            array(new \SplFileInfo(__FILE__), 'Object(SplFileInfo)'),
+        );
+    }
+
+    private function createCollector($queries)
+    {
+        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry
+                ->expects($this->once())
+                ->method('getConnectionNames')
+                ->will($this->returnValue(array('default' => 'doctrine.dbal.default_connection')));
+        $registry
+                ->expects($this->once())
+                ->method('getManagerNames')
+                ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager')));
+
+        $logger = $this->getMock('Symfony\Bridge\Doctrine\Logger\DbalLogger');
+        $logger->queries = $queries;
+
+        return new DoctrineDataCollector($registry, $logger);
+    }
+}

--- a/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
@@ -102,10 +102,10 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('some value', 'some value'),
-            array(1, 1),
-            array(true, true),
-            array(null, null),
-            array(new \stdClass(), new \stdClass()),
+            array(1, '1'),
+            array(true, 'true'),
+            array(null, 'null'),
+            array(new \stdClass(), 'Object(stdClass)'),
             array(fopen(__FILE__, 'r'), 'Resource(stream)'),
             array(new \SplFileInfo(__FILE__), 'Object(SplFileInfo)'),
         );

--- a/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
@@ -113,14 +113,14 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
 
     private function createCollector($queries)
     {
-        $registry = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $registry = $this->getMock('Symfony\Bridge\Doctrine\RegistryInterface');
         $registry
-                ->expects($this->once())
+                ->expects($this->any())
                 ->method('getConnectionNames')
                 ->will($this->returnValue(array('default' => 'doctrine.dbal.default_connection')));
         $registry
-                ->expects($this->once())
-                ->method('getManagerNames')
+                ->expects($this->any())
+                ->method('getEntityManagerNames')
                 ->will($this->returnValue(array('default' => 'doctrine.orm.default_entity_manager')));
 
         $logger = $this->getMock('Symfony\Bridge\Doctrine\Logger\DbalLogger');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no (99%)
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

The Doctrine DBAL type system does not pose any restrictions on the php-types of parameters in queries. Hence one could write a doctrine-type that uses a resource or an `\SplFileInfo` as its corresponding php-type. Parameters of these types are logged in the `DoctrineDataCollector` however, which is then serialized in the profiler. Since resources or `\SplFileInfo` variables cannot be serialized this throws an exception.

This PR fixes this problem (for known cases) by sanitizing the query parameters to only contain serializable types. The `isNotSerializable`-check surely is not complete yet, but more non-serializable classes can be added on a case-by-case basis.
