### PR TITLE
[FrameworkBundle] fixed small typo in Czech translation

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xliff
@@ -116,7 +116,7 @@
             </trans-unit>
             <trans-unit id="29">
                 <source>The uploaded file was too large. Please try to upload a smaller file</source>
-                <target>Nahraný soubor je příliš velký. Nahrejte prosím menší soubor</target>
+                <target>Nahraný soubor je příliš velký. Nahrajte prosím menší soubor</target>
             </trans-unit>
             <trans-unit id="30">
                 <source>The CSRF token is invalid. Please try to resubmit the form</source>


### PR DESCRIPTION
fixed small typo in Czech translation in validators.cs.xliff
