### PR TITLE
[form] Allow the date_format option to be passed to single_text dateTime fields

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -46,6 +46,9 @@ class DateTimeType extends AbstractType
         }
 
         if ($options['widget'] === 'single_text') {
+            if($options['date_format']) {
+            	$format = $options['date_format'];
+        	}
             $builder->appendClientTransformer(new DateTimeToStringTransformer($options['data_timezone'], $options['user_timezone'], $format));
         } else {
             // Only pass a subset of the options to children


### PR DESCRIPTION
Unless I've missed something, there's no way to pass a format string to a dateTime widget when you set the widget type to single_text.

This change just lets you pass a format using the date_format option.
