### PR TITLE
[WIP][Routing] Throw exception instead of silent overwriting already defined route with same name (id)

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -98,6 +98,10 @@ class RouteCollection implements \IteratorAggregate
             throw new \InvalidArgumentException(sprintf('Name "%s" contains non valid characters for a route name.', $name));
         }
 
+        if (isset($this->routes[$name])) {
+            throw new \InvalidArgumentException(sprintf('A route named "%s" already exists.', $name));
+        }
+
         $parent = $this;
         while ($parent->getParent()) {
             $parent = $parent->getParent();


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: Detect overriding of routes in one file.
