### PR TITLE
[FrameworkBundle] (PR) TraceableEventDispatcher creates NOTICE on Closures

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Debug/TraceableEventDispatcher.php
@@ -106,7 +106,11 @@ class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements 
 
             $this->called[$eventName.'.'.$info['pretty']] = $info;
 
-            $e2 = $this->stopwatch->start(substr($info['class'], strrpos($info['class'], '\\') + 1), 'event_listener');
+            $name = isset($info['class'])
+                  ? substr($info['class'], strrpos($info['class'], '\\') + 1)
+                  : 'Closure';
+
+            $e2 = $this->stopwatch->start($name, 'event_listener');
 
             call_user_func($listener, $event);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Debug/TraceableEventDispatcherTest.php
@@ -27,4 +27,24 @@ class TraceableEventDispatcherTest extends TestCase
         $dispatcher = new TraceableEventDispatcher($container, new Stopwatch());
         $dispatcher->addListener('onFooEvent', new \stdClass());
     }
+
+    public function testClosureDoesNotTriggerErrorNotice()
+    {
+        $container  = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $dispatcher = new TraceableEventDispatcher($container, new StopWatch());
+        $triggered  = false;
+
+        $dispatcher->addListener('onFooEvent', function() use (&$triggered) {
+            $triggered = true;
+        });
+
+        try {
+            $dispatcher->dispatch('onFooEvent');
+        } catch (\PHPUnit_Framework_Error_Notice $e) {
+            $this->fail($e->getMessage());
+        }
+
+        $this->assertTrue($triggered, 'Closure should have been executed upon dispatch');
+    }
+
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2743

Currently a `\Closure` will cause the error:

> Notice: Undefined index: class in ...\TraceableEventDispatcher`

The test will fail in the event this Notice occurs & passes when the Closure fires correctly.

**Note**: If you use error suppression (`@$dispatcher->dispatch('onFooEvent')`), then the notice does not occur (as expected) and the listener fires correctly.  This, in my opinion, is expected behavior.

If you'd like this change rebased against another branch, let me know...
