### PR TITLE
[Console] [Doctrine] Fixed: Entities are generated in wrong folder (doctrine:generate:entities Namespace)

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -112,8 +112,11 @@ EOT
                 $basename = substr($m->name, strrpos($m->name, '\\') + 1);
                 $output->writeln(sprintf('  > backing up <comment>%s.php</comment> to <comment>%s.php~</comment>', $basename, $basename));
             }
+            // Getting the metadata for the entity class once more to get the correct path if the namespace has multiple occurrences
+            $entityMetadata = $manager->getClassMetadata($m->getName(), $input->getOption('path'));
+
             $output->writeln(sprintf('  > generating <comment>%s</comment>', $m->name));
-            $generator->generate(array($m), $metadata->getPath());
+            $generator->generate(array($m), $entityMetadata->getPath());
 
             if ($m->customRepositoryClassName && false !== strpos($m->customRepositoryClassName, $metadata->getNamespace())) {
                 $repoGenerator->writeEntityRepositoryClass($m->customRepositoryClassName, $metadata->getPath());


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no
Fixes the following tickets: 2688
Todo: -

Bug-description:
In our project we have some bundles from the same root-namespace "ABC" stored under "vendors/bundles/ABC" and some bundles under "src/ABC".

Running the command "$php app/console doctrine:generate:entities ABC" from the commandline generates the entities from "src/ABC/" under "vendors/bundles/ABC/" or vice versa depending on their order in the bundle array in the Appkernel.php.

The error does not occur when the entities are generated by bundlename or by classname.

Bugfix:-description:
Bugfix was to get the path for each entity class once more before generating the entities. Before the bugfix the path was taken form the first entity class of the namespace without checking if the following entities have a different path.
