### PR TITLE
Test fixes for ci.qa.php.net

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
@@ -65,6 +65,10 @@ class FilesystemLoader implements LoaderInterface
             return false;
         }
 
+        if (!is_readable((string) $storage)) {
+            return false;
+        }
+
         return filemtime((string) $storage) < $time;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -95,13 +95,9 @@ class ControllerResolver implements ControllerResolverInterface
     {
         if (is_array($controller)) {
             $r = new \ReflectionMethod($controller[0], $controller[1]);
-        } elseif (is_object($controller)) {
-            if ($controller instanceof \Closure) {
-                $r = new \ReflectionFunction($controller);
-            } else {
-                $r = new \ReflectionObject($controller);
-                $r = $r->getMethod('__invoke');
-            }
+        } elseif (is_object($controller) && !$controller instanceof \Closure) {
+            $r = new \ReflectionObject($controller);
+            $r = $r->getMethod('__invoke');
         } else {
             $r = new \ReflectionFunction($controller);
         }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -96,8 +96,12 @@ class ControllerResolver implements ControllerResolverInterface
         if (is_array($controller)) {
             $r = new \ReflectionMethod($controller[0], $controller[1]);
         } elseif (is_object($controller)) {
-            $r = new \ReflectionObject($controller);
-            $r = $r->getMethod('__invoke');
+            if ($controller instanceof \Closure) {
+                $r = new \ReflectionFunction($controller);
+            } else {
+                $r = new \ReflectionObject($controller);
+                $r = $r->getMethod('__invoke');
+            }
         } else {
             $r = new \ReflectionFunction($controller);
         }

--- a/tests/Symfony/Tests/Component/Console/Helper/FormatterHelperTest.php
+++ b/tests/Symfony/Tests/Component/Console/Helper/FormatterHelperTest.php
@@ -50,6 +50,15 @@ class FormatterHelperTest extends \PHPUnit_Framework_TestCase
             $formatter->formatBlock('Some text to display', 'error', true),
             '::formatBlock() formats a message in a block'
         );
+    }
+
+    public function testFormatBlockWithDiacriticLetters() {
+
+        if (!extension_loaded('mbstring')) {
+            $this->markTestSkipped('This test requires mbstring to work.');
+        }
+
+        $formatter = new FormatterHelper();
 
         $this->assertEquals(
             '<error>                       </error>' . "\n" .

--- a/tests/Symfony/Tests/Component/Console/Helper/FormatterHelperTest.php
+++ b/tests/Symfony/Tests/Component/Console/Helper/FormatterHelperTest.php
@@ -52,7 +52,8 @@ class FormatterHelperTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testFormatBlockWithDiacriticLetters() {
+    public function testFormatBlockWithDiacriticLetters()
+    {
 
         if (!extension_loaded('mbstring')) {
             $this->markTestSkipped('This test requires mbstring to work.');

--- a/tests/Symfony/Tests/Component/HttpKernel/Controller/ControllerResolverTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Controller/ControllerResolverTest.php
@@ -104,6 +104,18 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::create('/');
         $request->attributes->set('foo', 'foo');
+        $controller = function ($foo, $bar = 'bar') {};
+        $this->assertEquals(array('foo', 'bar'), $resolver->getArguments($request, $controller));
+
+        $request = Request::create('/');
+        $request->attributes->set('foo', 'foo');
+        $controller = new self();
+        $this->assertEquals(array('foo', null), $resolver->getArguments($request, $controller));
+        $request->attributes->set('bar', 'bar');
+        $this->assertEquals(array('foo', 'bar'), $resolver->getArguments($request, $controller));
+
+        $request = Request::create('/');
+        $request->attributes->set('foo', 'foo');
         $request->attributes->set('foobar', 'foobar');
         $controller = array(new self(), 'controllerMethod3');
 
@@ -119,7 +131,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($request), $resolver->getArguments($request, $controller), '->getArguments() injects the request');
     }
 
-    public function __invoke()
+    public function __invoke($foo, $bar = null)
     {
     }
 

--- a/tests/Symfony/Tests/Component/Process/PhpExecutableFinderTest.php
+++ b/tests/Symfony/Tests/Component/Process/PhpExecutableFinderTest.php
@@ -48,7 +48,7 @@ class PhpExecutableFinderTest extends \PHPUnit_Framework_TestCase
         $current = $f->find();
 
         //TODO maybe php executable is custom or even windows
-        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->assertEquals($current, PHP_BINDIR.DIRECTORY_SEPARATOR.'php', '::find() returns the executable php with suffixes');
         }
     }

--- a/tests/Symfony/Tests/Component/Yaml/InlineTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/InlineTest.php
@@ -47,7 +47,10 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Your platform does not support locales.');
         }
 
-        setlocale(LC_ALL, 'fr_FR.UTF-8', 'fr_FR.UTF8', 'fr_FR.utf-8', 'fr_FR.utf8', 'French_France.1252');
+        $required_locales = array('fr_FR.UTF-8', 'fr_FR.UTF8', 'fr_FR.utf-8', 'fr_FR.utf8', 'French_France.1252');
+        if (false === setlocale(LC_ALL, $required_locales)) {
+            $this->markTestSkipped('Could not set any of required locales: ' . implode(", ", $required_locales));
+        }
 
         $this->assertEquals('1.2', Inline::dump(1.2));
         $this->assertContains('fr', strtolower(setlocale(LC_NUMERIC, 0)));


### PR DESCRIPTION
Hello!
My name is Shein Alexey and I'm writing on behalf of php-qa team. As you probably know we've set up build server for testing major php versions (5.3, 5.4 and trunk for now) on the url http://ci.qa.php.net. There's also an initiative also check these versions against major php projects with good test coverage like symfony.
In our symfony builds some tests constantly fail (see http://ci.qa.php.net/view/php-userland/job/php-symfony2/420/testReport/ for example) so here are the fixes I come up with: 
1. Separated testing diacritic letters with additional check for mbstring in Symfony\Tests\Component\Console\Helper\FormatterHelperT
2. Added check if French locale was correctly set, skip the test otherwise in  Symfony\Tests\Component\Yaml\InlineTest.php.
3. Inverted check for Windows platform since testing finding php with suffixes has meaning only in Windows in Symfony\Tests\Component\Process\PhpExecutableFinderTest.php.

There is also erratic test Symfony\Tests\Component\HttpKernel\HttpCache\HttpCacheTest:testFetchesFullResponseWhenCacheStaleAndNoValidatorsPresent which randomly fails when Age header is non-zero, I'm not sure what to do here, maybe this check should be deleted since page can have age greater than zero.

Let me know what you think.
Thank you.
