### PR TITLE
[Form] Date, Time, DateTimeType forget translation domain

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -56,7 +56,8 @@ class DateTimeType extends AbstractType
                 'empty_value',
                 'required',
                 'invalid_message',
-                'invalid_message_parameters'
+                'invalid_message_parameters',
+                'translation_domain',
             )));
             $timeOptions = array_intersect_key($options, array_flip(array(
                 'hours',
@@ -66,7 +67,8 @@ class DateTimeType extends AbstractType
                 'empty_value',
                 'required',
                 'invalid_message',
-                'invalid_message_parameters'
+                'invalid_message_parameters',
+                'translation_domain',
             )));
 
             // If `widget` is set, overwrite widget options from `date` and `time`

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -80,22 +80,24 @@ class DateType extends AbstractType
                         array_combine($options['years'], $options['years']), 4, '0', STR_PAD_LEFT
                     ),
                     'empty_value' => $options['empty_value']['year'],
-                    'required' => $options['required'],
                 );
                 $monthOptions = array(
                     'choice_list' => new MonthChoiceList(
                         $formatter, $options['months']
                     ),
                     'empty_value' => $options['empty_value']['month'],
-                    'required' => $options['required'],
                 );
                 $dayOptions = array(
                     'choice_list' => new PaddedChoiceList(
                         array_combine($options['days'], $options['days']), 2, '0', STR_PAD_LEFT
                     ),
                     'empty_value' => $options['empty_value']['day'],
-                    'required' => $options['required'],
                 );
+
+                // Append generic carry-along options
+                foreach (array('required', 'translation_domain') as $passOpt) {
+                    $yearOptions[$passOpt] = $monthOptions[$passOpt] = $dayOptions[$passOpt] = $options[$passOpt];
+                }
             }
 
             $builder

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -53,14 +53,12 @@ class TimeType extends AbstractType
                         array_combine($options['hours'], $options['hours']), 2, '0', STR_PAD_LEFT
                     ),
                     'empty_value' => $options['empty_value']['hour'],
-                    'required' => $options['required'],
                 );
                 $minuteOptions = array(
                     'choice_list' => new PaddedChoiceList(
                         array_combine($options['minutes'], $options['minutes']), 2, '0', STR_PAD_LEFT
                     ),
                     'empty_value' => $options['empty_value']['minute'],
-                    'required' => $options['required'],
                 );
 
                 if ($options['with_seconds']) {
@@ -69,8 +67,15 @@ class TimeType extends AbstractType
                             array_combine($options['seconds'], $options['seconds']), 2, '0', STR_PAD_LEFT
                         ),
                         'empty_value' => $options['empty_value']['second'],
-                        'required' => $options['required'],
                     );
+                }
+
+                // Append generic carry-along options
+                foreach (array('required', 'translation_domain') as $passOpt) {
+                    $hourOptions[$passOpt] = $minuteOptions[$passOpt] = $options[$passOpt];
+                    if ($options['with_seconds']) {
+                        $secondOptions[$passOpt] = $options[$passOpt];
+                    }
                 }
             }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Recently, `translation_domain` option was added to form options. In case of complex types like `DateType`, `TimeType` and `DateTimeType`, this option should be carried along to sub-types.
