### PR TITLE
[BugFix][DIC] Throw exception to avoid PHP fatal error in generated container class

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
 /**
  * Definition represents a service definition.
  *
@@ -308,10 +310,15 @@ class Definition
      *
      * @return Definition The current instance
      *
+     * @throws InvalidArgumentException on empty $method param
+     *
      * @api
      */
     public function addMethodCall($method, array $arguments = array())
     {
+        if (empty($method)) {
+            throw new InvalidArgumentException(sprintf('Method name cannot be empty.'));
+        }
         $this->calls[] = array($method, $arguments);
 
         return $this;

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
@@ -96,6 +96,16 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException Symfony\Component\DependencyInjection\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Method name cannot be empty.
+     */
+    public function testExceptionOnEmptyMethodCall()
+    {
+        $def = new Definition('stdClass');
+        $def->addMethodCall('');
+    }
+
+    /**
      * @covers Symfony\Component\DependencyInjection\Definition::setFile
      * @covers Symfony\Component\DependencyInjection\Definition::getFile
      */


### PR DESCRIPTION
Bug fix: yes
Feature add: no
Symfony2 tests pass: yes
Symfony2 tests added: yes

In general without this exception generated by php dumper container class, will cause PHP fatal error, bacause method call will look like this: `$instance->(/* arguments*/);`.
