### PR TITLE
[FrameworkBundle] fixed unescaped file_link_format parameter in CodeHelp...

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -86,6 +86,7 @@
             <tag name="templating.helper" alias="code" />
             <argument>%templating.helper.code.file_link_format%</argument>
             <argument>%kernel.root_dir%</argument>
+            <argument>%kernel.charset%</argument>
         </service>
 
         <service id="templating.helper.translator" class="%templating.helper.translator.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -22,17 +22,20 @@ class CodeHelper extends Helper
 {
     protected $fileLinkFormat;
     protected $rootDir;
+    protected $charset;
 
     /**
      * Constructor.
      *
      * @param string $fileLinkFormat The format for links to source files
      * @param string $rootDir        The project root directory
+     * @param string $charset        The charset
      */
-    public function __construct($fileLinkFormat, $rootDir)
+    public function __construct($fileLinkFormat, $rootDir, $charset)
     {
         $this->fileLinkFormat = empty($fileLinkFormat) ? ini_get('xdebug.file_link_format') : $fileLinkFormat;
         $this->rootDir = str_replace('\\', '/', $rootDir).'/';
+        $this->charset = $charset;
     }
 
     /**
@@ -173,7 +176,7 @@ class CodeHelper extends Helper
         }
 
         if (false !== $link = $this->getFileLink($file, $line)) {
-            return sprintf('<a href="%s" title="Click to open this file" class="file_link">%s</a>', $link, $text);
+            return sprintf('<a href="%s" title="Click to open this file" class="file_link">%s</a>', htmlspecialchars($link, ENT_QUOTES, $this->charset), $text);
         }
 
         return $text;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/CodeHelperTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/CodeHelperTest.php
@@ -19,7 +19,13 @@ class CodeHelperTest extends \PHPUnit_Framework_TestCase
 
     static public function setUpBeforeClass()
     {
-        self::$helper = new CodeHelper('format', '/root');
+        self::$helper = new CodeHelper('txmt://open?url=file://%f&line=%l', '/root', 'UTF-8');
+    }
+
+    public function testFormatFile()
+    {
+        $expected = sprintf('<a href="txmt://open?url=file://%s&amp;line=25" title="Click to open this file" class="file_link">%s at line 25</a>', __FILE__, __FILE__);
+        $this->assertEquals($expected, self::$helper->formatFile(__FILE__, 25));
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: tests suite was broken on my laptop before I changed the code...
Fixes the following tickets: none
Todo: none
