### PR TITLE
[Locale] StubNumberFormatter allow to parse 64bit number in 64bit mode

### DIFF
--- a/tests/Symfony/Tests/Component/Locale/TestCase.php
+++ b/tests/Symfony/Tests/Component/Locale/TestCase.php
@@ -44,6 +44,20 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         }
     }
 
+    protected function skipIfNot32Bit()
+    {
+        if (!$this->is32Bit()) {
+            $this->markTestSkipped('PHP must be compiled in 32 bit mode to run this test');
+        }
+    }
+
+    protected function skipIfNot64Bit()
+    {
+        if (!$this->is64Bit()) {
+            $this->markTestSkipped('PHP must be compiled in 64 bit mode to run this test');
+        }
+    }
+
     protected function isGreaterOrEqualThanIcuVersion($version)
     {
         $version = $this->normalizeIcuVersion($version);


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/stealth35/symfony.png?branch=fix_2735)](http://travis-ci.org/stealth35/symfony)
Fixes the following tickets: #2735
