### PR TITLE
[DoctrineBridge] Catch user-error when the identifier is not serialized ...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -75,12 +75,21 @@ class EntityUserProvider implements UserProviderInterface
         if (!$user instanceof $this->class) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
         }
+        
 
         // The user must be reloaded via the primary key as all other data
         // might have changed without proper persistence in the database.
         // That's the case when the user has been changed by a form with
         // validation errors.
-        return $this->repository->find($this->metadata->getIdentifierValues($user));
+        $id = $this->metadata->getIdentifierValues($user);
+        if (!$id) {
+            throw new \InvalidArgumentException("You cannot refresh a user ".
+                "from the EntityUserProvider that does not contain an identifier. ".
+                "The user object has to be serialized with its own identifier " .
+                "mapped by Doctrine."
+            );
+        }
+        return $this->repository->find($id);
     }
 
     /**

--- a/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
@@ -40,6 +40,20 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
 
         $this->assertSame($user1, $provider->refreshUser($user1));
     }
+    
+    public function testRefreshUserRequiresId()
+    {
+        $em = $this->createTestEntityManager();
+        
+        $user1 = new CompositeIdentEntity(null, null, 'user1');
+        $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
+        
+        $this->setExpectedException(
+            'InvalidArgumentException',
+            'You cannot refresh a user from the EntityUserProvider that does not contain an identifier. The user object has to be serialized with its own identifier mapped by Doctrine'
+        );
+        $provider->refreshUser($user1);
+    }
 
     private function createSchema($em)
     {


### PR DESCRIPTION
...with the User entity.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: GH-2670
