### PR TITLE
Fixed GH-2720 - Fix disabled atrribute handling for radio form elements

### DIFF
--- a/tests/Symfony/Tests/Component/DomCrawler/Field/ChoiceFormFieldTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/Field/ChoiceFormFieldTest.php
@@ -168,6 +168,22 @@ class ChoiceFormFieldTest extends FormFieldTestCase
         }
     }
 
+    public function testRadioButtonIsDisabled()
+    {
+        $node = $this->createNode('input', '', array('type' => 'radio', 'name' => 'name', 'value' => 'foo', 'disabled' => 'disabled'));
+        $field = new ChoiceFormField($node);
+        $node = $this->createNode('input', '', array('type' => 'radio', 'name' => 'name', 'value' => 'bar'));
+        $field->addChoice($node);
+
+        $field->select('foo');
+        $this->assertEquals('foo', $field->getValue(), '->getValue() returns the value attribute of the selected radio button');
+        $this->assertTrue($field->isDisabled());
+
+        $field->select('bar');
+        $this->assertEquals('bar', $field->getValue(), '->getValue() returns the value attribute of the selected radio button');
+        $this->assertFalse($field->isDisabled());
+    }
+    
     public function testCheckboxes()
     {
         $node = $this->createNode('input', '', array('type' => 'checkbox', 'name' => 'name'));


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: - GH-2720

I wasn't really sure about the correct approach. This one is very minimalistic and following the existing concept of not duplicating nodes of the same name, but only storing multiple values for the same node. If you think that should be changed, let me know. Hints appreciated.

Thanks
