### PR TITLE
Add the possibility to create a non-persistent flash

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session.php
@@ -256,17 +256,23 @@ class Session implements \Serializable
     /**
      * Sets a flash message.
      *
-     * @param string $name
-     * @param string $value
+     * @param string  $name
+     * @param string  $value
+     * @param Boolean $persist
      */
-    public function setFlash($name, $value)
+    public function setFlash($name, $value, $persist = true)
     {
         if (false === $this->started) {
             $this->start();
         }
 
         $this->flashes[$name] = $value;
-        unset($this->oldFlashes[$name]);
+
+        if ($persist) {
+            unset($this->oldFlashes[$name]);
+        } else {
+            $this->oldFlashes[$name] = true;
+        }
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/SessionTest.php
@@ -74,6 +74,16 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->session->hasFlash('foo'));
     }
 
+    public function testNonPersistentFlashesAreFlushedWhenNeeded()
+    {
+        $this->session->setFlash('foo', 'bar', false);
+        $this->assertTrue($this->session->hasFlash('foo'));
+        $this->session->save();
+
+        $this->session = $this->getSession();
+        $this->assertFalse($this->session->hasFlash('foo'));
+    }
+
     public function testAll()
     {
         $this->assertFalse($this->session->has('foo'));


### PR DESCRIPTION
I was just wondering if there is a reason why the ability to create non-persistent flashes (like in RoR or sf) was not ported into the Symfony session.

In the case, you'll find a simple implementation with the PR.
