### PR TITLE
[DependencyInjection] Refactor usage of SPL exceptions

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -106,6 +106,10 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
  * added support for loading globally-installed PEAR packages
 
+### DependencyInjection
+
+ * component exceptions that inherit base SPL classes are now used exclusively (this includes dumped containers)
+
 ### DomCrawler
 
  * added a way to get parsing errors for Crawler::addHtmlContent() and Crawler::addXmlContent() via libxml functions

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -50,7 +50,7 @@ class CheckCircularReferencesPass implements CompilerPassInterface
      * Checks for circular references.
      *
      * @param array $edges An array of Nodes
-     * @throws \RuntimeException When a circular reference is found.
+     * @throws ServiceCircularReferenceException When a circular reference is found.
      */
     private function checkOutEdges(array $edges)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckDefinitionValidityPass.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
  * This pass validates each definition individually only taking the information
@@ -33,14 +34,14 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
      * Processes the ContainerBuilder to validate the Definition.
      *
      * @param ContainerBuilder $container
-     * @throws \RuntimeException When the Definition is invalid
+     * @throws RuntimeException When the Definition is invalid
      */
     public function process(ContainerBuilder $container)
     {
         foreach ($container->getDefinitions() as $id => $definition) {
             // synthetic service is public
             if ($definition->isSynthetic() && !$definition->isPublic()) {
-                throw new \RuntimeException(sprintf(
+                throw new RuntimeException(sprintf(
                     'A synthetic service ("%s") must be public.',
                     $id
                 ));
@@ -48,7 +49,7 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
 
             // synthetic service has non-prototype scope
             if ($definition->isSynthetic() && ContainerInterface::SCOPE_PROTOTYPE === $definition->getScope()) {
-                throw new \RuntimeException(sprintf(
+                throw new RuntimeException(sprintf(
                     'A synthetic service ("%s") cannot be of scope "prototype".',
                     $id
                 ));
@@ -57,14 +58,14 @@ class CheckDefinitionValidityPass implements CompilerPassInterface
             // non-synthetic, non-abstract service has class
             if (!$definition->isAbstract() && !$definition->isSynthetic() && !$definition->getClass()) {
                 if ($definition->getFactoryClass() || $definition->getFactoryService()) {
-                    throw new \RuntimeException(sprintf(
+                    throw new RuntimeException(sprintf(
                         'Please add the class to service "%s" even if it is constructed by a factory '
                        .'since we might need to add method calls based on compile-time checks.',
                        $id
                     ));
                 }
 
-                throw new \RuntimeException(sprintf(
+                throw new RuntimeException(sprintf(
                     'The definition for "%s" has no class. If you intend to inject '
                    .'this service dynamically at runtime, please mark it as synthetic=true. '
                    .'If this is an abstract definition solely used by child definitions, '

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -115,7 +115,8 @@ class CheckReferenceValidityPass implements CompilerPassInterface
      *
      * @param Reference  $reference
      * @param Definition $definition
-     * @throws \RuntimeException when there is an issue with the Reference scope
+     * @throws ScopeWideningInjectionException when the definition references a service of a narrower scope
+     * @throws ScopeCrossingInjectionException when the definition references a service of another scope hierarchy
      */
     private function validateScope(Reference $reference, Definition $definition = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -11,12 +11,13 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
-use Symfony\Component\DependencyInjection\Exception\ScopeWideningInjectionException;
-use Symfony\Component\DependencyInjection\Exception\ScopeCrossingInjectionException;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ScopeCrossingInjectionException;
+use Symfony\Component\DependencyInjection\Exception\ScopeWideningInjectionException;
 
 /**
  * Checks the validity of references
@@ -85,7 +86,7 @@ class CheckReferenceValidityPass implements CompilerPassInterface
      * Validates an array of References.
      *
      * @param array $arguments An array of Reference objects
-     * @throws \RuntimeException when there is a reference to an abstract definition.
+     * @throws RuntimeException when there is a reference to an abstract definition.
      */
     private function validateReferences(array $arguments)
     {
@@ -96,7 +97,7 @@ class CheckReferenceValidityPass implements CompilerPassInterface
                 $targetDefinition = $this->getDefinition((string) $argument);
 
                 if (null !== $targetDefinition && $targetDefinition->isAbstract()) {
-                    throw new \RuntimeException(sprintf(
+                    throw new RuntimeException(sprintf(
                         'The definition "%s" has a reference to an abstract definition "%s". '
                        .'Abstract definitions cannot be the target of references.',
                        $this->currentId,

--- a/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PassConfig.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
 /**
  * Compiler Pass Configuration
  *
@@ -95,7 +97,7 @@ class PassConfig
      *
      * @param CompilerPassInterface $pass A Compiler pass
      * @param string $type The pass type
-     * @throws \InvalidArgumentException when a pass type doesn't exist
+     * @throws InvalidArgumentException when a pass type doesn't exist
      *
      * @api
      */
@@ -103,7 +105,7 @@ class PassConfig
     {
         $property = $type.'Passes';
         if (!isset($this->$property)) {
-            throw new \InvalidArgumentException(sprintf('Invalid type "%s".', $type));
+            throw new InvalidArgumentException(sprintf('Invalid type "%s".', $type));
         }
 
         $passes = &$this->$property;

--- a/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * A pass that might be run repeatedly.
@@ -32,7 +33,7 @@ class RepeatedPass implements CompilerPassInterface
     {
         foreach ($passes as $pass) {
             if (!$pass instanceof RepeatablePassInterface) {
-                throw new \InvalidArgumentException('$passes must be an array of RepeatablePassInterface.');
+                throw new InvalidArgumentException('$passes must be an array of RepeatablePassInterface.');
             }
 
             $pass->setRepeatedPass($this);

--- a/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
@@ -28,6 +28,7 @@ class RepeatedPass implements CompilerPassInterface
      * Constructor.
      *
      * @param array $passes An array of RepeatablePassInterface objects
+     * @throws InvalidArgumentException if a pass is not a RepeatablePassInterface instance
      */
     public function __construct(array $passes)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
  * This replaces all DefinitionDecorator instances with their equivalent fully
@@ -60,7 +61,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
     private function resolveDefinition($id, DefinitionDecorator $definition)
     {
         if (!$this->container->hasDefinition($parent = $definition->getParent())) {
-            throw new \RuntimeException(sprintf('The parent definition "%s" defined for definition "%s" does not exist.', $parent, $id));
+            throw new RuntimeException(sprintf('The parent definition "%s" defined for definition "%s" does not exist.', $parent, $id));
         }
 
         $parentDef = $this->container->getDefinition($parent);
@@ -116,7 +117,7 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
             }
 
             if (0 !== strpos($k, 'index_')) {
-                throw new \RuntimeException(sprintf('Invalid argument key "%s" found.', $k));
+                throw new RuntimeException(sprintf('Invalid argument key "%s" found.', $k));
             }
 
             $index = (integer) substr($k, strlen('index_'));

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
  * Emulates the invalid behavior if the reference is not found within the
@@ -46,7 +47,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
             foreach ($definition->getMethodCalls() as $call) {
                 try {
                     $calls[] = array($call[0], $this->processArguments($call[1], true));
-                } catch (\RuntimeException $ignore) {
+                } catch (RuntimeException $ignore) {
                     // this call is simply removed
                 }
             }
@@ -57,7 +58,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
                 try {
                     $value = $this->processArguments(array($value), true);
                     $properties[$name] = reset($value);
-                } catch (\RuntimeException $ignore) {
+                } catch (RuntimeException $ignore) {
                     // ignore property
                 }
             }
@@ -89,7 +90,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
                     $arguments[$k] = null;
                 } else if (!$exists && ContainerInterface::IGNORE_ON_INVALID_REFERENCE === $invalidBehavior) {
                     if ($inMethodCall) {
-                        throw new \RuntimeException('Method shouldn\'t be called.');
+                        throw new RuntimeException('Method shouldn\'t be called.');
                     }
 
                     $arguments[$k] = null;

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\Compiler;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
 /**
  * This is a directed graph of your services.
  *
@@ -51,7 +53,7 @@ class ServiceReferenceGraph
     public function getNode($id)
     {
         if (!isset($this->nodes[$id])) {
-            throw new \InvalidArgumentException(sprintf('There is no node with id "%s".', $id));
+            throw new InvalidArgumentException(sprintf('There is no node with id "%s".', $id));
         }
 
         return $this->nodes[$id];

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -48,7 +48,7 @@ class ServiceReferenceGraph
      *
      * @param string $id The id to retrieve
      * @return ServiceReferenceGraphNode The node matching the supplied identifier
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException if no node matches the supplied identifier
      */
     public function getNode($id)
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
@@ -135,7 +137,7 @@ class Container implements ContainerInterface
      *
      * @return mixed  The parameter value
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws InvalidArgumentException if the parameter is not defined
      *
      * @api
      */
@@ -183,14 +185,14 @@ class Container implements ContainerInterface
     public function set($id, $service, $scope = self::SCOPE_CONTAINER)
     {
         if (self::SCOPE_PROTOTYPE === $scope) {
-            throw new \InvalidArgumentException('You cannot set services of scope "prototype".');
+            throw new InvalidArgumentException('You cannot set services of scope "prototype".');
         }
 
         $id = strtolower($id);
 
         if (self::SCOPE_CONTAINER !== $scope) {
             if (!isset($this->scopedServices[$scope])) {
-                throw new \RuntimeException('You cannot set services of inactive scopes.');
+                throw new RuntimeException('You cannot set services of inactive scopes.');
             }
 
             $this->scopedServices[$scope][$id] = $service;
@@ -226,7 +228,7 @@ class Container implements ContainerInterface
      *
      * @return object The associated service
      *
-     * @throws \InvalidArgumentException if the service is not defined
+     * @throws InvalidArgumentException if the service is not defined
      *
      * @see Reference
      *
@@ -292,11 +294,11 @@ class Container implements ContainerInterface
     public function enterScope($name)
     {
         if (!isset($this->scopes[$name])) {
-            throw new \InvalidArgumentException(sprintf('The scope "%s" does not exist.', $name));
+            throw new InvalidArgumentException(sprintf('The scope "%s" does not exist.', $name));
         }
 
         if (self::SCOPE_CONTAINER !== $this->scopes[$name] && !isset($this->scopedServices[$this->scopes[$name]])) {
-            throw new \RuntimeException(sprintf('The parent scope "%s" must be active when entering this scope.', $this->scopes[$name]));
+            throw new RuntimeException(sprintf('The parent scope "%s" must be active when entering this scope.', $this->scopes[$name]));
         }
 
         // check if a scope of this name is already active, if so we need to
@@ -330,14 +332,14 @@ class Container implements ContainerInterface
      * scope.
      *
      * @param string $name The name of the scope to leave
-     * @throws \InvalidArgumentException if the scope is not active
+     * @throws InvalidArgumentException if the scope is not active
      *
      * @api
      */
     public function leaveScope($name)
     {
         if (!isset($this->scopedServices[$name])) {
-            throw new \InvalidArgumentException(sprintf('The scope "%s" is not active.', $name));
+            throw new InvalidArgumentException(sprintf('The scope "%s" is not active.', $name));
         }
 
         // remove all services of this scope, or any of its child scopes from
@@ -377,13 +379,13 @@ class Container implements ContainerInterface
         $parentScope = $scope->getParentName();
 
         if (self::SCOPE_CONTAINER === $name || self::SCOPE_PROTOTYPE === $name) {
-            throw new \InvalidArgumentException(sprintf('The scope "%s" is reserved.', $name));
+            throw new InvalidArgumentException(sprintf('The scope "%s" is reserved.', $name));
         }
         if (isset($this->scopes[$name])) {
-            throw new \InvalidArgumentException(sprintf('A scope with name "%s" already exists.', $name));
+            throw new InvalidArgumentException(sprintf('A scope with name "%s" already exists.', $name));
         }
         if (self::SCOPE_CONTAINER !== $parentScope && !isset($this->scopes[$parentScope])) {
-            throw new \InvalidArgumentException(sprintf('The parent scope "%s" does not exist, or is invalid.', $parentScope));
+            throw new InvalidArgumentException(sprintf('The parent scope "%s" does not exist, or is invalid.', $parentScope));
         }
 
         $this->scopes[$name] = $parentScope;

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -159,13 +159,14 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param array  $values    An array of values that customizes the extension
      *
      * @return ContainerBuilder The current instance
+     * @throws BadMethodCallException When this ContainerBuilder is frozen
      *
      * @api
      */
     public function loadFromExtension($extension, array $values = array())
     {
-        if (true === $this->isFrozen()) {
-            throw new LogicException('Cannot load from an extension on a frozen container.');
+        if ($this->isFrozen()) {
+            throw new BadMethodCallException('Cannot load from an extension on a frozen container.');
         }
 
         $namespace = $this->getExtension($extension)->getAlias();
@@ -371,14 +372,15 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * constructor.
      *
      * @param ContainerBuilder $container The ContainerBuilder instance to merge.
-     * @throws LogicException when this ContainerBuilder is frozen
+     *
+     * @throws BadMethodCallException When this ContainerBuilder is frozen
      *
      * @api
      */
     public function merge(ContainerBuilder $container)
     {
-        if (true === $this->isFrozen()) {
-            throw new LogicException('Cannot merge on a frozen container.');
+        if ($this->isFrozen()) {
+            throw new BadMethodCallException('Cannot merge on a frozen container.');
         }
 
         $this->addDefinitions($container->getDefinitions());

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -636,7 +636,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param  string     $id         The service identifier
      * @param  Definition $definition A Definition instance
      *
-     * @throws BadMethodCallException
+     * @throws BadMethodCallException When this ContainerBuilder is frozen
      *
      * @api
      */
@@ -719,6 +719,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @return object              The service described by the service definition
      *
+     * @throws RuntimeException         When factory specification is incomplete or scope is inactive
      * @throws InvalidArgumentException When configure callable is not callable
      */
     private function createService(Definition $definition, $id)

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -46,7 +46,7 @@ interface ContainerInterface
      *
      * @return object The associated service
      *
-     * @throws \InvalidArgumentException if the service is not defined
+     * @throws InvalidArgumentException if the service is not defined
      *
      * @see Reference
      *
@@ -72,7 +72,7 @@ interface ContainerInterface
      *
      * @return mixed  The parameter value
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws InvalidArgumentException if the parameter is not defined
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
 /**
  * ContainerInterface is the interface implemented by service container classes.
  *

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection;
 
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
 
 /**
  * Definition represents a service definition.
@@ -245,7 +246,7 @@ class Definition
     public function replaceArgument($index, $argument)
     {
         if ($index < 0 || $index > count($this->arguments) - 1) {
-            throw new \OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, count($this->arguments) - 1));
+            throw new OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, count($this->arguments) - 1));
         }
 
         $this->arguments[$index] = $argument;
@@ -277,7 +278,7 @@ class Definition
     public function getArgument($index)
     {
         if ($index < 0 || $index > count($this->arguments) - 1) {
-            throw new \OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, count($this->arguments) - 1));
+            throw new OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, count($this->arguments) - 1));
         }
 
         return $this->arguments[$index];

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\OutOfBoundsException;
+
 /**
  * This definition decorates another definition.
  *
@@ -167,7 +170,7 @@ class DefinitionDecorator extends Definition
         $lastIndex = count(array_filter(array_keys($this->arguments), 'is_int')) - 1;
 
         if ($index < 0 || $index > $lastIndex) {
-            throw new \OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, $lastIndex));
+            throw new OutOfBoundsException(sprintf('The index "%d" is not in the range [0, %d].', $index, $lastIndex));
         }
 
         return $this->arguments[$index];
@@ -185,14 +188,14 @@ class DefinitionDecorator extends Definition
      * @param mixed $value
      *
      * @return DefinitionDecorator the current instance
-     * @throws \InvalidArgumentException when $index isn't an integer
+     * @throws InvalidArgumentException when $index isn't an integer
      *
      * @api
      */
     public function replaceArgument($index, $value)
     {
         if (!is_int($index)) {
-            throw new \InvalidArgumentException('$index must be an integer.');
+            throw new InvalidArgumentException('$index must be an integer.');
         }
 
         $this->arguments['index_'.$index] = $value;

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -467,7 +467,7 @@ class PhpDumper extends Dumper
 
         $return = '';
         if ($definition->isSynthetic()) {
-            $return = sprintf('@throws \RuntimeException always since this service is expected to be injected dynamically');
+            $return = sprintf('@throws RuntimeException always since this service is expected to be injected dynamically');
         } elseif ($class = $definition->getClass()) {
             $return = sprintf("@return %s A %s instance.", 0 === strpos($class, '%') ? 'Object' : $class, $class);
         } elseif ($definition->getFactoryClass()) {
@@ -520,7 +520,7 @@ EOF;
         }
 
         if ($definition->isSynthetic()) {
-            $code .= sprintf("        throw new \RuntimeException('You have requested a synthetic service (\"%s\"). The DIC does not know how to construct this service.');\n    }\n", $id);
+            $code .= sprintf("        throw new RuntimeException('You have requested a synthetic service (\"%s\"). The DIC does not know how to construct this service.');\n    }\n", $id);
         } else {
             $code .=
                 $this->addServiceInclude($id, $definition).
@@ -617,6 +617,9 @@ EOF;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 $bagClass
@@ -730,7 +733,7 @@ EOF;
         \$name = strtolower(\$name);
 
         if (!array_key_exists(\$name, \$this->parameters)) {
-            throw new \InvalidArgumentException(sprintf('The parameter "%s" must be defined.', \$name));
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', \$name));
         }
 
         return \$this->parameters[\$name];
@@ -749,7 +752,7 @@ EOF;
      */
     public function setParameter(\$name, \$value)
     {
-        throw new \LogicException('Impossible to call set() on a frozen ParameterBag.');
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Dumper;
 
-use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Variable;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -19,6 +18,9 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 
 /**
  * PhpDumper dumps a service container as a PHP class.
@@ -232,7 +234,7 @@ class PhpDumper extends Dumper
                     } elseif (null !== $sDefinition->getFactoryService()) {
                         $code .= sprintf("        \$%s = %s->%s(%s);\n", $name, $this->getServiceCall($sDefinition->getFactoryService()), $sDefinition->getFactoryMethod(), implode(', ', $arguments));
                     } else {
-                        throw new \RuntimeException('Factory service or factory class must be defined in service definition for '.$id);
+                        throw new RuntimeException('Factory service or factory class must be defined in service definition for '.$id);
                     }
                 } elseif (false !== strpos($class, '$')) {
                     $code .= sprintf("        \$class = %s;\n        \$%s = new \$class(%s);\n", $class, $name, implode(', ', $arguments));
@@ -276,15 +278,15 @@ class PhpDumper extends Dumper
      * @param Definition $definition
      * @return string
      *
-     * @throws \InvalidArgumentException
-     * @throws \RuntimeException
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
      */
     private function addServiceInstance($id, $definition)
     {
         $class = $this->dumpValue($definition->getClass());
 
         if (0 === strpos($class, "'") && !preg_match('/^\'[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*(\\\{2}[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)*\'$/', $class)) {
-            throw new \InvalidArgumentException(sprintf('"%s" is not a valid class name for the "%s" service.', $class, $id));
+            throw new InvalidArgumentException(sprintf('"%s" is not a valid class name for the "%s" service.', $class, $id));
         }
 
         $arguments = array();
@@ -316,7 +318,7 @@ class PhpDumper extends Dumper
             } elseif (null !== $definition->getFactoryService()) {
                 $code = sprintf("        $return{$instantiation}%s->%s(%s);\n", $this->getServiceCall($definition->getFactoryService()), $definition->getFactoryMethod(), implode(', ', $arguments));
             } else {
-                throw new \RuntimeException('Factory method requires a factory service or factory class in service definition for '.$id);
+                throw new RuntimeException('Factory method requires a factory service or factory class in service definition for '.$id);
             }
         } elseif (false !== strpos($class, '$')) {
             $code = sprintf("        \$class = %s;\n        $return{$instantiation}new \$class(%s);\n", $class, implode(', ', $arguments));
@@ -796,11 +798,11 @@ EOF;
             if (is_array($value)) {
                 $value = $this->exportParameters($value, $path.'/'.$key, $indent + 4);
             } elseif ($value instanceof Variable) {
-                throw new \InvalidArgumentException(sprintf('You cannot dump a container with parameters that contain variable references. Variable "%s" found in "%s".', $value, $path.'/'.$key));
+                throw new InvalidArgumentException(sprintf('You cannot dump a container with parameters that contain variable references. Variable "%s" found in "%s".', $value, $path.'/'.$key));
             } elseif ($value instanceof Definition) {
-                throw new \InvalidArgumentException(sprintf('You cannot dump a container with parameters that contain service definitions. Definition for "%s" found in "%s".', $value->getClass(), $path.'/'.$key));
+                throw new InvalidArgumentException(sprintf('You cannot dump a container with parameters that contain service definitions. Definition for "%s" found in "%s".', $value->getClass(), $path.'/'.$key));
             } elseif ($value instanceof Reference) {
-                throw new \InvalidArgumentException(sprintf('You cannot dump a container with parameters that contain references to other services (reference to service "%s" found in "%s").', $value, $path.'/'.$key));
+                throw new InvalidArgumentException(sprintf('You cannot dump a container with parameters that contain references to other services (reference to service "%s" found in "%s").', $value, $path.'/'.$key));
             } else {
                 $value = var_export($value, true);
             }
@@ -969,10 +971,10 @@ EOF;
                 return $this->dumpValue($this->definitionVariables->offsetGet($value), $interpolate);
             }
             if (count($value->getMethodCalls()) > 0) {
-                throw new \RuntimeException('Cannot dump definitions which have method calls.');
+                throw new RuntimeException('Cannot dump definitions which have method calls.');
             }
             if (null !== $value->getConfigurator()) {
-                throw new \RuntimeException('Cannot dump definitions which have a configurator.');
+                throw new RuntimeException('Cannot dump definitions which have a configurator.');
             }
 
             $arguments = array();
@@ -982,7 +984,7 @@ EOF;
             $class = $this->dumpValue($value->getClass());
 
             if (false !== strpos($class, '$')) {
-                throw new \RuntimeException('Cannot dump definitions which have a variable class name.');
+                throw new RuntimeException('Cannot dump definitions which have a variable class name.');
             }
 
             if (null !== $value->getFactoryMethod()) {
@@ -991,7 +993,7 @@ EOF;
                 } elseif (null !== $value->getFactoryService()) {
                     return sprintf("%s->%s(%s)", $this->getServiceCall($value->getFactoryService()), $value->getFactoryMethod(), implode(', ', $arguments));
                 } else {
-                    throw new \RuntimeException('Cannot dump definitions which have factory method without factory service or factory class.');
+                    throw new RuntimeException('Cannot dump definitions which have factory method without factory service or factory class.');
                 }
             }
 
@@ -1026,7 +1028,7 @@ EOF;
                 return $code;
             }
         } elseif (is_object($value) || is_resource($value)) {
-            throw new \RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
+            throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
         } else {
             return var_export($value, true);
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
  * XmlDumper dumps a service container as an XML string.
@@ -277,7 +278,7 @@ class XmlDumper extends Dumper
      * Converts php types to xml types.
      *
      * @param mixed $value Value to convert
-     * @throws \RuntimeException When trying to dump object or resource
+     * @throws RuntimeException When trying to dump object or resource
      */
     static public function phpToXml($value)
     {
@@ -291,7 +292,7 @@ class XmlDumper extends Dumper
             case is_object($value) && $value instanceof Parameter:
                 return '%'.$value.'%';
             case is_object($value) || is_resource($value):
-                throw new \RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
+                throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
             default:
                 return (string) $value;
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -15,6 +15,7 @@ use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
  * YamlDumper dumps a service container as a YAML string.
@@ -175,7 +176,7 @@ class YamlDumper extends Dumper
      * Dumps the value to YAML format
      *
      * @param mixed $value
-     * @throws \RuntimeException When trying to dump object or resource
+     * @throws RuntimeException When trying to dump object or resource
      */
     private function dumpValue($value)
     {
@@ -191,7 +192,7 @@ class YamlDumper extends Dumper
         } elseif (is_object($value) && $value instanceof Parameter) {
             return $this->getParameterCall((string) $value);
         } elseif (is_object($value) || is_resource($value)) {
-            throw new \RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
+            throw new RuntimeException('Unable to dump a service container if a parameter is an object or a resource.');
         }
 
         return $value;

--- a/src/Symfony/Component/DependencyInjection/Exception/BadMethodCallException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/BadMethodCallException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * Base BadMethodCallException for Dependency Injection component.
+ */
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/ExceptionInterface.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Exception;
 
 /**
- * ExceptionInterface
+ * Base ExceptionInterface for Dependency Injection component.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Bulat Shakirzyanov <bulat@theopenskyproject.com>

--- a/src/Symfony/Component/DependencyInjection/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/InvalidArgumentException.php
@@ -11,13 +11,11 @@
 
 namespace Symfony\Component\DependencyInjection\Exception;
 
-use \InvalidArgumentException as BaseInvalidArgumentException;
-
 /**
- * InvalidArgumentException
+ * Base InvalidArgumentException for Dependency Injection component.
  *
  * @author Bulat Shakirzyanov <bulat@theopenskyproject.com>
  */
-class InvalidArgumentException extends BaseInvalidArgumentException implements ExceptionInterface
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/DependencyInjection/Exception/LogicException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/LogicException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * Base LogicException for Dependency Injection component.
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Exception/OutOfBoundsException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/OutOfBoundsException.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Component\DependencyInjection\Exception;
+
+/**
+ * Base OutOfBoundsException for Dependency Injection component.
+ */
+class OutOfBoundsException extends \OutOfBoundsException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/DependencyInjection/Exception/RuntimeException.php
+++ b/src/Symfony/Component/DependencyInjection/Exception/RuntimeException.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Exception;
 
 /**
- * Base RuntimeException for Dependency Injection Component.
+ * Base RuntimeException for Dependency Injection component.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */

--- a/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Extension/ExtensionInterface.php
@@ -28,7 +28,7 @@ interface ExtensionInterface
      * @param array            $config    An array of configuration values
      * @param ContainerBuilder $container A ContainerBuilder instance
      *
-     * @throws \InvalidArgumentException When provided tag is not defined in this extension
+     * @throws InvalidArgumentException When provided tag is not defined in this extension
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * IniFileLoader loads parameters from INI files.
@@ -26,7 +27,7 @@ class IniFileLoader extends FileLoader
      * @param mixed  $file     The resource
      * @param string $type     The resource type
      *
-     * @throws \InvalidArgumentException When ini file is not valid
+     * @throws InvalidArgumentException When ini file is not valid
      */
     public function load($file, $type = null)
     {
@@ -36,7 +37,7 @@ class IniFileLoader extends FileLoader
 
         $result = parse_ini_file($path, true);
         if (false === $result || array() === $result) {
-            throw new \InvalidArgumentException(sprintf('The "%s" file is not valid.', $file));
+            throw new InvalidArgumentException(sprintf('The "%s" file is not valid.', $file));
         }
 
         if (isset($result['parameters']) && is_array($result['parameters'])) {

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -12,13 +12,14 @@
 namespace Symfony\Component\DependencyInjection\Loader;
 
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
-
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\SimpleXMLElement;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
 /**
  * XmlFileLoader loads XML files service definitions.
@@ -198,14 +199,14 @@ class XmlFileLoader extends FileLoader
      * Parses a XML file.
      *
      * @param string $file Path to a file
-     * @throws \InvalidArgumentException When loading of XML file returns error
+     * @throws InvalidArgumentException When loading of XML file returns error
      */
     private function parseFile($file)
     {
         $dom = new \DOMDocument();
         libxml_use_internal_errors(true);
         if (!$dom->load($file, defined('LIBXML_COMPACT') ? LIBXML_COMPACT : 0)) {
-            throw new \InvalidArgumentException(implode("\n", $this->getXmlErrors()));
+            throw new InvalidArgumentException(implode("\n", $this->getXmlErrors()));
         }
         $dom->validateOnParse = true;
         $dom->normalizeDocument();
@@ -290,8 +291,8 @@ class XmlFileLoader extends FileLoader
      * @param \DOMDocument $dom
      * @param string $file
      *
-     * @throws \RuntimeException         When extension references a non-existent XSD file
-     * @throws \InvalidArgumentException When xml doesn't validate its xsd schema
+     * @throws RuntimeException         When extension references a non-existent XSD file
+     * @throws InvalidArgumentException When xml doesn't validate its xsd schema
      */
     private function validateSchema(\DOMDocument $dom, $file)
     {
@@ -308,7 +309,7 @@ class XmlFileLoader extends FileLoader
                     $path = str_replace($extension->getNamespace(), str_replace('\\', '/', $extension->getXsdValidationBasePath()).'/', $items[$i + 1]);
 
                     if (!is_file($path)) {
-                        throw new \RuntimeException(sprintf('Extension "%s" references a non-existent XSD file "%s"', get_class($extension), $path));
+                        throw new RuntimeException(sprintf('Extension "%s" references a non-existent XSD file "%s"', get_class($extension), $path));
                     }
 
                     $schemaLocations[$items[$i]] = $path;
@@ -353,7 +354,7 @@ EOF
             @unlink($tmpfile);
         }
         if (!$valid) {
-            throw new \InvalidArgumentException(implode("\n", $this->getXmlErrors()));
+            throw new InvalidArgumentException(implode("\n", $this->getXmlErrors()));
         }
         libxml_use_internal_errors($current);
     }
@@ -364,7 +365,7 @@ EOF
      * @param \DOMDocument $dom
      * @param string $file
      *
-     * @throws  \InvalidArgumentException When non valid tag are found or no extension are found
+     * @throws InvalidArgumentException When no extension is found corresponding to a tag
      */
     private function validateExtensions(\DOMDocument $dom, $file)
     {
@@ -376,7 +377,7 @@ EOF
             // can it be handled by an extension?
             if (!$this->container->hasExtension($node->namespaceURI)) {
                 $extensionNamespaces = array_filter(array_map(function ($ext) { return $ext->getNamespace(); }, $this->container->getExtensions()));
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'There is no extension able to load the configuration for "%s" (in %s). Looked for namespace "%s", found %s',
                     $node->tagName,
                     $file,

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -292,7 +292,7 @@ class XmlFileLoader extends FileLoader
      * @param string $file
      *
      * @throws RuntimeException         When extension references a non-existent XSD file
-     * @throws InvalidArgumentException When xml doesn't validate its xsd schema
+     * @throws InvalidArgumentException When XML doesn't validate its XSD schema
      */
     private function validateSchema(\DOMDocument $dom, $file)
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Yaml\Yaml;
 
@@ -198,12 +199,12 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['tags'])) {
             if (!is_array($service['tags'])) {
-                throw new \InvalidArgumentException(sprintf('Parameter "tags" must be an array for service "%s" in %s.', $id, $file));
+                throw new InvalidArgumentException(sprintf('Parameter "tags" must be an array for service "%s" in %s.', $id, $file));
             }
 
             foreach ($service['tags'] as $tag) {
                 if (!isset($tag['name'])) {
-                    throw new \InvalidArgumentException(sprintf('A "tags" entry is missing a "name" key for service "%s" in %s.', $id, $file));
+                    throw new InvalidArgumentException(sprintf('A "tags" entry is missing a "name" key for service "%s" in %s.', $id, $file));
                 }
 
                 $name = $tag['name'];
@@ -234,7 +235,7 @@ class YamlFileLoader extends FileLoader
      * @param string $file
      * @return array
      *
-     * @throws \InvalidArgumentException When service file is not valid
+     * @throws InvalidArgumentException When service file is not valid
      */
     private function validate($content, $file)
     {
@@ -243,7 +244,7 @@ class YamlFileLoader extends FileLoader
         }
 
         if (!is_array($content)) {
-            throw new \InvalidArgumentException(sprintf('The service file "%s" is not valid.', $file));
+            throw new InvalidArgumentException(sprintf('The service file "%s" is not valid.', $file));
         }
 
         foreach (array_keys($content) as $namespace) {
@@ -253,7 +254,7 @@ class YamlFileLoader extends FileLoader
 
             if (!$this->container->hasExtension($namespace)) {
                 $extensionNamespaces = array_filter(array_map(function ($ext) { return $ext->getAlias(); }, $this->container->getExtensions()));
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'There is no extension able to load the configuration for "%s" (in %s). Looked for namespace "%s", found %s',
                     $namespace,
                     $file,

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\DependencyInjection\ParameterBag;
 
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
 /**
  *
  * @author Fabien Potencier <fabien@symfony.com>
@@ -44,7 +46,7 @@ class FrozenParameterBag extends ParameterBag
      */
     public function clear()
     {
-        throw new \LogicException('Impossible to call clear() on a frozen ParameterBag.');
+        throw new LogicException('Impossible to call clear() on a frozen ParameterBag.');
     }
 
     /**
@@ -54,7 +56,7 @@ class FrozenParameterBag extends ParameterBag
      */
     public function add(array $parameters)
     {
-        throw new \LogicException('Impossible to call add() on a frozen ParameterBag.');
+        throw new LogicException('Impossible to call add() on a frozen ParameterBag.');
     }
 
     /**
@@ -64,6 +66,6 @@ class FrozenParameterBag extends ParameterBag
      */
     public function set($name, $value)
     {
-        throw new \LogicException('Impossible to call set() on a frozen ParameterBag.');
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
     }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Dumper/PhpDumperTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Dumper/PhpDumperTest.php
@@ -92,8 +92,8 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
             $dumper->dump();
             $this->fail('->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('\RuntimeException', $e, '->dump() returns a LogicException if the dump() method has not been overridden by a children class');
-            $this->assertEquals('Unable to dump a service container if a parameter is an object or a resource.', $e->getMessage(), '->dump() returns a LogicException if the dump() method has not been overridden by a children class');
+            $this->assertInstanceOf('\Symfony\Component\DependencyInjection\Exception\RuntimeException', $e, '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
+            $this->assertEquals('Unable to dump a service container if a parameter is an object or a resource.', $e->getMessage(), '->dump() throws a RuntimeException if the container to be dumped has reference to objects or resources');
         }
     }
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1-1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1-1.php
@@ -3,6 +3,9 @@
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1.php
@@ -3,6 +3,9 @@
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services10.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services10.php
@@ -3,6 +3,9 @@
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
@@ -53,7 +56,7 @@ class ProjectServiceContainer extends Container
         $name = strtolower($name);
 
         if (!array_key_exists($name, $this->parameters)) {
-            throw new \InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
+            throw new InvalidArgumentException(sprintf('The parameter "%s" must be defined.', $name));
         }
 
         return $this->parameters[$name];
@@ -72,7 +75,7 @@ class ProjectServiceContainer extends Container
      */
     public function setParameter($name, $value)
     {
-        throw new \LogicException('Impossible to call set() on a frozen ParameterBag.');
+        throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services8.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services8.php
@@ -3,6 +3,9 @@
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services9.php
@@ -3,6 +3,9 @@
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;


### PR DESCRIPTION
```
Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -
```

This was something discussed on the mailing list recently and a topic at the last IRC meeting. The DependencyInjection component was what I had in mind while discussing this with @lsmith a few weeks ago, as I found that it already had some local SPL exceptions, which weren't being used directly (only as base classes for the compiler exceptions). This PR replaces uses of core SPL exceptions with the component's equivalents. I've listed it as BC-breaking to be safe, but I don't think it should cause any trouble, since the new exceptions are sub-classes of those originally used.

I purposely avoided changing the exceptions in the dumped PHP container. If we agree that's worth doing, it would be a trivial addition to the PR.
