### PR TITLE
Note LoaderResolverInterface type hinting in the 2.1 changelog

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -96,6 +96,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 ### Config
 
  * implemented `Serializable` on resources
+ * LoaderResolverInterface is now used instead of LoaderResolver for type hinting
 
 ### Console
 


### PR DESCRIPTION
Although #2785 was originally opened against 2.0, its merge to master seems to be intentional. This documents the BC break that some experienced (see: FriendsOfSymfony/FOSRestBundle#155).
