### PR TITLE
[Form] setReadOnly and setAttribute on a Form after creation

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -295,6 +295,20 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * Set read only form status
+     *
+     * @param Boolean read only status
+     *
+     * @return Form The current form
+     */
+    public function setReadOnly($readOnly = true)
+    {
+        $this->readOnly = (Boolean) $readOnly;
+
+        return $this;
+    }
+
+    /**
      * Sets the parent form.
      *
      * @param FormInterface $parent The parent form
@@ -368,6 +382,21 @@ class Form implements \IteratorAggregate, FormInterface
     public function getAttribute($name)
     {
         return $this->attributes[$name];
+    }
+
+    /**
+     * Sets the value of the attributes with the given name.
+     *
+     * @param string $name The name of the attribute
+     * @param mixed $value The value of the attribute
+     *
+     * @return Form The current form
+     */
+    public function setAttribute($name, $value)
+    {
+        $this->attributes[$name] = $value;
+
+        return $this;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -229,6 +229,24 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($child->isReadOnly());
     }
 
+    public function testSetReadOnlyAfterFormCreation()
+    {
+        $parent = $this->getBuilder()->setReadOnly(false)->getForm();
+
+        $parent->setReadOnly(true);
+
+        $this->assertTrue($parent->isReadOnly());
+    }
+
+    public function testSetNotReadOnlyAfterFormCreation()
+    {
+        $parent = $this->getBuilder()->setReadOnly(true)->getForm();
+
+        $parent->setReadOnly(false);
+
+        $this->assertFalse($parent->isReadOnly());
+    }
+
     public function testCloneChildren()
     {
         $child = $this->getBuilder('child')->getForm();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/acasademont/symfony.png)](http://travis-ci.org/acasademont/symfony)
Fixes the following tickets: -
Todo: -

In a From EventSubscriber i can manage to get the form via $event->getForm() but i am pretty limited about what i can do with that form. If i only want to change the read_only property i can't because it's private, so i end up creating the field again with the same name and overwriting it with 

``` php
$form->add($this->factory->createNamed('text', 'name', null, array('read_only' => false)));
```

which is a bit time consuming since i only wanted to set the read_only property of that field to false. 

I must say that i found it a bit strange that there weren't any options for doing this so please, tell me if there is any powerful reason for not being able to change the read_only (or other attributes) when the form is already created.
