### PR TITLE
[DomCrawler] Errors already silenced by using libxml_use_internal_errors, @ is useless.

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -125,7 +125,7 @@ class Crawler extends \SplObjectStorage
         $dom->validateOnParse = true;
 
         $current = libxml_use_internal_errors(true);
-        @$dom->loadHTML($content);
+        $dom->loadHTML($content);
         libxml_use_internal_errors($current);
 
         $this->addDocument($dom);
@@ -159,7 +159,7 @@ class Crawler extends \SplObjectStorage
 
         // remove the default namespace to make XPath expressions simpler
         $current = libxml_use_internal_errors(true);
-        @$dom->loadXML(str_replace('xmlns', 'ns', $content));
+        $dom->loadXML(str_replace('xmlns', 'ns', $content));
         libxml_use_internal_errors($current);
 
         $this->addDocument($dom);


### PR DESCRIPTION
Bug fix: No
Feature addition: No
Backwards compatibility break: No
Symfony2 tests pass: Yes

[libxml_use_internal_errors](http://www.php.net/manual/en/function.libxml-use-internal-errors.php) — Disable libxml errors
The @ is not needed.
