### PR TITLE
[FrameworkBundle] Remove unused variable in TemplateLocator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -22,7 +22,6 @@ use Symfony\Component\Templating\TemplateReferenceInterface;
 class TemplateLocator implements FileLocatorInterface
 {
     protected $locator;
-    protected $path;
     protected $cache;
 
     /**
@@ -79,7 +78,7 @@ class TemplateLocator implements FileLocatorInterface
         try {
             return $this->cache[$key] = $this->locator->locate($template->getPath(), $currentPath);
         } catch (\InvalidArgumentException $e) {
-            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', $template, $this->path), 0, $e);
+            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', $template, $currentPath), 0, $e);
         }
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no (99% sure)
Symfony2 tests pass: no (currently some Locale\Stub* tests fail for me on latest master, all the rest succeeds)
Fixes the following tickets: -

Unused class field that survived an earlier refactor by @fabpot. Not 100% sure about BC break or not since the field is protected (could be used in subclasses?), but unused in the current code.
