### PR TITLE
Template locator/exception message

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -66,7 +66,7 @@ class TemplateLocator implements FileLocatorInterface
         try {
             return $this->cache[$key] = $this->locator->locate($template->getPath(), $currentPath);
         } catch (\InvalidArgumentException $e) {
-            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" in "%s".', $template, $currentPath), 0, $e);
+            throw new \InvalidArgumentException(sprintf('Unable to find template "%s" : "%s".', $template, $e->getMessage()), 0, $e);
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Loader/TemplateLocatorTest.php
@@ -35,24 +35,32 @@ class TemplateLocatorTest extends TestCase
         $this->assertEquals('/path/to/template', $locator->locate($template));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testThrowsExceptionWhenTemplateNotFound()
     {
         $template = new TemplateReference('bundle', 'controller', 'name', 'format', 'engine');
 
         $fileLocator = $this->getFileLocator();
 
+        $errorMessage = 'FileLocator exception message';
+
         $fileLocator
             ->expects($this->once())
             ->method('locate')
-            ->will($this->throwException(new \InvalidArgumentException()))
+            ->will($this->throwException(new \InvalidArgumentException($errorMessage)))
         ;
 
         $locator = new TemplateLocator($fileLocator);
 
-        $locator->locate($template);
+        try {
+            $locator->locate($template);
+            $this->fail('->locate() should throw an exception when the file is not found.');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertContains(
+                $errorMessage,
+                $e->getMessage(),
+                'TemplateLocator exception should propagate the FileLocator exception message'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Improve the error message to include the error message from the File Locator which is more accurate : the File Locator might also look in some fallback folder(s) (i.e.  `%kernel.root_dir%/Resources`)
