### PR TITLE
Allow for the theming of specific fields within a collection type

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -207,6 +207,9 @@
 
 ### Form
 
+  * You can now theme all form fields of a collection type by referencing it as
+    `_collectionChildName_fieldName`, e.g.: `_author_firstName`
+
 #### BC Breaks in Form Types and Options
 
   * A third argument `$options` was added to the methods `buildView()` and

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -66,6 +66,19 @@ class CollectionType extends AbstractType
         if ($form->getConfig()->hasAttribute('prototype') && $view->getVar('prototype')->getVar('multipart')) {
             $view->setVar('multipart', true);
         }
+        
+        foreach($view as $rowName => $rowView) {
+            $rowTypes = $form->get($rowName)->getTypes();
+            $rowTypeName = end($rowTypes)->getName();
+
+            if ($rowView->getVar('compound')) {
+                foreach($rowView as $childName => $childView) {
+                    $types = $childView->getVar('types');
+                    $types[] = sprintf("_%s_%s", $rowTypeName, $childName);
+                    $childView->setVar('types', $types);
+                }
+            }
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -197,4 +197,15 @@ class CollectionTypeTest extends TypeTestCase
 
         $this->assertSame('__test__label__', $form->createView()->getVar('prototype')->getVar('label'));
     }
+    
+    public function testViewTypesAreCorrectlySet()
+    {
+        $form = $this->factory->create('collection', array(new \Symfony\Component\Form\Tests\Fixtures\Author()), array(
+            'type' => new \Symfony\Component\Form\Tests\Fixtures\AuthorType()
+        ));
+        
+        $view = $form->createView();
+        var_dump( $view->get(0)->get('firstName')->getVar('types'));
+        $this->assertContains('_author_firstName', $view->get(0)->get('firstName')->getVar('types'));
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

At this moment it is not possible to theme fields in a collection form using blocks, other than:

``` twig
{% _form_name_0_fieldname_widget %}
```

0 begin the row index.

This patch adds the name of the type within the collection type to the list of types which allows overriding:

``` twig
{% _nameofrowtype_fieldname_widget %}
```
