### PR TITLE
[Config][HttpKernel][Templating] 'scheme://' paths not detected as absolute

### DIFF
--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -89,6 +89,7 @@ class FileLocator implements FileLocatorInterface
                 && $file[1] == ':'
                 && ($file[2] == '\\' || $file[2] == '/')
             )
+            || null !== parse_url($file, PHP_URL_SCHEME)
         ) {
             return true;
         }

--- a/src/Symfony/Component/HttpKernel/Util/Filesystem.php
+++ b/src/Symfony/Component/HttpKernel/Util/Filesystem.php
@@ -256,6 +256,7 @@ class Filesystem
                 && $file[1] == ':'
                 && ($file[2] == '\\' || $file[2] == '/')
             )
+            || null !== parse_url($file, PHP_URL_SCHEME)
         ) {
             return true;
         }

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -115,6 +115,7 @@ class FilesystemLoader extends Loader
                 && $file[1] == ':'
                 && ($file[2] == '\\' || $file[2] == '/')
             )
+            || null !== parse_url($file, PHP_URL_SCHEME)
         ) {
             return true;
         }

--- a/tests/Symfony/Tests/Component/Config/FileLocatorTest.php
+++ b/tests/Symfony/Tests/Component/Config/FileLocatorTest.php
@@ -35,6 +35,8 @@ class FileLocatorTest extends \PHPUnit_Framework_TestCase
             array('c:\\\\foo.xml'),
             array('c:/foo.xml'),
             array('\\server\\foo.xml'),
+            array('https://server/foo.xml'),
+            array('phar://server/foo.xml'),
         );
     }
 

--- a/tests/Symfony/Tests/Component/Templating/Loader/FilesystemLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Templating/Loader/FilesystemLoaderTest.php
@@ -42,6 +42,8 @@ class FilesystemLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(ProjectTemplateLoader2::isAbsolutePath('c:\\\\foo.xml'), '->isAbsolutePath() returns true if the path is an absolute path');
         $this->assertTrue(ProjectTemplateLoader2::isAbsolutePath('c:/foo.xml'), '->isAbsolutePath() returns true if the path is an absolute path');
         $this->assertTrue(ProjectTemplateLoader2::isAbsolutePath('\\server\\foo.xml'), '->isAbsolutePath() returns true if the path is an absolute path');
+        $this->assertTrue(ProjectTemplateLoader2::isAbsolutePath('https://server/foo.xml'), '->isAbsolutePath() returns true if the path is an absolute path');
+        $this->assertTrue(ProjectTemplateLoader2::isAbsolutePath('phar://server/foo.xml'), '->isAbsolutePath() returns true if the path is an absolute path');
     }
 
     public function testLoad()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no (99%)
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

The method `isAbsolutePath` does not detect URL schemes as absolute. This makes imposible the use of wrappers to access remote files or the use of files (mostly configuration or templates) stored on phar archives (uses the scheme `phar://` in the path).

Three classes implement this methods: `Symfony\Component\Config\FileLocator`, `Symfony\Component\HttpKernel\Util\Filesystem` and `Symfony\Component\Templating\Loader\FilesytemLoader`. All are updated. Also includes a new check  on all related tests (`Symfony\Component\HttpKernel\Util\Filesystem` lacks of test).
