### PR TITLE
fix Process::run in windows, when php.exe resides within a folder with a space in it

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -106,7 +106,7 @@ class Process
 
         $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
 
-        $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
+        $process = proc_open(escapeshellarg($this->commandline), $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 
         if (!is_resource($process)) {
             throw new \RuntimeException('Unable to launch a new process.');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Todo: please verify that this doesn't break anything in other platforms!

I was getting the following error when running the Symfony2 tests:

1) Symfony\Tests\Component\BrowserKit\ClientTest::testInsulatedRequests
RuntimeException: OUTPUT:  ERROR OUTPUT: 'C:\Program' is not recognized as an internal or external command,
operable program or batch file.

D:\workspace9\Symfony\src\Symfony\Component\BrowserKit\Client.php:294
D:\workspace9\Symfony\src\Symfony\Component\BrowserKit\Client.php:260
D:\workspace9\Symfony\tests\Symfony\Tests\Component\BrowserKit\ClientTest.php:298

This PR fixes that
