### PR TITLE
fixed test which would fail because of mismatch in newlines used

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -95,7 +95,7 @@ class ClassCollectionLoader
 
             // add namespace declaration for global code
             if (!$r->inNamespace()) {
-                $c = "\nnamespace\n{\n".self::stripComments($c)."\n}\n";
+                $c = PHP_EOL."namespace".PHP_EOL."{".PHP_EOL.self::stripComments($c).PHP_EOL."}".PHP_EOL;
             } else {
                 $c = self::fixNamespaceDeclarations('<?php '.$c);
                 $c = preg_replace('/^\s*<\?php/', '', $c);
@@ -142,7 +142,7 @@ class ClassCollectionLoader
                 continue;
             } elseif (T_NAMESPACE === $token[0]) {
                 if ($inNamespace) {
-                    $output .= "}\n";
+                    $output .= "}".PHP_EOL;
                 }
                 $output .= $token[1];
 
@@ -154,7 +154,7 @@ class ClassCollectionLoader
                     $inNamespace = false;
                     --$i;
                 } else {
-                    $output .= "\n{";
+                    $output .= PHP_EOL."{";
                     $inNamespace = true;
                 }
             } else {
@@ -163,7 +163,7 @@ class ClassCollectionLoader
         }
 
         if ($inNamespace) {
-            $output .= "}\n";
+            $output .= "}".PHP_EOL;
         }
 
         return $output;
@@ -215,7 +215,7 @@ class ClassCollectionLoader
         }
 
         // replace multiple new lines with a single newline
-        $output = preg_replace(array('/\s+$/Sm', '/\n+/S'), "\n", $output);
+        $output = preg_replace(array('/\s+$/Sm', '/\n+/S'), PHP_EOL, $output);
 
         return $output;
     }

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -95,7 +95,7 @@ class ClassCollectionLoader
 
             // add namespace declaration for global code
             if (!$r->inNamespace()) {
-                $c = PHP_EOL."namespace".PHP_EOL."{".PHP_EOL.self::stripComments($c).PHP_EOL."}".PHP_EOL;
+                $c = "\nnamespace\n{\n".self::stripComments($c)."\n}\n";
             } else {
                 $c = self::fixNamespaceDeclarations('<?php '.$c);
                 $c = preg_replace('/^\s*<\?php/', '', $c);
@@ -142,7 +142,7 @@ class ClassCollectionLoader
                 continue;
             } elseif (T_NAMESPACE === $token[0]) {
                 if ($inNamespace) {
-                    $output .= "}".PHP_EOL;
+                    $output .= "}\n";
                 }
                 $output .= $token[1];
 
@@ -154,7 +154,7 @@ class ClassCollectionLoader
                     $inNamespace = false;
                     --$i;
                 } else {
-                    $output .= PHP_EOL."{";
+                    $output .= "\n{";
                     $inNamespace = true;
                 }
             } else {
@@ -163,7 +163,7 @@ class ClassCollectionLoader
         }
 
         if ($inNamespace) {
-            $output .= "}".PHP_EOL;
+            $output .= "}\n";
         }
 
         return $output;
@@ -215,7 +215,7 @@ class ClassCollectionLoader
         }
 
         // replace multiple new lines with a single newline
-        $output = preg_replace(array('/\s+$/Sm', '/\n+/S'), PHP_EOL, $output);
+        $output = preg_replace(array('/\s+$/Sm', '/\n+/S'), "\n", $output);
 
         return $output;
     }

--- a/tests/Symfony/Tests/Component/ClassLoader/ClassCollectionLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/ClassCollectionLoaderTest.php
@@ -17,49 +17,47 @@ class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
 {
     public function testFixNamespaceDeclarations()
     {
-        $source = <<<EOF
-<?php
+        $source = "<?php\n"
+            ."\n"
+            ."namespace Foo;\n"
+            ."class Foo {}\n"
+            ."namespace   Bar ;\n"
+            ."class Foo {}\n"
+            ."namespace Foo\Bar;\n"
+            ."class Foo {}\n"
+            ."namespace Foo\Bar\Bar\n"
+            ."{\n"
+            ."    class Foo {}\n"
+            ."}\n"
+            ."namespace\n"
+            ."{\n"
+            ."    class Foo {}\n"
+            ."}\n"
+        ;
 
-namespace Foo;
-class Foo {}
-namespace   Bar ;
-class Foo {}
-namespace Foo\Bar;
-class Foo {}
-namespace Foo\Bar\Bar
-{
-    class Foo {}
-}
-namespace
-{
-    class Foo {}
-}
-EOF;
-
-        $expected = <<<EOF
-<?php
-
-namespace Foo
-{
-class Foo {}
-}
-namespace   Bar 
-{
-class Foo {}
-}
-namespace Foo\Bar
-{
-class Foo {}
-}
-namespace Foo\Bar\Bar
-{
-    class Foo {}
-}
-namespace
-{
-    class Foo {}
-}
-EOF;
+        $expected = "<?php\n"
+            . "\n"
+            . "namespace Foo\n"
+            . "{\n"
+            . "class Foo {}\n"
+            . "}\n"
+            . "namespace   Bar \n"
+            . "{\n"
+            . "class Foo {}\n"
+            . "}\n"
+            . "namespace Foo\\Bar\n"
+            . "{\n"
+            . "class Foo {}\n"
+            . "}\n"
+            . "namespace Foo\\Bar\\Bar\n"
+            . "{\n"
+            . "    class Foo {}\n"
+            . "}\n"
+            . "namespace\n"
+            . "{\n"
+            . "    class Foo {}\n"
+            . "}\n"
+        ;
 
         $this->assertEquals($expected, ClassCollectionLoader::fixNamespaceDeclarations($source));
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

the class loader uses "\n", which resulted in a failing test for me, because my OS uses "\r\n"
