### PR TITLE
fix Process::run in windows, when php.exe resides within a folder with a space in it

### DIFF
--- a/src/Symfony/Component/Process/PhpProcess.php
+++ b/src/Symfony/Component/Process/PhpProcess.php
@@ -70,7 +70,7 @@ class PhpProcess extends Process
             if (false === $php = $this->executableFinder->find()) {
                 throw new \RuntimeException('Unable to find the PHP executable.');
             }
-            $this->setCommandLine($php);
+            $this->setCommandLine(escapeshellarg($php));
         }
 
         return parent::run($callback);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Todo: please verify that this doesn't break anything in other platforms!

I was getting the following error when running the Symfony2 tests:

1) Symfony\Tests\Component\BrowserKit\ClientTest::testInsulatedRequests
RuntimeException: OUTPUT: ERROR OUTPUT: 'C:\Program' is not recognized as an internal or external command,
operable program or batch file.

D:\workspace9\Symfony\src\Symfony\Component\BrowserKit\Client.php:294
D:\workspace9\Symfony\src\Symfony\Component\BrowserKit\Client.php:260
D:\workspace9\Symfony\tests\Symfony\Tests\Component\BrowserKit\ClientTest.php:298

This PR fixes that
