### PR TITLE
[DependencyInjection] Made the reference case insensitive

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Reference.php
+++ b/src/Symfony/Component/DependencyInjection/Reference.php
@@ -35,7 +35,7 @@ class Reference
      */
     public function __construct($id, $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $strict = true)
     {
-        $this->id = $id;
+        $this->id = strtolower($id);
         $this->invalidBehavior = $invalidBehavior;
         $this->strict = $strict;
     }

--- a/tests/Symfony/Tests/Component/DependencyInjection/ReferenceTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ReferenceTest.php
@@ -23,4 +23,10 @@ class ReferenceTest extends \PHPUnit_Framework_TestCase
         $ref = new Reference('foo');
         $this->assertEquals('foo', (string) $ref, '__construct() sets the id of the reference, which is used for the __toString() method');
     }
+
+    public function testCaseInsensitive()
+    {
+        $ref = new Reference('FooBar');
+        $this->assertEquals('foobar', (string) $ref, 'the id is lowercased as the container is case insensitive');
+    }
 }


### PR DESCRIPTION
The container is case insensitive so using capital letters in a reference
made it fail in some cases when checking the dependencies.
Closes #2807

Replaces #2811 by targeting the good branch
