### PR TITLE
[Security] added SecurityContextInterface::getUser()

### DIFF
--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -89,4 +89,18 @@ class SecurityContext implements SecurityContextInterface
     {
         $this->token = $token;
     }
+
+    /**
+     * Returns the current user, if one exists.
+     *
+     * @return mixed Returns either an object which implements __toString(),
+     *               or a primitive string if there is a token, otherwise
+     *               returns null.
+     */
+    public function getUser()
+    {
+        if ($this->token) {
+            return $this->token->getUser();
+        }
+    }
 }

--- a/src/Symfony/Component/Security/Core/SecurityContextInterface.php
+++ b/src/Symfony/Component/Security/Core/SecurityContextInterface.php
@@ -39,6 +39,15 @@ interface SecurityContextInterface
     function setToken(TokenInterface $token = null);
 
     /**
+     * Returns the current user, if one exists.
+     *
+     * @return mixed Returns either an object which implements __toString(),
+     *               or a primitive string if there is a token, otherwise
+     *               returns null.
+     */
+    function getUser();
+
+    /**
      * Checks if the attributes are granted against the current authentication token and optionally supplied object.
      *
      * @param array $attributes

--- a/tests/Symfony/Tests/Component/Security/Core/SecurityContextTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/SecurityContextTest.php
@@ -89,4 +89,22 @@ class SecurityContextTest extends \PHPUnit_Framework_TestCase
         $context->setToken($token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
         $this->assertSame($token, $context->getToken());
     }
+
+    public function testGetUser()
+    {
+        $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $token->expects($this->once())
+            ->method('getUser')
+            ->will($this->returnValue('foo'));
+
+        $context = new SecurityContext(
+            $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface'),
+            $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface')
+        );
+
+        $this->assertNull($context->getUser(), '->getUser() returns null when there is no token');
+
+        $context->setToken($token);
+        $this->assertEquals('foo', $context->getUser(), '->getUser() return the token user');
+    }
 }


### PR DESCRIPTION
This changes helps the common use case of fetching the current user and better complies with the [Law of Demeter](http://en.wikipedia.org/wiki/Law_of_Demeter).

Before (still works):

```
$token = $context->getToken();
$user = $token ? $token->getUser() : null;
```

After:

```
$user = $context->getUser();
```

The fine print:

```
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
```
