### PR TITLE
[DependencyInjection] [XmlDumper] fixed filepath not escaping html entities

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -140,7 +140,7 @@ class XmlDumper extends Dumper
         }
 
         if ($definition->getFile()) {
-            $file = $this->document->createElement('file', $definition->getFile());
+            $file = $this->document->createElement('file', htmlentities($definition->getFile()));
             $service->appendChild($file);
         }
 


### PR DESCRIPTION
Bug fix: Yes
Feature addition: No
Backwards compatibility break: No
Symfony2 tests pass: Yes

The file path is not escaped when writing the XML document.

Error received:

```
[ErrorException]
Warning: DOMDocument::createElement(): unterminated entity reference  Mrs Joyce\Atticus\app/../vendor/facebook/src/base_facebook.php in D:\Development\Projects\Mr & Mrs Joyce\Atticus\vendor\symfony\src\Symfony\Component\DependencyInjection\Dumper\XmlDumper.php line 145
```
