### PR TITLE
[SecurityBundle] fix service class by adding a parameter, on twig extension

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_twig.xml
@@ -4,8 +4,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
+    <parameters>
+        <parameter key="twig.extension.security.class">Symfony\Bundle\SecurityBundle\Twig\Extension\SecurityExtension</parameter>
+    </parameters>
     <services>
-        <service id="twig.extension.security" class="Symfony\Bundle\SecurityBundle\Twig\Extension\SecurityExtension" public="false">
+        <service id="twig.extension.security" class="%twig.extension.security.class%" public="false">
             <tag name="twig.extension" />
             <argument type="service" id="security.context" on-invalid="ignore" />
         </service>


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

To override the is_granted twig function, the class of TwigExtension is now set in a parameter.
