### PR TITLE
fixed failing test in windows

### DIFF
--- a/tests/Symfony/Tests/Component/Process/PhpExecutableFinderTest.php
+++ b/tests/Symfony/Tests/Component/Process/PhpExecutableFinderTest.php
@@ -48,8 +48,9 @@ class PhpExecutableFinderTest extends \PHPUnit_Framework_TestCase
         $current = $f->find();
 
         //TODO maybe php executable is custom or even windows
-        if (false !== strstr(PHP_OS, 'WIN')) {
-            $this->assertEquals($current, PHP_BINDIR.DIRECTORY_SEPARATOR.'php', '::find() returns the executable php with suffixes');
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->assertTrue(is_executable($current));
+            $this->assertTrue((bool)preg_match('/'.addSlashes(DIRECTORY_SEPARATOR).'php\.(exe|bat|cmd|com)$/i', $current), '::find() returns the executable php with suffixes');
         }
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

fixed failing test in windows because

1) PHP_BINDIR is not secure to rely on
2) the assertion doesn't actually check for the suffix as the test implies
