### PR TITLE
[DoctrineBridge] fixed the refreshing of the user for invalid users

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -75,7 +75,6 @@ class EntityUserProvider implements UserProviderInterface
         if (!$user instanceof $this->class) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
         }
-        
 
         // The user must be reloaded via the primary key as all other data
         // might have changed without proper persistence in the database.
@@ -89,7 +88,11 @@ class EntityUserProvider implements UserProviderInterface
             );
         }
 
-        return $this->repository->find($id);
+        if (null === $refreshedUser = $this->repository->find($id)) {
+            throw new UsernameNotFoundException(sprintf('User with id %s not found', json_encode($id)));
+        }
+
+        return $refreshedUser;
     }
 
     /**

--- a/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
@@ -40,19 +40,39 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
 
         $this->assertSame($user1, $provider->refreshUser($user1));
     }
-    
+
     public function testRefreshUserRequiresId()
     {
         $em = $this->createTestEntityManager();
-        
+
         $user1 = new CompositeIdentEntity(null, null, 'user1');
         $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
-        
+
         $this->setExpectedException(
             'InvalidArgumentException',
             'You cannot refresh a user from the EntityUserProvider that does not contain an identifier. The user object has to be serialized with its own identifier mapped by Doctrine'
         );
         $provider->refreshUser($user1);
+    }
+
+    public function testRefreshInvalidUser()
+    {
+        $em = $this->createTestEntityManager();
+        $this->createSchema($em);
+
+        $user1 = new CompositeIdentEntity(1, 1, 'user1');
+
+        $em->persist($user1);
+        $em->flush();
+
+        $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
+
+        $user2 = new CompositeIdentEntity(1, 2, 'user2');
+        $this->setExpectedException(
+            'Symfony\Component\Security\Core\Exception\UsernameNotFoundException',
+            'User with id {"id1":1,"id2":2} not found'
+        );
+        $provider->refreshUser($user2);
     }
 
     private function createSchema($em)


### PR DESCRIPTION
A user provider is not allowed to return `null` when the user is not found.

This bug is the reason why #2845 has been submitted
