### PR TITLE
Use of self:: on private field

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -315,11 +315,11 @@ class Route
 
         $class = $this->getOption('compiler_class');
 
-        if (!isset(static::$compilers[$class])) {
-            static::$compilers[$class] = new $class;
+        if (!isset(self::$compilers[$class])) {
+            self::$compilers[$class] = new $class;
         }
 
-        return $this->compiled = static::$compilers[$class]->compile($this);
+        return $this->compiled = self::$compilers[$class]->compile($this);
     }
 
     private function sanitizeRequirement($key, $regex)


### PR DESCRIPTION
static::$privateField is an OOP non-sense (extending the class is not possible)
