### PR TITLE
[TwigBundle] Ensure base Filesystem loader paths are initialised

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -33,6 +33,8 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
      */
     public function __construct(FileLocatorInterface $locator, TemplateNameParserInterface $parser)
     {
+        parent::__construct(array());
+
         $this->locator = $locator;
         $this->parser = $parser;
         $this->cache = array();


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: #2817

Originated from #2817.
