### PR TITLE
[WebProfilerBundle] fixed and adjusted HTML5 markup

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -20,8 +20,7 @@
     {% endif %}
 
     {% set icon %}
-        <img width="21" height="28" alt="Environment" style="border-width: 0; vertical-align: middle; margin-right: 5px;" src="data:image/png;base64,
-        iVBORw0KGgoAAAANSUhEUgAAABUAAAAcCAYAAACOGPReAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAZNJREFUeNpi/P//PwO1ARMDDcCooWDA4+npeRiEQWw0NTweHh4nQZhYORYoLf39+3cbGBuIbyJplPnx44cZjA3ENwjJwQzljoqKOghjo7lGBAcbBLiA+g7B2DBBRqCXj3/79s0CRSUX14lt27a5AplfgNgBCPaDxA8cOOAIokBe9fLy2o1LHxO6BAhAxWTwxIUMPn0seDTCvPotLi7uJIyNIxhQ9OEzVADoRZSgWbRo0UmoF1vx6GPBl06l8XhRmtzEL0KmHF5DWcmUo1E21dLSeo0uCBX7jUffb3z6GIGFdC2QYXPp0iVw4Ovp6T0FUkeA+BUw0c/AZiIwE2QAKTEc+laBktQqIL6al5e3FqqhDsQHYhU8Ln0CzVnY9D1hghYeD5E0PISKfcDjxQ949H2FJX5eJEkY+820adMm4/DiGzz6GFgIeBFX0DzBF/swQ/8oKCi8h7Gh9FeodzikpKSeQ8XuopW12PQxMEKraE0gDoSKrQfi60gaSZaDGQqqCiShks+h5Si8yiBVjnFkNyYAAgwAQGPBFLF65f4AAAAASUVORK5CYII="/>
+        <img width="21" height="28" alt="Environment" style="border-width: 0; vertical-align: middle; margin-right: 5px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAcCAYAAACOGPReAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAZNJREFUeNpi/P//PwO1ARMDDcCooWDA4+npeRiEQWw0NTweHh4nQZhYORYoLf39+3cbGBuIbyJplPnx44cZjA3ENwjJwQzljoqKOghjo7lGBAcbBLiA+g7B2DBBRqCXj3/79s0CRSUX14lt27a5AplfgNgBCPaDxA8cOOAIokBe9fLy2o1LHxO6BAhAxWTwxIUMPn0seDTCvPotLi7uJIyNIxhQ9OEzVADoRZSgWbRo0UmoF1vx6GPBl06l8XhRmtzEL0KmHF5DWcmUo1E21dLSeo0uCBX7jUffb3z6GIGFdC2QYXPp0iVw4Ovp6T0FUkeA+BUw0c/AZiIwE2QAKTEc+laBktQqIL6al5e3FqqhDsQHYhU8Ln0CzVnY9D1hghYeD5E0PISKfcDjxQ949H2FJX5eJEkY+820adMm4/DiGzz6GFgIeBFX0DzBF/swQ/8oKCi8h7Gh9FeodzikpKSeQ8XuopW12PQxMEKraE0gDoSKrQfi60gaSZaDGQqqCiShks+h5Si8yiBVjnFkNyYAAgwAQGPBFLF65f4AAAAASUVORK5CYII="/>
     {% endset %}
     {% set text %}
         {% spaceless %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -1,7 +1,7 @@
 {% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
 
 {% block head %}
-    <link href="{{ asset('bundles/framework/css/exception.css') }}" rel="stylesheet" type="text/css" media="screen" />
+    <link rel="stylesheet" href="{{ asset('bundles/framework/css/exception.css') }}" />
     {{ parent() }}
 {% endblock %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -77,15 +77,13 @@
 
     <h2>Request Content</h2>
 
-    <p>
-        {% if collector.content == false %}
-            <em>Request content not available (it was retrieved as a resource).</em>
-        {% elseif collector.content %}
-            <pre>{{ collector.content }}</pre>
-        {% else %}
-            <em>No content</em>
-        {% endif %}
-    </p>
+    {% if collector.content == false %}
+        <p><em>Request content not available (it was retrieved as a resource).</em></p>
+    {% elseif collector.content %}
+        <pre>{{ collector.content }}</pre>
+    {% else %}
+        <p><em>No content</em></p>
+    {% endif %}
 
     <h2>Request Server Parameters</h2>
 
@@ -99,17 +97,21 @@
 
     {% if collector.sessionattributes|length %}
         <table>
-            <tr>
-                <th>Key</th>
-                <th>Value</th>
-            </tr>
-            {% set attributes = collector.sessionattributes %}
-            {% for key in attributes|keys|sort %}
+            <thead>
                 <tr>
-                    <th>{{ key }}</th>
-                    <td>{{ attributes[key]|yaml_dump }}</td>
+                    <th scope="col">Key</th>
+                    <th scope="col">Value</th>
                 </tr>
-            {% endfor %}
+            </thead>
+            <tbody>
+                {% set attributes = collector.sessionattributes %}
+                {% for key in attributes|keys|sort %}
+                    <tr>
+                        <th>{{ key }}</th>
+                        <td>{{ attributes[key]|yaml_dump }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
         </table>
     {% else %}
         <p>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
@@ -1,12 +1,16 @@
 <table>
+<thead>
     <tr>
-        <th>Key</th>
-        <th>Value</th>
+        <th scope="col">Key</th>
+        <th scope="col">Value</th>
     </tr>
+</thead>
+<tbody>
     {% for key in bag.keys|sort %}
         <tr>
             <th>{{ key }}</th>
             <td>{{ bag.get(key)|yaml_dump }}</td>
         </tr>
     {% endfor %}
+</tbody>
 </table>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base.html.twig
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta charset="UTF-8" />
         <meta name="robots" content="noindex,nofollow" />
         <title>{% block title 'Profiler' %}</title>
-        <link rel="shortcut icon" type="image/x-icon" href="{{ asset('bundles/webprofiler/favicon.ico') }}" />
+        <link rel="icon" type="image/x-icon" sizes="16x16" href="{{ asset('bundles/webprofiler/favicon.ico') }}" />
         {% block head %}
-            <link href="{{ asset('bundles/webprofiler/css/toolbar.css') }}" rel="stylesheet" type="text/css" media="screen" />
-            <link href="{{ asset('bundles/webprofiler/css/profiler.css') }}" rel="stylesheet" type="text/css" media="screen" />
+            <link rel="stylesheet" href="{{ asset('bundles/webprofiler/css/toolbar.css') }}"  />
+            <link rel="stylesheet" href="{{ asset('bundles/webprofiler/css/profiler.css') }}" />
         {% endblock %}
     </head>
     <body>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/results.html.twig
@@ -5,20 +5,24 @@
 
     {% if tokens %}
         <table>
-            <tr>
-                <th>Token</th>
-                <th>IP</th>
-                <th>URL</th>
-                <th>Time</th>
-            </tr>
-            {% for elements in tokens %}
+            <thead>
                 <tr>
-                    <td><a href="{{ path('_profiler', { 'token': elements.token }) }}">{{ elements.token }}</a></td>
-                    <td>{{ elements.ip }}</td>
-                    <td>{{ elements.url }}</td>
-                    <td>{{ elements.time|date('r') }}</td>
+                    <th scope="col">Token</th>
+                    <th scope="col">IP</th>
+                    <th scope="col">URL</th>
+                    <th scope="col">Time</th>
                 </tr>
-            {% endfor %}
+            </thead>
+            <tbody>
+                {% for elements in tokens %}
+                    <tr>
+                        <td><a href="{{ path('_profiler', { 'token': elements.token }) }}">{{ elements.token }}</a></td>
+                        <td>{{ elements.ip }}</td>
+                        <td>{{ elements.url }}</td>
+                        <td>{{ elements.time|date('r') }}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
         </table>
     {% else %}
         <p>


### PR DESCRIPTION
I corrected some markup errors that I found when validating the pages of the WebProfilerBundle.
Along the way I also improved the semantic structure of HTML5 like table header and body, lang attribute.
Removed type="text/css" that is the default with rel="stylesheet". Also no need for media="screen"!? Otherwise style does not apply when debugging with handheld device or when printing.
