### PR TITLE
[Cache][2.1] Added cache clear hook

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -64,6 +64,8 @@ EOF
         $kernel = $this->getContainer()->get('kernel');
         $output->writeln(sprintf('Clearing the cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
 
+        $this->getContainer()->get('cache_clearer')->clear($realCacheDir);
+
         if ($input->getOption('no-warmup')) {
             rename($realCacheDir, $oldCacheDir);
         } else {
@@ -168,3 +170,4 @@ EOF;
         return new $class($parent->getEnvironment(), $parent->isDebug());
     }
 }
+

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -170,4 +170,3 @@ EOF;
         return new $class($parent->getEnvironment(), $parent->isDebug());
     }
 }
-

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheClearerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheClearerPass.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+/**
+ * Registers the cache clearers.
+ *
+ * @author Dustin Dobervich <ddobervich@gmail.com>
+ */
+class AddCacheClearerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasDefinition('cache_clearer')) {
+            return;
+        }
+
+        $clearers = array();
+        foreach ($container->findTaggedServiceIds('kernel.cache_clearer') as $id => $attributes) {
+            $clearers[] = new Reference($id);
+        }
+
+        $container->getDefinition('cache_clearer')->replaceArgument(0, $clearers);
+    }
+}
+

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheClearerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheClearerPass.php
@@ -39,4 +39,3 @@ class AddCacheClearerPass implements CompilerPassInterface
         $container->getDefinition('cache_clearer')->replaceArgument(0, $clearers);
     }
 }
-

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RoutingResolverP
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ProfilerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslatorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheWarmerPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheClearerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilderDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CompilerDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationExtractorPass;
@@ -59,6 +60,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new FormPass());
         $container->addCompilerPass(new TranslatorPass());
         $container->addCompilerPass(new AddCacheWarmerPass());
+        $container->addCompilerPass(new AddCacheClearerPass());
         $container->addCompilerPass(new TranslationExtractorPass());
         $container->addCompilerPass(new TranslationDumperPass());
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -9,6 +9,7 @@
         <parameter key="http_kernel.class">Symfony\Bundle\FrameworkBundle\HttpKernel</parameter>
         <parameter key="filesystem.class">Symfony\Component\HttpKernel\Util\Filesystem</parameter>
         <parameter key="cache_warmer.class">Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate</parameter>
+        <parameter key="cache_clearer.class">Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer</parameter>
         <parameter key="file_locator.class">Symfony\Component\HttpKernel\Config\FileLocator</parameter>
     </parameters>
 
@@ -24,6 +25,10 @@
         </service>
 
         <service id="cache_warmer" class="%cache_warmer.class%">
+            <argument type="collection" />
+        </service>
+
+        <service id="cache_clearer" class="%cache_clearer.class%">
             <argument type="collection" />
         </service>
 

--- a/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php
+++ b/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\CacheClearer;
+
+/**
+ * CacheClearerInterface.
+ * 
+ * @author Dustin Dobervich <ddobervich@gmail.com>
+ */
+interface CacheClearerInterface
+{
+    /**
+     * Clears any caches necessary.
+     *
+     * @param string $cacheDir The cache directory.
+     */
+    function clear($cacheDir);
+}
+

--- a/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php
+++ b/src/Symfony/Component/HttpKernel/CacheClearer/CacheClearerInterface.php
@@ -25,4 +25,3 @@ interface CacheClearerInterface
      */
     function clear($cacheDir);
 }
-

--- a/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php
+++ b/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\CacheClearer;
+
+/**
+ * ChainCacheClearer.
+ * 
+ * @author Dustin Dobervich <ddobervich@gmail.com>
+ */
+class ChainCacheClearer implements CacheClearerInterface
+{
+    /**
+     * @var array $clearers
+     */
+    protected $clearers;
+
+    /**
+     * Constructs a new instance of ChainCacheClearer.
+     *
+     * @param array $clearers The initial clearers.
+     */
+    public function __construct(array $clearers = array())
+    {
+        $this->clearers = $clearers;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function clear($cacheDir)
+    {
+        foreach ($this->clearers as $clearer) {
+            $clearer->clear($cacheDir);
+        }
+    }
+    
+    /**
+     * Adds a cache clearer to the aggregate.
+     * 
+     * @param CacheClearerInterface $clearer 
+     */
+    public function add(CacheClearerInterface $clearer)
+    {
+        $this->clearers[] = $clearer;
+    }
+}
+

--- a/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php
+++ b/src/Symfony/Component/HttpKernel/CacheClearer/ChainCacheClearer.php
@@ -53,4 +53,3 @@ class ChainCacheClearer implements CacheClearerInterface
         $this->clearers[] = $clearer;
     }
 }
-

--- a/tests/Symfony/Tests/Component/HttpKernel/CacheClearer/ChainCacheClearerTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/CacheClearer/ChainCacheClearerTest.php
@@ -56,4 +56,3 @@ class ChainCacheClearerTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface');
     }
 }
-

--- a/tests/Symfony/Tests/Component/HttpKernel/CacheClearer/ChainCacheClearerTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/CacheClearer/ChainCacheClearerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpKernel\CacheClearer;
+
+use Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface;
+use Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer;
+
+class ChainCacheClearerTest extends \PHPUnit_Framework_TestCase
+{
+    protected static $cacheDir;
+
+    public static function setUpBeforeClass()
+    {
+        self::$cacheDir = tempnam(sys_get_temp_dir(), 'sf2_cache_clearer_dir');
+    }
+
+    public static function tearDownAfterClass()
+    {
+        @unlink(self::$cacheDir);
+    }
+
+    public function testInjectClearersInConstructor()
+    {
+        $clearer = $this->getMockClearer();
+        $clearer
+            ->expects($this->once())
+            ->method('clear');
+        
+        $chainClearer = new ChainCacheClearer(array($clearer));
+        $chainClearer->clear(self::$cacheDir);
+    }
+    
+    public function testInjectClearerUsingAdd()
+    {
+        $clearer = $this->getMockClearer();
+        $clearer
+            ->expects($this->once())
+            ->method('clear');
+        
+        $chainClearer = new ChainCacheClearer();
+        $chainClearer->add($clearer);
+        $chainClearer->clear(self::$cacheDir);
+    }
+    
+    protected function getMockClearer()
+    {
+        return $this->getMock('Symfony\Component\HttpKernel\CacheClearer\CacheClearerInterface');
+    }
+}
+


### PR DESCRIPTION
Allows bundles to hook into the `cache:clear` command by using the `kernel.cache_clearer` tag instead of using the `event_dispatcher` service.

See #1884

Bug fix: No
Feature addition: Yes
Backwards compatibility break: No
Symfony2 tests pass: Yes
Fixes the following tickets: #1884
References the following tickets: #1884
