### PR TITLE
Add exception on wrong type

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -225,8 +225,10 @@ class FormFactory implements FormFactoryInterface
                 }
 
                 $this->addType($type);
-            } else {
+            } elseif (is_string($type)) {
                 $type = $this->getType($type);
+            } else {
+                throw new UnexpectedTypeException($type, 'string or Symfony\Component\Form\FormTypeInterface');
             }
 
             $defaultOptions = $type->getDefaultOptions($options);

--- a/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
@@ -320,6 +320,15 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->factory->hasType('foo'));
     }
 
+    /**
+     * @expectedException        Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @expectedExceptionMessage Expected argument of type "string or Symfony\Component\Form\FormTypeInterface", "stdClass" given
+     */
+    public function testCreateNamedBuilderThrowsUnderstandableException()
+    {
+        $this->factory->createNamedBuilder(new \StdClass, 'name');
+    }
+
     public function testCreateUsesTypeNameAsName()
     {
         $type = new FooType();


### PR DESCRIPTION
When you forget to extend AbstractType in your form type, and then try to create a named builder from it, the error message is quite confusing:

Expected argument of type "string", "Samson\InvoiceBundle\Form\Type\PaymentTermsType" given (from the getType() method)

This PR checks for the right type at the relevant place
