### PR TITLE
[Doctrine][Bridge] EntityType: Allow empty result; default `choices` value changed to null

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -81,7 +81,7 @@ class EntityChoiceList extends ArrayChoiceList
 
     private $propertyPath;
 
-    public function __construct(EntityManager $em, $class, $property = null, $queryBuilder = null, $choices = array())
+    public function __construct(EntityManager $em, $class, $property = null, $queryBuilder = null, $choices = null)
     {
         // If a query builder was passed, it must be a closure or QueryBuilder
         // instance
@@ -109,7 +109,11 @@ class EntityChoiceList extends ArrayChoiceList
             $this->propertyPath = new PropertyPath($property);
         }
 
-        parent::__construct($choices);
+        if (!is_array($choices) && !$choices instanceof \Closure && !is_null($choices)) {
+            throw new UnexpectedTypeException($choices, 'array or \Closure or null');
+        }
+
+        $this->choices = $choices;
     }
 
     /**
@@ -127,7 +131,7 @@ class EntityChoiceList extends ArrayChoiceList
     {
         parent::load();
 
-        if ($this->choices) {
+        if (is_array($this->choices)) {
             $entities = $this->choices;
         } else if ($qb = $this->queryBuilder) {
             $entities = $qb->getQuery()->execute();

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -48,7 +48,7 @@ class EntityType extends AbstractType
             'class'             => null,
             'property'          => null,
             'query_builder'     => null,
-            'choices'           => array(),
+            'choices'           => null,
         );
 
         $options = array_replace($defaultOptions, $options);

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -88,6 +88,26 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
         $this->assertSame(array(1 => 'Foo', 2 => 'Bar'), $choiceList->getChoices());
     }
 
+    public function testEmptyChoicesAreManaged()
+    {
+        $entity1 = new SingleIdentEntity(1, 'Foo');
+        $entity2 = new SingleIdentEntity(2, 'Bar');
+
+        // Persist for managed state
+        $this->em->persist($entity1);
+        $this->em->persist($entity2);
+
+        $choiceList = new EntityChoiceList(
+            $this->em,
+            self::SINGLE_IDENT_CLASS,
+            'name',
+            null,
+            array()
+        );
+
+        $this->assertSame(array(), $choiceList->getChoices());
+    }
+
     public function testNestedChoicesAreManaged()
     {
         $entity1 = new SingleIdentEntity(1, 'Foo');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
References the following tickets: #2504
- added _testEmptyChoicesAreManaged_ test
- `null` as default value for choices.
-  is_array() used to test if choices are user-defined.
- `null` as default value in __construct too.
- `null` as default value for choices in EntityType.

I squashed commits from PR #2504 as requested.
