### PR TITLE
Failing Test for primed cache with Region Locale

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Bundle\FrameworkBundle\Tests\Translation;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\HttpKernel\Util\Filesystem;
-use Symfony\Component\Translation\MessageSelector;
 
 class TranslatorTest extends \PHPUnit_Framework_TestCase
 {
@@ -45,12 +44,21 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $translator = $this->getTranslator($this->getLoader());
         $translator->setLocale('fr');
-        $translator->setFallbackLocale(array('en', 'es'));
+        $translator->setFallbackLocale('en');
 
         $this->assertEquals('foo (FR)', $translator->trans('foo'));
         $this->assertEquals('bar (EN)', $translator->trans('bar'));
-        $this->assertEquals('foobar (ES)', $translator->trans('foobar'));
-        $this->assertEquals('choice 0 (EN)', $translator->transChoice('choice', 0));
+        $this->assertEquals('no translation', $translator->trans('no translation'));
+    }
+
+    public function testRegionTransWithoutCaching()
+    {
+        $translator = $this->getTranslator($this->getLoader());
+        $translator->setLocale('fr_FR');
+        $translator->setFallbackLocale('en');
+
+        $this->assertEquals('foo (FR)', $translator->trans('foo'));
+        $this->assertEquals('bar (EN)', $translator->trans('bar'));
         $this->assertEquals('no translation', $translator->trans('no translation'));
     }
 
@@ -59,24 +67,42 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         // prime the cache
         $translator = $this->getTranslator($this->getLoader(), array('cache_dir' => $this->tmpDir));
         $translator->setLocale('fr');
-        $translator->setFallbackLocale(array('en', 'es'));
+        $translator->setFallbackLocale('en');
 
         $this->assertEquals('foo (FR)', $translator->trans('foo'));
         $this->assertEquals('bar (EN)', $translator->trans('bar'));
-        $this->assertEquals('foobar (ES)', $translator->trans('foobar'));
-        $this->assertEquals('choice 0 (EN)', $translator->transChoice('choice', 0));
         $this->assertEquals('no translation', $translator->trans('no translation'));
 
         // do it another time as the cache is primed now
         $loader = $this->getMock('Symfony\Component\Translation\Loader\LoaderInterface');
         $translator = $this->getTranslator($loader, array('cache_dir' => $this->tmpDir));
         $translator->setLocale('fr');
-        $translator->setFallbackLocale(array('en', 'es'));
+        $translator->setFallbackLocale('en');
 
         $this->assertEquals('foo (FR)', $translator->trans('foo'));
         $this->assertEquals('bar (EN)', $translator->trans('bar'));
-        $this->assertEquals('foobar (ES)', $translator->trans('foobar'));
-        $this->assertEquals('choice 0 (EN)', $translator->transChoice('choice', 0));
+        $this->assertEquals('no translation', $translator->trans('no translation'));
+    }
+
+    public function testRegionTransWithCaching()
+    {
+        // prime the cache
+        $translator = $this->getTranslator($this->getLoader(), array('cache_dir' => $this->tmpDir));
+        $translator->setLocale('fr_FR');
+        $translator->setFallbackLocale('en');
+
+        $this->assertEquals('foo (FR)', $translator->trans('foo'));
+        $this->assertEquals('bar (EN)', $translator->trans('bar'));
+        $this->assertEquals('no translation', $translator->trans('no translation'));
+
+        // do it another time as the cache is primed now
+        $loader     = $this->getMock('Symfony\Component\Translation\Loader\LoaderInterface');
+        $translator = $this->getTranslator($loader, array('cache_dir' => $this->tmpDir));
+        $translator->setLocale('fr_FR');
+        $translator->setFallbackLocale('en');
+
+        $this->assertEquals('foo (FR)', $translator->trans('foo'));
+        $this->assertEquals('bar (EN)', $translator->trans('bar'));
         $this->assertEquals('no translation', $translator->trans('no translation'));
     }
 
@@ -96,25 +122,12 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $loader
             ->expects($this->at(0))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('fr', array(
-                'foo' => 'foo (FR)',
-            ))))
+            ->will($this->returnValue($this->getCatalogue('fr', array('foo' => 'foo (FR)'))))
         ;
         $loader
             ->expects($this->at(1))
             ->method('load')
-            ->will($this->returnValue($this->getCatalogue('en', array(
-                'foo'    => 'foo (EN)',
-                'bar'    => 'bar (EN)',
-                'choice' => '{0} choice 0 (EN)|{1} choice 1 (EN)|]1,Inf] choice inf (EN)',
-            ))))
-        ;
-        $loader
-            ->expects($this->at(2))
-            ->method('load')
-            ->will($this->returnValue($this->getCatalogue('es', array(
-                'foobar' => 'foobar (ES)',
-            ))))
+            ->will($this->returnValue($this->getCatalogue('en', array('foo' => 'foo (EN)', 'bar' => 'bar (EN)'))))
         ;
 
         return $loader;
@@ -136,14 +149,13 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $translator = new Translator(
             $this->getContainer($loader),
-            new MessageSelector(),
-            array('loader' => array('loader')),
+            $this->getMock('Symfony\Component\Translation\MessageSelector'),
+            array('loader' => 'loader'),
             $options
         );
 
         $translator->addResource('loader', 'foo', 'fr');
         $translator->addResource('loader', 'foo', 'en');
-        $translator->addResource('loader', 'foo', 'es');
 
         return $translator;
     }


### PR DESCRIPTION
testRegionTransWithCaching fails when cache is primed (seems like the config fallback locale isn't written to the cache)
