### PR TITLE
[Console] [Doctrine] Fixed: Entities are generated in wrong folder (doctrine:generate:entities Namespace)

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -113,7 +113,12 @@ EOT
                 $output->writeln(sprintf('  > backing up <comment>%s.php</comment> to <comment>%s.php~</comment>', $basename, $basename));
             }
             // Getting the metadata for the entity class once more to get the correct path if the namespace has multiple occurrences
-            $entityMetadata = $manager->getClassMetadata($m->getName(), $input->getOption('path'));
+            try {
+                $entityMetadata = $manager->getClassMetadata($m->getName(), $input->getOption('path'));
+            } catch(\RuntimeException $e) {
+                // fall back to the bundle metadata when no entity class could be found
+                $entityMetadata = $metadata;
+            }
 
             $output->writeln(sprintf('  > generating <comment>%s</comment>', $m->name));
             $generator->generate(array($m), $entityMetadata->getPath());

--- a/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Command/GenerateEntitiesDoctrineCommand.php
@@ -115,7 +115,7 @@ EOT
             // Getting the metadata for the entity class once more to get the correct path if the namespace has multiple occurrences
             try {
                 $entityMetadata = $manager->getClassMetadata($m->getName(), $input->getOption('path'));
-            } catch(\RuntimeException $e) {
+            } catch (\RuntimeException $e) {
                 // fall back to the bundle metadata when no entity class could be found
                 $entityMetadata = $metadata;
             }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no
Fixes the following tickets: 2688
Todo: -

See PR 2746 for the description of the bug.

Bug-description:
Running the command "$php app/console doctrine:generate:entities [bundle name]" from the commandline throws an exception when the entities do not exist yet. Because metadata of the entity class could not be retrieved.

Bugfix:-description:
Fall back to bundle metadata when no entity metadata could not be retrieved.
