### PR TITLE
[Console] Improve input definition output for Boolean defaults

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -426,7 +426,7 @@ class InputDefinition
             $text[] = '<comment>Arguments:</comment>';
             foreach ($this->getArguments() as $argument) {
                 if (null !== $argument->getDefault() && (!is_array($argument->getDefault()) || count($argument->getDefault()))) {
-                    $default = sprintf('<comment> (default: %s)</comment>', is_array($argument->getDefault()) ? str_replace("\n", '', var_export($argument->getDefault(), true)): $argument->getDefault());
+                    $default = sprintf('<comment> (default: %s)</comment>', is_bool($argument->getDefault()) || is_array($argument->getDefault()) ? str_replace("\n", '', var_export($argument->getDefault(), true)): $argument->getDefault());
                 } else {
                     $default = '';
                 }
@@ -444,7 +444,7 @@ class InputDefinition
 
             foreach ($this->getOptions() as $option) {
                 if ($option->acceptValue() && null !== $option->getDefault() && (!is_array($option->getDefault()) || count($option->getDefault()))) {
-                    $default = sprintf('<comment> (default: %s)</comment>', is_array($option->getDefault()) ? str_replace("\n", '', print_r($option->getDefault(), true)): $option->getDefault());
+                    $default = sprintf('<comment> (default: %s)</comment>', is_bool($option->getDefault()) || is_array($option->getDefault()) ? str_replace("\n", '', var_export($option->getDefault(), true)): $option->getDefault());
                 } else {
                     $default = '';
                 }
@@ -491,7 +491,7 @@ class InputDefinition
             $descriptionXML->appendChild($dom->createTextNode($argument->getDescription()));
 
             $argumentXML->appendChild($defaultsXML = $dom->createElement('defaults'));
-            $defaults = is_array($argument->getDefault()) ? $argument->getDefault() : ($argument->getDefault() ? array($argument->getDefault()) : array());
+            $defaults = is_array($argument->getDefault()) ? $argument->getDefault() : (is_bool($argument->getDefault()) ? array(var_export($argument->getDefault(), true)) : ($argument->getDefault() ? array($argument->getDefault()) : array()));
             foreach ($defaults as $default) {
                 $defaultsXML->appendChild($defaultXML = $dom->createElement('default'));
                 $defaultXML->appendChild($dom->createTextNode($default));
@@ -511,7 +511,7 @@ class InputDefinition
 
             if ($option->acceptValue()) {
                 $optionXML->appendChild($defaultsXML = $dom->createElement('defaults'));
-                $defaults = is_array($option->getDefault()) ? $option->getDefault() : ($option->getDefault() ? array($option->getDefault()) : array());
+                $defaults = is_array($option->getDefault()) ? $option->getDefault() : (is_bool($option->getDefault()) ? array(var_export($option->getDefault(), true)) : ($option->getDefault() ? array($option->getDefault()) : array()));
                 foreach ($defaults as $default) {
                     $defaultsXML->appendChild($defaultXML = $dom->createElement('default'));
                     $defaultXML->appendChild($dom->createTextNode($default));

--- a/tests/Symfony/Tests/Component/Console/Fixtures/definition_astext.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/definition_astext.txt
@@ -1,7 +1,9 @@
 <comment>Arguments:</comment>
- <info>foo       </info> The bar argument
- <info>bar       </info> The foo argument<comment> (default: array (  0 => 'bar',))</comment>
+ <info>foo       </info> The foo argument
+ <info>baz       </info> The baz argument<comment> (default: true)</comment>
+ <info>bar       </info> The bar argument<comment> (default: array (  0 => 'bar',))</comment>
 
 <comment>Options:</comment>
  <info>--foo</info> (-f) The foo option
- <info>--bar</info> (-b) The foo option<comment> (default: bar)</comment>
+ <info>--baz</info>      The baz option<comment> (default: false)</comment>
+ <info>--bar</info> (-b) The bar option<comment> (default: bar)</comment>

--- a/tests/Symfony/Tests/Component/Console/Fixtures/definition_asxml.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/definition_asxml.txt
@@ -2,11 +2,17 @@
 <definition>
   <arguments>
     <argument name="foo" is_required="0" is_array="0">
-      <description>The bar argument</description>
+      <description>The foo argument</description>
       <defaults/>
     </argument>
+    <argument name="baz" is_required="0" is_array="0">
+      <description>The baz argument</description>
+      <defaults>
+        <default>true</default>
+      </defaults>
+    </argument>
     <argument name="bar" is_required="0" is_array="1">
-      <description>The foo argument</description>
+      <description>The bar argument</description>
       <defaults>
         <default>bar</default>
       </defaults>
@@ -17,8 +23,14 @@
       <description>The foo option</description>
       <defaults/>
     </option>
+    <option name="--baz" shortcut="" accept_value="1" is_value_required="0" is_multiple="0">
+      <description>The baz option</description>
+      <defaults>
+        <default>false</default>
+      </defaults>
+    </option>
     <option name="--bar" shortcut="-b" accept_value="1" is_value_required="0" is_multiple="0">
-      <description>The foo option</description>
+      <description>The bar option</description>
       <defaults>
         <default>bar</default>
       </defaults>

--- a/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
@@ -321,10 +321,12 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
     public function testAsText()
     {
         $definition = new InputDefinition(array(
-            new InputArgument('foo', InputArgument::OPTIONAL, 'The bar argument'),
-            new InputArgument('bar', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The foo argument', array('bar')),
+            new InputArgument('foo', InputArgument::OPTIONAL, 'The foo argument'),
+            new InputArgument('baz', InputArgument::OPTIONAL, 'The baz argument', true),
+            new InputArgument('bar', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The bar argument', array('bar')),
             new InputOption('foo', 'f', InputOption::VALUE_REQUIRED, 'The foo option'),
-            new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL, 'The foo option', 'bar'),
+            new InputOption('baz', null, InputOption::VALUE_OPTIONAL, 'The baz option', false),
+            new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL, 'The bar option', 'bar'),
         ));
         $this->assertStringEqualsFile(self::$fixtures.'/definition_astext.txt', $definition->asText(), '->asText() returns a textual representation of the InputDefinition');
     }
@@ -332,10 +334,12 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
     public function testAsXml()
     {
         $definition = new InputDefinition(array(
-            new InputArgument('foo', InputArgument::OPTIONAL, 'The bar argument'),
-            new InputArgument('bar', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The foo argument', array('bar')),
+            new InputArgument('foo', InputArgument::OPTIONAL, 'The foo argument'),
+            new InputArgument('baz', InputArgument::OPTIONAL, 'The baz argument', true),
+            new InputArgument('bar', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The bar argument', array('bar')),
             new InputOption('foo', 'f', InputOption::VALUE_REQUIRED, 'The foo option'),
-            new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL, 'The foo option', 'bar'),
+            new InputOption('baz', null, InputOption::VALUE_OPTIONAL, 'The baz option', false),
+            new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL, 'The bar option', 'bar'),
         ));
         $this->assertXmlStringEqualsXmlFile(self::$fixtures.'/definition_asxml.txt', $definition->asXml(), '->asText() returns a textual representation of the InputDefinition');
     }


### PR DESCRIPTION
This addresses an annoyance I had with command help printing `(default: )` for arguments and options that default to `false`.

```
Bug fix: no
Feature addition: yes
Backwards compatibility break: no (documentation text/XML output is slightly changed)
Symfony2 tests pass: yes
```
