### PR TITLE
[HttpKernel][Client] Set cookie fix

### DIFF
--- a/src/Symfony/Component/HttpKernel/Client.php
+++ b/src/Symfony/Component/HttpKernel/Client.php
@@ -169,7 +169,7 @@ EOF;
             foreach ($response->headers->getCookies() as $cookie) {
                 $cookies[] = new DomCookie($cookie->getName(), $cookie->getValue(), $cookie->getExpiresTime(), $cookie->getPath(), $cookie->getDomain(), $cookie->isSecure(), $cookie->isHttpOnly());
             }
-            $headers['Set-Cookie'] = implode(', ', $cookies);
+            $headers['Set-Cookie'] = $cookies;
         }
 
         return new DomResponse($response->getContent(), $response->getStatusCode(), $headers);

--- a/tests/Symfony/Tests/Component/HttpKernel/ClientTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/ClientTest.php
@@ -66,16 +66,22 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $m = $r->getMethod('filterResponse');
         $m->setAccessible(true);
 
+        $expected = array(
+            'foo=bar; expires=Sun, 15 Feb 2009 20:00:00 GMT; domain=http://example.com; path=/foo; secure; httponly',
+            'foo1=bar1; expires=Sun, 15 Feb 2009 20:00:00 GMT; domain=http://example.com; path=/foo; secure; httponly'
+        );
+
         $response = new Response();
         $response->headers->setCookie(new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
         $domResponse = $m->invoke($client, $response);
-        $this->assertEquals('foo=bar; expires=Sun, 15 Feb 2009 20:00:00 GMT; domain=http://example.com; path=/foo; secure; httponly', $domResponse->getHeader('Set-Cookie'));
+        $this->assertEquals($expected[0], $domResponse->getHeader('Set-Cookie'));
 
         $response = new Response();
         $response->headers->setCookie(new Cookie('foo', 'bar', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
         $response->headers->setCookie(new Cookie('foo1', 'bar1', \DateTime::createFromFormat('j-M-Y H:i:s T', '15-Feb-2009 20:00:00 GMT')->format('U'), '/foo', 'http://example.com', true, true));
         $domResponse = $m->invoke($client, $response);
-        $this->assertEquals('foo=bar; expires=Sun, 15 Feb 2009 20:00:00 GMT; domain=http://example.com; path=/foo; secure; httponly, foo1=bar1; expires=Sun, 15 Feb 2009 20:00:00 GMT; domain=http://example.com; path=/foo; secure; httponly', $domResponse->getHeader('Set-Cookie'));
+        $this->assertEquals($expected[0], $domResponse->getHeader('Set-Cookie'));
+        $this->assertEquals($expected, $domResponse->getHeader('Set-Cookie', false));
     }
 
     public function testUploadedFile()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no(?)
Symfony2 tests pass: yes
Fixes the following tickets: #2881

Only simple cookies can be stored in same line:
- Used by now (**wrong**): `Set-Cookie: name1=value, name2=value`
- Proper according to RFCs: `Set-Cookie: name1=value; name2=value`

So lets add every as standalone ([next header](http://tools.ietf.org/html/rfc6265#section-3.1)) to be compliant with [RFC6265](http://tools.ietf.org/html/rfc6265). This fixes #2881.
