### PR TITLE
Doctrine profiler view

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Resources/views/Collector/db.html.twig
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/views/Collector/db.html.twig
@@ -36,7 +36,7 @@
                         <code>{{ query.sql }}</code>
                     </div>
                     <small>
-                        <strong>Parameters</strong>: {{ query.params }}<br />
+                        <strong>Parameters</strong>: {{ query.params|yaml_encode }}<br />
                         <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
                     </small>
                 </li>


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

After the changes in #2733, the parameters to Doctrine queries were
always shown as 'Array' in the profiler. This commit puts back the
yaml_encode that is still needed after all.
