### PR TITLE
[Console] Enable stderr support

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -20,6 +20,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Command\ListCommand;
@@ -108,7 +109,11 @@ class Application
                 throw $e;
             }
 
-            $this->renderException($e, $output);
+            if ($output instanceof ConsoleOutputInterface) {
+                $this->renderException($e, $output->getErrorOutput());
+            } else {
+                $this->renderException($e, $output);
+            }
             $statusCode = $e->getCode();
 
             $statusCode = is_numeric($statusCode) && $statusCode ? $statusCode : 1;

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Console\Output;
 
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 
 /**
  * ConsoleOutput is the default class for all CLI output. It uses STDOUT.
@@ -28,8 +30,10 @@ use Symfony\Component\Console\Formatter\OutputFormatter;
  *
  * @api
  */
-class ConsoleOutput extends StreamOutput
+class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
 {
+    private $stderr;
+
     /**
      * Constructor.
      *
@@ -43,5 +47,37 @@ class ConsoleOutput extends StreamOutput
     public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatter $formatter = null)
     {
         parent::__construct(fopen('php://stdout', 'w'), $verbosity, $decorated, $formatter);
+        $this->stderr = new StreamOutput(fopen('php://stderr', 'w'), $verbosity, $decorated, $formatter);
+    }
+
+    public function setDecorated($decorated)
+    {
+        parent::setDecorated($decorated);
+        $this->stderr->setDecorated($decorated);
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter)
+    {
+        parent::setFormatter($formatter);
+        $this->stderr->setFormatter($formatter);
+    }
+
+    public function setVerbosity($level)
+    {
+        parent::setVerbosity($level);
+        $this->stderr->setVerbosity($level);
+    }
+
+    /**
+     * @return OutputInterface
+     */
+    public function getErrorOutput()
+    {
+        return $this->stderr;
+    }
+
+    public function setErrorOutput(OutputInterface $error)
+    {
+        $this->stderr = $error;
     }
 }

--- a/src/Symfony/Component/Console/Output/ConsoleOutputInterface.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutputInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Output;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * ConsoleOutputInterface is the interface implemented by ConsoleOutput class.
+ * This adds information about stderr output stream.
+ *
+ * @author Dariusz Górecki <darek.krk@gmail.com>
+ */
+interface ConsoleOutputInterface extends OutputInterface
+{
+    /**
+     * @return OutputInterface
+     */
+    public function getErrorOutput();
+
+    public function setErrorOutput(OutputInterface $error);
+}

--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Console\Tester;
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\StreamOutput;
 
 /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
BC break: no
Symfony2 test pass: yes, but some tests had to be modified

Now all error messages goes to stdout, we cannot separate error
from normal behaviour, this enables writing to stderr stream,
so scripts ran e.g. from cron, can benefit from this well known concept.

There are 2 much nicer implememntations, but:
1) First requires to break the `@api` tagged interfaces.
2) Second requires rewrite of `execute` command declatarion all commands in bundles.
