### PR TITLE
Warning thrown on $options['widget']

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -199,7 +199,7 @@ class DateType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return (isset($options['widget']) && $options['widget']) === 'single_text' ? 'field' : 'form';
+        return (isset($options['widget']) && $options['widget'] === 'single_text') ? 'field' : 'form';
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -199,7 +199,7 @@ class DateType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return $options['widget'] === 'single_text' ? 'field' : 'form';
+        return (isset($options['widget']) && $options['widget']) === 'single_text' ? 'field' : 'form';
     }
 
     /**


### PR DESCRIPTION
I'm trying to avoid getting a warning thrown when $options['widget'] isn't set.  Hoping this is the right solution, alternatively $options['widget'] could have a default?  I realize that the real problem might be the method that calls this should have this option set.  So this is just doing a simple isset() check before using it.
