### PR TITLE
[Security] Fix SwitchUser functionality to work with non-latin usernames

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -116,7 +116,12 @@ class SwitchUserListener implements ListenerInterface
             throw new AccessDeniedException();
         }
 
-        $username = $request->get($this->usernameParameter);
+        $username = urldecode($request->get($this->usernameParameter));
+        if (function_exists('mb_convert_encoding')) {
+            $username = mb_convert_encoding($username, 'UTF-8');
+        } elseif (function_exists('iconv')) {
+            $username = iconv('ISO-8859-1', 'UTF-8', $username);
+        }
 
         if (null !== $this->logger) {
             $this->logger->info(sprintf('Attempt to switch to user "%s"', $username));


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2899
