### PR TITLE
[Routing] provide extra code to the PhpMatcherDumper

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -243,7 +243,7 @@ EOF
         }
         $code[] = "        }";
 
-        if ($req) {
+        if ($req || null !== $extraCode) {
             $code[] = "        $gotoname:";
         }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -212,6 +212,10 @@ EOF
             , $name);
         }
 
+        if (null !== ($extraCode = $this->getExtraCode($route))) {
+            $code[] = $extraCode;
+        }
+
         if ($scheme = $route->getRequirement('_scheme')) {
             if (!$supportsRedirections) {
                 throw new \LogicException('The "_scheme" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.');
@@ -246,6 +250,16 @@ EOF
         $code[] = '';
 
         return $code;
+    }
+
+    /**
+     * Override this method if you want to add aditional route informations
+     *
+     * @param Route $route
+     */
+    protected function getExtraCode(Route $route)
+    {
+        return null;
     }
 
     private function startClass($class, $baseClass)

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -212,7 +212,7 @@ EOF
             , $name);
         }
 
-        if (null !== ($extraCode = $this->getExtraCode($route))) {
+        if (null !== ($extraCode = static::getExtraCode($route, $name))) {
             $code[] = $extraCode;
         }
 
@@ -256,8 +256,9 @@ EOF
      * Override this method if you want to add aditional route informations
      *
      * @param Route $route
+     * @param string $name
      */
-    protected function getExtraCode(Route $route)
+    protected function getExtraCode(Route $route, $name)
     {
         return null;
     }


### PR DESCRIPTION
Actually it seems difficult to extend the `PhpMatcherDumper` to add custom logic without copying lots of code.

here's an exemple showing the code duplication :
http://jay-team.blogspot.com/2011/09/symfony2-routing-requirement-in.html

BugFix: no
Feature addition: yes
Sysmfony2 test pass: yes
