### PR TITLE
Raw output of commands in app/console list

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -630,7 +630,7 @@ class Application
     {
         $commands = $namespace ? $this->all($this->findNamespace($namespace)) : $this->commands;
         
-        if($raw) {
+        if ($raw) {
             return array_keys($commands);
         }
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -622,12 +622,17 @@ class Application
      * Returns a text representation of the Application.
      *
      * @param string $namespace An optional namespace name
+     * @param boolean $raw Whether to return raw command list
      *
      * @return string A string representing the Application
      */
-    public function asText($namespace = null)
+    public function asText($namespace = null, $raw = false)
     {
         $commands = $namespace ? $this->all($this->findNamespace($namespace)) : $this->commands;
+        
+        if($raw) {
+            return array_keys($commands);
+        }
 
         $messages = array($this->getHelp(), '');
         if ($namespace) {

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -34,6 +34,7 @@ class ListCommand extends Command
             ->setDefinition(array(
                 new InputArgument('namespace', InputArgument::OPTIONAL, 'The namespace name'),
                 new InputOption('xml', null, InputOption::VALUE_NONE, 'To output help as XML'),
+                new InputOption('raw', null, InputOption::VALUE_NONE, 'To output raw command list')
             ))
             ->setName('list')
             ->setDescription('Lists commands')
@@ -49,6 +50,10 @@ You can also display the commands for a specific namespace:
 You can also output the information as XML by using the <comment>--xml</comment> option:
 
   <info>php app/console list --xml</info>
+
+It's also possible to get raw list of commands (useful for embedding command runner):
+
+  <info>php app/console list --raw</info>
 EOF
             );
     }
@@ -61,7 +66,7 @@ EOF
         if ($input->getOption('xml')) {
             $output->writeln($this->getApplication()->asXml($input->getArgument('namespace')), OutputInterface::OUTPUT_RAW);
         } else {
-            $output->writeln($this->getApplication()->asText($input->getArgument('namespace')));
+            $output->writeln($this->getApplication()->asText($input->getArgument('namespace'), $input->getOption('raw')));
         }
     }
 }

--- a/tests/Symfony/Tests/Component/Console/Command/HelpCommandTest.php
+++ b/tests/Symfony/Tests/Component/Console/Command/HelpCommandTest.php
@@ -25,7 +25,7 @@ class HelpCommandTest extends \PHPUnit_Framework_TestCase
 
         $commandTester = new CommandTester($command);
         $commandTester->execute(array());
-        $this->assertRegExp('/list \[--xml\] \[namespace\]/', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertRegExp('/list \[--xml\] \[--raw\] \[namespace\]/', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
 
         $commandTester->execute(array('--xml' => true));
         $this->assertRegExp('/<command/', $commandTester->getDisplay(), '->execute() returns an XML help text if --xml is passed');
@@ -33,7 +33,7 @@ class HelpCommandTest extends \PHPUnit_Framework_TestCase
         $application = new Application();
         $commandTester = new CommandTester($application->get('help'));
         $commandTester->execute(array('command_name' => 'list'));
-        $this->assertRegExp('/list \[--xml\] \[namespace\]/', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
+        $this->assertRegExp('/list \[--xml\] \[--raw\] \[namespace\]/', $commandTester->getDisplay(), '->execute() returns a text help for the given command');
 
         $commandTester->execute(array('command_name' => 'list', '--xml' => true));
         $this->assertRegExp('/<command/', $commandTester->getDisplay(), '->execute() returns an XML help text if --xml is passed');

--- a/tests/Symfony/Tests/Component/Console/Command/ListCommandTest.php
+++ b/tests/Symfony/Tests/Component/Console/Command/ListCommandTest.php
@@ -26,5 +26,8 @@ class ListCommandTest extends \PHPUnit_Framework_TestCase
 
         $commandTester->execute(array('command' => $command->getName(), '--xml' => true));
         $this->assertRegExp('/<command id="list" name="list">/', $commandTester->getDisplay(), '->execute() returns a list of available commands in XML if --xml is passed');
+        
+        $commandTester->execute(array('command' => $command->getName(), '--raw' => true));
+        $this->assertRegExp('/help\n/', $commandTester->getDisplay(), 'boo');
     }
 }

--- a/tests/Symfony/Tests/Component/Console/Fixtures/application_asxml1.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/application_asxml1.txt
@@ -27,7 +27,7 @@
   </options>
 </command>
     <command id="list" name="list">
-  <usage>list [--xml] [namespace]</usage>
+  <usage>list [--xml] [--raw] [namespace]</usage>
   <description>Lists commands</description>
   <help>The &lt;info&gt;list&lt;/info&gt; command lists all commands:
  
@@ -39,7 +39,11 @@
  
  You can also output the information as XML by using the &lt;comment&gt;--xml&lt;/comment&gt; option:
  
-   &lt;info&gt;php app/console list --xml&lt;/info&gt;</help>
+   &lt;info&gt;php app/console list --xml&lt;/info&gt;
+ 
+ It's also possible to get raw list of commands (useful for embedding command runner):
+ 
+   &lt;info&gt;php app/console list --raw&lt;/info&gt;</help>
   <aliases/>
   <arguments>
     <argument name="namespace" is_required="0" is_array="0">
@@ -50,6 +54,9 @@
   <options>
     <option name="--xml" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
       <description>To output help as XML</description>
+    </option>
+    <option name="--raw" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>To output raw command list</description>
     </option>
   </options>
 </command>

--- a/tests/Symfony/Tests/Component/Console/Fixtures/application_renderexception2.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/application_renderexception2.txt
@@ -6,6 +6,6 @@
                                       
 
 
-list [--xml] [namespace]
+list [--xml] [--raw] [namespace]
 
 

--- a/tests/Symfony/Tests/Component/Console/Fixtures/application_run3.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/application_run3.txt
@@ -1,11 +1,12 @@
 Usage:
- list [--xml] [namespace]
+ list [--xml] [--raw] [namespace]
 
 Arguments:
  namespace  The namespace name
 
 Options:
  --xml      To output help as XML
+ --raw      To output raw command list
 
 Help:
  The list command lists all commands:
@@ -19,4 +20,8 @@ Help:
  You can also output the information as XML by using the --xml option:
  
    php app/console list --xml
+ 
+ It's also possible to get raw list of commands (useful for embedding command runner):
+ 
+   php app/console list --raw
 


### PR DESCRIPTION
Breaks compatibility: no
Feature addition: yes
Symfony test pass: yes, with appropriate modifications

Simply, it adds `--raw` parameter to `app/console list` command. With this key, `list` returns simply command names.

This is mainly useful in command completion / embedding, like https://github.com/andrewtch/oh-my-zsh/tree/symfony2-completion/plugins/symfony2 ; I know about the presence of --xml, but in some environments (like shell scripts) parsing XML could be a problem.

This is an unobtrusive feature addition that is not likely to add problems in future. 
