### PR TITLE
Fixed the entity provider to support proxies

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -100,6 +100,6 @@ class EntityUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)
     {
-        return $class === $this->class;
+        return $class === $this->class || is_subclass_of($class, $this->class);
     }
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
@@ -75,6 +75,23 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
         $provider->refreshUser($user2);
     }
 
+    public function testSupportProxy()
+    {
+        $em = $this->createTestEntityManager();
+        $this->createSchema($em);
+
+        $user1 = new CompositeIdentEntity(1, 1, 'user1');
+
+        $em->persist($user1);
+        $em->flush();
+        $em->clear();
+
+        $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
+
+        $user2 = $em->getReference('Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', array('id1' => 1, 'id2' => 1));
+        $this->assertTrue($provider->supportsClass(get_class($user2)));
+    }
+
     private function createSchema($em)
     {
         $schemaTool = new SchemaTool($em);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes

If a proxy object was used, the `supportsClass` method would fail becasue it does a string comparison for the class name.

This issue has not been reported by users yet because it is an edge case:
- `supportsClass` is used only in the RememberMe system
- getting a proxy in the entity provider is possible only if a listener running before the firewall loaded an object which has a relation to the user, which is far from being a standard use case.
