### PR TITLE
[BC Break][Security][Option2] Moved user comparsion logic out of UserInterface

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -79,6 +79,10 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
                             toto: { password: foobar, roles: [ROLE_USER] }
                             foo: { password: bar, roles: [ROLE_USER, ROLE_ADMIN] }
 
+ * [BC BREAK] Method `equals` was removed from `UserInterface` to its own new
+   `EquatableInterface`, now user class can implement this interface to override
+   the default implementation of users equality test.
+
  * added a validator for the user password
  * added 'erase_credentials' as a configuration key (true by default)
  * added new events: `security.authentication.success` and `security.authentication.failure`

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -40,3 +40,31 @@ UPGRADE FROM 2.0 to 2.1
 
   Before: $session->getLocale()
   After: $request->getLocale()
+
+* Method `equals` of `Symfony\Component\Security\Core\User\UserInterface` has
+  moved to `Symfony\Component\Security\Core\User\EquatableInterface`.
+
+  You have to change the name of the `equals` function in your implementation
+  of the `User` class to `isEqualTo` and implement `EquatableInterface`.
+  Apart from that, no other changes are required to make it behave as before.
+  Alternatively, you can use the default implementation provided
+  by `AbstractToken:hasUserChanged` if you do not need any custom comparison logic.
+  In this case do not implement the interface and remove your comparison function.
+
+  Before:
+
+      class User implements UserInterface
+      {
+          // ...
+          public function equals(UserInterface $user) { /* ... */ }
+          // ...
+      }
+
+  After:
+
+      class User implements UserInterface, EquatableInterface
+      {
+          // ...
+          public function isEqualTo(UserInterface $user) { /* ... */ }
+          // ...
+      }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\Security\Core\Authentication\Token;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\ComparableInterface;
 
 /**
  * Base class for Token instances.
@@ -87,7 +89,7 @@ abstract class AbstractToken implements TokenInterface
             if (!$user instanceof UserInterface) {
                 $changed = true;
             } else {
-                $changed = !$this->user->equals($user);
+                $changed = !$this->compareUser($user);
             }
         } elseif ($user instanceof UserInterface) {
             $changed = true;
@@ -219,5 +221,50 @@ abstract class AbstractToken implements TokenInterface
         }
 
         return sprintf('%s(user="%s", authenticated=%s, roles="%s")', $class, $this->getUsername(), json_encode($this->authenticated), implode(', ', $roles));
+    }
+
+    private function compareUser(UserInterface $user)
+    {
+        if (!($this->user instanceof UserInterface)) {
+            throw new \BadMethodCallException('Method "compareUser" should be called when current user class is instance of "UserInterface".');
+        }
+
+        if ($this->user instanceof ComparableInterface) {
+            return $this->user->compareTo($user);
+        }
+
+        if ($this->user->getPassword() !== $user->getPassword()) {
+            return false;
+        }
+
+        if ($this->user->getSalt() !== $user->getSalt()) {
+            return false;
+        }
+
+        if ($this->user->getUsername() !== $user->getUsername()) {
+            return false;
+        }
+
+        if ($this->user instanceof AdvancedUserInterface && $user instanceof AdvancedUserInterface) {
+            if ($this->user->isAccountNonExpired() !== $user->isAccountNonExpired()) {
+                return false;
+            }
+
+            if ($this->user->isAccountNonLocked() !== $user->isAccountNonLocked()) {
+                return false;
+            }
+
+            if ($this->user->isCredentialsNonExpired() !== $user->isCredentialsNonExpired()) {
+                return false;
+            }
+
+            if ($this->user->isEnabled() !== $user->isEnabled()) {
+                return false;
+            }
+        } elseif ($this->user instanceof AdvancedUserInterface xor $user instanceof AdvancedUserInterface) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\AdvancedUserInterface;
-use Symfony\Component\Security\Core\User\ComparableInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
 
 /**
  * Base class for Token instances.
@@ -89,7 +89,7 @@ abstract class AbstractToken implements TokenInterface
             if (!$user instanceof UserInterface) {
                 $changed = true;
             } else {
-                $changed = !$this->compareUser($user);
+                $changed = !$this->isUserChanged($user);
             }
         } elseif ($user instanceof UserInterface) {
             $changed = true;
@@ -223,14 +223,14 @@ abstract class AbstractToken implements TokenInterface
         return sprintf('%s(user="%s", authenticated=%s, roles="%s")', $class, $this->getUsername(), json_encode($this->authenticated), implode(', ', $roles));
     }
 
-    private function compareUser(UserInterface $user)
+    private function isUserChanged(UserInterface $user)
     {
         if (!($this->user instanceof UserInterface)) {
             throw new \BadMethodCallException('Method "compareUser" should be called when current user class is instance of "UserInterface".');
         }
 
-        if ($this->user instanceof ComparableInterface) {
-            return $this->user->compareTo($user);
+        if ($this->user instanceof EquatableInterface) {
+            return $this->user->isEqualTo($user);
         }
 
         if ($this->user->getPassword() !== $user->getPassword()) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -89,7 +89,7 @@ abstract class AbstractToken implements TokenInterface
             if (!$user instanceof UserInterface) {
                 $changed = true;
             } else {
-                $changed = !$this->isUserChanged($user);
+                $changed = !$this->hasUserChanged($user);
             }
         } elseif ($user instanceof UserInterface) {
             $changed = true;
@@ -223,10 +223,10 @@ abstract class AbstractToken implements TokenInterface
         return sprintf('%s(user="%s", authenticated=%s, roles="%s")', $class, $this->getUsername(), json_encode($this->authenticated), implode(', ', $roles));
     }
 
-    private function isUserChanged(UserInterface $user)
+    private function hasUserChanged(UserInterface $user)
     {
         if (!($this->user instanceof UserInterface)) {
-            throw new \BadMethodCallException('Method "compareUser" should be called when current user class is instance of "UserInterface".');
+            throw new \BadMethodCallException('Method "hasUserChanged" should be called when current user class is instance of "UserInterface".');
         }
 
         if ($this->user instanceof EquatableInterface) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -89,7 +89,7 @@ abstract class AbstractToken implements TokenInterface
             if (!$user instanceof UserInterface) {
                 $changed = true;
             } else {
-                $changed = !$this->hasUserChanged($user);
+                $changed = $this->hasUserChanged($user);
             }
         } elseif ($user instanceof UserInterface) {
             $changed = true;
@@ -230,41 +230,41 @@ abstract class AbstractToken implements TokenInterface
         }
 
         if ($this->user instanceof EquatableInterface) {
-            return $this->user->isEqualTo($user);
+            return !$this->user->isEqualTo($user);
         }
 
         if ($this->user->getPassword() !== $user->getPassword()) {
-            return false;
+            return true;
         }
 
         if ($this->user->getSalt() !== $user->getSalt()) {
-            return false;
+            return true;
         }
 
         if ($this->user->getUsername() !== $user->getUsername()) {
-            return false;
+            return true;
         }
 
         if ($this->user instanceof AdvancedUserInterface && $user instanceof AdvancedUserInterface) {
             if ($this->user->isAccountNonExpired() !== $user->isAccountNonExpired()) {
-                return false;
+                return true;
             }
 
             if ($this->user->isAccountNonLocked() !== $user->isAccountNonLocked()) {
-                return false;
+                return true;
             }
 
             if ($this->user->isCredentialsNonExpired() !== $user->isCredentialsNonExpired()) {
-                return false;
+                return true;
             }
 
             if ($this->user->isEnabled() !== $user->isEnabled()) {
-                return false;
+                return true;
             }
         } elseif ($this->user instanceof AdvancedUserInterface xor $user instanceof AdvancedUserInterface) {
-            return false;
+            return true;
         }
 
-        return true;
+        return false;
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -230,7 +230,7 @@ abstract class AbstractToken implements TokenInterface
         }
 
         if ($this->user instanceof EquatableInterface) {
-            return !$this->user->isEqualTo($user);
+            return ! (Boolean) $this->user->isEqualTo($user);
         }
 
         if ($this->user->getPassword() !== $user->getPassword()) {

--- a/src/Symfony/Component/Security/Core/User/ComparableInterface.php
+++ b/src/Symfony/Component/Security/Core/User/ComparableInterface.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Core\User;
 
 /**
- * ComparatorInterface used to test if two object are equal in security
+ * ComparableInterface used to test if two objects are equal in security
  * and re-authentication context.
  *
  * @author Dariusz Górecki <darek.krk@gmail.com>
@@ -26,7 +26,9 @@ interface ComparableInterface
      * However, you do not need to compare every attribute, but only those that
      * are relevant for assessing whether re-authentication is required.
      *
-     * @return boolean
+     * @param UserInterface $user
+     *
+     * @return Boolean
      */
-    public function compareTo($object);
+    function compareTo(UserInterface $user);
 }

--- a/src/Symfony/Component/Security/Core/User/ComparableInterface.php
+++ b/src/Symfony/Component/Security/Core/User/ComparableInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\User;
+
+/**
+ * ComparatorInterface used to test if two object are equal in security
+ * and re-authentication context.
+ *
+ * @author Dariusz Górecki <darek.krk@gmail.com>
+ */
+interface ComparableInterface
+{
+    /**
+     * The equality comparison should neither be done by referential equality
+     * nor by comparing identities (i.e. getId() === getId()).
+     *
+     * However, you do not need to compare every attribute, but only those that
+     * are relevant for assessing whether re-authentication is required.
+     *
+     * @return boolean
+     */
+    public function compareTo($object);
+}

--- a/src/Symfony/Component/Security/Core/User/EquatableInterface.php
+++ b/src/Symfony/Component/Security/Core/User/EquatableInterface.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\Security\Core\User;
 
 /**
- * ComparableInterface used to test if two objects are equal in security
+ * EquatableInterface used to test if two objects are equal in security
  * and re-authentication context.
  *
  * @author Dariusz Górecki <darek.krk@gmail.com>
  */
-interface ComparableInterface
+interface EquatableInterface
 {
     /**
      * The equality comparison should neither be done by referential equality
@@ -30,5 +30,5 @@ interface ComparableInterface
      *
      * @return Boolean
      */
-    function compareTo(UserInterface $user);
+    function isEqualTo(UserInterface $user);
 }

--- a/src/Symfony/Component/Security/Core/User/EquatableInterface.php
+++ b/src/Symfony/Component/Security/Core/User/EquatableInterface.php
@@ -26,6 +26,9 @@ interface EquatableInterface
      * However, you do not need to compare every attribute, but only those that
      * are relevant for assessing whether re-authentication is required.
      *
+     * Also implementation should consider that $user instance may implement
+     * the extended user interface `AdvancedUserInterface`.
+     *
      * @param UserInterface $user
      *
      * @return Boolean

--- a/src/Symfony/Component/Security/Core/User/User.php
+++ b/src/Symfony/Component/Security/Core/User/User.php
@@ -112,44 +112,4 @@ final class User implements AdvancedUserInterface
     public function eraseCredentials()
     {
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function equals(UserInterface $user)
-    {
-        if (!$user instanceof User) {
-            return false;
-        }
-
-        if ($this->password !== $user->getPassword()) {
-            return false;
-        }
-
-        if ($this->getSalt() !== $user->getSalt()) {
-            return false;
-        }
-
-        if ($this->username !== $user->getUsername()) {
-            return false;
-        }
-
-        if ($this->accountNonExpired !== $user->isAccountNonExpired()) {
-            return false;
-        }
-
-        if ($this->accountNonLocked !== $user->isAccountNonLocked()) {
-            return false;
-        }
-
-        if ($this->credentialsNonExpired !== $user->isCredentialsNonExpired()) {
-            return false;
-        }
-
-        if ($this->enabled !== $user->isEnabled()) {
-            return false;
-        }
-
-        return true;
-    }
 }

--- a/src/Symfony/Component/Security/Core/User/UserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserInterface.php
@@ -84,19 +84,4 @@ interface UserInterface
      * @return void
      */
     function eraseCredentials();
-
-    /**
-     * Returns whether or not the given user is equivalent to *this* user.
-     *
-     * The equality comparison should neither be done by referential equality
-     * nor by comparing identities (i.e. getId() === getId()).
-     *
-     * However, you do not need to compare every attribute, but only those that
-     * are relevant for assessing whether re-authentication is required.
-     *
-     * @param UserInterface $user
-     *
-     * @return Boolean
-     */
-    function equals(UserInterface $user);
 }

--- a/tests/Symfony/Tests/Component/Security/Core/Authentication/Token/AbstractTokenTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/Authentication/Token/AbstractTokenTest.php
@@ -144,11 +144,6 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
     public function getUsers()
     {
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
-        $user
-            ->expects($this->any())
-            ->method('equals')
-            ->will($this->returnValue(true))
-        ;
 
         return array(
             array($user),
@@ -176,11 +171,6 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
     public function getUserChanges()
     {
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
-        $user
-            ->expects($this->any())
-            ->method('equals')
-            ->will($this->returnValue(false))
-        ;
 
         return array(
             array(
@@ -191,9 +181,6 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 'foo', $user,
-            ),
-            array(
-                $user, $user,
             ),
             array(
                 $user, 'foo'

--- a/tests/Symfony/Tests/Component/Security/Core/Authentication/Token/AbstractTokenTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/Authentication/Token/AbstractTokenTest.php
@@ -144,8 +144,10 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
     public function getUsers()
     {
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $advancedUser = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
 
         return array(
+            array($advancedUser),
             array($user),
             array(new TestUser('foo')),
             array('foo'),
@@ -171,6 +173,7 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
     public function getUserChanges()
     {
         $user = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+        $advancedUser = $this->getMock('Symfony\Component\Security\Core\User\AdvancedUserInterface');
 
         return array(
             array(
@@ -183,10 +186,19 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
                 'foo', $user,
             ),
             array(
+                'foo', $advancedUser
+            ),
+            array(
                 $user, 'foo'
             ),
             array(
+                $advancedUser, 'foo'
+            ),
+            array(
                 $user, new TestUser('foo'),
+            ),
+            array(
+                $advancedUser, new TestUser('foo'),
             ),
             array(
                 new TestUser('foo'), new TestUser('bar'),
@@ -196,6 +208,15 @@ class AbstractTokenTest extends \PHPUnit_Framework_TestCase
             ),
             array(
                 new TestUser('foo'), $user,
+            ),
+            array(
+                new TestUser('foo'), $advancedUser,
+            ),
+            array(
+                $user, $advancedUser
+            ),
+            array(
+                $advancedUser, $user
             ),
         );
     }

--- a/tests/Symfony/Tests/Component/Security/Core/User/UserTest.php
+++ b/tests/Symfony/Tests/Component/Security/Core/User/UserTest.php
@@ -123,22 +123,4 @@ class UserTest extends \PHPUnit_Framework_TestCase
         $user->eraseCredentials();
         $this->assertEquals('superpass', $user->getPassword());
     }
-
-    public function testUsersAreEqual()
-    {
-        $user1 = new User('fabien', 'superpass', array('ROLE_USER'));
-        $user2 = clone $user1;
-
-        $this->assertTrue($user1->equals($user2));
-        $this->assertTrue($user2->equals($user1));
-    }
-
-    public function testUsersAreNotEqual()
-    {
-        $user1 = new User('fabien', 'superpass', array('ROLE_USER'));
-        $user2 = new User('fabien', 'superpass', array('ROLE_USER'), false);
-
-        $this->assertFalse($user1->equals($user2));
-        $this->assertFalse($user2->equals($user1));
-    }
 }


### PR DESCRIPTION
As discussed on IRC meetings and in PR #2669 I came up with implementation.
This is option2, I think more elegant.

BC break: yes
Feature addition: no/feature move
Symfony2 test pass: yes
Symfony2 test written: yes
Todo: decide about naming

[![Build Status](https://secure.travis-ci.org/canni/symfony.png)](http://travis-ci.org/canni/symfony)
