### PR TITLE
[DoctrineBridge] Made it possible to change the manager used by the provider

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\DoctrineBundle\DependencyInjection\Security\UserProvider;
+namespace Symfony\Bridge\Doctrine\DependencyInjection\Security\UserProvider;
 
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
@@ -25,10 +25,19 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class EntityFactory implements UserProviderFactoryInterface
 {
+    private $key;
+    private $providerId;
+
+    public function __construct($key, $providerId)
+    {
+        $this->key = $key;
+        $this->providerId = $providerId;
+    }
+
     public function create(ContainerBuilder $container, $id, $config)
     {
         $container
-            ->setDefinition($id, new DefinitionDecorator('doctrine.orm.security.user.provider'))
+            ->setDefinition($id, new DefinitionDecorator($this->providerId))
             ->addArgument($config['class'])
             ->addArgument($config['property'])
             ->addArgument($config['manager_name'])
@@ -37,7 +46,7 @@ class EntityFactory implements UserProviderFactoryInterface
 
     public function getKey()
     {
-        return 'entity';
+        return $this->key;
     }
 
     public function addConfiguration(NodeDefinition $node)

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bridge\Doctrine\Security\User;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\User\UserProviderInterface;

--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Security\User;
 
+use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
@@ -32,8 +33,9 @@ class EntityUserProvider implements UserProviderInterface
     private $property;
     private $metadata;
 
-    public function __construct(ObjectManager $em, $class, $property = null)
+    public function __construct(ManagerRegistry $registry, $class, $property = null, $managerName = null)
     {
+        $em = $registry->getManager($managerName);
         $this->class = $class;
         $this->metadata = $em->getClassMetadata($class);
 

--- a/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DependencyInjection/Security/UserProvider/EntityFactory.php
@@ -31,6 +31,7 @@ class EntityFactory implements UserProviderFactoryInterface
             ->setDefinition($id, new DefinitionDecorator('doctrine.orm.security.user.provider'))
             ->addArgument($config['class'])
             ->addArgument($config['property'])
+            ->addArgument($config['manager_name'])
         ;
     }
 
@@ -45,6 +46,7 @@ class EntityFactory implements UserProviderFactoryInterface
             ->children()
                 ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
                 ->scalarNode('property')->defaultNull()->end()
+                ->scalarNode('manager_name')->defaultNull()->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bundle\DoctrineBundle;
 
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
-use Symfony\Bundle\DoctrineBundle\DependencyInjection\Security\UserProvider\EntityFactory;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\DoctrineValidationPass;
+use Symfony\Bridge\Doctrine\DependencyInjection\Security\UserProvider\EntityFactory;
 use Symfony\Bundle\DoctrineBundle\DependencyInjection\Compiler\RegisterEventListenersAndSubscribersPass;
 
 /**
@@ -33,7 +33,7 @@ class DoctrineBundle extends Bundle
         $container->addCompilerPass(new RegisterEventListenersAndSubscribersPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION);
 
         if ($container->hasExtension('security')) {
-            $container->getExtension('security')->addUserProviderFactory(new EntityFactory());
+            $container->getExtension('security')->addUserProviderFactory(new EntityFactory('entity', 'doctrine.orm.security.user.provider'));
         }
 
         $container->addCompilerPass(new DoctrineValidationPass('orm'));

--- a/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
+++ b/src/Symfony/Bundle/DoctrineBundle/Resources/config/orm.xml
@@ -75,7 +75,7 @@
 
         <!-- security -->
         <service id="doctrine.orm.security.user.provider" class="%doctrine.orm.security.user.provider.class%" abstract="true" public="false">
-            <argument type="service" id="doctrine.orm.entity_manager" />
+            <argument type="service" id="doctrine" />
         </service>
     </services>
 </container>

--- a/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
@@ -33,7 +33,7 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
         $em->persist($user2);
         $em->flush();
 
-        $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
+        $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
 
         // try to change the user identity
         $user1->name = 'user2';
@@ -46,7 +46,7 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
         $em = $this->createTestEntityManager();
 
         $user1 = new CompositeIdentEntity(null, null, 'user1');
-        $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
+        $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
 
         $this->setExpectedException(
             'InvalidArgumentException',
@@ -65,7 +65,7 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
         $em->persist($user1);
         $em->flush();
 
-        $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
+        $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
 
         $user2 = new CompositeIdentEntity(1, 2, 'user2');
         $this->setExpectedException(
@@ -90,6 +90,17 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
 
         $user2 = $em->getReference('Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', array('id1' => 1, 'id2' => 1));
         $this->assertTrue($provider->supportsClass(get_class($user2)));
+    }
+
+    private function getManager($em, $name = null)
+    {
+        $manager = $this->getMock('Doctrine\Common\Persistence\ManagerRegistry');
+        $manager->expects($this->once())
+            ->method('getManager')
+            ->with($this->equalTo($name))
+            ->will($this->returnValue($em));
+
+        return $manager;
     }
 
     private function createSchema($em)

--- a/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Security/User/EntityUserProviderTest.php
@@ -86,7 +86,7 @@ class EntityUserProviderTest extends DoctrineOrmTestCase
         $em->flush();
         $em->clear();
 
-        $provider = new EntityUserProvider($em, 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
+        $provider = new EntityUserProvider($this->getManager($em), 'Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', 'name');
 
         $user2 = $em->getReference('Symfony\Tests\Bridge\Doctrine\Fixtures\CompositeIdentEntity', array('id1' => 1, 'id2' => 1));
         $this->assertTrue($provider->supportsClass(get_class($user2)));


### PR DESCRIPTION
This improves the support of several entity managers by allowing using a non-default one for the provider.

It is BC for the user as the default value for the name is `null` which means using the default one.

I'm preparing the PR for DoctrineBundle too
