### PR TITLE
[WIP][Process] Quote commandline

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -106,7 +106,7 @@ class Process
 
         $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
 
-        $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
+        $process = proc_open("\"$this->commandline\"", $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 
         if (!is_resource($process)) {
             throw new \RuntimeException('Unable to launch a new process.');

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -105,8 +105,8 @@ class Process
         };
 
         $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
-
-        $process = proc_open("\"$this->commandline\"", $descriptors, $pipes, $this->cwd, $this->env, $this->options);
+        $commandline = preg_match('#[^a-z/]i#', $this->commandline) ? '"'.$this->commandline.'"' : $this->commandline;
+        $process = proc_open($commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 
         if (!is_resource($process)) {
             throw new \RuntimeException('Unable to launch a new process.');


### PR DESCRIPTION
Quote commandline to prevent special chars

Example 

When PHP bin is : `C:\Program Files (x86)\PHP\php.exe`
Command should be `"C:\Program Files (x86)\PHP\php.exe"`

Now all tests pass under Windows with a standard PHP (php.net) Install (but not on unix ...)
