### PR TITLE
added a setReadOnly method

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -295,6 +295,20 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * Sets whether this form is read only.
+     *
+     * @param Boolean
+     *
+     * @return Form The current form
+     */
+    public function setReadOnly($readOnly)
+    {
+        $this->readOnly = (Boolean) $readOnly;
+
+        return $this;
+    }
+
+    /**
      * Sets the parent form.
      *
      * @param FormInterface $parent The parent form

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -229,6 +229,18 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($child->isReadOnly());
     }
 
+    public function testSetReadOnly()
+    {
+        $form = $this->getBuilder()->getForm();
+        $this->assertFalse($form->isReadOnly());
+
+        $form->setReadOnly(true);
+        $this->assertTrue($form->isReadOnly());
+
+        $form->setReadOnly(false);
+        $this->assertFalse($form->isReadOnly());
+    }
+
     public function testCloneChildren()
     {
         $child = $this->getBuilder('child')->getForm();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

Being able to set read-only directly in the form is useful when you want to set it from a (pre-/post-)setData listener
