### PR TITLE
[Form] Enable empty root form name

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -153,6 +153,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * made the translation catalogue configurable via the "translation_domain" option
  * added Form::getErrorsAsString() to help debugging forms
  * allowed setting different options for RepeatedType fields (like the label)
+ * added support for empty form name at root level, this enables rendering forms
+   without form name prefix in field names
 
 ### HttpFoundation
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -74,10 +74,15 @@ class FieldType extends AbstractType
         $name = $form->getName();
 
         if ($view->hasParent()) {
-            $parentId = $view->getParent()->get('id');
-            $parentFullName = $view->getParent()->get('full_name');
-            $id = sprintf('%s_%s', $parentId, $name);
-            $fullName = sprintf('%s[%s]', $parentFullName, $name);
+            if ('' === $name) {
+                throw new FormException('Form node with empty name can be used only as root form node.');
+            } elseif ('' !== ($parentFullName = $view->getParent()->get('full_name'))) {
+                $id = sprintf('%s_%s', $view->getParent()->get('id'), $name);
+                $fullName = sprintf('%s[%s]', $parentFullName, $name);
+            } else {
+                $id = $name;
+                $fullName = $name;
+            }
         } else {
             $id = $name;
             $fullName = $name;

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -86,7 +86,9 @@ class FieldType extends AbstractType
                 $fullName = $name;
             }
         } else {
-            $id = $name;
+            // If this form node have empty name, set id to `form`
+            // to avoid rendering `id=""` in html structure
+            $id = $name ?: 'form';
             $fullName = $name;
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -76,7 +76,9 @@ class FieldType extends AbstractType
         if ($view->hasParent()) {
             if ('' === $name) {
                 throw new FormException('Form node with empty name can be used only as root form node.');
-            } elseif ('' !== ($parentFullName = $view->getParent()->get('full_name'))) {
+            }
+
+            if ('' !== ($parentFullName = $view->getParent()->get('full_name'))) {
                 $id = sprintf('%s_%s', $view->getParent()->get('id'), $name);
                 $fullName = sprintf('%s[%s]', $parentFullName, $name);
             } else {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -303,6 +303,10 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function setParent(FormInterface $parent = null)
     {
+        if ('' === $this->getName()) {
+            throw new FormException('Form with empty name can not have parent form.');
+        }
+
         $this->parent = $parent;
 
         return $this;

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -577,13 +577,20 @@ class Form implements \IteratorAggregate, FormInterface
         switch ($request->getMethod()) {
             case 'POST':
             case 'PUT':
-                $data = array_replace_recursive(
-                    $request->request->get($this->getName(), array()),
-                    $request->files->get($this->getName(), array())
-                );
+                if ('' === $this->getName()) {
+                    $data = array_replace_recursive(
+                        $request->request->all(),
+                        $request->files->all()
+                    );
+                } else {
+                    $data = array_replace_recursive(
+                        $request->request->get($this->getName(), array()),
+                        $request->files->get($this->getName(), array())
+                    );
+                }
                 break;
             case 'GET':
-                $data = $request->query->get($this->getName(), array());
+                $data = '' === $this->getName() ? $request->query->all() : $request->query->get($this->getName(), array());
                 break;
             default:
                 throw new FormException(sprintf('The request method "%s" is not supported', $request->getMethod()));

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -411,7 +411,7 @@ class FormFactory implements FormFactoryInterface
 
     private function validateFormTypeName(FormTypeInterface $type)
     {
-        if (!preg_match('/^[a-z0-9_]+$/i', $type->getName())) {
+        if (!preg_match('/^[a-z0-9_]*$/i', $type->getName())) {
             throw new FormException(sprintf('The "%s" form type name ("%s") is not valid. Names must only contain letters, numbers, and "_".', get_class($type), $type->getName()));
         }
     }

--- a/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
+++ b/tests/Symfony/Tests/Component/Form/AbstractLayoutTest.php
@@ -1790,4 +1790,19 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 '
         );
     }
+
+    public function testEmptyRootFormName()
+    {
+        $form = $this->factory->createNamedBuilder('form', '', '', array(
+                'property_path' => 'name',
+            ))
+            ->add('child', 'text')
+            ->getForm();
+
+        $this->assertMatchesXpath($this->renderWidget($form->createView()),
+            '//input[@type="hidden"][@id="_token"][@name="_token"]
+            |
+             //input[@type="text"][@id="child"][@name="child"]'
+        , 2);
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
@@ -254,4 +254,10 @@ class FieldTypeTest extends TypeTestCase
         $form = $this->factory->create('field', null, array('attr' => ''));
     }
 
+    public function testNameCanBeEmptyString()
+    {
+        $form = $this->factory->createNamed('field', '');
+
+        $this->assertEquals('', $form->getName());
+    }
 }


### PR DESCRIPTION
BC Break: no
Feature addition: yes
Symfony2 tests pass: yes
Fixes the following issues: #2790
Todo: need more testing

This PR enables usage of empty string as a form name (only at root level).
