### PR TITLE
[HttpFoundation][File] Add flv file default extension

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -428,6 +428,7 @@ class File extends \SplFileInfo
         'video/vnd.sealedmedia.softseal.mov' => 'smov',
         'video/vnd.vivo' => 'vivo',
         'video/x-fli' => 'fli',
+        'video/x-flv' => 'flv',
         'video/x-ms-asf' => 'asf',
         'video/x-ms-wmv' => 'wmv',
         'video/x-msvideo' => 'avi',


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes (doesn't affect tests)
Fixes the following tickets: -
Todo: -

This commit adds default extension for video/x-flv mime-type, which is a Flash Video file. Lack of this definition causes File::guessExtension() return null for this type of file, which breaks uploaded file in some user cases.
