### PR TITLE
Bugfix. Entities passed to the choice field must have a "__toString()" method...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -103,7 +103,7 @@ class EntityChoiceList extends ArrayChoiceList
         // displaying entities as strings
         if ($property) {
             $this->propertyPath = new PropertyPath($property);
-        } elseif (!method_exists($this->class, '__toString')) {
+        } elseif (!method_exists($this->classMetadata, '__toString')) {
             // Otherwise expect a __toString() method in the entity
             throw new FormException('Entities passed to the choice field must have a "__toString()" method defined (or you can also override the "property" option).');
         }


### PR DESCRIPTION
$this -> class contains only class name (string). So this script will throw FormException always. Need to use classMetadata instead of just class property here.
