### PR TITLE
fixed EntityChoiceList BC break

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -103,7 +103,7 @@ class EntityChoiceList extends ArrayChoiceList
         // displaying entities as strings
         if ($property) {
             $this->propertyPath = new PropertyPath($property);
-        } elseif (!method_exists($this->class, '__toString')) {
+        } elseif (!method_exists($this->classMetadata->getName(), '__toString')) {
             // Otherwise expect a __toString() method in the entity
             throw new FormException('Entities passed to the choice field must have a "__toString()" method defined (or you can also override the "property" option).');
         }

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -197,7 +197,7 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
         ), $choiceList->getChoices('choices'));
     }
 
-    public function testPossibleToProviceShorthandEntityName()
+    public function testPossibleToProvideShorthandEntityName()
     {
         $shorthandName = 'FooBarBundle:Bar';
 

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -196,4 +196,24 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
             2 => 'Bar'
         ), $choiceList->getChoices('choices'));
     }
+
+    public function testPossibleToProviceShorthandEntityName()
+    {
+        $shorthandName = 'FooBarBundle:Bar';
+
+        $metadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
+        $metadata->expects($this->any())->method('getName')->will($this->returnValue('Symfony\Tests\Bridge\Doctrine\Fixtures\SingleIdentEntity'));
+
+        $em = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
+        $em->expects($this->once())->method('getClassMetaData')->with($shorthandName)->will($this->returnValue($metadata));
+
+        $choiceList = new EntityChoiceList(
+            $em,
+            $shorthandName,
+            null,
+            null,
+            null,
+            null
+        );
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: fixes a BC break
Symfony2 tests pass: yes

This PR resolves a serious BC break introduced in commit b919d92b523eb5fb35e25f40245d8d00e67627ef
Prior to this commit, it was possible to use the entity shorthand notation in the EntityChoiceList constructor, but it broke because the EntityChoiceList now expects the second argument to be the actual class name

There is another issue at hand here, but I'm not sure how to fix it:

The EntityChoiceManager expects an Doctrine\Common\Persistence\ObjectManager instance, then the ClassMetadata is fetched from it and the method getIdentifierFieldNames is called on it. Yet, according to the docblock, getClassMetadata of the ObjectManager returns an instance of Doctrine\Common\Persistence\Mapping\ClassMetadata, which doesn't have a getIdentifierFieldNames() method.

So either the EntityChoiceList should expect an instance of EntityManager, or it should be rewritten to not use getIdentifierFieldNames() anymore.

Any ideas?
