### PR TITLE
fixed the display of the current value in a doctrine entity type

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -305,6 +305,8 @@ class EntityChoiceList extends ArrayChoiceList
             throw new FormException('Entities passed to the choice field must be managed');
         }
 
+        $this->em->initializeObject($entity);
+
         return $this->classMetadata->getIdentifierValues($entity);
     }
 }


### PR DESCRIPTION
 when the current value is an instance of Doctrine\Orm\Proxy\Proxy

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Arguably, this is a Doctrine issue rather than a Symfony one, but when the current value in the entity type is a proxy instance, no item is selected, because "$this->reflFields[$this->identifier[0]]->getValue($entity);" (in ClassMetadata) always returns null unless the entity is loaded
