### PR TITLE
Be more tolerant and also accept <esi:include ...></esi:include>

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -154,8 +154,8 @@ class Esi
 
         // we don't use a proper XML parser here as we can have ESI tags in a plain text response
         $content = $response->getContent();
-        $content = preg_replace_callback('#<esi\:include\s+(.*?)\s*/>#', array($this, 'handleEsiIncludeTag'), $content);
-        $content = preg_replace('#<esi\:comment[^>]*/>#', '', $content);
+        $content = preg_replace_callback('#<esi\:include\s+(.*?)\s*(?:/|</esi\:include)>#', array($this, 'handleEsiIncludeTag'), $content);
+        $content = preg_replace('#<esi\:comment[^>]*(?:/|</esi\:comment)>#', '', $content);
         $content = preg_replace('#<esi\:remove>.*?</esi\:remove>#', '', $content);
 
         $response->setContent($content);


### PR DESCRIPTION
I know this is not 100% standards compliant, but:

We need to do some XHTML processing on the output using PHP's DOM extension and the underlying libxml2.

libxml2 seems to be unable to keep the <esi:include /> tag as such and will expand it to `<esi:include ...></esi:include>`.

Note this has nothing to do with having LIBXML_NOEMPTYTAG set (http://php.net/manual/de/domdocument.savexml.php). Rather it seems to be a problem for libxml that it cannot recognize esi:include as an "EMPTY" tag (in the DTD sense) because it is not defined in a standard xhtml1-strict DTD.
