### PR TITLE
[WebProfilerBundle] javascript typo fixes

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -14,7 +14,7 @@
             if (4 === xhr.readyState && 200 === xhr.status && -1 !== xhr.responseText.indexOf('sf-toolbarreset')) {
                 wdt.innerHTML = xhr.responseText;
                 wdt.style.display = 'block';
-            } elseif (4 === xhr.readyState && xhr.status != 200) {
+            } else if (4 === xhr.readyState && xhr.status != 200) {
                 confirm('An error occurred while loading the web debug toolbar (' + xhr.status + ': ' + xhr.statusText + ').\n\nDo you want to open the profiler?') && (window.location = '{{ path("_profiler", { "token": token }) }}');
             }
         };


### PR DESCRIPTION
There should be a space between 'else if' in JavaScript, this causes the profiler to not load properly.
