### PR TITLE
[HttpFoundation] don't urldecode pathinfo in Request::getPathInfo()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1396,6 +1396,7 @@ class Request
      *
      * @param string $string url-encoded string
      * @param string $prefix non-url-encoded string
+     * @return string The prefix as it is encoded in $string, or false
      */
     private function urlencodedStringPrefix($string, $prefix)
     {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1400,9 +1400,7 @@ class Request
      */
     private function urlencodedStringPrefix($string, $prefix)
     {
-        $decoded = urldecode($string);
-
-        if (0 !== $pos = strpos($decoded, $prefix)) {
+        if (0 !== strpos(urldecode($string), $prefix)) {
             return false;
         }
 
@@ -1410,8 +1408,6 @@ class Request
 
         if (preg_match("#(?:%[[:xdigit:]]{2}|.){{$len}}#A", $string, $match)) {
             return $match[0];
-        } else {
-            return false;
         }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1409,5 +1409,7 @@ class Request
         if (preg_match("#(?:%[[:xdigit:]]{2}|.){{$len}}#A", $string, $match)) {
             return $match[0];
         }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1344,7 +1344,7 @@ class Request
             $requestUri = substr($requestUri, 0, $pos);
         }
 
-        if ((null !== $baseUrl) && (false === ($pathInfo = substr(urldecode($requestUri), strlen(urldecode($baseUrl)))))) {
+        if ((null !== $baseUrl) && (false === ($pathInfo = substr($requestUri, strlen($baseUrl))))) {
             // If substr() returns false then PATH_INFO is set to an empty string
             return '/';
         } elseif (null === $baseUrl) {

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -881,6 +881,59 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('text/html,application/xhtml+xml', array('application/xhtml+xml' => 1, 'text/html' => 1)),
         );
     }
+
+    /**
+     * @dataProvider getBaseUrlData
+     */
+    public function testGetBaseUrl($uri, $server, $expectedBaseUrl, $expectedPathInfo)
+    {
+        $request = Request::create($uri, 'GET', array(), array(), array(), $server);
+
+        $this->assertSame($expectedBaseUrl, $request->getBaseUrl());
+        $this->assertSame($expectedPathInfo, $request->getPathInfo());
+    }
+
+    public function getBaseUrlData()
+    {
+        return array(
+            array(
+                '/foo%20bar', array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME' => '/foo bar/app.php',
+                    'PHP_SELF' => '/foo bar/app.php',
+                ),
+                '/foo%20bar',
+                '/',
+            ),
+            array(
+                '/foo%20bar/home', array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME' => '/foo bar/app.php',
+                    'PHP_SELF' => '/foo bar/app.php',
+                ),
+                '/foo%20bar',
+                '/home',
+            ),
+            array(
+                '/foo%20bar/app.php/home', array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME' => '/foo bar/app.php',
+                    'PHP_SELF' => '/foo bar/app.php',
+                ),
+                '/foo%20bar/app.php',
+                '/home',
+            ),
+            array(
+                '/foo%20bar/app.php/home%2Fbaz', array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME' => '/foo bar/app.php',
+                    'PHP_SELF' => '/foo bar/app.php',
+                ),
+                '/foo%20bar/app.php',
+                '/home%2Fbaz',
+            ),
+        );
+    }
 }
 
 class RequestContentProxy extends Request

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -721,17 +721,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/path/info', $request->getPathInfo());
 
         $server = array();
-        $server['REQUEST_URI'] = '/path test/info';
+        $server['REQUEST_URI'] = '/path%20test/info';
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
-        $this->assertEquals('/path test/info', $request->getPathInfo());
+        $this->assertEquals('/path%20test/info', $request->getPathInfo());
 
         $server = array();
         $server['REQUEST_URI'] = '/path%20test/info';
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
-        $this->assertEquals('/path test/info', $request->getPathInfo());
-
+        $this->assertEquals('/path%20test/info', $request->getPathInfo());
     }
 
     public function testGetPreferredLanguage()

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -934,6 +934,31 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             ),
         );
     }
+
+    /**
+     * @dataProvider urlencodedStringPrefixData
+     */
+    public function testUrlencodedStringPrefix($string, $prefix, $expect)
+    {
+        $request = new Request;
+
+        $me = new \ReflectionMethod($request, 'urlencodedStringPrefix');
+        $me->setAccessible(true);
+
+        $this->assertSame($expect, $me->invoke($request, $string, $prefix));
+    }
+
+    public function urlencodedStringPrefixData()
+    {
+        return array(
+            array('foo', 'foo', 'foo'),
+            array('fo%6f', 'foo', 'fo%6f'),
+            array('foo/bar', 'foo', 'foo'),
+            array('fo%6f/bar', 'foo', 'fo%6f'),
+            array('f%6f%6f/bar', 'foo', 'f%6f%6f'),
+            array('%66%6F%6F/bar', 'foo', '%66%6F%6F'),
+        );
+    }
 }
 
 class RequestContentProxy extends Request


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: potentially
Symfony2 tests pass: yes
Fixes the following tickets: #2962, #2579

This fixes #2962 by not decoding the path info in Request->getPathInfo().
