### PR TITLE
[Twig] Fix TransNode with Twig 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,8 @@ php:
   - 5.3
   - 5.4
 
+env:
+  - TWIG_VERSION=v1.4.0
+  - TWIG_VERSION=v1.5.0-RC1
+
 before_script: php vendors.php

--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -93,7 +93,7 @@ class TransNode extends \Twig_Node
 
         if (version_compare(\Twig_Environment::VERSION, '1.5', '>=')) {
             foreach ($matches[1] as $var) {
-                $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $body->getLine());
+                $key = new \Twig_Node_Expression_Constant('%'.$var.'%', $this->getLine());
                 if (!$vars->hasElement($key)) {
                     $vars->addElement(new \Twig_Node_Expression_Name($var, $body->getLine()), $key);
                 }

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/TranslationExtensionTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/TranslationExtensionTest.php
@@ -74,6 +74,8 @@ class TranslationExtensionTest extends TestCase
                 'There is 5 apples (Symfony2)', array('count' => 5, 'name' => 'Symfony2')),
             array('{% transchoice count with { \'%name%\': \'Symfony2\' } %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}',
                 'There is 5 apples (Symfony2)', array('count' => 5)),
+            array("{% transchoice count with {'%name%': 'Symfony2'} %}\n{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%)\n{% endtranschoice %}",
+                'There is 5 apples (Symfony2)', array('count' => 5)),
             array('{% transchoice count into "fr"%}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples{% endtranschoice %}',
                 'There is no apples', array('count' => 0)),
 

--- a/vendors.php
+++ b/vendors.php
@@ -31,13 +31,15 @@ if (isset($argv[1]) && in_array($argv[1], array('--transport=http', '--transport
     $transport = preg_replace('/^--transport=(.*)$/', '$1', $argv[1]);
 }
 
+$twigVersion = isset($_SERVER['TWIG_VERSION']) ? $_SERVER['TWIG_VERSION'] : 'v1.4.0';
+
 $deps = array(
     array('doctrine', 'http://github.com/doctrine/doctrine2.git', '2.1.5'),
     array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', '2.1.5'),
     array('doctrine-common', 'http://github.com/doctrine/common.git', '2.1.4'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', '1.0.2'),
     array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.4'),
-    array('twig', 'http://github.com/fabpot/Twig.git', 'v1.4.0'),
+    array('twig', 'http://github.com/fabpot/Twig.git', $twigVersion),
 );
 
 foreach ($deps as $dep) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

In some cases, the tag `transchoice` doesn't work with Twig 1.5. Same code with Twig 1.4 works fine.
The bug occurs when the tag `transchoice` uses multiple lines.

With Twig 1.5, `TransNode` class checks if all variables objects (name + line number) used in the tag body is defined but with Twig 1.4 only the variable name is checked.

Example:

This code will work with Twig 1.4 and 1.5

```
{% transchoice count with {'%name%': 'Symfony2'} %}{0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%){% endtranschoice %}
```

but the following code doesn't work with v1.5

```
{% transchoice count with {'%name%': 'Symfony2'} %}
    {0} There is no apples|{1} There is one apple|]1,Inf] There is %count% apples (%name%)
{% endtranschoice %}
```
