### PR TITLE
use the forward compat version in the Filesystem service

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -7,7 +7,7 @@
     <parameters>
         <parameter key="event_dispatcher.class">Symfony\Bundle\FrameworkBundle\ContainerAwareEventDispatcher</parameter>
         <parameter key="http_kernel.class">Symfony\Bundle\FrameworkBundle\HttpKernel</parameter>
-        <parameter key="filesystem.class">Symfony\Component\HttpKernel\Util\Filesystem</parameter>
+        <parameter key="filesystem.class">Symfony\Component\Filesystem\Filesystem</parameter>
         <parameter key="cache_warmer.class">Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate</parameter>
         <parameter key="file_locator.class">Symfony\Component\HttpKernel\Config\FileLocator</parameter>
     </parameters>


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: ![Build Status](https://secure.travis-ci.org/lsmith77/symfony.png?branch=forward_compat_filesystem)
Fixes the following tickets: -

by changing the service it should fix any type hints for the Filesystem class inside 2.1, but it shouldn't affect anyone still type hinting the old location in 2.0 since the new forward compat file extends the old file.

See
https://github.com/liip/LiipImagineBundle/commit/00c988bf0c0718a6861d59877e1aa525738669f7#commitcomment-820879
