### PR TITLE
[DependencyInjection] Parameters with spaces are not resolved

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -198,7 +198,7 @@ class ParameterBag implements ParameterBagInterface
         // we do this to deal with non string values (Boolean, integer, ...)
         // as the preg_replace_callback throw an exception when trying
         // a non-string in a parameter value
-        if (preg_match('/^%([^%]+)%$/', $value, $match)) {
+        if (preg_match('/^%([^%\s]+)%$/', $value, $match)) {
             $key = strtolower($match[1]);
 
             if (isset($resolving[$key])) {
@@ -212,7 +212,7 @@ class ParameterBag implements ParameterBagInterface
 
         $self = $this;
 
-        return preg_replace_callback('/(?<!%)%([^%]+)%/', function ($match) use ($self, $resolving, $value) {
+        return preg_replace_callback('/(?<!%)%([^%\s]+)%/', function ($match) use ($self, $resolving, $value) {
             $key = strtolower($match[1]);
             if (isset($resolving[$key])) {
                 throw new ParameterCircularReferenceException(array_keys($resolving));

--- a/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
@@ -164,4 +164,29 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('The parameter "foo" has a dependency on a non-existent parameter "bar".', $e->getMessage());
         }
     }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolve
+     * @dataProvider stringsWithSpacesProvider
+     */
+    public function testResolveStringWithSpacesReturnsString($expected, $test, $description)
+    {
+        $bag = new ParameterBag(array('foo' => 'bar'));
+
+        try {
+            $this->assertEquals($expected, $bag->resolveString($test), $description);
+        } catch (ParameterNotFoundException $e) {
+            $this->fail(sprintf('%s - "%s"', $description, $expected));
+        }
+    }
+
+    public function stringsWithSpacesProvider()
+    {
+        return array(
+            array('bar', '%foo%', 'Parameters must be wrapped by %.'),
+            array('% foo %', '% foo %', 'Parameters should not have spaces.'),
+            array('{% set my_template = "foo" %}', '{% set my_template = "foo" %}', 'Twig-like strings are not parameters.'),
+            array('50% is less than 100%', '50% is less than 100%', 'Text between % signs is allowed, if there are spaces.'),
+        );
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no (not likely, according to convention)
Symfony2 tests pass: yes
Fixes the following tickets: #2884

`ParameterBag` currently resolves anything between two `%` signs, which creates issues for any parameters in the DIC that are legitimate text.  This PR enforces the [documented parameter convention](http://symfony.com/doc/2.0/book/service_container.html#service-parameters) so that only `%parameters.with.no_spaces%` are resolved.

I was considering using instead `^%([^\w\._-]+)%$`, but felt that was too constricting & could easily introduce issues with existing applications.
