### PR TITLE
[Serializer] GetSetMethodNormalizer uses `lcfirst` instead of `strtolower`

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -46,7 +46,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer
         $attributes = array();
         foreach ($reflectionMethods as $method) {
             if ($this->isGetMethod($method)) {
-                $attributeName = strtolower(substr($method->getName(), 3));
+                $attributeName = lcfirst(substr($method->getName(), 3));
 
                 $attributeValue = $method->invoke($object);
                 if (null !== $attributeValue && !is_scalar($attributeValue)) {
@@ -73,7 +73,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer
 
             $params = array();
             foreach ($constructorParameters as $constructorParameter) {
-                $paramName = strtolower($constructorParameter->getName());
+                $paramName = lcfirst($constructorParameter->getName());
 
                 if (isset($data[$paramName])) {
                     $params[] = $data[$paramName];

--- a/tests/Symfony/Tests/Component/Serializer/Normalizer/GetSetMethodNormalizerTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/Normalizer/GetSetMethodNormalizerTest.php
@@ -27,7 +27,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $obj->setFoo('foo');
         $obj->setBar('bar');
         $this->assertEquals(
-            array('foo' => 'foo', 'bar' => 'bar', 'foobar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
             $this->normalizer->normalize($obj, 'any')
         );
     }
@@ -35,7 +35,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     public function testDenormalize()
     {
         $obj = $this->normalizer->denormalize(
-            array('foo' => 'foo', 'bar' => 'bar', 'foobar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
             __NAMESPACE__.'\GetSetDummy',
             'any'
         );
@@ -46,7 +46,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
-            array('foo' => 'foo', 'bar' => 'bar', 'foobar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
             __NAMESPACE__.'\GetConstructorDummy', 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #2863

As a courtesy to @lxg, this PR calculates method names using `lcfirst` instead of `strtolower`: `fooBar` was converted to `getFoobar`, but is now `getFooBar`.

However, according to the [PHP documentation](http://www.php.net/manual/en/functions.user-defined.php):

> **Note**: Function names are case-insensitive, though it is usually good form to call functions as they appear in their declaration.

In my opinion, this PR is simply cleanup, letting the normalized structure accurately reflect the underlying methods/properties.  If anyone is using the normalizer now, their keys may change, causing a BC break.

If this PR is considered for merging, I recommend making it in `master` rather than `2.0`, because of potential BC issues.
