### PR TITLE
reverseTransform doesn't take a second argument

### DIFF
--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DataTransformerChainTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DataTransformerChainTest.php
@@ -48,6 +48,6 @@ class DataTransformerChainTest extends \PHPUnit_Framework_TestCase
 
         $chain = new DataTransformerChain(array($transformer1, $transformer2));
 
-        $this->assertEquals('baz', $chain->reverseTransform('foo', null));
+        $this->assertEquals('baz', $chain->reverseTransform('foo'));
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
@@ -124,7 +124,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     public function testTransformRequiresDateTime()
     {
         $transformer = new DateTimeToArrayTransformer();
-        $transformer->reverseTransform('12345', null);
+        $transformer->reverseTransform('12345');
     }
 
     public function testReverseTransform()
@@ -142,7 +142,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
 
         $output = new \DateTime('2010-02-03 04:05:06 UTC');
 
-        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input));
     }
 
     public function testReverseTransformWithSomeZero()
@@ -160,7 +160,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
 
         $output = new \DateTime('2010-02-03 04:00:00 UTC');
 
-        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input));
     }
 
     public function testReverseTransform_completelyEmpty()
@@ -176,7 +176,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
             'second' => '',
         );
 
-        $this->assertNull($transformer->reverseTransform($input, null));
+        $this->assertNull($transformer->reverseTransform($input));
     }
 
     public function testReverseTransform_completelyEmpty_subsetOfFields()
@@ -189,7 +189,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
             'day' => '',
         );
 
-        $this->assertNull($transformer->reverseTransform($input, null));
+        $this->assertNull($transformer->reverseTransform($input));
     }
 
     /**
@@ -286,7 +286,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     {
         $transformer = new DateTimeToArrayTransformer();
 
-        $this->assertNull($transformer->reverseTransform(null, null));
+        $this->assertNull($transformer->reverseTransform(null));
     }
 
     public function testReverseTransform_differentTimezones()
@@ -305,7 +305,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $output = new \DateTime('2010-02-03 04:05:06 Asia/Hong_Kong');
         $output->setTimezone(new \DateTimeZone('America/New_York'));
 
-        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input));
     }
 
     public function testReverseTransformToDifferentTimezone()
@@ -324,7 +324,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $output = new \DateTime('2010-02-03 04:05:06 UTC');
         $output->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
 
-        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $transformer->reverseTransform($input));
     }
 
     /**
@@ -333,7 +333,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     public function testReverseTransformRequiresArray()
     {
         $transformer = new DateTimeToArrayTransformer();
-        $transformer->reverseTransform('12345', null);
+        $transformer->reverseTransform('12345');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -164,49 +164,49 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::SHORT);
 
-        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.10 04:05', null));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.10 04:05'));
     }
 
     public function testReverseTransformMediumDate()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::MEDIUM);
 
-        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.2010 04:05', null));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.2010 04:05'));
     }
 
     public function testReverseTransformLongDate()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::LONG);
 
-        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03. Februar 2010 04:05', null));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03. Februar 2010 04:05'));
     }
 
     public function testReverseTransformFullDate()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL);
 
-        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Mittwoch, 03. Februar 2010 04:05', null));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Mittwoch, 03. Februar 2010 04:05'));
     }
 
     public function testReverseTransformShortTime()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::SHORT);
 
-        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.2010 04:05', null));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.2010 04:05'));
     }
 
     public function testReverseTransformMediumTime()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::MEDIUM);
 
-        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06', null));
+        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06'));
     }
 
     public function testReverseTransformLongTime()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::LONG);
 
-        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06 GMT+00:00', null));
+        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06 GMT+00:00'));
     }
 
     public function testReverseTransformFullTime()
@@ -217,7 +217,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
 
-        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06 GMT+00:00', null));
+        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06 GMT+00:00'));
     }
 
     public function testReverseTransformFromDifferentLocale()
@@ -226,7 +226,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
 
-        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Feb 3, 2010 04:05 AM', null));
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Feb 3, 2010 04:05 AM'));
     }
 
     public function testReverseTransform_differentTimezones()
@@ -236,21 +236,21 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $dateTime = new \DateTime('2010-02-03 04:05:00 Asia/Hong_Kong');
         $dateTime->setTimezone(new \DateTimeZone('America/New_York'));
 
-        $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('03.02.2010 04:05', null));
+        $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('03.02.2010 04:05'));
     }
 
     public function testReverseTransform_differentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
-        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06', null));
+        $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06'));
     }
 
     public function testReverseTransform_empty()
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
 
-        $this->assertNull($transformer->reverseTransform('', null));
+        $this->assertNull($transformer->reverseTransform(''));
     }
 
     /**
@@ -259,7 +259,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
     public function testReverseTransformRequiresString()
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
-        $transformer->reverseTransform(12345, null);
+        $transformer->reverseTransform(12345);
     }
 
     /**
@@ -268,7 +268,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
     public function testReverseTransformWrapsIntlErrors()
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
-        $transformer->reverseTransform('12345', null);
+        $transformer->reverseTransform('12345');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -77,7 +77,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $output = new \DateTime('2010-02-03 04:05:06 UTC');
         $input = $output->format('Y-m-d H:i:s');
 
-        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
     /**
@@ -90,7 +90,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $dateTime = new \DateTime($datetime);
         $input = $dateTime->format($format);
 
-        $this->assertDateTimeEquals($dateTime, $reverseTransformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($dateTime, $reverseTransformer->reverseTransform($input));
     }
 
     public function getFormatAndDateTime()
@@ -109,7 +109,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
     {
         $reverseTransformer = new DateTimeToStringTransformer();
 
-        $this->assertNull($reverseTransformer->reverseTransform('', null));
+        $this->assertNull($reverseTransformer->reverseTransform(''));
     }
 
     public function testReverseTransform_differentTimezones()
@@ -120,7 +120,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $input = $output->format('Y-m-d H:i:s');
         $output->setTimeZone(new \DateTimeZone('America/New_York'));
 
-        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
     public function testReverseTransformExpectsString()
@@ -129,7 +129,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
 
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
 
-        $reverseTransformer->reverseTransform(1234, null);
+        $reverseTransformer->reverseTransform(1234);
     }
 
     public function testReverseTransformExpectsValidDateString()
@@ -138,6 +138,6 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
 
         $this->setExpectedException('Symfony\Component\Form\Exception\TransformationFailedException');
 
-        $reverseTransformer->reverseTransform('2010-2010-2010', null);
+        $reverseTransformer->reverseTransform('2010-2010-2010');
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
@@ -74,14 +74,14 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
         $output = new \DateTime('2010-02-03 04:05:06 UTC');
         $input = $output->format('U');
 
-        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
     public function testReverseTransform_empty()
     {
         $reverseTransformer = new DateTimeToTimestampTransformer();
 
-        $this->assertNull($reverseTransformer->reverseTransform(null, null));
+        $this->assertNull($reverseTransformer->reverseTransform(null));
     }
 
     public function testReverseTransform_differentTimezones()
@@ -92,7 +92,7 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
         $input = $output->format('U');
         $output->setTimezone(new \DateTimeZone('Asia/Hong_Kong'));
 
-        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input, null));
+        $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
     public function testReverseTransformExpectsValidTimestamp()
@@ -101,6 +101,6 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
 
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
 
-        $reverseTransformer->reverseTransform('2010-2010-2010', null);
+        $reverseTransformer->reverseTransform('2010-2010-2010');
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -52,7 +52,7 @@ class MoneyToLocalizedStringTransformerTest extends LocalizedTestCase
     {
         $transformer = new MoneyToLocalizedStringTransformer(null, null, null, 100);
 
-        $this->assertEquals(123, $transformer->reverseTransform('1,23', null));
+        $this->assertEquals(123, $transformer->reverseTransform('1,23'));
     }
 
     public function testReverseTransformExpectsString()
@@ -61,13 +61,13 @@ class MoneyToLocalizedStringTransformerTest extends LocalizedTestCase
 
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
 
-        $transformer->reverseTransform(12345, null);
+        $transformer->reverseTransform(12345);
     }
 
     public function testReverseTransform_empty()
     {
         $transformer = new MoneyToLocalizedStringTransformer();
 
-        $this->assertNull($transformer->reverseTransform('', null));
+        $this->assertNull($transformer->reverseTransform(''));
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -62,34 +62,34 @@ class PercentToLocalizedStringTransformerTest extends LocalizedTestCase
     {
         $transformer = new PercentToLocalizedStringTransformer();
 
-        $this->assertEquals(0.1, $transformer->reverseTransform('10', null));
-        $this->assertEquals(0.15, $transformer->reverseTransform('15', null));
-        $this->assertEquals(0.12, $transformer->reverseTransform('12', null));
-        $this->assertEquals(2, $transformer->reverseTransform('200', null));
+        $this->assertEquals(0.1, $transformer->reverseTransform('10'));
+        $this->assertEquals(0.15, $transformer->reverseTransform('15'));
+        $this->assertEquals(0.12, $transformer->reverseTransform('12'));
+        $this->assertEquals(2, $transformer->reverseTransform('200'));
     }
 
     public function testReverseTransform_empty()
     {
         $transformer = new PercentToLocalizedStringTransformer();
 
-        $this->assertNull($transformer->reverseTransform('', null));
+        $this->assertNull($transformer->reverseTransform(''));
     }
 
     public function testReverseTransformWithInteger()
     {
         $transformer = new PercentToLocalizedStringTransformer(null, 'integer');
 
-        $this->assertEquals(10, $transformer->reverseTransform('10', null));
-        $this->assertEquals(15, $transformer->reverseTransform('15', null));
-        $this->assertEquals(12, $transformer->reverseTransform('12', null));
-        $this->assertEquals(200, $transformer->reverseTransform('200', null));
+        $this->assertEquals(10, $transformer->reverseTransform('10'));
+        $this->assertEquals(15, $transformer->reverseTransform('15'));
+        $this->assertEquals(12, $transformer->reverseTransform('12'));
+        $this->assertEquals(200, $transformer->reverseTransform('200'));
     }
 
     public function testReverseTransformWithPrecision()
     {
         $transformer = new PercentToLocalizedStringTransformer(2);
 
-        $this->assertEquals(0.1234, $transformer->reverseTransform('12,34', null));
+        $this->assertEquals(0.1234, $transformer->reverseTransform('12,34'));
     }
 
     public function testTransformExpectsNumeric()
@@ -107,6 +107,6 @@ class PercentToLocalizedStringTransformerTest extends LocalizedTestCase
 
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
 
-        $transformer->reverseTransform(1, null);
+        $transformer->reverseTransform(1);
     }
 }


### PR DESCRIPTION
removed the second argument (which was always "null") in some reverseTransform calls
