### PR TITLE
[Form] Added getValidators() to Form class

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -771,6 +771,16 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * Returns the Validators
+     *
+     * @return array An array of FormValidatorInterface
+     */
+    public function getValidators()
+    {
+        return $this->validators;
+    }
+
+    /**
      * Returns all children in this group.
      *
      * @return array

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -1024,6 +1024,16 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("name:\n    ERROR: Error!\nfoo:\n    No errors\n", $parent->getErrorsAsString());
     }
 
+    public function testGetValidatorsReturnsValidators()
+    {
+        $validator = $this->getFormValidator();
+        $form = $this->getBuilder()
+            ->addValidator($validator)
+            ->getForm();
+
+        $this->assertEquals(array($validator), $form->getValidators());
+    }
+
     protected function getBuilder($name = 'name', EventDispatcherInterface $dispatcher = null)
     {
         return new FormBuilder($name, $this->factory, $dispatcher ?: $this->dispatcher);


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

I am working implementing client side validation in a bundle that adds validation rules via a form builder. I am currently unable to pull the validators from the Form class which is making the implementation incredibly difficult.

I noticed that the transformers are currently exposed and based on some feedback I got on IRC I am guessing these weren't exposed simply because no one needed them at the time.
