### PR TITLE
[FrameworkBundle][Validator] Allow Constraints to be skipped.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -338,6 +338,7 @@ class Configuration implements ConfigurationInterface
                     ->booleanNode('enabled')->defaultTrue()->end()
                         ->scalarNode('cache')->end()
                         ->booleanNode('enable_annotations')->defaultFalse()->end()
+                        ->booleanNode('skip_constraints_on_errors')->defaultFalse()->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -562,6 +562,10 @@ class FrameworkExtension extends Extension
                 'validator_'.md5($container->getParameter('kernel.root_dir'))
             );
         }
+
+        if (array_key_exists('skip_constraints_on_errors', $config) && $config['enable_annotations']) {
+            $container->setParameter('validator.skip_constraints', true);
+        }
     }
 
     private function getValidatorXmlMappingFiles(ContainerBuilder $container)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -563,9 +563,7 @@ class FrameworkExtension extends Extension
             );
         }
 
-        if (array_key_exists('skip_constraints_on_errors', $config) && $config['enable_annotations']) {
-            $container->setParameter('validator.skip_constraints', true);
-        }
+        $container->setParameter('validator.skip_constraints', $config['skip_constraints_on_errors']);
     }
 
     private function getValidatorXmlMappingFiles(ContainerBuilder $container)

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -6,7 +6,6 @@
 
     <parameters>
         <parameter key="validator.class">Symfony\Component\Validator\Validator</parameter>
-        <parameter key="validator.skip_constraints">false</parameter>
         <parameter key="validator.mapping.class_metadata_factory.class">Symfony\Component\Validator\Mapping\ClassMetadataFactory</parameter>
         <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache</parameter>
         <parameter key="validator.mapping.cache.prefix" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/validator.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="validator.class">Symfony\Component\Validator\Validator</parameter>
+        <parameter key="validator.skip_constraints">false</parameter>
         <parameter key="validator.mapping.class_metadata_factory.class">Symfony\Component\Validator\Mapping\ClassMetadataFactory</parameter>
         <parameter key="validator.mapping.cache.apc.class">Symfony\Component\Validator\Mapping\Cache\ApcCache</parameter>
         <parameter key="validator.mapping.cache.prefix" />
@@ -24,6 +25,9 @@
             <argument type="service" id="validator.mapping.class_metadata_factory" />
             <argument type="service" id="validator.validator_factory" />
             <argument type="collection" />
+            <call method="setSkipOnError">
+                <argument>%validator.skip_constraints%</argument>
+            </call>
         </service>
 
         <service id="validator.mapping.class_metadata_factory" class="%validator.mapping.class_metadata_factory.class%" public="false">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -174,6 +174,7 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('validator'), '->registerValidationConfiguration() loads validator.xml');
         $this->assertTrue($container->hasDefinition('validator.mapping.loader.xml_files_loader'), '->registerValidationConfiguration() defines the XML loader');
         $this->assertTrue($container->hasDefinition('validator.mapping.loader.yaml_files_loader'), '->registerValidationConfiguration() defines the YAML loader');
+        $this->assertFalse($container->getParameter('validator.skip_constraints'), '->registerValidationConfiguration() defines "skip on errors" parameter, default to false (for BC)');
 
         $xmlFiles = $container->getParameter('validator.mapping.loader.xml_files_loader.mapping_files');
         $this->assertContains(

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -54,6 +54,11 @@ abstract class Constraint
     public $groups = array(self::DEFAULT_GROUP);
 
     /**
+     * @var Boolean
+     */
+    public $skipOnError = false;
+
+    /**
      * Initializes the constraint with options.
      *
      * You should pass an associative array. The keys should be the names of

--- a/src/Symfony/Component/Validator/Constraint.php
+++ b/src/Symfony/Component/Validator/Constraint.php
@@ -54,9 +54,12 @@ abstract class Constraint
     public $groups = array(self::DEFAULT_GROUP);
 
     /**
-     * @var Boolean
+     * Explicit definition of "skip on error functionality".
+     * If set to null, the default behaviour from config is used.
+     *
+     * @var Boolean|null
      */
-    public $skipOnError = false;
+    public $skipOnError;
 
     /**
      * Initializes the constraint with options.

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -33,7 +33,7 @@ class GraphWalker
     protected $validatorInitializers = array();
     protected $validatedObjects = array();
 
-    private $skipOnError;
+    private $skipOnError = false;
 
     public function __construct($root, ClassMetadataFactoryInterface $metadataFactory, ConstraintValidatorFactoryInterface $factory, array $validatorInitializers = array())
     {
@@ -41,7 +41,6 @@ class GraphWalker
         $this->validatorFactory = $factory;
         $this->metadataFactory = $metadataFactory;
         $this->validatorInitializers = $validatorInitializers;
-        $this->skipOnError = false;
     }
 
     /**
@@ -194,10 +193,8 @@ class GraphWalker
         $this->context->setPropertyPath($propertyPath);
         $this->context->setGroup($group);
 
-        /**
-         * If Constraint have explicit definition use it, othervise use default behaviour
-         */
-        $skipOnError = is_null($constraint->skipOnError) ? $this->skipOnError : (Boolean) $constraint->skipOnError;
+        //If constraint have explicit definition use it, othervise use default behaviour
+        $skipOnError = null === $constraint->skipOnError ? $this->skipOnError : (Boolean) $constraint->skipOnError;
 
         if ($skipOnError && count($this->context->getViolations()) > 0) {
             return;

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -171,6 +171,10 @@ class GraphWalker
         $this->context->setPropertyPath($propertyPath);
         $this->context->setGroup($group);
 
+        if ($constraint->skipOnError && count($this->getViolations()) > 0) {
+            return;
+        }
+
         $validator->initialize($this->context);
 
         if (!$validator->isValid($value, $constraint)) {

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -33,12 +33,15 @@ class GraphWalker
     protected $validatorInitializers = array();
     protected $validatedObjects = array();
 
+    private $skipOnError;
+
     public function __construct($root, ClassMetadataFactoryInterface $metadataFactory, ConstraintValidatorFactoryInterface $factory, array $validatorInitializers = array())
     {
         $this->context = new ExecutionContext($root, $this, $metadataFactory);
         $this->validatorFactory = $factory;
         $this->metadataFactory = $metadataFactory;
         $this->validatorInitializers = $validatorInitializers;
+        $this->skipOnError = false;
     }
 
     /**
@@ -47,6 +50,26 @@ class GraphWalker
     public function getViolations()
     {
         return $this->context->getViolations();
+    }
+
+    /**
+     * Get current "skip constraints on errors" behaviour value.
+     *
+     * @return Boolean
+     */
+    public function getSkipOnError()
+    {
+        return $this->skipOnError;
+    }
+
+    /**
+     * Enable/disable "skip constraints on errors" behaviour.
+     *
+     * @param Boolean $skipOnError
+     */
+    public function setSkipOnError($skipOnError)
+    {
+        $this->skipOnError = (Boolean) $skipOnError;
     }
 
     /**
@@ -171,7 +194,12 @@ class GraphWalker
         $this->context->setPropertyPath($propertyPath);
         $this->context->setGroup($group);
 
-        if ($constraint->skipOnError && count($this->getViolations()) > 0) {
+        /**
+         * If Constraint have explicit definition use it, othervise use default behaviour
+         */
+        $skipOnError = is_null($constraint->skipOnError) ? $this->skipOnError : (Boolean) $constraint->skipOnError;
+
+        if ($skipOnError && count($this->context->getViolations()) > 0) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -30,6 +30,8 @@ class Validator implements ValidatorInterface
     protected $validatorFactory;
     protected $validatorInitializers;
 
+    private $skipOnError;
+
     public function __construct(
         ClassMetadataFactoryInterface $metadataFactory,
         ConstraintValidatorFactoryInterface $validatorFactory,
@@ -39,6 +41,7 @@ class Validator implements ValidatorInterface
         $this->metadataFactory = $metadataFactory;
         $this->validatorFactory = $validatorFactory;
         $this->validatorInitializers = $validatorInitializers;
+        $this->skipOnError = false;
     }
 
     /**
@@ -47,6 +50,16 @@ class Validator implements ValidatorInterface
     public function getMetadataFactory()
     {
         return $this->metadataFactory;
+    }
+
+    public function getSkipOnError()
+    {
+        return $this->skipOnError;
+    }
+
+    public function setSkipOnError($skipOnError)
+    {
+        $this->skipOnError = (Boolean) $skipOnError;
     }
 
     /**
@@ -114,6 +127,7 @@ class Validator implements ValidatorInterface
     protected function validateGraph($root, \Closure $walk, $groups = null)
     {
         $walker = new GraphWalker($root, $this->metadataFactory, $this->validatorFactory, $this->validatorInitializers);
+        $walker->setSkipOnError($this->skipOnError);
         $groups = $groups ? (array) $groups : array(Constraint::DEFAULT_GROUP);
 
         foreach ($groups as $group) {

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -30,7 +30,7 @@ class Validator implements ValidatorInterface
     protected $validatorFactory;
     protected $validatorInitializers;
 
-    private $skipOnError;
+    private $skipOnError = false;
 
     public function __construct(
         ClassMetadataFactoryInterface $metadataFactory,
@@ -41,7 +41,6 @@ class Validator implements ValidatorInterface
         $this->metadataFactory = $metadataFactory;
         $this->validatorFactory = $validatorFactory;
         $this->validatorInitializers = $validatorInitializers;
-        $this->skipOnError = false;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
+++ b/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
@@ -443,6 +443,19 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($this->walker->getViolations()));
     }
 
+    public function testWalkConstraintSkipsValidationWhenDefaultSkipOnError()
+    {
+        $constraint1 = new ConstraintA();
+        $constraint2 = new ConstraintA();
+
+        $this->walker->setSkipOnError(true);
+
+        $this->walker->walkConstraint($constraint1, 'IN-VALID', 'Default', 'firstName.path');
+        $this->walker->walkConstraint($constraint2, 'IN-VALID', 'Default', 'firstName.path');
+
+        $this->assertEquals(1, count($this->walker->getViolations()));
+    }
+
     public function testWalkObjectUsesCorrectPropertyPathInViolationsWhenUsingCollections()
     {
         $constraint = new Collection(array(

--- a/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
+++ b/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
@@ -440,7 +440,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
         $this->walker->walkConstraint($constraint1, 'IN-VALID', 'Default', 'firstName.path');
         $this->walker->walkConstraint($constraint2, 'IN-VALID', 'Default', 'firstName.path');
 
-        $this->assertEquals(1, count($this->walker->getViolations()));
+        $this->assertCount(1, count($this->walker->getViolations()));
     }
 
     public function testWalkConstraintSkipsValidationWhenDefaultSkipOnError()
@@ -453,7 +453,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
         $this->walker->walkConstraint($constraint1, 'IN-VALID', 'Default', 'firstName.path');
         $this->walker->walkConstraint($constraint2, 'IN-VALID', 'Default', 'firstName.path');
 
-        $this->assertEquals(1, count($this->walker->getViolations()));
+        $this->assertCount(1, count($this->walker->getViolations()));
     }
 
     public function testWalkObjectUsesCorrectPropertyPathInViolationsWhenUsingCollections()

--- a/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
+++ b/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
@@ -432,6 +432,17 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($this->walker->getViolations()));
     }
 
+    public function testWalkConstraintSkipsValidationWhenConstraintHasSkipOnError()
+    {
+        $constraint1 = new ConstraintA();
+        $constraint2 = new ConstraintA(array('skipOnError' => true));
+
+        $this->walker->walkConstraint($constraint1, 'IN-VALID', 'Default', 'firstName.path');
+        $this->walker->walkConstraint($constraint2, 'IN-VALID', 'Default', 'firstName.path');
+
+        $this->assertEquals(1, count($this->walker->getViolations()));
+    }
+
     public function testWalkObjectUsesCorrectPropertyPathInViolationsWhenUsingCollections()
     {
         $constraint = new Collection(array(

--- a/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
@@ -160,4 +160,19 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             $this->validator->getMetadataFactory()
         );
     }
+
+    public function testValidatorSetUpSkipOnError()
+    {
+        $this->validator->setSkipOnError(true);
+
+        $entity = new Entity();
+        $metadata = new ClassMetadata(get_class($entity));
+        $metadata->addPropertyConstraint('firstName', new FailingConstraint());
+        $metadata->addPropertyConstraint('firstName', new FailingConstraint());
+        $this->factory->addClassMetadata($metadata);
+
+        $result = $this->validator->validateProperty($entity, 'firstName');
+
+        $this->assertEquals(1, count($result));
+    }
 }


### PR DESCRIPTION
BC Break: no
Feature addition: yes
Symfony2 tests pass: yes
New feature tests added: yes
Fixes the following tixkets: #2947

This allows skipping validation of constraints that have
`skipOnError` option set, this may reduce the "noice" of multiple failed
constraints.
