### PR TITLE
[Routing] Add a '_host' requirement for routes

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -146,9 +146,14 @@ class UrlGenerator implements UrlGeneratorInterface
 
         if ($this->context->getHost()) {
             $scheme = $this->context->getScheme();
+            $host = $this->context->getHost();
             if (isset($requirements['_scheme']) && ($req = strtolower($requirements['_scheme'])) && $scheme != $req) {
                 $absolute = true;
                 $scheme = $req;
+            }
+            if (isset($requirements['_host']) && ($req = $requirements['_host']) && $host != $req) {
+                $absolute = true;
+                $host = $req;
             }
 
             if ($absolute) {
@@ -159,7 +164,7 @@ class UrlGenerator implements UrlGeneratorInterface
                     $port = ':'.$this->context->getHttpsPort();
                 }
 
-                $url = $scheme.'://'.$this->context->getHost().$port.$url;
+                $url = $scheme.'://'.$host.$port.$url;
             }
         }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -68,7 +68,7 @@ class ApacheMatcherDumper extends MatcherDumper
 
             $rule = array("# $name");
 
-            if($hostreq = $route->getRequirement('_host')) {
+            if ($hostreq = $route->getRequirement('_host')) {
                 $rule[] = "RewriteCond %{HTTP_HOST} $hostreq";
             }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -68,6 +68,10 @@ class ApacheMatcherDumper extends MatcherDumper
 
             $rule = array("# $name");
 
+            if($hostreq = $route->getRequirement('_host')) {
+                $rule[] = "RewriteCond %{HTTP_HOST} $hostreq";
+            }
+
             // method mismatch
             if ($req = $route->getRequirement('_method')) {
                 $methods = explode('|', strtoupper($req));

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -181,9 +181,9 @@ EOF;
 
         if ($hostreq = $route->getRequirement('_host')) {
             $code[] = <<<EOF
-        if(\$this->context->getHost() !== '$hostreq') {
-            goto $gotoname;
-        }
+            if(\$this->context->getHost() !== '$hostreq') {
+                goto $gotoname;
+            }
 EOF;
         }
 

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -179,6 +179,14 @@ EOF;
         if ($conditions) {
 EOF;
 
+        if ($hostreq = $route->getRequirement('_host')) {
+            $code[] = <<<EOF
+        if(\$this->context->getHost() !== '$hostreq') {
+            goto $gotoname;
+        }
+EOF;
+        }
+
         if ($req = $route->getRequirement('_method')) {
             $methods = explode('|', strtoupper($req));
             // GET and HEAD are equivalent
@@ -239,7 +247,7 @@ EOF
         }
         $code[] = "        }";
 
-        if ($req) {
+        if ($req || $hostreq) {
             $code[] = "        $gotoname:";
         }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -112,10 +112,9 @@ class UrlMatcher implements UrlMatcherInterface
                 continue;
             }
 
-            if ($hostreq = $route->getRequirement('_host')) {
-                if ($hostreq !== $this->context->getHost()) {
+            // check host requirement
+            if (($req = $route->getRequirement('_host')) && $req !== $this->context->getHost()) {
                     continue;
-                }
             }
 
             // check HTTP method requirement

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -112,6 +112,12 @@ class UrlMatcher implements UrlMatcherInterface
                 continue;
             }
 
+            if ($hostreq = $route->getRequirement('_host')) {
+                if ($hostreq !== $this->context->getHost()) {
+                    continue;
+                }
+            }
+
             // check HTTP method requirement
             if ($req = $route->getRequirement('_method')) {
                 // HEAD and GET are equivalent as per RFC

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.apache
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.apache
@@ -6,6 +6,11 @@ RewriteRule .* - [QSA,L]
 RewriteCond %{REQUEST_URI} ^/foo/(baz|symfony)$
 RewriteRule .* app.php [QSA,L,E=_ROUTING__route:foo,E=_ROUTING_bar:%1,E=_ROUTING_def:test]
 
+# hostbar
+RewriteCond %{HTTP_HOST} example.org
+RewriteCond %{REQUEST_URI} ^/hostbar$
+RewriteRule .* app.php [QSA,L,E=_ROUTING__route:hostbar]
+
 # bar
 RewriteCond %{REQUEST_URI} ^/bar/([^/]+?)$
 RewriteCond %{REQUEST_METHOD} !^(GET|HEAD)$ [NC]

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
@@ -41,6 +41,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
         not_bar:
 
+        // barhost
+        if ($pathinfo === '/bar/') {
+            if($this->context->getHost() !== 'example.org') {
+                goto not_barhost;
+            }
+            return array('_route' => 'barhost');
+        }
+        not_barhost:
+
         // barhead
         if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]+?)$#xs', $pathinfo, $matches)) {
             if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher2.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher2.php
@@ -41,6 +41,18 @@ class ProjectUrlMatcher extends Symfony\Tests\Component\Routing\Fixtures\Redirec
         }
         not_bar:
 
+        // barhost
+        if (rtrim($pathinfo, '/') === '/bar') {
+            if($this->context->getHost() !== 'example.org') {
+                goto not_barhost;
+            }
+            if (substr($pathinfo, -1) !== '/') {
+                return $this->redirect($pathinfo.'/', 'barhost');
+            }
+            return array('_route' => 'barhost');
+        }
+        not_barhost:
+
         // barhead
         if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?P<foo>[^/]+?)$#xs', $pathinfo, $matches)) {
             if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {

--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -18,6 +18,14 @@ use Symfony\Component\Routing\RequestContext;
 
 class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 {
+    public function testAbsoluteUrlWithHost()
+    {
+        $routes = $this->getRoutes('test', new Route( '/testing', array(), array('_host' => 'example.org')));
+        $url = $this->getGenerator($routes)->generate('test', array(), true);
+
+        $this->assertEquals('http://example.org/app.php/testing', $url);
+    }
+
     public function testAbsoluteUrlWithPort80()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/ApacheMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/ApacheMatcherDumperTest.php
@@ -34,6 +34,12 @@ class ApacheMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array('def' => 'test'),
             array('bar' => 'baz|symfony')
         ));
+        // host requirement
+        $collection->add('hostbar', new Route(
+            '/hostbar',
+            array(),
+            array('_host' => 'example.org')
+        ));
         // method requirement
         $collection->add('bar', new Route(
             '/bar/{foo}',

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -78,6 +78,12 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array(),
             array('_method' => 'GET|head')
         ));
+        // host requirement
+        $collection->add('barhost', new Route(
+            '/bar/',
+            array(),
+            array('_host' => 'example.org')
+        ));
         // GET method requirement automatically adds HEAD as valid
         $collection->add('barhead', new Route(
             '/barhead/{foo}',

--- a/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
@@ -29,21 +29,20 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher->match('/foo');
     }
 
-    public function testHostRequirement() 
+    public function testHostRequirement()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo', array(), array('_host' => 'example.org')));
 
         $matcher = new UrlMatcher($coll, new RequestContext('', 'get', 'example.org'));
-        $this->assertEquals(array('_route' => 'foo'), $matcher->match( '/foo' ) );    
+        $this->assertEquals(array('_route' => 'foo'), $matcher->match('/foo'));
 
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'get', 'other.host'));
 
-        $matcher = new UrlMatcher($coll, new RequestContext('', 'get', 'other.host')); 
         try {
-            $matcher->match( '/foo' );
+            $matcher->match('/foo');
             $this->fail();
         } catch (ResourceNotFoundException $e) {}
-
     }
 
     public function testMethodNotAllowed()

--- a/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
@@ -29,6 +29,23 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher->match('/foo');
     }
 
+    public function testHostRequirement() 
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo', array(), array('_host' => 'example.org')));
+
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'get', 'example.org'));
+        $this->assertEquals(array('_route' => 'foo'), $matcher->match( '/foo' ) );    
+
+
+        $matcher = new UrlMatcher($coll, new RequestContext('', 'get', 'other.host')); 
+        try {
+            $matcher->match( '/foo' );
+            $this->fail();
+        } catch (ResourceNotFoundException $e) {}
+
+    }
+
     public function testMethodNotAllowed()
     {
         $coll = new RouteCollection();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

Today I wanted to add different routes for different hosts in a project. Therefore I added a new _host requirement to the routing system. This makes it possible to work with several host names in one symfony installation. It can be easily added to any route like

```
 _welcome:
   pattern: /
   requirements: { _host: 'example.org' }
```

It is quite useful when you define routes as annotations, because you can set a host for a whole controller:

```
/**
* @Route(requirements={"_host"="example.org"})
*/
class MyController { ... }
```

I also added an UrlGenerator so it is possible to generate urls just like before. The only difference is that an absolute URL will be generated if the current request has not the same host name.

Maybe it could be a bit more flexible to define host routes, but it is a first attempt. What do you think?
