### PR TITLE
[Tests] Skip segfaulting form test when using PHP <= 5.3.2

### DIFF
--- a/tests/Symfony/Tests/Component/Form/Util/FormUtilTest.php
+++ b/tests/Symfony/Tests/Component/Form/Util/FormUtilTest.php
@@ -63,7 +63,6 @@ class FormUtilTest extends \PHPUnit_Framework_TestCase
             array(false, true),
 
             array(true, array()),
-            array(true, new \SplFixedArray(1)),
         );
     }
 
@@ -73,6 +72,15 @@ class FormUtilTest extends \PHPUnit_Framework_TestCase
     public function testIsChoiceGroup($expected, $value)
     {
         $this->assertSame($expected, FormUtil::isChoiceGroup($value));
+    }
+
+    public function testIsChoiceGroupPart2()
+    {
+        if (version_compare(PHP_VERSION, '5.3.2') <= 0) {
+            $this->markTestSkipped('PHP prior to 5.3.3 has issue with SplFixedArrays - https://bugs.php.net/bug.php?id=50481');
+        }
+
+        $this->assertSame(true, FormUtil::isChoiceGroup(new \SplFixedArray(1)));
     }
 
     public function isChoiceSelectedProvider()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2958

http://travis-ci.org/#!/stloyd/symfony/jobs/461563
