### PR TITLE
[HttpKernel] Fix missing $method argument in MongoDbProfilerStorageTest

### DIFF
--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
@@ -44,9 +44,10 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
             $profile = new Profile('token_'.$i);
             $profile->setIp('127.0.0.1');
             $profile->setUrl('http://foo.bar');
+            $profile->setMethod('GET');
             self::$storage->write($profile);
         }
-        $this->assertCount(10, self::$storage->find('127.0.0.1', 'http://foo.bar', 20), '->write() stores data in the database');
+        $this->assertCount(10, self::$storage->find('127.0.0.1', 'http://foo.bar', 20, 'GET'), '->write() stores data in the database');
         self::$storage->purge();
     }
 
@@ -56,16 +57,19 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
         // supposed to contain them)
         $profile = new Profile('simple_quote');
         $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
         $this->assertTrue(false !== self::$storage->read('simple_quote'), '->write() accepts single quotes in URL');
 
         $profile = new Profile('double_quote');
         $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
         $this->assertTrue(false !== self::$storage->read('double_quote'), '->write() accepts double quotes in URL');
 
         $profile = new Profile('backslash');
         $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
         $this->assertTrue(false !== self::$storage->read('backslash'), '->write() accpets backslash in URL');
 
@@ -81,9 +85,10 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
             $profile->setIp('127.0.0.1');
             $profile->setUrl('http://foo.bar');
             $profile->setTime($dt->getTimestamp());
+            $profile->setMethod('GET');
             self::$storage->write($profile);
         }
-        $records = self::$storage->find('', '', 3);
+        $records = self::$storage->find('', '', 3, 'GET');
         $this->assertCount(3, $records, '->find() returns all previously added records');
         $this->assertEquals($records[0]['token'], 'time_2', '->find() returns records ordered by time in descendant order');
         $this->assertEquals($records[1]['token'], 'time_1', '->find() returns records ordered by time in descendant order');
@@ -95,12 +100,13 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
     {
         $profile = new Profile('token');
         $profile->setIp('127.0.0.1');
+        $profile->setMethod('GET');
 
         self::$storage->write($profile);
 
-        $this->assertCount(1, self::$storage->find('127.0.0.1', '', 10), '->find() retrieve a record by IP');
-        $this->assertCount(0, self::$storage->find('127.0.%.1', '', 10), '->find() does not interpret a "%" as a wildcard in the IP');
-        $this->assertCount(0, self::$storage->find('127.0._.1', '', 10), '->find() does not interpret a "_" as a wildcard in the IP');
+        $this->assertCount(1, self::$storage->find('127.0.0.1', '', 10, 'GET'), '->find() retrieve a record by IP');
+        $this->assertCount(0, self::$storage->find('127.0.%.1', '', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the IP');
+        $this->assertCount(0, self::$storage->find('127.0._.1', '', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the IP');
 
         self::$storage->purge();
     }
@@ -110,33 +116,38 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
         $profile = new Profile('simple_quote');
         $profile->setIp('127.0.0.1');
         $profile->setUrl('http://foo.bar/\'');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
 
         $profile = new Profile('double_quote');
         $profile->setIp('127.0.0.1');
         $profile->setUrl('http://foo.bar/"');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
 
         $profile = new Profile('backslash');
         $profile->setIp('127.0.0.1');
         $profile->setUrl('http://foo\\bar/');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
 
         $profile = new Profile('percent');
         $profile->setIp('127.0.0.1');
         $profile->setUrl('http://foo.bar/%');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
 
         $profile = new Profile('underscore');
         $profile->setIp('127.0.0.1');
         $profile->setUrl('http://foo.bar/_');
+        $profile->setMethod('GET');
         self::$storage->write($profile);
 
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10), '->find() accepts single quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10), '->find() accepts double quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10), '->find() accepts backslash in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10), '->find() does not interpret a "%" as a wildcard in the URL');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10), '->find() does not interpret a "_" as a wildcard in the URL');
+        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10, 'GET'), '->find() accepts single quotes in URLs');
+        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10, 'GET'), '->find() accepts double quotes in URLs');
+        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10, 'GET'), '->find() accepts backslash in URLs');
+        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the URL');
+        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the URL');
 
         self::$storage->purge();
     }
@@ -145,9 +156,10 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
     {
         for ($i = 0; $i < 5; $i++) {
             $profile = new Profile('token_'.$i);
+            $profile->setMethod('GET');
             self::$storage->write($profile);
         }
-        $this->assertCount(5, self::$storage->find('', '', 10), '->find() returns all previously added records');
+        $this->assertCount(5, self::$storage->find('', '', 10, 'GET'), '->find() returns all previously added records');
         self::$storage->purge();
     }
 
@@ -158,9 +170,10 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
             $dt->modify('-1 day');
             $profile = new Profile('time_'.$i);
             $profile->setTime($dt->getTimestamp());
+            $profile->setMethod('GET');
             self::$storage->write($profile);
         }
-        $records = self::$storage->find('', '', 3);
+        $records = self::$storage->find('', '', 3, 'GET');
         $this->assertCount(1, $records, '->find() returns only one record');
         $this->assertEquals($records[0]['token'], 'time_2', '->find() returns the latest added record');
         self::$storage->purge();


### PR DESCRIPTION
```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```

This test case fixes failures related to a signature change for ProfilerStorageInterface::find(). See: 1aef4e806b5a99312b82a0b10a9d2e2f4d4314ba and 5f2226807cfe4f37c461709d41f991d615cf0684.

This was easily missed as the test case is skipped unless a MongoDB server is running.
