### PR TITLE
[Propel1] Add a PropelExtension

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
@@ -20,7 +20,6 @@ use Symfony\Component\Form\AbstractExtension;
  */
 class PropelExtension extends AbstractExtension
 {
-
     protected function loadTypes()
     {
         return array(

--- a/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Propel1\Form;
+
+use Symfony\Component\Form\AbstractExtension;
+
+/**
+ * Represents the Propel form extension, which loads the Propel functionality.
+ *
+ * @author Joseph Rouff <rouffj@gmail.com>
+ */
+class PropelExtension extends AbstractExtension
+{
+
+    protected function loadTypes()
+    {
+        return array(
+            new Type\ModelType(),
+        );
+    }
+
+    protected function loadTypeGuesser()
+    {
+        return new PropelTypeGuesser();
+    }
+}


### PR DESCRIPTION
The propel extension allow to use propel specific type (ModelType) outside of
Symfony2.
