### PR TITLE
[HttpFoundation] Do not set a Transfer-Encoding header of chunked for streaming responses

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -70,7 +70,6 @@ class StreamedResponse extends Response
     {
         if ('1.0' != $request->server->get('SERVER_PROTOCOL')) {
             $this->setProtocolVersion('1.1');
-            $this->headers->set('Transfer-Encoding', 'chunked');
         }
 
         $this->headers->set('Cache-Control', 'no-cache');

--- a/tests/Symfony/Tests/Component/HttpFoundation/StreamedResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/StreamedResponseTest.php
@@ -33,7 +33,6 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
         $response->prepare($request);
 
         $this->assertEquals('1.1', $response->getProtocolVersion());
-        $this->assertEquals('chunked', $response->headers->get('Transfer-Encoding'));
         $this->assertEquals('no-cache, private', $response->headers->get('Cache-Control'));
     }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/StreamedResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/StreamedResponseTest.php
@@ -33,6 +33,7 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
         $response->prepare($request);
 
         $this->assertEquals('1.1', $response->getProtocolVersion());
+        $this->assertNotEquals('chunked', $response->headers->get('Transfer-Encoding'), 'Apache assumes responses with a Transfer-Encoding header set to chunked to already be encoded.');
         $this->assertEquals('no-cache, private', $response->headers->get('Cache-Control'));
     }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

This is an adjustment to the streaming introduced in #2935.

Apache expects the response to already be in chunked format when the Transfer-Encoding header is set to chunked, which causes it to not deliver the streamed body.

If no Content-Length is set on the response (regardless of Transfer-Encoding), web servers will automatically switch to chunked Transfer-Encoding, and handle the chunking for you.

I have tested this with Apache 2.2.2 and nginx 1.0.5. Testing with other webservers is appreciated.
