### PR TITLE
[DoctrineBridge] Account for $query['params'] being null in DoctrineDataCollector's sanitizeQueries method

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -88,7 +88,7 @@ class DoctrineDataCollector extends DataCollector
     private function sanitizeQueries($queries)
     {
         foreach ($queries as $i => $query) {
-            foreach ($query['params'] as $j => $param) {
+            foreach ((array)$query['params'] as $j => $param) {
                 $queries[$i]['params'][$j] = $this->varToString($param);
             }
         }


### PR DESCRIPTION
I was getting this error because inside the sanitizeQueries method of DoctrineDataCollector, there's no handling for $query['params'] being null.

ErrorException: Warning: Invalid argument supplied for foreach() in .../vendor/symfony/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php line 91
