### PR TITLE
[FrameworkBundle] Invalid composer ref fix

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "self.version",
         "symfony/routing": "self.version",
         "symfony/templating": "self.version",
-        "symfony/translator": "self.version",
+        "symfony/translation": "self.version",
         "doctrine/common": ">=2.1,<2.3-dev"
     },
     "recommend": {


### PR DESCRIPTION
Changes the `composer.json` reference in the FrameworkBundle to use the `symfony/translation` package rather than the current `symfony/translator` (which doesn't exist).
