### PR TITLE
[TwigBridge] Improve test coverage

### DIFF
--- a/tests/Symfony/Tests/Bridge/Twig/Node/FormThemeTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Node/FormThemeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Bridge\Twig\Node;
+
+use Symfony\Tests\Bridge\Twig\TestCase;
+use Symfony\Bridge\Twig\Node\FormThemeNode;
+
+class FormThemeTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
+            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
+        }
+    }
+    
+    public function testConstructor()
+    {
+        $form = new \Twig_Node_Expression_Name('form', 0);
+        $resources = new \Twig_Node(array(
+            new \Twig_Node_Expression_Constant('tpl1', 0),
+            new \Twig_Node_Expression_Constant('tpl2', 0)
+        ));
+
+        $node = new FormThemeNode($form, $resources, 0);
+
+        $this->assertEquals($form, $node->getNode('form'));
+        $this->assertEquals($resources, $node->getNode('resources'));
+    }
+
+    public function testCompile()
+    {
+        $form = new \Twig_Node_Expression_Name('form', 0);
+        $resources = new \Twig_Node(array(
+            new \Twig_Node_Expression_Constant('tpl1', 0),
+            new \Twig_Node_Expression_Constant('tpl2', 0)
+        ));
+
+        $node = new FormThemeNode($form, $resources, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                'echo $this->env->getExtension(\'form\')->setTheme(%s, array("tpl1", "tpl2", ));',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    protected function getVariableGetter($name)
+    {
+        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+            return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
+        }
+
+        return sprintf('$this->getContext($context, "%s")', $name);
+    }
+}

--- a/tests/Symfony/Tests/Bridge/Twig/TokenParser/FormThemeTokenParserTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/TokenParser/FormThemeTokenParserTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Bridge\Twig\Node;
+
+use Symfony\Tests\Bridge\Twig\TestCase;
+use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
+use Symfony\Bridge\Twig\Node\FormThemeNode;
+
+class FormThemeTokenParserTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
+            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
+        }
+    }
+    
+    /**
+     * @dataProvider getTestsForFormTheme
+     */
+    public function testCompile($source, $expected)
+    {
+        $env = new \Twig_Environment(new \Twig_Loader_String(), array('cache' => false, 'autoescape' => false, 'optimizations' => 0));
+        $env->addTokenParser(new FormThemeTokenParser());
+        $stream = $env->tokenize($source);
+        $parser = new \Twig_Parser($env);
+
+        $this->assertEquals($expected, $parser->parse($stream)->getNode('body')->getNode(0));
+    }
+
+    public function getTestsForFormTheme()
+    {
+        return array(
+            array(
+                '{% form_theme form "tpl1" %}',
+                new FormThemeNode(
+                    new \Twig_Node_Expression_Name('form', 1),
+                    new \Twig_Node(array(
+                        new \Twig_Node_Expression_Constant('tpl1', 1),
+                    )),
+                    1,
+                    'form_theme'
+                )
+            ),
+            array(
+                '{% form_theme form "tpl1" "tpl2" %}',
+                new FormThemeNode(
+                    new \Twig_Node_Expression_Name('form', 1),
+                    new \Twig_Node(array(
+                        new \Twig_Node_Expression_Constant('tpl1', 1),
+                        new \Twig_Node_Expression_Constant('tpl2', 1)
+                    )),
+                    1,
+                    'form_theme'
+                )
+            ),
+        );
+    }
+}


### PR DESCRIPTION
related to https://github.com/fabpot/Twig/issues/580

[Travis is happy](http://travis-ci.org/#!/vicb/symfony/builds/484594) but it seems he doesn't like branch name with `/` when displaying status images.

It could have been submitted against 2.0 but there is an issue here: the bridge is tied to Twig so that would mean testing against every single Twig version shipped with 2.0 which I don't want.

I have "solved" the issue by ensuring that Twig version is at least 1.5.0 in the tests set up. This is not a perfect solution but I can not imagine something better for now.
