### PR TITLE
[DependencyInjection] PhpDumper, fixes #2730

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -653,6 +653,8 @@ EOF;
      */
     private function addConstructor()
     {
+        $arguments = $this->container->getParameterBag()->all() ? 'new ParameterBag($this->getDefaultParameters())' : null;
+
         $code = <<<EOF
 
     /**
@@ -660,7 +662,7 @@ EOF;
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag(\$this->getDefaultParameters()));
+        parent::__construct($arguments);
 
 EOF;
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1-1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1-1.php
@@ -23,6 +23,6 @@ class Container extends AbstractContainer
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
+        parent::__construct();
     }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1.php
@@ -23,6 +23,6 @@ class ProjectServiceContainer extends Container
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
+        parent::__construct();
     }
 }


### PR DESCRIPTION
Hey, this PR fixes #2730, if no parameters are set, the constructor wont get passed a ParameterBag

Bug fix: yes (#2730)
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
