### PR TITLE
[Serializer] GetSetMethodNormalizer uses `lcfirst` instead of `strtolower` (on master)

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -201,6 +201,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 ### Serializer
 
+ * [BC BREAK] changed `GetSetMethodNormalizer`'s key names from all lowercased to camelCased (e.g. `mypropertyvalue` to `myPropertyValue`)
  * [BC BREAK] convert the `item` XML tag to an array 
 
    ``` xml
@@ -226,7 +227,6 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
                 )
             )
         )
-
 
 ### Translation
 

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -46,7 +46,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
         $attributes = array();
         foreach ($reflectionMethods as $method) {
             if ($this->isGetMethod($method)) {
-                $attributeName = strtolower(substr($method->getName(), 3));
+                $attributeName = lcfirst(substr($method->getName(), 3));
 
                 $attributeValue = $method->invoke($object);
                 if (null !== $attributeValue && !is_scalar($attributeValue)) {
@@ -73,7 +73,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
 
             $params = array();
             foreach ($constructorParameters as $constructorParameter) {
-                $paramName = strtolower($constructorParameter->getName());
+                $paramName = lcfirst($constructorParameter->getName());
 
                 if (isset($data[$paramName])) {
                     $params[] = $data[$paramName];

--- a/tests/Symfony/Tests/Component/Serializer/Normalizer/GetSetMethodNormalizerTest.php
+++ b/tests/Symfony/Tests/Component/Serializer/Normalizer/GetSetMethodNormalizerTest.php
@@ -27,7 +27,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $obj->setFoo('foo');
         $obj->setBar('bar');
         $this->assertEquals(
-            array('foo' => 'foo', 'bar' => 'bar', 'foobar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
             $this->normalizer->normalize($obj, 'any')
         );
     }
@@ -35,7 +35,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     public function testDenormalize()
     {
         $obj = $this->normalizer->denormalize(
-            array('foo' => 'foo', 'bar' => 'bar', 'foobar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
             __NAMESPACE__.'\GetSetDummy',
             'any'
         );
@@ -46,7 +46,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
     public function testConstructorDenormalize()
     {
         $obj = $this->normalizer->denormalize(
-            array('foo' => 'foo', 'bar' => 'bar', 'foobar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
             __NAMESPACE__.'\GetConstructorDummy', 'any');
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #2863

Rebased PR #2977 onto `master` (was on `2.0`).
