### PR TITLE
[DependencyInjection] PhpDumper, fixes #2730

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -648,6 +648,8 @@ EOF;
      */
     private function addConstructor()
     {
+        $arguments = $this->container->getParameterBag()->all() ? 'new ParameterBag($this->getDefaultParameters())' : null;
+
         $code = <<<EOF
 
     /**
@@ -655,7 +657,7 @@ EOF;
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag(\$this->getDefaultParameters()));
+        parent::__construct($arguments);
 
 EOF;
 

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1-1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1-1.php
@@ -20,6 +20,6 @@ class Container extends AbstractContainer
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
+        parent::__construct();
     }
 }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/php/services1.php
@@ -20,6 +20,6 @@ class ProjectServiceContainer extends Container
      */
     public function __construct()
     {
-        parent::__construct(new ParameterBag($this->getDefaultParameters()));
+        parent::__construct();
     }
 }


### PR DESCRIPTION
Hey, this PR fixes #2730, if no parameters are set, the constructor wont get passed a ParameterBag

Bug fix: yes (#2730)
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

3rd and last try ;) this time i think its all fine
