### PR TITLE
[Routing] added support for hostname requirement to routes

### DIFF
--- a/src/Symfony/Component/Routing/Exception/HostnameNotAllowedException.php
+++ b/src/Symfony/Component/Routing/Exception/HostnameNotAllowedException.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exception;
+
+/**
+ * The resource was found but the hostname is not allowed.
+ *
+ * This exception should trigger an HTTP 404 response in your application code.
+ *
+ * @author Gunnar Lium <post@gunnarlium.com>
+ *
+ */
+class HostnameNotAllowedException extends \RuntimeException implements ExceptionInterface
+{
+    protected $allowedHostnames;
+
+    public function __construct(array $allowedHostnames, $message = null, $code = 0, \Exception $previous = null)
+    {
+        $this->allowedHostnames = array_map('strtolower', $allowedHostnames);
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function getAllowedHostnames()
+    {
+        return $this->allowedHostnames;
+    }
+}

--- a/src/Symfony/Component/Routing/Exception/InvalidHostnameParameterException.php
+++ b/src/Symfony/Component/Routing/Exception/InvalidHostnameParameterException.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Exception;
+
+/**
+ * Exception thrown when hostname parameter doesn't match hostname from requirements
+ *
+ * @author Gunnar Lium <post@gunnarlium.com>
+ *
+ * @api
+ */
+class InvalidHostnameParameterException extends \InvalidArgumentException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\HostnameNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RequestContext;
 
@@ -23,6 +24,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     public function match($pathinfo)
     {
         $allow = array();
+        $hosts = array();
         $pathinfo = urldecode($pathinfo);
 
         // foo
@@ -51,6 +53,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return $matches;
         }
         not_barhead:
+
+        // barhost
+        if (0 === strpos($pathinfo, '/barhost') && preg_match('#^/barhost/(?P<foo>[^/]+?)$#xs', $pathinfo, $matches)) {
+            if (!in_array($this->context->getHost(), array('symfony.com', 'symfony.org'))) {
+                $hosts = array_merge($hosts, array('symfony.com', 'symfony.org'));
+                goto not_barhost;
+            }
+            $matches['_route'] = 'barhost';
+            return $matches;
+        }
+        not_barhost:
 
         // baz
         if ($pathinfo === '/test/baz') {
@@ -162,6 +175,8 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return $matches;
         }
 
-        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) :
+                0 < count($hosts) ? new HostnameNotAllowedException(array_unique($hosts)) :
+                new ResourceNotFoundException();
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -50,6 +50,38 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https://localhost:8080/app.php/testing', $url);
     }
 
+    public function testAbsoluteUrlWithOneHostnameAddsHostname()
+    {
+        $routes = $this->getRoutes('test', new Route('/hostname', array(), array('_host' => 'symfony.com')));
+        $url = $this->getGenerator($routes)->generate('test', array(), true);
+
+        $this->assertEquals('http://symfony.com/app.php/hostname', $url);
+    }
+
+    public function testAbsoluteUrlWithMultipleHostnamesPicksFirstHostnameIfHostnameNotInContext()
+    {
+        $routes = $this->getRoutes('test', new Route('/hostname', array(), array('_host' => 'symfony.com|symfony.org')));
+        $url = $this->getGenerator($routes, array('host' => 'symfony.net'))->generate('test', array(), true);
+
+        $this->assertEquals('http://symfony.com/app.php/hostname', $url);
+    }
+
+    public function testAbsoluteUrlWithMultipleHostnamesPicksHostnameFromContextIfAvailable()
+    {
+        $routes = $this->getRoutes('test', new Route('/hostname', array(), array('_host' => 'symfony.com|symfony.org')));
+        $url = $this->getGenerator($routes, array('host' => 'symfony.org'))->generate('test', array(), true);
+
+        $this->assertEquals('http://symfony.org/app.php/hostname', $url);
+    }
+
+    public function testAbsoluteUrlWithMultipleHostnamesAndSpecifiedHostUsesSpecified()
+    {
+        $routes = $this->getRoutes('test', new Route('/hostname', array(), array('_host' => 'symfony.com|symfony.org')));
+        $url = $this->getGenerator($routes)->generate('test', array('_host' => 'symfony.org'), true);
+
+        $this->assertEquals('http://symfony.org/app.php/hostname', $url);
+    }
+
     public function testRelativeUrlWithoutParameters()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -84,6 +84,12 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array(),
             array('_method' => 'GET')
         ));
+        // hostname requirement
+        $collection->add('barhost', new Route(
+            '/barhost/{foo}',
+            array(),
+            array('_host' => 'symfony.com|symfony.org')
+        ));
         // simple
         $collection->add('baz', new Route(
             '/test/baz'


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes (All Routing tests pass, Locale tests fail on my localhost, but I have not touched those files)
Fixes the following tickets: -
Todo:
- Add documentation if feature is approved
- Maybe add/test wildcard support

This patch adds support for hostname requirements on routes:

```
hostbased_route:
  pattern:  /
  requirements:
    _host: symfony.com|symfony.org
```

This route would only match if RequestContext::getHost() matches symfony.com or symfony.org.
