### PR TITLE
[Console] Format simple arrays nicer

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -422,11 +422,20 @@ class InputDefinition
 
         $text = array();
 
+        $formatDefault = function ($default) {
+            if (is_array($default) && $default === array_values($default)) {
+                $default = 'array('.implode(', ', $default).')';
+            } elseif (is_bool($default) || is_array($default)) {
+                $default = str_replace("\n", '', var_export($default, true));
+            }
+            return $default;
+        };
+
         if ($this->getArguments()) {
             $text[] = '<comment>Arguments:</comment>';
             foreach ($this->getArguments() as $argument) {
                 if (null !== $argument->getDefault() && (!is_array($argument->getDefault()) || count($argument->getDefault()))) {
-                    $default = sprintf('<comment> (default: %s)</comment>', is_bool($argument->getDefault()) || is_array($argument->getDefault()) ? str_replace("\n", '', var_export($argument->getDefault(), true)): $argument->getDefault());
+                    $default = sprintf('<comment> (default: %s)</comment>', $formatDefault($argument->getDefault()));
                 } else {
                     $default = '';
                 }
@@ -444,7 +453,7 @@ class InputDefinition
 
             foreach ($this->getOptions() as $option) {
                 if ($option->acceptValue() && null !== $option->getDefault() && (!is_array($option->getDefault()) || count($option->getDefault()))) {
-                    $default = sprintf('<comment> (default: %s)</comment>', is_bool($option->getDefault()) || is_array($option->getDefault()) ? str_replace("\n", '', var_export($option->getDefault(), true)): $option->getDefault());
+                    $default = sprintf('<comment> (default: %s)</comment>', $formatDefault($option->getDefault()));
                 } else {
                     $default = '';
                 }

--- a/tests/Symfony/Tests/Component/Console/Fixtures/definition_astext.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/definition_astext.txt
@@ -1,9 +1,11 @@
 <comment>Arguments:</comment>
  <info>foo       </info> The foo argument
  <info>baz       </info> The baz argument<comment> (default: true)</comment>
- <info>bar       </info> The bar argument<comment> (default: array (  0 => 'bar',))</comment>
+ <info>bar       </info> The bar argument<comment> (default: array(bar))</comment>
 
 <comment>Options:</comment>
  <info>--foo</info> (-f) The foo option
  <info>--baz</info>      The baz option<comment> (default: false)</comment>
  <info>--bar</info> (-b) The bar option<comment> (default: bar)</comment>
+ <info>--qux</info>      The qux option<comment> (default: array(bar))</comment><comment> (multiple values allowed)</comment>
+ <info>--qux2</info>     The qux2 option<comment> (default: array (  'foo' => 'bar',))</comment><comment> (multiple values allowed)</comment>

--- a/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputDefinitionTest.php
@@ -327,6 +327,8 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
             new InputOption('foo', 'f', InputOption::VALUE_REQUIRED, 'The foo option'),
             new InputOption('baz', null, InputOption::VALUE_OPTIONAL, 'The baz option', false),
             new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL, 'The bar option', 'bar'),
+            new InputOption('qux', '', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The qux option', array('bar')),
+            new InputOption('qux2', '', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The qux2 option', array('foo' => 'bar')),
         ));
         $this->assertStringEqualsFile(self::$fixtures.'/definition_astext.txt', $definition->asText(), '->asText() returns a textual representation of the InputDefinition');
     }


### PR DESCRIPTION
Minor cosmetic adjustment for simple (i.e. with sequential numeric keys) arrays
