### PR TITLE
[Console] Allow redefinition of application options descriptions

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -261,9 +261,9 @@ class InputDefinition
      */
     public function addOption(InputOption $option)
     {
-        if (isset($this->options[$option->getName()])) {
+        if (isset($this->options[$option->getName()]) && !$option->equals($this->options[$option->getName()])) {
             throw new \LogicException(sprintf('An option named "%s" already exist.', $option->getName()));
-        } elseif (isset($this->shortcuts[$option->getShortcut()])) {
+        } elseif (isset($this->shortcuts[$option->getShortcut()]) && !$option->equals($this->options[$this->shortcuts[$option->getShortcut()]])) {
             throw new \LogicException(sprintf('An option with shortcut "%s" already exist.', $option->getShortcut()));
         }
 

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -181,4 +181,21 @@ class InputOption
     {
         return $this->description;
     }
+
+    /**
+     * Checks whether the given option equals this one
+     *
+     * @param InputOption $option option to compare
+     * @return Boolean
+     */
+    public function equals(InputOption $option)
+    {
+        return $option->getName() === $this->getName()
+            && $option->getShortcut() === $this->getShortcut()
+            && $option->getDefault() === $this->getDefault()
+            && $option->isArray() === $this->isArray()
+            && $option->isValueRequired() === $this->isValueRequired()
+            && $option->isValueOptional() === $this->isValueOptional()
+        ;
+    }
 }

--- a/tests/Symfony/Tests/Component/Console/Input/InputOptionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputOptionTest.php
@@ -140,4 +140,27 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
             $this->assertEquals('A default value for an array option must be an array.', $e->getMessage());
         }
     }
+
+    public function testEquals()
+    {
+        $option = new InputOption('foo', 'f', null, 'Some description');
+        $option2 = new InputOption('foo', 'f', null, 'Alternative description');
+        $this->assertTrue($option->equals($option2));
+
+        $option = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL, 'Some description');
+        $option2 = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL, 'Some description', true);
+        $this->assertFalse($option->equals($option2));
+
+        $option = new InputOption('foo', 'f', null, 'Some description');
+        $option2 = new InputOption('bar', 'f', null, 'Some description');
+        $this->assertFalse($option->equals($option2));
+
+        $option = new InputOption('foo', 'f', null, 'Some description');
+        $option2 = new InputOption('foo', '', null, 'Some description');
+        $this->assertFalse($option->equals($option2));
+
+        $option = new InputOption('foo', 'f', null, 'Some description');
+        $option2 = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL, 'Some description');
+        $this->assertFalse($option->equals($option2));
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

This allows you to redefine an `InputOption` as long as it keeps the same semantic (same default, same name, same alias, same modes). There are two purposes:
- Modifying the description with a more accurate one
- Making sure the option appears in your commands' help

Concrete example: I often want to provide a verbose version of commands. It's an elegant and very common pattern, but I basically can't document what is going to happen if you do `--verbose` since the base Application already defines `--verbose`. Also the `--verbose` option does not appear when you do `console <command> --help`, which means people probably won't think of using that option.
