### PR TITLE
Protect template filename variable from overwriting

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -155,14 +155,14 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     {
         $__template__ = $template;
         if ($__template__ instanceof FileStorage) {
-            extract($parameters);
+            extract($parameters, EXTR_SKIP);
             $view = $this;
             ob_start();
             require $__template__;
 
             return ob_get_clean();
         } elseif ($__template__ instanceof StringStorage) {
-            extract($parameters);
+            extract($parameters, EXTR_SKIP);
             $view = $this;
             ob_start();
             eval('; ?>'.$__template__.'<?php ;');

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -154,6 +154,12 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected function evaluate(Storage $template, array $parameters = array())
     {
         $__template__ = $template;
+        
+        if (isset($parameters['__template__']))
+        {
+            throw new \RuntimeException('Invalid parameter name (__template__).');
+        }
+        
         if ($__template__ instanceof FileStorage) {
             extract($parameters, EXTR_SKIP);
             $view = $this;


### PR DESCRIPTION
When used standalone, the PHP templating component could be passed a `__template__` parameter which may load and execute an arbitrary file. 

The `extract()` calls have been modified to prevent overwriting the local scope of the `evaluate()` method, and an exception is thrown if a `__template__` key is found in the `$parameters` array.
