### PR TITLE
Prevent parameters from overwriting the template filename. 

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -150,15 +150,20 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected function evaluate(Storage $template, array $parameters = array())
     {
         $__template__ = $template;
+        
+        if (isset($parameters['__template__'])) {
+            throw new \InvalidArgumentException('Invalid parameter (__template__)');
+        }
+        
         if ($__template__ instanceof FileStorage) {
-            extract($parameters);
+            extract($parameters, EXTR_SKIP);
             $view = $this;
             ob_start();
             require $__template__;
 
             return ob_get_clean();
         } elseif ($__template__ instanceof StringStorage) {
-            extract($parameters);
+            extract($parameters, EXTR_SKIP);
             $view = $this;
             ob_start();
             eval('; ?>'.$__template__.'<?php ;');


### PR DESCRIPTION
Fixes a potential arbitrary file execution exploit.
