### PR TITLE
[FrameworkBundle] Use only _route_params to generate redirect routes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -42,8 +42,8 @@ class RedirectController extends ContainerAware
             return new Response(null, 410);
         }
 
-        $attributes = $this->container->get('request')->attributes->all();
-        unset($attributes['_route'], $attributes['route'], $attributes['permanent'] );
+        $attributes = $this->container->get('request')->attributes->get('_route_params');
+        unset($attributes['route'], $attributes['permanent']);
 
         return new RedirectResponse($this->container->get('router')->generate($route, $attributes), $permanent ? 301 : 302);
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -46,8 +46,18 @@ class RedirectControllerTest extends TestCase
         $route = 'new-route';
         $url = '/redirect-url';
         $params = array('additional-parameter' => 'value');
+        $attributes = array(
+            'route' => $route,
+            'permanent' => $permanent,
+            '_route' => 'current-route',
+            '_route_params' => array(
+                'route' => $route,
+                'permanent' => $permanent,
+            ),
+        );
+        $attributes['_route_params'] = $attributes['_route_params'] + $params;
 
-        $request->attributes = new ParameterBag(array('route' => $route, '_route' => 'current-route', 'permanent' => $permanent) + $params);
+        $request->attributes = new ParameterBag($attributes);
 
         $router = $this->getMock('Symfony\Component\Routing\RouterInterface');
         $router


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Routes in RedirectController are generated using all request attributes, which is inconvenient since I abuse request attributes to store other things (device types and such) relevant to the app. It renders the RedirectController useless since it adds unrelated query parameters to URLs it creates.
