### PR TITLE
[BugFix][Validator] Fix for PHP incosistent behaviour of ArrayAccess

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -52,7 +52,11 @@ class CollectionValidator extends ConstraintValidator
         }
 
         foreach ($constraint->fields as $field => $constraints) {
-            if (array_key_exists($field, $value)) {
+            if (
+                // bug fix issue #2779
+                (is_array($value) && array_key_exists($field, $value)) ||
+                ($value instanceof \ArrayAccess && $value->offsetExists($field))
+            ) {
                 // cannot simply cast to array, because then the object is converted to an
                 // array instead of wrapped inside
                 $constraints = is_array($constraints) ? $constraints : array($constraints);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no 
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2779
Todo: -

[![Build Status](https://secure.travis-ci.org/canni/symfony.png)](http://travis-ci.org/canni/symfony)

Because PHP function `array_key_exists` is buggy, it works great with native 
PHP `ArrayObject` instances, but hand written implementations of `ArrayAccess`
and `Traversable` objects will fail to work with `CollectionValidator`

Tests from second commit are valid use cases, but without this change, they will fail.
