### PR TITLE
[Twig] [FrameworkBundle] added CSRF token helper

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -14,6 +14,7 @@ namespace Symfony\Bridge\Twig\Extension;
 use Symfony\Bridge\Twig\TokenParser\FormThemeTokenParser;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\Form\Util\FormUtil;
 
 /**
@@ -24,6 +25,7 @@ use Symfony\Component\Form\Util\FormUtil;
  */
 class FormExtension extends \Twig_Extension
 {
+    protected $csrfProvider;
     protected $resources;
     protected $blocks;
     protected $environment;
@@ -31,8 +33,9 @@ class FormExtension extends \Twig_Extension
     protected $varStack;
     protected $template;
 
-    public function __construct(array $resources = array())
+    public function __construct(CsrfProviderInterface $csrfProvider, array $resources = array())
     {
+        $this->csrfProvider = $csrfProvider;
         $this->themes = new \SplObjectStorage();
         $this->varStack = array();
         $this->blocks = new \SplObjectStorage();
@@ -81,6 +84,7 @@ class FormExtension extends \Twig_Extension
             'form_label'               => new \Twig_Function_Method($this, 'renderLabel', array('is_safe' => array('html'))),
             'form_row'                 => new \Twig_Function_Method($this, 'renderRow', array('is_safe' => array('html'))),
             'form_rest'                => new \Twig_Function_Method($this, 'renderRest', array('is_safe' => array('html'))),
+            'csrf_token'               => new \Twig_Function_Method($this, 'getCsrfToken'),
             '_form_is_choice_group'    => new \Twig_Function_Method($this, 'isChoiceGroup', array('is_safe' => array('html'))),
             '_form_is_choice_selected' => new \Twig_Function_Method($this, 'isChoiceSelected', array('is_safe' => array('html'))),
         );
@@ -267,6 +271,34 @@ class FormExtension extends \Twig_Extension
             'Unable to render the form as none of the following blocks exist: "%s".',
             implode('", "', array_reverse($types))
         ));
+    }
+
+    /**
+     * Returns a CSRF token.
+     *
+     * Use this helper for CSRF protection without the overhead of creating a
+     * form.
+     *
+     * <code>
+     * <input type="hidden" name="token" value="{{ csrf_token('rm_user_' ~ user.id) }}">
+     * </code>
+     *
+     * Check the token in your action using the same intention.
+     *
+     * <code>
+     * $csrfProvider = $this->get('form.csrf_provider');
+     * if (!$csrfProvider->isCsrfTokenValid('rm_user_'.$user->getId(), $token)) {
+     *     throw new \RuntimeException('CSRF attack detected.');
+     * }
+     * </code>
+     *
+     * @param string $intention The intention of the protected action
+     *
+     * @return string A CSRF token
+     */
+    public function getCsrfToken($intention)
+    {
+        return $this->csrfProvider->generateCsrfToken($intention);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -97,6 +97,7 @@
         <service id="templating.helper.form" class="%templating.helper.form.class%">
             <tag name="templating.helper" alias="form" />
             <argument type="service" id="templating.engine.php" />
+            <argument type="service" id="form.csrf_provider" />
             <argument>%templating.helper.form.resources%</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -15,6 +15,7 @@ use Symfony\Component\Templating\Helper\Helper;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\Form\Util\FormUtil;
 
 /**
@@ -27,6 +28,8 @@ class FormHelper extends Helper
 {
     protected $engine;
 
+    protected $csrfProvider;
+
     protected $varStack;
 
     protected $context;
@@ -38,14 +41,16 @@ class FormHelper extends Helper
     protected $templates;
 
     /**
-     * Constructor;
+     * Constructor.
      *
-     * @param EngineInterface $engine    The templating engine
-     * @param array           $resources An array of theme name
+     * @param EngineInterface       $engine       The templating engine
+     * @param CsrfProviderInterface $csrfProvider The CSRF provider
+     * @param array                 $resources    An array of theme names
      */
-    public function __construct(EngineInterface $engine, array $resources)
+    public function __construct(EngineInterface $engine, CsrfProviderInterface $csrfProvider, array $resources)
     {
         $this->engine = $engine;
+        $this->csrfProvider = $csrfProvider;
         $this->resources = $resources;
         $this->varStack = array();
         $this->context = array();
@@ -170,6 +175,34 @@ class FormHelper extends Helper
     public function rest(FormView $view, array $variables = array())
     {
         return $this->renderSection($view, 'rest', $variables);
+    }
+
+    /**
+     * Returns a CSRF token.
+     *
+     * Use this helper for CSRF protection without the overhead of creating a
+     * form.
+     *
+     * <code>
+     * echo $view['form']->csrfToken('rm_user_'.$user->getId());
+     * </code>
+     *
+     * Check the token in your action using the same intention.
+     *
+     * <code>
+     * $csrfProvider = $this->get('form.csrf_provider');
+     * if (!$csrfProvider->isCsrfTokenValid('rm_user_'.$user->getId(), $token)) {
+     *     throw new \RuntimeException('CSRF attack detected.');
+     * }
+     * </code>
+     *
+     * @param string $intention The intention of the protected action
+     *
+     * @return string A CSRF token
+     */
+    public function csrfToken($intention)
+    {
+        return $this->csrfProvider->generateCsrfToken($intention);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperDivLayoutTest.php
@@ -37,7 +37,7 @@ class FormHelperDivLayoutTest extends AbstractDivLayoutTest
         $loader = new FilesystemLoader(array());
         $engine = new PhpEngine($templateNameParser, $loader);
 
-        $this->helper = new FormHelper($engine, array('FrameworkBundle:Form'));
+        $this->helper = new FormHelper($engine, $this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'), array('FrameworkBundle:Form'));
 
         $engine->setHelpers(array(
             $this->helper,

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Helper/FormHelperTableLayoutTest.php
@@ -37,7 +37,7 @@ class FormHelperTableLayoutTest extends AbstractTableLayoutTest
         $loader = new FilesystemLoader(array());
         $engine = new PhpEngine($templateNameParser, $loader);
 
-        $this->helper = new FormHelper($engine, array(
+        $this->helper = new FormHelper($engine, $this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'), array(
             'FrameworkBundle:Form',
             'FrameworkBundle:FormTable'
         ));

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -75,6 +75,7 @@
 
         <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">
             <tag name="twig.extension" />
+            <argument type="service" id="form.csrf_provider" />
             <argument>%twig.form.resources%</argument>
         </service>
 

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionDivLayoutTest.php
@@ -38,7 +38,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
             __DIR__,
         ));
 
-        $this->extension = new FormExtension(array(
+        $this->extension = new FormExtension($this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'), array(
             'form_div_layout.html.twig',
             'custom_widgets.html.twig',
         ));

--- a/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionTableLayoutTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Extension/FormExtensionTableLayoutTest.php
@@ -38,7 +38,7 @@ class FormExtensionTableLayoutTest extends AbstractTableLayoutTest
             __DIR__,
         ));
 
-        $this->extension = new FormExtension(array(
+        $this->extension = new FormExtension($this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface'), array(
             'form_table_layout.html.twig',
             'custom_widgets.html.twig',
         ));


### PR DESCRIPTION
I've added a templating helper and Twig function for generating a CSRF token without the overhead of creating a form.

``` html+jinja
<form action="{{ path('user_delete', { 'id': user.id }) }}" method="post">
    <input type="hidden" name="_method" value="delete">
    <input type="hidden" name="_token" value="{{ csrf_token('delete_user_' ~ user.id) }}">
    <button type="submit">delete</button>
</form>
```

``` php
<?php

class UserController extends Controller
{
    public function delete(User $user, Request $request)
    {
        $csrfProvider = $this->get('form.csrf_provider');
        if (!$csrfProvider->isCsrfTokenValid('delete_user_'.$user->getId(), $request->request->get('_token')) {
            throw new RuntimeException('CSRF attack detected.');
        }

        // etc...
    }
}
```

The test that is failing on Travis appears to be unrelated, but I may be wrong?

```
1) Symfony\Bundle\SecurityBundle\Tests\Functional\LocalizedRoutesAsPathTest::testLoginLogoutProcedure with data set #1 ('de')
RuntimeException: OUTPUT: 
Catchable fatal error: Argument 3 passed to Symfony\Bundle\FrameworkBundle\Controller\TraceableControllerResolver::__construct() must be an instance of Symfony\Component\HttpKernel\Debug\Stopwatch, instance of Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser given, called in /tmp/2.1.0-DEV/StandardFormLogin/cache/securitybundletest/appSecuritybundletestDebugProjectContainer.php on line 94 and defined in /home/vagrant/builds/kriswallsmith/symfony/src/Symfony/Bundle/FrameworkBundle/Controller/TraceableControllerResolver.php on line 37
```
