### PR TITLE
[Form] fixed flawed condition

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
@@ -76,7 +76,7 @@ class DelegatingValidator implements FormValidatorInterface
                         $child->addError($error);
                     }
                 }
-            } elseif ($violations = $this->validator->validate($form)) {
+            } elseif (count($violations = $this->validator->validate($form))) {
                 foreach ($violations as $violation) {
                     $propertyPath = $violation->getPropertyPath();
                     $template = $violation->getMessageTemplate();


### PR DESCRIPTION
The validate() method always returns an object. The test is whether there are violations in that object.

```
Bug fix: yes
Feature addition: no 
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```
