### PR TITLE
Made some small performance optimizations

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -79,7 +79,7 @@ class Configuration implements ConfigurationInterface
                     ->useAttributeAsKey('key')
                     ->prototype('array')
                         ->beforeNormalization()
-                            ->ifTrue(function($v){ return is_string($v) && '@' === substr($v, 0, 1); })
+                            ->ifTrue(function($v){ return is_string($v) && '@' === $v[0]; })
                             ->then(function($v){ return array('id' => substr($v, 1), 'type' => 'service'); })
                         ->end()
                         ->beforeNormalization()

--- a/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/CsvFileLoader.php
@@ -49,7 +49,7 @@ class CsvFileLoader extends ArrayLoader implements LoaderInterface
         $file->setCsvControl($this->delimiter, $this->enclosure, $this->escape);
 
         foreach ($file as $data) {
-            if (substr($data[0], 0, 1) === '#') {
+            if (is_string($data[0]) && '#' === $data[0][0]) {
                 continue;
             }
 

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -188,7 +188,7 @@ class Parser
 
                     if (is_array($value)) {
                         $first = reset($value);
-                        if (is_string($first) && '*' === substr($first, 0, 1)) {
+                        if (is_string($first) && '*' === $first[0]) {
                             $data = array();
                             foreach ($value as $alias) {
                                 $data[] = $this->refs[substr($alias, 1)];
@@ -347,7 +347,7 @@ class Parser
      */
     private function parseValue($value)
     {
-        if ('*' === substr($value, 0, 1)) {
+        if ('*' === $value[0]) {
             if (false !== $pos = strpos($value, '#')) {
                 $value = substr($value, 1, $pos - 2);
             } else {


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

---

I changed it because `$a[0]` is 10 time faster than `substr($a, 0, 1)`

```
php > $a = "@testttttt" ; $t  = microtime(true); for ($i = 0 ; $i <= 10000000 ; $i ++) { $a[0] ; } ; echo  microtime(true) - $t;
1.6929659843445
php > $a = "@testttttt" ; $t  = microtime(true); for ($i = 0 ; $i <= 10000000 ; $i ++) { substr($a, 0, 1) ; } ; echo  microtime(true) - $t;
12.946933984756
```

Add I fixed a CS typo in CsvFileLoader.php
