### PR TITLE
[HttpKernel] removed unnecessary regex

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -64,7 +64,7 @@ class Esi
             return false;
         }
 
-        return (Boolean) preg_match('#ESI/1.0#', $value);
+        return false !== strpos($value, 'ESI/1.0');
     }
 
     /**


### PR DESCRIPTION
The pattern was also flawed because of the unescaped `.`

```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```
