### PR TITLE
[Locale] Fixed incomplete Locale data loading

### DIFF
--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -61,9 +61,9 @@ class Locale extends \Locale
                 }
             }
 
-            $parentLocale = self::getParentLocale($locale);
-            if (null !== $parentLocale) {
-                $countries = array_merge(self::getDisplayCountries($parentLocale), $countries);
+            $fallbackLocale = self::getFallbackLocale($locale);
+            if (null !== $fallbackLocale) {
+                $countries = array_merge(self::getDisplayCountries($fallbackLocale), $countries);
             }
 
             $collator->asort($countries);
@@ -113,9 +113,9 @@ class Locale extends \Locale
                 }
             }
 
-            $parentLocale = self::getParentLocale($locale);
-            if (null !== $parentLocale) {
-                $languages = array_merge(self::getDisplayLanguages($parentLocale), $languages);
+            $fallbackLocale = self::getFallbackLocale($locale);
+            if (null !== $fallbackLocale) {
+                $languages = array_merge(self::getDisplayLanguages($fallbackLocale), $languages);
             }
 
             $collator->asort($languages);
@@ -160,9 +160,9 @@ class Locale extends \Locale
                 $locales[$code] = $name;
             }
 
-            $parentLocale = self::getParentLocale($locale);
-            if (null !== $parentLocale) {
-                $locales = array_merge(self::getDisplayLocales($parentLocale), $locales);
+            $fallbackLocale = self::getFallbackLocale($locale);
+            if (null !== $fallbackLocale) {
+                $locales = array_merge(self::getDisplayLocales($fallbackLocale), $locales);
             }
 
             $collator->asort($locales);
@@ -185,12 +185,12 @@ class Locale extends \Locale
     }
 
     /**
-     * Returns the parent locale for a given locale, if any
+     * Returns the fallback locale for a given locale, if any
      *
-     * @param $locale             The locale to find the parent for
-     * @return string|null        The parent locale, or null if no parent exists
+     * @param $locale             The locale to find the fallback for
+     * @return string|null        The fallback locale, or null if no parent exists
      */
-    static protected function getParentLocale($locale)
+    static protected function getFallbackLocale($locale)
     {
         if ($locale === self::getDefault()) {
             return null;

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -61,12 +61,12 @@ class Locale extends \Locale
                 }
             }
 
-            $collator->asort($countries);
-
             $parentLocale = self::getParentLocale($locale);
             if ($parentLocale !== null) {
                 $countries = array_merge(self::getDisplayCountries($parentLocale), $countries);
             }
+
+            $collator->asort($countries);
 
             self::$countries[$locale] = $countries;
         }
@@ -113,12 +113,12 @@ class Locale extends \Locale
                 }
             }
 
-            $collator->asort($languages);
-
             $parentLocale = self::getParentLocale($locale);
             if ($parentLocale !== null) {
                 $languages = array_merge(self::getDisplayLanguages($parentLocale), $languages);
             }
+
+            $collator->asort($languages);
 
             self::$languages[$locale] = $languages;
         }
@@ -160,12 +160,12 @@ class Locale extends \Locale
                 $locales[$code] = $name;
             }
 
-            $collator->asort($locales);
-
             $parentLocale = self::getParentLocale($locale);
             if ($parentLocale !== null) {
                 $locales = array_merge(self::getDisplayLocales($parentLocale), $locales);
             }
+
+            $collator->asort($locales);
 
             self::$locales[$locale] = $locales;
         }

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -63,6 +63,11 @@ class Locale extends \Locale
 
             $collator->asort($countries);
 
+            $parentLocale = self::getParentLocale($locale);
+            if ($parentLocale !== null) {
+                $countries = array_merge(self::getDisplayCountries($parentLocale), $countries);
+            }
+
             self::$countries[$locale] = $countries;
         }
 
@@ -110,6 +115,11 @@ class Locale extends \Locale
 
             $collator->asort($languages);
 
+            $parentLocale = self::getParentLocale($locale);
+            if ($parentLocale !== null) {
+                $languages = array_merge(self::getDisplayLanguages($parentLocale), $languages);
+            }
+
             self::$languages[$locale] = $languages;
         }
 
@@ -152,6 +162,11 @@ class Locale extends \Locale
 
             $collator->asort($locales);
 
+            $parentLocale = self::getParentLocale($locale);
+            if ($parentLocale !== null) {
+                $locales = array_merge(self::getDisplayLocales($parentLocale), $locales);
+            }
+
             self::$locales[$locale] = $locales;
         }
 
@@ -167,5 +182,25 @@ class Locale extends \Locale
     static public function getLocales()
     {
         return array_keys(self::getDisplayLocales(self::getDefault()));
+    }
+
+    /**
+     * Returns the parent locale for a given locale, if any
+     *
+     * @static
+     * @param $locale
+     * @return string|null Parent locale, or null if no parent
+     */
+    static protected function getParentLocale($locale)
+    {
+        if ($locale === self::getDefault()) {
+            return null;
+        }
+        if (!strstr($locale, '_')) {
+            return self::getDefault();
+        };
+
+        $lastUnderlinePos = strlen($locale) - strpos(strrev($locale), '_') - 1;
+        return substr($locale, 0, $lastUnderlinePos);
     }
 }

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -195,12 +195,12 @@ class Locale extends \Locale
         if ($locale === self::getDefault()) {
             return null;
         }
-        if (!strstr($locale, '_')) {
+
+        $localeParts = explode('_', $locale);
+        if (count($localeParts) == 1) {
             return self::getDefault();
         };
 
-        $lastUnderlinePos = strlen($locale) - strpos(strrev($locale), '_') - 1;
-
-        return substr($locale, 0, $lastUnderlinePos);
+        return implode('_', array_slice($localeParts, 0, -1));
     }
 }

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -196,11 +196,10 @@ class Locale extends \Locale
             return null;
         }
 
-        $localeParts = explode('_', $locale);
-        if (1 === count($localeParts)) {
+        if (false === $pos = strrpos($locale, '_')) {
             return self::getDefault();
         };
 
-        return implode('_', array_slice($localeParts, 0, -1));
+        return substr($locale, 0, $pos);
     }
 }

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -62,7 +62,7 @@ class Locale extends \Locale
             }
 
             $parentLocale = self::getParentLocale($locale);
-            if ($parentLocale !== null) {
+            if (null !== $parentLocale) {
                 $countries = array_merge(self::getDisplayCountries($parentLocale), $countries);
             }
 
@@ -114,7 +114,7 @@ class Locale extends \Locale
             }
 
             $parentLocale = self::getParentLocale($locale);
-            if ($parentLocale !== null) {
+            if (null !== $parentLocale) {
                 $languages = array_merge(self::getDisplayLanguages($parentLocale), $languages);
             }
 
@@ -161,7 +161,7 @@ class Locale extends \Locale
             }
 
             $parentLocale = self::getParentLocale($locale);
-            if ($parentLocale !== null) {
+            if (null !== $parentLocale) {
                 $locales = array_merge(self::getDisplayLocales($parentLocale), $locales);
             }
 
@@ -187,7 +187,6 @@ class Locale extends \Locale
     /**
      * Returns the parent locale for a given locale, if any
      *
-     * @static
      * @param $locale             The locale to find the parent for
      * @return string|null        The parent locale, or null if no parent exists
      */
@@ -201,6 +200,7 @@ class Locale extends \Locale
         };
 
         $lastUnderlinePos = strlen($locale) - strpos(strrev($locale), '_') - 1;
+
         return substr($locale, 0, $lastUnderlinePos);
     }
 }

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -188,8 +188,8 @@ class Locale extends \Locale
      * Returns the parent locale for a given locale, if any
      *
      * @static
-     * @param $locale
-     * @return string|null Parent locale, or null if no parent
+     * @param $locale             The locale to find the parent for
+     * @return string|null        The parent locale, or null if no parent exists
      */
     static protected function getParentLocale($locale)
     {

--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -197,7 +197,7 @@ class Locale extends \Locale
         }
 
         $localeParts = explode('_', $locale);
-        if (count($localeParts) == 1) {
+        if (1 === count($localeParts)) {
             return self::getDefault();
         };
 

--- a/tests/Symfony/Tests/Component/Locale/LocaleTest.php
+++ b/tests/Symfony/Tests/Component/Locale/LocaleTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Locale;
+
+use Symfony\Component\Locale\Locale;
+
+class LocaleTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetDisplayCountriesReturnsFullListForSubLocale()
+    {
+        $countriesDe = Locale::getDisplayCountries('de');
+        $countriesDeCh = Locale::getDisplayCountries('de_CH');
+
+        $this->assertEquals(count($countriesDe), count($countriesDeCh));
+        $this->assertEquals($countriesDe['BD'], 'Bangladesch');
+        $this->assertEquals($countriesDeCh['BD'], 'Bangladesh');
+    }
+
+    public function testGetDisplayLanguagesReturnsFullListForSubLocale()
+    {
+        $languagesDe = Locale::getDisplayLanguages('de');
+        $languagesDeCh = Locale::getDisplayLanguages('de_CH');
+
+        $this->assertEquals(count($languagesDe), count($languagesDeCh));
+        $this->assertEquals($languagesDe['be'], 'Weißrussisch');
+        $this->assertEquals($languagesDeCh['be'], 'Weissrussisch');
+    }
+
+    public function testGetDisplayLocalesReturnsFullListForSubLocale()
+    {
+        $localesDe = Locale::getDisplayLocales('de');
+        $localesDeCh = Locale::getDisplayLocales('de_CH');
+
+        $this->assertEquals(count($localesDe), count($localesDeCh));
+        $this->assertEquals($localesDe['be'], 'Weißrussisch');
+        $this->assertEquals($localesDeCh['be'], 'Weissrussisch');
+    }
+}


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: ![Build Status](https://secure.travis-ci.org/ManuelKiessling/symfony.png?branch=ticket_3106) Fixes the following tickets: #3106
Todo: -

Sublocales like de_CH returned only incomplete results for
getDisplayCountries(), getDisplayLanguages() and getDisplayLocales(),
consisting only of results specific for this sublocale, but without the
results of their respective parent locale
