### PR TITLE
[HttpFoundation] check trust setting in getPort()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -562,7 +562,11 @@ class Request
      */
     public function getPort()
     {
-        return $this->headers->get('X-Forwarded-Port') ?: $this->server->get('SERVER_PORT');
+        if (self::$trustProxy && $this->headers->has('X-Forwarded-Port')) {
+            return $this->headers->get('X-Forwarded-Port');
+        } else {
+            return $this->server->get('SERVER_PORT');
+        }
     }
 
     /**


### PR DESCRIPTION
Added a missing `self::$trustProxy` check in `Request::getPort()`.

```
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```
