### PR TITLE
[Validator] Dynamic constraints

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintProviderInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintProviderInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace Symfony\Component\Validator;
+
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+/**
+ * Makes it possible to define dynamic constraints for an object.
+ */
+interface ConstraintProviderInterface
+{
+    /**
+     * Lets the user create dynamic constraints
+     *
+     * @param Mapping\ClassMetadata
+     */
+    public function getConstraints(ClassMetadata $metadata);
+}

--- a/src/Symfony/Component/Validator/ConstraintProviderInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintProviderInterface.php
@@ -23,5 +23,5 @@ interface ConstraintProviderInterface
      *
      * @param Mapping\ClassMetadata
      */
-    public function getConstraints(ClassMetadata $metadata);
+    function registerConstraints(ClassMetadata $metadata);
 }

--- a/src/Symfony/Component/Validator/ConstraintProviderInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintProviderInterface.php
@@ -23,5 +23,5 @@ interface ConstraintProviderInterface
      *
      * @param Mapping\ClassMetadata
      */
-    function registerConstraints(ClassMetadata $metadata);
+    function loadDynamicValidatorMetadata(ClassMetadata $metadata);
 }

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -62,7 +62,7 @@ class Validator implements ValidatorInterface
         if ($object instanceof ConstraintProviderInterface) {
             $dynamicMetadata = new ClassMetadata(get_class($object));
             $dynamicMetadata->mergeConstraints($metadata);
-            $object->getConstraints($dynamicMetadata);
+            $object->registerConstraints($dynamicMetadata);
             $metadata = $dynamicMetadata;
         }
 

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -57,6 +57,10 @@ class Validator implements ValidatorInterface
     public function validate($object, $groups = null)
     {
         $metadata = $this->metadataFactory->getClassMetadata(get_class($object));
+        
+        if ($object instanceof ConstraintProviderInterface) {
+            $object->getConstraints($metadata);
+        }
 
         $walk = function(GraphWalker $walker, $group) use ($metadata, $object) {
             return $walker->walkObject($metadata, $object, $group, '');

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator;
 
 use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 /**
  * The default implementation of the ValidatorInterface.
@@ -59,7 +60,10 @@ class Validator implements ValidatorInterface
         $metadata = $this->metadataFactory->getClassMetadata(get_class($object));
         
         if ($object instanceof ConstraintProviderInterface) {
-            $object->getConstraints($metadata);
+            $dynamicMetadata = new ClassMetadata(get_class($object));
+            $dynamicMetadata->mergeConstraints($metadata);
+            $object->getConstraints($dynamicMetadata);
+            $metadata = $dynamicMetadata;
         }
 
         $walk = function(GraphWalker $walker, $group) use ($metadata, $object) {

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -62,7 +62,7 @@ class Validator implements ValidatorInterface
         if ($object instanceof ConstraintProviderInterface) {
             $dynamicMetadata = new ClassMetadata(get_class($object));
             $dynamicMetadata->mergeConstraints($metadata);
-            $object->registerConstraints($dynamicMetadata);
+            $object->loadDynamicValidatorMetadata($dynamicMetadata);
             $metadata = $dynamicMetadata;
         }
 

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
@@ -7,15 +7,24 @@ use Symfony\Component\Validator\Mapping\ClassMetadata;
 
 class DynamicConstraintsEntity implements ConstraintProviderInterface
 {
+    protected $validationEnabled = false;
     protected $firstValue;
     
-    public function getSecondValue() {
+    public function setValidation($enabled)
+    {
+        $this->validationEnabled = $enabled;
+    }
+    
+    public function getSecondValue() 
+    {
         return null;
     }
     
     public function getConstraints(ClassMetadata $metadata)
     {
-        $metadata->addPropertyConstraint('firstValue', new FailingConstraint());
-        $metadata->addGetterConstraint('secondValue', new FailingConstraint());
+        if ($this->validationEnabled) {
+            $metadata->addPropertyConstraint('firstValue', new FailingConstraint());
+            $metadata->addGetterConstraint('secondValue', new FailingConstraint());
+        }
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
@@ -20,7 +20,7 @@ class DynamicConstraintsEntity implements ConstraintProviderInterface
         return null;
     }
     
-    public function getConstraints(ClassMetadata $metadata)
+    public function registerConstraints(ClassMetadata $metadata)
     {
         if ($this->validationEnabled) {
             $metadata->addPropertyConstraint('firstValue', new FailingConstraint());

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Tests\Component\Validator\Fixtures;
+
+use Symfony\Component\Validator\ConstraintProviderInterface;
+use Symfony\Component\Validator\Mapping\ClassMetadata;
+
+class DynamicConstraintsEntity implements ConstraintProviderInterface
+{
+    protected $firstValue;
+    
+    public function getSecondValue() {
+        return null;
+    }
+    
+    public function getConstraints(ClassMetadata $metadata)
+    {
+        $metadata->addPropertyConstraint('firstValue', new FailingConstraint());
+        $metadata->addGetterConstraint('secondValue', new FailingConstraint());
+    }
+}

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/DynamicConstraintsEntity.php
@@ -20,7 +20,7 @@ class DynamicConstraintsEntity implements ConstraintProviderInterface
         return null;
     }
     
-    public function registerConstraints(ClassMetadata $metadata)
+    public function loadDynamicValidatorMetadata(ClassMetadata $metadata)
     {
         if ($this->validationEnabled) {
             $metadata->addPropertyConstraint('firstValue', new FailingConstraint());

--- a/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
@@ -129,8 +129,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $entity = new DynamicConstraintsEntity();
         $metadata = new ClassMetadata(get_class($entity));
         $this->factory->addClassMetadata($metadata);
+        
+        $entity->setValidation(true);
 
-        // Only the constraint of group "Default" failed
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
             '',
@@ -146,7 +147,12 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
             'secondValue',
             ''
         ));
-
+        
+        $this->assertEquals($violations, $this->validator->validate($entity));
+        
+        $entity->setValidation(false);
+        
+        $violations = new ConstraintViolationList();
         $this->assertEquals($violations, $this->validator->validate($entity));
     }
 

--- a/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
@@ -15,10 +15,12 @@ require_once __DIR__.'/Fixtures/Entity.php';
 require_once __DIR__.'/Fixtures/FailingConstraint.php';
 require_once __DIR__.'/Fixtures/FailingConstraintValidator.php';
 require_once __DIR__.'/Fixtures/FakeClassMetadataFactory.php';
+require_once __DIR__.'/Fixtures/DynamicConstraintsEntity.php';
 
 use Symfony\Tests\Component\Validator\Fixtures\Entity;
 use Symfony\Tests\Component\Validator\Fixtures\FakeClassMetadataFactory;
 use Symfony\Tests\Component\Validator\Fixtures\FailingConstraint;
+use Symfony\Tests\Component\Validator\Fixtures\DynamicConstraintsEntity;
 use Symfony\Component\Validator\Validator;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -120,6 +122,32 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $result = $this->validator->validate($entity, array('First', 'Second'));
 
         $this->assertEquals($violations, $result);
+    }
+    
+    public function testValidate_constraintProvider()
+    {
+        $entity = new DynamicConstraintsEntity();
+        $metadata = new ClassMetadata(get_class($entity));
+        $this->factory->addClassMetadata($metadata);
+
+        // Only the constraint of group "Default" failed
+        $violations = new ConstraintViolationList();
+        $violations->add(new ConstraintViolation(
+            '',
+            array(),
+            $entity,
+            'firstValue',
+            ''
+        ));
+        $violations->add(new ConstraintViolation(
+            '',
+            array(),
+            $entity,
+            'secondValue',
+            ''
+        ));
+
+        $this->assertEquals($violations, $this->validator->validate($entity));
     }
 
     public function testValidateProperty()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

By now the Validator component is based on a per-class configuration of
constraints, but in some cases it might be neccessary to add new constraints
dynamically at runtime.
This pull request adds a "ConstraintProviderInterface" to the Validator component. If an object is validated that implements this interface the method "getConstraints" is used to add dynamic constraints:

```
class User implements ConstraintProviderInterface
{
    protected $isPremium;
    protected $paymentInformation;

    public function getConstraints(ClassMetadata $metadata)
    {
        if ($this->isPremium) {
            $metadata->addPropertyConstraint('paymentInformation', new NotBlank());
        }
    }
}
```
