### PR TITLE
[FrameworkBundle][Templating] add TemplateNameParserInterface

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\CacheWarmer;
 
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Finder\Finder;
-use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParserInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 /**
@@ -35,7 +35,7 @@ class TemplateFinder implements TemplateFinderInterface
      * @param TemplateNameParser   $parser  A TemplateNameParser instance
      * @param string               $rootDir The directory where global templates can be stored
      */
-    public function __construct(KernelInterface $kernel, TemplateNameParser $parser, $rootDir)
+    public function __construct(KernelInterface $kernel, TemplateNameParserInterface $parser, $rootDir)
     {
         $this->kernel = $kernel;
         $this->parser = $parser;
@@ -107,3 +107,4 @@ class TemplateFinder implements TemplateFinderInterface
         return $templates;
     }
 }
+

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplateFinder.php
@@ -32,7 +32,7 @@ class TemplateFinder implements TemplateFinderInterface
      * Constructor.
      *
      * @param KernelInterface      $kernel  A KernelInterface instance
-     * @param TemplateNameParser   $parser  A TemplateNameParser instance
+     * @param TemplateNameParserInterface   $parser  A TemplateNameParser instance
      * @param string               $rootDir The directory where global templates can be stored
      */
     public function __construct(KernelInterface $kernel, TemplateNameParserInterface $parser, $rootDir)

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
@@ -33,7 +33,7 @@ class PhpEngine extends BasePhpEngine implements EngineInterface
      * @param LoaderInterface             $loader    A loader instance
      * @param GlobalVariables|null        $globals   A GlobalVariables instance or null
      */
-    public function __construct(BaseTemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader, GlobalVariables $globals = null)
+    public function __construct(TemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader, GlobalVariables $globals = null)
     {
         $this->container = $container;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\FrameworkBundle\Templating;
 
 use Symfony\Component\Templating\PhpEngine as BasePhpEngine;
 use Symfony\Component\Templating\Loader\LoaderInterface;
-use Symfony\Component\Templating\TemplateNameParserInterface as BaseTemplateNameParserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/PhpEngine.php
@@ -13,7 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Templating;
 
 use Symfony\Component\Templating\PhpEngine as BasePhpEngine;
 use Symfony\Component\Templating\Loader\LoaderInterface;
-use Symfony\Component\Templating\TemplateNameParserInterface;
+use Symfony\Component\Templating\TemplateNameParserInterface as BaseTemplateNameParserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -34,7 +34,7 @@ class PhpEngine extends BasePhpEngine implements EngineInterface
      * @param LoaderInterface             $loader    A loader instance
      * @param GlobalVariables|null        $globals   A GlobalVariables instance or null
      */
-    public function __construct(TemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader, GlobalVariables $globals = null)
+    public function __construct(BaseTemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader, GlobalVariables $globals = null)
     {
         $this->container = $container;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
@@ -22,7 +22,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class TemplateNameParser extends BaseTemplateNameParser
+class TemplateNameParser extends BaseTemplateNameParser implements TemplateNameParserInterface
 {
     protected $kernel;
     protected $cache;

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParserInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParserInterface.php
@@ -29,6 +29,6 @@ interface TemplateNameParserInterface extends BaseTemplateNameParserInterface
      *
      * @return TemplateReferenceInterface A template
      */
-    public function parseFromFilename($file);
+    function parseFromFilename($file);
 
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParserInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParserInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Templating;
+
+use Symfony\Component\Templating\TemplateNameParserInterface as BaseTemplateNameParserInterface;
+
+/**
+ * TemplateNameParserInterface converts template names to TemplateReferenceInterface
+ * instances.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @api
+ */
+interface TemplateNameParserInterface extends BaseTemplateNameParserInterface
+{
+
+    /**
+     * Convert a filename to a template.
+     *
+     * @param string $file The filename
+     *
+     * @return TemplateReferenceInterface A template
+     */
+    public function parseFromFilename($file);
+
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParserInterface.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParserInterface.php
@@ -18,8 +18,6 @@ use Symfony\Component\Templating\TemplateNameParserInterface as BaseTemplateName
  * instances.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- *
- * @api
  */
 interface TemplateNameParserInterface extends BaseTemplateNameParserInterface
 {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
-use Symfony\Component\Templating\TemplateNameParser;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
-use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;
+use Symfony\Component\Templating\TemplateNameParser;
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 
@@ -25,8 +25,9 @@ class PhpEngineTest extends TestCase
     public function testEvaluateAddsAppGlobal()
     {
         $container = $this->getContainer();
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
-        $engine = new PhpEngine(new TemplateNameParser(), $container, $loader, $app = new GlobalVariables($container));
+        $engine = new PhpEngine(new TemplateNameParser($kernel), $container, $loader, $app = new GlobalVariables($container));
         $globals = $engine->getGlobals();
         $this->assertSame($app, $globals['app']);
     }
@@ -34,8 +35,9 @@ class PhpEngineTest extends TestCase
     public function testEvaluateWithoutAvailableRequest()
     {
         $container = new Container();
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
-        $engine = new PhpEngine(new TemplateNameParser(), $container, $loader, new GlobalVariables($container));
+        $engine = new PhpEngine(new TemplateNameParser($kernel), $container, $loader, new GlobalVariables($container));
 
         $container->set('request', null);
 
@@ -49,8 +51,9 @@ class PhpEngineTest extends TestCase
     public function testGetInvalidHelper()
     {
         $container = $this->getContainer();
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
         $loader = $this->getMockForAbstractClass('Symfony\Component\Templating\Loader\Loader');
-        $engine = new PhpEngine(new TemplateNameParser(), $container, $loader);
+        $engine = new PhpEngine(new TemplateNameParser($kernel), $container, $loader);
 
         $engine->get('non-existing-helper');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
-use Symfony\Component\Templating\TemplateNameParser;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/PhpEngineTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
-use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
 

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Loader;
 
-use Symfony\Bundle\FrameworkBundle\TemplateNameParserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParserInterface;
 use Symfony\Component\Config\FileLocatorInterface;
 
 /**

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\TwigBundle\Loader;
 
-use Symfony\Component\Templating\TemplateNameParserInterface;
+use Symfony\Bundle\FrameworkBundle\TemplateNameParserInterface;
 use Symfony\Component\Config\FileLocatorInterface;
 
 /**

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
-use Symfony\Bundle\FrameworkBundle\TemplateNameParserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParserInterface;
 use InvalidArgumentException;
 
 class FilesystemLoaderTest extends TestCase

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -32,7 +32,7 @@ class FilesystemLoaderTest extends TestCase
         parent::setUp();
 
         $this->locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
-        $this->parser = $this->getMock('Symfony\Bundle\FrameworkBundle\TemplateNameParserInterface');
+        $this->parser = $this->getMock('Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParserInterface');
         $this->loader = new FilesystemLoader($this->locator, $this->parser);
 
         $this->parser->expects($this->once())

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -14,8 +14,8 @@ namespace Symfony\Bundle\TwigBundle\Tests\Loader;
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
 use Symfony\Component\Config\FileLocatorInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use InvalidArgumentException;
 
 class FilesystemLoaderTest extends TestCase

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
-use Symfony\Component\Templating\TemplateNameParserInterface;
+use Symfony\Bundle\FrameworkBundle\TemplateNameParserInterface;
 use InvalidArgumentException;
 
 class FilesystemLoaderTest extends TestCase
@@ -32,7 +32,7 @@ class FilesystemLoaderTest extends TestCase
         parent::setUp();
 
         $this->locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
-        $this->parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
+        $this->parser = $this->getMock('Symfony\Bundle\FrameworkBundle\TemplateNameParserInterface');
         $this->loader = new FilesystemLoader($this->locator, $this->parser);
 
         $this->parser->expects($this->once())

--- a/src/Symfony/Bundle/TwigBundle/Tests/TwigEngineTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TwigEngineTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
-use Symfony\Component\Templating\TemplateNameParser;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 
 class TwigEngineTest extends TestCase
@@ -24,9 +24,10 @@ class TwigEngineTest extends TestCase
     public function testEvaluateAddsAppGlobal()
     {
         $environment = $this->getTwigEnvironment();
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
         $container = $this->getContainer();
         $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
-        $engine = new TwigEngine($environment, new TemplateNameParser(), $locator, $app = new GlobalVariables($container));
+        $engine = new TwigEngine($environment, new TemplateNameParser($kernel), $locator, $app = new GlobalVariables($container));
 
         $template = $this->getMock('\Twig_TemplateInterface');
 
@@ -44,9 +45,10 @@ class TwigEngineTest extends TestCase
     public function testEvaluateWithoutAvailableRequest()
     {
         $environment = $this->getTwigEnvironment();
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
         $container = new Container();
         $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
-        $engine = new TwigEngine($environment, new TemplateNameParser(), $locator, new GlobalVariables($container));
+        $engine = new TwigEngine($environment, new TemplateNameParser($kernel), $locator, new GlobalVariables($container));
 
         $template = $this->getMock('\Twig_TemplateInterface');
 

--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\TwigBundle;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
-use Symfony\Component\Templating\TemplateNameParserInterface;
+use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParserInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Templating\StreamingEngineInterface;


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/neni/symfony.png)](http://travis-ci.org/neni/symfony)
Fixes the following tickets: -
Todo: -

Is it possible to add a  TemplateNameParserInterface in [FrameworkBundle][Templating] for facilitate usage of no standard TemplateReference (add method parseFromFilename to Symfony\Component\Templating\TemplateNameParserInterface) and allow to use it on [AsseticBundle] for use "templating.name_parser" ?

https://github.com/neni/AsseticBundle/commit/0f9d176ffc60c041130311ec8742a809f8bfb554
