### PR TITLE
[Form] Made validation of form children configurable

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtension.php
@@ -38,6 +38,7 @@ class FieldTypeValidatorExtension extends AbstractTypeExtension
         $builder
             ->setAttribute('validation_groups', $options['validation_groups'])
             ->setAttribute('validation_constraint', $options['validation_constraint'])
+            ->setAttribute('cascade_validation', $options['cascade_validation'])
             ->addValidator(new DelegatingValidator($this->validator));
     }
 
@@ -46,6 +47,7 @@ class FieldTypeValidatorExtension extends AbstractTypeExtension
         return array(
             'validation_groups' => null,
             'validation_constraint' => null,
+            'cascade_validation' => false,
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
@@ -127,6 +127,29 @@ class DelegatingValidator implements FormValidatorInterface
         }
     }
 
+    static public function validateFormChildren(FormInterface $form, ExecutionContext $context)
+    {
+        if ($form->getAttribute('cascade_validation')) {
+            $propertyPath = $context->getPropertyPath();
+            $graphWalker = $context->getGraphWalker();
+
+            // The Execute constraint is called on class level, so we need to
+            // set the property manually
+            $context->setCurrentProperty('children');
+
+            // Adjust the property path accordingly
+            if (!empty($propertyPath)) {
+                $propertyPath .= '.';
+            }
+
+            $propertyPath .= 'children';
+
+            foreach (self::getFormValidationGroups($form) as $group) {
+                $graphWalker->walkReference($form->getChildren(), $group, $propertyPath, true);
+            }
+        }
+    }
+
     static protected function getFormValidationGroups(FormInterface $form)
     {
         $groups = null;

--- a/src/Symfony/Component/Form/Resources/config/validation.xml
+++ b/src/Symfony/Component/Form/Resources/config/validation.xml
@@ -10,9 +10,10 @@
         <value>Symfony\Component\Form\Extension\Validator\Validator\DelegatingValidator</value>
         <value>validateFormData</value>
       </value>
+      <value>
+        <value>Symfony\Component\Form\Extension\Validator\Validator\DelegatingValidator</value>
+        <value>validateFormChildren</value>
+      </value>
     </constraint>
-    <property name="children">
-      <constraint name="Valid" />
-    </property>
   </class>
 </constraint-mapping>


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #797
Todo: adapt documentation

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=optional-form-child-validation)

Child forms now aren't validated anymore by default. This is not a problem as long as @Valid constraints are properly put in your model. If you want to enable cascading validation, for example when there is no connection between the parent and the child model, you can set the option "cascade_validation" in the parent form to true.

This change is not backwards compatible, but from my estimation the break should not affect many applications.
