### PR TITLE
[Bridge] [Twig] fixed typo in a comment of the Twig FormExtension extension

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -67,7 +67,7 @@ class FormExtension extends \Twig_Extension
     public function getTokenParsers()
     {
         return array(
-            // {% form_theme form "SomeBungle::widgets.twig" %}
+            // {% form_theme form "SomeBundle::widgets.twig" %}
             new FormThemeTokenParser(),
         );
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
