### PR TITLE
[Locale][Testing] Fixed breaking tests if 'intl' extension is not installed (#3139)

### DIFF
--- a/tests/Symfony/Tests/Component/Locale/LocaleTest.php
+++ b/tests/Symfony/Tests/Component/Locale/LocaleTest.php
@@ -11,12 +11,16 @@
 
 namespace Symfony\Tests\Component\Locale;
 
-use Symfony\Component\Locale\Locale;
+require_once __DIR__.'/TestCase.php';
 
-class LocaleTest extends \PHPUnit_Framework_TestCase
+use Symfony\Component\Locale\Locale;
+use Symfony\Tests\Component\Locale\TestCase as LocaleTestCase;
+
+class LocaleTest extends LocaleTestCase
 {
     public function testGetDisplayCountriesReturnsFullListForSubLocale()
     {
+        $this->skipIfIntlExtensionIsNotLoaded();
         $countriesDe = Locale::getDisplayCountries('de');
         $countriesDeCh = Locale::getDisplayCountries('de_CH');
 
@@ -27,6 +31,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDisplayLanguagesReturnsFullListForSubLocale()
     {
+        $this->skipIfIntlExtensionIsNotLoaded();
         $languagesDe = Locale::getDisplayLanguages('de');
         $languagesDeCh = Locale::getDisplayLanguages('de_CH');
 
@@ -37,6 +42,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDisplayLocalesReturnsFullListForSubLocale()
     {
+        $this->skipIfIntlExtensionIsNotLoaded();
         $localesDe = Locale::getDisplayLocales('de');
         $localesDeCh = Locale::getDisplayLocales('de_CH');
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: ![Build Status](https://secure.travis-ci.org/ManuelKiessling/symfony.png?branch=ticket_3139) Fixes the following tickets: #3139
Todo: -

Symfony\Tests\Component\Locale\LocaleTest->testGetDisplayCountriesReturnsFullListForSubLocale()
fails with a fatal error if the PHP extension 'intl' is not installed on the system.
Added a check which skips the affected tests if the extension is not available.
Fixes #3139
