### PR TITLE
2.0 - Suggestion for bin/vendors script.

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -67,7 +67,7 @@ class FormExtension extends \Twig_Extension
     public function getTokenParsers()
     {
         return array(
-            // {% form_theme form "SomeBungle::widgets.twig" %}
+            // {% form_theme form "SomeBundle::widgets.twig" %}
             new FormThemeTokenParser(),
         );
     }

--- a/tests/Symfony/Tests/Component/Locale/LocaleTest.php
+++ b/tests/Symfony/Tests/Component/Locale/LocaleTest.php
@@ -11,12 +11,16 @@
 
 namespace Symfony\Tests\Component\Locale;
 
-use Symfony\Component\Locale\Locale;
+require_once __DIR__.'/TestCase.php';
 
-class LocaleTest extends \PHPUnit_Framework_TestCase
+use Symfony\Component\Locale\Locale;
+use Symfony\Tests\Component\Locale\TestCase as LocaleTestCase;
+
+class LocaleTest extends LocaleTestCase
 {
     public function testGetDisplayCountriesReturnsFullListForSubLocale()
     {
+        $this->skipIfIntlExtensionIsNotLoaded();
         $countriesDe = Locale::getDisplayCountries('de');
         $countriesDeCh = Locale::getDisplayCountries('de_CH');
 
@@ -27,6 +31,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDisplayLanguagesReturnsFullListForSubLocale()
     {
+        $this->skipIfIntlExtensionIsNotLoaded();
         $languagesDe = Locale::getDisplayLanguages('de');
         $languagesDeCh = Locale::getDisplayLanguages('de_CH');
 
@@ -37,6 +42,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
 
     public function testGetDisplayLocalesReturnsFullListForSubLocale()
     {
+        $this->skipIfIntlExtensionIsNotLoaded();
         $localesDe = Locale::getDisplayLocales('de');
         $localesDeCh = Locale::getDisplayLocales('de_CH');
 

--- a/vendors.php
+++ b/vendors.php
@@ -51,7 +51,7 @@ foreach ($deps as $dep) {
 
     $installDir = $vendorDir.'/'.$name;
     if (!is_dir($installDir)) {
-        system(sprintf('git clone %s %s', escapeshellarg($url), escapeshellarg($installDir)));
+        system(sprintf('git clone --depth=1 %s %s', escapeshellarg($url), escapeshellarg($installDir)));
     }
 
     system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));


### PR DESCRIPTION
As noticed in issue [969 of the Symfony-docs](https://github.com/symfony/symfony-docs/pull/969) project, the .git folders of the vendors are taking up an incredible amount of space. 

Since history of the git repository is absolutely useless for common developers, my suggestion is to clone the vendors repository with only last commit as history. 

This can be done simply by using the `--depth=n` parameter of `git clone`. 

Gave it a try locally and it works like a charm. Here are some results. 

Before: 

```
$ du -sh vendors 
57M vendor/
```

After : 

```
$ du -sh vendors 
124M    vendor/
```
