### PR TITLE
[vendors] - Suggestion for bin/vendors script.

### DIFF
--- a/vendors.php
+++ b/vendors.php
@@ -51,7 +51,7 @@ foreach ($deps as $dep) {
 
     $installDir = $vendorDir.'/'.$name;
     if (!is_dir($installDir)) {
-        system(sprintf('git clone %s %s', escapeshellarg($url), escapeshellarg($installDir)));
+        system(sprintf('git clone --depth=1 %s %s', escapeshellarg($url), escapeshellarg($installDir)));
     }
 
     system(sprintf('cd %s && git fetch origin && git reset --hard %s', escapeshellarg($installDir), escapeshellarg($rev)));


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: none
Todo: none

As noticed in issue [969 of the Symfony-docs](https://github.com/symfony/symfony-docs/pull/969) project, the .git folders of the vendors are taking up an incredible amount of space. 

Since history of the git repository is absolutely useless for common developers, my suggestion is to clone the vendors repository with only last commit as history. 

This can be done simply by using the `--depth=n` parameter of `git clone`. 

Gave it a try locally and it works like a charm. Here are some results. 

Before: 

```
$ du -sh vendors 
57M vendor/
```

After : 

```
$ du -sh vendors 
124M    vendor/
```
