### PR TITLE
[Form] add missing interface method

### DIFF
--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -47,9 +47,18 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     function add(FormInterface $child);
 
     /**
+     * Returns the child with the given name.
+     * 
+     * @param string $name The name of the child
+     * 
+     * @return FormInterface The child form
+     */
+    function get($name);
+
+    /**
      * Returns whether a child with the given name exists.
      *
-     * @param string $name
+     * @param string $name The name of the child
      *
      * @return Boolean
      */


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Quite simply, the interface misses `get`, but has `add`, `has` and `remove`.
