### PR TITLE
[Form] Do not render default ID attribute on empty form name

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -287,7 +287,7 @@
 
 {% block widget_container_attributes %}
 {% spaceless %}
-    id="{{ id }}"
+    {% if id is not empty %}id="{{ id }}" {% endif %}
     {% for attrname,attrvalue in attr %}{{attrname}}="{{attrvalue}}" {% endfor %}
 {% endspaceless %}
 {% endblock widget_container_attributes %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/container_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/container_attributes.html.php
@@ -1,2 +1,2 @@
-id="<?php echo $view->escape($id) ?>"
+<?php if (!empty($id)): ?>id="<?php echo $view->escape($id) ?>" <?php endif; ?>
 <?php foreach($attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -86,9 +86,7 @@ class FieldType extends AbstractType
                 $fullName = $name;
             }
         } else {
-            // If this form node have empty name, set id to `form`
-            // to avoid rendering `id=""` in html structure
-            $id = $name ?: 'form';
+            $id = $name;
             $fullName = $name;
         }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

[![Build Status](https://secure.travis-ci.org/canni/symfony.png)](http://travis-ci.org/canni/symfony)

This is cleanup after enabling empty form names, now form with empty name
will not render the default `id="form"` container attribute.
Developers can extend/override this behaviour by standard form theming methods.

See discussion [here](https://github.com/symfony/symfony/pull/2936/files)
