### PR TITLE
Add help option to form fields

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -1,5 +1,11 @@
 {# Widgets #}
 
+{% block field_help %}
+    {% if help is defined %}
+        <span class="help">{{ help }}</span>
+    {% endif %}
+{% endblock %}
+
 {% block form_widget %}
 {% spaceless %}
     <div {{ block('widget_container_attributes') }}>
@@ -21,6 +27,7 @@
 {% block textarea_widget %}
 {% spaceless %}
     <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock textarea_widget %}
 
@@ -65,18 +72,21 @@
         {{ block('widget_choice_options') }}
     </select>
     {% endif %}
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock choice_widget %}
 
 {% block checkbox_widget %}
 {% spaceless %}
     <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock checkbox_widget %}
 
 {% block radio_widget %}
 {% spaceless %}
     <input type="radio" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %} />
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock radio_widget %}
 
@@ -92,6 +102,7 @@
             {{ form_widget(form.time) }}
         </div>
     {% endif %}
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock datetime_widget %}
 
@@ -108,6 +119,7 @@
             })|raw }}
         </div>
     {% endif %}
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock date_widget %}
 
@@ -120,6 +132,7 @@
             {{ form_widget(form.hour, { 'attr': { 'size': '1' } }) }}:{{ form_widget(form.minute, { 'attr': { 'size': '1' } }) }}{% if with_seconds %}:{{ form_widget(form.second, { 'attr': { 'size': '1' } }) }}{% endif %}
         </div>
     {% endif %}
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock time_widget %}
 
@@ -169,6 +182,7 @@
 {% spaceless %}
     {% set type = type|default('text') %}
     <input type="{{ type }}" {{ block('widget_attributes') }} {% if value is not empty %}value="{{ value }}" {% endif %}/>
+    {{ block('field_help') }}
 {% endspaceless %}
 {% endblock field_widget %}
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -54,6 +54,9 @@
             <tag name="form.type" alias="field" />
             <argument type="service" id="validator" />
         </service>
+        <service id="form.type_extension.field.help" class="Symfony\Component\Form\Extension\Core\Type\FieldTypeHelpExtension">
+            <tag name="form.type_extension" alias="field" />
+        </service>
         <service id="form.type.form" class="Symfony\Component\Form\Extension\Core\Type\FormType">
             <tag name="form.type" alias="form" />
         </service>

--- a/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/CoreExtension.php
@@ -53,4 +53,11 @@ class CoreExtension extends AbstractExtension
             new Type\FileType(),
         );
     }
+
+    protected function loadTypeExtensions()
+    {
+        return array(
+            new Type\FieldTypeHelpExtension(),
+        );
+    }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldTypeHelpExtension.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldTypeHelpExtension.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\Type;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+
+class FieldTypeHelpExtension extends AbstractTypeExtension
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder->setAttribute('help', $options['help']);
+    }
+
+    public function buildView(FormView $view, FormInterface $form)
+    {
+        $view->set('help', $form->getAttribute('help'));
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        return array(
+            'help' => null,
+        );
+    }
+
+    public function getExtendedType()
+    {
+        return 'field';
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeHelpExtensionTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeHelpExtensionTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Form\Extension\Validator\Type;
+
+use Symfony\Component\Form\FormInterface;
+
+class FieldTypeHelpExtensionTest extends TypeTestCase
+{
+    public function testHelpNullByDefault()
+    {
+        $form =  $this->factory->create('field');
+
+        $this->assertNull($form->getAttribute('help'));
+    }
+
+    public function testHelpCanBeSetToString()
+    {
+        $form = $this->factory->create('field', null, array(
+            'help' => 'message',
+        ));
+
+        $this->assertEquals('message', $form->getAttribute('help'));
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
@@ -164,6 +164,22 @@ class FieldTypeTest extends TypeTestCase
         $this->assertSame('messages', $view->get('translation_domain'));
     }
 
+    public function testPassHelpToView()
+    {
+        $form = $this->factory->create('field', null, array('help' => 'test'));
+        $view = $form->createView();
+
+        $this->assertSame('test', $view->get('help'));
+    }
+
+    public function testDefaultHelp()
+    {
+        $form = $this->factory->create('field');
+        $view = $form->createView();
+
+        $this->assertSame(null, $view->get('help'));
+    }
+
     public function testBindWithEmptyDataCreatesObjectIfClassAvailable()
     {
         $form = $this->factory->create('form', null, array(


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

It adds a help option to form field types as basic described here
http://toni.uebernickel.info/2011/11/25/how-to-extend-form-fields-in-symfony2.html
http://symfony.com/doc/2.0/cookbook/form/form_customization.html#adding-help-messages

Now you can pass the help option in the form type

```
$builder->add('message', 'textarea', array('help' => 'Enter your bug describtion here'));
```
