### PR TITLE
[Security] allow unsetting the parent ACL

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -314,9 +314,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritDoc}
      */
-    public function setParentAcl(AclInterface $acl)
+    public function setParentAcl(AclInterface $acl = null)
     {
-        if (null === $acl->getId()) {
+        if (null !== $acl && null === $acl->getId()) {
             throw new \InvalidArgumentException('$acl must have an ID.');
         }
 

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
@@ -123,10 +123,10 @@ interface MutableAclInterface extends AclInterface
     /**
      * Sets the parent ACL
      *
-     * @param AclInterface $acl
+     * @param AclInterface|null $acl
      * @return void
      */
-    function setParentAcl(AclInterface $acl);
+    function setParentAcl(AclInterface $acl = null);
 
     /**
      * Updates a class-based ACE

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/AclTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/AclTest.php
@@ -250,6 +250,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($acl->getParentAcl());
         $acl->setParentAcl($parentAcl);
         $this->assertSame($parentAcl, $acl->getParentAcl());
+
+        $acl->setParentAcl(null);
+        $this->assertNull($acl->getParentAcl());
     }
 
     public function testSetIsEntriesInheriting()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: **yes**
Symfony2 tests pass: yes

``` plain
 symfony2 git:2.0 ✗ ≠  phpunit tests/Symfony/Tests/Component/Security      ~/Web Development/symfony2
PHPUnit 3.6.4 by Sebastian Bergmann.

Configuration read from /Users/havvg/Web Development/symfony2/phpunit.xml

...............................................................  63 / 418 ( 15%)
............................................................... 126 / 418 ( 30%)
............................................................... 189 / 418 ( 45%)
............................................................... 252 / 418 ( 60%)
............................................................... 315 / 418 ( 75%)
............................................................... 378 / 418 ( 90%)
.......................................

Time: 14 seconds, Memory: 48.25Mb

OK (417 tests, 1154 assertions)
```
