### PR TITLE
[SwiftmailerBundle] Add a "recover-timeout" option to swiftmailer:spool:send

### DIFF
--- a/src/Symfony/Bundle/SwiftmailerBundle/Command/SendEmailCommand.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Command/SendEmailCommand.php
@@ -58,6 +58,8 @@ EOF
             if ($spool instanceof \Swift_ConfigurableSpool) {
                 $spool->setMessageLimit($input->getOption('message-limit'));
                 $spool->setTimeLimit($input->getOption('time-limit'));
+            }
+            if ($spool instanceof \Swift_FileSpool) {
                 if (null !== $input->getOption('recover-timeout')) {
                     $spool->recover($input->getOption('recover-timeout'));
                 } else {

--- a/src/Symfony/Bundle/SwiftmailerBundle/Command/SendEmailCommand.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Command/SendEmailCommand.php
@@ -34,10 +34,11 @@ class SendEmailCommand extends ContainerAwareCommand
             ->setDescription('Sends emails from the spool')
             ->addOption('message-limit', 0, InputOption::VALUE_OPTIONAL, 'The maximum number of messages to send.')
             ->addOption('time-limit', 0, InputOption::VALUE_OPTIONAL, 'The time limit for sending messages (in seconds).')
+            ->addOption('recover-timeout', 0, InputOption::VALUE_OPTIONAL, 'The timeout for recovering messages that have taken too long to send (in seconds).')
             ->setHelp(<<<EOF
 The <info>swiftmailer:spool:send</info> command sends all emails from the spool.
 
-<info>php app/console swiftmailer:spool:send --message-limit=10 --time-limit=10</info>
+<info>php app/console swiftmailer:spool:send --message-limit=10 --time-limit=10 --recover-timeout=900</info>
 
 EOF
             )
@@ -57,6 +58,7 @@ EOF
             if ($spool instanceof \Swift_ConfigurableSpool) {
                 $spool->setMessageLimit($input->getOption('message-limit'));
                 $spool->setTimeLimit($input->getOption('time-limit'));
+                NULL !== $input->getOption('recover-timeout') ? $spool->recover($input->getOption('recover-timeout')) : $spool->recover();
             }
             $sent = $spool->flushQueue($this->getContainer()->get('swiftmailer.transport.real'));
 

--- a/src/Symfony/Bundle/SwiftmailerBundle/Command/SendEmailCommand.php
+++ b/src/Symfony/Bundle/SwiftmailerBundle/Command/SendEmailCommand.php
@@ -58,7 +58,11 @@ EOF
             if ($spool instanceof \Swift_ConfigurableSpool) {
                 $spool->setMessageLimit($input->getOption('message-limit'));
                 $spool->setTimeLimit($input->getOption('time-limit'));
-                NULL !== $input->getOption('recover-timeout') ? $spool->recover($input->getOption('recover-timeout')) : $spool->recover();
+                if (null !== $input->getOption('recover-timeout')) {
+                    $spool->recover($input->getOption('recover-timeout'));
+                } else {
+                    $spool->recover();
+                }
             }
             $sent = $spool->flushQueue($this->getContainer()->get('swiftmailer.transport.real'));
 


### PR DESCRIPTION
This would allow for easy resending of messages that were marked as being sent, but for whatever reason were never actually sent.
