### PR TITLE
[Form] Support DELETE HTTP verb

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -581,6 +581,7 @@ class Form implements \IteratorAggregate, FormInterface
         switch ($request->getMethod()) {
             case 'POST':
             case 'PUT':
+            case 'DELETE':
                 if ('' === $this->getName()) {
                     $data = array_replace_recursive(
                         $request->request->all(),

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -822,6 +822,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
         return array(
             array('POST'),
             array('PUT'),
+            array('DELETE'),
         );
     }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: none
Todo: -

As `Symfony\Component\HttpFoundation\Request` already support DELETE requests nicely by parsing the request for us, support for the HTTPs DELETE verb can be easily done.
