### PR TITLE
[Routing] Added a 'match_suffix' option

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -93,10 +93,12 @@ class RouteCompiler implements RouteCompilerInterface
             $regex .= str_repeat(' ', $indent * 4).")?\n";
         }
 
+        $matchSuffix = (bool)$route->getOption('match_suffix');
+
         return new CompiledRoute(
             $route,
             'text' === $tokens[0][0] ? $tokens[0][1] : '',
-            sprintf("#^\n%s$#xs", $regex),
+            sprintf("#^\n%s%s#xs", $regex, $matchSuffix ? '' : '$'),
             array_reverse($tokens),
             $variables
         );

--- a/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
@@ -118,6 +118,12 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher = new UrlMatcher($collection, new RequestContext(), array());
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'foo'), $matcher->match('/foo'));
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'bar'), $matcher->match('/'));
+
+        // route with arbitrary suffix
+        $collection = new RouteCollection();
+        $collection->add('bar', new Route('/foo', array(), array(), array('match_suffix' => true)));
+        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $this->assertEquals(array('_route' => 'bar'), $matcher->match('/foo/test'));
     }
 
     public function testMatchWithPrefixes()

--- a/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
@@ -96,6 +96,13 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                 '', '#^/(?:(?P<bar>(foo|bar)))?$#xs', array('bar'), array(
                     array('variable', '/', '(foo|bar)', 'bar'),
                 )),
+
+            array(
+                'Static route with arbitrary suffix',
+                array('/foo', array(), array(), array('match_suffix' => true)),
+                '/foo', '#^/foo#xs', array(), array(
+                    array('text', '/foo'),
+                )),
         );
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

Just a small addition which allows you to define a "match_suffix" option for routes. This means that "/foo" also matches "/foo/bar/test" while an ordinary route would only match "/foo":

```
my_route:
    pattern:   /foo
    defaults:  { _controller: MyBundle:MyController:myAction }
    options: { match_suffix: true }
```
