### PR TITLE
[Form] Customise output string format of single text datetime fields

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -46,6 +46,9 @@ class DateTimeType extends AbstractType
         }
 
         if ($options['widget'] === 'single_text') {
+            if (isset($options['date_format'])) {
+                $format = $options['date_format'];
+            }
             $builder->appendClientTransformer(new DateTimeToStringTransformer($options['data_timezone'], $options['user_timezone'], $format));
         } else {
             // Only pass a subset of the options to children


### PR DESCRIPTION
Adding the following to a form:

```
->add("dueAt", "datetime", array(
    'input'  => 'datetime',
    'widget' => 'single_text',
    "required" => false
))
```

results in fix format output `Y-m-d H:i:00` or `Y-m-d H:i:s` with seconds. This change allows the developer to change the output format using the `date_format` parameter.
- Bug fix : no
- BC break : no
- Feature addition : yes
- Symfony2 tests pass: ???
