### PR TITLE
Send remember_me secure by default

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -23,7 +23,7 @@ class RememberMeFactory implements SecurityFactoryInterface
         'lifetime' => 31536000,
         'path' => '/',
         'domain' => null,
-        'secure' => false,
+        'secure' => true,
         'httponly' => true,
         'always_remember_me' => false,
         'remember_me_parameter' => '_remember_me',


### PR DESCRIPTION
Its better for security and a good practice if the cookie its sended secure by default.

Looking the documentation, an administrator maybe can guess that the cookie is 
sended secure by default when is not true 
(http://symfony.com/doc/2.0/reference/configuration/security.html)
