### PR TITLE
[Form] Pass translation domain to the sub-forms when choice list is expanded

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -63,11 +63,13 @@ class ChoiceType extends AbstractType
                         // The user can check 0 or more checkboxes. If required
                         // is true, he is required to check all of them.
                         'required'  => false,
+                        'translation_domain' => $options['translation_domain'],
                     ));
                 } else {
                     $builder->add((string) $choice, 'radio', array(
                         'value' => $choice,
                         'label' => $value,
+                        'translation_domain' => $options['translation_domain'],
                     ));
                 }
             }


### PR DESCRIPTION
- Bug fix: yes
- Tests pass: yes
- Feature addition: no
- BC compatibility break: no

When you have a select list with `translation_domain`, you loose translations by expanding the list.
