### PR TITLE
New validation messages and translated to Serbian language.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr.xlf
@@ -126,6 +126,74 @@
                 <source>The two values should be equal</source>
                 <target>Обе вредности треба да буду једнаке</target>
             </trans-unit>
+             <trans-unit id="32">
+                <source>The file is too large. Allowed maximum size is {{ limit }}</source>
+                <target>Датотека је превелика. Највећа дозвољена величина је {{ limit }}</target>
+            </trans-unit>
+            <trans-unit id="33">
+                <source>The file is too large</source>
+                <target>Датотека је превелика</target>
+            </trans-unit>
+            <trans-unit id="34">
+                <source>The file could not be uploaded</source>
+                <target>Датотека не може бити отпремљена</target>
+            </trans-unit>
+            <trans-unit id="35">
+                <source>This value should be a valid number</source>
+                <target>Вредност треба да буде валидан број</target>
+            </trans-unit>
+            <trans-unit id="36">
+                <source>This file is not a valid image</source>
+                <target>Ова датотека није валидна слика</target>
+            </trans-unit>
+            <trans-unit id="37">
+                <source>This is not a valid IP address</source>
+                <target>Ово није валидна ИП адреса</target>
+            </trans-unit>
+            <trans-unit id="38">
+                <source>This value is not a valid language</source>
+                <target>Вредност није валидан језик</target>
+            </trans-unit>
+            <trans-unit id="39">
+                <source>This value is not a valid locale</source>
+                <target>Вредност није валидан локал</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country</source>
+                <target>Вредност није валидна земља</target>
+            </trans-unit>
+            <trans-unit id="41">
+                <source>This value is already used</source>
+                <target>Вредност је већ искоришћена</target>
+            </trans-unit>
+            <trans-unit id="42">
+                <source>The size of the image could not be detected</source>
+                <target>Величина слике не може бити одређена</target>
+            </trans-unit>
+            <trans-unit id="43">
+                <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px</source>
+                <target>Ширина слике је превелика ({{ width }}px). Најећа дозвољена ширина је {{ max_width }}px</target>
+            </trans-unit>
+            <trans-unit id="44">
+                <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px</source>
+                <target>Ширина слике је премала ({{ width }}px). Најмања дозвољена ширина је {{ min_width }}px</target>
+            </trans-unit>
+            <trans-unit id="45">
+                <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px</source>
+                <target>Висина слике је превелика ({{ height }}px). Најећа дозвољена висина је {{ max_height }}px</target>
+            </trans-unit>
+            <trans-unit id="46">
+                <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px</source>
+                <target>Висина слике је премала ({{ height }}px). Најмања дозвољена висина је {{ min_height }}px</target>
+            </trans-unit>
+            <trans-unit id="47">
+                <source>This value should be the user current password</source>
+                <target>Вредност треба да буде тренутна корисничка лозинка</target>
+            </trans-unit>
+            <trans-unit id="48">
+                <source>This value should have exactly {{ limit }} characters</source>
+                <target>Вредност треба да има тачно {{ limit }} карактера</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
It would be nice for translators to be notified somehow when new validation messages appear. I copied those from French translation, not sure if that is the right way to go?

Also, in addition, I would like to contribute sr@latin translation. To explain, Serbian language have dual alphabet, both cyrillic and latin. I'm not sure if Symfony locale supports locale variants? Can you suggest right translation file name for this?
