### PR TITLE
Doctrine collector

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Doctrine\DataCollector;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Logging\DebugStack;
+use Doctrine\DBAL\Types\Type;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -54,7 +55,7 @@ class DoctrineDataCollector extends DataCollector
     {
         $queries = array();
         foreach ($this->loggers as $name => $logger) {
-            $queries[$name] = $this->sanitizeQueries($logger->queries);
+            $queries[$name] = $this->sanitizeQueries($name, $logger->queries);
         }
 
         $this->data = array(
@@ -104,48 +105,73 @@ class DoctrineDataCollector extends DataCollector
         return 'db';
     }
 
-    private function sanitizeQueries($queries)
+    private function sanitizeQueries($connectionName, $queries)
     {
         foreach ($queries as $i => $query) {
-            foreach ((array) $query['params'] as $j => $param) {
-                $queries[$i]['params'][$j] = $this->varToString($param);
-            }
+            $queries[$i] = $this->sanitizeQuery($connectionName, $query);
         }
 
         return $queries;
     }
 
-    private function varToString($var)
+    private function sanitizeQuery($connectionName, $query)
+    {
+        $query['explainable'] = true;
+        $query['params'] = (array) $query['params'];
+        foreach ($query['params'] as $j => &$param) {
+            if (isset($query['types'][$j])) {
+                // Transform the param according to the type
+                $type = $query['types'][$j];
+                if (is_string($type)) {
+                    $type = Type::getType($type);
+                }
+                if ($type instanceof Type) {
+                    $query['types'][$j] = $type->getBindingType();
+                    $param = $type->convertToDatabaseValue($param, $this->registry->getConnection($connectionName)->getDatabasePlatform());
+                }
+            }
+
+            list($param, $explainable) = $this->sanitizeParam($param);
+            if (!$explainable) {
+                $query['explainable'] = false;
+            }
+        }
+
+        return $query;
+    }
+
+    /**
+     * Sanitizes a param.
+     *
+     * The return value is an array with the sanitized value and a boolean
+     * indicating if the original value was kept (allowing to use the sanitized
+     * value to explain the query).
+     *
+     * @param mixed $var
+     * @return array
+     */
+    private function sanitizeParam($var)
     {
         if (is_object($var)) {
-            return sprintf('Object(%s)', get_class($var));
+            return array(sprintf('Object(%s)', get_class($var)), false);
         }
 
         if (is_array($var)) {
             $a = array();
+            $original = true;
             foreach ($var as $k => $v) {
-                $a[] = sprintf('%s => %s', $k, $this->varToString($v));
+                list($value, $orig) = $this->sanitizeParam($v);
+                $original = $original && $orig;
+                $a[$k] = $value;
             }
 
-            return sprintf("Array(%s)", implode(', ', $a));
+            return array($a, $original);
         }
 
         if (is_resource($var)) {
-            return sprintf('Resource(%s)', get_resource_type($var));
+            return array(sprintf('Resource(%s)', get_resource_type($var)), false);
         }
 
-        if (null === $var) {
-            return 'null';
-        }
-
-        if (false === $var) {
-            return 'false';
-        }
-
-        if (true === $var) {
-            return 'true';
-        }
-
-        return (string) $var;
+        return array($var, true);
     }
 }

--- a/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DataCollector/DoctrineDataCollectorTest.php
@@ -79,7 +79,7 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
         $c->collect(new Request(), new Response());
 
         $collected_queries = $c->getQueries();
-        $this->assertEquals($expected, $collected_queries[0]['params'][0]);
+        $this->assertEquals($expected, $collected_queries['default'][0]['params'][0]);
     }
 
     /**
@@ -95,7 +95,7 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
         $c = unserialize(serialize($c));
 
         $collected_queries = $c->getQueries();
-        $this->assertEquals($expected, $collected_queries[0]['params'][0]);
+        $this->assertEquals($expected, $collected_queries['default'][0]['params'][0]);
     }
 
     public function paramProvider()
@@ -126,6 +126,9 @@ class DoctrineDataCollectorTest extends \PHPUnit_Framework_TestCase
         $logger = $this->getMock('Doctrine\DBAL\Logging\DebugStack');
         $logger->queries = $queries;
 
-        return new DoctrineDataCollector($registry, $logger);
+        $collector = new DoctrineDataCollector($registry);
+        $collector->addLogger('default', $logger);
+
+        return $collector;
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes (for the end user, it will require deleting old profiler data)
Symfony2 tests pass: yes ![Build Status](https://secure.travis-ci.org/stof/symfony.png?branch=doctrine_collector)

This refactors the Doctrine collector to allow implementing doctrine/DoctrineBundle#7
The first commit splits the logging of queries per connection to be able to know which connection was used instead of using a shared stack.

The second commit refactors the sanitation of the parameters to apply the DBAL conversion and then keep the param whenever possible (i.e. when we are sure it is serializable). Such queries will then be explainable in the profiler as we will be able to use the parameters again. Due to the way PDO works, the only cases where we would get an unexplainable queries due to the parameters are queries using a LOB parameter (as it is a resource) or broken queries (passing an object to PDO for instance). And this second case does not make sense to explain the query of course.
