### PR TITLE
handle disabled csrf protection in the PHP templating form helper

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -33,7 +33,7 @@ class FormExtension extends \Twig_Extension
     protected $varStack;
     protected $template;
 
-    public function __construct(CsrfProviderInterface $csrfProvider, array $resources = array())
+    public function __construct(CsrfProviderInterface $csrfProvider = null, array $resources = array())
     {
         $this->csrfProvider = $csrfProvider;
         $this->themes = new \SplObjectStorage();
@@ -298,6 +298,10 @@ class FormExtension extends \Twig_Extension
      */
     public function getCsrfToken($intention)
     {
+        if (!$this->csrfProvider instanceof CsrfProviderInterface) {
+            throw new \BadMethodCallException('CSRF token can only be generated if the "form.csrf_provider" service is available');
+        }
+
         return $this->csrfProvider->generateCsrfToken($intention);
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -299,7 +299,7 @@ class FormExtension extends \Twig_Extension
     public function getCsrfToken($intention)
     {
         if (!$this->csrfProvider instanceof CsrfProviderInterface) {
-            throw new \BadMethodCallException('CSRF token can only be generated if the "form.csrf_provider" service is available');
+            throw new \BadMethodCallException('CSRF token can only be generated if a CsrfProviderInterface is injected in the constructor.');
         }
 
         return $this->csrfProvider->generateCsrfToken($intention);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -97,7 +97,7 @@
         <service id="templating.helper.form" class="%templating.helper.form.class%">
             <tag name="templating.helper" alias="form" />
             <argument type="service" id="templating.engine.php" />
-            <argument type="service" id="form.csrf_provider" />
+            <argument type="service" id="form.csrf_provider" on-invalid="null" />
             <argument>%templating.helper.form.resources%</argument>
         </service>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -47,7 +47,7 @@ class FormHelper extends Helper
      * @param CsrfProviderInterface $csrfProvider The CSRF provider
      * @param array                 $resources    An array of theme names
      */
-    public function __construct(EngineInterface $engine, CsrfProviderInterface $csrfProvider, array $resources)
+    public function __construct(EngineInterface $engine, CsrfProviderInterface $csrfProvider = null, array $resources = array())
     {
         $this->engine = $engine;
         $this->csrfProvider = $csrfProvider;
@@ -202,6 +202,10 @@ class FormHelper extends Helper
      */
     public function csrfToken($intention)
     {
+        if (! $this->csrfProvider instanceof CsrfProviderInterface) {
+            throw new \BadMethodCallException('CSRF token can only be generated if the "form.csrf_provider" service is available');
+        }
+
         return $this->csrfProvider->generateCsrfToken($intention);
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -202,7 +202,7 @@ class FormHelper extends Helper
      */
     public function csrfToken($intention)
     {
-        if (! $this->csrfProvider instanceof CsrfProviderInterface) {
+        if (!$this->csrfProvider instanceof CsrfProviderInterface) {
             throw new \BadMethodCallException('CSRF token can only be generated if the "form.csrf_provider" service is available');
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -203,7 +203,7 @@ class FormHelper extends Helper
     public function csrfToken($intention)
     {
         if (!$this->csrfProvider instanceof CsrfProviderInterface) {
-            throw new \BadMethodCallException('CSRF token can only be generated if the "form.csrf_provider" service is available');
+            throw new \BadMethodCallException('CSRF token can only be generated if a CsrfProviderInterface is injected in the constructor.');
         }
 
         return $this->csrfProvider->generateCsrfToken($intention);

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -75,7 +75,7 @@
 
         <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">
             <tag name="twig.extension" />
-            <argument type="service" id="form.csrf_provider" />
+            <argument type="service" id="form.csrf_provider" on-invalid="null" />
             <argument>%twig.form.resources%</argument>
         </service>
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: ![Build Status](https://secure.travis-ci.org/lsmith77/symfony.png?branch=form_helper_csrf_off)
Fixes the following tickets: -
