### PR TITLE
[HttpFoundation] Added RSS HTTP request format (in 2.0)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1238,6 +1238,7 @@ class Request
             'xml'  => array('text/xml', 'application/xml', 'application/x-xml'),
             'rdf'  => array('application/rdf+xml'),
             'atom' => array('application/atom+xml'),
+            'rss'  => array('application/rss+xml'),
         );
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

The RSS HTTP request format was added to the master branch some while ago: #2096.

Can we also have it in the 2.0 releases? Please see the arguments of the previous PR.
