### PR TITLE
[Security] Authentication(Success|Failure)Handler can now return null

### DIFF
--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationFailureHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationFailureHandlerInterface.php
@@ -33,7 +33,7 @@ interface AuthenticationFailureHandlerInterface
      * @param Request                 $request
      * @param AuthenticationException $exception
      *
-     * @return Response the response to return
+     * @return Response|null the response to return
      */
     function onAuthenticationFailure(Request $request, AuthenticationException $exception);
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -33,7 +33,7 @@ interface AuthenticationSuccessHandlerInterface
      * @param Request        $request
      * @param TokenInterface $token
      *
-     * @return Response the response to return
+     * @return Response|null the response to return
      */
     function onAuthenticationSuccess(Request $request, TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -192,7 +192,9 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
         $this->securityContext->setToken(null);
 
         if (null !== $this->failureHandler) {
-            return $this->failureHandler->onAuthenticationFailure($request, $failed);
+            if (null !== $response = $this->failureHandler->onAuthenticationFailure($request, $failed)) {
+                return $response;
+            }
         }
 
         if (null === $this->options['failure_path']) {
@@ -236,9 +238,11 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
             $this->dispatcher->dispatch(SecurityEvents::INTERACTIVE_LOGIN, $loginEvent);
         }
 
+        $response = null;
         if (null !== $this->successHandler) {
             $response = $this->successHandler->onAuthenticationSuccess($request, $token);
-        } else {
+        }
+        if (null === $response) {
             $response = $this->httpUtils->createRedirectResponse($request, $this->determineTargetUrl($request));
         }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Related to the following ticket: #838

[![Build Status](https://secure.travis-ci.org/odolbeau/symfony.png)](http://travis-ci.org/odolbeau/symfony)

Correct me if I'm wrong but for now it's not possible to handle Authentication(Success|Failure) in some case only (for example to handle XmlHttpRequest on login form).

With this change, if the handler return null, the default behavior is kept.
