### PR TITLE
optimizations not configurable

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -122,6 +122,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('debug')->defaultValue('%kernel.debug%')->end()
                 ->scalarNode('strict_variables')->end()
                 ->scalarNode('auto_reload')->end()
+                ->scalarNode('optimizations')->end()
             ->end()
         ;
     }


### PR DESCRIPTION
Valid option for twig but missing in the configuration. I am currently hardsetting this in my own bundle.
