### PR TITLE
[form] Support for PATCH method in forms

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -103,7 +103,7 @@ class Form extends Link implements \ArrayAccess
      */
     public function getFiles()
     {
-        if (!in_array($this->getMethod(), array('POST', 'PUT', 'DELETE'))) {
+        if (!in_array($this->getMethod(), array('POST', 'PUT', 'DELETE', 'PATCH'))) {
             return array();
         }
 
@@ -173,7 +173,7 @@ class Form extends Link implements \ArrayAccess
     {
         $uri = parent::getUri();
 
-        if (!in_array($this->getMethod(), array('POST', 'PUT', 'DELETE')) && $queryString = http_build_query($this->getValues(), null, '&')) {
+        if (!in_array($this->getMethod(), array('POST', 'PUT', 'DELETE', 'PATCH')) && $queryString = http_build_query($this->getValues(), null, '&')) {
             $sep = false === strpos($uri, '?') ? '?' : '&';
             $uri .= $sep.$queryString;
         }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -582,6 +582,7 @@ class Form implements \IteratorAggregate, FormInterface
             case 'POST':
             case 'PUT':
             case 'DELETE':
+            case 'PATCH':
                 if ('' === $this->getName()) {
                     $data = array_replace_recursive(
                         $request->request->all(),

--- a/tests/Symfony/Tests/Component/DomCrawler/FormTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/FormTest.php
@@ -202,6 +202,12 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         $form = $this->createForm('<form method="post"><input type="submit" /></form>', 'put');
         $this->assertEquals('PUT', $form->getMethod(), '->getMethod() returns the method defined in the constructor if provided');
+
+        $form = $this->createForm('<form method="post"><input type="submit" /></form>', 'delete');
+        $this->assertEquals('DELETE', $form->getMethod(), '->getMethod() returns the method defined in the constructor if provided');
+
+        $form = $this->createForm('<form method="post"><input type="submit" /></form>', 'patch');
+        $this->assertEquals('PATCH', $form->getMethod(), '->getMethod() returns the method defined in the constructor if provided');
     }
 
     public function testGetSetValue()
@@ -278,7 +284,16 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $form->getFiles(), '->getFiles() returns an empty array if method is get');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>');
-        $this->assertEquals(array('foo[bar]' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0)), $form->getFiles(), '->getFiles() only returns file fields');
+        $this->assertEquals(array('foo[bar]' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0)), $form->getFiles(), '->getFiles() only returns file fields for POST');
+
+        $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'put');
+        $this->assertEquals(array('foo[bar]' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0)), $form->getFiles(), '->getFiles() only returns file fields for PUT');
+
+        $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'delete');
+        $this->assertEquals(array('foo[bar]' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0)), $form->getFiles(), '->getFiles() only returns file fields for DELETE');
+
+        $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" /><input type="text" name="bar" value="bar" /><input type="submit" /></form>', 'patch');
+        $this->assertEquals(array('foo[bar]' => array('name' => '', 'type' => '', 'tmp_name' => '', 'error' => 4, 'size' => 0)), $form->getFiles(), '->getFiles() only returns file fields for PATCH');
 
         $form = $this->createForm('<form method="post"><input type="file" name="foo[bar]" disabled="disabled" /><input type="submit" /></form>');
         $this->assertEquals(array(), $form->getFiles(), '->getFiles() does not include disabled file fields');
@@ -293,9 +308,9 @@ class FormTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideGetUriValues
      */
-    public function testGetUri($message, $form, $values, $uri)
+    public function testGetUri($message, $form, $values, $uri, $method = null)
     {
-        $form = $this->createForm($form);
+        $form = $this->createForm($form, $method);
         $form->setValues($values);
 
         $this->assertEquals('http://example.com'.$uri, $form->getUri(), '->getUri() '.$message);
@@ -386,6 +401,27 @@ class FormTest extends \PHPUnit_Framework_TestCase
                 '<form action="/foo" method="post"><input type="text" name="foo" value="foo" /><input type="submit" /></form>',
                 array(),
                 '/foo'
+            ),
+            array(
+                'does not append values if the method is patch',
+                '<form action="/foo" method="post"><input type="text" name="foo" value="foo" /><input type="submit" /></form>',
+                array(),
+                '/foo',
+                'PUT'
+            ),
+            array(
+                'does not append values if the method is delete',
+                '<form action="/foo" method="post"><input type="text" name="foo" value="foo" /><input type="submit" /></form>',
+                array(),
+                '/foo',
+                'DELETE'
+            ),
+            array(
+                'does not append values if the method is put',
+                '<form action="/foo" method="post"><input type="text" name="foo" value="foo" /><input type="submit" /></form>',
+                array(),
+                '/foo',
+                'PATCH'
             ),
             array(
                 'appends the form values to an existing query string',

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -823,6 +823,7 @@ class FormTest extends \PHPUnit_Framework_TestCase
             array('POST'),
             array('PUT'),
             array('DELETE'),
+            array('PATCH'),
         );
     }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -585,7 +585,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public static function overloadedMethodProvider()
+    public function provideOverloadedMethods()
     {
         return array(
             array('PUT'),
@@ -595,7 +595,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider overloadedMethodProvider
+     * @dataProvider provideOverloadedMethods
      */
     public function testCreateFromGlobals($method)
     {

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -585,7 +585,19 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function testCreateFromGlobals()
+    public static function overloadedMethodProvider()
+    {
+        return array(
+            array('PUT'),
+            array('DELETE'),
+            array('PATCH'),
+        );
+    }
+
+    /**
+     * @dataProvider overloadedMethodProvider
+     */
+    public function testCreateFromGlobals($method)
     {
         $_GET['foo1']    = 'bar1';
         $_POST['foo2']   = 'bar2';
@@ -602,19 +614,19 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         unset($_GET['foo1'], $_POST['foo2'], $_COOKIE['foo3'], $_FILES['foo4'], $_SERVER['foo5']);
 
-        $_SERVER['REQUEST_METHOD'] = 'PUT';
+        $_SERVER['REQUEST_METHOD'] = $method;
         $_SERVER['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
         $request = RequestContentProxy::createFromGlobals();
-        $this->assertEquals('PUT', $request->getMethod());
+        $this->assertEquals($method, $request->getMethod());
         $this->assertEquals('mycontent', $request->request->get('content'));
 
         unset($_SERVER['REQUEST_METHOD'], $_SERVER['CONTENT_TYPE']);
 
-        $_POST['_method']   = 'PUT';
+        $_POST['_method']   = $method;
         $_POST['foo6']      = 'bar6';
         $_SERVER['REQUEST_METHOD'] = 'POST';
         $request = Request::createFromGlobals();
-        $this->assertEquals('PUT', $request->getMethod());
+        $this->assertEquals($method, $request->getMethod());
         $this->assertEquals('bar6', $request->request->get('foo6'));
 
         unset($_POST['_method'], $_POST['foo6'], $_SERVER['REQUEST_METHOD']);


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Adds support for PATCH method. Accidentally I refactored the test RequestTest a bit to verify PUT, DELETE and PATCH and not only PUT.
