### PR TITLE
[Bugfix][Form] Fixed broken MoneyType regexp for JPY

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -100,7 +100,7 @@ class MoneyType extends AbstractType
 
             // the regex also considers non-break spaces (0xC2 or 0xA0 in UTF-8)
 
-            preg_match('/^([^\s\xc2\xa0]*)[\s\xc2\xa0]*123[,.]00[\s\xc2\xa0]*([^\s\xc2\xa0]*)$/', $pattern, $matches);
+            preg_match('/^([^\s\xc2\xa0]*)[\s\xc2\xa0]*123(?:[,.]0+)?[\s\xc2\xa0]*([^\s\xc2\xa0]*)$/u', $pattern, $matches);
 
             if (!empty($matches[1])) {
                 self::$patterns[\Locale::getDefault()] = $matches[1].' {{ widget }}';

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/MoneyTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/MoneyTypeTest.php
@@ -34,6 +34,6 @@ class MoneyTypeTest extends LocalizedTestCase
 
         $form = $this->factory->create('money', null, array('currency' => 'JPY'));
         $view = $form->createView();
-        $this->assertTrue((bool)strstr($view->get('money_pattern'), '¥'));
+        $this->assertTrue((Boolean) strstr($view->get('money_pattern'), '¥'));
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/MoneyTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/MoneyTypeTest.php
@@ -11,7 +11,10 @@
 
 namespace Symfony\Tests\Component\Form\Extension\Core\Type;
 
+use Symfony\Component\Form\FormFactory;
+
 require_once __DIR__ . '/LocalizedTestCase.php';
+require_once __DIR__ . '/../../../../../../../../src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php';
 
 class MoneyTypeTest extends LocalizedTestCase
 {
@@ -23,5 +26,14 @@ class MoneyTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertSame('{{ widget }} €', $view->get('money_pattern'));
+    }
+
+    public function testMoneyPatternWorksForYen()
+    {
+        \Locale::setDefault('en_US');
+
+        $form = $this->factory->create('money', null, array('currency' => 'JPY'));
+        $view = $form->createView();
+        $this->assertTrue((bool)strstr($view->get('money_pattern'), '¥'));
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: ![Build Status](https://secure.travis-ci.org/ManuelKiessling/symfony.png?branch=ticket_3124) Fixes the following tickets: #3124
Todo: -

The regexp in MoneyType doesn't work if currency format has no decimal
(like JPY) and doesn't work either if the currency symbol is unicode

This change fixes both issues and adds a unit test
