### PR TITLE
[DoctrineBundle] Doctrine 2.2 compatibilty

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/Mapping/MetadataFactory.php
+++ b/src/Symfony/Bundle/DoctrineBundle/Mapping/MetadataFactory.php
@@ -75,8 +75,8 @@ class MetadataFactory
 
         $all = $metadata->getMetadata();
         if (class_exists($class)) {
-            $r = $all[0]->getReflectionClass();
-            $path = $this->getBasePathForClass($class, $r->getNamespacename(), dirname($r->getFilename()));
+            $r = new \ReflectionClass($all[0]->name);
+            $path = $this->getBasePathForClass($class, $r->getNamespaceName(), dirname($r->getFilename()));
             $metadata->setNamespace($r->getNamespacename());
         } elseif (!$path) {
             throw new \RuntimeException(sprintf('Unable to determine where to save the "%s" class (use the --path option).', $class));
@@ -104,8 +104,8 @@ class MetadataFactory
 
         $all = $metadata->getMetadata();
         if (class_exists($all[0]->name)) {
-            $r = $all[0]->getReflectionClass();
-            $path = $this->getBasePathForClass($namespace, $r->getNamespacename(), dirname($r->getFilename()));
+            $r = new \ReflectionClass($all[0]->name);
+            $path = $this->getBasePathForClass($namespace, $r->getNamespaceName(), dirname($r->getFilename()));
         } elseif (!$path) {
             throw new \RuntimeException(sprintf('Unable to determine where to save the "%s" class (use the --path option).', $all[0]->name));
         }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Doctrine 2.2 does not initialize reflection anymore when in a code-generation context. This fails with the Symfony Metadata Factory that acceses the ReflectionClass after checking that the entity class_exists. This occurs when using code-generation in combination with the annotation driver.

This PR fixes the problem.
