### PR TITLE
[Form] Disallowed "NaN" as input in number fields

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformer.php
@@ -35,6 +35,10 @@ class IntegerToLocalizedStringTransformer extends NumberToLocalizedStringTransfo
             return null;
         }
 
+        if ('NaN' === $value) {
+            throw new TransformationFailedException('"NaN" is not a valid integer');
+        }
+
         $formatter = $this->getNumberFormatter();
         $value = $formatter->parse(
             $value,

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformer.php
@@ -103,6 +103,10 @@ class NumberToLocalizedStringTransformer implements DataTransformerInterface
             return null;
         }
 
+        if ('NaN' === $value) {
+            throw new TransformationFailedException('"NaN" is not a valid number');
+        }
+
         $formatter = $this->getNumberFormatter();
         $value = $formatter->parse($value);
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -70,4 +70,24 @@ class IntegerToLocalizedStringTransformerTest extends LocalizedTestCase
 
         $transformer->reverseTransform('foo');
     }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformDisallowsNaN()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $transformer->reverseTransform('NaN');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new IntegerToLocalizedStringTransformer();
+
+        $transformer->reverseTransform('nan');
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -123,4 +123,15 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
 
         $transformer->reverseTransform('foo');
     }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
+     * @link https://github.com/symfony/symfony/issues/3161
+     */
+    public function testReverseTransformExpectsValidNumberFromNan()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $transformer->reverseTransform('NaN');
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -128,10 +128,20 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      * @link https://github.com/symfony/symfony/issues/3161
      */
-    public function testReverseTransformExpectsValidNumberFromNan()
+    public function testReverseTransformDisallowsNaN()
     {
         $transformer = new NumberToLocalizedStringTransformer();
 
         $transformer->reverseTransform('NaN');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformDisallowsNaN2()
+    {
+        $transformer = new NumberToLocalizedStringTransformer();
+
+        $transformer->reverseTransform('nan');
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3161, #3196
Todo: nothing

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3161)
