### PR TITLE
[Form] Added an isHidden() method to FormView

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -285,7 +285,7 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     {
         return count($this->children);
     }
-    
+
     /**
      * Checks whether the field is hidden or not
      * 

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -285,4 +285,14 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     {
         return count($this->children);
     }
+    
+    /**
+     * Checks whether the field is hidden or not
+     * 
+     * @return Boolean
+     */
+    public function isHidden()
+    {
+        return in_array('hidden', $this->vars['types']);
+    }
 }


### PR DESCRIPTION
Hi, 

I have seen [many people](https://www.google.com/search?q=%22symfony+2%22+OR+%22symfony2%22+%22ishidden%22) using an `isHidden()` method to check whether a form field is hidden or not. 
Surprisingly, it seems that this method doesn't actually exist, neither in the FormView class nor in the whole Symfony 2 API. 
So, here it is. 

Cheers, 
Samy
