### PR TITLE
[Security] allow unsetting the parent ACL

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -248,6 +248,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
  * after login, the user is now redirected to `default_target_path` if `use_referer` is true and the referrer is the `login_path`.
  * added a way to remove a token from a session
+ * [BC BREAK] changed `MutableAclInterface::setParentAcl` to accept `null`, review your implementation to reflect this change.
 
 ### Serializer
 

--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -311,9 +311,9 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
     /**
      * {@inheritDoc}
      */
-    public function setParentAcl(AclInterface $acl)
+    public function setParentAcl(AclInterface $acl = null)
     {
-        if (null === $acl->getId()) {
+        if (null !== $acl && null === $acl->getId()) {
             throw new \InvalidArgumentException('$acl must have an ID.');
         }
 

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
@@ -114,9 +114,10 @@ interface MutableAclInterface extends AclInterface
     /**
      * Sets the parent ACL
      *
-     * @param AclInterface $acl
+     * @param AclInterface|null $acl
+     * @return void
      */
-    function setParentAcl(AclInterface $acl);
+    function setParentAcl(AclInterface $acl = null);
 
     /**
      * Updates a class-based ACE

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/AclTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/AclTest.php
@@ -250,6 +250,9 @@ class AclTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($acl->getParentAcl());
         $acl->setParentAcl($parentAcl);
         $this->assertSame($parentAcl, $acl->getParentAcl());
+
+        $acl->setParentAcl(null);
+        $this->assertNull($acl->getParentAcl());
     }
 
     public function testSetIsEntriesInheriting()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes

The #3151 rebased onto master. 
Sorry for the delay, was on vacations.

``` plain
 symfony2 git:acl-unset-parent ✔  phpunit tests/Symfony/Tests/Component/Security         ~/Web Development/symfony2
PHPUnit 3.6.4 by Sebastian Bergmann.

Configuration read from /Users/havvg/Web Development/symfony2/phpunit.xml

...............................................................  63 / 428 ( 14%)
............................................................... 126 / 428 ( 29%)
............................................................... 189 / 428 ( 44%)
............................................................... 252 / 428 ( 58%)
............................................................... 315 / 428 ( 73%)
............................................................... 378 / 428 ( 88%)
.................................................

Time: 15 seconds, Memory: 49.00Mb

OK (427 tests, 1180 assertions)
```
