### PR TITLE
[Validator] Improved "missing" and "extra" errors of Collection constraint

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -300,6 +300,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * changed default value for `extraFieldsMessage` and `missingFieldsMessage`
    in Collection constraint
  * made ExecutionContext immutable
+ * deprecated Constraint methods `setMessage`, `getMessageTemplate` and
+   `getMessageParameters`
 
 ### Yaml
 

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -299,6 +299,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
    individual fields
  * changed default value for `extraFieldsMessage` and `missingFieldsMessage`
    in Collection constraint
+ * made ExecutionContext immutable
 
 ### Yaml
 

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -295,6 +295,10 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * added a SizeLength validator
  * improved the ImageValidator with min width, max width, min height, and max height constraints
  * added support for MIME with wildcard in FileValidator
+ * changed Collection validator to add "missing" and "extra" errors to
+   individual fields
+ * changed default value for `extraFieldsMessage` and `missingFieldsMessage`
+   in Collection constraint
 
 ### Yaml
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -141,3 +141,37 @@ UPGRADE FROM 2.0 to 2.1
         $builder->add('tags', 'collection', array('prototype' => '__proto__'));
 
         // results in the name "__proto__" in the template
+
+* The methods `setMessage`, `getMessageTemplate` and `getMessageParameters`
+  in Constraint were deprecated
+
+    If you have implemented custom validators, you should use either of the
+    `addViolation*` methods of the context object instead.
+
+    Before:
+
+        public function isValid($value, Constraint $constraint)
+        {
+            // ...
+            if (!$valid) {
+                $this->setMessage($constraint->message, array(
+                    '{{ value }}' => $value,
+                ));
+
+                return false;
+            }
+        }
+
+    After:
+
+        public function isValid($value, Constraint $constraint)
+        {
+            // ...
+            if (!$valid) {
+                $this->context->addViolation($constraint->message, array(
+                    '{{ value }}' => $value,
+                ));
+
+                return false;
+            }
+        }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -102,7 +102,7 @@ class UniqueEntityValidator extends ConstraintValidator
             return true;
         }
 
-        $this->context->addViolationAtRelativePath($fields[0], $constraint->message, array(), $criteria[$fields[0]]);
+        $this->context->addViolationAtSubPath($fields[0], $constraint->message, array(), $criteria[$fields[0]]);
 
         return true; // all true, we added the violation already!
     }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -102,7 +102,7 @@ class UniqueEntityValidator extends ConstraintValidator
             return true;
         }
 
-        $this->context->addNestedViolationAt($fields[0], $constraint->message, array(), $criteria[$fields[0]]);
+        $this->context->addViolationAtRelativePath($fields[0], $constraint->message, array(), $criteria[$fields[0]]);
 
         return true; // all true, we added the violation already!
     }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -102,10 +102,7 @@ class UniqueEntityValidator extends ConstraintValidator
             return true;
         }
 
-        $oldPath = $this->context->getPropertyPath();
-        $this->context->setPropertyPath( empty($oldPath) ? $fields[0] : $oldPath.'.'.$fields[0]);
-        $this->context->addViolation($constraint->message, array(), $criteria[$fields[0]]);
-        $this->context->setPropertyPath($oldPath);
+        $this->context->addNestedViolationAt($fields[0], $constraint->message, array(), $criteria[$fields[0]]);
 
         return true; // all true, we added the violation already!
     }

--- a/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
@@ -40,7 +40,7 @@ class UserPasswordValidator extends ConstraintValidator
         $encoder = $this->encoderFactory->getEncoder($user);
 
         if (!$encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt())) {
-            $this->setMessage($constraint->message);
+            $this->context->addViolation($constraint->message);
 
             return false;
         }

--- a/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
@@ -111,10 +111,6 @@ class DelegatingValidator implements FormValidatorInterface
             $propertyPath = $context->getPropertyPath();
             $graphWalker = $context->getGraphWalker();
 
-            // The Execute constraint is called on class level, so we need to
-            // set the property manually
-            $context->setCurrentProperty('data');
-
             // Adjust the property path accordingly
             if (!empty($propertyPath)) {
                 $propertyPath .= '.';
@@ -133,10 +129,6 @@ class DelegatingValidator implements FormValidatorInterface
         if ($form->getAttribute('cascade_validation')) {
             $propertyPath = $context->getPropertyPath();
             $graphWalker = $context->getGraphWalker();
-
-            // The Execute constraint is called on class level, so we need to
-            // set the property manually
-            $context->setCurrentProperty('children');
 
             // Adjust the property path accordingly
             if (!empty($propertyPath)) {

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -11,7 +11,11 @@
 
 namespace Symfony\Component\Validator;
 
-/*
+/**
+ * Base class for constraint validators
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 abstract class ConstraintValidator implements ConstraintValidatorInterface

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -24,12 +24,18 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      * @var ExecutionContext
      */
     protected $context;
+
     /**
      * @var string
+     *
+     * @deprecated
      */
     private $messageTemplate;
+
     /**
      * @var array
+     *
+     * @deprecated
      */
     private $messageParameters;
 
@@ -46,7 +52,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     /**
      * {@inheritDoc}
      *
-     * @api
+     * @deprecated
      */
     public function getMessageTemplate()
     {
@@ -56,7 +62,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     /**
      * {@inheritDoc}
      *
-     * @api
+     * @deprecated
      */
     public function getMessageParameters()
     {
@@ -64,11 +70,15 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     }
 
     /**
-     * @api
+     * Wrapper for $this->context->addViolation()
+     *
+     * @deprecated
      */
     protected function setMessage($template, array $parameters = array())
     {
         $this->messageTemplate = $template;
         $this->messageParameters = $parameters;
+
+        $this->context->addViolation($template, $parameters);
     }
 }

--- a/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Validator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 interface ConstraintValidatorInterface
@@ -34,18 +36,4 @@ interface ConstraintValidatorInterface
      * @api
      */
     function isValid($value, Constraint $constraint);
-
-    /**
-     * @return string
-     *
-     * @api
-     */
-    function getMessageTemplate();
-
-    /**
-     * @return array
-     *
-     * @api
-     */
-    function getMessageParameters();
 }

--- a/src/Symfony/Component/Validator/ConstraintViolation.php
+++ b/src/Symfony/Component/Validator/ConstraintViolation.php
@@ -35,6 +35,21 @@ class ConstraintViolation
 
     /**
      * @return string
+     */
+    public function __toString()
+    {
+        $class = (string) (is_object($this->root) ? get_class($this->root) : $this->root);
+        $propertyPath = (string) $this->propertyPath;
+
+        if ('' !== $propertyPath && '[' !== $propertyPath[0] && '' !== $class) {
+            $class .= '.';
+        }
+
+        return $class . $propertyPath . ":\n    " . $this->getMessage();
+    }
+
+    /**
+     * @return string
      *
      * @api
      */
@@ -62,7 +77,15 @@ class ConstraintViolation
      */
     public function getMessage()
     {
-        return strtr($this->messageTemplate, $this->messageParameters);
+        $parameters = $this->messageParameters;
+
+        foreach ($parameters as $i => $parameter) {
+            if (is_array($parameter)) {
+                $parameters[$i] = 'Array';
+            }
+        }
+
+        return strtr($this->messageTemplate, $parameters);
     }
 
     public function getRoot()

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Validator;
 
 /**
- * An list of ConstrainViolation objects.
+ * A list of ConstrainViolation objects.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
@@ -28,7 +28,7 @@ class ConstraintViolationList implements \IteratorAggregate, \Countable, \ArrayA
     protected $violations = array();
 
     /**
-     * Creates a new constraint violation list
+     * Creates a new constraint violation list.
      *
      * @param array $violations The constraint violations to add to the list
      */

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -12,13 +12,32 @@
 namespace Symfony\Component\Validator;
 
 /**
- * An array-acting object that holds many ConstrainViolation instances.
+ * An list of ConstrainViolation objects.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
 class ConstraintViolationList implements \IteratorAggregate, \Countable, \ArrayAccess
 {
+    /**
+     * The constraint violations
+     *
+     * @var array
+     */
     protected $violations = array();
+
+    /**
+     * Creates a new constraint violation list
+     *
+     * @param array $violations The constraint violations to add to the list
+     */
+    public function __construct(array $violations = array())
+    {
+        foreach ($violations as $violation) {
+            $this->add($violation);
+        }
+    }
 
     /**
      * @return string

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -50,7 +50,7 @@ class ConstraintViolationList implements \IteratorAggregate, \Countable, \ArrayA
             $root = $violation->getRoot();
             $class = (string) (is_object($root) ? get_class($root) : $root);
             $propertyPath = (string) $violation->getPropertyPath();
-            if ('' !== $propertyPath && '[' !== $propertyPath{0} && '' !== $class) {
+            if ('' !== $propertyPath && '[' !== $propertyPath[0] && '' !== $class) {
                 $class .= '.';
             }
             $string .= <<<EOF

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -47,17 +47,7 @@ class ConstraintViolationList implements \IteratorAggregate, \Countable, \ArrayA
         $string = '';
 
         foreach ($this->violations as $violation) {
-            $root = $violation->getRoot();
-            $class = (string) (is_object($root) ? get_class($root) : $root);
-            $propertyPath = (string) $violation->getPropertyPath();
-            if ('' !== $propertyPath && '[' !== $propertyPath[0] && '' !== $class) {
-                $class .= '.';
-            }
-            $string .= <<<EOF
-{$class}{$propertyPath}:
-    {$violation->getMessage()}
-
-EOF;
+            $string .= $violation . "\n";
         }
 
         return $string;

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -29,9 +29,13 @@ class ConstraintViolationList implements \IteratorAggregate, \Countable, \ArrayA
 
         foreach ($this->violations as $violation) {
             $root = $violation->getRoot();
-            $class = is_object($root) ? get_class($root) : $root;
+            $class = (string) (is_object($root) ? get_class($root) : $root);
+            $propertyPath = (string) $violation->getPropertyPath();
+            if ('' !== $propertyPath && '[' !== $propertyPath{0} && '' !== $class) {
+                $class .= '.';
+            }
             $string .= <<<EOF
-{$class}.{$violation->getPropertyPath()}:
+{$class}{$propertyPath}:
     {$violation->getMessage()}
 
 EOF;

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -78,13 +78,13 @@ EOF;
     /**
      * Merge an existing ConstraintViolationList into this list.
      *
-     * @param ConstraintViolationList $violations
+     * @param ConstraintViolationList $otherList
      *
      * @api
      */
-    public function addAll(ConstraintViolationList $violations)
+    public function addAll(ConstraintViolationList $otherList)
     {
-        foreach ($violations->violations as $violation) {
+        foreach ($otherList->violations as $violation) {
             $this->violations[] = $violation;
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -32,7 +32,7 @@ class BlankValidator extends ConstraintValidator
     public function isValid($value, Constraint $constraint)
     {
         if ('' !== $value && null !== $value) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -48,13 +48,6 @@ class CallbackValidator extends ConstraintValidator
         }
 
         $methods = $constraint->methods;
-        $context = $this->context;
-
-        // save context state
-        $currentClass = $context->getCurrentClass();
-        $currentProperty = $context->getCurrentProperty();
-        $group = $context->getGroup();
-        $propertyPath = $context->getPropertyPath();
 
         foreach ($methods as $method) {
             if (is_array($method) || $method instanceof \Closure) {
@@ -62,20 +55,14 @@ class CallbackValidator extends ConstraintValidator
                     throw new ConstraintDefinitionException(sprintf('"%s::%s" targeted by Callback constraint is not a valid callable', $method[0], $method[1]));
                 }
 
-                call_user_func($method, $object, $context);
+                call_user_func($method, $object, $this->context);
             } else {
                 if (!method_exists($object, $method)) {
                     throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Callback constraint does not exist', $method));
                 }
 
-                $object->$method($context);
+                $object->$method($this->context);
             }
-
-            // restore context state
-            $context->setCurrentClass($currentClass);
-            $context->setCurrentProperty($currentProperty);
-            $context->setGroup($group);
-            $context->setPropertyPath($propertyPath);
         }
 
         return true;

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -48,6 +48,7 @@ class CallbackValidator extends ConstraintValidator
         }
 
         $methods = $constraint->methods;
+        $success = true;
 
         foreach ($methods as $method) {
             if (is_array($method) || $method instanceof \Closure) {
@@ -55,16 +56,16 @@ class CallbackValidator extends ConstraintValidator
                     throw new ConstraintDefinitionException(sprintf('"%s::%s" targeted by Callback constraint is not a valid callable', $method[0], $method[1]));
                 }
 
-                call_user_func($method, $object, $this->context);
+                $success = call_user_func($method, $object, $this->context) && $success;
             } else {
                 if (!method_exists($object, $method)) {
                     throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Callback constraint does not exist', $method));
                 }
 
-                $object->$method($this->context);
+                $success = $object->$method($this->context) && $success;
             }
         }
 
-        return true;
+        return $success;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -66,7 +66,7 @@ class ChoiceValidator extends ConstraintValidator
         if ($constraint->multiple) {
             foreach ($value as $_value) {
                 if (!in_array($_value, $choices, $constraint->strict)) {
-                    $this->setMessage($constraint->multipleMessage, array('{{ value }}' => $_value));
+                    $this->context->addViolation($constraint->multipleMessage, array('{{ value }}' => $_value));
 
                     return false;
                 }
@@ -75,18 +75,18 @@ class ChoiceValidator extends ConstraintValidator
             $count = count($value);
 
             if ($constraint->min !== null && $count < $constraint->min) {
-                $this->setMessage($constraint->minMessage, array('{{ limit }}' => $constraint->min));
+                $this->context->addViolation($constraint->minMessage, array('{{ limit }}' => $constraint->min));
 
                 return false;
             }
 
             if ($constraint->max !== null && $count > $constraint->max) {
-                $this->setMessage($constraint->maxMessage, array('{{ limit }}' => $constraint->max));
+                $this->context->addViolation($constraint->maxMessage, array('{{ limit }}' => $constraint->max));
 
                 return false;
             }
         } elseif (!in_array($value, $choices, $constraint->strict)) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -23,8 +23,8 @@ class Collection extends Constraint
     public $fields;
     public $allowExtraFields = false;
     public $allowMissingFields = false;
-    public $extraFieldsMessage = 'The fields {{ fields }} were not expected';
-    public $missingFieldsMessage = 'The fields {{ fields }} are missing';
+    public $extraFieldsMessage = 'This field was not expected';
+    public $missingFieldsMessage = 'This field is missing';
 
     /**
      * {@inheritDoc}

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -68,10 +68,9 @@ class CollectionValidator extends ConstraintValidator
                     $walker->walkConstraint($constr, $value[$field], $group, $propertyPath.'['.$field.']');
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
-                $this->context->setPropertyPath($propertyPath.'['.$field.']');
-                $this->context->addViolation($constraint->missingFieldsMessage, array(
+                $this->context->addViolationAt($propertyPath.'['.$field.']', $constraint->missingFieldsMessage, array(
                     '{{ field }}' => '"'.$field.'"'
-                ), $value);
+                ), null);
                 $valid = false;
             }
         }
@@ -79,10 +78,9 @@ class CollectionValidator extends ConstraintValidator
         if (!$constraint->allowExtraFields) {
             foreach ($value as $field => $fieldValue) {
                 if (!isset($constraint->fields[$field])) {
-                    $this->context->setPropertyPath($propertyPath.'['.$field.']');
-                    $this->context->addViolation($constraint->extraFieldsMessage, array(
+                    $this->context->addViolationAt($propertyPath.'['.$field.']', $constraint->extraFieldsMessage, array(
                         '{{ field }}' => '"'.$field.'"'
-                    ), $value);
+                    ), $fieldValue);
                     $valid = false;
                 }
             }

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -68,7 +68,7 @@ class CollectionValidator extends ConstraintValidator
                     $walker->walkConstraint($constr, $value[$field], $group, $propertyPath.'['.$field.']');
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
-                $this->context->addViolationAtRelativePath('['.$field.']', $constraint->missingFieldsMessage, array(
+                $this->context->addViolationAtSubPath('['.$field.']', $constraint->missingFieldsMessage, array(
                     '{{ field }}' => $field
                 ), null);
                 $valid = false;
@@ -78,7 +78,7 @@ class CollectionValidator extends ConstraintValidator
         if (!$constraint->allowExtraFields) {
             foreach ($value as $field => $fieldValue) {
                 if (!isset($constraint->fields[$field])) {
-                    $this->context->addViolationAtRelativePath('['.$field.']', $constraint->extraFieldsMessage, array(
+                    $this->context->addViolationAtSubPath('['.$field.']', $constraint->extraFieldsMessage, array(
                         '{{ field }}' => $field
                     ), $fieldValue);
                     $valid = false;

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -68,7 +68,7 @@ class CollectionValidator extends ConstraintValidator
                     $walker->walkConstraint($constr, $value[$field], $group, $propertyPath.'['.$field.']');
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
-                $this->context->addViolationAt($propertyPath.'['.$field.']', $constraint->missingFieldsMessage, array(
+                $this->context->addNestedViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(
                     '{{ field }}' => '"'.$field.'"'
                 ), null);
                 $valid = false;
@@ -78,7 +78,7 @@ class CollectionValidator extends ConstraintValidator
         if (!$constraint->allowExtraFields) {
             foreach ($value as $field => $fieldValue) {
                 if (!isset($constraint->fields[$field])) {
-                    $this->context->addViolationAt($propertyPath.'['.$field.']', $constraint->extraFieldsMessage, array(
+                    $this->context->addNestedViolationAt('['.$field.']', $constraint->extraFieldsMessage, array(
                         '{{ field }}' => '"'.$field.'"'
                     ), $fieldValue);
                     $valid = false;

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -68,8 +68,8 @@ class CollectionValidator extends ConstraintValidator
                     $walker->walkConstraint($constr, $value[$field], $group, $propertyPath.'['.$field.']');
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
-                $this->context->addNestedViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(
-                    '{{ field }}' => '"'.$field.'"'
+                $this->context->addViolationAtRelativePath('['.$field.']', $constraint->missingFieldsMessage, array(
+                    '{{ field }}' => $field
                 ), null);
                 $valid = false;
             }
@@ -78,8 +78,8 @@ class CollectionValidator extends ConstraintValidator
         if (!$constraint->allowExtraFields) {
             foreach ($value as $field => $fieldValue) {
                 if (!isset($constraint->fields[$field])) {
-                    $this->context->addNestedViolationAt('['.$field.']', $constraint->extraFieldsMessage, array(
-                        '{{ field }}' => '"'.$field.'"'
+                    $this->context->addViolationAtRelativePath('['.$field.']', $constraint->extraFieldsMessage, array(
+                        '{{ field }}' => $field
                     ), $fieldValue);
                     $valid = false;
                 }

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -46,12 +46,7 @@ class CollectionValidator extends ConstraintValidator
         $group = $this->context->getGroup();
         $propertyPath = $this->context->getPropertyPath();
 
-        $missingFields = array();
-        $extraFields = array();
-
-        foreach ($value as $field => $fieldValue) {
-            $extraFields[$field] = $fieldValue;
-        }
+        $valid = true;
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
             if (
@@ -72,29 +67,27 @@ class CollectionValidator extends ConstraintValidator
                 foreach ($constraints as $constr) {
                     $walker->walkConstraint($constr, $value[$field], $group, $propertyPath.'['.$field.']');
                 }
-
-                unset($extraFields[$field]);
-            } elseif (!$fieldConstraint instanceof Optional) {
-                $missingFields[] = $field;
+            } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
+                $this->context->setPropertyPath($propertyPath.'['.$field.']');
+                $this->context->addViolation($constraint->missingFieldsMessage, array(
+                    '{{ field }}' => '"'.$field.'"'
+                ), $value);
+                $valid = false;
             }
         }
 
-        if (count($extraFields) > 0 && !$constraint->allowExtraFields) {
-            $this->setMessage($constraint->extraFieldsMessage, array(
-                '{{ fields }}' => '"'.implode('", "', array_keys($extraFields)).'"'
-            ));
-
-            return false;
+        if (!$constraint->allowExtraFields) {
+            foreach ($value as $field => $fieldValue) {
+                if (!isset($constraint->fields[$field])) {
+                    $this->context->setPropertyPath($propertyPath.'['.$field.']');
+                    $this->context->addViolation($constraint->extraFieldsMessage, array(
+                        '{{ field }}' => '"'.$field.'"'
+                    ), $value);
+                    $valid = false;
+                }
+            }
         }
 
-        if (count($missingFields) > 0 && !$constraint->allowMissingFields) {
-            $this->setMessage($constraint->missingFieldsMessage, array(
-                '{{ fields }}' => '"'.implode('", "', $missingFields).'"'
-            ));
-
-            return false;
-        }
-
-        return true;
+        return $valid;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -47,7 +47,7 @@ class CountryValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!in_array($value, \Symfony\Component\Locale\Locale::getCountries())) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -48,12 +48,12 @@ class DateValidator extends ConstraintValidator
 
         $value = (string) $value;
 
-        if (!preg_match(static::PATTERN, $value, $matches)) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+        if (!preg_match(static::PATTERN, $value, $matches) || !checkdate($matches[2], $matches[3], $matches[1])) {
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }
 
-        return checkdate($matches[2], $matches[3], $matches[1]);
+        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -58,7 +58,7 @@ class EmailValidator extends ConstraintValidator
         }
 
         if (!$valid) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -39,7 +39,7 @@ class FalseValidator extends ConstraintValidator
             return true;
         }
 
-        $this->setMessage($constraint->message);
+        $this->context->addViolation($constraint->message);
 
         return false;
     }

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -44,15 +44,15 @@ class FileValidator extends ConstraintValidator
                 case UPLOAD_ERR_INI_SIZE:
                     $maxSize = UploadedFile::getMaxFilesize();
                     $maxSize = $constraint->maxSize ? min($maxSize, $constraint->maxSize) : $maxSize;
-                    $this->setMessage($constraint->uploadIniSizeErrorMessage, array('{{ limit }}' => $maxSize.' bytes'));
+                    $this->context->addViolation($constraint->uploadIniSizeErrorMessage, array('{{ limit }}' => $maxSize.' bytes'));
 
                     return false;
                 case UPLOAD_ERR_FORM_SIZE:
-                    $this->setMessage($constraint->uploadFormSizeErrorMessage);
+                    $this->context->addViolation($constraint->uploadFormSizeErrorMessage);
 
                     return false;
                 default:
-                    $this->setMessage($constraint->uploadErrorMessage);
+                    $this->context->addViolation($constraint->uploadErrorMessage);
 
                     return false;
             }
@@ -65,13 +65,13 @@ class FileValidator extends ConstraintValidator
         $path = $value instanceof FileObject ? $value->getPathname() : (string) $value;
 
         if (!is_file($path)) {
-            $this->setMessage($constraint->notFoundMessage, array('{{ file }}' => $path));
+            $this->context->addViolation($constraint->notFoundMessage, array('{{ file }}' => $path));
 
             return false;
         }
 
         if (!is_readable($path)) {
-            $this->setMessage($constraint->notReadableMessage, array('{{ file }}' => $path));
+            $this->context->addViolation($constraint->notReadableMessage, array('{{ file }}' => $path));
 
             return false;
         }
@@ -94,7 +94,7 @@ class FileValidator extends ConstraintValidator
             }
 
             if ($size > $limit) {
-                $this->setMessage($constraint->maxSizeMessage, array(
+                $this->context->addViolation($constraint->maxSizeMessage, array(
                     '{{ size }}'    => $size.$suffix,
                     '{{ limit }}'   => $limit.$suffix,
                     '{{ file }}'    => $path,
@@ -128,7 +128,7 @@ class FileValidator extends ConstraintValidator
             }
 
             if (false === $valid) {
-                $this->setMessage($constraint->mimeTypesMessage, array(
+                $this->context->addViolation($constraint->mimeTypesMessage, array(
                     '{{ type }}'    => '"'.$mime.'"',
                     '{{ types }}'   => '"'.implode('", "', $mimeTypes) .'"',
                     '{{ file }}'    => $path,

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -40,7 +40,7 @@ class ImageValidator extends FileValidator
 
         $size = @getimagesize($value);
         if (empty($size) || ($size[0] === 0) || ($size[1] === 0)) {
-            $this->setMessage($constraint->sizeNotDetectedMessage);
+            $this->context->addViolation($constraint->sizeNotDetectedMessage);
 
             return false;
         }
@@ -54,7 +54,7 @@ class ImageValidator extends FileValidator
             }
 
             if ($width < $constraint->minWidth) {
-                $this->setMessage($constraint->minWidthMessage, array(
+                $this->context->addViolation($constraint->minWidthMessage, array(
                     '{{ width }}'    => $width,
                     '{{ min_width }}' => $constraint->minWidth
                 ));
@@ -69,7 +69,7 @@ class ImageValidator extends FileValidator
             }
 
             if ($width > $constraint->maxWidth) {
-                $this->setMessage($constraint->maxWidthMessage, array(
+                $this->context->addViolation($constraint->maxWidthMessage, array(
                     '{{ width }}'    => $width,
                     '{{ max_width }}' => $constraint->maxWidth
                 ));
@@ -84,7 +84,7 @@ class ImageValidator extends FileValidator
             }
 
             if ($height < $constraint->minHeight) {
-                $this->setMessage($constraint->minHeightMessage, array(
+                $this->context->addViolation($constraint->minHeightMessage, array(
                     '{{ height }}'    => $height,
                     '{{ min_height }}' => $constraint->minHeight
                 ));
@@ -99,7 +99,7 @@ class ImageValidator extends FileValidator
             }
 
             if ($height > $constraint->maxHeight) {
-                $this->setMessage($constraint->maxHeightMessage, array(
+                $this->context->addViolation($constraint->maxHeightMessage, array(
                     '{{ height }}'    => $height,
                     '{{ max_height }}' => $constraint->maxHeight
                 ));

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -98,7 +98,7 @@ class IpValidator extends ConstraintValidator
         }
 
         if (!filter_var($value, FILTER_VALIDATE_IP, $flag)) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -47,7 +47,7 @@ class LanguageValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!in_array($value, \Symfony\Component\Locale\Locale::getLanguages())) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -47,7 +47,7 @@ class LocaleValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!in_array($value, \Symfony\Component\Locale\Locale::getLocales())) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
@@ -51,7 +51,7 @@ class MaxLengthValidator extends ConstraintValidator
         }
 
         if ($length > $constraint->limit) {
-            $this->setMessage($constraint->message, array(
+            $this->context->addViolation($constraint->message, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));

--- a/src/Symfony/Component/Validator/Constraints/MaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxValidator.php
@@ -36,7 +36,7 @@ class MaxValidator extends ConstraintValidator
         }
 
         if (!is_numeric($value)) {
-            $this->setMessage($constraint->invalidMessage, array(
+            $this->context->addViolation($constraint->invalidMessage, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));
@@ -45,7 +45,7 @@ class MaxValidator extends ConstraintValidator
         }
 
         if ($value > $constraint->limit) {
-            $this->setMessage($constraint->message, array(
+            $this->context->addViolation($constraint->message, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));

--- a/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
@@ -51,7 +51,7 @@ class MinLengthValidator extends ConstraintValidator
         }
 
         if ($length < $constraint->limit) {
-            $this->setMessage($constraint->message, array(
+            $this->context->addViolation($constraint->message, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));

--- a/src/Symfony/Component/Validator/Constraints/MinValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinValidator.php
@@ -36,7 +36,7 @@ class MinValidator extends ConstraintValidator
         }
 
         if (!is_numeric($value)) {
-            $this->setMessage($constraint->invalidMessage, array(
+            $this->context->addViolation($constraint->invalidMessage, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));
@@ -45,7 +45,7 @@ class MinValidator extends ConstraintValidator
         }
 
         if ($value < $constraint->limit) {
-            $this->setMessage($constraint->message, array(
+            $this->context->addViolation($constraint->message, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -32,7 +32,7 @@ class NotBlankValidator extends ConstraintValidator
     public function isValid($value, Constraint $constraint)
     {
         if (false === $value || (empty($value) && '0' != $value)) {
-            $this->setMessage($constraint->message);
+            $this->context->addViolation($constraint->message);
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -32,7 +32,7 @@ class NotNullValidator extends ConstraintValidator
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
-            $this->setMessage($constraint->message);
+            $this->context->addViolation($constraint->message);
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -32,7 +32,7 @@ class NullValidator extends ConstraintValidator
     public function isValid($value, Constraint $constraint)
     {
         if (null !== $value) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -48,7 +48,7 @@ class RegexValidator extends ConstraintValidator
         $value = (string) $value;
 
         if ($constraint->match xor preg_match($constraint->pattern, $value)) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/SizeLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/SizeLengthValidator.php
@@ -51,7 +51,7 @@ class SizeLengthValidator extends ConstraintValidator
         }
 
         if ($constraint->min == $constraint->max && $length != $constraint->max) {
-            $this->setMessage($constraint->exactMessage, array(
+            $this->context->addViolation($constraint->exactMessage, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->max,
             ));
@@ -60,7 +60,7 @@ class SizeLengthValidator extends ConstraintValidator
         }
 
         if ($length > $constraint->max) {
-            $this->setMessage($constraint->maxMessage, array(
+            $this->context->addViolation($constraint->maxMessage, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->max,
             ));
@@ -69,7 +69,7 @@ class SizeLengthValidator extends ConstraintValidator
         }
 
         if ($length < $constraint->min) {
-            $this->setMessage($constraint->minMessage, array(
+            $this->context->addViolation($constraint->minMessage, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->min,
             ));

--- a/src/Symfony/Component/Validator/Constraints/SizeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/SizeValidator.php
@@ -36,7 +36,7 @@ class SizeValidator extends ConstraintValidator
         }
 
         if (!is_numeric($value)) {
-            $this->setMessage($constraint->invalidMessage, array(
+            $this->context->addViolation($constraint->invalidMessage, array(
                 '{{ value }}' => $value,
             ));
 
@@ -44,7 +44,7 @@ class SizeValidator extends ConstraintValidator
         }
 
         if ($value > $constraint->max) {
-            $this->setMessage($constraint->maxMessage, array(
+            $this->context->addViolation($constraint->maxMessage, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->max,
             ));
@@ -53,7 +53,7 @@ class SizeValidator extends ConstraintValidator
         }
 
         if ($value < $constraint->min) {
-            $this->setMessage($constraint->minMessage, array(
+            $this->context->addViolation($constraint->minMessage, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->min,
             ));

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -49,7 +49,7 @@ class TimeValidator extends ConstraintValidator
         $value = (string) $value;
 
         if (!preg_match(static::PATTERN, $value)) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -39,7 +39,7 @@ class TrueValidator extends ConstraintValidator
             return true;
         }
 
-        $this->setMessage($constraint->message);
+        $this->context->addViolation($constraint->message);
 
         return false;
     }

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -48,8 +48,8 @@ class TypeValidator extends ConstraintValidator
             return true;
         }
 
-        $this->setMessage($constraint->message, array(
-            '{{ value }}' => is_object($value) ? get_class($value) : is_array($value) ? 'Array' : (string) $value,
+        $this->context->addViolation($constraint->message, array(
+            '{{ value }}' => is_object($value) ? get_class($value) : (is_array($value) ? 'Array' : (string) $value),
             '{{ type }}'  => $constraint->type,
         ));
 

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -60,7 +60,7 @@ class UrlValidator extends ConstraintValidator
         $pattern = sprintf(static::PATTERN, implode('|', $constraint->protocols));
 
         if (!preg_match($pattern, $value)) {
-            $this->setMessage($constraint->message, array('{{ value }}' => $value));
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
 
             return false;
         }

--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -96,18 +96,18 @@ class ExecutionContext
      * Adds a violation at the validation graph node with the given property
      * path relative to the current property path.
      *
-     * @param string $relativePath The relative property path for the violation.
+     * @param string $subPath The relative property path for the violation.
      * @param string $message The error message.
      * @param array $params The parameters parsed into the error message.
      * @param mixed $invalidValue The invalid, validated value.
      */
-    public function addViolationAtRelativePath($relativePath, $message, array $params = array(), $invalidValue = null)
+    public function addViolationAtSubPath($subPath, $message, array $params = array(), $invalidValue = null)
     {
         $this->globalContext->addViolation(new ConstraintViolation(
             $message,
             $params,
             $this->globalContext->getRoot(),
-            $this->getAbsolutePropertyPath($relativePath),
+            $this->getPropertyPath($subPath),
             // check using func_num_args() to allow passing null values
             func_num_args() === 4 ? $invalidValue : $this->value
         ));
@@ -128,18 +128,13 @@ class ExecutionContext
         return $this->globalContext->getRoot();
     }
 
-    public function getPropertyPath()
+    public function getPropertyPath($subPath = null)
     {
-        return $this->propertyPath;
-    }
-
-    public function getAbsolutePropertyPath($relativePath)
-    {
-        if ('' !== $this->propertyPath && '' !== $relativePath && '[' !== $relativePath[0]) {
-            return $this->propertyPath . '.' . $relativePath;
+        if (null !== $subPath && '' !== $this->propertyPath && '' !== $subPath && '[' !== $subPath[0]) {
+            return $this->propertyPath . '.' . $subPath;
         }
 
-        return $this->propertyPath . $relativePath;
+        return $this->propertyPath . $subPath;
     }
 
     public function getCurrentClass()

--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -14,13 +14,13 @@ namespace Symfony\Component\Validator;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
 
 /**
- * The central object representing a single validation process.
+ * Stores the state of the current node in the validation graph.
  *
  * This object is used by the GraphWalker to initialize validation of different
  * items and keep track of the violations.
  *
  * @author Fabien Potencier <fabien@symfony.com>
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -30,6 +30,7 @@ class ExecutionContext
     protected $propertyPath;
     protected $class;
     protected $property;
+    protected $value;
     protected $group;
     protected $violations;
     protected $graphWalker;
@@ -55,14 +56,27 @@ class ExecutionContext
     /**
      * @api
      */
-    public function addViolation($message, array $params, $invalidValue)
+    public function addViolation($message, array $params = array(), $invalidValue = null)
     {
         $this->violations->add(new ConstraintViolation(
             $message,
             $params,
             $this->root,
             $this->propertyPath,
-            $invalidValue
+            // check using func_num_args() to allow passing null values
+            func_num_args() === 3 ? $invalidValue : $this->value
+        ));
+    }
+
+    public function addViolationAt($propertyPath, $message, array $params = array(), $invalidValue = null)
+    {
+        $this->violations->add(new ConstraintViolation(
+            $message,
+            $params,
+            $this->root,
+            $propertyPath,
+            // check using func_num_args() to allow passing null values
+            func_num_args() === 4 ? $invalidValue : $this->value
         ));
     }
 
@@ -109,6 +123,16 @@ class ExecutionContext
     public function getCurrentProperty()
     {
         return $this->property;
+    }
+
+    public function setCurrentValue($value)
+    {
+        $this->value = $value;
+    }
+
+    public function getCurrentValue()
+    {
+        return $this->value;
     }
 
     public function setGroup($group)

--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -80,7 +80,7 @@ class ExecutionContext
      * @param array $params The parameters parsed into the error message.
      * @param mixed $invalidValue The invalid, validated value.
      */
-    public function addViolationAt($propertyPath, $message, array $params = array(), $invalidValue = null)
+    public function addViolationAtPath($propertyPath, $message, array $params = array(), $invalidValue = null)
     {
         $this->globalContext->addViolation(new ConstraintViolation(
             $message,
@@ -93,27 +93,21 @@ class ExecutionContext
     }
 
     /**
-     * Adds a violation at the child of the current validation graph node with
-     * the given property path.
+     * Adds a violation at the validation graph node with the given property
+     * path relative to the current property path.
      *
-     * @param string $childPropertyPath The property path of the child node.
+     * @param string $relativePath The relative property path for the violation.
      * @param string $message The error message.
      * @param array $params The parameters parsed into the error message.
      * @param mixed $invalidValue The invalid, validated value.
      */
-    public function addNestedViolationAt($childPropertyPath, $message, array $params = array(), $invalidValue = null)
+    public function addViolationAtRelativePath($relativePath, $message, array $params = array(), $invalidValue = null)
     {
-        $propertyPath = $this->propertyPath;
-
-        if ('' !== $propertyPath && '' !== $childPropertyPath && '[' !== $childPropertyPath[0]) {
-            $propertyPath .= '.';
-        }
-
         $this->globalContext->addViolation(new ConstraintViolation(
             $message,
             $params,
             $this->globalContext->getRoot(),
-            $propertyPath . $childPropertyPath,
+            $this->getAbsolutePropertyPath($relativePath),
             // check using func_num_args() to allow passing null values
             func_num_args() === 4 ? $invalidValue : $this->value
         ));
@@ -137,6 +131,15 @@ class ExecutionContext
     public function getPropertyPath()
     {
         return $this->propertyPath;
+    }
+
+    public function getAbsolutePropertyPath($relativePath)
+    {
+        if ('' !== $this->propertyPath && '' !== $relativePath && '[' !== $relativePath[0]) {
+            return $this->propertyPath . '.' . $relativePath;
+        }
+
+        return $this->propertyPath . $relativePath;
     }
 
     public function getCurrentClass()

--- a/src/Symfony/Component/Validator/GlobalExecutionContext.php
+++ b/src/Symfony/Component/Validator/GlobalExecutionContext.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator;
+
+use Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface;
+
+/**
+ * Stores the node-independent information of a validation run.
+ *
+ * This class is immutable by design, except for violation tracking.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class GlobalExecutionContext
+{
+    private $root;
+    private $graphWalker;
+    private $metadataFactory;
+    private $violations;
+
+    public function __construct(
+        $root,
+        GraphWalker $graphWalker,
+        ClassMetadataFactoryInterface $metadataFactory
+    )
+    {
+        $this->root = $root;
+        $this->graphWalker = $graphWalker;
+        $this->metadataFactory = $metadataFactory;
+        $this->violations = new ConstraintViolationList();
+    }
+
+    public function __clone()
+    {
+        $this->violations = clone $this->violations;
+    }
+
+    public function addViolation(ConstraintViolation $violation)
+    {
+        $this->violations->add($violation);
+    }
+
+    /**
+     * @return ConstraintViolationList
+     */
+    public function getViolations()
+    {
+        return $this->violations;
+    }
+
+    public function getRoot()
+    {
+        return $this->root;
+    }
+
+    /**
+     * @return GraphWalker
+     */
+    public function getGraphWalker()
+    {
+        return $this->graphWalker;
+    }
+
+    /**
+     * @return ClassMetadataFactoryInterface
+     */
+    public function getMetadataFactory()
+    {
+        return $this->metadataFactory;
+    }
+}

--- a/src/Symfony/Component/Validator/GlobalExecutionContext.php
+++ b/src/Symfony/Component/Validator/GlobalExecutionContext.php
@@ -27,11 +27,7 @@ class GlobalExecutionContext
     private $metadataFactory;
     private $violations;
 
-    public function __construct(
-        $root,
-        GraphWalker $graphWalker,
-        ClassMetadataFactoryInterface $metadataFactory
-    )
+    public function __construct($root, GraphWalker $graphWalker, ClassMetadataFactoryInterface $metadataFactory)
     {
         $this->root = $root;
         $this->graphWalker = $graphWalker;

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -178,17 +178,6 @@ class GraphWalker
         );
 
         $validator->initialize($localContext);
-
-        if (!$validator->isValid($value, $constraint)) {
-            $messageTemplate = $validator->getMessageTemplate();
-            $messageParams = $validator->getMessageParameters();
-
-            // Somewhat ugly hack: Don't add a violation if no message is set.
-            // This is required if the validator added its violations directly
-            // to the globalContext already
-            if (!empty($messageTemplate)) {
-                $localContext->addViolation($messageTemplate, $messageParams);
-            }
-        }
+        $validator->isValid($value, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -174,16 +174,20 @@ class GraphWalker
         $validator->initialize($this->context);
 
         if (!$validator->isValid($value, $constraint)) {
-            // Resetting the property path. This is needed because some
-            // validators, like CollectionValidator, use the walker internally
-            // and so change the context.
-            $this->context->setPropertyPath($propertyPath);
+            $messageTemplate = $validator->getMessageTemplate();
+            $messageParams = $validator->getMessageParameters();
 
-            $this->context->addViolation(
-                $validator->getMessageTemplate(),
-                $validator->getMessageParameters(),
-                $value
-            );
+            // Somewhat ugly hack: Don't add a violation if no message is set.
+            // This is required if the validator added its violations directly
+            // to the context already
+            if (!empty($messageTemplate)) {
+                // Resetting the property path. This is needed because some
+                // validators, like CollectionValidator, use the walker internally
+                // and so change the context.
+                $this->context->setPropertyPath($propertyPath);
+
+                $this->context->addViolation($messageTemplate, $messageParams, $value);
+            }
         }
     }
 }

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -27,15 +27,15 @@ use Symfony\Component\Validator\Mapping\MemberMetadata;
  */
 class GraphWalker
 {
-    protected $context;
-    protected $validatorFactory;
-    protected $metadataFactory;
-    protected $validatorInitializers = array();
-    protected $validatedObjects = array();
+    private $globalContext;
+    private $validatorFactory;
+    private $metadataFactory;
+    private $validatorInitializers = array();
+    private $validatedObjects = array();
 
     public function __construct($root, ClassMetadataFactoryInterface $metadataFactory, ConstraintValidatorFactoryInterface $factory, array $validatorInitializers = array())
     {
-        $this->context = new ExecutionContext($root, $this, $metadataFactory);
+        $this->globalContext = new GlobalExecutionContext($root, $this, $metadataFactory);
         $this->validatorFactory = $factory;
         $this->metadataFactory = $metadataFactory;
         $this->validatorInitializers = $validatorInitializers;
@@ -46,7 +46,7 @@ class GraphWalker
      */
     public function getViolations()
     {
-        return $this->context->getViolations();
+        return $this->globalContext->getViolations();
     }
 
     /**
@@ -66,8 +66,6 @@ class GraphWalker
             }
             $initializer->initialize($object);
         }
-
-        $this->context->setCurrentClass($metadata->getClassName());
 
         if ($group === Constraint::DEFAULT_GROUP && $metadata->hasGroupSequence()) {
             $groups = $metadata->getGroupSequence();
@@ -100,8 +98,10 @@ class GraphWalker
         // traversing the object graph
         $this->validatedObjects[$hash][$group] = true;
 
+        $currentClass = $metadata->getClassName();
+
         foreach ($metadata->findConstraints($group) as $constraint) {
-            $this->walkConstraint($constraint, $object, $group, $propertyPath);
+            $this->walkConstraint($constraint, $object, $group, $propertyPath, $currentClass);
         }
 
         if (null !== $object) {
@@ -129,11 +129,11 @@ class GraphWalker
 
     protected function walkMember(MemberMetadata $metadata, $value, $group, $propertyPath, $propagatedGroup = null)
     {
-        $this->context->setCurrentClass($metadata->getClassName());
-        $this->context->setCurrentProperty($metadata->getPropertyName());
+        $currentClass = $metadata->getClassName();
+        $currentProperty = $metadata->getPropertyName();
 
         foreach ($metadata->findConstraints($group) as $constraint) {
-            $this->walkConstraint($constraint, $value, $group, $propertyPath);
+            $this->walkConstraint($constraint, $value, $group, $propertyPath, $currentClass, $currentProperty);
         }
 
         if ($metadata->isCascaded()) {
@@ -164,15 +164,20 @@ class GraphWalker
         }
     }
 
-    public function walkConstraint(Constraint $constraint, $value, $group, $propertyPath)
+    public function walkConstraint(Constraint $constraint, $value, $group, $propertyPath, $currentClass = null, $currentProperty = null)
     {
         $validator = $this->validatorFactory->getInstance($constraint);
 
-        $this->context->setCurrentValue($value);
-        $this->context->setPropertyPath($propertyPath);
-        $this->context->setGroup($group);
+        $localContext = new ExecutionContext(
+            $this->globalContext,
+            $value,
+            $propertyPath,
+            $group,
+            $currentClass,
+            $currentProperty
+        );
 
-        $validator->initialize($this->context);
+        $validator->initialize($localContext);
 
         if (!$validator->isValid($value, $constraint)) {
             $messageTemplate = $validator->getMessageTemplate();
@@ -180,15 +185,9 @@ class GraphWalker
 
             // Somewhat ugly hack: Don't add a violation if no message is set.
             // This is required if the validator added its violations directly
-            // to the context already
+            // to the globalContext already
             if (!empty($messageTemplate)) {
-                // Resetting the property path. This is needed because some
-                // validators, like CollectionValidator, use the walker internally
-                // and so change the context.
-                $this->context->setCurrentValue($value);
-                $this->context->setPropertyPath($propertyPath);
-
-                $this->context->addViolation($messageTemplate, $messageParams);
+                $localContext->addViolation($messageTemplate, $messageParams);
             }
         }
     }

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -168,6 +168,7 @@ class GraphWalker
     {
         $validator = $this->validatorFactory->getInstance($constraint);
 
+        $this->context->setCurrentValue($value);
         $this->context->setPropertyPath($propertyPath);
         $this->context->setGroup($group);
 
@@ -184,9 +185,10 @@ class GraphWalker
                 // Resetting the property path. This is needed because some
                 // validators, like CollectionValidator, use the walker internally
                 // and so change the context.
+                $this->context->setCurrentValue($value);
                 $this->context->setPropertyPath($propertyPath);
 
-                $this->context->addViolation($messageTemplate, $messageParams, $value);
+                $this->context->addViolation($messageTemplate, $messageParams);
             }
         }
     }

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -108,7 +108,7 @@ class Validator implements ValidatorInterface
             return $walker->walkConstraint($constraint, $value, $group, '');
         };
 
-        return $this->validateGraph($value, $walk, $groups);
+        return $this->validateGraph('', $walk, $groups);
     }
 
     protected function validateGraph($root, \Closure $walk, $groups = null)

--- a/tests/Symfony/Tests/Component/Validator/ConstraintViolationListTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ConstraintViolationListTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Validator;
+
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+class ConstraintViolationListTest extends \PHPUnit_Framework_TestCase
+{
+    protected $list;
+
+    protected function setUp()
+    {
+        $this->list = new ConstraintViolationList();
+    }
+
+    protected function tearDown()
+    {
+        $this->list = null;
+    }
+
+    public function testInit()
+    {
+        $this->assertCount(0, $this->list);
+    }
+
+    public function testInitWithViolations()
+    {
+        $violation = $this->getViolation('Error');
+        $this->list = new ConstraintViolationList(array($violation));
+
+        $this->assertCount(1, $this->list);
+        $this->assertSame($violation, $this->list[0]);
+    }
+
+    public function testAdd()
+    {
+        $violation = $this->getViolation('Error');
+        $this->list->add($violation);
+
+        $this->assertCount(1, $this->list);
+        $this->assertSame($violation, $this->list[0]);
+    }
+
+    public function testAddAll()
+    {
+        $violations = array(
+            10 => $this->getViolation('Error 1'),
+            20 => $this->getViolation('Error 2'),
+            30 => $this->getViolation('Error 3'),
+        );
+        $otherList = new ConstraintViolationList($violations);
+        $this->list->addAll($otherList);
+
+        $this->assertCount(3, $this->list);
+
+        $this->assertSame($violations[10], $this->list[0]);
+        $this->assertSame($violations[20], $this->list[1]);
+        $this->assertSame($violations[30], $this->list[2]);
+    }
+
+    public function testIterator()
+    {
+        $violations = array(
+            10 => $this->getViolation('Error 1'),
+            20 => $this->getViolation('Error 2'),
+            30 => $this->getViolation('Error 3'),
+        );
+
+        $this->list = new ConstraintViolationList($violations);
+
+        // indices are reset upon adding -> array_values()
+        $this->assertSame(array_values($violations), iterator_to_array($this->list));
+    }
+
+    public function testArrayAccess()
+    {
+        $violation = $this->getViolation('Error');
+        $this->list[] = $violation;
+
+        $this->assertSame($violation, $this->list[0]);
+        $this->assertTrue(isset($this->list[0]));
+
+        unset($this->list[0]);
+
+        $this->assertFalse(isset($this->list[0]));
+
+        $this->list[10] = $violation;
+
+        $this->assertSame($violation, $this->list[10]);
+        $this->assertTrue(isset($this->list[10]));
+    }
+
+    public function testToString()
+    {
+        $this->list = new ConstraintViolationList(array(
+            $this->getViolation('Error 1', 'Root'),
+            $this->getViolation('Error 2', 'Root', 'foo.bar'),
+            $this->getViolation('Error 3', 'Root', '[baz]'),
+            $this->getViolation('Error 4', '', 'foo.bar'),
+            $this->getViolation('Error 5', '', '[baz]'),
+        ));
+
+        $expected = <<<EOF
+Root:
+    Error 1
+Root.foo.bar:
+    Error 2
+Root[baz]:
+    Error 3
+foo.bar:
+    Error 4
+[baz]:
+    Error 5
+
+EOF;
+
+        $this->assertEquals($expected, (string) $this->list);
+    }
+
+    protected function getViolation($message, $root = null, $propertyPath = null)
+    {
+        return new ConstraintViolation($message, array(), $root, $propertyPath, null);
+    }
+}

--- a/tests/Symfony/Tests/Component/Validator/ConstraintViolationTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ConstraintViolationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Validator;
+
+use Symfony\Component\Validator\ConstraintViolation;
+
+class ConstraintViolationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testToStringHandlesArrays()
+    {
+        $violation = new ConstraintViolation(
+            '{{ value }}',
+            array('{{ value }}' => array(1, 2, 3)),
+            'Root',
+            'property.path',
+            null
+        );
+
+        $expected = <<<EOF
+Root.property.path:
+    Array
+EOF;
+
+        $this->assertSame($expected, (string) $violation);
+    }
+}

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Tests\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\GlobalExecutionContext;
+
 use Symfony\Component\Validator\ExecutionContext;
 use Symfony\Component\Validator\Constraints\Min;
 use Symfony\Component\Validator\Constraints\All;
@@ -26,8 +28,9 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
         $metadataFactory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
+        $globalContext = new GlobalExecutionContext('Root', $this->walker, $metadataFactory);
 
-        $this->context = new ExecutionContext('Root', $this->walker, $metadataFactory);
+        $this->context = new ExecutionContext($globalContext, null, 'foo', 'MyGroup', null, null);
 
         $this->validator = new AllValidator();
         $this->validator->initialize($this->context);
@@ -57,9 +60,6 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testWalkSingleConstraint($array)
     {
-        $this->context->setGroup('MyGroup');
-        $this->context->setPropertyPath('foo');
-
         $constraint = new Min(4);
 
         foreach ($array as $key => $value) {
@@ -76,9 +76,6 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testWalkMultipleConstraints($array)
     {
-        $this->context->setGroup('MyGroup');
-        $this->context->setPropertyPath('foo');
-
         $constraint = new Min(4);
         // can only test for twice the same constraint because PHPUnits mocking
         // can't test method calls with different arguments

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
@@ -15,25 +15,32 @@ use Symfony\Component\Validator\GlobalExecutionContext;
 
 use Symfony\Component\Validator\ExecutionContext;
 use Symfony\Component\Validator\Constraints\Min;
+use Symfony\Component\Validator\Constraints\Max;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\AllValidator;
 
 class AllValidatorTest extends \PHPUnit_Framework_TestCase
 {
-    protected $validator;
     protected $walker;
     protected $context;
+    protected $validator;
 
     protected function setUp()
     {
         $this->walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
-        $metadataFactory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
-        $globalContext = new GlobalExecutionContext('Root', $this->walker, $metadataFactory);
-
-        $this->context = new ExecutionContext($globalContext, null, 'foo', 'MyGroup', null, null);
-
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new AllValidator();
         $this->validator->initialize($this->context);
+
+        $this->context->expects($this->any())
+            ->method('getGraphWalker')
+            ->will($this->returnValue($this->walker));
+        $this->context->expects($this->any())
+            ->method('getGroup')
+            ->will($this->returnValue('MyGroup'));
+        $this->context->expects($this->any())
+            ->method('getPropertyPath')
+            ->will($this->returnValue('foo.bar'));
     }
 
     protected function tearDown()
@@ -48,11 +55,13 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->validator->isValid(null, new All(new Min(4))));
     }
 
+
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
     public function testThrowsExceptionIfNotTraversable()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
-
-        $this->validator->isValid('foobar', new All(new Min(4)));
+        $this->validator->isValid('foo.barbar', new All(new Min(4)));
     }
 
     /**
@@ -62,11 +71,16 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $constraint = new Min(4);
 
+        $i = 0;
+
         foreach ($array as $key => $value) {
-            $this->walker->expects($this->once())
-                                     ->method('walkConstraint')
-                                     ->with($this->equalTo($constraint), $this->equalTo($value), $this->equalTo('MyGroup'), $this->equalTo('foo['.$key.']'));
+            $this->walker->expects($this->at($i++))
+                ->method('walkConstraint')
+                ->with($constraint, $value, 'MyGroup', 'foo.bar['.$key.']');
         }
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
 
         $this->assertTrue($this->validator->isValid($array, new All($constraint)));
     }
@@ -76,16 +90,23 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testWalkMultipleConstraints($array)
     {
-        $constraint = new Min(4);
-        // can only test for twice the same constraint because PHPUnits mocking
-        // can't test method calls with different arguments
-        $constraints = array($constraint, $constraint);
+        $constraint1 = new Min(4);
+        $constraint2 = new Max(6);
+
+        $constraints = array($constraint1, $constraint2);
+        $i = 0;
 
         foreach ($array as $key => $value) {
-            $this->walker->expects($this->exactly(2))
-                                     ->method('walkConstraint')
-                                     ->with($this->equalTo($constraint), $this->equalTo($value), $this->equalTo('MyGroup'), $this->equalTo('foo['.$key.']'));
+            $this->walker->expects($this->at($i++))
+                ->method('walkConstraint')
+                ->with($constraint1, $value, 'MyGroup', 'foo.bar['.$key.']');
+            $this->walker->expects($this->at($i++))
+                ->method('walkConstraint')
+                ->with($constraint2, $value, 'MyGroup', 'foo.bar['.$key.']');
         }
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
 
         $this->assertTrue($this->validator->isValid($array, new All($constraints)));
     }
@@ -93,10 +114,8 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
     public function getValidArguments()
     {
         return array(
-            // can only test for one entry, because PHPUnits mocking does not allow
-            // to expect multiple method calls with different arguments
-            array(array(1)),
-            array(new \ArrayObject(array(1))),
+            array(array(5, 6, 7)),
+            array(new \ArrayObject(array(5, 6, 7))),
         );
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/ChoiceValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/ChoiceValidatorTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Tests\Component\Validator\Constraints;
 
+use Symfony\Component\Validator\GlobalExecutionContext;
+
 use Symfony\Component\Validator\ExecutionContext;
 use Symfony\Component\Validator\Constraints\Choice;
 use Symfony\Component\Validator\Constraints\ChoiceValidator;
@@ -33,8 +35,8 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
         $factory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
-        $context = new ExecutionContext('root', $walker, $factory);
-        $context->setCurrentClass(__CLASS__);
+        $globalContext = new GlobalExecutionContext('root', $walker, $factory);
+        $context = new ExecutionContext($globalContext, null, null, null, __CLASS__, null);
         $this->validator = new ChoiceValidator();
         $this->validator->initialize($context);
     }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/ChoiceValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/ChoiceValidatorTest.php
@@ -24,6 +24,7 @@ function choice_callback()
 
 class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     public static function staticCallback()
@@ -33,19 +34,24 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
-        $factory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
-        $globalContext = new GlobalExecutionContext('root', $walker, $factory);
-        $context = new ExecutionContext($globalContext, null, null, null, __CLASS__, null);
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new ChoiceValidator();
-        $this->validator->initialize($context);
+        $this->validator->initialize($this->context);
+
+        $this->context->expects($this->any())
+            ->method('getCurrentClass')
+            ->will($this->returnValue(__CLASS__));
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
     public function testExpectArrayIfMultipleIsTrue()
     {
         $constraint = new Choice(array(
@@ -53,27 +59,30 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'multiple' => true,
         ));
 
-        $this->setExpectedException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
-
         $this->validator->isValid('asdf', $constraint);
     }
 
     public function testNullIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(null, new Choice(array('choices' => array('foo', 'bar')))));
     }
 
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
     public function testChoicesOrCallbackExpected()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
-
         $this->validator->isValid('foobar', new Choice());
     }
 
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
     public function testValidCallbackExpected()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
-
         $this->validator->isValid('foobar', new Choice(array('callback' => 'abcd')));
     }
 
@@ -81,12 +90,18 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $constraint = new Choice(array('choices' => array('foo', 'bar')));
 
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('bar', $constraint));
     }
 
     public function testValidChoiceCallbackFunction()
     {
         $constraint = new Choice(array('callback' => __NAMESPACE__.'\choice_callback'));
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
 
         $this->assertTrue($this->validator->isValid('bar', $constraint));
     }
@@ -97,6 +112,9 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             return array('foo', 'bar');
         }));
 
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('bar', $constraint));
     }
 
@@ -104,12 +122,18 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $constraint = new Choice(array('callback' => array(__CLASS__, 'staticCallback')));
 
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('bar', $constraint));
     }
 
     public function testValidChoiceCallbackContextMethod()
     {
         $constraint = new Choice(array('callback' => 'staticCallback'));
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
 
         $this->assertTrue($this->validator->isValid('bar', $constraint));
     }
@@ -121,6 +145,9 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'multiple' => true,
         ));
 
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(array('baz', 'bar'), $constraint));
     }
 
@@ -131,11 +158,13 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => 'baz',
+            ));
+
         $this->assertFalse($this->validator->isValid('baz', $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array(
-            '{{ value }}' => 'baz',
-        ));
     }
 
     public function testInvalidChoiceMultiple()
@@ -146,11 +175,13 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'multiple' => true,
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => 'baz',
+            ));
+
         $this->assertFalse($this->validator->isValid(array('foo', 'baz'), $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array(
-            '{{ value }}' => 'baz',
-        ));
     }
 
     public function testTooFewChoices()
@@ -162,11 +193,13 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'minMessage' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ limit }}' => 2,
+            ));
+
         $this->assertFalse($this->validator->isValid(array('foo'), $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array(
-            '{{ limit }}' => 2,
-        ));
     }
 
     public function testTooManyChoices()
@@ -178,36 +211,60 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'maxMessage' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ limit }}' => 2,
+            ));
+
         $this->assertFalse($this->validator->isValid(array('foo', 'bar', 'moo'), $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array(
-            '{{ limit }}' => 2,
-        ));
     }
 
-    public function testStrictIsFalse()
+    public function testNonStrict()
     {
         $constraint = new Choice(array(
             'choices' => array(1, 2),
             'strict' => false,
         ));
 
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('2', $constraint));
         $this->assertTrue($this->validator->isValid(2, $constraint));
     }
 
-    public function testStrictIsTrue()
+    public function testStrictAllowsExactValue()
     {
         $constraint = new Choice(array(
             'choices' => array(1, 2),
             'strict' => true,
         ));
 
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(2, $constraint));
+    }
+
+    public function testStrictDisallowsDifferentType()
+    {
+        $constraint = new Choice(array(
+            'choices' => array(1, 2),
+            'strict' => true,
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => '2',
+            ));
+
         $this->assertFalse($this->validator->isValid('2', $constraint));
     }
 
-    public function testStrictIsFalseWhenMultipleChoices()
+    public function testNonStrictWithMultipleChoices()
     {
         $constraint = new Choice(array(
             'choices' => array(1, 2, 3),
@@ -215,16 +272,26 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'strict' => false
         ));
 
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(array('2', 3), $constraint));
     }
 
-    public function testStrictIsTrueWhenMultipleChoices()
+    public function testStrictWithMultipleChoices()
     {
         $constraint = new Choice(array(
             'choices' => array(1, 2, 3),
             'multiple' => true,
-            'strict' => true
+            'strict' => true,
+            'multipleMessage' => 'myMessage',
         ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => '3',
+            ));
 
         $this->assertFalse($this->validator->isValid(array(2, '3'), $constraint));
     }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/CollectionValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/CollectionValidatorTest.php
@@ -59,7 +59,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
     public function testNullIsValid()
     {
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid(null, new Collection(array('fields' => array(
             'foo' => new Min(4),
@@ -71,7 +71,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $data = $this->prepareTestData(array('foo' => 'foobar'));
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, new Collection(array(
             'foo' => new Min(4),
@@ -107,7 +107,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $data = $this->prepareTestData($array);
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, new Collection(array(
             'fields' => array(
@@ -141,7 +141,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $data = $this->prepareTestData($array);
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, new Collection(array(
             'fields' => array(
@@ -159,7 +159,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->context->expects($this->once())
-            ->method('addViolationAtRelativePath')
+            ->method('addViolationAtSubPath')
             ->with('[baz]', 'myMessage', array(
                 '{{ field }}' => 'baz'
             ));
@@ -186,7 +186,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, $constraint));
     }
@@ -206,7 +206,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, $constraint));
     }
@@ -223,7 +223,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->context->expects($this->once())
-            ->method('addViolationAtRelativePath')
+            ->method('addViolationAtSubPath')
             ->with('[foo]', 'myMessage', array(
                 '{{ field }}' => 'foo',
             ));
@@ -243,7 +243,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, $constraint));
     }
@@ -255,7 +255,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, new Collection(array(
             'foo' => new Optional(),
@@ -267,7 +267,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $data = $this->prepareTestData(array());
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, new Collection(array(
             'foo' => new Optional(),
@@ -287,7 +287,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ->with($constraint, $array['foo'], 'MyGroup', 'foo.bar[foo]');
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $data = $this->prepareTestData($array);
 
@@ -314,7 +314,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $data = $this->prepareTestData($array);
 
@@ -330,7 +330,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $this->assertTrue($this->validator->isValid($data, new Collection(array(
             'foo' => new Required(),
@@ -342,7 +342,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $data = $this->prepareTestData(array());
 
         $this->context->expects($this->once())
-            ->method('addViolationAtRelativePath')
+            ->method('addViolationAtSubPath')
             ->with('[foo]', 'myMessage', array(
                 '{{ field }}' => 'foo',
             ));
@@ -368,7 +368,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ->with($constraint, $array['foo'], 'MyGroup', 'foo.bar[foo]');
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $data = $this->prepareTestData($array);
 
@@ -395,7 +395,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->context->expects($this->never())
-            ->method('addViolationAtRelativePath');
+            ->method('addViolationAtSubPath');
 
         $data = $this->prepareTestData($array);
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/CollectionValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/CollectionValidatorTest.php
@@ -127,12 +127,13 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testExtraFieldsDisallowed()
     {
-        $this->context->setPropertyPath('bar');
-
         $data = $this->prepareTestData(array(
             'foo' => 5,
             'baz' => 6,
         ));
+
+        $this->context->setCurrentValue($data);
+        $this->context->setPropertyPath('bar');
 
         $this->assertFalse($this->validator->isValid($data, new Collection(array(
             'fields' => array(
@@ -146,7 +147,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 array('{{ field }}' => '"baz"'),
                 'Root',
                 'bar[baz]',
-                $data
+                6
             ),
         )), $this->context->getViolations());
     }
@@ -184,8 +185,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testMissingFieldsDisallowed()
     {
-        $this->context->setPropertyPath('bar');
         $data = $this->prepareTestData(array());
+        $this->context->setCurrentValue($data);
+        $this->context->setPropertyPath('bar');
 
         $this->assertFalse($this->validator->isValid($data, new Collection(array(
             'fields' => array(
@@ -199,7 +201,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 array('{{ field }}' => '"foo"'),
                 'Root',
                 'bar[foo]',
-                $data
+                null
             ),
         )), $this->context->getViolations());
     }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/FalseValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/FalseValidatorTest.php
@@ -16,25 +16,35 @@ use Symfony\Component\Validator\Constraints\FalseValidator;
 
 class FalseValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new FalseValidator();
+        $this->validator->initialize($this->context);
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
     public function testNullIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(null, new False()));
     }
 
     public function testFalseIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(false, new False()));
     }
 
@@ -44,8 +54,10 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array());
+
         $this->assertFalse($this->validator->isValid(true, $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array());
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorObjectTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorObjectTest.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Validator\Constraints;
+
+use Symfony\Component\HttpFoundation\File\File;
+
+class FileValidatorObjectTest extends FileValidatorTest
+{
+    protected function getFile($filename)
+    {
+        return new File($filename);
+    }
+}

--- a/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorPathTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorPathTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraints\File;
+
+class FileValidatorPathTest extends FileValidatorTest
+{
+    protected function getFile($filename)
+    {
+        return $filename;
+    }
+
+    public function testFileNotFound()
+    {
+        $constraint = new File(array(
+            'notFoundMessage' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ file }}' => 'foobar',
+            ));
+
+        $this->assertFalse($this->validator->isValid('foobar', $constraint));
+    }
+}

--- a/tests/Symfony/Tests/Component/Validator/Constraints/ImageValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/ImageValidatorTest.php
@@ -16,33 +16,48 @@ use Symfony\Component\Validator\Constraints\ImageValidator;
 
 class ImageValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
     protected $path;
     protected $image;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new ImageValidator();
+        $this->validator->initialize($this->context);
         $this->image = __DIR__.'/Fixtures/test.gif';
     }
 
     public function testNullIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(null, new Image()));
     }
 
     public function testEmptyStringIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('', new Image()));
     }
 
     public function testValidImage()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid($this->image, new Image()));
     }
 
     public function testValidSize()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $constraint = new Image(array(
             'minWidth' => 1,
             'maxWidth' => 2,
@@ -60,12 +75,14 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'minWidthMessage' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ width }}' => '2',
+                '{{ min_width }}' => '3',
+            ));
+
         $this->assertFalse($this->validator->isValid($this->image, $constraint));
-        $this->assertEquals('myMessage', $this->validator->getMessageTemplate());
-        $this->assertEquals(array(
-            '{{ width }}' => '2',
-            '{{ min_width }}' => '3',
-        ), $this->validator->getMessageParameters());
     }
 
     public function testWidthTooBig()
@@ -75,12 +92,14 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxWidthMessage' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ width }}' => '2',
+                '{{ max_width }}' => '1',
+            ));
+
         $this->assertFalse($this->validator->isValid($this->image, $constraint));
-        $this->assertEquals('myMessage', $this->validator->getMessageTemplate());
-        $this->assertEquals(array(
-            '{{ width }}' => '2',
-            '{{ max_width }}' => '1',
-        ), $this->validator->getMessageParameters());
     }
 
     public function testHeightTooSmall()
@@ -90,12 +109,14 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'minHeightMessage' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ height }}' => '2',
+                '{{ min_height }}' => '3',
+            ));
+
         $this->assertFalse($this->validator->isValid($this->image, $constraint));
-        $this->assertEquals('myMessage', $this->validator->getMessageTemplate());
-        $this->assertEquals(array(
-            '{{ height }}' => '2',
-            '{{ min_height }}' => '3',
-        ), $this->validator->getMessageParameters());
     }
 
     public function testHeightTooBig()
@@ -105,12 +126,14 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxHeightMessage' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ height }}' => '2',
+                '{{ max_height }}' => '1',
+            ));
+
         $this->assertFalse($this->validator->isValid($this->image, $constraint));
-        $this->assertEquals('myMessage', $this->validator->getMessageTemplate());
-        $this->assertEquals(array(
-            '{{ height }}' => '2',
-            '{{ max_height }}' => '1',
-        ), $this->validator->getMessageParameters());
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Validator/Constraints/IpValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/IpValidatorTest.php
@@ -16,39 +16,51 @@ use Symfony\Component\Validator\Constraints\IpValidator;
 
 class IpValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new IpValidator();
+        $this->validator->initialize($this->context);
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
     public function testNullIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(null, new Ip()));
     }
 
     public function testEmptyStringIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('', new Ip()));
     }
 
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
     public function testExpectsStringCompatibleType()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
-
         $this->validator->isValid(new \stdClass(), new Ip());
     }
 
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
     public function testInvalidValidatorVersion()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
-
         $ip = new Ip(array(
             'version' => 666,
         ));
@@ -59,6 +71,9 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIpsV4($ip)
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid($ip, new Ip(array(
             'version' => Ip::V4,
         ))));
@@ -83,6 +98,9 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIpsV6($ip)
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid($ip, new Ip(array(
             'version' => Ip::V6,
         ))));
@@ -118,6 +136,9 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidIpsAll($ip)
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid($ip, new Ip(array(
             'version' => Ip::ALL,
         ))));
@@ -133,9 +154,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIpsV4($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V4,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidIpsV4()
@@ -158,9 +188,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidPrivateIpsV4($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V4_NO_PRIV,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidPrivateIpsV4()
@@ -177,9 +216,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidReservedIpsV4($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V4_NO_RES,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidReservedIpsV4()
@@ -196,9 +244,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidPublicIpsV4($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V4_ONLY_PUBLIC,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidPublicIpsV4()
@@ -211,9 +268,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIpsV6($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V6,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidIpsV6()
@@ -240,9 +306,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidPrivateIpsV6($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V6_NO_PRIV,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidPrivateIpsV6()
@@ -259,9 +334,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidReservedIpsV6($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V6_NO_RES,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidReservedIpsV6()
@@ -277,9 +361,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidPublicIpsV6($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::V6_ONLY_PUBLIC,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidPublicIpsV6()
@@ -292,9 +385,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidIpsAll($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::ALL,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidIpsAll()
@@ -307,9 +409,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidPrivateIpsAll($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::ALL_NO_PRIV,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidPrivateIpsAll()
@@ -322,9 +433,18 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidReservedIpsAll($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::ALL_NO_RES,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidReservedIpsAll()
@@ -337,26 +457,22 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidPublicIpsAll($ip)
     {
-        $this->assertFalse($this->validator->isValid($ip, new Ip(array(
+        $constraint = new Ip(array(
             'version' => Ip::ALL_ONLY_PUBLIC,
-        ))));
+            'message' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $ip,
+            ));
+
+        $this->assertFalse($this->validator->isValid($ip, $constraint));
     }
 
     public function getInvalidPublicIpsAll()
     {
         return array_merge($this->getInvalidPublicIpsV4(), $this->getInvalidPublicIpsV6());
-    }
-
-    public function testMessageIsSet()
-    {
-        $constraint = new Ip(array(
-            'message' => 'myMessage'
-        ));
-
-        $this->assertFalse($this->validator->isValid('foobar', $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array(
-            '{{ value }}' => 'foobar',
-        ));
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/MinLengthValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/MinLengthValidatorTest.php
@@ -16,44 +16,60 @@ use Symfony\Component\Validator\Constraints\MinLengthValidator;
 
 class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new MinLengthValidator();
+        $this->validator->initialize($this->context);
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
     public function testNullIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(null, new MinLength(array('limit' => 6))));
     }
 
     public function testEmptyStringIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('', new MinLength(array('limit' => 6))));
     }
 
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
     public function testExpectsStringCompatibleType()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
-
         $this->validator->isValid(new \stdClass(), new MinLength(array('limit' => 5)));
     }
 
     /**
      * @dataProvider getValidValues
      */
-    public function testValidValues($value, $skip = false)
+    public function testValidValues($value, $mbOnly = false)
     {
-        if (!$skip) {
-            $constraint = new MinLength(array('limit' => 6));
-            $this->assertTrue($this->validator->isValid($value, $constraint));
+        if ($mbOnly && !function_exists('mb_strlen')) {
+            return $this->markTestSkipped('mb_strlen does not exist');
         }
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $constraint = new MinLength(array('limit' => 6));
+        $this->assertTrue($this->validator->isValid($value, $constraint));
     }
 
     public function getValidValues()
@@ -61,45 +77,43 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
         return array(
             array(123456),
             array('123456'),
-            array('üüüüüü', !function_exists('mb_strlen')),
-            array('éééééé', !function_exists('mb_strlen')),
+            array('üüüüüü', true),
+            array('éééééé', true),
         );
     }
 
     /**
      * @dataProvider getInvalidValues
      */
-    public function testInvalidValues($value, $skip = false)
+    public function testInvalidValues($value, $mbOnly = false)
     {
-        if (!$skip) {
-            $constraint = new MinLength(array('limit' => 6));
-            $this->assertFalse($this->validator->isValid($value, $constraint));
+        if ($mbOnly && !function_exists('mb_strlen')) {
+            return $this->markTestSkipped('mb_strlen does not exist');
         }
+
+        $constraint = new MinLength(array(
+            'limit' => 5,
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $value,
+                '{{ limit }}' => 5,
+            ));
+
+        $this->assertFalse($this->validator->isValid($value, $constraint));
     }
 
     public function getInvalidValues()
     {
         return array(
-            array(12345),
-            array('12345'),
-            array('üüüüü', !function_exists('mb_strlen')),
-            array('ééééé', !function_exists('mb_strlen')),
+            array(1234),
+            array('1234'),
+            array('üüüü', true),
+            array('éééé', true),
         );
-    }
-
-    public function testMessageIsSet()
-    {
-        $constraint = new MinLength(array(
-            'limit' => 5,
-            'message' => 'myMessage'
-            ));
-
-        $this->assertFalse($this->validator->isValid('1234', $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array(
-            '{{ value }}' => '1234',
-            '{{ limit }}' => 5,
-        ));
     }
 
     public function testConstraintGetDefaultOption()

--- a/tests/Symfony/Tests/Component/Validator/Constraints/NotBlankValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/NotBlankValidatorTest.php
@@ -16,15 +16,19 @@ use Symfony\Component\Validator\Constraints\NotBlankValidator;
 
 class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new NotBlankValidator();
+        $this->validator->initialize($this->context);
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
@@ -33,6 +37,9 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValues($date)
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid($date, new NotBlank()));
     }
 
@@ -49,33 +56,54 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testNullIsInvalid()
     {
-        $this->assertFalse($this->validator->isValid(null, new NotBlank()));
+        $constraint = new NotBlank(array(
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage');
+
+        $this->assertFalse($this->validator->isValid(null, $constraint));
     }
 
     public function testBlankIsInvalid()
-    {
-        $this->assertFalse($this->validator->isValid('', new NotBlank()));
-    }
-
-    public function testFalseIsInvalid()
-    {
-        $this->assertFalse($this->validator->isValid(false, new NotBlank()));
-    }
-
-    public function testEmptyArrayIsInvalid()
-    {
-        $this->assertFalse($this->validator->isValid(array(), new NotBlank()));
-    }
-
-    public function testSetMessage()
     {
         $constraint = new NotBlank(array(
             'message' => 'myMessage'
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage');
+
         $this->assertFalse($this->validator->isValid('', $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array());
+    }
+
+    public function testFalseIsInvalid()
+    {
+        $constraint = new NotBlank(array(
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage');
+
+        $this->assertFalse($this->validator->isValid(false, $constraint));
+    }
+
+    public function testEmptyArrayIsInvalid()
+    {
+        $constraint = new NotBlank(array(
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage');
+
+        $this->assertFalse($this->validator->isValid(array(), $constraint));
     }
 }
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/NotNullValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/NotNullValidatorTest.php
@@ -16,15 +16,19 @@ use Symfony\Component\Validator\Constraints\NotNullValidator;
 
 class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new NotNullValidator();
+        $this->validator->initialize($this->context);
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
@@ -33,6 +37,9 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidValues($value)
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid($value, new NotNull()));
     }
 
@@ -52,8 +59,11 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+            ));
+
         $this->assertFalse($this->validator->isValid(null, $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array());
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/SizeLengthValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/SizeLengthValidatorTest.php
@@ -2,12 +2,12 @@
 
 /*
  * This file is part of the Symfony package.
- *
- * (c) Fabien Potencier <fabien@symfony.com>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
 
 namespace Symfony\Tests\Component\Validator\Constraints;
 
@@ -16,44 +16,60 @@ use Symfony\Component\Validator\Constraints\SizeLengthValidator;
 
 class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new SizeLengthValidator();
+        $this->validator->initialize($this->context);
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
     public function testNullIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(null, new SizeLength(array('min' => 6, 'max' => 10))));
     }
 
     public function testEmptyStringIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid('', new SizeLength(array('min' => 6, 'max' => 10))));
     }
 
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\UnexpectedTypeException
+     */
     public function testExpectsStringCompatibleType()
     {
-        $this->setExpectedException('Symfony\Component\Validator\Exception\UnexpectedTypeException');
-
         $this->validator->isValid(new \stdClass(), new SizeLength(array('min' => 6, 'max' => 10)));
     }
 
     /**
      * @dataProvider getValidValues
      */
-    public function testValidValues($value, $skip = false)
+    public function testValidValues($value, $mbOnly = false)
     {
-        if (!$skip) {
-            $constraint = new SizeLength(array('min' => 6, 'max' => 10));
-            $this->assertTrue($this->validator->isValid($value, $constraint));
+        if ($mbOnly && !function_exists('mb_strlen')) {
+            return $this->markTestSkipped('mb_strlen does not exist');
         }
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $constraint = new SizeLength(array('min' => 6, 'max' => 10));
+        $this->assertTrue($this->validator->isValid($value, $constraint));
     }
 
     public function getValidValues()
@@ -63,22 +79,27 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
             array(1234567890),
             array('123456'),
             array('1234567890'),
-            array('üüüüüü', !function_exists('mb_strlen')),
-            array('üüüüüüüüüü', !function_exists('mb_strlen')),
-            array('éééééé', !function_exists('mb_strlen')),
-            array('éééééééééé', !function_exists('mb_strlen')),
+            array('üüüüüü', true),
+            array('üüüüüüüüüü', true),
+            array('éééééé', true),
+            array('éééééééééé', true),
         );
     }
 
     /**
      * @dataProvider getInvalidValues
      */
-    public function testInvalidValues($value, $skip = false)
+    public function testInvalidValues($value, $mbOnly = false)
     {
-        if (!$skip) {
-            $constraint = new SizeLength(array('min' => 6, 'max' => 10));
-            $this->assertFalse($this->validator->isValid($value, $constraint));
+        if ($mbOnly && !function_exists('mb_strlen')) {
+            return $this->markTestSkipped('mb_strlen does not exist');
         }
+
+        $this->context->expects($this->once())
+            ->method('addViolation');
+
+        $constraint = new SizeLength(array('min' => 6, 'max' => 10));
+        $this->assertFalse($this->validator->isValid($value, $constraint));
     }
 
     public function getInvalidValues()
@@ -88,49 +109,64 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
             array(12345678901),
             array('12345'),
             array('12345678901'),
-            array('üüüüü', !function_exists('mb_strlen')),
-            array('üüüüüüüüüüü', !function_exists('mb_strlen')),
-            array('ééééé', !function_exists('mb_strlen')),
-            array('ééééééééééé', !function_exists('mb_strlen')),
+            array('üüüüü', true),
+            array('üüüüüüüüüüü', true),
+            array('ééééé', true),
+            array('ééééééééééé', true),
         );
     }
 
-    public function testMessageIsSet()
+    public function testMinMessageIsSet()
     {
         $constraint = new SizeLength(array(
             'min' => 5,
             'max' => 10,
-            'minMessage' => 'myMinMessage',
-            'maxMessage' => 'myMaxMessage',
+            'minMessage' => 'myMessage',
         ));
 
-        $this->assertFalse($this->validator->isValid('1234', $constraint));
-        $this->assertEquals('myMinMessage', $this->validator->getMessageTemplate());
-        $this->assertEquals(array(
-            '{{ value }}' => '1234',
-            '{{ limit }}' => 5,
-        ), $this->validator->getMessageParameters());
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => '1234',
+                '{{ limit }}' => 5,
+            ));
 
-        $this->assertFalse($this->validator->isValid('12345678901', $constraint));
-        $this->assertEquals('myMaxMessage', $this->validator->getMessageTemplate());
-        $this->assertEquals(array(
-            '{{ value }}' => '12345678901',
-            '{{ limit }}' => 10,
-        ), $this->validator->getMessageParameters());
+        $this->assertFalse($this->validator->isValid('1234', $constraint));
     }
 
-    public function testExactErrorMessage()
+    public function testMaxMessageIsSet()
+    {
+        $constraint = new SizeLength(array(
+            'min' => 5,
+            'max' => 10,
+            'maxMessage' => 'myMessage',
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => '12345678901',
+                '{{ limit }}' => 10,
+            ));
+
+        $this->assertFalse($this->validator->isValid('12345678901', $constraint));
+    }
+
+    public function testExactMessageIsSet()
     {
         $constraint = new SizeLength(array(
             'min' => 5,
             'max' => 5,
+            'exactMessage' => 'myMessage',
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => '1234',
+                '{{ limit }}' => 5,
+            ));
+
         $this->assertFalse($this->validator->isValid('1234', $constraint));
-        $this->assertEquals('This value should have exactly {{ limit }} characters', $this->validator->getMessageTemplate());
-        $this->assertEquals(array(
-            '{{ value }}' => '1234',
-            '{{ limit }}' => 5,
-        ), $this->validator->getMessageParameters());
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/Constraints/TrueValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/TrueValidatorTest.php
@@ -16,25 +16,35 @@ use Symfony\Component\Validator\Constraints\TrueValidator;
 
 class TrueValidatorTest extends \PHPUnit_Framework_TestCase
 {
+    protected $context;
     protected $validator;
 
     protected function setUp()
     {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new TrueValidator();
+        $this->validator->initialize($this->context);
     }
 
     protected function tearDown()
     {
+        $this->context = null;
         $this->validator = null;
     }
 
     public function testNullIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(null, new True()));
     }
 
     public function testTrueIsValid()
     {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
         $this->assertTrue($this->validator->isValid(true, new True()));
     }
 
@@ -44,8 +54,11 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
             'message' => 'myMessage'
         ));
 
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+            ));
+
         $this->assertFalse($this->validator->isValid(false, $constraint));
-        $this->assertEquals($this->validator->getMessageTemplate(), 'myMessage');
-        $this->assertEquals($this->validator->getMessageParameters(), array());
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
@@ -11,6 +11,10 @@
 
 namespace Symfony\Tests\Component\Validator;
 
+use Symfony\Component\Validator\ConstraintViolation;
+
+use Symfony\Component\Validator\ConstraintViolationList;
+
 use Symfony\Component\Validator\ExecutionContext;
 
 class ExecutionContextTest extends \PHPUnit_Framework_TestCase
@@ -43,9 +47,119 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
     public function testAddViolation()
     {
         $this->assertCount(0, $this->context->getViolations());
-        $this->context->addViolation('', array(), '');
 
-        $this->assertCount(1, $this->context->getViolations());
+        $this->context->setPropertyPath('foo.bar');
+        $this->context->addViolation('Error', array('foo' => 'bar'), 'invalid');
+
+        $this->assertEquals(new ConstraintViolationList(array(
+            new ConstraintViolation(
+                'Error',
+                array('foo' => 'bar'),
+                'Root',
+                'foo.bar',
+                'invalid'
+            ),
+        )), $this->context->getViolations());
+    }
+
+    public function testAddViolationUsesPreconfiguredValueIfNotPassed()
+    {
+        $this->assertCount(0, $this->context->getViolations());
+
+        $this->context->setPropertyPath('foo.bar');
+        $this->context->setCurrentValue('invalid');
+        $this->context->addViolation('Error');
+
+        $this->assertEquals(new ConstraintViolationList(array(
+            new ConstraintViolation(
+                'Error',
+                array(),
+                'Root',
+                'foo.bar',
+                'invalid'
+            ),
+        )), $this->context->getViolations());
+    }
+
+    public function testAddViolationUsesPassedNulValue()
+    {
+        $this->assertCount(0, $this->context->getViolations());
+
+        $this->context->setPropertyPath('foo.bar');
+        $this->context->setCurrentValue('invalid');
+
+        // passed null value should override preconfigured value "invalid"
+        $this->context->addViolation('Error', array('foo' => 'bar'), null);
+
+        $this->assertEquals(new ConstraintViolationList(array(
+            new ConstraintViolation(
+                'Error',
+                array('foo' => 'bar'),
+                'Root',
+                'foo.bar',
+                null
+            ),
+        )), $this->context->getViolations());
+    }
+
+    public function testAddViolationAt()
+    {
+        $this->assertCount(0, $this->context->getViolations());
+
+        $this->context->setPropertyPath('foo.bar');
+
+        // override preconfigured property path
+        $this->context->addViolationAt('bar.baz', 'Error', array('foo' => 'bar'), 'invalid');
+
+        $this->assertEquals(new ConstraintViolationList(array(
+            new ConstraintViolation(
+                'Error',
+                array('foo' => 'bar'),
+                'Root',
+                'bar.baz',
+                'invalid'
+            ),
+        )), $this->context->getViolations());
+    }
+
+    public function testAddViolationAtUsesPreconfiguredValueIfNotPassed()
+    {
+        $this->assertCount(0, $this->context->getViolations());
+
+        $this->context->setPropertyPath('foo.bar');
+        $this->context->setCurrentValue('invalid');
+        $this->context->addViolationAt('bar.baz', 'Error');
+
+        $this->assertEquals(new ConstraintViolationList(array(
+            new ConstraintViolation(
+                'Error',
+                array(),
+                'Root',
+                'bar.baz',
+                'invalid'
+            ),
+        )), $this->context->getViolations());
+    }
+
+    public function testAddViolationAtUsesPassedNulValue()
+    {
+        $this->assertCount(0, $this->context->getViolations());
+
+        $this->context->setPropertyPath('foo.bar');
+        $this->context->setCurrentValue('invalid');
+
+        // passed null value should override preconfigured value "invalid"
+        $this->context->addViolationAt('bar.baz', 'Error', array('foo' => 'bar'), null);
+
+        $this->assertEquals(new ConstraintViolationList(array(
+            new ConstraintViolation(
+                'Error',
+                array('foo' => 'bar'),
+                'Root',
+                'bar.baz',
+                null
+            ),
+        )), $this->context->getViolations());
     }
 
     public function testGetViolations()

--- a/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
@@ -89,7 +89,7 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationUsesPassedNulValue()
+    public function testAddViolationUsesPassedNullValue()
     {
         // passed null value should override preconfigured value "invalid"
         $this->context->addViolation('Error', array('foo' => 'bar'), null);
@@ -136,7 +136,7 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationAtUsesPassedNulValue()
+    public function testAddViolationAtUsesPassedNullValue()
     {
         // passed null value should override preconfigured value "invalid"
         $this->context->addViolationAt('bar.baz', 'Error', array('foo' => 'bar'), null);
@@ -233,7 +233,7 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddNestedViolationAtUsesPassedNulValue()
+    public function testAddNestedViolationAtUsesPassedNullValue()
     {
         // passed null value should override preconfigured value "invalid"
         $this->context->addNestedViolationAt('bam.baz', 'Error', array('foo' => 'bar'), null);

--- a/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
@@ -98,9 +98,9 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         $violations = $this->context->getViolations();
 
         $expected = <<<EOF
-Root.:
+Root:
     Message 1
-Root.:
+Root:
     Message 2
 
 EOF;

--- a/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
@@ -105,10 +105,10 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationAt()
+    public function testAddViolationAtPath()
     {
         // override preconfigured property path
-        $this->context->addViolationAt('bar.baz', 'Error', array('foo' => 'bar'), 'invalid');
+        $this->context->addViolationAtPath('bar.baz', 'Error', array('foo' => 'bar'), 'invalid');
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
@@ -121,9 +121,9 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationAtUsesPreconfiguredValueIfNotPassed()
+    public function testAddViolationAtPathUsesPreconfiguredValueIfNotPassed()
     {
-        $this->context->addViolationAt('bar.baz', 'Error');
+        $this->context->addViolationAtPath('bar.baz', 'Error');
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
@@ -136,10 +136,10 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationAtUsesPassedNullValue()
+    public function testAddViolationAtPathUsesPassedNullValue()
     {
         // passed null value should override preconfigured value "invalid"
-        $this->context->addViolationAt('bar.baz', 'Error', array('foo' => 'bar'), null);
+        $this->context->addViolationAtPath('bar.baz', 'Error', array('foo' => 'bar'), null);
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
@@ -152,10 +152,10 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddNestedViolationAt()
+    public function testAddViolationAtRelativePath()
     {
         // override preconfigured property path
-        $this->context->addNestedViolationAt('bam.baz', 'Error', array('foo' => 'bar'), 'invalid');
+        $this->context->addViolationAtRelativePath('bam.baz', 'Error', array('foo' => 'bar'), 'invalid');
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
@@ -168,84 +168,51 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddNestedViolationAtWithIndexPath()
+    public function testAddViolationAtRelativePathUsesPreconfiguredValueIfNotPassed()
     {
-        // override preconfigured property path
-        $this->context->addNestedViolationAt('[bam]', 'Error', array('foo' => 'bar'), 'invalid');
+        $this->context->addViolationAtRelativePath('bam.baz', 'Error');
+
+        $this->assertEquals(new ConstraintViolationList(array(
+            new ConstraintViolation(
+                'Error',
+                array(),
+                'Root',
+                'foo.bar.bam.baz',
+                'currentValue'
+            ),
+        )), $this->context->getViolations());
+    }
+
+    public function testAddViolationAtRelativePathUsesPassedNullValue()
+    {
+        // passed null value should override preconfigured value "invalid"
+        $this->context->addViolationAtRelativePath('bam.baz', 'Error', array('foo' => 'bar'), null);
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
                 'Error',
                 array('foo' => 'bar'),
                 'Root',
-                'foo.bar[bam]',
-                'invalid'
+                'foo.bar.bam.baz',
+                null
             ),
         )), $this->context->getViolations());
     }
 
-    public function testAddNestedViolationAtWithEmptyPath()
+    public function testGetAbsolutePropertyPathWithIndexPath()
     {
-        // override preconfigured property path
-        $this->context->addNestedViolationAt('', 'Error', array('foo' => 'bar'), 'invalid');
-
-        $this->assertEquals(new ConstraintViolationList(array(
-            new ConstraintViolation(
-                'Error',
-                array('foo' => 'bar'),
-                'Root',
-                'foo.bar',
-                'invalid'
-            ),
-        )), $this->context->getViolations());
+        $this->assertEquals('foo.bar[bam]', $this->context->getAbsolutePropertyPath('[bam]'));
     }
 
-    public function testAddNestedViolationAtWithEmptyCurrentPropertyPath()
+    public function testGetAbsolutePropertyPathWithEmptyPath()
+    {
+        $this->assertEquals('foo.bar', $this->context->getAbsolutePropertyPath(''));
+    }
+
+    public function testGetAbsolutePropertyPathWithEmptyCurrentPropertyPath()
     {
         $this->context = new ExecutionContext($this->globalContext, 'currentValue', '', 'Group', 'ClassName', 'propertyName');
 
-        // override preconfigured property path
-        $this->context->addNestedViolationAt('bam.baz', 'Error', array('foo' => 'bar'), 'invalid');
-
-        $this->assertEquals(new ConstraintViolationList(array(
-            new ConstraintViolation(
-                'Error',
-                array('foo' => 'bar'),
-                'Root',
-                'bam.baz',
-                'invalid'
-            ),
-        )), $this->context->getViolations());
-    }
-
-    public function testAddNestedViolationAtUsesPreconfiguredValueIfNotPassed()
-    {
-        $this->context->addNestedViolationAt('bam.baz', 'Error');
-
-        $this->assertEquals(new ConstraintViolationList(array(
-            new ConstraintViolation(
-                'Error',
-                array(),
-                'Root',
-                'foo.bar.bam.baz',
-                'currentValue'
-            ),
-        )), $this->context->getViolations());
-    }
-
-    public function testAddNestedViolationAtUsesPassedNullValue()
-    {
-        // passed null value should override preconfigured value "invalid"
-        $this->context->addNestedViolationAt('bam.baz', 'Error', array('foo' => 'bar'), null);
-
-        $this->assertEquals(new ConstraintViolationList(array(
-            new ConstraintViolation(
-                'Error',
-                array('foo' => 'bar'),
-                'Root',
-                'foo.bar.bam.baz',
-                null
-            ),
-        )), $this->context->getViolations());
+        $this->assertEquals('bam.baz', $this->context->getAbsolutePropertyPath('bam.baz'));
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ExecutionContextTest.php
@@ -152,10 +152,10 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationAtRelativePath()
+    public function testAddViolationAtSubPath()
     {
         // override preconfigured property path
-        $this->context->addViolationAtRelativePath('bam.baz', 'Error', array('foo' => 'bar'), 'invalid');
+        $this->context->addViolationAtSubPath('bam.baz', 'Error', array('foo' => 'bar'), 'invalid');
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
@@ -168,9 +168,9 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationAtRelativePathUsesPreconfiguredValueIfNotPassed()
+    public function testAddViolationAtSubPathUsesPreconfiguredValueIfNotPassed()
     {
-        $this->context->addViolationAtRelativePath('bam.baz', 'Error');
+        $this->context->addViolationAtSubPath('bam.baz', 'Error');
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
@@ -183,10 +183,10 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testAddViolationAtRelativePathUsesPassedNullValue()
+    public function testAddViolationAtSubPathUsesPassedNullValue()
     {
         // passed null value should override preconfigured value "invalid"
-        $this->context->addViolationAtRelativePath('bam.baz', 'Error', array('foo' => 'bar'), null);
+        $this->context->addViolationAtSubPath('bam.baz', 'Error', array('foo' => 'bar'), null);
 
         $this->assertEquals(new ConstraintViolationList(array(
             new ConstraintViolation(
@@ -199,20 +199,25 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
-    public function testGetAbsolutePropertyPathWithIndexPath()
+    public function testGetPropertyPath()
     {
-        $this->assertEquals('foo.bar[bam]', $this->context->getAbsolutePropertyPath('[bam]'));
+        $this->assertEquals('foo.bar', $this->context->getPropertyPath());
     }
 
-    public function testGetAbsolutePropertyPathWithEmptyPath()
+    public function testGetPropertyPathWithIndexPath()
     {
-        $this->assertEquals('foo.bar', $this->context->getAbsolutePropertyPath(''));
+        $this->assertEquals('foo.bar[bam]', $this->context->getPropertyPath('[bam]'));
     }
 
-    public function testGetAbsolutePropertyPathWithEmptyCurrentPropertyPath()
+    public function testGetPropertyPathWithEmptyPath()
+    {
+        $this->assertEquals('foo.bar', $this->context->getPropertyPath(''));
+    }
+
+    public function testGetPropertyPathWithEmptyCurrentPropertyPath()
     {
         $this->context = new ExecutionContext($this->globalContext, 'currentValue', '', 'Group', 'ClassName', 'propertyName');
 
-        $this->assertEquals('bam.baz', $this->context->getAbsolutePropertyPath('bam.baz'));
+        $this->assertEquals('bam.baz', $this->context->getPropertyPath('bam.baz'));
     }
 }

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/ConstraintAValidator.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/ConstraintAValidator.php
@@ -20,7 +20,7 @@ class ConstraintAValidator extends ConstraintValidator
     public function isValid($value, Constraint $constraint)
     {
         if ('VALID' != $value) {
-            $this->setMessage('message', array('param' => 'value'));
+            $this->context->addViolation('message', array('param' => 'value'));
 
             return false;
         }

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/ConstraintAValidator.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/ConstraintAValidator.php
@@ -4,9 +4,19 @@ namespace Symfony\Tests\Component\Validator\Fixtures;
 
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\ExecutionContext;
 
 class ConstraintAValidator extends ConstraintValidator
 {
+    static public $passedContext;
+
+    public function initialize(ExecutionContext $context)
+    {
+        parent::initialize($context);
+
+        self::$passedContext = $context;
+    }
+
     public function isValid($value, Constraint $constraint)
     {
         if ('VALID' != $value) {

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/FailingConstraint.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/FailingConstraint.php
@@ -6,7 +6,7 @@ use Symfony\Component\Validator\Constraint;
 
 class FailingConstraint extends Constraint
 {
-    public $message = '';
+    public $message = 'Failed';
 
     public function getTargets()
     {

--- a/tests/Symfony/Tests/Component/Validator/Fixtures/FailingConstraintValidator.php
+++ b/tests/Symfony/Tests/Component/Validator/Fixtures/FailingConstraintValidator.php
@@ -9,7 +9,7 @@ class FailingConstraintValidator extends ConstraintValidator
 {
     public function isValid($value, Constraint $constraint)
     {
-        $this->setMessage($constraint->message, array());
+        $this->context->addViolation($constraint->message, array());
 
         return false;
     }

--- a/tests/Symfony/Tests/Component/Validator/GlobalExecutionContextTest.php
+++ b/tests/Symfony/Tests/Component/Validator/GlobalExecutionContextTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Validator;
+
+use Symfony\Component\Validator\ConstraintViolation;
+
+use Symfony\Component\Validator\ConstraintViolationList;
+
+use Symfony\Component\Validator\GlobalExecutionContext;
+
+class GlobalExecutionContextTest extends \PHPUnit_Framework_TestCase
+{
+    protected $walker;
+    protected $metadataFactory;
+    protected $context;
+
+    protected function setUp()
+    {
+        $this->walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
+        $this->metadataFactory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
+        $this->context = new GlobalExecutionContext('Root', $this->walker, $this->metadataFactory);
+    }
+
+    protected function tearDown()
+    {
+        $this->walker = null;
+        $this->metadataFactory = null;
+        $this->context = null;
+    }
+
+    public function testInit()
+    {
+        $this->assertCount(0, $this->context->getViolations());
+        $this->assertSame('Root', $this->context->getRoot());
+        $this->assertSame($this->walker, $this->context->getGraphWalker());
+        $this->assertSame($this->metadataFactory, $this->context->getMetadataFactory());
+    }
+
+    public function testClone()
+    {
+        $clone = clone $this->context;
+
+        $this->assertNotSame($this->context->getViolations(), $clone->getViolations());
+    }
+
+    public function testAddViolation()
+    {
+        $violation = new ConstraintViolation('Error', array(), 'Root', 'foo.bar', 'invalid');
+
+        $this->context->addViolation($violation);
+
+        $this->assertEquals(new ConstraintViolationList(array($violation)), $this->context->getViolations());
+    }
+}

--- a/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
+++ b/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
@@ -58,9 +58,11 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
     {
         $this->metadata->addConstraint(new ConstraintA());
 
-        $this->walker->walkObject($this->metadata, new Entity(), 'Default', '');
+        $entity = new Entity();
+        $this->walker->walkObject($this->metadata, $entity, 'Default', '');
 
         $this->assertEquals('Symfony\Tests\Component\Validator\Fixtures\Entity', $this->getContext()->getCurrentClass());
+        $this->assertEquals($entity, $this->getContext()->getCurrentValue());
     }
 
     public function testWalkObjectValidatesConstraints()
@@ -220,6 +222,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Symfony\Tests\Component\Validator\Fixtures\Entity', $this->getContext()->getCurrentClass());
         $this->assertEquals('firstName', $this->getContext()->getCurrentProperty());
+        $this->assertEquals('value', $this->getContext()->getCurrentValue());
     }
 
     public function testWalkPropertyValueValidatesConstraints()

--- a/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
+++ b/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
@@ -143,7 +143,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
         // validated
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             'Root',
             'firstName',
@@ -175,7 +175,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
         // "Default" was launched
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             'Root',
             'reference',
@@ -202,7 +202,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
         // Only group "Second" was validated
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             'Root',
             'lastName',
@@ -254,7 +254,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
 
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             'Root',
             'path',
@@ -286,7 +286,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
 
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             'Root',
             'path[key]',
@@ -319,7 +319,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
 
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             'Root',
             'path[key]',

--- a/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
+++ b/tests/Symfony/Tests/Component/Validator/GraphWalkerTest.php
@@ -441,7 +441,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
 
         $this->walker->walkConstraint($constraint, array('foo' => 'VALID'), 'Default', 'collection');
         $violations = $this->walker->getViolations();
-        $this->assertEquals('collection', $violations[0]->getPropertyPath());
+        $this->assertEquals('collection[bar]', $violations[0]->getPropertyPath());
     }
 
     public function testWalkObjectUsesCorrectPropertyPathInViolationsWhenUsingNestedCollections()
@@ -455,7 +455,7 @@ class GraphWalkerTest extends \PHPUnit_Framework_TestCase
 
         $this->walker->walkConstraint($constraint, array('foo' => array('foo' => 'VALID')), 'Default', 'collection');
         $violations = $this->walker->getViolations();
-        $this->assertEquals('collection[foo]', $violations[0]->getPropertyPath());
+        $this->assertEquals('collection[foo][bar]', $violations[0]->getPropertyPath());
     }
 
     protected function getContext()

--- a/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
@@ -148,9 +148,16 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testValidateValue()
     {
-        $result = $this->validator->validateValue('Bernhard', new FailingConstraint());
+        $violations = new ConstraintViolationList();
+        $violations->add(new ConstraintViolation(
+            '',
+            array(),
+            '',
+            '',
+            'Bernhard'
+        ));
 
-        $this->assertCount(1, $result);
+        $this->assertEquals($violations, $this->validator->validateValue('Bernhard', new FailingConstraint()));
     }
 
     public function testGetMetadataFactory()

--- a/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ValidatorTest.php
@@ -55,7 +55,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         // Only the constraint of group "Default" failed
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             $entity,
             'firstName',
@@ -78,7 +78,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         // Only the constraint of group "Custom" failed
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             $entity,
             'lastName',
@@ -103,14 +103,14 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         // The constraints of both groups failed
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             $entity,
             'firstName',
             ''
         ));
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             $entity,
             'lastName',
@@ -150,7 +150,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $violations = new ConstraintViolationList();
         $violations->add(new ConstraintViolation(
-            '',
+            'Failed',
             array(),
             '',
             '',


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2615
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue2615)

Instead of a single violation

```
Array:
    The fields "foo", "bar" are missing
```

various violations are now generated.

```
Array[foo]:
    This field is missing
Array[bar]:
    This field is missing
```

Apart from that, the PR contains various minor fixes to the Validator.
