### PR TITLE
Fixing typo in XLIFF Dumper

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -88,7 +88,7 @@
             <tag name="translation.dumper" alias="php" />
         </service>
 
-        <service id="tranlsation.dumper.xliff" class="%translation.dumper.xliff.class%">
+        <service id="translation.dumper.xliff" class="%translation.dumper.xliff.class%">
             <tag name="translation.dumper" alias="xlf" />
         </service>
 


### PR DESCRIPTION
There was a typo in the service name for the XLIFF Dumper
