### PR TITLE
fix for entity choice list when ->loaded is false and the class name is ...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -79,9 +79,9 @@ class EntityChoiceList extends ObjectChoiceList
     public function __construct(ObjectManager $manager, $class, $labelPath = null, EntityLoaderInterface $entityLoader = null, $entities = null, $groupPath = null)
     {
         $this->em = $manager;
-        $this->class = $class;
         $this->entityLoader = $entityLoader;
         $this->classMetadata = $manager->getClassMetadata($class);
+        $this->class = $this->classMetadata->getName();
         $this->identifier = $this->classMetadata->getIdentifierFieldNames();
         $this->loaded = is_array($entities) || $entities instanceof \Traversable;
 

--- a/tests/Symfony/Tests/Bridge/Doctrine/DoctrineOrmTestCase.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DoctrineOrmTestCase.php
@@ -33,6 +33,7 @@ abstract class DoctrineOrmTestCase extends \PHPUnit_Framework_TestCase
             self::markTestSkipped('This test requires SQLite support in your environment');
         }
         $config = new \Doctrine\ORM\Configuration();
+        $config->setEntityNamespaces(array('SymfonyTestsDoctrine' => 'Symfony\Tests\Bridge\Doctrine\Fixtures'));
         $config->setAutoGenerateProxyClasses(true);
         $config->setProxyDir(\sys_get_temp_dir());
         $config->setProxyNamespace('SymfonyTests\Doctrine');

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/EntityChoiceListTest.php
@@ -202,21 +202,24 @@ class EntityChoiceListTest extends DoctrineOrmTestCase
 
     public function testPossibleToProvideShorthandEntityName()
     {
-        $shorthandName = 'FooBarBundle:Bar';
+        $shorthandName = 'SymfonyTestsDoctrine:SingleIdentEntity';
 
-        $metadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')->disableOriginalConstructor()->getMock();
-        $metadata->expects($this->any())->method('getName')->will($this->returnValue('Symfony\Tests\Bridge\Doctrine\Fixtures\SingleIdentEntity'));
+        $item1 = new SingleIdentEntity(1, 'Foo');
+        $item2 = new SingleIdentEntity(2, 'Bar');
 
-        $em = $this->getMock('Doctrine\Common\Persistence\ObjectManager');
-        $em->expects($this->once())->method('getClassMetaData')->with($shorthandName)->will($this->returnValue($metadata));
+        $this->em->persist($item1);
+        $this->em->persist($item2);
 
         $choiceList = new EntityChoiceList(
-            $em,
+            $this->em,
             $shorthandName,
             null,
             null,
             null,
             null
         );
+
+        $this->assertEquals(array(1, 2), $choiceList->getValuesForChoices(array($item1, $item2)));
+        $this->assertEquals(array(1, 2), $choiceList->getIndicesForChoices(array($item1, $item2)));
     }
 }


### PR DESCRIPTION
...an entity shorthand name

This bug was reintroduced after the latest choicelist refactoring and was originally fixed in 231e79ce0fa4bab295d8d347205fda0b6b468323
