### PR TITLE
Avoid Client eating exceptions - fixes issue #3237

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -79,7 +79,7 @@ class Client extends BaseClient
             $this->hasPerformedRequest = true;
         }
 
-        return $this->kernel->handle($request);
+        return $this->kernel->handle($request, HttpKernelInterface::MASTER_REQUEST, false);
     }
 
     /**


### PR DESCRIPTION
Pass $catch=false when calling kernel->handle from FrameworkBundle\Client to avoid the kernel eating exceptions that may be thrown during controller execution.
