### PR TITLE
Fix % parameter escaping

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -138,8 +138,7 @@ class ParameterBag implements ParameterBagInterface
         $parameters = array();
         foreach ($this->parameters as $key => $value) {
             try {
-                $value = $this->resolveValue($value);
-                $parameters[$key] = is_string($value) ? str_replace('%%', '%', $value) : $value;
+                $parameters[$key] = $this->resolveValue($value);
             } catch (ParameterNotFoundException $e) {
                 $e->setSourceKey($key);
 
@@ -212,7 +211,7 @@ class ParameterBag implements ParameterBagInterface
 
         $self = $this;
 
-        return preg_replace_callback('/(?<!%)%([^%\s]+)%/', function ($match) use ($self, $resolving, $value) {
+        $value = preg_replace_callback('/(?<!%)%([^%\s]+)%/', function ($match) use ($self, $resolving, $value) {
             $key = strtolower($match[1]);
             if (isset($resolving[$key])) {
                 throw new ParameterCircularReferenceException(array_keys($resolving));
@@ -229,6 +228,8 @@ class ParameterBag implements ParameterBagInterface
 
             return $self->isResolved() ? $resolved : $self->resolveString($resolved, $resolving);
         }, $value);
+
+        return str_replace('%%', '%', $value);;
     }
 
     public function isResolved()

--- a/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
@@ -92,8 +92,9 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('I\'m a bar', $bag->resolveValue('I\'m a %foo%'), '->resolveValue() replaces placeholders by their values');
         $this->assertEquals(array('bar' => 'bar'), $bag->resolveValue(array('%foo%' => '%foo%')), '->resolveValue() replaces placeholders in keys and values of arrays');
         $this->assertEquals(array('bar' => array('bar' => array('bar' => 'bar'))), $bag->resolveValue(array('%foo%' => array('%foo%' => array('%foo%' => '%foo%')))), '->resolveValue() replaces placeholders in nested arrays');
-        $this->assertEquals('I\'m a %%foo%%', $bag->resolveValue('I\'m a %%foo%%'), '->resolveValue() supports % escaping by doubling it');
-        $this->assertEquals('I\'m a bar %%foo bar', $bag->resolveValue('I\'m a %foo% %%foo %foo%'), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals('I\'m a %foo%', $bag->resolveValue('I\'m a %%foo%%'), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals('I\'m a bar %foo bar', $bag->resolveValue('I\'m a %foo% %%foo %foo%'), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals(array('foo' => array('bar' => array('ding' => 'I\'m a bar %foo %bar'))), $bag->resolveValue(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')))), '->resolveValue() supports % escaping by doubling it');
 
         $bag = new ParameterBag(array('foo' => true));
         $this->assertSame(true, $bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');


### PR DESCRIPTION
Some how the tests do not match what I would expect in terms of behavior.

With my changes the following:

``` yaml
parameters:
    lala: huhu
    foo:
        bar: %%lala%%1 %ding
        foo:
            bar: %%lala%%1 %ding
        huhu: %kernel.root_dir%
```

Gives me what I would expect:

``` php
// var_dump($foo->getParameter('foo')); die;
array(3) { ["bar"]=> string(13) "%lala%1 %ding" ["foo"]=> array(1) { ["bar"]=> string(13) "%lala%1 %ding" } ["huhu"]=> string(41) "/Users/lsmith/htdocs/symfony-standard/app" } 
```

But as you can see the test suite fails quite miserably:
http://travis-ci.org/#!/lsmith77/symfony/builds/611912
