### PR TITLE
Exceptions: Break source-paths with CSS

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
@@ -60,6 +60,7 @@ build: 56
     font-family: Georgia, "Times New Roman", Times, serif;
     font-size: 20px;
     color: #313131;
+    word-break: break-all;
 }
 
 .sf-exceptionreset li {


### PR DESCRIPTION
Sometimes in exceptions absolute paths of files are pretty long and need more than one line.

eg.: `/Volumes/Macintosh HD/Users/blabla/Sites/project/files/src/SomeProjectsName/SomeProjectsNameFrontendBundle/Controller/CreateController.php`

This should be displayed within the width of the `h1`.

Using CSS `word-break: break-all;`.
