### PR TITLE
[Console] Use default value for console ArrayInput::$parameters in constructor

### DIFF
--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -34,7 +34,7 @@ class ArrayInput extends Input
      *
      * @api
      */
-    public function __construct(array $parameters, InputDefinition $definition = null)
+    public function __construct(array $parameters = array(), InputDefinition $definition = null)
     {
         $this->parameters = $parameters;
 


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

This allows executing a command with array input that has no required input, e.g.:

``` php
<?php

use Symfony\Bundle\SecurityBundle\Command\InitAclCommand;
use Symfony\Component\Console\Input\ArrayInput;
use Symfony\Component\Console\Output\NullOutput;

$aclCommand = new InitAclCommand();
$aclCommand->run(new ArrayInput(), new NullOutput());
```

Currently, I'll get an error telling me that arg1 passed to `ArrayInput` must be an array which is unnecessary.
