### PR TITLE
[Router] RouteCollection `prefix` optional for default values/requirements

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -228,7 +228,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 ### Routing
 
  * added a TraceableUrlMatcher
- * added the possibility to define default values and requirements for placeholders in prefix
+ * added the possibility to define default values and requirements for placeholders in prefix, including imported routes
  * added RouterInterface::getRouteCollection
 
 ### Security

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -209,12 +209,8 @@ class RouteCollection implements \IteratorAggregate
         // a prefix must not end with a slash
         $prefix = rtrim($prefix, '/');
 
-        if (!$prefix) {
-            return;
-        }
-
         // a prefix must start with a slash
-        if ('/' !== $prefix[0]) {
+        if ($prefix && '/' !== $prefix[0]) {
             $prefix = '/'.$prefix;
         }
 

--- a/tests/Symfony/Tests/Component/Routing/RouteCollectionTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteCollectionTest.php
@@ -141,6 +141,19 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('https', $collection->get('bar')->getRequirement('_scheme'), '->addPrefix() overrides existing requirements');
     }
 
+    public function testAddCollectionOverridesDefaultsAndRequirements()
+    {
+        $imported = new RouteCollection();
+        $imported->add('foo', $foo = new Route('/foo'));
+        $imported->add('bar', $bar = new Route('/bar', array(), array('_scheme' => 'http')));
+
+        $collection = new RouteCollection();
+        $collection->addCollection($imported, null, array(), array('_scheme' => 'https'));
+
+        $this->assertEquals('https', $collection->get('foo')->getRequirement('_scheme'), '->addCollection() overrides existing requirements');
+        $this->assertEquals('https', $collection->get('bar')->getRequirement('_scheme'), '->addCollection() overrides existing requirements');
+    }
+
     public function testResource()
     {
         $collection = new RouteCollection();


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3194

[![Build Status](https://secure.travis-ci.org/ericclemmons/symfony.png)](https://secure.travis-ci.org/ericclemmons/symfony.png)

With the commit 2e1344eb7ef1e4a6c5cc21e098fd2a6404f2b289 (thanks @vicb!), imported routes could have `defaults` and `requirements` set, but only as long as there is a `prefix`.

Thisfix allows any imported route to have defaults set, whether or not `prefix` is set.

(See #3194 for specifics)
