### PR TITLE
[Form] Forms now don't create empty objects anymore if they are empty and not required

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -200,6 +200,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
    model
  * added options "adder_prefix" and "remover_prefix" to collection and choice
    type
+ * forms now don't create an empty object anymore if they are completely
+   empty and not required. The empty value for such forms is null.
 
 ### HttpFoundation
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -156,7 +156,11 @@ class FieldType extends AbstractType
         }
 
         if ($class) {
-            $defaultOptions['empty_data'] = function () use ($class) {
+            $defaultOptions['empty_data'] = function (FormInterface $form) use ($class) {
+                if ($form->isEmpty() && !$form->isRequired()) {
+                    return null;
+                }
+
                 return new $class();
             };
         } else {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -517,7 +517,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         // Merge form data from children into existing client data
-        if (count($this->children) > 0 && $this->dataMapper) {
+        if (count($this->children) > 0 && $this->dataMapper && null !== $clientData) {
             $this->dataMapper->mapFormsToData($this->children, $clientData);
         }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
@@ -178,16 +178,50 @@ class FieldTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('form', null, array(
             'data_class' => 'Symfony\Tests\Component\Form\Fixtures\Author',
+            'required' => false,
         ));
         $form->add($this->factory->createNamed('field', 'firstName'));
+        $form->add($this->factory->createNamed('field', 'lastName'));
 
         $form->setData(null);
-        $form->bind(array('firstName' => 'Bernhard'));
+        // partially empty, still an object is created
+        $form->bind(array('firstName' => 'Bernhard', 'lastName' => ''));
 
         $author = new Author();
         $author->firstName = 'Bernhard';
+        $author->setLastName('');
 
         $this->assertEquals($author, $form->getData());
+    }
+
+    public function testBindEmptyWithEmptyDataCreatesNoObjectIfNotRequired()
+    {
+        $form = $this->factory->create('form', null, array(
+            'data_class' => 'Symfony\Tests\Component\Form\Fixtures\Author',
+            'required' => false,
+        ));
+        $form->add($this->factory->createNamed('field', 'firstName'));
+        $form->add($this->factory->createNamed('field', 'lastName'));
+
+        $form->setData(null);
+        $form->bind(array('firstName' => '', 'lastName' => ''));
+
+        $this->assertNull($form->getData());
+    }
+
+    public function testBindEmptyWithEmptyDataCreatesObjectIfRequired()
+    {
+        $form = $this->factory->create('form', null, array(
+            'data_class' => 'Symfony\Tests\Component\Form\Fixtures\Author',
+            'required' => true,
+        ));
+        $form->add($this->factory->createNamed('field', 'firstName'));
+        $form->add($this->factory->createNamed('field', 'lastName'));
+
+        $form->setData(null);
+        $form->bind(array('firstName' => '', 'lastName' => ''));
+
+        $this->assertEquals(new Author(), $form->getData());
     }
 
     /*


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2861
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue2861)

If a form (or a nested form) is left completely empty upon submission and is not required, no new data object will be generated anymore. Instead, the form returns null as data.
