### PR TITLE
Unescape paramaters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -139,7 +139,7 @@ class ParameterBag implements ParameterBagInterface
         foreach ($this->parameters as $key => $value) {
             try {
                 $value = $this->resolveValue($value);
-                $parameters[$key] = is_string($value) ? str_replace('%%', '%', $value) : $value;
+                $parameters[$key] = $this->unescapeString($value);
             } catch (ParameterNotFoundException $e) {
                 $e->setSourceKey($key);
 
@@ -234,5 +234,23 @@ class ParameterBag implements ParameterBagInterface
     public function isResolved()
     {
         return $this->resolved;
+    }
+
+    private function unescapeString($value)
+    {
+        if (is_string($value)) {
+            return str_replace('%%', '%', $value);
+        }
+
+        if (is_array($value)) {
+            $result = array();
+            foreach ($value as $k => $v) {
+                $result[$k] = $this->unescapeString($v);
+            }
+
+            return $result;
+        }
+
+        return $value;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -139,7 +139,7 @@ class ParameterBag implements ParameterBagInterface
         foreach ($this->parameters as $key => $value) {
             try {
                 $value = $this->resolveValue($value);
-                $parameters[$key] = $this->unescapeString($value);
+                $parameters[$key] = $this->unescapeValue($value);
             } catch (ParameterNotFoundException $e) {
                 $e->setSourceKey($key);
 
@@ -236,7 +236,7 @@ class ParameterBag implements ParameterBagInterface
         return $this->resolved;
     }
 
-    private function unescapeString($value)
+    private function unescapeValue($value)
     {
         if (is_string($value)) {
             return str_replace('%%', '%', $value);
@@ -245,7 +245,7 @@ class ParameterBag implements ParameterBagInterface
         if (is_array($value)) {
             $result = array();
             foreach ($value as $k => $v) {
-                $result[$k] = $this->unescapeString($v);
+                $result[$k] = $this->unescapeValue($v);
             }
 
             return $result;

--- a/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
@@ -94,6 +94,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('bar' => array('bar' => array('bar' => 'bar'))), $bag->resolveValue(array('%foo%' => array('%foo%' => array('%foo%' => '%foo%')))), '->resolveValue() replaces placeholders in nested arrays');
         $this->assertEquals('I\'m a %%foo%%', $bag->resolveValue('I\'m a %%foo%%'), '->resolveValue() supports % escaping by doubling it');
         $this->assertEquals('I\'m a bar %%foo bar', $bag->resolveValue('I\'m a %foo% %%foo %foo%'), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals(array('foo' => array('bar' => array('ding' => 'I\'m a bar %foo %bar'))), $bag->resolveValue(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')))), '->resolveValue() supports % escaping by doubling it');
 
         $bag = new ParameterBag(array('foo' => true));
         $this->assertSame(true, $bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');

--- a/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
@@ -94,7 +94,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('bar' => array('bar' => array('bar' => 'bar'))), $bag->resolveValue(array('%foo%' => array('%foo%' => array('%foo%' => '%foo%')))), '->resolveValue() replaces placeholders in nested arrays');
         $this->assertEquals('I\'m a %%foo%%', $bag->resolveValue('I\'m a %%foo%%'), '->resolveValue() supports % escaping by doubling it');
         $this->assertEquals('I\'m a bar %%foo bar', $bag->resolveValue('I\'m a %foo% %%foo %foo%'), '->resolveValue() supports % escaping by doubling it');
-        $this->assertEquals(array('foo' => array('bar' => array('ding' => 'I\'m a bar %foo %bar'))), $bag->resolveValue(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')))), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar'))), $bag->resolveValue(array('foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')))), '->resolveValue() supports % escaping by doubling it');
 
         $bag = new ParameterBag(array('foo' => true));
         $this->assertSame(true, $bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');
@@ -164,6 +164,22 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         } catch (ParameterNotFoundException $e) {
             $this->assertEquals('The parameter "foo" has a dependency on a non-existent parameter "bar".', $e->getMessage());
         }
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolve
+     */
+    public function testResolveUnespacesValue()
+    {
+        $bag = new ParameterBag(array(
+            'foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')),
+            'bar' => 'I\'m a %%foo%%',
+        ));
+
+        $bag->resolve();
+
+        $this->assertEquals('I\'m a %foo%', $bag->get('bar'), '->resolveValue() supports % escaping by doubling it');
+        $this->assertEquals(array('bar' => array('ding' => 'I\'m a bar %foo %bar')), $bag->get('foo'), '->resolveValue() supports % escaping by doubling it');
     }
 
     /**


### PR DESCRIPTION
This fixes the unescaping of % in parameters when it is used in an array.

It is a replacement for @lsmith77's work done in #3241 but with a working fix this time :)
