### PR TITLE
[Form] Fixed incorrect sorting in ChoiceList::getChoicesForValues

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -200,8 +200,8 @@ class ChoiceList implements ChoiceListInterface
 
         $choices = array();
 
-        foreach ($this->values as $i => $value) {
-            foreach ($values as $j => $givenValue) {
+        foreach ($values as $j => $givenValue) {
+            foreach ($this->values as $i => $value) {
                 if ($value === $givenValue) {
                     $choices[] = $this->choices[$i];
                     unset($values[$j]);

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/ChoiceList/ChoiceListTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/ChoiceList/ChoiceListTest.php
@@ -146,6 +146,12 @@ class ChoiceListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array($this->obj2, $this->obj3), $this->list->getChoicesForValues($values));
     }
 
+    public function testGetChoicesForValuesCorrectOrderingOfResult()
+    {
+        $values = array('2', '1');
+        $this->assertSame(array($this->obj3, $this->obj2), $this->list->getChoicesForValues($values));
+    }
+    
     public function testGetChoicesForValuesIgnoresNonExistingValues()
     {
         $values = array('1', '2', '5');


### PR DESCRIPTION
ChoiceList::getChoicesForValues return collection with sorting, that not corresponding to the sorting for input keys
