### PR TITLE
[Validator] Throwing exception in ConstraintValidator::setMessage() if initialize() wasn't called

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -18,6 +18,8 @@ namespace Symfony\Component\Validator;
  *
  * @api
  */
+use Symfony\Component\Validator\Exception\ValidatorException;
+
 abstract class ConstraintValidator implements ConstraintValidatorInterface
 {
     /**
@@ -78,6 +80,10 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     {
         $this->messageTemplate = $template;
         $this->messageParameters = $parameters;
+
+        if (!$this->context instanceof ExecutionContext) {
+            throw new ValidatorException('ConstraintValidator::initialize() must be called before setting violation messages');
+        }
 
         $this->context->addViolation($template, $parameters);
     }

--- a/tests/Symfony/Tests/Component/Validator/ConstraintValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/ConstraintValidatorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Validator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+class ConstraintValidatorTest_Validator extends ConstraintValidator
+{
+    private $message;
+    private $params;
+
+    public function __construct($message, array $params = array())
+    {
+        $this->message = $message;
+        $this->params = $params;
+    }
+
+    public function isValid($value, Constraint $constraint)
+    {
+        $this->setMessage($this->message, $this->params);
+    }
+}
+
+class ConstraintValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSetMessage()
+    {
+        $context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $constraint = $this->getMock('Symfony\Component\Validator\Constraint', array(), array(), '', false);
+        $validator = new ConstraintValidatorTest_Validator('error message', array('foo' => 'bar'));
+        $validator->initialize($context);
+
+        $context->expects($this->once())
+            ->method('addViolation')
+            ->with('error message', array('foo' => 'bar'));
+
+        $validator->isValid('bam', $constraint);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Validator\Exception\ValidatorException
+     */
+    public function testSetMessageFailsIfNoContextSet()
+    {
+        $constraint = $this->getMock('Symfony\Component\Validator\Constraint', array(), array(), '', false);
+        $validator = new ConstraintValidatorTest_Validator('error message', array('foo' => 'bar'));
+
+        $validator->isValid('bam', $constraint);
+    }
+}


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3269)
