### PR TITLE
[Form][DelegatingValidator] Fix path mapping for embedded forms

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -283,7 +283,11 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             return true;
         }
 
-        $parameter = $request->request->get($this->options['remember_me_parameter'], null, true);
+        $parameter = $request->request->get(
+                $this->options['remember_me_parameter'],
+                $request->query->get($this->options['remember_me_parameter'], null),
+                true
+        );
 
         if ($parameter === null && null !== $this->logger) {
             $this->logger->debug(sprintf('Did not send remember-me cookie (remember-me parameter "%s" was not sent).', $this->options['remember_me_parameter']));


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: DelegatingValidatorTest
Fixes the following tickets: [#1917](https://github.com/symfony/symfony/issues/1917), [#3018](https://github.com/symfony/symfony/issues/3018)

Tried to fix the bug where multi-input types (i.e. date, radio) of embedded forms get wrong path mapping

```
children[subForm][choiceType].data
```

should be

```
children[subForm].data.choiceType
```
