### PR TITLE
Removed try...catch which prevents Symfony to notify files not found.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
@@ -40,17 +40,11 @@ class FilesystemLoader implements LoaderInterface
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|Boolean false if the template cannot be loaded, a Storage instance otherwise
+     * @return FileStorage
      */
     public function load(TemplateReferenceInterface $template)
     {
-        try {
-            $file = $this->locator->locate($template);
-        } catch (\InvalidArgumentException $e) {
-            return false;
-        }
-
-        return new FileStorage($file);
+        return new FileStorage($this->locator->locate($template));
     }
 
     /**


### PR DESCRIPTION
When using in conjunction with LiipThemeBundle, the extension does its part and throws an InvalidArgumentException whenever it is unable to find the template file. This is also the same behavior that Symfony\Bundle\FrameworkBundle\Templating\Loader\TemplateLoader does too.

The Exception is then passed to Symfony\Bundle\FrameworkBundle\Templating\Loader\FilesystemLoader (at line 48), it swallow it and return false.
A FileStorage is expected in Symfony\Bundle\AsseticBundle\Factory\Resource\FileResource::getContent(), but since currently it returns false (what the try..catch does), it throws an E_FATAL like this:

```
PHP Fatal error:  Call to a member function getContent() on a non-object in /root/nde/site-steve/symfony/vendor/bundles/Symfony/Bundle/AsseticBundle/Factory/Resource/FileResource.php on line 54
PHP Stack trace:
PHP   1. {main}() /root/nde/site-steve/symfony/app/console:0
PHP   2. Symfony\Component\Console\Application->run() /root/nde/site-steve/symfony/app/console:22
PHP   3. Symfony\Bundle\FrameworkBundle\Console\Application->doRun() /root/nde/site-steve/symfony/vendor/symfony/src/Symfony/Component/Console/Application.php:118
PHP   4. Symfony\Component\Console\Application->doRun() /root/nde/site-steve/symfony/vendor/symfony/src/Symfony/Bundle/FrameworkBundle/Console/Application.php:75
PHP   5. Symfony\Component\Console\Command\Command->run() /root/nde/site-steve/symfony/vendor/symfony/src/Symfony/Component/Console/Application.php:194
PHP   6. Symfony\Bundle\FrameworkBundle\Command\CacheWarmupCommand->execute() /root/nde/site-steve/symfony/vendor/symfony/src/Symfony/Component/Console/Command/Command.php:224
PHP   7. Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate->warmUp() /root/nde/site-steve/symfony/vendor/symfony/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php:50
PHP   8. Symfony\Bundle\AsseticBundle\CacheWarmer\AssetManagerCacheWarmer->warmUp() /root/nde/site-steve/symfony/vendor/symfony/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php:47
PHP   9. Assetic\Factory\LazyAssetManager->load() /root/nde/site-steve/symfony/vendor/bundles/Symfony/Bundle/AsseticBundle/CacheWarmer/AssetManagerCacheWarmer.php:34
PHP  10. Assetic\Factory\Loader\CachedFormulaLoader->load() /root/nde/site-steve/symfony/vendor/assetic/src/Assetic/Factory/LazyAssetManager.php:159
PHP  11. Assetic\Extension\Twig\TwigFormulaLoader->load() /root/nde/site-steve/symfony/vendor/assetic/src/Assetic/Factory/Loader/CachedFormulaLoader.php:59
PHP  12. Symfony\Bundle\AsseticBundle\Factory\Resource\FileResource->getContent() /root/nde/site-steve/symfony/vendor/assetic/src/Assetic/Extension/Twig/TwigFormulaLoader.php:34
```

By applying this patch it now exposes the error on exception page.
