### PR TITLE
[DoctrineBridge] Change the array access used in UniqueEntityValidator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -94,11 +94,17 @@ class UniqueEntityValidator extends ConstraintValidator
         $repository = $em->getRepository($className);
         $result = $repository->findBy($criteria);
 
+        // MongoDB will return a Cursor so we need to change it to an array
+        // so it is compatible with the orm returning an array
+        if ($result instanceof \Iterator && !$result instanceof \ArrayAccess) {
+            $result = iterator_to_array($result);
+        }
+
         /* If no entity matched the query criteria or a single entity matched,
          * which is the same as the entity being validated, the criteria is
          * unique.
          */
-        if (0 === count($result) || (1 === count($result) && $entity === $result[0])) {
+        if (0 === count($result) || (1 === count($result) && $entity === reset($result))) {
             return true;
         }
 


### PR DESCRIPTION
MongoDB ODM Cursor does not implement ArrayAccess and therefor using
`$result[0]` will fail. `reset()` rewinds the array and returns the
first element value.

DoctrineMongoDBBundle#77

/cc @beberlei
