### PR TITLE
[Form] Fixed: "date", "time" and "datetime" fields can be initialized with \DateTime objects

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -202,6 +202,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * added options "add_method" and "remove_method" to collection and choice type
  * forms now don't create an empty object anymore if they are completely
    empty and not required. The empty value for such forms is null.
+ * FormType::getDefaultOptions() now sees default options defined by parent types
+ * [BC BREAK] FormType::getParent() does not see default options anymore
 
 ### HttpFoundation
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -229,3 +229,22 @@ UPGRADE FROM 2.0 to 2.1
                 return false;
             }
         }
+
+* The options passed to `getParent` of the form types don't contain default
+  options anymore
+
+    You should check with `isset` if options exist before checking their value.
+
+    Before:
+
+        public function getParent()
+        {
+            return 'single_text' === $options['widget'] ? 'text' : 'choice';
+        }
+
+    After:
+
+        public function getParent()
+        {
+            return isset($options['widget']) && 'single_text' === $options['widget'] ? 'text' : 'choice';
+        }

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -237,14 +237,14 @@ UPGRADE FROM 2.0 to 2.1
 
     Before:
 
-        public function getParent()
+        public function getParent(array $options)
         {
             return 'single_text' === $options['widget'] ? 'text' : 'choice';
         }
 
     After:
 
-        public function getParent()
+        public function getParent(array $options)
         {
             return isset($options['widget']) && 'single_text' === $options['widget'] ? 'text' : 'choice';
         }

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -50,7 +50,6 @@ abstract class DoctrineType extends AbstractType
             'property'          => null,
             'query_builder'     => null,
             'loader'            => null,
-            'choices'           => null,
             'group_by'          => null,
         );
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
@@ -107,7 +107,7 @@ class ChoicesToBooleanArrayTransformer implements DataTransformerInterface
         }
 
         if (count($unknown) > 0) {
-            throw new TransformationFailedException('The choices "' . implode('", "', $unknown) . '" where not found');
+            throw new TransformationFailedException('The choices "' . implode('", "', $unknown) . '" were not found');
         }
 
         return $result;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
@@ -107,7 +107,7 @@ class ChoicesToBooleanArrayTransformer implements DataTransformerInterface
         }
 
         if (count($unknown) > 0) {
-            throw new TransformationFailedException('The choices "' . implode('", "', $unknown, $code, $previous) . '" where not found');
+            throw new TransformationFailedException('The choices "' . implode('", "', $unknown) . '" where not found');
         }
 
         return $result;

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -149,7 +149,7 @@ class ChoiceType extends AbstractType
             'multiple'          => false,
             'expanded'          => false,
             'choice_list'       => null,
-            'choices'           => array(),
+            'choices'           => null,
             'preferred_choices' => array(),
             'value_strategy'    => ChoiceList::GENERATE,
             'index_strategy'    => ChoiceList::GENERATE,
@@ -166,7 +166,7 @@ class ChoiceType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return $options['expanded'] ? 'form' : 'field';
+        return isset($options['expanded']) && $options['expanded'] ? 'form' : 'field';
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -200,7 +200,7 @@ class DateTimeType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return 'single_text' === $options['widget'] ? 'field' : 'form';
+        return isset($options['widget']) && 'single_text' === $options['widget'] ? 'field' : 'form';
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -158,6 +158,11 @@ class DateTimeType extends AbstractType
             'widget'        => null,
             // This will overwrite "empty_value" child options
             'empty_value'   => null,
+            // If initialized with a \DateTime object, FieldType initializes
+            // this option to "\DateTime". Since the internal, normalized
+            // representation is not \DateTime, but an array, we need to unset
+            // this option.
+            'data_class'    => null,
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -183,6 +183,11 @@ class DateType extends AbstractType
             // them like immutable value objects
             'by_reference'   => false,
             'error_bubbling' => false,
+            // If initialized with a \DateTime object, FieldType initializes
+            // this option to "\DateTime". Since the internal, normalized
+            // representation is not \DateTime, but an array, we need to unset
+            // this option.
+            'data_class'     => null,
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -211,7 +211,7 @@ class DateType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return 'single_text' === $options['widget'] ? 'field' : 'form';
+        return isset($options['widget']) && 'single_text' === $options['widget'] ? 'field' : 'form';
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -156,6 +156,11 @@ class TimeType extends AbstractType
             // them like immutable value objects
             'by_reference'   => false,
             'error_bubbling' => false,
+            // If initialized with a \DateTime object, FieldType initializes
+            // this option to "\DateTime". Since the internal, normalized
+            // representation is not \DateTime, but an array, we need to unset
+            // this option.
+            'data_class'     => null,
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -184,7 +184,7 @@ class TimeType extends AbstractType
      */
     public function getParent(array $options)
     {
-        return 'single_text' === $options['widget'] ? 'field' : 'form';
+        return isset($options['widget']) && 'single_text' === $options['widget'] ? 'field' : 'form';
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimezoneType.php
@@ -31,7 +31,7 @@ class TimezoneType extends AbstractType
             'value_strategy' => ChoiceList::COPY_CHOICE,
         );
 
-        if (!isset($options['choice_list']) && !isset($options['choices'])) {
+        if (empty($options['choice_list']) && empty($options['choices'])) {
             $defaultOptions['choices'] = self::getTimezones();
         }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
@@ -264,6 +264,6 @@ class DateTimeTypeTest extends LocalizedTestCase
     {
         // Throws an exception if "data_class" option is not explicitely set
         // to null in the type
-        $form = $this->factory->create('datetime', new \DateTime());
+        $this->factory->create('datetime', new \DateTime());
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
@@ -258,4 +258,12 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['date']->getErrors());
         $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['time']->getErrors());
     }
+
+    // Bug fix
+    public function testInitializeWithDateTime()
+    {
+        // Throws an exception if "data_class" option is not explicitely set
+        // to null in the type
+        $form = $this->factory->create('datetime', new \DateTime());
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
@@ -536,6 +536,6 @@ class DateTypeTest extends LocalizedTestCase
     {
         // Throws an exception if "data_class" option is not explicitely set
         // to null in the type
-        $form = $this->factory->create('date', new \DateTime());
+        $this->factory->create('date', new \DateTime());
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
@@ -530,4 +530,12 @@ class DateTypeTest extends LocalizedTestCase
 
         $this->assertSame('single_text', $view->get('widget'));
     }
+
+    // Bug fix
+    public function testInitializeWithDateTime()
+    {
+        // Throws an exception if "data_class" option is not explicitely set
+        // to null in the type
+        $form = $this->factory->create('date', new \DateTime());
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/FieldTypeTest.php
@@ -221,6 +221,42 @@ class FieldTypeTest extends TypeTestCase
         $this->assertEquals($author, $form->getData());
     }
 
+    public function testBindWithEmptyDataCreatesObjectIfInitiallyBoundWithObject()
+    {
+        $form = $this->factory->create('form', null, array(
+            // data class is inferred from the passed object
+            'data' => new Author(),
+            'required' => false,
+        ));
+        $form->add($this->factory->createNamed('field', 'firstName'));
+        $form->add($this->factory->createNamed('field', 'lastName'));
+
+        $form->setData(null);
+        // partially empty, still an object is created
+        $form->bind(array('firstName' => 'Bernhard', 'lastName' => ''));
+
+        $author = new Author();
+        $author->firstName = 'Bernhard';
+        $author->setLastName('');
+
+        $this->assertEquals($author, $form->getData());
+    }
+
+    public function testBindWithEmptyDataDoesNotCreateObjectIfDataClassIsNull()
+    {
+        $form = $this->factory->create('form', null, array(
+            'data' => new Author(),
+            'data_class' => null,
+            'required' => false,
+        ));
+        $form->add($this->factory->createNamed('field', 'firstName'));
+
+        $form->setData(null);
+        $form->bind(array('firstName' => 'Bernhard'));
+
+        $this->assertSame(array('firstName' => 'Bernhard'), $form->getData());
+    }
+
     public function testBindEmptyWithEmptyDataCreatesNoObjectIfNotRequired()
     {
         $form = $this->factory->create('form', null, array(

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/TimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/TimeTypeTest.php
@@ -407,6 +407,6 @@ class TimeTypeTest extends LocalizedTestCase
     {
         // Throws an exception if "data_class" option is not explicitely set
         // to null in the type
-        $form = $this->factory->create('time', new \DateTime());
+        $this->factory->create('time', new \DateTime());
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/TimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/TimeTypeTest.php
@@ -401,4 +401,12 @@ class TimeTypeTest extends LocalizedTestCase
 
         $this->assertTrue($form->isPartiallyFilled());
     }
+
+    // Bug fix
+    public function testInitializeWithDateTime()
+    {
+        // Throws an exception if "data_class" option is not explicitely set
+        // to null in the type
+        $form = $this->factory->create('time', new \DateTime());
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: **yes**
Symfony2 tests pass: yes
Fixes the following tickets: #3288
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3288)

Fixed exception that was thrown when doing:

```
$builder->add('createdAt', 'date', array('data' => new \DateTime()));
```

On a side note, the options passed to `FieldType::getDefaultOptions` now always also contain the default options of any parent types. This is necessary if you want to be independent of how `getDefaultOptions` is implemented in the parent type and still rely on the already defined values.

As a result, `FieldType::getParent` doesn't see default options anymore. This shouldn't be a big problem, because this method only relies on options in few cases. If it does, options now need to be checked for existence with `isset` before being used (BC break).
