### PR TITLE
[Form] Allow empty choices array for ChoiceType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -37,7 +37,7 @@ class ChoiceType extends AbstractType
             throw new FormException('The "choice_list" must be an instance of "Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceListInterface".');
         }
 
-        if (!$options['choice_list'] && !$options['choices']) {
+        if (!$options['choice_list'] && !is_array($options['choices']) && !$options['choices'] instanceof \Traversable) {
             throw new FormException('Either the option "choices" or "choice_list" must be set.');
         }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/ChoiceTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/ChoiceTypeTest.php
@@ -662,4 +662,12 @@ class ChoiceTypeTest extends TypeTestCase
 
         $this->assertSame('name[]', $view->get('full_name'));
     }
+
+    // https://github.com/symfony/symfony/issues/3298
+    public function testInitializeWithEmptyChoices()
+    {
+        $this->factory->createNamed('choice', 'name', null, array(
+            'choices' => array(),
+        ));
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

The documentation about ChoiceType says, that default for 'choices' is array(). 
This is not allowed because an empty array evaluates to false: 

if (!$options['choice_list'] && !$options['choices']) {

Use case: choices are empty and items are added dynamically.
