### PR TITLE
[WebTestCase] Initialize Kernel with FQDN

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -126,6 +126,11 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
 
         require_once $file;
 
+        preg_match('/^namespace (.*);$/m', file_get_contents($file), $matches);
+        if (count($matches) > 0) {
+            $class = sprintf('%s\%s', $matches[1], $class);
+        }
+
         return $class;
     }
 


### PR DESCRIPTION
Bug fix: debatable
Feature addition: debatable
Backwards compatibility break: no
Tests pass: ![Tests](https://secure.travis-ci.org/helmer/symfony.png?branch=webtest_fqdn)

Application kernel resides in a namespace for me. Finding the file and including it is no problem, but for instantiating you need to know the FQDN, which this PR should solve.
