### PR TITLE
[Form] Fixed MergeCollectionListener for the case that the form's data is updated by the data mapper

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Extension\Core\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\Event\DataEvent;
 use Symfony\Component\Form\Event\FilterDataEvent;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Exception\FormException;
@@ -23,6 +24,21 @@ use Symfony\Component\Form\Util\FormUtil;
  */
 class MergeCollectionListener implements EventSubscriberInterface
 {
+    /**
+     * Strategy for merging the new collection into the old collection
+     *
+     * @var integer
+     */
+    const MERGE_NORMAL = 1;
+
+    /**
+     * Strategy for calling add/remove methods on the parent data for all
+     * new/removed elements in the new collection
+     *
+     * @var integer
+     */
+    const MERGE_INTO_PARENT = 2;
+
     /**
      * Whether elements may be added to the collection
      * @var Boolean
@@ -39,7 +55,7 @@ class MergeCollectionListener implements EventSubscriberInterface
      * Whether to search for and use adder and remover methods
      * @var Boolean
      */
-    private $useAccessors;
+    private $mergeStrategy;
 
     /**
      * The name of the adder method to look for
@@ -53,35 +69,91 @@ class MergeCollectionListener implements EventSubscriberInterface
      */
     private $removeMethod;
 
-    public function __construct($allowAdd = false, $allowDelete = false, $useAccessors = true, $addMethod = null, $removeMethod = null)
+    /**
+     * A copy of the data before starting binding for this form
+     * @var mixed
+     */
+    private $dataSnapshot;
+
+    /**
+     * Creates a new listener.
+     *
+     * @param  Boolean $allowAdd      Whether values might be added to the
+     *                                collection.
+     * @param  Boolean $allowDelete   Whether values might be removed from the
+     *                                collection.
+     * @param  integer $mergeStrategy Which strategy to use for merging the
+     *                                bound collection with the original
+     *                                collection. Might be any combination of
+     *                                MERGE_NORMAL and MERGE_INTO_PARENT.
+     *                                MERGE_INTO_PARENT has precedence over
+     *                                MERGE_NORMAL if an adder/remover method
+     *                                is found. The default strategy is to use
+     *                                both strategies.
+     * @param  string $addMethod      The name of the adder method to use. If
+     *                                not given, the listener tries to discover
+     *                                the method automatically.
+     * @param  string $removeMethod   The name of the remover method to use. If
+     *                                not given, the listener tries to discover
+     *                                the method automatically.
+     *
+     * @throws FormException          If the given strategy is invalid.
+     */
+    public function __construct($allowAdd = false, $allowDelete = false, $mergeStrategy = null, $addMethod = null, $removeMethod = null)
     {
+        if ($mergeStrategy && !($mergeStrategy & (self::MERGE_NORMAL | self::MERGE_INTO_PARENT))) {
+            throw new FormException('The merge strategy needs to be at least MERGE_NORMAL or MERGE_INTO_PARENT');
+        }
+
         $this->allowAdd = $allowAdd;
         $this->allowDelete = $allowDelete;
-        $this->useAccessors = $useAccessors;
+        $this->mergeStrategy = $mergeStrategy ?: self::MERGE_NORMAL | self::MERGE_INTO_PARENT;
         $this->addMethod = $addMethod;
         $this->removeMethod = $removeMethod;
     }
 
     static public function getSubscribedEvents()
     {
-        return array(FormEvents::BIND_NORM_DATA => 'onBindNormData');
+        return array(
+            FormEvents::PRE_BIND => 'preBind',
+            FormEvents::BIND_NORM_DATA => 'onBindNormData',
+        );
+    }
+
+    public function preBind(DataEvent $event)
+    {
+        // Get a snapshot of the current state of the normalized data
+        // to compare against later
+        $this->dataSnapshot = $event->getForm()->getNormData();
+
+        if (is_object($this->dataSnapshot)) {
+            // Make sure the snapshot remains stable and doesn't change
+            $this->dataSnapshot = clone $this->dataSnapshot;
+        }
+
+        if (null !== $this->dataSnapshot && !is_array($this->dataSnapshot) && !($this->dataSnapshot instanceof \Traversable && $this->dataSnapshot instanceof \ArrayAccess)) {
+            throw new UnexpectedTypeException($this->dataSnapshot, 'array or (\Traversable and \ArrayAccess)');
+        }
     }
 
     public function onBindNormData(FilterDataEvent $event)
     {
-        $originalData = $event->getForm()->getData();
+        $originalData = $event->getForm()->getNormData();
 
         // If we are not allowed to change anything, return immediately
         if (!$this->allowAdd && !$this->allowDelete) {
+            // Don't set to the snapshot as then we are switching from the
+            // original object to its copy, which might break things
             $event->setData($originalData);
             return;
         }
 
         $form = $event->getForm();
         $data = $event->getData();
-        $parentData = $form->hasParent() ? $form->getParent()->getData() : null;
+        $parentData = $form->hasParent() ? $form->getParent()->getClientData() : null;
         $addMethod = null;
         $removeMethod = null;
+        $getMethod = null;
 
         if (null === $data) {
             $data = array();
@@ -96,24 +168,35 @@ class MergeCollectionListener implements EventSubscriberInterface
         }
 
         // Check if the parent has matching methods to add/remove items
-        if ($this->useAccessors && is_object($parentData)) {
+        if (($this->mergeStrategy & self::MERGE_INTO_PARENT) && is_object($parentData)) {
+            $plural = ucfirst($form->getName());
             $reflClass = new \ReflectionClass($parentData);
             $addMethodNeeded = $this->allowAdd && !$this->addMethod;
             $removeMethodNeeded = $this->allowDelete && !$this->removeMethod;
 
             // Any of the two methods is required, but not yet known
             if ($addMethodNeeded || $removeMethodNeeded) {
-                $singulars = (array) FormUtil::singularify(ucfirst($form->getName()));
+                $singulars = (array) FormUtil::singularify($plural);
 
                 foreach ($singulars as $singular) {
                     // Try to find adder, but don't override preconfigured one
                     if ($addMethodNeeded) {
-                        $addMethod = $this->checkMethod($reflClass, 'add' . $singular);
+                        $addMethod = 'add' . $singular;
+
+                        // False alert
+                        if (!$this->isAccessible($reflClass, $addMethod, 1)) {
+                            $addMethod = null;
+                        }
                     }
 
                     // Try to find remover, but don't override preconfigured one
                     if ($removeMethodNeeded) {
-                        $removeMethod = $this->checkMethod($reflClass, 'remove' . $singular);
+                        $removeMethod = 'remove' . $singular;
+
+                        // False alert
+                        if (!$this->isAccessible($reflClass, $removeMethod, 1)) {
+                            $removeMethod = null;
+                        }
                     }
 
                     // Found all that we need. Abort search.
@@ -129,12 +212,12 @@ class MergeCollectionListener implements EventSubscriberInterface
 
             // Set preconfigured adder
             if ($this->allowAdd && $this->addMethod) {
-                $addMethod = $this->checkMethod($reflClass, $this->addMethod);
+                $addMethod = $this->addMethod;
 
-                if (!$addMethod) {
+                if (!$this->isAccessible($reflClass, $addMethod, 1)) {
                     throw new FormException(sprintf(
-                        'The method "%s" could not be found on class %s',
-                        $this->addMethod,
+                        'The public method "%s" could not be found on class %s',
+                        $addMethod,
                         $reflClass->getName()
                     ));
                 }
@@ -142,25 +225,36 @@ class MergeCollectionListener implements EventSubscriberInterface
 
             // Set preconfigured remover
             if ($this->allowDelete && $this->removeMethod) {
-                $removeMethod = $this->checkMethod($reflClass, $this->removeMethod);
+                $removeMethod = $this->removeMethod;
 
-                if (!$removeMethod) {
+                if (!$this->isAccessible($reflClass, $removeMethod, 1)) {
                     throw new FormException(sprintf(
-                        'The method "%s" could not be found on class %s',
-                        $this->removeMethod,
+                        'The public method "%s" could not be found on class %s',
+                        $removeMethod,
+                        $reflClass->getName()
+                    ));
+                }
+            }
+
+            if ($addMethod || $removeMethod) {
+                $getMethod = 'get' . $plural;
+
+                if (!$this->isAccessible($reflClass, $getMethod, 0)) {
+                    throw new FormException(sprintf(
+                        'The public method "%s" could not be found on class %s',
+                        $getMethod,
                         $reflClass->getName()
                     ));
                 }
             }
         }
 
-        // Check which items are in $data that are not in $originalData and
-        // vice versa
+        // Calculate delta between $data and the snapshot created in PRE_BIND
         $itemsToDelete = array();
         $itemsToAdd = is_object($data) ? clone $data : $data;
 
-        if ($originalData) {
-            foreach ($originalData as $originalKey => $originalItem) {
+        if ($this->dataSnapshot) {
+            foreach ($this->dataSnapshot as $originalItem) {
                 foreach ($data as $key => $item) {
                     if ($item === $originalItem) {
                         // Item found, next original item
@@ -170,7 +264,12 @@ class MergeCollectionListener implements EventSubscriberInterface
                 }
 
                 // Item not found, remember for deletion
-                $itemsToDelete[$originalKey] = $originalItem;
+                foreach ($originalData as $key => $item) {
+                    if ($item === $originalItem) {
+                        $itemsToDelete[$key] = $item;
+                        continue 2;
+                    }
+                }
             }
         }
 
@@ -187,43 +286,47 @@ class MergeCollectionListener implements EventSubscriberInterface
                     $parentData->$addMethod($item);
                 }
             }
-        } elseif (!$originalData) {
-            // No original data was set. Set it if allowed
-            if ($this->allowAdd) {
-                $originalData = $data;
-            }
-        } else {
-            // Original data is an array-like structure
-            // Add and remove items in the original variable
-            if ($this->allowDelete) {
-                foreach ($itemsToDelete as $key => $item) {
-                    unset($originalData[$key]);
-                }
-            }
 
-            if ($this->allowAdd) {
-                foreach ($itemsToAdd as $key => $item) {
-                    if (!isset($originalData[$key])) {
-                        $originalData[$key] = $item;
-                    } else {
-                        $originalData[] = $item;
+            $event->setData($parentData->$getMethod());
+        } elseif ($this->mergeStrategy & self::MERGE_NORMAL) {
+            if (!$originalData) {
+                // No original data was set. Set it if allowed
+                if ($this->allowAdd) {
+                    $originalData = $data;
+                }
+            } else {
+                // Original data is an array-like structure
+                // Add and remove items in the original variable
+                if ($this->allowDelete) {
+                    foreach ($itemsToDelete as $key => $item) {
+                        unset($originalData[$key]);
+                    }
+                }
+
+                if ($this->allowAdd) {
+                    foreach ($itemsToAdd as $key => $item) {
+                        if (!isset($originalData[$key])) {
+                            $originalData[$key] = $item;
+                        } else {
+                            $originalData[] = $item;
+                        }
                     }
                 }
             }
-        }
 
-        $event->setData($originalData);
+            $event->setData($originalData);
+        }
     }
 
-    private function checkMethod(\ReflectionClass $reflClass, $methodName) {
+    private function isAccessible(\ReflectionClass $reflClass, $methodName, $numberOfRequiredParameters) {
         if ($reflClass->hasMethod($methodName)) {
             $method = $reflClass->getMethod($methodName);
 
-            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === 1) {
-                return $methodName;
+            if ($method->isPublic() && $method->getNumberOfRequiredParameters() === $numberOfRequiredParameters) {
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -38,23 +38,23 @@ class CollectionType extends AbstractType
             $options['allow_delete']
         );
 
-        $mergeListener = new MergeCollectionListener(
-            $options['allow_add'],
-            $options['allow_delete'],
-            // If "by_reference" is disabled (explicit calling of the setter
-            // is desired), disable support for adders/removers
-            // Same as in ChoiceType
-            $options['by_reference'],
-            $options['add_method'],
-            $options['remove_method']
-        );
-
         $builder
             ->addEventSubscriber($resizeListener)
-            ->addEventSubscriber($mergeListener)
             ->setAttribute('allow_add', $options['allow_add'])
             ->setAttribute('allow_delete', $options['allow_delete'])
         ;
+
+        // Enable support for adders/removers unless "by_reference" is disabled
+        // (explicit calling of the setter is desired)
+        if ($options['by_reference']) {
+            $builder->addEventSubscriber(new MergeCollectionListener(
+                $options['allow_add'],
+                $options['allow_delete'],
+                MergeCollectionListener::MERGE_INTO_PARENT,
+                $options['add_method'],
+                $options['remove_method']
+            ));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -111,6 +111,16 @@ class PropertyPath implements \IteratorAggregate
     }
 
     /**
+     * Returns the length of the property path.
+     *
+     * @return integer
+     */
+    public function getLength()
+    {
+        return $this->length;
+    }
+
+    /**
      * Returns the parent property path.
      *
      * The parent property path is the one that contains the same items as

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -27,26 +27,32 @@ class PropertyPath implements \IteratorAggregate
      * The elements of the property path
      * @var array
      */
-    protected $elements = array();
+    private $elements = array();
 
     /**
      * The number of elements in the property path
      * @var integer
      */
-    protected $length;
+    private $length;
 
     /**
      * Contains a Boolean for each property in $elements denoting whether this
      * element is an index. It is a property otherwise.
      * @var array
      */
-    protected $isIndex = array();
+    private $isIndex = array();
 
     /**
      * String representation of the path
      * @var string
      */
-    protected $string;
+    private $string;
+
+    /**
+     * Positions where the individual elements start in the string representation
+     * @var array
+     */
+    private $positions;
 
     /**
      * Parses the given property path
@@ -67,6 +73,8 @@ class PropertyPath implements \IteratorAggregate
         $pattern = '/^(([^\.\[]+)|\[([^\]]+)\])(.*)/';
 
         while (preg_match($pattern, $remaining, $matches)) {
+            $this->positions[] = $position;
+
             if ('' !== $matches[2]) {
                 $this->elements[] = $matches[2];
                 $this->isIndex[] = false;
@@ -100,6 +108,33 @@ class PropertyPath implements \IteratorAggregate
     public function __toString()
     {
         return $this->string;
+    }
+
+    /**
+     * Returns the parent property path.
+     *
+     * The parent property path is the one that contains the same items as
+     * this one except for the last one.
+     *
+     * If this property path only contains one item, null is returned.
+     *
+     * @return PropertyPath The parent path or null.
+     */
+    public function getParent()
+    {
+        if ($this->length <= 1) {
+            return null;
+        }
+
+        $parent = clone $this;
+
+        --$parent->length;
+        $parent->string = substr($parent->string, 0, $parent->positions[$parent->length]);
+        array_pop($parent->elements);
+        array_pop($parent->isIndex);
+        array_pop($parent->positions);
+
+        return $parent;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Form/PropertyPathTest.php
+++ b/tests/Symfony/Tests/Component/Form/PropertyPathTest.php
@@ -391,4 +391,25 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
 
         new PropertyPath(null);
     }
+
+    public function testGetParent_dot()
+    {
+        $propertyPath = new PropertyPath('grandpa.parent.child');
+
+        $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
+    }
+
+    public function testGetParent_index()
+    {
+        $propertyPath = new PropertyPath('grandpa.parent[child]');
+
+        $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
+    }
+
+    public function testGetParent_noParent()
+    {
+        $propertyPath = new PropertyPath('path');
+
+        $this->assertNull($propertyPath->getParent());
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3293, #1499
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3293)

This fixes CollectionType to properly use adders and removers. Apart from that, adders and removers now work with custom property paths. PropertyPath was extended for a method `getParent`.
