### PR TITLE
[Routing] Allow using kernel parameters in routes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -44,6 +44,7 @@
 
         <service id="routing.loader" class="%routing.loader.class%">
             <tag name="monolog.logger" channel="router" />
+            <argument type="service" id="service_container" />
             <argument type="service" id="controller_name_converter" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="routing.resolver" />


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Tests pass: ![Tests](https://secure.travis-ci.org/helmer/symfony.png?branch=route_parameters)

I've had this snippet in my DelegatingLoader override for a while now, but as I saw others are also interested (#3276), I thought I'd share.
