### PR TITLE
[Validator] Renamed ConstraintValidatorInterface::isValid() to validate() and removed return value

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -434,6 +434,9 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * deprecated Constraint methods `setMessage`, `getMessageTemplate` and
    `getMessageParameters`
  * added support for dynamic group sequences with the GroupSequenceProvider pattern
+ * [BC BREAK] ConstraintValidatorInterface method `isValid` has been renamed to
+   `validate`, its return value was dropped. ConstraintValidator still contains
+   `isValid` for BC
 
 ### Yaml
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -135,7 +135,7 @@
   * `MutableAclInterface::setParentAcl` now accepts `null`, review any
     implementations of this interface to reflect this change.
 
-### Form and Validator
+### Form
 
   * Child forms are no longer automatically validated. That means that you must
     explicitly set the `Valid` constraint in your model if you want to validate
@@ -283,73 +283,6 @@
   * `FormUtil::toArrayKey()` and `FormUtil::toArrayKeys()` have been removed.
     They were merged into ChoiceList and have no public equivalent anymore.
 
-  * The methods `setMessage()`, `getMessageTemplate()` and
-    `getMessageParameters()` in the Constraint class were deprecated.
-
-    If you have implemented custom validators, you should use the
-    `addViolation()` method on the `ExecutionContext` object instead.
-
-    Before:
-
-    ```
-    public function isValid($value, Constraint $constraint)
-    {
-        // ...
-        if (!$valid) {
-            $this->setMessage($constraint->message, array(
-                '{{ value }}' => $value,
-            ));
-
-            return false;
-        }
-    }
-    ```
-
-    After:
-
-    ```
-    public function isValid($value, Constraint $constraint)
-    {
-        // ...
-        if (!$valid) {
-            $this->context->addViolation($constraint->message, array(
-                '{{ value }}' => $value,
-            ));
-
-            return false;
-        }
-    }
-    ```
-
-  * The method `setPropertyPath()` in the ExecutionContext class
-    was removed.
-
-    You should use the `addViolationAtSubPath()` method on the
-    `ExecutionContext` object instead.
-
-    Before:
-
-    ```
-    public function isPropertyValid(ExecutionContext $context)
-    {
-        // ...
-        $propertyPath = $context->getPropertyPath() . '.property';
-        $context->setPropertyPath($propertyPath);
-        $context->addViolation('Error Message', array(), null);
-    }
-    ```
-
-    After:
-
-    ```
-    public function isPropertyValid(ExecutionContext $context)
-    {
-        // ...
-        $context->addViolationAtSubPath('property', 'Error Message', array(), null);
-
-    }
-    ```
-
   * The options passed to the `getParent()` method of form types no longer
     contain default options. They only contain the options passed by the user.
 
@@ -424,6 +357,116 @@
     substitute them by event listeners listening to the FormEvents::POST_BIND
     (or any other of the BIND events). In case you used the CallbackValidator
     class, you should now pass the callback directly to `addEventListener`.
+
+### Validator
+
+  * The methods `setMessage()`, `getMessageTemplate()` and
+    `getMessageParameters()` in the Constraint class were deprecated and will
+    be removed in Symfony 2.3.
+
+    If you have implemented custom validators, you should use the
+    `addViolation()` method on the `ExecutionContext` object instead.
+
+    Before:
+
+    ```
+    public function isValid($value, Constraint $constraint)
+    {
+        // ...
+        if (!$valid) {
+            $this->setMessage($constraint->message, array(
+                '{{ value }}' => $value,
+            ));
+
+            return false;
+        }
+    }
+    ```
+
+    After:
+
+    ```
+    public function isValid($value, Constraint $constraint)
+    {
+        // ...
+        if (!$valid) {
+            $this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $value,
+            ));
+
+            return false;
+        }
+    }
+    ```
+
+  * The method `setPropertyPath()` in the ExecutionContext class
+    was removed.
+
+    You should use the `addViolationAtSubPath()` method on the
+    `ExecutionContext` object instead.
+
+    Before:
+
+    ```
+    public function isPropertyValid(ExecutionContext $context)
+    {
+        // ...
+        $propertyPath = $context->getPropertyPath() . '.property';
+        $context->setPropertyPath($propertyPath);
+        $context->addViolation('Error Message', array(), null);
+    }
+    ```
+
+    After:
+
+    ```
+    public function isPropertyValid(ExecutionContext $context)
+    {
+        // ...
+        $context->addViolationAtSubPath('property', 'Error Message', array(), null);
+
+    }
+    ```
+
+  * The method `isValid` of `ConstraintValidatorInterface` was renamed to
+    `validate` and its return value was dropped.
+
+    `ConstraintValidator` still contains the deprecated `isValid` method and
+    forwards `validate` calls to `isValid` by default. This BC layer will be 
+    removed in Symfony 2.3. You are advised to rename your methods. You should
+    also remove the return values, which have never been used by the framework.
+
+    Before:
+
+    ```
+    public function isValid($value, Constraint $constraint)
+    {
+        // ...
+        if (!$valid) {
+            $this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $value,
+            ));
+
+            return false;
+        }
+    }
+    ```
+
+    After:
+
+    ```
+    public function validate($value, Constraint $constraint)
+    {
+        // ...
+        if (!$valid) {
+            $this->context->addViolation($constraint->message, array(
+                '{{ value }}' => $value,
+            ));
+            
+            return;
+        }
+    }
+    ```
 
 ### Session
 

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -40,8 +40,6 @@ class UniqueEntityValidator extends ConstraintValidator
     /**
      * @param object $entity
      * @param Constraint $constraint
-     *
-     * @return bool
      */
     public function isValid($entity, Constraint $constraint)
     {
@@ -74,7 +72,7 @@ class UniqueEntityValidator extends ConstraintValidator
             $criteria[$fieldName] = $class->reflFields[$fieldName]->getValue($entity);
 
             if (null === $criteria[$fieldName]) {
-                return true;
+                return;
             }
 
             if ($class->hasAssociation($fieldName)) {
@@ -113,11 +111,9 @@ class UniqueEntityValidator extends ConstraintValidator
          * unique.
          */
         if (0 === count($result) || (1 === count($result) && $entity === ($result instanceof \Iterator ? $result->current() : current($result)))) {
-            return true;
+            return;
         }
 
         $this->context->addViolationAtSubPath($fields[0], $constraint->message, array(), $criteria[$fields[0]]);
-
-        return true; // all true, we added the violation already!
     }
 }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -41,7 +41,7 @@ class UniqueEntityValidator extends ConstraintValidator
      * @param object $entity
      * @param Constraint $constraint
      */
-    public function isValid($entity, Constraint $constraint)
+    public function validate($entity, Constraint $constraint)
     {
         if (!is_array($constraint->fields) && !is_string($constraint->fields)) {
             throw new UnexpectedTypeException($constraint->fields, 'array');

--- a/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
@@ -29,7 +29,7 @@ class UserPasswordValidator extends ConstraintValidator
         $this->encoderFactory = $encoderFactory;
     }
 
-    public function isValid($password, Constraint $constraint)
+    public function validate($password, Constraint $constraint)
     {
         $user = $this->securityContext->getToken()->getUser();
 

--- a/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
+++ b/src/Symfony/Bundle/SecurityBundle/Validator/Constraint/UserPasswordValidator.php
@@ -41,10 +41,6 @@ class UserPasswordValidator extends ConstraintValidator
 
         if (!$encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt())) {
             $this->context->addViolation($constraint->message);
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Validator;
 
+use Symfony\Component\Validator\Exception\ValidatorException;
+
 /**
  * Base class for constraint validators
  *
@@ -18,8 +20,6 @@ namespace Symfony\Component\Validator;
  *
  * @api
  */
-use Symfony\Component\Validator\Exception\ValidatorException;
-
 abstract class ConstraintValidator implements ConstraintValidatorInterface
 {
     /**
@@ -54,7 +54,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     /**
      * {@inheritDoc}
      *
-     * @deprecated
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
     public function getMessageTemplate()
     {
@@ -64,7 +64,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     /**
      * {@inheritDoc}
      *
-     * @deprecated
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
     public function getMessageParameters()
     {
@@ -74,7 +74,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
     /**
      * Wrapper for $this->context->addViolation()
      *
-     * @deprecated
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
     protected function setMessage($template, array $parameters = array())
     {
@@ -86,5 +86,26 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
         }
 
         $this->context->addViolation($template, $parameters);
+    }
+
+    /**
+     * Stub implementation delegating to the deprecated isValid method.
+     *
+     * This stub exists for BC and will be dropped in Symfony 2.3.
+     *
+     * @see ConstraintValidatorInterface::validate
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        return $this->isValid($valoue, $constraint);
+    }
+
+    /**
+     * BC variant of validate.
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
+     */
+    protected function isValid($value, Constraint $constraint)
+    {
     }
 }

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -97,7 +97,7 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      */
     public function validate($value, Constraint $constraint)
     {
-        return $this->isValid($valoue, $constraint);
+        return $this->isValid($value, $constraint);
     }
 
     /**

--- a/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
@@ -31,8 +31,6 @@ interface ConstraintValidatorInterface
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constrain for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     function isValid($value, Constraint $constraint);

--- a/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
@@ -33,5 +33,5 @@ interface ConstraintValidatorInterface
      *
      * @api
      */
-    function isValid($value, Constraint $constraint);
+    function validate($value, Constraint $constraint);
 }

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -30,7 +30,7 @@ class AllValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class AllValidator extends ConstraintValidator
@@ -26,14 +28,12 @@ class AllValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
-            return true;
+            return;
         }
 
         if (!is_array($value) && !$value instanceof \Traversable) {
@@ -53,7 +53,5 @@ class AllValidator extends ConstraintValidator
                 $walker->walkConstraint($constr, $element, $group, $propertyPath.'['.$key.']');
             }
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -29,7 +29,7 @@ class BlankValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if ('' !== $value && null !== $value) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class BlankValidator extends ConstraintValidator
@@ -25,18 +27,12 @@ class BlankValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if ('' !== $value && null !== $value) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 /**
  * Validator for Callback constraint
  *
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -31,14 +31,12 @@ class CallbackValidator extends ConstraintValidator
      * @param mixed      $object     The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($object, Constraint $constraint)
     {
         if (null === $object) {
-            return true;
+            return;
         }
 
         // has to be an array so that we can differentiate between callables
@@ -48,7 +46,6 @@ class CallbackValidator extends ConstraintValidator
         }
 
         $methods = $constraint->methods;
-        $success = true;
 
         foreach ($methods as $method) {
             if (is_array($method) || $method instanceof \Closure) {
@@ -56,16 +53,14 @@ class CallbackValidator extends ConstraintValidator
                     throw new ConstraintDefinitionException(sprintf('"%s::%s" targeted by Callback constraint is not a valid callable', $method[0], $method[1]));
                 }
 
-                $success = call_user_func($method, $object, $this->context) && $success;
+                call_user_func($method, $object, $this->context);
             } else {
                 if (!method_exists($object, $method)) {
                     throw new ConstraintDefinitionException(sprintf('Method "%s" targeted by Callback constraint does not exist', $method));
                 }
 
-                $success = $object->$method($this->context) && $success;
+                $object->$method($this->context);
             }
         }
-
-        return $success;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -33,7 +33,7 @@ class CallbackValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($object, Constraint $constraint)
+    public function validate($object, Constraint $constraint)
     {
         if (null === $object) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -35,7 +35,7 @@ class ChoiceValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (!$constraint->choices && !$constraint->callback) {
             throw new ConstraintDefinitionException('Either "choices" or "callback" must be specified on constraint Choice');

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -33,8 +33,6 @@ class ChoiceValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
@@ -44,7 +42,7 @@ class ChoiceValidator extends ConstraintValidator
         }
 
         if (null === $value) {
-            return true;
+            return;
         }
 
         if ($constraint->multiple && !is_array($value)) {
@@ -67,8 +65,6 @@ class ChoiceValidator extends ConstraintValidator
             foreach ($value as $_value) {
                 if (!in_array($_value, $choices, $constraint->strict)) {
                     $this->context->addViolation($constraint->multipleMessage, array('{{ value }}' => $_value));
-
-                    return false;
                 }
             }
 
@@ -77,20 +73,16 @@ class ChoiceValidator extends ConstraintValidator
             if ($constraint->min !== null && $count < $constraint->min) {
                 $this->context->addViolation($constraint->minMessage, array('{{ limit }}' => $constraint->min), null, (int) $constraint->min);
 
-                return false;
+                return;
             }
 
             if ($constraint->max !== null && $count > $constraint->max) {
                 $this->context->addViolation($constraint->maxMessage, array('{{ limit }}' => $constraint->max), null, (int) $constraint->max);
 
-                return false;
+                return;
             }
         } elseif (!in_array($value, $choices, $constraint->strict)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -18,6 +18,8 @@ use Symfony\Component\Validator\Constraints\Collection\Optional;
 use Symfony\Component\Validator\Constraints\Collection\Required;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class CollectionValidator extends ConstraintValidator
@@ -28,14 +30,12 @@ class CollectionValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
-            return true;
+            return;
         }
 
         if (!is_array($value) && !($value instanceof \Traversable && $value instanceof \ArrayAccess)) {
@@ -45,8 +45,6 @@ class CollectionValidator extends ConstraintValidator
         $walker = $this->context->getGraphWalker();
         $group = $this->context->getGroup();
         $propertyPath = $this->context->getPropertyPath();
-
-        $valid = true;
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
             if (
@@ -71,7 +69,6 @@ class CollectionValidator extends ConstraintValidator
                 $this->context->addViolationAtSubPath('['.$field.']', $constraint->missingFieldsMessage, array(
                     '{{ field }}' => $field
                 ), null);
-                $valid = false;
             }
         }
 
@@ -81,11 +78,8 @@ class CollectionValidator extends ConstraintValidator
                     $this->context->addViolationAtSubPath('['.$field.']', $constraint->extraFieldsMessage, array(
                         '{{ field }}' => $field
                     ), $fieldValue);
-                    $valid = false;
                 }
             }
         }
-
-        return $valid;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -32,7 +32,7 @@ class CollectionValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates whether a value is a valid country code
  *
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -30,14 +30,12 @@ class CountryValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -48,10 +46,6 @@ class CountryValidator extends ConstraintValidator
 
         if (!in_array($value, \Symfony\Component\Locale\Locale::getCountries())) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -32,7 +32,7 @@ class CountryValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Validator\Constraints;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class DateTimeValidator extends DateValidator

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class DateValidator extends ConstraintValidator
@@ -28,18 +30,12 @@ class DateValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value || '' === $value) {
-            return true;
-        }
-
-        if ($value instanceof \DateTime) {
-            return true;
+        if (null === $value || '' === $value || $value instanceof \DateTime) {
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -50,10 +46,6 @@ class DateValidator extends ConstraintValidator
 
         if (!preg_match(static::PATTERN, $value, $matches) || !checkdate($matches[2], $matches[3], $matches[1])) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -32,7 +32,7 @@ class DateValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value || $value instanceof \DateTime) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class EmailValidator extends ConstraintValidator
@@ -26,14 +28,12 @@ class EmailValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -61,11 +61,7 @@ class EmailValidator extends ConstraintValidator
 
         if (!$valid) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 
     /**

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -30,7 +30,7 @@ class EmailValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -29,7 +29,7 @@ class FalseValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || false === $value || 0 === $value || '0' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class FalseValidator extends ConstraintValidator
@@ -25,22 +27,14 @@ class FalseValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value) {
-            return true;
-        }
-
-        if (false === $value || 0 === $value || '0' === $value) {
-            return true;
+        if (null === $value || false === $value || 0 === $value || '0' === $value) {
+            return;
         }
 
         $this->context->addViolation($constraint->message);
-
-        return false;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -19,6 +19,8 @@ use Symfony\Component\HttpFoundation\File\File as FileObject;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class FileValidator extends ConstraintValidator
@@ -29,14 +31,12 @@ class FileValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if ($value instanceof UploadedFile && !$value->isValid()) {
@@ -46,35 +46,35 @@ class FileValidator extends ConstraintValidator
                     $maxSize = $constraint->maxSize ? min($maxSize, $constraint->maxSize) : $maxSize;
                     $this->context->addViolation($constraint->uploadIniSizeErrorMessage, array('{{ limit }}' => $maxSize.' bytes'));
 
-                    return false;
+                    return;
                 case UPLOAD_ERR_FORM_SIZE:
                     $this->context->addViolation($constraint->uploadFormSizeErrorMessage);
 
-                    return false;
+                    return;
                 case UPLOAD_ERR_PARTIAL:
                     $this->context->addViolation($constraint->uploadPartialErrorMessage);
 
-                    return false;
+                    return;
                 case UPLOAD_ERR_NO_FILE:
                     $this->context->addViolation($constraint->uploadNoFileErrorMessage);
 
-                    return false;
+                    return;
                 case UPLOAD_ERR_NO_TMP_DIR:
                     $this->context->addViolation($constraint->uploadNoTmpDirErrorMessage);
 
-                    return false;
+                    return;
                 case UPLOAD_ERR_CANT_WRITE:
                     $this->context->addViolation($constraint->uploadCantWriteErrorMessage);
 
-                    return false;
+                    return;
                 case UPLOAD_ERR_EXTENSION:
                     $this->context->addViolation($constraint->uploadExtensionErrorMessage);
 
-                    return false;
+                    return;
                 default:
                     $this->context->addViolation($constraint->uploadErrorMessage);
 
-                    return false;
+                    return;
             }
         }
 
@@ -87,13 +87,13 @@ class FileValidator extends ConstraintValidator
         if (!is_file($path)) {
             $this->context->addViolation($constraint->notFoundMessage, array('{{ file }}' => $path));
 
-            return false;
+            return;
         }
 
         if (!is_readable($path)) {
             $this->context->addViolation($constraint->notReadableMessage, array('{{ file }}' => $path));
 
-            return false;
+            return;
         }
 
         if ($constraint->maxSize) {
@@ -120,7 +120,7 @@ class FileValidator extends ConstraintValidator
                     '{{ file }}'    => $path,
                 ));
 
-                return false;
+                return;
             }
         }
 
@@ -153,11 +153,7 @@ class FileValidator extends ConstraintValidator
                     '{{ types }}'   => '"'.implode('", "', $mimeTypes) .'"',
                     '{{ file }}'    => $path,
                 ));
-
-                return false;
             }
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -33,7 +33,7 @@ class FileValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -24,25 +24,26 @@ class ImageValidator extends FileValidator
 {
     public function isValid($value, Constraint $constraint)
     {
-        $isValid = parent::isValid($value, $constraint);
-        if (!$isValid) {
-            return false;
-        }
+        $violations = count($this->context->getViolations());
 
-        if (null === $value || '' === $value) {
-            return true;
+        parent::isValid($value, $constraint);
+
+        $isValid = count($this->context->getViolations()) === $violations;
+
+        if (!$isValid || null === $value || '' === $value) {
+            return;
         }
 
         if (null === $constraint->minWidth && null === $constraint->maxWidth
             && null === $constraint->minHeight && null === $constraint->maxHeight) {
-            return true;
+            return;
         }
 
         $size = @getimagesize($value);
         if (empty($size) || ($size[0] === 0) || ($size[1] === 0)) {
             $this->context->addViolation($constraint->sizeNotDetectedMessage);
 
-            return false;
+            return;
         }
 
         $width  = $size[0];
@@ -59,7 +60,7 @@ class ImageValidator extends FileValidator
                     '{{ min_width }}' => $constraint->minWidth
                 ));
 
-                return false;
+                return;
             }
         }
 
@@ -74,7 +75,7 @@ class ImageValidator extends FileValidator
                     '{{ max_width }}' => $constraint->maxWidth
                 ));
 
-                return false;
+                return;
             }
         }
 
@@ -89,7 +90,7 @@ class ImageValidator extends FileValidator
                     '{{ min_height }}' => $constraint->minHeight
                 ));
 
-                return false;
+                return;
             }
         }
 
@@ -103,11 +104,7 @@ class ImageValidator extends FileValidator
                     '{{ height }}'    => $height,
                     '{{ max_height }}' => $constraint->maxHeight
                 ));
-
-                return false;
             }
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -22,15 +22,15 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class ImageValidator extends FileValidator
 {
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         $violations = count($this->context->getViolations());
 
-        parent::isValid($value, $constraint);
+        parent::validate($value, $constraint);
 
-        $isValid = count($this->context->getViolations()) === $violations;
+        $failed = count($this->context->getViolations()) !== $violations;
 
-        if (!$isValid || null === $value || '' === $value) {
+        if ($failed || null === $value || '' === $value) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -33,7 +33,7 @@ class IpValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates whether a value is a valid IP address
  *
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Joseph Bielawski <stloyd@gmail.com>
  *
  * @api
@@ -31,14 +31,12 @@ class IpValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -99,10 +97,6 @@ class IpValidator extends ConstraintValidator
 
         if (!filter_var($value, FILTER_VALIDATE_IP, $flag)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -32,7 +32,7 @@ class LanguageValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates whether a value is a valid language code
  *
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -30,14 +30,12 @@ class LanguageValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -48,10 +46,6 @@ class LanguageValidator extends ConstraintValidator
 
         if (!in_array($value, \Symfony\Component\Locale\Locale::getLanguages())) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates whether a value is a valid locale code
  *
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  *
  * @api
  */
@@ -30,14 +30,12 @@ class LocaleValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -48,10 +46,6 @@ class LocaleValidator extends ConstraintValidator
 
         if (!in_array($value, \Symfony\Component\Locale\Locale::getLocales())) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -32,7 +32,7 @@ class LocaleValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class MaxLengthValidator extends ConstraintValidator
@@ -26,14 +28,12 @@ class MaxLengthValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -55,10 +55,6 @@ class MaxLengthValidator extends ConstraintValidator
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ), null, (int) $constraint->limit);
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
@@ -30,7 +30,7 @@ class MaxLengthValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/MaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxValidator.php
@@ -29,7 +29,7 @@ class MaxValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/MaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class MaxValidator extends ConstraintValidator
@@ -25,14 +27,12 @@ class MaxValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constrain for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
-            return true;
+            return;
         }
 
         if (!is_numeric($value)) {
@@ -41,7 +41,7 @@ class MaxValidator extends ConstraintValidator
                 '{{ limit }}' => $constraint->limit,
             ));
 
-            return false;
+            return;
         }
 
         if ($value > $constraint->limit) {
@@ -49,10 +49,6 @@ class MaxValidator extends ConstraintValidator
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class MinLengthValidator extends ConstraintValidator
@@ -26,14 +28,12 @@ class MinLengthValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -55,10 +55,6 @@ class MinLengthValidator extends ConstraintValidator
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ), null, (int) $constraint->limit);
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
@@ -30,7 +30,7 @@ class MinLengthValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/MinValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class MinValidator extends ConstraintValidator
@@ -25,14 +27,12 @@ class MinValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
-            return true;
+            return;
         }
 
         if (!is_numeric($value)) {
@@ -41,7 +41,7 @@ class MinValidator extends ConstraintValidator
                 '{{ limit }}' => $constraint->limit,
             ));
 
-            return false;
+            return;
         }
 
         if ($value < $constraint->limit) {
@@ -49,10 +49,6 @@ class MinValidator extends ConstraintValidator
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
             ));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/MinValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinValidator.php
@@ -29,7 +29,7 @@ class MinValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class NotBlankValidator extends ConstraintValidator
@@ -25,18 +27,12 @@ class NotBlankValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (false === $value || (empty($value) && '0' != $value)) {
             $this->context->addViolation($constraint->message);
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -29,7 +29,7 @@ class NotBlankValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (false === $value || (empty($value) && '0' != $value)) {
             $this->context->addViolation($constraint->message);

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class NotNullValidator extends ConstraintValidator
@@ -25,18 +27,12 @@ class NotNullValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
             $this->context->addViolation($constraint->message);
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -29,7 +29,7 @@ class NotNullValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             $this->context->addViolation($constraint->message);

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -29,7 +29,7 @@ class NullValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null !== $value) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class NullValidator extends ConstraintValidator
@@ -25,18 +27,12 @@ class NullValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null !== $value) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -33,7 +33,7 @@ class RegexValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -18,7 +18,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 /**
  * Validates whether a value match or not given regexp pattern
  *
- * @author Bernhard Schussek <bernhard.schussek@symfony.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Joseph Bielawski <stloyd@gmail.com>
  *
  * @api
@@ -31,14 +31,12 @@ class RegexValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -49,10 +47,6 @@ class RegexValidator extends ConstraintValidator
 
         if ($constraint->match xor preg_match($constraint->pattern, $value)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/SizeLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/SizeLengthValidator.php
@@ -28,7 +28,7 @@ class SizeLengthValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/SizeLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/SizeLengthValidator.php
@@ -26,14 +26,12 @@ class SizeLengthValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -56,7 +54,7 @@ class SizeLengthValidator extends ConstraintValidator
                 '{{ limit }}' => $constraint->max,
             ), null, (int) $constraint->max);
 
-            return false;
+            return;
         }
 
         if ($length > $constraint->max) {
@@ -65,7 +63,7 @@ class SizeLengthValidator extends ConstraintValidator
                 '{{ limit }}' => $constraint->max,
             ), null, (int) $constraint->max);
 
-            return false;
+            return;
         }
 
         if ($length < $constraint->min) {
@@ -73,10 +71,6 @@ class SizeLengthValidator extends ConstraintValidator
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->min,
             ), null, (int) $constraint->min);
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/SizeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/SizeValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class SizeValidator extends ConstraintValidator
@@ -32,7 +34,7 @@ class SizeValidator extends ConstraintValidator
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
-            return true;
+            return;
         }
 
         if (!is_numeric($value)) {
@@ -40,7 +42,7 @@ class SizeValidator extends ConstraintValidator
                 '{{ value }}' => $value,
             ));
 
-            return false;
+            return;
         }
 
         if ($value > $constraint->max) {
@@ -49,7 +51,7 @@ class SizeValidator extends ConstraintValidator
                 '{{ limit }}' => $constraint->max,
             ));
 
-            return false;
+            return;
         }
 
         if ($value < $constraint->min) {
@@ -57,10 +59,6 @@ class SizeValidator extends ConstraintValidator
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->min,
             ));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/SizeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/SizeValidator.php
@@ -31,7 +31,7 @@ class SizeValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class TimeValidator extends ConstraintValidator
@@ -28,18 +30,12 @@ class TimeValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
-        if (null === $value || '' === $value) {
-            return true;
-        }
-
-        if ($value instanceof \DateTime) {
-            return true;
+        if (null === $value || '' === $value || $value instanceof \DateTime) {
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -50,10 +46,6 @@ class TimeValidator extends ConstraintValidator
 
         if (!preg_match(static::PATTERN, $value)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -32,7 +32,7 @@ class TimeValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value || $value instanceof \DateTime) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class TrueValidator extends ConstraintValidator
@@ -24,8 +26,6 @@ class TrueValidator extends ConstraintValidator
      *
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
-     *
-     * @return Boolean Whether or not the value is valid
      *
      * @api
      */

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -29,7 +29,7 @@ class TrueValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             return true;

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -15,6 +15,8 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class TypeValidator extends ConstraintValidator
@@ -25,14 +27,12 @@ class TypeValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value) {
-            return true;
+            return;
         }
 
         $type = strtolower($constraint->type);
@@ -41,18 +41,16 @@ class TypeValidator extends ConstraintValidator
         $ctypeFunction = 'ctype_'.$type;
 
         if (function_exists($isFunction) && call_user_func($isFunction, $value)) {
-            return true;
+            return;
         } elseif (function_exists($ctypeFunction) && call_user_func($ctypeFunction, $value)) {
-            return true;
+            return;
         } elseif ($value instanceof $constraint->type) {
-            return true;
+            return;
         }
 
         $this->context->addViolation($constraint->message, array(
             '{{ value }}' => is_object($value) ? get_class($value) : (is_array($value) ? 'Array' : (string) $value),
             '{{ type }}'  => $constraint->type,
         ));
-
-        return false;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -29,7 +29,7 @@ class TypeValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value) {
             return;

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -16,6 +16,8 @@ use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
  * @api
  */
 class UrlValidator extends ConstraintValidator
@@ -41,14 +43,12 @@ class UrlValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
-     *
      * @api
      */
     public function isValid($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
-            return true;
+            return;
         }
 
         if (!is_scalar($value) && !(is_object($value) && method_exists($value, '__toString'))) {
@@ -61,10 +61,6 @@ class UrlValidator extends ConstraintValidator
 
         if (!preg_match($pattern, $value)) {
             $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
-
-            return false;
         }
-
-        return true;
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -45,7 +45,7 @@ class UrlValidator extends ConstraintValidator
      *
      * @api
      */
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if (null === $value || '' === $value) {
             return;

--- a/src/Symfony/Component/Validator/GraphWalker.php
+++ b/src/Symfony/Component/Validator/GraphWalker.php
@@ -183,6 +183,6 @@ class GraphWalker
         );
 
         $validator->initialize($localContext);
-        $validator->isValid($value, $constraint);
+        $validator->validate($value, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintValidatorTest.php
@@ -25,7 +25,7 @@ class ConstraintValidatorTest_Validator extends ConstraintValidator
         $this->params = $params;
     }
 
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         $this->setMessage($this->message, $this->params);
     }
@@ -44,7 +44,7 @@ class ConstraintValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('error message', array('foo' => 'bar'));
 
-        $validator->isValid('bam', $constraint);
+        $validator->validate('bam', $constraint);
     }
 
     /**
@@ -55,6 +55,6 @@ class ConstraintValidatorTest extends \PHPUnit_Framework_TestCase
         $constraint = $this->getMock('Symfony\Component\Validator\Constraint', array(), array(), '', false);
         $validator = new ConstraintValidatorTest_Validator('error message', array('foo' => 'bar'));
 
-        $validator->isValid('bam', $constraint);
+        $validator->validate('bam', $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -54,7 +54,7 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new All(new Min(4)));
+        $this->validator->validate(null, new All(new Min(4)));
     }
 
 
@@ -63,7 +63,7 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionIfNotTraversable()
     {
-        $this->validator->isValid('foo.barbar', new All(new Min(4)));
+        $this->validator->validate('foo.barbar', new All(new Min(4)));
     }
 
     /**
@@ -84,7 +84,7 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($array, new All($constraint));
+        $this->validator->validate($array, new All($constraint));
     }
 
     /**
@@ -110,7 +110,7 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($array, new All($constraints));
+        $this->validator->validate($array, new All($constraints));
     }
 
     public function getValidArguments()

--- a/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/AllValidatorTest.php
@@ -51,7 +51,10 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testNullIsValid()
     {
-        $this->assertTrue($this->validator->isValid(null, new All(new Min(4))));
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->isValid(null, new All(new Min(4)));
     }
 
 
@@ -81,7 +84,7 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($array, new All($constraint)));
+        $this->validator->isValid($array, new All($constraint));
     }
 
     /**
@@ -107,7 +110,7 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($array, new All($constraints)));
+        $this->validator->isValid($array, new All($constraints));
     }
 
     public function getValidArguments()

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -37,7 +37,7 @@ class BlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Blank()));
+        $this->validator->isValid(null, new Blank());
     }
 
     public function testBlankIsValid()
@@ -45,7 +45,7 @@ class BlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Blank()));
+        $this->validator->isValid('', new Blank());
     }
 
     /**
@@ -63,7 +63,7 @@ class BlankValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $value,
             ));
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/BlankValidatorTest.php
@@ -37,7 +37,7 @@ class BlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Blank());
+        $this->validator->validate(null, new Blank());
     }
 
     public function testBlankIsValid()
@@ -45,7 +45,7 @@ class BlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Blank());
+        $this->validator->validate('', new Blank());
     }
 
     /**
@@ -63,7 +63,7 @@ class BlankValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $value,
             ));
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -65,7 +65,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Callback(array('foo'))));
+        $this->validator->isValid(null, new Callback(array('foo')));
     }
 
     public function testCallbackSingleMethod()
@@ -79,7 +79,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'foobar',
             ));
 
-        $this->assertFalse($this->validator->isValid($object, $constraint));
+        $this->validator->isValid($object, $constraint);
     }
 
     public function testCallbackSingleStaticMethod()
@@ -92,9 +92,9 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'foobar',
             ));
 
-        $this->assertFalse($this->validator->isValid($object, new Callback(array(
+        $this->validator->isValid($object, new Callback(array(
             array(__CLASS__.'_Class', 'validateStatic')
-        ))));
+        )));
     }
 
     public function testCallbackMultipleMethods()
@@ -113,9 +113,9 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
             ));
 
 
-        $this->assertFalse($this->validator->isValid($object, new Callback(array(
+        $this->validator->isValid($object, new Callback(array(
             'validateOne', 'validateTwo'
-        ))));
+        )));
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CallbackValidatorTest.php
@@ -65,7 +65,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Callback(array('foo')));
+        $this->validator->validate(null, new Callback(array('foo')));
     }
 
     public function testCallbackSingleMethod()
@@ -79,7 +79,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'foobar',
             ));
 
-        $this->validator->isValid($object, $constraint);
+        $this->validator->validate($object, $constraint);
     }
 
     public function testCallbackSingleStaticMethod()
@@ -92,7 +92,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'foobar',
             ));
 
-        $this->validator->isValid($object, new Callback(array(
+        $this->validator->validate($object, new Callback(array(
             array(__CLASS__.'_Class', 'validateStatic')
         )));
     }
@@ -113,7 +113,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
             ));
 
 
-        $this->validator->isValid($object, new Callback(array(
+        $this->validator->validate($object, new Callback(array(
             'validateOne', 'validateTwo'
         )));
     }
@@ -125,7 +125,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $object = new CallbackValidatorTest_Object();
 
-        $this->validator->isValid($object, new Callback('foobar'));
+        $this->validator->validate($object, new Callback('foobar'));
     }
 
     /**
@@ -135,7 +135,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $object = new CallbackValidatorTest_Object();
 
-        $this->validator->isValid($object, new Callback(array('foobar')));
+        $this->validator->validate($object, new Callback(array('foobar')));
     }
 
     /**
@@ -145,7 +145,7 @@ class CallbackValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $object = new CallbackValidatorTest_Object();
 
-        $this->validator->isValid($object, new Callback(array(array('foo', 'bar'))));
+        $this->validator->validate($object, new Callback(array(array('foo', 'bar'))));
     }
 
     public function testConstraintGetTargets()

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -66,7 +66,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Choice(array('choices' => array('foo', 'bar')))));
+        $this->validator->isValid(null, new Choice(array('choices' => array('foo', 'bar'))));
     }
 
     /**
@@ -92,7 +92,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('bar', $constraint));
+        $this->validator->isValid('bar', $constraint);
     }
 
     public function testValidChoiceCallbackFunction()
@@ -102,7 +102,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('bar', $constraint));
+        $this->validator->isValid('bar', $constraint);
     }
 
     public function testValidChoiceCallbackClosure()
@@ -114,7 +114,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('bar', $constraint));
+        $this->validator->isValid('bar', $constraint);
     }
 
     public function testValidChoiceCallbackStaticMethod()
@@ -124,7 +124,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('bar', $constraint));
+        $this->validator->isValid('bar', $constraint);
     }
 
     public function testValidChoiceCallbackContextMethod()
@@ -134,7 +134,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('bar', $constraint));
+        $this->validator->isValid('bar', $constraint);
     }
 
     public function testMultipleChoices()
@@ -147,7 +147,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(array('baz', 'bar'), $constraint));
+        $this->validator->isValid(array('baz', 'bar'), $constraint);
     }
 
     public function testInvalidChoice()
@@ -163,7 +163,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'baz',
             ), null, null);
 
-        $this->assertFalse($this->validator->isValid('baz', $constraint));
+        $this->validator->isValid('baz', $constraint);
     }
 
     public function testInvalidChoiceMultiple()
@@ -180,7 +180,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'baz',
             ));
 
-        $this->assertFalse($this->validator->isValid(array('foo', 'baz'), $constraint));
+        $this->validator->isValid(array('foo', 'baz'), $constraint);
     }
 
     public function testTooFewChoices()
@@ -198,7 +198,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 2,
             ), null, 2);
 
-        $this->assertFalse($this->validator->isValid(array('foo'), $constraint));
+        $this->validator->isValid(array('foo'), $constraint);
     }
 
     public function testTooManyChoices()
@@ -216,7 +216,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 2,
             ), null, 2);
 
-        $this->assertFalse($this->validator->isValid(array('foo', 'bar', 'moo'), $constraint));
+        $this->validator->isValid(array('foo', 'bar', 'moo'), $constraint);
     }
 
     public function testNonStrict()
@@ -229,8 +229,8 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('2', $constraint));
-        $this->assertTrue($this->validator->isValid(2, $constraint));
+        $this->validator->isValid('2', $constraint);
+        $this->validator->isValid(2, $constraint);
     }
 
     public function testStrictAllowsExactValue()
@@ -243,7 +243,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(2, $constraint));
+        $this->validator->isValid(2, $constraint);
     }
 
     public function testStrictDisallowsDifferentType()
@@ -260,7 +260,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => '2',
             ));
 
-        $this->assertFalse($this->validator->isValid('2', $constraint));
+        $this->validator->isValid('2', $constraint);
     }
 
     public function testNonStrictWithMultipleChoices()
@@ -274,7 +274,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(array('2', 3), $constraint));
+        $this->validator->isValid(array('2', 3), $constraint);
     }
 
     public function testStrictWithMultipleChoices()
@@ -292,6 +292,6 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => '3',
             ));
 
-        $this->assertFalse($this->validator->isValid(array(2, '3'), $constraint));
+        $this->validator->isValid(array(2, '3'), $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -58,7 +58,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
             'multiple' => true,
         ));
 
-        $this->validator->isValid('asdf', $constraint);
+        $this->validator->validate('asdf', $constraint);
     }
 
     public function testNullIsValid()
@@ -66,7 +66,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Choice(array('choices' => array('foo', 'bar'))));
+        $this->validator->validate(null, new Choice(array('choices' => array('foo', 'bar'))));
     }
 
     /**
@@ -74,7 +74,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testChoicesOrCallbackExpected()
     {
-        $this->validator->isValid('foobar', new Choice());
+        $this->validator->validate('foobar', new Choice());
     }
 
     /**
@@ -82,7 +82,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidCallbackExpected()
     {
-        $this->validator->isValid('foobar', new Choice(array('callback' => 'abcd')));
+        $this->validator->validate('foobar', new Choice(array('callback' => 'abcd')));
     }
 
     public function testValidChoiceArray()
@@ -92,7 +92,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('bar', $constraint);
+        $this->validator->validate('bar', $constraint);
     }
 
     public function testValidChoiceCallbackFunction()
@@ -102,7 +102,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('bar', $constraint);
+        $this->validator->validate('bar', $constraint);
     }
 
     public function testValidChoiceCallbackClosure()
@@ -114,7 +114,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('bar', $constraint);
+        $this->validator->validate('bar', $constraint);
     }
 
     public function testValidChoiceCallbackStaticMethod()
@@ -124,7 +124,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('bar', $constraint);
+        $this->validator->validate('bar', $constraint);
     }
 
     public function testValidChoiceCallbackContextMethod()
@@ -134,7 +134,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('bar', $constraint);
+        $this->validator->validate('bar', $constraint);
     }
 
     public function testMultipleChoices()
@@ -147,7 +147,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(array('baz', 'bar'), $constraint);
+        $this->validator->validate(array('baz', 'bar'), $constraint);
     }
 
     public function testInvalidChoice()
@@ -163,7 +163,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'baz',
             ), null, null);
 
-        $this->validator->isValid('baz', $constraint);
+        $this->validator->validate('baz', $constraint);
     }
 
     public function testInvalidChoiceMultiple()
@@ -180,7 +180,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'baz',
             ));
 
-        $this->validator->isValid(array('foo', 'baz'), $constraint);
+        $this->validator->validate(array('foo', 'baz'), $constraint);
     }
 
     public function testTooFewChoices()
@@ -198,7 +198,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 2,
             ), null, 2);
 
-        $this->validator->isValid(array('foo'), $constraint);
+        $this->validator->validate(array('foo'), $constraint);
     }
 
     public function testTooManyChoices()
@@ -216,7 +216,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 2,
             ), null, 2);
 
-        $this->validator->isValid(array('foo', 'bar', 'moo'), $constraint);
+        $this->validator->validate(array('foo', 'bar', 'moo'), $constraint);
     }
 
     public function testNonStrict()
@@ -229,8 +229,8 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('2', $constraint);
-        $this->validator->isValid(2, $constraint);
+        $this->validator->validate('2', $constraint);
+        $this->validator->validate(2, $constraint);
     }
 
     public function testStrictAllowsExactValue()
@@ -243,7 +243,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(2, $constraint);
+        $this->validator->validate(2, $constraint);
     }
 
     public function testStrictDisallowsDifferentType()
@@ -260,7 +260,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => '2',
             ));
 
-        $this->validator->isValid('2', $constraint);
+        $this->validator->validate('2', $constraint);
     }
 
     public function testNonStrictWithMultipleChoices()
@@ -274,7 +274,7 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(array('2', 3), $constraint);
+        $this->validator->validate(array('2', 3), $constraint);
     }
 
     public function testStrictWithMultipleChoices()
@@ -292,6 +292,6 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => '3',
             ));
 
-        $this->validator->isValid(array(2, '3'), $constraint);
+        $this->validator->validate(array(2, '3'), $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -58,7 +58,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid(null, new Collection(array('fields' => array(
+        $this->validator->validate(null, new Collection(array('fields' => array(
             'foo' => new Min(4),
         ))));
     }
@@ -70,7 +70,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Min(4),
         )));
     }
@@ -80,7 +80,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionIfNotTraversable()
     {
-        $this->validator->isValid('foobar', new Collection(array('fields' => array(
+        $this->validator->validate('foobar', new Collection(array('fields' => array(
             'foo' => new Min(4),
         ))));
     }
@@ -106,7 +106,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
                 'foo' => $constraint,
                 'bar' => $constraint,
@@ -140,7 +140,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
                 'foo' => $constraints,
                 'bar' => $constraints,
@@ -161,7 +161,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ field }}' => 'baz'
             ));
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
                 'foo' => new Min(4),
             ),
@@ -185,7 +185,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, $constraint);
+        $this->validator->validate($data, $constraint);
     }
 
     public function testExtraFieldsAllowed()
@@ -205,7 +205,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, $constraint);
+        $this->validator->validate($data, $constraint);
     }
 
     public function testMissingFieldsDisallowed()
@@ -225,7 +225,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ field }}' => 'foo',
             ));
 
-        $this->validator->isValid($data, $constraint);
+        $this->validator->validate($data, $constraint);
     }
 
     public function testMissingFieldsAllowed()
@@ -242,7 +242,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, $constraint);
+        $this->validator->validate($data, $constraint);
     }
 
     public function testOptionalFieldPresent()
@@ -254,7 +254,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Optional(),
         )));
     }
@@ -266,7 +266,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Optional(),
         )));
     }
@@ -288,7 +288,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Optional($constraint),
         )));
     }
@@ -315,7 +315,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Optional($constraints),
         )));
     }
@@ -329,7 +329,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Required(),
         )));
     }
@@ -344,7 +344,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ field }}' => 'foo',
             ));
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'fields' => array(
                  'foo' => new Required(),
              ),
@@ -369,7 +369,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->isValid($data, new Collection(array(
+        $this->validator->validate($data, new Collection(array(
             'foo' => new Required($constraint),
         )));
     }
@@ -396,7 +396,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->validator->isValid($array, new Collection(array(
+        $this->validator->validate($array, new Collection(array(
             'foo' => new Required($constraints),
         )));
     }
@@ -407,7 +407,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => 3
         ));
 
-        $this->validator->isValid($value, new Collection(array(
+        $this->validator->validate($value, new Collection(array(
             'fields' => array(
                 'foo' => new Min(2),
             )

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -58,9 +58,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid(null, new Collection(array('fields' => array(
+        $this->validator->isValid(null, new Collection(array('fields' => array(
             'foo' => new Min(4),
-        )))));
+        ))));
     }
 
     public function testFieldsAsDefaultOption()
@@ -70,9 +70,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'foo' => new Min(4),
-        ))));
+        )));
     }
 
     /**
@@ -106,12 +106,12 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'fields' => array(
                 'foo' => $constraint,
                 'bar' => $constraint,
             ),
-        ))));
+        )));
     }
 
     public function testWalkMultipleConstraints()
@@ -140,12 +140,12 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'fields' => array(
                 'foo' => $constraints,
                 'bar' => $constraints,
             )
-        ))));
+        )));
     }
 
     public function testExtraFieldsDisallowed()
@@ -161,12 +161,12 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ field }}' => 'baz'
             ));
 
-        $this->assertFalse($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'fields' => array(
                 'foo' => new Min(4),
             ),
             'extraFieldsMessage' => 'myMessage',
-        ))));
+        )));
     }
 
     // bug fix
@@ -185,7 +185,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, $constraint));
+        $this->validator->isValid($data, $constraint);
     }
 
     public function testExtraFieldsAllowed()
@@ -205,7 +205,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, $constraint));
+        $this->validator->isValid($data, $constraint);
     }
 
     public function testMissingFieldsDisallowed()
@@ -225,7 +225,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ field }}' => 'foo',
             ));
 
-        $this->assertFalse($this->validator->isValid($data, $constraint));
+        $this->validator->isValid($data, $constraint);
     }
 
     public function testMissingFieldsAllowed()
@@ -242,7 +242,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, $constraint));
+        $this->validator->isValid($data, $constraint);
     }
 
     public function testOptionalFieldPresent()
@@ -254,9 +254,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'foo' => new Optional(),
-        ))));
+        )));
     }
 
     public function testOptionalFieldNotPresent()
@@ -266,9 +266,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'foo' => new Optional(),
-        ))));
+        )));
     }
 
     public function testOptionalFieldSingleConstraint()
@@ -288,9 +288,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'foo' => new Optional($constraint),
-        ))));
+        )));
     }
 
     public function testOptionalFieldMultipleConstraints()
@@ -315,9 +315,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'foo' => new Optional($constraints),
-        ))));
+        )));
     }
 
     public function testRequiredFieldPresent()
@@ -329,9 +329,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolationAtSubPath');
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'foo' => new Required(),
-        ))));
+        )));
     }
 
     public function testRequiredFieldNotPresent()
@@ -344,12 +344,12 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ field }}' => 'foo',
             ));
 
-        $this->assertFalse($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'fields' => array(
                  'foo' => new Required(),
              ),
             'missingFieldsMessage' => 'myMessage',
-        ))));
+        )));
     }
 
     public function testRequiredFieldSingleConstraint()
@@ -369,9 +369,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->assertTrue($this->validator->isValid($data, new Collection(array(
+        $this->validator->isValid($data, new Collection(array(
             'foo' => new Required($constraint),
-        ))));
+        )));
     }
 
     public function testRequiredFieldMultipleConstraints()
@@ -396,9 +396,9 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $data = $this->prepareTestData($array);
 
-        $this->assertTrue($this->validator->isValid($array, new Collection(array(
+        $this->validator->isValid($array, new Collection(array(
             'foo' => new Required($constraints),
-        ))));
+        )));
     }
 
     public function testObjectShouldBeLeftUnchanged()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -39,7 +39,7 @@ class CountryValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Country());
+        $this->validator->validate(null, new Country());
     }
 
     public function testEmptyStringIsValid()
@@ -47,7 +47,7 @@ class CountryValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Country());
+        $this->validator->validate('', new Country());
     }
 
     /**
@@ -55,7 +55,7 @@ class CountryValidatorTest extends LocalizedTestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Country());
+        $this->validator->validate(new \stdClass(), new Country());
     }
 
     /**
@@ -70,7 +70,7 @@ class CountryValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($country, new Country());
+        $this->validator->validate($country, new Country());
     }
 
     public function getValidCountries()
@@ -101,7 +101,7 @@ class CountryValidatorTest extends LocalizedTestCase
                 '{{ value }}' => $country,
             ));
 
-        $this->validator->isValid($country, $constraint);
+        $this->validator->validate($country, $constraint);
     }
 
     public function getInvalidCountries()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -39,7 +39,7 @@ class CountryValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Country()));
+        $this->validator->isValid(null, new Country());
     }
 
     public function testEmptyStringIsValid()
@@ -47,7 +47,7 @@ class CountryValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Country()));
+        $this->validator->isValid('', new Country());
     }
 
     /**
@@ -70,7 +70,7 @@ class CountryValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($country, new Country()));
+        $this->validator->isValid($country, new Country());
     }
 
     public function getValidCountries()
@@ -101,7 +101,7 @@ class CountryValidatorTest extends LocalizedTestCase
                 '{{ value }}' => $country,
             ));
 
-        $this->assertFalse($this->validator->isValid($country, $constraint));
+        $this->validator->isValid($country, $constraint);
     }
 
     public function getInvalidCountries()

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -37,7 +37,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new DateTime()));
+        $this->validator->isValid(null, new DateTime());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new DateTime()));
+        $this->validator->isValid('', new DateTime());
     }
 
     public function testDateTimeClassIsValid()
@@ -53,7 +53,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(new \DateTime(), new DateTime()));
+        $this->validator->isValid(new \DateTime(), new DateTime());
     }
 
     /**
@@ -72,7 +72,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($dateTime, new DateTime()));
+        $this->validator->isValid($dateTime, new DateTime());
     }
 
     public function getValidDateTimes()
@@ -99,7 +99,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $dateTime,
             ));
 
-        $this->assertFalse($this->validator->isValid($dateTime, $constraint));
+        $this->validator->isValid($dateTime, $constraint);
     }
 
     public function getInvalidDateTimes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -37,7 +37,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new DateTime());
+        $this->validator->validate(null, new DateTime());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new DateTime());
+        $this->validator->validate('', new DateTime());
     }
 
     public function testDateTimeClassIsValid()
@@ -53,7 +53,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(new \DateTime(), new DateTime());
+        $this->validator->validate(new \DateTime(), new DateTime());
     }
 
     /**
@@ -61,7 +61,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new DateTime());
+        $this->validator->validate(new \stdClass(), new DateTime());
     }
 
     /**
@@ -72,7 +72,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($dateTime, new DateTime());
+        $this->validator->validate($dateTime, new DateTime());
     }
 
     public function getValidDateTimes()
@@ -99,7 +99,7 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $dateTime,
             ));
 
-        $this->validator->isValid($dateTime, $constraint);
+        $this->validator->validate($dateTime, $constraint);
     }
 
     public function getInvalidDateTimes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -37,7 +37,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Date());
+        $this->validator->validate(null, new Date());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Date());
+        $this->validator->validate('', new Date());
     }
 
     public function testDateTimeClassIsValid()
@@ -53,7 +53,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(new \DateTime(), new Date());
+        $this->validator->validate(new \DateTime(), new Date());
     }
 
     /**
@@ -61,7 +61,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Date());
+        $this->validator->validate(new \stdClass(), new Date());
     }
 
     /**
@@ -72,7 +72,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($date, new Date());
+        $this->validator->validate($date, new Date());
     }
 
     public function getValidDates()
@@ -99,7 +99,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $date,
             ));
 
-        $this->validator->isValid($date, $constraint);
+        $this->validator->validate($date, $constraint);
     }
 
     public function getInvalidDates()

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -37,7 +37,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Date()));
+        $this->validator->isValid(null, new Date());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Date()));
+        $this->validator->isValid('', new Date());
     }
 
     public function testDateTimeClassIsValid()
@@ -53,7 +53,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(new \DateTime(), new Date()));
+        $this->validator->isValid(new \DateTime(), new Date());
     }
 
     /**
@@ -72,7 +72,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($date, new Date()));
+        $this->validator->isValid($date, new Date());
     }
 
     public function getValidDates()
@@ -99,7 +99,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $date,
             ));
 
-        $this->assertFalse($this->validator->isValid($date, $constraint));
+        $this->validator->isValid($date, $constraint);
     }
 
     public function getInvalidDates()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -37,7 +37,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Email()));
+        $this->validator->isValid(null, new Email());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Email()));
+        $this->validator->isValid('', new Email());
     }
 
     /**
@@ -64,7 +64,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($email, new Email()));
+        $this->validator->isValid($email, new Email());
     }
 
     public function getValidEmails()
@@ -91,7 +91,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $email,
             ));
 
-        $this->assertFalse($this->validator->isValid($email, $constraint));
+        $this->validator->isValid($email, $constraint);
     }
 
     public function getInvalidEmails()

--- a/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/EmailValidatorTest.php
@@ -37,7 +37,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Email());
+        $this->validator->validate(null, new Email());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Email());
+        $this->validator->validate('', new Email());
     }
 
     /**
@@ -53,7 +53,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Email());
+        $this->validator->validate(new \stdClass(), new Email());
     }
 
     /**
@@ -64,7 +64,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($email, new Email());
+        $this->validator->validate($email, new Email());
     }
 
     public function getValidEmails()
@@ -91,7 +91,7 @@ class EmailValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $email,
             ));
 
-        $this->validator->isValid($email, $constraint);
+        $this->validator->validate($email, $constraint);
     }
 
     public function getInvalidEmails()

--- a/src/Symfony/Component/Validator/Tests/Constraints/FalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FalseValidatorTest.php
@@ -37,7 +37,7 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new False());
+        $this->validator->validate(null, new False());
     }
 
     public function testFalseIsValid()
@@ -45,7 +45,7 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(false, new False());
+        $this->validator->validate(false, new False());
     }
 
     public function testTrueIsInvalid()
@@ -58,6 +58,6 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', array());
 
-        $this->validator->isValid(true, $constraint);
+        $this->validator->validate(true, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FalseValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FalseValidatorTest.php
@@ -37,7 +37,7 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new False()));
+        $this->validator->isValid(null, new False());
     }
 
     public function testFalseIsValid()
@@ -45,7 +45,7 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(false, new False()));
+        $this->validator->isValid(false, new False());
     }
 
     public function testTrueIsInvalid()
@@ -58,6 +58,6 @@ class FalseValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', array());
 
-        $this->assertFalse($this->validator->isValid(true, $constraint));
+        $this->validator->isValid(true, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
@@ -32,6 +32,6 @@ class FileValidatorPathTest extends FileValidatorTest
                 '{{ file }}' => 'foobar',
             ));
 
-        $this->validator->isValid('foobar', $constraint);
+        $this->validator->validate('foobar', $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorPathTest.php
@@ -32,6 +32,6 @@ class FileValidatorPathTest extends FileValidatorTest
                 '{{ file }}' => 'foobar',
             ));
 
-        $this->assertFalse($this->validator->isValid('foobar', $constraint));
+        $this->validator->isValid('foobar', $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -51,7 +51,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new File());
+        $this->validator->validate(null, new File());
     }
 
     public function testEmptyStringIsValid()
@@ -59,7 +59,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new File());
+        $this->validator->validate('', new File());
     }
 
     /**
@@ -67,7 +67,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleTypeOrFile()
     {
-        $this->validator->isValid(new \stdClass(), new File());
+        $this->validator->validate(new \stdClass(), new File());
     }
 
     public function testValidFile()
@@ -75,7 +75,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($this->path, new File());
+        $this->validator->validate($this->path, new File());
     }
 
     public function testValidUploadedfile()
@@ -84,7 +84,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $file = new UploadedFile($this->path, 'originalName');
-        $this->validator->isValid($file, new File());
+        $this->validator->validate($file, new File());
     }
 
     public function testTooLargeBytes()
@@ -104,7 +104,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->validator->isValid($this->getFile($this->path), $constraint);
+        $this->validator->validate($this->getFile($this->path), $constraint);
     }
 
     public function testTooLargeKiloBytes()
@@ -124,7 +124,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->validator->isValid($this->getFile($this->path), $constraint);
+        $this->validator->validate($this->getFile($this->path), $constraint);
     }
 
     public function testTooLargeMegaBytes()
@@ -144,7 +144,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->validator->isValid($this->getFile($this->path), $constraint);
+        $this->validator->validate($this->getFile($this->path), $constraint);
     }
 
     /**
@@ -156,7 +156,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             'maxSize' => '1abc',
         ));
 
-        $this->validator->isValid($this->path, $constraint);
+        $this->validator->validate($this->path, $constraint);
     }
 
     public function testValidMimeType()
@@ -184,7 +184,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             'mimeTypes' => array('image/png', 'image/jpg'),
         ));
 
-        $this->validator->isValid($file, $constraint);
+        $this->validator->validate($file, $constraint);
     }
 
     public function testValidWildcardMimeType()
@@ -212,7 +212,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             'mimeTypes' => array('image/*'),
         ));
 
-        $this->validator->isValid($file, $constraint);
+        $this->validator->validate($file, $constraint);
     }
 
     public function testInvalidMimeType()
@@ -246,7 +246,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->validator->isValid($file, $constraint);
+        $this->validator->validate($file, $constraint);
     }
 
     public function testInvalidWildcardMimeType()
@@ -280,7 +280,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->validator->isValid($file, $constraint);
+        $this->validator->validate($file, $constraint);
     }
 
     /**
@@ -298,7 +298,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', $params);
 
-        $this->validator->isValid($file, $constraint);
+        $this->validator->validate($file, $constraint);
 
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -51,7 +51,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new File()));
+        $this->validator->isValid(null, new File());
     }
 
     public function testEmptyStringIsValid()
@@ -59,7 +59,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new File()));
+        $this->validator->isValid('', new File());
     }
 
     /**
@@ -75,7 +75,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($this->path, new File()));
+        $this->validator->isValid($this->path, new File());
     }
 
     public function testValidUploadedfile()
@@ -84,7 +84,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $file = new UploadedFile($this->path, 'originalName');
-        $this->assertTrue($this->validator->isValid($file, new File()));
+        $this->validator->isValid($file, new File());
     }
 
     public function testTooLargeBytes()
@@ -104,7 +104,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->assertFalse($this->validator->isValid($this->getFile($this->path), $constraint));
+        $this->validator->isValid($this->getFile($this->path), $constraint);
     }
 
     public function testTooLargeKiloBytes()
@@ -124,7 +124,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->assertFalse($this->validator->isValid($this->getFile($this->path), $constraint));
+        $this->validator->isValid($this->getFile($this->path), $constraint);
     }
 
     public function testTooLargeMegaBytes()
@@ -144,7 +144,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->assertFalse($this->validator->isValid($this->getFile($this->path), $constraint));
+        $this->validator->isValid($this->getFile($this->path), $constraint);
     }
 
     /**
@@ -184,7 +184,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             'mimeTypes' => array('image/png', 'image/jpg'),
         ));
 
-        $this->assertTrue($this->validator->isValid($file, $constraint));
+        $this->validator->isValid($file, $constraint);
     }
 
     public function testValidWildcardMimeType()
@@ -212,7 +212,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             'mimeTypes' => array('image/*'),
         ));
 
-        $this->assertTrue($this->validator->isValid($file, $constraint));
+        $this->validator->isValid($file, $constraint);
     }
 
     public function testInvalidMimeType()
@@ -246,7 +246,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->assertFalse($this->validator->isValid($file, $constraint));
+        $this->validator->isValid($file, $constraint);
     }
 
     public function testInvalidWildcardMimeType()
@@ -280,7 +280,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ file }}'    => $this->path,
             ));
 
-        $this->assertFalse($this->validator->isValid($file, $constraint));
+        $this->validator->isValid($file, $constraint);
     }
 
     /**
@@ -298,7 +298,7 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage', $params);
 
-        $this->assertFalse($this->validator->isValid($file, $constraint));
+        $this->validator->isValid($file, $constraint);
 
     }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -34,7 +34,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Image());
+        $this->validator->validate(null, new Image());
     }
 
     public function testEmptyStringIsValid()
@@ -42,7 +42,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Image());
+        $this->validator->validate('', new Image());
     }
 
     public function testValidImage()
@@ -54,7 +54,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($this->image, new Image());
+        $this->validator->validate($this->image, new Image());
     }
 
     public function testValidSize()
@@ -73,7 +73,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxHeight' => 2,
         ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     public function testWidthTooSmall()
@@ -94,7 +94,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ min_width }}' => '3',
             ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     public function testWidthTooBig()
@@ -115,7 +115,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ max_width }}' => '1',
             ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     public function testHeightTooSmall()
@@ -136,7 +136,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ min_height }}' => '3',
             ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     public function testHeightTooBig()
@@ -157,7 +157,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ max_height }}' => '1',
             ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     /**
@@ -173,7 +173,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'minWidth' => '1abc',
         ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     /**
@@ -189,7 +189,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxWidth' => '1abc',
         ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     /**
@@ -205,7 +205,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'minHeight' => '1abc',
         ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 
     /**
@@ -221,6 +221,6 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxHeight' => '1abc',
         ));
 
-        $this->validator->isValid($this->image, $constraint);
+        $this->validator->validate($this->image, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ImageValidatorTest.php
@@ -34,7 +34,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Image()));
+        $this->validator->isValid(null, new Image());
     }
 
     public function testEmptyStringIsValid()
@@ -42,7 +42,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Image()));
+        $this->validator->isValid('', new Image());
     }
 
     public function testValidImage()
@@ -54,7 +54,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($this->image, new Image()));
+        $this->validator->isValid($this->image, new Image());
     }
 
     public function testValidSize()
@@ -73,7 +73,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
             'maxHeight' => 2,
         ));
 
-        $this->assertTrue($this->validator->isValid($this->image, $constraint));
+        $this->validator->isValid($this->image, $constraint);
     }
 
     public function testWidthTooSmall()
@@ -94,7 +94,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ min_width }}' => '3',
             ));
 
-        $this->assertFalse($this->validator->isValid($this->image, $constraint));
+        $this->validator->isValid($this->image, $constraint);
     }
 
     public function testWidthTooBig()
@@ -115,7 +115,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ max_width }}' => '1',
             ));
 
-        $this->assertFalse($this->validator->isValid($this->image, $constraint));
+        $this->validator->isValid($this->image, $constraint);
     }
 
     public function testHeightTooSmall()
@@ -136,7 +136,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ min_height }}' => '3',
             ));
 
-        $this->assertFalse($this->validator->isValid($this->image, $constraint));
+        $this->validator->isValid($this->image, $constraint);
     }
 
     public function testHeightTooBig()
@@ -157,7 +157,7 @@ class ImageValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ max_height }}' => '1',
             ));
 
-        $this->assertFalse($this->validator->isValid($this->image, $constraint));
+        $this->validator->isValid($this->image, $constraint);
     }
 
     /**

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -37,7 +37,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Ip()));
+        $this->validator->isValid(null, new Ip());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Ip()));
+        $this->validator->isValid('', new Ip());
     }
 
     /**
@@ -74,9 +74,9 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($ip, new Ip(array(
+        $this->validator->isValid($ip, new Ip(array(
             'version' => Ip::V4,
-        ))));
+        )));
     }
 
     public function getValidIpsV4()
@@ -101,9 +101,9 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($ip, new Ip(array(
+        $this->validator->isValid($ip, new Ip(array(
             'version' => Ip::V6,
-        ))));
+        )));
     }
 
     public function getValidIpsV6()
@@ -139,9 +139,9 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($ip, new Ip(array(
+        $this->validator->isValid($ip, new Ip(array(
             'version' => Ip::ALL,
-        ))));
+        )));
     }
 
     public function getValidIpsAll()
@@ -165,7 +165,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidIpsV4()
@@ -199,7 +199,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidPrivateIpsV4()
@@ -227,7 +227,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidReservedIpsV4()
@@ -255,7 +255,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidPublicIpsV4()
@@ -279,7 +279,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidIpsV6()
@@ -317,7 +317,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidPrivateIpsV6()
@@ -345,7 +345,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidReservedIpsV6()
@@ -372,7 +372,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidPublicIpsV6()
@@ -396,7 +396,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidIpsAll()
@@ -420,7 +420,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidPrivateIpsAll()
@@ -444,7 +444,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidReservedIpsAll()
@@ -468,7 +468,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->assertFalse($this->validator->isValid($ip, $constraint));
+        $this->validator->isValid($ip, $constraint);
     }
 
     public function getInvalidPublicIpsAll()

--- a/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IpValidatorTest.php
@@ -37,7 +37,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Ip());
+        $this->validator->validate(null, new Ip());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Ip());
+        $this->validator->validate('', new Ip());
     }
 
     /**
@@ -53,7 +53,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Ip());
+        $this->validator->validate(new \stdClass(), new Ip());
     }
 
     /**
@@ -74,7 +74,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($ip, new Ip(array(
+        $this->validator->validate($ip, new Ip(array(
             'version' => Ip::V4,
         )));
     }
@@ -101,7 +101,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($ip, new Ip(array(
+        $this->validator->validate($ip, new Ip(array(
             'version' => Ip::V6,
         )));
     }
@@ -139,7 +139,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($ip, new Ip(array(
+        $this->validator->validate($ip, new Ip(array(
             'version' => Ip::ALL,
         )));
     }
@@ -165,7 +165,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidIpsV4()
@@ -199,7 +199,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidPrivateIpsV4()
@@ -227,7 +227,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidReservedIpsV4()
@@ -255,7 +255,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidPublicIpsV4()
@@ -279,7 +279,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidIpsV6()
@@ -317,7 +317,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidPrivateIpsV6()
@@ -345,7 +345,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidReservedIpsV6()
@@ -372,7 +372,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidPublicIpsV6()
@@ -396,7 +396,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidIpsAll()
@@ -420,7 +420,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidPrivateIpsAll()
@@ -444,7 +444,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidReservedIpsAll()
@@ -468,7 +468,7 @@ class IpValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $ip,
             ));
 
-        $this->validator->isValid($ip, $constraint);
+        $this->validator->validate($ip, $constraint);
     }
 
     public function getInvalidPublicIpsAll()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -39,7 +39,7 @@ class LanguageValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Language()));
+        $this->validator->isValid(null, new Language());
     }
 
     public function testEmptyStringIsValid()
@@ -47,7 +47,7 @@ class LanguageValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Language()));
+        $this->validator->isValid('', new Language());
     }
 
     /**
@@ -70,7 +70,7 @@ class LanguageValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($language, new Language()));
+        $this->validator->isValid($language, new Language());
     }
 
     public function getValidLanguages()
@@ -101,7 +101,7 @@ class LanguageValidatorTest extends LocalizedTestCase
                 '{{ value }}' => $language,
             ));
 
-        $this->assertFalse($this->validator->isValid($language, $constraint));
+        $this->validator->isValid($language, $constraint);
     }
 
     public function getInvalidLanguages()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -39,7 +39,7 @@ class LanguageValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Language());
+        $this->validator->validate(null, new Language());
     }
 
     public function testEmptyStringIsValid()
@@ -47,7 +47,7 @@ class LanguageValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Language());
+        $this->validator->validate('', new Language());
     }
 
     /**
@@ -55,7 +55,7 @@ class LanguageValidatorTest extends LocalizedTestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Language());
+        $this->validator->validate(new \stdClass(), new Language());
     }
 
     /**
@@ -70,7 +70,7 @@ class LanguageValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($language, new Language());
+        $this->validator->validate($language, new Language());
     }
 
     public function getValidLanguages()
@@ -101,7 +101,7 @@ class LanguageValidatorTest extends LocalizedTestCase
                 '{{ value }}' => $language,
             ));
 
-        $this->validator->isValid($language, $constraint);
+        $this->validator->validate($language, $constraint);
     }
 
     public function getInvalidLanguages()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -39,7 +39,7 @@ class LocaleValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Locale());
+        $this->validator->validate(null, new Locale());
     }
 
     public function testEmptyStringIsValid()
@@ -47,7 +47,7 @@ class LocaleValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Locale());
+        $this->validator->validate('', new Locale());
     }
 
     /**
@@ -55,7 +55,7 @@ class LocaleValidatorTest extends LocalizedTestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Locale());
+        $this->validator->validate(new \stdClass(), new Locale());
     }
 
     /**
@@ -70,7 +70,7 @@ class LocaleValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($locale, new Locale());
+        $this->validator->validate($locale, new Locale());
     }
 
     public function getValidLocales()
@@ -102,7 +102,7 @@ class LocaleValidatorTest extends LocalizedTestCase
                 '{{ value }}' => $locale,
             ));
 
-        $this->validator->isValid($locale, $constraint);
+        $this->validator->validate($locale, $constraint);
     }
 
     public function getInvalidLocales()

--- a/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LocaleValidatorTest.php
@@ -39,7 +39,7 @@ class LocaleValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Locale()));
+        $this->validator->isValid(null, new Locale());
     }
 
     public function testEmptyStringIsValid()
@@ -47,7 +47,7 @@ class LocaleValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Locale()));
+        $this->validator->isValid('', new Locale());
     }
 
     /**
@@ -70,7 +70,7 @@ class LocaleValidatorTest extends LocalizedTestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($locale, new Locale()));
+        $this->validator->isValid($locale, new Locale());
     }
 
     public function getValidLocales()
@@ -102,7 +102,7 @@ class LocaleValidatorTest extends LocalizedTestCase
                 '{{ value }}' => $locale,
             ));
 
-        $this->assertFalse($this->validator->isValid($locale, $constraint));
+        $this->validator->isValid($locale, $constraint);
     }
 
     public function getInvalidLocales()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
@@ -37,7 +37,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new MaxLength(array('limit' => 5)));
+        $this->validator->validate(null, new MaxLength(array('limit' => 5)));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new MaxLength(array('limit' => 5)));
+        $this->validator->validate('', new MaxLength(array('limit' => 5)));
     }
 
     /**
@@ -53,7 +53,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new MaxLength(array('limit' => 5)));
+        $this->validator->validate(new \stdClass(), new MaxLength(array('limit' => 5)));
     }
 
     /**
@@ -69,7 +69,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new MaxLength(array('limit' => 5));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -103,7 +103,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
@@ -37,7 +37,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new MaxLength(array('limit' => 5))));
+        $this->validator->isValid(null, new MaxLength(array('limit' => 5)));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new MaxLength(array('limit' => 5))));
+        $this->validator->isValid('', new MaxLength(array('limit' => 5)));
     }
 
     /**
@@ -69,7 +69,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new MaxLength(array('limit' => 5));
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -103,7 +103,7 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MaxValidatorTest.php
@@ -37,7 +37,7 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Max(array('limit' => 10)));
+        $this->validator->validate(null, new Max(array('limit' => 10)));
     }
 
     /**
@@ -49,7 +49,7 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Max(array('limit' => 10));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -80,7 +80,7 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ));
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MaxValidatorTest.php
@@ -37,7 +37,7 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Max(array('limit' => 10))));
+        $this->validator->isValid(null, new Max(array('limit' => 10)));
     }
 
     /**
@@ -49,7 +49,7 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Max(array('limit' => 10));
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -80,7 +80,7 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ));
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MinLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MinLengthValidatorTest.php
@@ -37,7 +37,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new MinLength(array('limit' => 6)));
+        $this->validator->validate(null, new MinLength(array('limit' => 6)));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new MinLength(array('limit' => 6)));
+        $this->validator->validate('', new MinLength(array('limit' => 6)));
     }
 
     /**
@@ -53,7 +53,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new MinLength(array('limit' => 5)));
+        $this->validator->validate(new \stdClass(), new MinLength(array('limit' => 5)));
     }
 
     /**
@@ -69,7 +69,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new MinLength(array('limit' => 6));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -103,7 +103,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MinLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MinLengthValidatorTest.php
@@ -37,7 +37,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new MinLength(array('limit' => 6))));
+        $this->validator->isValid(null, new MinLength(array('limit' => 6)));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new MinLength(array('limit' => 6))));
+        $this->validator->isValid('', new MinLength(array('limit' => 6)));
     }
 
     /**
@@ -69,7 +69,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new MinLength(array('limit' => 6));
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -103,7 +103,7 @@ class MinLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MinValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MinValidatorTest.php
@@ -31,7 +31,7 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Min(array('limit' => 10)));
+        $this->validator->validate(null, new Min(array('limit' => 10)));
     }
 
     /**
@@ -43,7 +43,7 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Min(array('limit' => 10));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -74,7 +74,7 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ));
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MinValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MinValidatorTest.php
@@ -31,7 +31,7 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Min(array('limit' => 10))));
+        $this->validator->isValid(null, new Min(array('limit' => 10)));
     }
 
     /**
@@ -43,7 +43,7 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Min(array('limit' => 10));
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -74,7 +74,7 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ));
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -40,7 +40,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($date, new NotBlank()));
+        $this->validator->isValid($date, new NotBlank());
     }
 
     public function getValidValues()
@@ -64,7 +64,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->assertFalse($this->validator->isValid(null, $constraint));
+        $this->validator->isValid(null, $constraint);
     }
 
     public function testBlankIsInvalid()
@@ -77,7 +77,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->assertFalse($this->validator->isValid('', $constraint));
+        $this->validator->isValid('', $constraint);
     }
 
     public function testFalseIsInvalid()
@@ -90,7 +90,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->assertFalse($this->validator->isValid(false, $constraint));
+        $this->validator->isValid(false, $constraint);
     }
 
     public function testEmptyArrayIsInvalid()
@@ -103,7 +103,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->assertFalse($this->validator->isValid(array(), $constraint));
+        $this->validator->isValid(array(), $constraint);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotBlankValidatorTest.php
@@ -40,7 +40,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($date, new NotBlank());
+        $this->validator->validate($date, new NotBlank());
     }
 
     public function getValidValues()
@@ -64,7 +64,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->validator->isValid(null, $constraint);
+        $this->validator->validate(null, $constraint);
     }
 
     public function testBlankIsInvalid()
@@ -77,7 +77,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->validator->isValid('', $constraint);
+        $this->validator->validate('', $constraint);
     }
 
     public function testFalseIsInvalid()
@@ -90,7 +90,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->validator->isValid(false, $constraint);
+        $this->validator->validate(false, $constraint);
     }
 
     public function testEmptyArrayIsInvalid()
@@ -103,7 +103,7 @@ class NotBlankValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation')
             ->with('myMessage');
 
-        $this->validator->isValid(array(), $constraint);
+        $this->validator->validate(array(), $constraint);
     }
 }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
@@ -40,7 +40,7 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($value, new NotNull());
+        $this->validator->validate($value, new NotNull());
     }
 
     public function getValidValues()
@@ -64,6 +64,6 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
             ->with('myMessage', array(
             ));
 
-        $this->validator->isValid(null, $constraint);
+        $this->validator->validate(null, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NotNullValidatorTest.php
@@ -40,7 +40,7 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($value, new NotNull()));
+        $this->validator->isValid($value, new NotNull());
     }
 
     public function getValidValues()
@@ -64,6 +64,6 @@ class NotNullValidatorTest extends \PHPUnit_Framework_TestCase
             ->with('myMessage', array(
             ));
 
-        $this->assertFalse($this->validator->isValid(null, $constraint));
+        $this->validator->isValid(null, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/NullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NullValidatorTest.php
@@ -37,7 +37,7 @@ class NullValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Null());
+        $this->validator->validate(null, new Null());
     }
 
     /**
@@ -55,7 +55,7 @@ class NullValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $value,
             ));
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/NullValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/NullValidatorTest.php
@@ -37,7 +37,7 @@ class NullValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Null()));
+        $this->validator->isValid(null, new Null());
     }
 
     /**
@@ -55,7 +55,7 @@ class NullValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $value,
             ));
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -37,7 +37,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Regex(array('pattern' => '/^[0-9]+$/'))));
+        $this->validator->isValid(null, new Regex(array('pattern' => '/^[0-9]+$/')));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Regex(array('pattern' => '/^[0-9]+$/'))));
+        $this->validator->isValid('', new Regex(array('pattern' => '/^[0-9]+$/')));
     }
 
     /**
@@ -65,7 +65,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Regex(array('pattern' => '/^[0-9]+$/'));
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -94,7 +94,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $value,
             ));
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -37,7 +37,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Regex(array('pattern' => '/^[0-9]+$/')));
+        $this->validator->validate(null, new Regex(array('pattern' => '/^[0-9]+$/')));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Regex(array('pattern' => '/^[0-9]+$/')));
+        $this->validator->validate('', new Regex(array('pattern' => '/^[0-9]+$/')));
     }
 
     /**
@@ -53,7 +53,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Regex(array('pattern' => '/^[0-9]+$/')));
+        $this->validator->validate(new \stdClass(), new Regex(array('pattern' => '/^[0-9]+$/')));
     }
 
     /**
@@ -65,7 +65,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Regex(array('pattern' => '/^[0-9]+$/'));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -94,7 +94,7 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $value,
             ));
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/SizeLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SizeLengthValidatorTest.php
@@ -37,7 +37,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new SizeLength(array('min' => 6, 'max' => 10)));
+        $this->validator->validate(null, new SizeLength(array('min' => 6, 'max' => 10)));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new SizeLength(array('min' => 6, 'max' => 10)));
+        $this->validator->validate('', new SizeLength(array('min' => 6, 'max' => 10)));
     }
 
     /**
@@ -53,7 +53,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new SizeLength(array('min' => 6, 'max' => 10)));
+        $this->validator->validate(new \stdClass(), new SizeLength(array('min' => 6, 'max' => 10)));
     }
 
     /**
@@ -69,7 +69,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new SizeLength(array('min' => 6, 'max' => 10));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -99,7 +99,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new SizeLength(array('min' => 6, 'max' => 10));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()
@@ -131,7 +131,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->validator->isValid('1234', $constraint);
+        $this->validator->validate('1234', $constraint);
     }
 
     public function testMaxMessageIsSet()
@@ -149,7 +149,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ), null, 10);
 
-        $this->validator->isValid('12345678901', $constraint);
+        $this->validator->validate('12345678901', $constraint);
     }
 
     public function testExactMessageIsSet()
@@ -167,6 +167,6 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->validator->isValid('1234', $constraint);
+        $this->validator->validate('1234', $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/SizeLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SizeLengthValidatorTest.php
@@ -37,7 +37,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new SizeLength(array('min' => 6, 'max' => 10))));
+        $this->validator->isValid(null, new SizeLength(array('min' => 6, 'max' => 10)));
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new SizeLength(array('min' => 6, 'max' => 10))));
+        $this->validator->isValid('', new SizeLength(array('min' => 6, 'max' => 10)));
     }
 
     /**
@@ -69,7 +69,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new SizeLength(array('min' => 6, 'max' => 10));
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -99,7 +99,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new SizeLength(array('min' => 6, 'max' => 10));
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()
@@ -131,7 +131,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->assertFalse($this->validator->isValid('1234', $constraint));
+        $this->validator->isValid('1234', $constraint);
     }
 
     public function testMaxMessageIsSet()
@@ -149,7 +149,7 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ), null, 10);
 
-        $this->assertFalse($this->validator->isValid('12345678901', $constraint));
+        $this->validator->isValid('12345678901', $constraint);
     }
 
     public function testExactMessageIsSet()
@@ -167,6 +167,6 @@ class SizeLengthValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 5,
             ), null, 5);
 
-        $this->assertFalse($this->validator->isValid('1234', $constraint));
+        $this->validator->isValid('1234', $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/SizeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SizeValidatorTest.php
@@ -31,7 +31,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Size(array('min' => 10, 'max' => 20))));
+        $this->validator->isValid(null, new Size(array('min' => 10, 'max' => 20)));
     }
 
     /**
@@ -43,7 +43,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Size(array('min' => 10, 'max' => 20));
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -69,7 +69,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Size(array('min' => 10, 'max' => 20));
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()
@@ -98,7 +98,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ));
 
-        $this->assertFalse($this->validator->isValid(9, $constraint));
+        $this->validator->isValid(9, $constraint);
     }
 
     public function testMaxMessageIsSet()
@@ -116,6 +116,6 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 20,
             ));
 
-        $this->assertFalse($this->validator->isValid(21, $constraint));
+        $this->validator->isValid(21, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/SizeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/SizeValidatorTest.php
@@ -31,7 +31,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Size(array('min' => 10, 'max' => 20)));
+        $this->validator->validate(null, new Size(array('min' => 10, 'max' => 20)));
     }
 
     /**
@@ -43,7 +43,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Size(array('min' => 10, 'max' => 20));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -69,7 +69,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolation');
 
         $constraint = new Size(array('min' => 10, 'max' => 20));
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()
@@ -98,7 +98,7 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 10,
             ));
 
-        $this->validator->isValid(9, $constraint);
+        $this->validator->validate(9, $constraint);
     }
 
     public function testMaxMessageIsSet()
@@ -116,6 +116,6 @@ class SizeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 20,
             ));
 
-        $this->validator->isValid(21, $constraint);
+        $this->validator->validate(21, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -37,7 +37,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Time()));
+        $this->validator->isValid(null, new Time());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Time()));
+        $this->validator->isValid('', new Time());
     }
 
     public function testDateTimeClassIsValid()
@@ -53,7 +53,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(new \DateTime(), new Time()));
+        $this->validator->isValid(new \DateTime(), new Time());
     }
 
     /**
@@ -72,7 +72,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($time, new Time()));
+        $this->validator->isValid($time, new Time());
     }
 
     public function getValidTimes()
@@ -99,7 +99,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $time,
             ));
 
-        $this->assertFalse($this->validator->isValid($time, $constraint));
+        $this->validator->isValid($time, $constraint);
     }
 
     public function getInvalidTimes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TimeValidatorTest.php
@@ -37,7 +37,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Time());
+        $this->validator->validate(null, new Time());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Time());
+        $this->validator->validate('', new Time());
     }
 
     public function testDateTimeClassIsValid()
@@ -53,7 +53,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(new \DateTime(), new Time());
+        $this->validator->validate(new \DateTime(), new Time());
     }
 
     /**
@@ -61,7 +61,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Time());
+        $this->validator->validate(new \stdClass(), new Time());
     }
 
     /**
@@ -72,7 +72,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($time, new Time());
+        $this->validator->validate($time, new Time());
     }
 
     public function getValidTimes()
@@ -99,7 +99,7 @@ class TimeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $time,
             ));
 
-        $this->validator->isValid($time, $constraint);
+        $this->validator->validate($time, $constraint);
     }
 
     public function getInvalidTimes()

--- a/src/Symfony/Component/Validator/Tests/Constraints/TrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TrueValidatorTest.php
@@ -37,7 +37,7 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new True());
+        $this->validator->validate(null, new True());
     }
 
     public function testTrueIsValid()
@@ -45,7 +45,7 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(true, new True());
+        $this->validator->validate(true, new True());
     }
 
     public function testFalseIsInvalid()
@@ -59,6 +59,6 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
             ->with('myMessage', array(
             ));
 
-        $this->validator->isValid(false, $constraint);
+        $this->validator->validate(false, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TrueValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TrueValidatorTest.php
@@ -37,7 +37,7 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new True()));
+        $this->validator->isValid(null, new True());
     }
 
     public function testTrueIsValid()
@@ -45,7 +45,7 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(true, new True()));
+        $this->validator->isValid(true, new True());
     }
 
     public function testFalseIsInvalid()
@@ -59,6 +59,6 @@ class TrueValidatorTest extends \PHPUnit_Framework_TestCase
             ->with('myMessage', array(
             ));
 
-        $this->assertFalse($this->validator->isValid(false, $constraint));
+        $this->validator->isValid(false, $constraint);
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -39,7 +39,7 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Type(array('type' => 'integer')));
+        $this->validator->validate(null, new Type(array('type' => 'integer')));
     }
 
     public function testEmptyIsValidIfString()
@@ -47,12 +47,12 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Type(array('type' => 'string')));
+        $this->validator->validate('', new Type(array('type' => 'string')));
     }
 
     public function testEmptyIsInvalidIfNoString()
     {
-        $this->validator->isValid('', new Type(array('type' => 'integer')));
+        $this->validator->validate('', new Type(array('type' => 'integer')));
     }
 
     /**
@@ -65,7 +65,7 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Type(array('type' => $type));
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getValidValues()
@@ -122,7 +122,7 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ type }}' => $type,
             ));
 
-        $this->validator->isValid($value, $constraint);
+        $this->validator->validate($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/TypeValidatorTest.php
@@ -39,7 +39,7 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Type(array('type' => 'integer'))));
+        $this->validator->isValid(null, new Type(array('type' => 'integer')));
     }
 
     public function testEmptyIsValidIfString()
@@ -47,12 +47,12 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Type(array('type' => 'string'))));
+        $this->validator->isValid('', new Type(array('type' => 'string')));
     }
 
     public function testEmptyIsInvalidIfNoString()
     {
-        $this->assertFalse($this->validator->isValid('', new Type(array('type' => 'integer'))));
+        $this->validator->isValid('', new Type(array('type' => 'integer')));
     }
 
     /**
@@ -65,7 +65,7 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Type(array('type' => $type));
 
-        $this->assertTrue($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getValidValues()
@@ -122,7 +122,7 @@ class TypeValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ type }}' => $type,
             ));
 
-        $this->assertFalse($this->validator->isValid($value, $constraint));
+        $this->validator->isValid($value, $constraint);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -37,7 +37,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid(null, new Url());
+        $this->validator->validate(null, new Url());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid('', new Url());
+        $this->validator->validate('', new Url());
     }
 
     /**
@@ -53,7 +53,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testExpectsStringCompatibleType()
     {
-        $this->validator->isValid(new \stdClass(), new Url());
+        $this->validator->validate(new \stdClass(), new Url());
     }
 
     /**
@@ -64,7 +64,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->validator->isValid($url, new Url());
+        $this->validator->validate($url, new Url());
     }
 
     public function getValidUrls()
@@ -119,7 +119,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $url,
             ));
 
-        $this->validator->isValid($url, $constraint);
+        $this->validator->validate($url, $constraint);
     }
 
     public function getInvalidUrls()
@@ -154,7 +154,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
             'protocols' => array('ftp', 'file', 'git')
         ));
 
-        $this->validator->isValid($url, $constraint);
+        $this->validator->validate($url, $constraint);
     }
 
     public function getValidCustomUrls()

--- a/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/UrlValidatorTest.php
@@ -37,7 +37,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid(null, new Url()));
+        $this->validator->isValid(null, new Url());
     }
 
     public function testEmptyStringIsValid()
@@ -45,7 +45,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid('', new Url()));
+        $this->validator->isValid('', new Url());
     }
 
     /**
@@ -64,7 +64,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->never())
             ->method('addViolation');
 
-        $this->assertTrue($this->validator->isValid($url, new Url()));
+        $this->validator->isValid($url, new Url());
     }
 
     public function getValidUrls()
@@ -119,7 +119,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => $url,
             ));
 
-        $this->assertFalse($this->validator->isValid($url, $constraint));
+        $this->validator->isValid($url, $constraint);
     }
 
     public function getInvalidUrls()
@@ -154,7 +154,7 @@ class UrlValidatorTest extends \PHPUnit_Framework_TestCase
             'protocols' => array('ftp', 'file', 'git')
         ));
 
-        $this->assertTrue($this->validator->isValid($url, $constraint));
+        $this->validator->isValid($url, $constraint);
     }
 
     public function getValidCustomUrls()

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
@@ -31,9 +31,9 @@ class ConstraintAValidator extends ConstraintValidator
         if ('VALID' != $value) {
             $this->context->addViolation('message', array('param' => 'value'));
 
-            return false;
+            return;
         }
 
-        return true;
+        return;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/ConstraintAValidator.php
@@ -26,7 +26,7 @@ class ConstraintAValidator extends ConstraintValidator
         self::$passedContext = $context;
     }
 
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         if ('VALID' != $value) {
             $this->context->addViolation('message', array('param' => 'value'));

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraintValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraintValidator.php
@@ -20,6 +20,6 @@ class FailingConstraintValidator extends ConstraintValidator
     {
         $this->context->addViolation($constraint->message, array());
 
-        return false;
+        return;
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraintValidator.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FailingConstraintValidator.php
@@ -16,7 +16,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 class FailingConstraintValidator extends ConstraintValidator
 {
-    public function isValid($value, Constraint $constraint)
+    public function validate($value, Constraint $constraint)
     {
         $this->context->addViolation($constraint->message, array());
 


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: **YES**
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: update the documentation

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3228)

Before I begin, this PR is up for discussion.

I removed the return value of ConstraintValidator::isValid() because it wasn't used anymore within the framework. Removing it also means a simplification for userland implementations. Already now the validation component only depended on violation errors being present for deciding whether the validation was considered failed or not.

Because the name `isValid` does not make a lot of sense without a return value, I changed it to `validate`. Note that this affects an interface (ConstraintValidatorInterface) previously marked with `@api` by us!

What do you think about this change?
