### PR TITLE
[Form] Fixed Form::bindRequest() when used on a form without children

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -578,15 +578,22 @@ class Form implements \IteratorAggregate, FormInterface
             case 'DELETE':
             case 'PATCH':
                 if ('' === $this->getName()) {
-                    $data = array_replace_recursive(
-                        $request->request->all(),
-                        $request->files->all()
-                    );
+                    // Form bound without name
+                    $params = $request->request->all();
+                    $files = $request->files->all();
+                } elseif ($this->hasChildren()) {
+                    // Form bound with name and children
+                    $params = $request->request->get($this->getName(), array());
+                    $files = $request->files->get($this->getName(), array());
                 } else {
-                    $data = array_replace_recursive(
-                        $request->request->get($this->getName(), array()),
-                        $request->files->get($this->getName(), array())
-                    );
+                    // Form bound with name, but without children
+                    $params = $request->request->get($this->getName(), null);
+                    $files = $request->files->get($this->getName(), null);
+                }
+                if (is_array($params) && is_array($files)) {
+                    $data = array_replace_recursive($params, $files);
+                } else {
+                    $data = $params ?: $files;
                 }
                 break;
             case 'GET':

--- a/tests/Symfony/Tests/Component/Form/FormTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormTest.php
@@ -936,7 +936,6 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         $values = array(
             'name' => 'Bernhard',
-            'image' => array('filename' => 'foobar.png'),
             'extra' => 'data',
         );
 
@@ -965,6 +964,64 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Bernhard', $form['name']->getData());
         $this->assertEquals($file, $form['image']->getData());
         $this->assertEquals(array('extra' => 'data'), $form->getExtraData());
+
+        unlink($path);
+    }
+
+    /**
+     * @dataProvider requestMethodProvider
+     */
+    public function testBindPostOrPutRequestWithSingleFieldForm($method)
+    {
+        $path = tempnam(sys_get_temp_dir(), 'sf2');
+        touch($path);
+
+        $files = array(
+            'image' => array(
+                'error' => UPLOAD_ERR_OK,
+                'name' => 'upload.png',
+                'size' => 123,
+                'tmp_name' => $path,
+                'type' => 'image/png',
+            ),
+        );
+
+        $request = new Request(array(), array(), array(), array(), $files, array(
+            'REQUEST_METHOD' => $method,
+        ));
+
+        $form = $this->getBuilder('image')->getForm();
+
+        $form->bindRequest($request);
+
+        $file = new UploadedFile($path, 'upload.png', 'image/png', 123, UPLOAD_ERR_OK);
+
+        $this->assertEquals($file, $form->getData());
+
+        unlink($path);
+    }
+
+    /**
+     * @dataProvider requestMethodProvider
+     */
+    public function testBindPostOrPutRequestWithSingleFieldFormUploadedFile($method)
+    {
+        $path = tempnam(sys_get_temp_dir(), 'sf2');
+        touch($path);
+
+        $values = array(
+            'name' => 'Bernhard',
+        );
+
+        $request = new Request(array(), $values, array(), array(), array(), array(
+            'REQUEST_METHOD' => $method,
+        ));
+
+        $form = $this->getBuilder('name')->getForm();
+
+        $form->bindRequest($request);
+
+        $this->assertEquals('Bernhard', $form->getData());
 
         unlink($path);
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2553
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue2553)
