### PR TITLE
[Console] Added suggest on bad command name

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -560,8 +560,8 @@ class Application
             $message = sprintf('Command "%s" is not defined.', $name);
 
             if ($alternatives = $this->findAlternativeCommands($searchName)) {
-                $message .= PHP_EOL.'Did you mean one of these?'.PHP_EOL.'    ';
-                $message .= implode(PHP_EOL.'    ', $alternatives);
+                $message .= "\nDid you mean one of these?\n    ";
+                $message .= implode("\n    ", $alternatives);
             }
 
             throw new \InvalidArgumentException($message);

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -492,7 +492,7 @@ class Application
                 $message = sprintf('There are no commands defined in the "%s" namespace.', $namespace);
 
                 if (1 <= $i) {
-                    $part = implode(':',$found).':'.$part;
+                    $part = implode(':', $found).':'.$part;
                 }
 
                 if ($alternatives = $this->findAlternativeNamespace($part, $abbrevs)) {
@@ -979,7 +979,7 @@ class Application
         $alternatives = array();
 
         foreach ($collection as $item) {
-            if(null !== $callback) {
+            if (null !== $callback) {
                 $item = call_user_func($callback, $item);
             }
 

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -242,6 +242,35 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testFindAlternativeNamespace()
+    {
+        $application = new Application();
+
+        $application->add(new \FooCommand());
+        $application->add(new \Foo1Command());
+        $application->add(new \Foo2Command());
+        $application->add(new \foo3Command());
+
+        try {
+            $application->find('Unknow-namespace:Unknow-command');
+            $this->fail('->find() throws an \InvalidArgumentException if namespace does not exist');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if namespace does not exist');
+            $this->assertEquals('There are no commands defined in the "Unknow-namespace" namespace.', $e->getMessage(), '->find() throws an \InvalidArgumentException if namespace does not exist, without alternatives');
+        }
+
+        try {
+            $application->find('foo2:command');
+            $this->fail('->find() throws an \InvalidArgumentException if namespace does not exist');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if namespace does not exist');
+            $this->assertRegExp('/There are no commands defined in the "foo2" namespace./', $e->getMessage(), '->find() throws an \InvalidArgumentException if namespace does not exist, with alternative');
+            $this->assertRegExp('/foo/', $e->getMessage(), '->find() throws an \InvalidArgumentException if namespace does not exist, with alternative : "foo"');
+            $this->assertRegExp('/foo1/', $e->getMessage(), '->find() throws an \InvalidArgumentException if namespace does not exist, with alternative : "foo1"');
+            $this->assertRegExp('/foo3/', $e->getMessage(), '->find() throws an \InvalidArgumentException if namespace does not exist, with alternative : "foo3"');
+        }
+    }
+
     public function testSetCatchExceptions()
     {
         $application = new Application();

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -183,7 +183,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             $this->fail('->find() throws an \InvalidArgumentException if the abbreviation is ambiguous for a namespace');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if the abbreviation is ambiguous for a namespace');
-            $this->assertEquals('Command "f" is not defined.', $e->getMessage(), '->find() throws an \InvalidArgumentException if the abbreviation is ambiguous for a namespace');
+            $this->assertRegExp('/Command "f" is not defined./', $e->getMessage(), '->find() throws an \InvalidArgumentException if the abbreviation is ambiguous for a namespace');
         }
 
         try {
@@ -200,6 +200,45 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if the abbreviation is ambiguous for a command');
             $this->assertEquals('Command "foo:b" is ambiguous (foo:bar, foo:bar1).', $e->getMessage(), '->find() throws an \InvalidArgumentException if the abbreviation is ambiguous for a command');
+        }
+    }
+
+    public function testFindAlternativeCommands()
+    {
+        $application = new Application();
+
+        $application->add(new \FooCommand());
+        $application->add(new \Foo1Command());
+        $application->add(new \Foo2Command());
+
+        try {
+            $application->find($commandName = 'Unknow command');
+            $this->fail('->find() throws an \InvalidArgumentException if command does not exist');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if command does not exist');
+            $this->assertEquals(sprintf('Command "%s" is not defined.', $commandName), $e->getMessage(), '->find() throws an \InvalidArgumentException if command does not exist, without alternatives');
+        }
+
+        try {
+            $application->find($commandName = 'foo');
+            $this->fail('->find() throws an \InvalidArgumentException if command does not exist');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if command does not exist');
+            $this->assertRegExp(sprintf('/Command "%s" is not defined./', $commandName), $e->getMessage(), '->find() throws an \InvalidArgumentException if command does not exist, with alternatives');
+            $this->assertRegExp('/foo:bar/', $e->getMessage(), '->find() throws an \InvalidArgumentException if command does not exist, with alternative : "foo:bar"');
+            $this->assertRegExp('/foo1:bar/', $e->getMessage(), '->find() throws an \InvalidArgumentException if command does not exist, with alternative : "foo1:bar"');
+            $this->assertRegExp('/foo:bar1/', $e->getMessage(), '->find() throws an \InvalidArgumentException if command does not exist, with alternative : "foo:bar1"');
+        }
+
+        // Test if "foo1" command throw an "\InvalidArgumentException" and does not contain
+        // "foo:bar" as alternative because "foo1" is too far from "foo:bar"
+        try {
+            $application->find($commandName = 'foo1');
+            $this->fail('->find() throws an \InvalidArgumentException if command does not exist');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if command does not exist');
+            $this->assertRegExp(sprintf('/Command "%s" is not defined./', $commandName), $e->getMessage(), '->find() throws an \InvalidArgumentException if command does not exist, with alternatives');
+            $this->assertFalse(strpos($e->getMessage(), 'foo:bar'), '->find() throws an \InvalidArgumentException if command does not exist, without "foo:bar" alternative');
         }
     }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: namespace ?

Added something like in `git` :  if user type a wrong command and if a close alternative exists, Command compenent will display a list of similar command(s).

Note : It does not work with namespace. If this PR will be merged, I could work on namespace.

see : https://github.com/fabpot/Twig/blob/master/lib/Twig/Environment.php#L1003
