### PR TITLE
[DoctrineBridge] Add common data fixtures loader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,9 @@
         "symfony/validator": "self.version",
         "symfony/yaml": "self.version"
     },
+    "suggest": {
+        "doctrine/data-fixtures": "1.0.*"
+    },
     "autoload": {
         "psr-0": { "Symfony": "src/" }
     }

--- a/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
+++ b/src/Symfony/Bridge/Doctrine/DataFixtures/ContainerAwareLoader.php
@@ -12,21 +12,29 @@
 namespace Symfony\Bridge\Doctrine\DataFixtures;
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\DataFixtures\Loader as BaseLoader;
+use Doctrine\Common\DataFixtures\Loader;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Doctrine data fixtures loader that injects the service container for
- * fixtures objects that implement ContainerAwareInterface.
+ * Doctrine data fixtures loader that injects the service container into
+ * fixture objects that implement ContainerAwareInterface.
  *
- * Note: This class cannot be used without the Doctrine data fixtures extension,
- * which is not listed as a required dependency for Symfony.
+ * Note: Use of this class requires the Doctrine data fixtures extension, which
+ * is a suggested dependency for Symfony.
  */
-class Loader extends BaseLoader
+class ContainerAwareLoader extends Loader
 {
+    /**
+     * @var ContainerInterface
+     */
     private $container;
 
+    /**
+     * Constructor.
+     *
+     * @param ContainerInterface $container A ContainerInterface instance
+     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;

--- a/src/Symfony/Bridge/Doctrine/DataFixtures/Loader.php
+++ b/src/Symfony/Bridge/Doctrine/DataFixtures/Loader.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\DataFixtures;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\DataFixtures\Loader as BaseLoader;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Doctrine data fixtures loader that injects the service container for
+ * fixtures objects that implement ContainerAwareInterface.
+ *
+ * Note: This class cannot be used without the Doctrine data fixtures extension,
+ * which is not listed as a required dependency for Symfony.
+ */
+class Loader extends BaseLoader
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addFixture(FixtureInterface $fixture)
+    {
+        if ($fixture instanceof ContainerAwareInterface) {
+            $fixture->setContainer($this->container);
+        }
+
+        parent::addFixture($fixture);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -26,7 +26,8 @@
     },
     "suggest": {
         "symfony/form": "self.version",
-        "symfony/validator": "self.version"
+        "symfony/validator": "self.version",
+        "doctrine/data-fixtures": "1.0.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Doctrine": "" }


### PR DESCRIPTION
Symfony does not depend on doctrine/data-fixtures, but having this class in the bridge would enable DoctrineMongoDBBundle (and possibly others) to load fixtures without requiring DoctrineFixturesBundle to be installed.

Additionally, DoctrineFixturesBundle seems to only consist of this class and a command for loading ORM fixtures. With this in the bridge, we can possibly eliminate DoctrineFixturesBundle altogether by merging its command into DoctrineBundle.
