### PR TITLE
[WebProfilerBundle] moved variable initialization from condition

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -146,8 +146,9 @@ class ProfilerController extends ContainerAware
     public function toolbarAction($token, $position = null)
     {
         $request = $this->container->get('request');
+        $session = $request->getSession();
 
-        if (null !== $session = $request->getSession() && $session->getFlashBag() instanceof AutoExpireFlashBag) {
+        if (null !== $session && $session->getFlashBag() instanceof AutoExpireFlashBag) {
             // keep current flashes for one more request if using AutoExpireFlashBag
             $session->getFlashBag()->setAll($session->getFlashBag()->peekAll());
         }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

I got fatal error for the original condition on PHP 5.3.8:

```
Fatal error: Call to a member function getFlashBag() on a non-object in /home/context/httpd/vendor/symfony/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php on line 150
```
