### PR TITLE
[Profiler] Ajax

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * ProfilerController.
@@ -27,11 +28,12 @@ class ProfilerController extends ContainerAware
     /**
      * Renders a profiler panel for the given token.
      *
-     * @param string $token The profiler token
+     * @param Request $request The HTTP request
+     * @param string  $token   The profiler token
      *
      * @return Response A Response instance
      */
-    public function panelAction($token)
+    public function panelAction(Request $request, $token)
     {
         $profiler = $this->container->get('profiler');
         $profiler->disable();
@@ -54,6 +56,7 @@ class ProfilerController extends ContainerAware
             'panel'     => $panel,
             'page'      => $page,
             'templates' => $this->getTemplates($profiler),
+            'is_ajax'   => $request->isXmlHttpRequest(),
         ));
     }
 


### PR DESCRIPTION
The first commit should be merged as `app` is not always accessible in the twig template due to the ways the templating system is used. Then there is currently no way to check if we are dealing with an ajax request in the view.

The second commit use ajax to load the panels. This should make the interface more responsive as you don't have to load the layout each time + the panels are cached. Loading via AJAX would also work if your panel does not extend the ajax layout (legacy support) - this would be less efficient though as you would load the layout and filter it out afterwards.

I am not sure if the second commit is worth merging, maybe it is useless ?
