### PR TITLE
[FrameworkBundle][Session] Add auto_start pass to the storage options

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -294,7 +294,7 @@ class FrameworkExtension extends Extension
         // session storage
         $container->setAlias('session.storage', $config['storage_id']);
         $options = array();
-        foreach (array('name', 'lifetime', 'path', 'domain', 'secure', 'httponly') as $key) {
+        foreach (array('name', 'lifetime', 'path', 'domain', 'secure', 'httponly', 'auto_start') as $key) {
             if (isset($config[$key])) {
                 $options[$key] = $config[$key];
             }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

I think that is bugfix. 
In currently value of auto_start in config has no effect, at least when using the session in WebTestCase context.
