### PR TITLE
Added support for SVG mime type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeExtensionGuesser.php
@@ -340,6 +340,7 @@ class MimeTypeExtensionGuesser implements ExtensionGuesserInterface
         'image/pict' => 'pic',
         'image/pjpeg' => 'jpg',
         'image/png' => 'png',
+        'image/svg+xml' => 'svg',
         'image/targa' => 'tga',
         'image/tiff' => 'tif',
         'image/vn-svf' => 'svf',


### PR DESCRIPTION
Hi, MimeTypeExtensionGuesser doesn't have a default type for SVG files, I've added this in.

Craig
