### PR TITLE
[Propel] Added Propel to Stopwatch

### DIFF
--- a/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
+++ b/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bridge\Propel1\Logger;
 
+use Symfony\Component\HttpKernel\Debug\Stopwatch;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 /**
@@ -32,14 +33,24 @@ class PropelLogger
     protected $queries;
 
     /**
+     * @var \Symfony\Component\HttpKernel\Debug\Stopwatch
+     */
+    protected $stopwatch;
+
+    private $isPrepare;
+
+    /**
      * Constructor.
      *
      * @param LoggerInterface $logger A LoggerInterface instance
+     * @param Stopwatch       $stopwatch A Stopwatch instance
      */
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(LoggerInterface $logger = null, Stopwatch $stopwatch = null)
     {
-        $this->logger  = $logger;
-        $this->queries = array();
+        $this->logger    = $logger;
+        $this->queries   = array();
+        $this->stopwatch = $stopwatch;
+        $this->isPrepare = true;
     }
 
     /**
@@ -121,9 +132,25 @@ class PropelLogger
      */
     public function debug($message)
     {
-        $this->queries[] = $message;
-        if (null !== $this->logger) {
-            $this->logger->debug($message);
+        $add = true;
+
+        if (null !== $this->stopwatch) {
+            if ($this->isPrepare) {
+                $this->stopwatch->start('propel', 'propel');
+                $this->isPrepare = false;
+
+                $add = false;
+            } else {
+                $this->stopwatch->stop('propel');
+                $this->isPrepare = true;
+            }
+        }
+
+        if ($add) {
+            $this->queries[] = $message;
+            if (null !== $this->logger) {
+                $this->logger->debug($message);
+            }
         }
     }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.html.twig
@@ -8,6 +8,7 @@
         'event_listener_loading': '#add',
         'template':               '#dd3',
         'doctrine':               '#d3d',
+        'propel':                 '#f4d',
         'child_sections':         '#eed',
     } %}
 {% endif %}


### PR DESCRIPTION
I've added the Stopwatch feature, everything is ready on the PropelBundle.
The trick is to log `prepare` queries in Propel, that way we got first the prepared statement, and then the executed query. That's why there is a `$isPrepare` boolean.

I kept BC if people don't update the PropelBundle too.

William
