### PR TITLE
[HttpKernel] Fix call to Memcached::set() in MemcachedProfilerStorage

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -67,7 +67,7 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
      */
     protected function setValue($key, $value, $expiration = 0)
     {
-        return $this->getMemcached()->set($key, $value, false, $expiration);
+        return $this->getMemcached()->set($key, $value, $expiration);
     }
 
     /**


### PR DESCRIPTION
The existing code seems to have been copied from MemcacheProfilerStorage. Memcache::set() includes a $flag argument, but Memcached::set() omits that. See:
- http://php.net/manual/en/memcached.set.php
- http://php.net/manual/en/memcache.set.php

---

I assume Travis-CI didn't catch the MemcachedProfilerStorageTest failures because those tests are skipped: http://travis-ci.org/#!/symfony/symfony/jobs/678889/L104
