### PR TITLE
[Profiler] Fix memcache(d) storages

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
@@ -29,7 +29,7 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
      * @param string $dsn      A data source name
      * @param string $username
      * @param string $password
-     * @param int $lifetime    The lifetime to use for the purge
+     * @param int    $lifetime The lifetime to use for the purge
      */
     public function __construct($dsn, $username = '', $password = '', $lifetime = 86400)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -63,7 +63,7 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
      */
     protected function setValue($key, $value, $expiration = 0)
     {
-        return $this->getMemcache()->set($key, $value, false, $expiration);
+        return $this->getMemcache()->set($key, $value, false, time() + $expiration);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -67,7 +67,7 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
      */
     protected function setValue($key, $value, $expiration = 0)
     {
-        return $this->getMemcached()->set($key, $value, false, $expiration);
+        return $this->getMemcached()->set($key, $value, false, time() + $expiration);
     }
 
     /**


### PR DESCRIPTION
This fixes an ambiguity...

The memcache(d) storages have a `$lifetime` option. The name indicates that we are talking about a ttl (in seconds). This is wrong is `$lifetime` > 2592000 (=30 days), see http://fr.php.net/manual/en/memcache.set.php.

Doctrine is also [affected](https://github.com/vicb/common/commit/e9ab2d2ccaa825778bbf8a4e419534cb392246ea).

The ambiguity also exists in the session storage but to a lesser extend as those storage directly use memcache(d) options rather than a `$lifetime`. @drak could you confirm ?

Hopefully the Cache Component will get it right (#3211). 
