### PR TITLE
[HttpFoundation] Response invalidation is naive and what about not limiting symfony to RFC-2616?

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -858,7 +858,7 @@ class Response
      */
     public function isInvalid()
     {
-        return $this->statusCode < 100 || $this->statusCode >= 600;
+        return !isset(self::$statusTexts[$this->statusCode]);
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -356,7 +356,7 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
 
         try {
             $response->setStatusCode(422);
-            $this->pass();
+            $this->fail();
         } catch(\InvalidArgumentException $e) {
             $this->assertTrue($response->isInvalid());
         }

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -343,21 +343,21 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         try {
             $response->setStatusCode(99);
             $this->fail();
-        } catch(\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             $this->assertTrue($response->isInvalid());
         }
 
         try {
             $response->setStatusCode(650);
             $this->fail();
-        } catch(\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             $this->assertTrue($response->isInvalid());
         }
 
         try {
             $response->setStatusCode(422);
             $this->fail();
-        } catch(\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException $e) {
             $this->assertTrue($response->isInvalid());
         }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -354,6 +354,13 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue($response->isInvalid());
         }
 
+        try {
+            $response->setStatusCode(422);
+            $this->pass();
+        } catch(\InvalidArgumentException $e) {
+            $this->assertTrue($response->isInvalid());
+        }
+
         $response = new Response('', 200);
         $this->assertFalse($response->isInvalid());
     }


### PR DESCRIPTION
Using `HttpFoundation` as a standalone component for one of my projects, I noticed a bug in invalidation of the `Response`.

I was instantiating a new `Response`, with the data I received from an HTTP client (`Kriswallsmith\Buzz`):

```
new Response($body, 422, $headers);
```

which ended in:

```
Undefined offset: 422

/home/odino/projects/symfony/src/Symfony/Component/HttpFoundation/Response.php:318
/home/odino/projects/symfony/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php:358
```

That's because `422` status code is not defined in `RFC-2616`.

For now, I just added a test case to solve this issue (like [Agavi does](http://trac.agavi.org/browser/trunk/src/response/AgaviWebResponse.class.php#L331)), but I propose a further discussion to support HTTP extensions, like WebDAV (from which 422 comes).
