### PR TITLE
[Security] added AccessMapInterface

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -171,6 +171,7 @@ class SecurityExtension extends Extension
         }
 
         $this->addClassesToCompile(array(
+            'Symfony\\Component\\Security\\Http\\AccessMapInterface',
             'Symfony\\Component\\Security\\Http\\AccessMap',
         ));
 

--- a/src/Symfony/Component/Security/Http/AccessMap.php
+++ b/src/Symfony/Component/Security/Http/AccessMap.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class AccessMap
+class AccessMap implements AccessMapInterface
 {
     private $map = array();
 

--- a/src/Symfony/Component/Security/Http/AccessMapInterface.php
+++ b/src/Symfony/Component/Security/Http/AccessMapInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * AccessMap allows configuration of different access control rules for
+ * specific parts of the website.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Kris Wallsmith <kris@symfony.com>
+ */
+interface AccessMapInterface
+{
+    /**
+     * Returns security attributes and required channel for the supplied request.
+     *
+     * @param Request $request The current request
+     *
+     * @return array A tuple of security attributes and the required channel
+     */
+    function getPatterns(Request $request);
+}

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
-use Symfony\Component\Security\Http\AccessMap;
+use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -33,7 +33,7 @@ class AccessListener implements ListenerInterface
     private $authManager;
     private $logger;
 
-    public function __construct(SecurityContextInterface $context, AccessDecisionManagerInterface $accessDecisionManager, AccessMap $map, AuthenticationManagerInterface $authManager, LoggerInterface $logger = null)
+    public function __construct(SecurityContextInterface $context, AccessDecisionManagerInterface $accessDecisionManager, AccessMapInterface $map, AuthenticationManagerInterface $authManager, LoggerInterface $logger = null)
     {
         $this->context = $context;
         $this->accessDecisionManager = $accessDecisionManager;

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\Security\Http\AccessMap;
+use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -28,7 +28,7 @@ class ChannelListener implements ListenerInterface
     private $authenticationEntryPoint;
     private $logger;
 
-    public function __construct(AccessMap $map, AuthenticationEntryPointInterface $authenticationEntryPoint, LoggerInterface $logger = null)
+    public function __construct(AccessMapInterface $map, AuthenticationEntryPointInterface $authenticationEntryPoint, LoggerInterface $logger = null)
     {
         $this->map = $map;
         $this->authenticationEntryPoint = $authenticationEntryPoint;

--- a/tests/Symfony/Tests/Component/Security/Http/Firewall/AccessListenerTest.php
+++ b/tests/Symfony/Tests/Component/Security/Http/Firewall/AccessListenerTest.php
@@ -13,7 +13,7 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
 
-        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMap');
+        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMapInterface');
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
@@ -64,7 +64,7 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
 
-        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMap');
+        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMapInterface');
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
@@ -135,7 +135,7 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
 
-        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMap');
+        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMapInterface');
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
@@ -188,7 +188,7 @@ class AccessListenerTest extends \PHPUnit_Framework_TestCase
         $listener = new AccessListener(
             $context,
             $this->getMock('Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface'),
-            $this->getMock('Symfony\Component\Security\Http\AccessMap'),
+            $this->getMock('Symfony\Component\Security\Http\AccessMapInterface'),
             $this->getMock('Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface')
         );
 

--- a/tests/Symfony/Tests/Component/Security/Http/Firewall/ChannelListenerTest.php
+++ b/tests/Symfony/Tests/Component/Security/Http/Firewall/ChannelListenerTest.php
@@ -17,7 +17,7 @@ class ChannelListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(false))
         ;
 
-        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMap');
+        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMapInterface');
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
@@ -55,7 +55,7 @@ class ChannelListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue(true))
         ;
 
-        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMap');
+        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMapInterface');
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
@@ -95,7 +95,7 @@ class ChannelListenerTest extends \PHPUnit_Framework_TestCase
 
         $response = new Response();
 
-        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMap');
+        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMapInterface');
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')
@@ -138,7 +138,7 @@ class ChannelListenerTest extends \PHPUnit_Framework_TestCase
 
         $response = new Response();
 
-        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMap');
+        $accessMap = $this->getMock('Symfony\Component\Security\Http\AccessMapInterface');
         $accessMap
             ->expects($this->any())
             ->method('getPatterns')


### PR DESCRIPTION
I am optimizing the security layer at OpenSky and need to make this class smarter instead of running through all of the many access rules for each request. I would like to do this by creating a delegating access map composed of many inner maps and would rather implement an interface than extending a core class without using any of its functionality.

```
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```
