### PR TITLE
[json-response] Add a JsonResponse class for convenient JSON encoding

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * Response represents an HTTP response in JSON format.
+ *
+ * @author Igor Wiedler <igor@wiedler.ch>
+ */
+class JsonResponse extends Response
+{
+    /**
+     * Constructor.
+     *
+     * @param mixed   $data    The response data
+     * @param integer $status  The response status code
+     * @param array   $headers An array of response headers
+     */
+    public function __construct($data = array(), $status = 200, $headers = array())
+    {
+        // root should be JSON object, not array
+        if (is_array($data) && 0 === count($data)) {
+            $data = new \ArrayObject();
+        }
+
+        parent::__construct(
+            json_encode($data),
+            $status,
+            array_merge(array('Content-Type' => 'application/json'), $headers)
+        );
+    }
+}

--- a/tests/Symfony/Tests/Component/HttpFoundation/JsonResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/JsonResponseTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpFoundation;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * @covers Symfony\Component\HttpFoundation\JsonResponse::__construct
+ */
+class JsonResponseTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructorEmptyCreatesJsonObject()
+    {
+        $response = new JsonResponse();
+        $this->assertSame('{}', $response->getContent());
+    }
+
+    public function testConstructorWithArrayCreatesJsonArray()
+    {
+        $response = new JsonResponse(array(0, 1, 2, 3));
+        $this->assertSame('[0,1,2,3]', $response->getContent());
+    }
+
+    public function testConstructorWithAssocArrayCreatesJsonObject()
+    {
+        $response = new JsonResponse(array('foo' => 'bar'));
+        $this->assertSame('{"foo":"bar"}', $response->getContent());
+    }
+
+    public function testConstructorWithSimpleTypes()
+    {
+        $response = new JsonResponse('foo');
+        $this->assertSame('"foo"', $response->getContent());
+
+        $response = new JsonResponse(0);
+        $this->assertSame('0', $response->getContent());
+
+        $response = new JsonResponse(0.1);
+        $this->assertSame('0.1', $response->getContent());
+
+        $response = new JsonResponse(true);
+        $this->assertSame('true', $response->getContent());
+    }
+
+    public function testConstructorWithCustomStatus()
+    {
+        $response = new JsonResponse(array(), 202);
+        $this->assertSame(202, $response->getStatusCode());
+    }
+
+    public function testConstructorAddsContentTypeHeader()
+    {
+        $response = new JsonResponse();
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+    }
+
+    public function testConstructorWithCustomHeaders()
+    {
+        $response = new JsonResponse(array(), 200, array('ETag' => 'foo'));
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('foo', $response->headers->get('ETag'));
+    }
+
+    public function testConstructorWithCustomContentType()
+    {
+        $headers = array('Content-Type' => 'application/vnd.acme.blog-v1+json');
+
+        $response = new JsonResponse(array(), 200, $headers);
+        $this->assertSame('application/vnd.acme.blog-v1+json', $response->headers->get('Content-Type'));
+    }
+}


### PR DESCRIPTION
Usage example:

```
$data = array(user => $user->toArray());
return new JsonResponse($data);
```
