### PR TITLE
ProcessBuilder clean up

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -116,7 +116,7 @@ class Process
         }
         $this->stdin = $stdin;
         $this->timeout = $timeout;
-        $this->options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true), $options);
+        $this->options = array_replace(array('suppress_errors' => true, 'binary_pipes' => true), $options);
     }
 
     /**

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -89,7 +89,7 @@ class Process
      *
      * @param string  $commandline The command line to run
      * @param string  $cwd         The working directory
-     * @param array   $env         The environment variables
+     * @param array   $env         The environment variables or null to inherit
      * @param string  $stdin       The STDIN content
      * @param integer $timeout     The timeout in seconds
      * @param array   $options     An array of options for proc_open

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -34,6 +34,7 @@ class Process
     private $status;
     private $stdout;
     private $stderr;
+    private $enhanceWindowsCompatibility = true;
 
     /**
      * Exit codes translation table.
@@ -159,7 +160,13 @@ class Process
 
         $descriptors = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
 
-        $process = proc_open($this->commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
+        $commandline = $this->commandline;
+
+        if (defined('PHP_WINDOWS_VERSION_BUILD') && $this->enhanceWindowsCompatibility) {
+            $commandline = 'cmd /V:ON /E:ON /C "'.$commandline.'"';
+        }
+
+        $process = proc_open($commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);
 
         if (!is_resource($process)) {
             throw new \RuntimeException('Unable to launch a new process.');
@@ -431,4 +438,15 @@ class Process
     {
         $this->options = $options;
     }
+
+    public function getEnhanceWindowsCompatibility()
+    {
+        return $this->enhanceWindowsCompatibility;
+    }
+
+    public function setEnhanceWindowsCompatibility($enhance)
+    {
+        $this->enhanceWindowsCompatibility = (Boolean) $enhance;
+    }
+
 }

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -116,7 +116,7 @@ class Process
         }
         $this->stdin = $stdin;
         $this->timeout = $timeout;
-        $this->options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true, 'bypass_shell' => false), $options);
+        $this->options = array_merge(array('suppress_errors' => true, 'binary_pipes' => true), $options);
     }
 
     /**
@@ -164,6 +164,9 @@ class Process
 
         if (defined('PHP_WINDOWS_VERSION_BUILD') && $this->enhanceWindowsCompatibility) {
             $commandline = 'cmd /V:ON /E:ON /C "'.$commandline.'"';
+            if (!isset($this->options['bypass_shell'])) {
+                $this->options['bypass_shell'] = true;
+            }
         }
 
         $process = proc_open($commandline, $descriptors, $pipes, $this->cwd, $this->env, $this->options);

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -35,6 +35,11 @@ class ProcessBuilder
         $this->inheritEnv = false;
     }
 
+    public static function create(array $arguments = array())
+    {
+        return new static($arguments);
+    }
+
     /**
      * Adds an unescaped argument to the command string.
      *

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -110,7 +110,12 @@ class ProcessBuilder
             $script .= ' '.implode(' ', array_map('escapeshellarg', $arguments));
         }
 
-        $env = $this->inheritEnv && $_ENV ? $this->env + $_ENV : $this->env;
+        $env = null;
+        if ($this->inheritEnv) {
+            $env = $_ENV ? $this->env + $_ENV : $this->env;
+        } else {
+            $env = $this->env;
+        }
 
         return new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
     }

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -20,7 +20,7 @@ class ProcessBuilder
 {
     private $arguments;
     private $cwd;
-    private $env;
+    private $env = array();
     private $stdin;
     private $timeout;
     private $options;
@@ -63,10 +63,6 @@ class ProcessBuilder
 
     public function setEnv($name, $value)
     {
-        if (null === $this->env) {
-            $this->env = array();
-        }
-
         $this->env[$name] = $value;
 
         return $this;
@@ -117,7 +113,7 @@ class ProcessBuilder
             $script = implode(' ', array_map('escapeshellarg', $this->arguments));
         }
 
-        $env = $this->inheritEnv && $_ENV ? ($this->env ?: array()) + $_ENV : $this->env;
+        $env = $this->inheritEnv && $_ENV ? $this->env + $_ENV : $this->env;
 
         return new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
     }

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -32,7 +32,7 @@ class ProcessBuilder
 
         $this->timeout = 60;
         $this->options = array();
-        $this->inheritEnv = false;
+        $this->inheritEnv = true;
     }
 
     public static function create(array $arguments = array())
@@ -112,7 +112,7 @@ class ProcessBuilder
 
         $env = null;
         if ($this->inheritEnv) {
-            $env = $_ENV ? $this->env + $_ENV : $this->env;
+            $env = $this->env ? $this->env + $_ENV : null;
         } else {
             $env = $this->env;
         }

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -102,20 +102,12 @@ class ProcessBuilder
 
         $options = $this->options;
 
-        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $options['bypass_shell'] = true;
+        $arguments = $this->arguments;
+        $command = array_shift($arguments);
 
-            $arguments = $this->arguments;
-            $command = array_shift($arguments);
-
-            $script = '"'.$command.'"';
-            if ($arguments) {
-                $script .= ' '.implode(' ', array_map('escapeshellarg', $arguments));
-            }
-
-            $script = 'cmd /V:ON /E:ON /C "'.$script.'"';
-        } else {
-            $script = implode(' ', array_map('escapeshellarg', $this->arguments));
+        $script = escapeshellcmd($command);
+        if ($arguments) {
+            $script .= ' '.implode(' ', array_map('escapeshellarg', $arguments));
         }
 
         $env = $this->inheritEnv && $_ENV ? $this->env + $_ENV : $this->env;

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -20,7 +20,7 @@ class ProcessBuilder
 {
     private $arguments;
     private $cwd;
-    private $env = array();
+    private $env;
     private $stdin;
     private $timeout;
     private $options;
@@ -32,6 +32,7 @@ class ProcessBuilder
 
         $this->timeout = 60;
         $this->options = array();
+        $this->env = array();
         $this->inheritEnv = true;
     }
 
@@ -110,7 +111,6 @@ class ProcessBuilder
             $script .= ' '.implode(' ', array_map('escapeshellarg', $arguments));
         }
 
-        $env = null;
         if ($this->inheritEnv) {
             $env = $this->env ? $this->env + $_ENV : null;
         } else {

--- a/tests/Symfony/Tests/Component/Process/ProcessBuilderTest.php
+++ b/tests/Symfony/Tests/Component/Process/ProcessBuilderTest.php
@@ -27,7 +27,7 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
         $pb->add('foo')->inheritEnvironmentVariables();
         $proc = $pb->getProcess();
 
-        $this->assertEquals($expected, $proc->getEnv(), '->inheritEnvironmentVariables() copies $_ENV');
+        $this->assertEquals(null, $proc->getEnv(), '->inheritEnvironmentVariables() copies $_ENV');
 
         $_ENV = $snapshot;
     }
@@ -54,12 +54,12 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function shouldNotInheritEnvironmentVarsByDefault()
+    public function shouldInheritEnvironmentVarsByDefault()
     {
         $pb = new ProcessBuilder();
         $proc = $pb->add('foo')->getProcess();
 
-        $this->assertEquals(array(), $proc->getEnv());
+        $this->assertEquals(null, $proc->getEnv());
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Process/ProcessBuilderTest.php
+++ b/tests/Symfony/Tests/Component/Process/ProcessBuilderTest.php
@@ -35,6 +35,36 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
+    public function shouldInheritAndOverrideEnvironmentVars()
+    {
+        $snapshot = $_ENV;
+        $_ENV = array('foo' => 'bar', 'bar' => 'baz');
+        $expected = array('foo' => 'foo', 'bar' => 'baz');
+
+        $pb = new ProcessBuilder();
+        $pb->add('foo')->inheritEnvironmentVariables()
+            ->setEnv('foo', 'foo');
+        $proc = $pb->getProcess();
+
+        $this->assertEquals($expected, $proc->getEnv(), '->inheritEnvironmentVariables() copies $_ENV');
+
+        $_ENV = $snapshot;
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotInheritEnvironmentVarsByDefault()
+    {
+        $pb = new ProcessBuilder();
+        $proc = $pb->add('foo')->getProcess();
+
+        $this->assertEquals(array(), $proc->getEnv());
+    }
+
+    /**
+     * @test
+     */
     public function shouldNotReplaceExplicitlySetVars()
     {
         $snapshot = $_ENV;


### PR DESCRIPTION
- Code cleanup
- Added create() static method for easy creation until we can do `$process = (new ProcessBuilder())->add()->getProcess();`
- Removed windows wrapping of commands. This does not belong there IMO. If assetic needs that it should add it, and if it's generally beneficial to everyone then we should add it to Process, but having it implicitly only when using ProcessBuilder makes on sense.
