### PR TITLE
fixed timezone bug in DateTimeToTimestampTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -75,9 +75,7 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
         try {
             $dateTime = new \DateTime(sprintf("@%s %s", $value, $this->outputTimezone));
 
-            if ($this->inputTimezone !== $this->outputTimezone) {
-                $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
-            }
+            $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }


### PR DESCRIPTION
I think the timezone of $dateTime may differ from inputTimezone although input and outputTimeZone are equal.
Therefore it has to be always set!
