### PR TITLE
test for ensuring creating form returns data of type specified in data_c...

### DIFF
--- a/tests/Symfony/Tests/Component/Form/Fixtures/BarType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/BarType.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Tests\Component\Form\Fixtures\Author;
+
+class BarType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder->setAttribute('bar', 'x');
+        $builder->setAttribute('data_option', $options['data']);
+    }
+
+    public function getName()
+    {
+        return 'bar';
+    }
+
+    public function createBuilder($name, FormFactoryInterface $factory, array $options)
+    {
+        return new FormBuilder($name, $factory, new EventDispatcher());
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        return array(
+            'data' => null,
+            'data_class' => 'Symfony\Tests\Component\Form\Fixtures\Author',
+            'empty_data' => true,
+            'required' => false,
+            'max_length' => null,
+            'a_or_b' => 'a',
+        );
+    }
+
+    public function getAllowedOptionValues(array $options)
+    {
+        return array(
+            'a_or_b' => array('a', 'b'),
+        );
+    }
+
+    public function getParent(array $options)
+    {
+        return null;
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
@@ -18,6 +18,8 @@ use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Tests\Component\Form\Fixtures\TestExtension;
 use Symfony\Tests\Component\Form\Fixtures\FooType;
+use Symfony\Tests\Component\Form\Fixtures\BarType;
+use Symfony\Tests\Component\Form\Fixtures\Author;
 use Symfony\Tests\Component\Form\Fixtures\FooTypeBarExtension;
 use Symfony\Tests\Component\Form\Fixtures\FooTypeBazExtension;
 
@@ -514,6 +516,19 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             '"translation_domain", "empty_data"'
         );
         $factory->createNamedBuilder($type, "text", "value", array("invalid" => "opt", "unknown" => "opt"));
+    }
+
+    public function testNullObjectWithCustomTypeReturnsCorrectObjectType()
+    {
+        $type = new BarType();
+        $form = $this->factory->create($type);
+        $form->setData(new Author());
+        $fdata = $form->getData();
+        $this->assertTrue($fdata instanceof Author);
+
+        $form = $this->factory->create($type);
+        $fdata = $form->getData();
+        $this->assertTrue($fdata instanceof Author, 'Failing in returning object of type specified in data_class when creating with empty data');
     }
 
     public function testUnknownOption()


### PR DESCRIPTION
...lass

``` sh

~ phpunit tests/Symfony/Tests/Component/Form/FormFactoryTest.php 
PHPUnit 3.6.4 by Sebastian Bergmann.

Configuration read from /home/cordoval/sites-2/forum/vendor/symfony/phpunit.xml.dist

..........................F.

Time: 0 seconds, Memory: 11.25Mb

There was 1 failure:

1) Symfony\Tests\Component\Form\FormFactoryTest::testNullObjectWithCustomTypeReturnsCorrectObjectType
Failing in returning object of type specified in data_class when creating with empty data
Failed asserting that false is true.

/home/cordoval/sites-2/forum/vendor/symfony/tests/Symfony/Tests/Component/Form/FormFactoryTest.php:531

FAILURES!
Tests: 28, Assertions: 57, Failures: 1.
```
