### PR TITLE
Update src/Symfony/Component/Security/Http/Firewall/ContextListener.php

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -152,7 +152,6 @@ class ContextListener implements ListenerInterface
                     $this->logger->warn(sprintf('Username "%s" could not be found.', $user->getUsername()));
                 }
 
-                return null;
             }
         }
 


### PR DESCRIPTION
The refreshUser method loops through multiple user providers but returns null on the first one that fails to provide a user.  Modified so continues to check other providers before failing.
