### PR TITLE
[FrameworkBundle] Feature/class map generator command [#2407, #2471]

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ClassMapDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ClassMapDumperCommand.php
@@ -15,8 +15,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Routing\Matcher\Dumper\ApacheMatcherDumper;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\ClassLoader\ClassMapGenerator;
+use Symfony\Component\Validator\Exception\InvalidOptionsException;
 
 /**
  * ClassMapDumperCommand.
@@ -32,8 +32,8 @@ class ClassMapDumperCommand extends ContainerAwareCommand
     {
         $this
             ->setDefinition(array(
-                new InputArgument('dir', InputArgument::OPTIONAL, 'Directories or a single path to search in.'),
-                new InputOption('file', null, InputOption::VALUE_REQUIRED, 'The name of the class map file.'),
+                new InputArgument('dir', InputArgument::REQUIRED, 'Directories or a single path to search in.'),
+                new InputOption('file', null, InputOption::VALUE_REQUIRED, 'The name of the class map file.', 'classmap.php'),
             ))
             ->setName('generate:class-map')
             ->setDescription('Generates class map file')
@@ -54,9 +54,12 @@ EOF
         if ($input->getArgument('dir')) {
             $dir = $input->getArgument('dir');
         }
+
         if ($input->getOption('file')) {
             $file = $input->getOption('file');
         }
+
+        ClassMapGenerator::dump($dir, $file);
 
         $output->writeln('Class map has been generated.');
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ClassMapDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ClassMapDumperCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Routing\Matcher\Dumper\ApacheMatcherDumper;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * ClassMapDumperCommand.
+ *
+ * @author Luis Cordova <cordoval@gmail.com>
+ */
+class ClassMapDumperCommand extends ContainerAwareCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputArgument('dir', InputArgument::OPTIONAL, 'Directories or a single path to search in.'),
+                new InputOption('file', null, InputOption::VALUE_REQUIRED, 'The name of the class map file.'),
+            ))
+            ->setName('generate:class-map')
+            ->setDescription('Generates class map file')
+            ->setHelp(<<<EOF
+The <info>generate:class-map</info> generates class map file.
+
+  <info>generate:class-map</info>
+EOF
+            )
+        ;
+    }
+
+    /**
+     * @see Command
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        if ($input->getArgument('dir')) {
+            $dir = $input->getArgument('dir');
+        }
+        if ($input->getOption('file')) {
+            $file = $input->getOption('file');
+        }
+
+        $output->writeln('Class map has been generated.');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ClassMapDumperCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ClassMapDumperCommand.php
@@ -16,7 +16,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\ClassLoader\ClassMapGenerator;
-use Symfony\Component\Validator\Exception\InvalidOptionsException;
 
 /**
  * ClassMapDumperCommand.
@@ -40,7 +39,7 @@ class ClassMapDumperCommand extends ContainerAwareCommand
             ->setHelp(<<<EOF
 The <info>generate:class-map</info> generates class map file.
 
-  <info>generate:class-map</info>
+  <info>generate:class-map dir file</info>
 EOF
             )
         ;


### PR DESCRIPTION
Adds a command for Map Class Generator

https://github.com/symfony/symfony/issues/2407

quote @lsmith77 :

"it appears we do not have tools to generate a class map to be used in the map class loader. maybe we should even provide a command. then again maybe this should be handled by https://github.com/sensio/SensioDistributionBundle/tree/master/Resources/bin ?"
