### PR TITLE
[EventDispatcher] Removed useless code

### DIFF
--- a/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
+++ b/tests/Symfony/Tests/Component/EventDispatcher/EventDispatcherTest.php
@@ -62,9 +62,6 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $listener1 = new TestEventListener();
         $listener2 = new TestEventListener();
         $listener3 = new TestEventListener();
-        $listener1->name = '1';
-        $listener2->name = '2';
-        $listener3->name = '3';
 
         $this->dispatcher->addListener('pre.foo', array($listener1, 'preFoo'), -10);
         $this->dispatcher->addListener('pre.foo', array($listener2, 'preFoo'), 10);


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Just removed useless code.

But one extra question: Why don't tests always use class constant ?
