### PR TITLE
[HttpFoundation] Fix session.cache_limiter is not set correctly

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/AbstractSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/AbstractSessionStorage.php
@@ -58,6 +58,7 @@ abstract class AbstractSessionStorage implements SessionStorageInterface
      * but we omit 'session.' from the beginning of the keys.
      *
      * auto_start, "0"
+     * cache_limiter, ""
      * cookie_domain, ""
      * cookie_httponly, ""
      * cookie_lifetime, "0"
@@ -216,7 +217,7 @@ abstract class AbstractSessionStorage implements SessionStorageInterface
         // Unless session.cache_limiter has been set explicitly, disable it
         // because this is managed by HeaderBag directly (if used).
         if (!isset($this->options['cache_limiter'])) {
-            $this->options['cache_limiter'] = 0;
+            $this->options['cache_limiter'] = false;
         }
 
         if (!isset($this->options['auto_start'])) {
@@ -229,7 +230,7 @@ abstract class AbstractSessionStorage implements SessionStorageInterface
 
         foreach ($this->options as $key => $value) {
             if (in_array($key, array(
-                'auto_start', 'cookie_domain', 'cookie_httponly',
+                'auto_start', 'cache_limiter', 'cookie_domain', 'cookie_httponly',
                 'cookie_lifetime', 'cookie_path', 'cookie_secure',
                 'entropy_file', 'entropy_length', 'gc_divisor',
                 'gc_maxlifetime', 'gc_probability', 'hash_bits_per_character',

--- a/tests/Symfony/Tests/Component/HttpFoundation/Session/Storage/AbstractSessionStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/Session/Storage/AbstractSessionStorageTest.php
@@ -124,4 +124,20 @@ class AbstractSessionStorageTest extends \PHPUnit_Framework_TestCase
         $storage = new ConcreteSessionStorage();
         $this->assertNotEquals('user', ini_get('session.save_handler'));
     }
+
+    public function testDefaultSessionCacheLimiter()
+    {
+        ini_set('session.cache_limiter', 'nocache');
+
+        $storage = new ConcreteSessionStorage();
+        $this->assertEquals('', ini_get('session.cache_limiter'));
+    }
+
+    public function testExplicitSessionCacheLimiter()
+    {
+        ini_set('session.cache_limiter', 'nocache');
+
+        $storage = new ConcreteSessionStorage(array('cache_limiter' => 'public'));
+        $this->assertEquals('public', ini_get('session.cache_limiter'));
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Fixes a regression after the session refactoring where extra cache control http headers are sent.

This was previously handled by [calling session_cache_limiter(false) in NativeSessionStorage](https://github.com/symfony/symfony/blob/2.0/src/Symfony/Component/HttpFoundation/SessionStorage/NativeSessionStorage.php#L81)
