### PR TITLE
Improving performance on digit filtering

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -229,7 +229,8 @@ class ParameterBag
      */
     public function getDigits($key, $default = '', $deep = false)
     {
-        return preg_replace('/[^[:digit:]]/', '', $this->get($key, $default, $deep));
+        // we need to remove - and + because they're allowed in the filter
+        return str_replace(array('-','+'),'', $this->filter($key, $default, $deep, FILTER_SANITIZE_NUMBER_INT));
     }
 
     /**


### PR DESCRIPTION
I haven't tested it on a productive system but I think it should be way faster to use filter_var() instead of preg_replace() for several reasons.

This is my first pull request for symfony and I don't know how you do those kind of performance tests but please verify my assumption if you can :-)

Maybe we can also use filter_var() to replace other regular expressions :-)

HTH =)
