### PR TITLE
[Form] Support for custom DateTime objects

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -214,6 +214,12 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * [BC BREAK] FormType::getParent() does not see default options anymore
  * [BC BREAK] The methods `add`, `remove`, `setParent`, `bind` and `setData`
    in class Form now throw an exception if the form is already bound
+ * [BC BREAK] DateTimeToArrayTransformer, BaseDateTimeTransformer
+   DateTimeToLocalizedStringTransformer, DateTimeToStringTransformer
+   DateTimeToTimestampTransformer now take $dateTimeClass and $dateTimeZoneClass
+   constructor parameters to support passing custom date time classes via
+   parameters datetime_class and datetimezone_class for DateTimeType, DateType
+   and TimeType
 
 ### HttpFoundation
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -52,11 +52,11 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($outputTimezone, 'string');
         }
 
-        if ($dateTimeClass && !is_a($dateTimeClass, 'DateTime', true)) {
-            throw new UnexpectedTypeException($dateTimeClass, 'DateTime');
+        if ($dateTimeClass && !$this->isOfType('DateTime', $dateTimeClass)) {
+            throw new UnexpectedTypeException(new $dateTimeClass('NOW'), 'DateTime');
         }
 
-        if ($dateTimeZoneClass && !is_a($dateTimeZoneClass, 'DateTimeZone', true)) {
+        if ($dateTimeZoneClass && !$this->isOfType('DateTimeZone', $dateTimeZoneClass)) {
             throw new UnexpectedTypeException($dateTimeZoneClass, 'DateTimeZone');
         }
 
@@ -68,13 +68,16 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
 
     protected function createDate($dateString, \DateTimeZone $timezone)
     {
-        $date = new $this->dateTimeClass($dateString, $timezone);
-
-        return $date;
+        return new $this->dateTimeClass($dateString, $timezone);
     }
 
     protected function createTimezone($timezoneName)
     {
         return new $this->dateTimeZoneClass($timezoneName);
+    }
+
+    private function isOfType($parentClass, $class)
+    {
+        return ltrim($class, '\\') === $parentClass || is_subclass_of($class, $parentClass);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -42,12 +42,7 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */
-    public function __construct(
-        $inputTimezone = null,
-        $outputTimezone = null,
-        $dateTimeClass = null,
-        $dateTimeZoneClass = null
-    )
+    public function __construct($inputTimezone = null, $outputTimezone = null, $dateTimeClass = null, $dateTimeZoneClass = null)
     {
         if (!is_string($inputTimezone) && null !== $inputTimezone) {
             throw new UnexpectedTypeException($inputTimezone, 'string');

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 abstract class BaseDateTimeTransformer implements DataTransformerInterface
 {
@@ -27,15 +28,26 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
 
     protected $outputTimezone;
 
+    protected $dateTimeClass;
+
+    protected $dateTimeZoneClass;
+
     /**
      * Constructor.
      *
-     * @param string $inputTimezone  The name of the input timezone
-     * @param string $outputTimezone The name of the output timezone
+     * @param string $inputTimezone     The name of the input timezone
+     * @param string $outputTimezone    The name of the output timezone
+     * @param string $dateTimeClass     The date time class (must be compatible with DateTime)
+     * @param string $dateTimeZoneClass The date time zone class (must be compatible with DateTimeZone)
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */
-    public function __construct($inputTimezone = null, $outputTimezone = null)
+    public function __construct(
+        $inputTimezone = null,
+        $outputTimezone = null,
+        $dateTimeClass = null,
+        $dateTimeZoneClass = null
+    )
     {
         if (!is_string($inputTimezone) && null !== $inputTimezone) {
             throw new UnexpectedTypeException($inputTimezone, 'string');
@@ -45,7 +57,29 @@ abstract class BaseDateTimeTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($outputTimezone, 'string');
         }
 
+        if ($dateTimeClass && !is_a($dateTimeClass, 'DateTime', true)) {
+            throw new UnexpectedTypeException($dateTimeClass, 'DateTime');
+        }
+
+        if ($dateTimeZoneClass && !is_a($dateTimeZoneClass, 'DateTimeZone', true)) {
+            throw new UnexpectedTypeException($dateTimeZoneClass, 'DateTimeZone');
+        }
+
         $this->inputTimezone = $inputTimezone ?: date_default_timezone_get();
         $this->outputTimezone = $outputTimezone ?: date_default_timezone_get();
+        $this->dateTimeClass = $dateTimeClass ?: 'DateTime';
+        $this->dateTimeZoneClass = $dateTimeZoneClass ?: 'DateTimeZone';
+    }
+
+    protected function createDate($dateString, \DateTimeZone $timezone)
+    {
+        $date = new $this->dateTimeClass($dateString, $timezone);
+
+        return $date;
+    }
+
+    protected function createTimezone($timezoneName)
+    {
+        return new $this->dateTimeZoneClass($timezoneName);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -29,16 +29,25 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
     /**
      * Constructor.
      *
-     * @param string  $inputTimezone    The input timezone
-     * @param string  $outputTimezone   The output timezone
-     * @param array   $fields           The date fields
-     * @param Boolean $pad              Whether to use padding
+     * @param string  $inputTimezone     The input timezone
+     * @param string  $outputTimezone    The output timezone
+     * @param string  $dateTimeClass     The date time class (must be compatible with DateTime)
+     * @param string  $dateTimeZoneClass The date time zone class (must be compatible with DateTimeZone)
+     * @param array   $fields            The date fields
+     * @param Boolean $pad               Whether to use padding
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */
-    public function __construct($inputTimezone = null, $outputTimezone = null, array $fields = null, $pad = false)
+    public function __construct(
+        $inputTimezone = null,
+        $outputTimezone = null,
+        $dateTimeClass = null,
+        $dateTimeZoneClass = null,
+        array $fields = null,
+        $pad = false
+    )
     {
-        parent::__construct($inputTimezone, $outputTimezone);
+        parent::__construct($inputTimezone, $outputTimezone, $dateTimeClass, $dateTimeZoneClass);
 
         if (null === $fields) {
             $fields = array('year', 'month', 'day', 'hour', 'minute', 'second');
@@ -71,14 +80,14 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
             ), array_flip($this->fields));
         }
 
-        if (!$dateTime instanceof \DateTime) {
-            throw new UnexpectedTypeException($dateTime, '\DateTime');
+        if (!$dateTime instanceof $this->dateTimeClass) {
+            throw new UnexpectedTypeException($dateTime, $this->dateTimeClass);
         }
 
         $dateTime = clone $dateTime;
         if ($this->inputTimezone !== $this->outputTimezone) {
             try {
-                $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
+                $dateTime->setTimezone($this->createTimeZone($this->outputTimezone));
             } catch (\Exception $e) {
                 throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
             }
@@ -159,19 +168,22 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         }
 
         try {
-            $dateTime = new \DateTime(sprintf(
-                '%s-%s-%s %s:%s:%s %s',
-                empty($value['year']) ? '1970' : $value['year'],
-                empty($value['month']) ? '1' : $value['month'],
-                empty($value['day']) ? '1' : $value['day'],
-                empty($value['hour']) ? '0' : $value['hour'],
-                empty($value['minute']) ? '0' : $value['minute'],
-                empty($value['second']) ? '0' : $value['second'],
-                $this->outputTimezone
-            ));
+            $dateTime = $this->createDate(
+                sprintf(
+                    '%s-%s-%s %s:%s:%s %s',
+                    empty($value['year']) ? '1970' : $value['year'],
+                    empty($value['month']) ? '1' : $value['month'],
+                    empty($value['day']) ? '1' : $value['day'],
+                    empty($value['hour']) ? '0' : $value['hour'],
+                    empty($value['minute']) ? '0' : $value['minute'],
+                    empty($value['second']) ? '0' : $value['second'],
+                    $this->outputTimezone
+                ),
+                $this->createTimezone($this->outputTimezone)
+            );
 
             if ($this->inputTimezone !== $this->outputTimezone) {
-                $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
+                $dateTime->setTimezone($this->createTimezone($this->inputTimezone));
             }
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -38,14 +38,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */
-    public function __construct(
-        $inputTimezone = null,
-        $outputTimezone = null,
-        $dateTimeClass = null,
-        $dateTimeZoneClass = null,
-        array $fields = null,
-        $pad = false
-    )
+    public function __construct($inputTimezone = null, $outputTimezone = null, $dateTimeClass = null, $dateTimeZoneClass = null, array $fields = null, $pad = false)
     {
         parent::__construct($inputTimezone, $outputTimezone, $dateTimeClass, $dateTimeZoneClass);
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -44,16 +44,7 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
      * @throws UnexpectedTypeException If a format is not supported
      * @throws UnexpectedTypeException if a timezone is not a string
      */
-    public function __construct(
-        $inputTimezone = null,
-        $outputTimezone = null,
-        $dateTimeClass = null,
-        $dateTimeZoneClass = null,
-        $dateFormat = null,
-        $timeFormat = null,
-        $calendar = \IntlDateFormatter::GREGORIAN,
-        $pattern = null
-    )
+    public function __construct($inputTimezone = null, $outputTimezone = null, $dateTimeClass = null, $dateTimeZoneClass = null, $dateFormat = null, $timeFormat = null, $calendar = \IntlDateFormatter::GREGORIAN, $pattern = null)
     {
         parent::__construct($inputTimezone, $outputTimezone, $dateTimeClass, $dateTimeZoneClass);
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -37,13 +37,7 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */
-    public function __construct(
-        $inputTimezone = null,
-        $outputTimezone = null,
-        $dateTimeClass = null,
-        $dateTimeZoneClass = null,
-        $format = 'Y-m-d H:i:s'
-    )
+    public function __construct($inputTimezone = null, $outputTimezone = null, $dateTimeClass = null, $dateTimeZoneClass = null, $format = 'Y-m-d H:i:s')
     {
         parent::__construct($inputTimezone, $outputTimezone, $dateTimeClass, $dateTimeZoneClass);
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -38,13 +38,13 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
             return null;
         }
 
-        if (!$value instanceof \DateTime) {
+        if (!$value instanceof $this->dateTimeClass) {
             throw new UnexpectedTypeException($value, '\DateTime');
         }
 
         $value = clone $value;
         try {
-            $value->setTimezone(new \DateTimeZone($this->outputTimezone));
+            $value->setTimezone($this->createTimezone($this->outputTimezone));
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
         }
@@ -73,10 +73,13 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
         }
 
         try {
-            $dateTime = new \DateTime(sprintf("@%s %s", $value, $this->outputTimezone));
+            $dateTime = $this->createDate(
+                sprintf("@%s %s", $value, $this->outputTimezone),
+                $this->createTimezone($this->outputTimezone)
+            );
 
             if ($this->inputTimezone !== $this->outputTimezone) {
-                $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));
+                $dateTime->setTimezone($this->createTimeZone($this->inputTimezone));
             }
         } catch (\Exception $e) {
             throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -46,7 +46,15 @@ class DateTimeType extends AbstractType
         }
 
         if ('single_text' === $options['widget']) {
-            $builder->appendClientTransformer(new DateTimeToStringTransformer($options['data_timezone'], $options['user_timezone'], $format));
+            $builder->appendClientTransformer(
+                new DateTimeToStringTransformer(
+                    $options['data_timezone'],
+                    $options['user_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $format
+                )
+            );
         } else {
             // Only pass a subset of the options to children
             $dateOptions = array_intersect_key($options, array_flip(array(
@@ -94,7 +102,13 @@ class DateTimeType extends AbstractType
 
             $builder
                 ->appendClientTransformer(new DataTransformerChain(array(
-                    new DateTimeToArrayTransformer($options['data_timezone'], $options['user_timezone'], $parts),
+                    new DateTimeToArrayTransformer(
+                        $options['data_timezone'],
+                        $options['user_timezone'],
+                        $options['datetime_class'],
+                        $options['datetimezone_class'],
+                        $parts
+                    ),
                     new ArrayToPartsTransformer(array(
                         'date' => array('year', 'month', 'day'),
                         'time' => $timeParts,
@@ -107,15 +121,32 @@ class DateTimeType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], $format)
+                new DateTimeToStringTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $format
+                )
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['data_timezone'], $options['data_timezone'])
+                new DateTimeToTimestampTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class']
+                )
             ));
         } elseif ('array' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['data_timezone'], $options['data_timezone'], $parts)
+                new DateTimeToArrayTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $parts
+                )
             ));
         }
 
@@ -136,33 +167,35 @@ class DateTimeType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         return array(
-            'input'         => 'datetime',
-            'data_timezone' => null,
-            'user_timezone' => null,
-            'date_widget'   => null,
-            'date_format'   => null,
-            'time_widget'   => null,
+            'input'              => 'datetime',
+            'data_timezone'      => null,
+            'user_timezone'      => null,
+            'date_widget'        => null,
+            'date_format'        => null,
+            'time_widget'        => null,
             /* Defaults for date field */
-            'years'         => range(date('Y') - 5, date('Y') + 5),
-            'months'        => range(1, 12),
-            'days'          => range(1, 31),
+            'years'              => range(date('Y') - 5, date('Y') + 5),
+            'months'             => range(1, 12),
+            'days'               => range(1, 31),
             /* Defaults for time field */
-            'hours'         => range(0, 23),
-            'minutes'       => range(0, 59),
-            'seconds'       => range(0, 59),
-            'with_seconds'  => false,
+            'hours'              => range(0, 23),
+            'minutes'            => range(0, 59),
+            'seconds'            => range(0, 59),
+            'with_seconds'       => false,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
-            'by_reference'  => false,
+            'by_reference'       => false,
             // This will overwrite "widget" child options
-            'widget'        => null,
+            'widget'             => null,
             // This will overwrite "empty_value" child options
-            'empty_value'   => null,
+            'empty_value'        => null,
             // If initialized with a \DateTime object, FieldType initializes
             // this option to "\DateTime". Since the internal, normalized
             // representation is not \DateTime, but an array, we need to unset
             // this option.
-            'data_class'    => null,
+            'data_class'         => null,
+            'datetime_class'     => 'DateTime',
+            'datetimezone_class' => 'DateTimeZone',
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -63,7 +63,18 @@ class DateType extends AbstractType
         );
 
         if ('single_text' === $options['widget']) {
-            $builder->appendClientTransformer(new DateTimeToLocalizedStringTransformer($options['data_timezone'], $options['user_timezone'], $format, \IntlDateFormatter::NONE, \IntlDateFormatter::GREGORIAN, $pattern));
+            $builder->appendClientTransformer(
+                new DateTimeToLocalizedStringTransformer(
+                    $options['data_timezone'],
+                    $options['user_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $format,
+                    \IntlDateFormatter::NONE,
+                    \IntlDateFormatter::GREGORIAN,
+                    $pattern
+                )
+            );
         } else {
             $yearOptions = $monthOptions = $dayOptions = array();
 
@@ -117,22 +128,43 @@ class DateType extends AbstractType
                 ->add('month', $options['widget'], $monthOptions)
                 ->add('day', $options['widget'], $dayOptions)
                 ->appendClientTransformer(new DateTimeToArrayTransformer(
-                    $options['data_timezone'], $options['user_timezone'], array('year', 'month', 'day')
+                    $options['data_timezone'],
+                    $options['user_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    array('year', 'month', 'day')
                 ))
             ;
         }
 
         if ('string' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], 'Y-m-d')
+                new DateTimeToStringTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    'Y-m-d'
+                )
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['data_timezone'], $options['data_timezone'])
+                new DateTimeToTimestampTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class']
+                )
             ));
         } elseif ('array' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['data_timezone'], $options['data_timezone'], array('year', 'month', 'day'))
+                new DateTimeToArrayTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    array('year', 'month', 'day')
+                )
             ));
         }
 
@@ -170,24 +202,26 @@ class DateType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         return array(
-            'years'          => range(date('Y') - 5, date('Y') + 5),
-            'months'         => range(1, 12),
-            'days'           => range(1, 31),
-            'widget'         => 'choice',
-            'input'          => 'datetime',
-            'format'         => \IntlDateFormatter::MEDIUM,
-            'data_timezone'  => null,
-            'user_timezone'  => null,
-            'empty_value'    => null,
+            'years'              => range(date('Y') - 5, date('Y') + 5),
+            'months'             => range(1, 12),
+            'days'               => range(1, 31),
+            'widget'             => 'choice',
+            'input'              => 'datetime',
+            'format'             => \IntlDateFormatter::MEDIUM,
+            'data_timezone'      => null,
+            'user_timezone'      => null,
+            'empty_value'        => null,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
-            'by_reference'   => false,
-            'error_bubbling' => false,
+            'by_reference'       => false,
+            'error_bubbling'     => false,
             // If initialized with a \DateTime object, FieldType initializes
             // this option to "\DateTime". Since the internal, normalized
             // representation is not \DateTime, but an array, we need to unset
             // this option.
-            'data_class'     => null,
+            'data_class'         => null,
+            'datetime_class'     => 'DateTime',
+            'datetimezone_class' => 'DateTimeZone',
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -36,7 +36,15 @@ class TimeType extends AbstractType
         }
 
         if ('single_text' === $options['widget']) {
-            $builder->appendClientTransformer(new DateTimeToStringTransformer($options['data_timezone'], $options['user_timezone'], $format));
+            $builder->appendClientTransformer(
+                new DateTimeToStringTransformer(
+                    $options['data_timezone'],
+                    $options['user_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $format
+                )
+            );
         } else {
             $hourOptions = $minuteOptions = $secondOptions = array();
 
@@ -103,20 +111,46 @@ class TimeType extends AbstractType
                 $builder->add('second', $options['widget'], $secondOptions);
             }
 
-            $builder->appendClientTransformer(new DateTimeToArrayTransformer($options['data_timezone'], $options['user_timezone'], $parts, 'text' === $options['widget']));
+            $builder->appendClientTransformer(
+                new DateTimeToArrayTransformer(
+                    $options['data_timezone'],
+                    $options['user_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $parts,
+                    'text' === $options['widget']
+                )
+            );
         }
 
         if ('string' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], $format)
+                new DateTimeToStringTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $format
+                )
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['data_timezone'], $options['data_timezone'])
+                new DateTimeToTimestampTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class']
+                )
             ));
         } elseif ('array' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['data_timezone'], $options['data_timezone'], $parts)
+                new DateTimeToArrayTransformer(
+                    $options['data_timezone'],
+                    $options['data_timezone'],
+                    $options['datetime_class'],
+                    $options['datetimezone_class'],
+                    $parts
+                )
             ));
         }
 
@@ -143,24 +177,26 @@ class TimeType extends AbstractType
     public function getDefaultOptions(array $options)
     {
         return array(
-            'hours'          => range(0, 23),
-            'minutes'        => range(0, 59),
-            'seconds'        => range(0, 59),
-            'widget'         => 'choice',
-            'input'          => 'datetime',
-            'with_seconds'   => false,
-            'data_timezone'  => null,
-            'user_timezone'  => null,
-            'empty_value'    => null,
+            'hours'              => range(0, 23),
+            'minutes'            => range(0, 59),
+            'seconds'            => range(0, 59),
+            'widget'             => 'choice',
+            'input'              => 'datetime',
+            'with_seconds'       => false,
+            'data_timezone'      => null,
+            'user_timezone'      => null,
+            'empty_value'        => null,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
-            'by_reference'   => false,
-            'error_bubbling' => false,
+            'by_reference'       => false,
+            'error_bubbling'     => false,
             // If initialized with a \DateTime object, FieldType initializes
             // this option to "\DateTime". Since the internal, normalized
             // representation is not \DateTime, but an array, we need to unset
             // this option.
-            'data_class'     => null,
+            'data_class'         => null,
+            'datetime_class'     => 'DateTime',
+            'datetimezone_class' => 'DateTimeZone',
         );
     }
 

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -48,48 +48,48 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
     public function testTransformShortDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::SHORT);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::SHORT);
         $this->assertEquals('03.02.10 04:05', $transformer->transform($this->dateTime));
     }
 
     public function testTransformMediumDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::MEDIUM);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::MEDIUM);
 
         $this->assertEquals('03.02.2010 04:05', $transformer->transform($this->dateTime));
     }
 
     public function testTransformLongDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::LONG);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::LONG);
 
         $this->assertEquals('03. Februar 2010 04:05', $transformer->transform($this->dateTime));
     }
 
     public function testTransformFullDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::FULL);
 
         $this->assertEquals('Mittwoch, 03. Februar 2010 04:05', $transformer->transform($this->dateTime));
     }
 
     public function testTransformShortTime()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::SHORT);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::SHORT);
 
         $this->assertEquals('03.02.2010 04:05', $transformer->transform($this->dateTime));
     }
 
     public function testTransformMediumTime()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::MEDIUM);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::MEDIUM);
 
         $this->assertEquals('03.02.2010 04:05:06', $transformer->transform($this->dateTime));
     }
 
     public function testTransformLongTime()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::LONG);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::LONG);
 
         $this->assertEquals('03.02.2010 04:05:06 GMT+00:00', $transformer->transform($this->dateTime));
     }
@@ -100,7 +100,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
             $this->markTestSkipped('Please upgrade ICU version to 3.8+');
         }
 
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::FULL);
 
         $this->assertEquals('03.02.2010 04:05:06 GMT+00:00', $transformer->transform($this->dateTime));
     }
@@ -135,7 +135,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
     public function testTransform_differentPatterns()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
         $this->assertEquals('02*2010*03 04|05|06', $transformer->transform($this->dateTime));
     }
@@ -162,49 +162,49 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
     public function testReverseTransformShortDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::SHORT);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::SHORT);
 
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.10 04:05'));
     }
 
     public function testReverseTransformMediumDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::MEDIUM);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::MEDIUM);
 
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.2010 04:05'));
     }
 
     public function testReverseTransformLongDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::LONG);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::LONG);
 
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03. Februar 2010 04:05'));
     }
 
     public function testReverseTransformFullDate()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::FULL);
 
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Mittwoch, 03. Februar 2010 04:05'));
     }
 
     public function testReverseTransformShortTime()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::SHORT);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::SHORT);
 
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('03.02.2010 04:05'));
     }
 
     public function testReverseTransformMediumTime()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::MEDIUM);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::MEDIUM);
 
         $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06'));
     }
 
     public function testReverseTransformLongTime()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::LONG);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::LONG);
 
         $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06 GMT+00:00'));
     }
@@ -215,7 +215,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
             $this->markTestSkipped('Please upgrade ICU version to 3.8+');
         }
 
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, \IntlDateFormatter::FULL);
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, null, \IntlDateFormatter::FULL);
 
         $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('03.02.2010 04:05:06 GMT+00:00'));
     }
@@ -241,9 +241,40 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
     public function testReverseTransform_differentPatterns()
     {
-        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', null, null, \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
         $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06'));
+    }
+
+    public function testReverseTransformingToCustomDateObjects()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            'America/New_York',
+            'Asia/Hong_Kong',
+            'Symfony\Tests\Component\Form\Fixtures\CustomDateTime',
+            'Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone'
+        );
+
+        $expected = new \Symfony\Tests\Component\Form\Fixtures\CustomDateTime('2010-02-03 04:05:00 Asia/Hong_Kong');
+        $expected->setTimezone(new \Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone('America/New_York'));
+
+        $output = $transformer->reverseTransform('03.02.2010 04:05');
+        $this->assertDateTimeEquals($expected, $output);
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTime', $output);
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone', $output->getTimeZone());
+    }
+
+   /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testTransformToFromInvalidType()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer(
+            'America/New_York',
+            'Asia/Hong_Kong',
+            'Symfony\Tests\Component\Form\Fixtures\CustomDateTime'
+        );
+        $transformer->transform(new \DateTime());
     }
 
     public function testReverseTransform_empty()
@@ -276,7 +307,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
      */
     public function testValidateDateFormatOption()
     {
-        new DateTimeToLocalizedStringTransformer(null, null, 'foobar');
+        new DateTimeToLocalizedStringTransformer(null, null, null, null, 'foobar');
     }
 
     /**
@@ -284,6 +315,6 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
      */
     public function testValidateTimeFormatOption()
     {
-        new DateTimeToLocalizedStringTransformer(null, null, null, 'foobar');
+        new DateTimeToLocalizedStringTransformer(null, null, null, null, null, 'foobar');
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
@@ -17,6 +17,11 @@ use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToTimestampTra
 
 class DateTimeToTimestampTransformerTest extends DateTimeTestCase
 {
+    /** Override LocalizedTestCase::setUp(), ext/intl is not needed */
+    public function setUp()
+    {
+    }
+
     public function testTransform()
     {
         $transformer = new DateTimeToTimestampTransformer('UTC', 'UTC');
@@ -102,5 +107,38 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
 
         $reverseTransformer->reverseTransform('2010-2010-2010');
+    }
+
+
+    public function testReverseTransformingToCustomDateObjects()
+    {
+        $reverseTransformer = new DateTimeToTimestampTransformer(
+            'America/New_York',
+            'Asia/Hong_Kong',
+            'Symfony\Tests\Component\Form\Fixtures\CustomDateTime',
+            'Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone'
+        );
+
+        $expected = new \Symfony\Tests\Component\Form\Fixtures\CustomDateTime('2010-02-03 04:05:06 Asia/Hong_Kong');
+        $input = $expected->format('U');
+        $expected->setTimeZone(new \Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone('America/New_York'));
+
+        $output = $reverseTransformer->reverseTransform($input);
+        $this->assertDateTimeEquals($expected, $output);
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTime', $output);
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone', $output->getTimeZone());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testTransformToFromInvalidType()
+    {
+        $transformer = new DateTimeToTimestampTransformer(
+            'America/New_York',
+            'Asia/Hong_Kong',
+            'Symfony\Tests\Component\Form\Fixtures\CustomDateTime'
+        );
+        $transformer->transform(new \DateTime());
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
@@ -266,4 +266,26 @@ class DateTimeTypeTest extends LocalizedTestCase
         // to null in the type
         $this->factory->create('datetime', new \DateTime());
     }
+
+
+    public function testSubmit_CustomDateObjects()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'date_format' => 'Y-m-d',
+            'date_widget' => 'single_text',
+            'time_widget' => 'single_text',
+            'input' => 'datetime',
+            'datetime_class' => 'Symfony\Tests\Component\Form\Fixtures\CustomDateTime',
+            'datetimezone_class' => 'Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone',
+        ));
+
+        $form->bind(array(
+            'date' => '2011-02-03',
+            'time' => '03:04',
+        ));
+
+        $dateTime = $form->getNormData();
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTime', $dateTime);
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone', $dateTime->getTimeZone());
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
@@ -538,4 +538,23 @@ class DateTypeTest extends LocalizedTestCase
         // to null in the type
         $this->factory->create('date', new \DateTime());
     }
+
+    public function testSubmit_CustomDateObjects()
+    {
+        $form = $this->factory->create('date', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'format'        => 'Y-m-d',
+            'widget' => 'single_text',
+            'input' => 'datetime',
+            'datetime_class' => 'Symfony\Tests\Component\Form\Fixtures\CustomDateTime',
+            'datetimezone_class' => 'Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone',
+        ));
+
+        $form->bind('2010-10-02');
+
+        $dateTime = $form->getNormData();
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTime', $dateTime);
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone', $dateTime->getTimeZone());
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/TimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/TimeTypeTest.php
@@ -409,4 +409,36 @@ class TimeTypeTest extends LocalizedTestCase
         // to null in the type
         $this->factory->create('time', new \DateTime());
     }
+
+    public function provideVariants()
+    {
+        return array(
+            array('string', '12:23', 'single_text'),
+            array('datetime', '2011-02-03 10:01:23', 'single_text'),
+            array('array', '12:12', 'single_text'),
+            array('array', array('hour' => '3', 'minute' => '4'), 'choice'),
+            array('timestamp', '@1329933477', 'single_text'),
+        );
+    }
+
+    /**
+     * @dataProvider  provideVariants
+     */
+    public function testSubmit_CustomDateObjects($type, $data, $widget)
+    {
+        $form = $this->factory->create('time', null, array(
+            'data_timezone'      => 'UTC',
+            'user_timezone'      => 'Europe/Berlin',
+            'input'              =>  $type,
+            'widget'             => $widget,
+            'datetime_class'     => 'Symfony\Tests\Component\Form\Fixtures\CustomDateTime',
+            'datetimezone_class' => 'Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone',
+        ));
+
+        $form->bind($data);
+
+        $dateTime = $form->getNormData();
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTime', $dateTime);
+        $this->assertInstanceOf('Symfony\Tests\Component\Form\Fixtures\CustomDateTimeZone', $dateTime->getTimeZone());
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Fixtures/CustomDateTime.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/CustomDateTime.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+class CustomDateTime extends \DateTime
+{
+    private $timezone;
+
+    public function __construct($date, $timezone = null)
+    {
+        parent::__construct($date, $timezone);
+        $this->timezone = $timezone;
+    }
+
+    public function setTimeZone(\DateTimeZone $timezone)
+    {
+        $this->timezone = $timezone;
+        return parent::setTimeZone($timezone);
+    }
+
+    public function getTimeZone()
+    {
+        return $this->timezone ?: parent::getTimezone();
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Fixtures/CustomDateTimeZone.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/CustomDateTimeZone.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+class CustomDateTimeZone extends \DateTimeZone
+{
+}


### PR DESCRIPTION
This patch allows to use child classes of DateTime and DateTimeZone in models.

Bug fix: yes
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
