### PR TITLE
[Request] Added a getBaseServerUrl() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 README
 ======
 
-[![Build Status](https://secure.travis-ci.org/COil/symfony.png?branch=master)](http://travis-ci.org/COil/symfony)
+[![Build Status](https://secure.travis-ci.org/symfony/symfony.png?branch=master)](http://travis-ci.org/symfony/symfony)
 
 What is Symfony2?
 -----------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 README
 ======
 
-[![Build Status](https://secure.travis-ci.org/symfony/symfony.png?branch=master)](http://travis-ci.org/symfony/symfony)
+[![Build Status](https://secure.travis-ci.org/symfony/symfony.png?branch=master)](http://travis-ci.org/COil/symfony)
 
 What is Symfony2?
 -----------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 README
 ======
 
-[![Build Status](https://secure.travis-ci.org/symfony/symfony.png?branch=master)](http://travis-ci.org/COil/symfony)
+[![Build Status](https://secure.travis-ci.org/COil/symfony.png?branch=master)](http://travis-ci.org/COil/symfony)
 
 What is Symfony2?
 -----------------

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -744,7 +744,19 @@ class Request
      */
     public function getUriForPath($path)
     {
-        return $this->getScheme().'://'.$this->getHttpHost().$this->getBaseUrl().$path;
+        return $this->getBaseUri().$this->getBaseUrl().$path;
+    }
+
+    /**
+     * Generates the base URI.
+     *
+     * @return string The URI for the base public path
+     *
+     * @api
+     */
+    public function getBaseUri()
+    {
+        return $this->getScheme().'://'.$this->getHttpHost();
     }
 
     /**
@@ -1228,7 +1240,7 @@ class Request
         } elseif ($this->server->has('REQUEST_URI')) {
             $requestUri = $this->server->get('REQUEST_URI');
             // HTTP proxy reqs setup request uri with scheme and host [and port] + the url path, only use url path
-            $schemeAndHttpHost = $this->getScheme().'://'.$this->getHttpHost();
+            $schemeAndHttpHost = $this->getBaseUri();
             if (strpos($requestUri, $schemeAndHttpHost) === 0) {
                 $requestUri = substr($requestUri, strlen($schemeAndHttpHost));
             }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -744,7 +744,7 @@ class Request
      */
     public function getUriForPath($path)
     {
-        return $this->getBaseUri().$this->getBaseUrl().$path;
+        return $this->getBaseServerUrl().$this->getBaseUrl().$path;
     }
 
     /**
@@ -754,7 +754,7 @@ class Request
      *
      * @api
      */
-    public function getBaseUri()
+    public function getBaseServerUrl()
     {
         return $this->getScheme().'://'.$this->getHttpHost();
     }
@@ -1240,7 +1240,7 @@ class Request
         } elseif ($this->server->has('REQUEST_URI')) {
             $requestUri = $this->server->get('REQUEST_URI');
             // HTTP proxy reqs setup request uri with scheme and host [and port] + the url path, only use url path
-            $schemeAndHttpHost = $this->getBaseUri();
+            $schemeAndHttpHost = $this->getBaseServerUrl();
             if (strpos($requestUri, $schemeAndHttpHost) === 0) {
                 $requestUri = substr($requestUri, strlen($schemeAndHttpHost));
             }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -748,9 +748,9 @@ class Request
     }
 
     /**
-     * Generates the base URI.
+     * Generates the absolute base server URL.
      *
-     * @return string The URI for the base public path
+     * @return string The base URL of the server
      *
      * @api
      */

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -409,15 +409,15 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\HttpFoundation\Request::getBaseUri
+     * @covers Symfony\Component\HttpFoundation\Request::getBaseServerUrl
      */
-    public function testGetBaseUri()
+    public function testgetBaseServerUrl()
     {
         $request = Request::create('http://test.com/foo?bar=baz');
-        $this->assertEquals('http://test.com', $request->getBaseUri());
+        $this->assertEquals('http://test.com', $request->getBaseServerUrl());
 
         $request = Request::create('http://test.com:90/foo?bar=baz');
-        $this->assertEquals('http://test.com:90', $request->getBaseUri());
+        $this->assertEquals('http://test.com:90', $request->getBaseServerUrl());
 
         $server = array();
 
@@ -440,7 +440,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request->initialize(array(), array(), array(), array(), array(),$server);
 
-        $this->assertEquals('http://hostname:8080', $request->getBaseUri(), '->getBaseUri() with non default port');
+        $this->assertEquals('http://hostname:8080', $request->getBaseServerUrl(), '->getBaseServerUrl() with non default port');
 
         // Use std port number
         $server['HTTP_HOST'] = 'hostname';
@@ -449,16 +449,26 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
-        $this->assertEquals('http://hostname', $request->getBaseUri(), '->getBaseUri() with default port');
+        $this->assertEquals('http://hostname', $request->getBaseServerUrl(), '->getBaseServerUrl() with default port');
 
-        // Without HOST HEADER
-        unset($server['HTTP_HOST']);
+        // With a sub directory for the public web root
+        $server['HTTP_HOST'] = 'hostname';
         $server['SERVER_NAME'] = 'servername';
         $server['SERVER_PORT'] = '80';
 
+        $server['QUERY_STRING'] = 'query=string';
+        $server['REQUEST_URI'] = '/web/index.php/path/info?query=string';
+        $server['SCRIPT_NAME'] = '/index.php';
+        $server['PATH_INFO'] = '/path/info';
+        $server['PATH_TRANSLATED'] = 'redirect:/web/index.php/path/info';
+        $server['PHP_SELF'] = '/web/index_dev.php/path/info';
+        $server['SCRIPT_FILENAME'] = '/some/where/index.php';
+
+        $request = new Request();
+
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
-        $this->assertEquals('http://servername', $request->getBaseUri(), '->getBaseUri() with default port without HOST_HEADER');
+        $this->assertEquals('http://hostname', $request->getBaseServerUrl(), '->getBaseServerUrl() does not take care of the base path');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -409,6 +409,59 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\HttpFoundation\Request::getBaseUri
+     */
+    public function testGetBaseUri()
+    {
+        $request = Request::create('http://test.com/foo?bar=baz');
+        $this->assertEquals('http://test.com', $request->getBaseUri());
+
+        $request = Request::create('http://test.com:90/foo?bar=baz');
+        $this->assertEquals('http://test.com:90', $request->getBaseUri());
+
+        $server = array();
+
+        // Standard Request on non default PORT
+        // http://hostname:8080/index.php/path/info?query=string
+
+        $server['HTTP_HOST'] = 'hostname:8080';
+        $server['SERVER_NAME'] = 'servername';
+        $server['SERVER_PORT'] = '8080';
+
+        $server['QUERY_STRING'] = 'query=string';
+        $server['REQUEST_URI'] = '/index.php/path/info?query=string';
+        $server['SCRIPT_NAME'] = '/index.php';
+        $server['PATH_INFO'] = '/path/info';
+        $server['PATH_TRANSLATED'] = 'redirect:/index.php/path/info';
+        $server['PHP_SELF'] = '/index_dev.php/path/info';
+        $server['SCRIPT_FILENAME'] = '/some/where/index.php';
+
+        $request = new Request();
+
+        $request->initialize(array(), array(), array(), array(), array(),$server);
+
+        $this->assertEquals('http://hostname:8080', $request->getBaseUri(), '->getBaseUri() with non default port');
+
+        // Use std port number
+        $server['HTTP_HOST'] = 'hostname';
+        $server['SERVER_NAME'] = 'servername';
+        $server['SERVER_PORT'] = '80';
+
+        $request->initialize(array(), array(), array(), array(), array(), $server);
+
+        $this->assertEquals('http://hostname', $request->getBaseUri(), '->getBaseUri() with default port');
+
+        // Without HOST HEADER
+        unset($server['HTTP_HOST']);
+        $server['SERVER_NAME'] = 'servername';
+        $server['SERVER_PORT'] = '80';
+
+        $request->initialize(array(), array(), array(), array(), array(), $server);
+
+        $this->assertEquals('http://servername', $request->getBaseUri(), '->getBaseUri() with default port without HOST_HEADER');
+    }
+
+    /**
      * @covers Symfony\Component\HttpFoundation\Request::getQueryString
      */
     public function testGetQueryString()


### PR DESCRIPTION
Here is a use case for this little PR. I wanted to have the full URL for an image related to an object (relative URL is stored into the 'webPath' property of the 'job' object)

``` jinja
<div>
    <a href="{{ job.url }}">
        <img src="{{ app.request.scheme ~ '://' ~ app.request.host }}{{ asset(job.webPath) }}" alt="{{ job.company }} logo" />
    </a>
</div>
```

This twig code is quiet complicated just to retrieve the base URi... so with the PR the code turns into:

``` jinja
<div>
    <a href="{{ job.url }}">
        <img src="{{ app.request.getBaseUri }}{{ asset(job.webPath) }}" alt="{{ job.company }} logo" />
    </a>
</div>
```

Which is far more compact. Additional unit tests are included.

COil.
