### PR TITLE
[MonologBundle] allow a fully qualified service_id for the handler parameter

### DIFF
--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/Compiler/AddProcessorsPass.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/Compiler/AddProcessorsPass.php
@@ -35,7 +35,8 @@ class AddProcessorsPass implements CompilerPassInterface
                 }
 
                 if (!empty($tag['handler'])) {
-                    $definition = $container->getDefinition(sprintf('monolog.handler.%s', $tag['handler']));
+                    $service_id = sprintf('monolog.handler.%s', $tag['handler']);
+                    $definition = $container->getDefinition($container->hasDefinition($service_id) ? $service_id : $tag['handler']);
                 } elseif (!empty($tag['channel'])) {
                     if ('app' === $tag['channel']) {
                         $definition = $container->getDefinition('monolog.logger');


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

I created a custom Monolog handler to submit logs to Graylog2 for storage. I wanted to add some processors to this handler only, but if I set the handler parameter to gelf on the tag for the processor I received a service not found exception (monolog.handler.gelf). I am not sure if this is the best fix for the situation, but it did resolve it for me. Sample configuration follows.

```
services:
    tellecore_api.monolog.handler.gelf:
        class: Tellecore\Monolog\Handler\GELFHandler
        arguments:
            publisher: "@tellecore_api.gelf.message_publisher"
            system_name: %system_name% 
            level: debug

    monolog.processor.introspection:
        class: Monolog\Processor\IntrospectionProcessor
        tags:
            - { name: monolog.processor, handler: tellecore_api.monolog.handler.gelf }

    monolog.processor.web:
        class: Monolog\Processor\WebProcessor
        tags:
            - { name: monolog.processor, handler: tellecore_api.monolog.handler.gelf }

monolog:
    handlers:
        gelf:
            type: service
            id: tellecore_api.monolog.handler.gelf
```
