### PR TITLE
[DoctrineBundle] fixed proxy loader memory leak

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -42,9 +42,9 @@ class DoctrineBundle extends Bundle
         if ($this->container->hasParameter('doctrine.orm.proxy_namespace')) {
             $namespace = $this->container->getParameter('doctrine.orm.proxy_namespace');
             $dir = $this->container->getParameter('doctrine.orm.proxy_dir');
-            $container = $this->container;
+            $container =& $this->container;
 
-            spl_autoload_register(function($class) use ($namespace, $dir, $container) {
+            spl_autoload_register(function($class) use ($namespace, $dir, &$container) {
                 if (0 === strpos($class, $namespace)) {
                     $className = substr($class, strlen($namespace) +1);
                     $file = $dir.DIRECTORY_SEPARATOR.$className.'.php';


### PR DESCRIPTION
[![Build Status](https://secure.travis-ci.org/kriswallsmith/symfony.png?branch=doctrine/proxy-loader-fix)](http://travis-ci.org/kriswallsmith/symfony)

The hack for loading Doctrine proxy classes has an obscure memory leak, fixed here by @jjbohn.
## The Proof

Run this test case before and after this patch:

``` php
<?php

namespace Kris\JunkBundle\Tests\Controller;

use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;

class DefaultControllerTest extends WebTestCase
{
    /**
     * @dataProvider asdf
     */
    public function testIndex()
    {
        $client = static::createClient();

        $crawler = $client->request('GET', '/hello/Fabien');

        $this->assertTrue($crawler->filter('html:contains("Hello Fabien")')->count() > 0);
    }

    public function asdf()
    {
        return array_fill(0, 500, array());
    }
}
```
### Before

```
~/Sites/symfony/standard (2.0) $ phpunit -c app/
PHPUnit 3.6.10 by Sebastian Bergmann.

Configuration read from /Users/kriswallsmith/Sites/symfony/standard/app/phpunit.xml.dist

...............................................................  63 / 500 ( 12%)
............................................................... 126 / 500 ( 25%)
............................................................... 189 / 500 ( 37%)
............................................................... 252 / 500 ( 50%)
............................................................... 315 / 500 ( 63%)
............................................................... 378 / 500 ( 75%)
............................................................... 441 / 500 ( 88%)
...........................................................

Time: 31 seconds, Memory: 289.50Mb

OK (500 tests, 500 assertions)
```
### After

```
~/Sites/symfony/standard (2.0) $ phpunit -c app/
PHPUnit 3.6.10 by Sebastian Bergmann.

Configuration read from /Users/kriswallsmith/Sites/symfony/standard/app/phpunit.xml.dist

...............................................................  63 / 500 ( 12%)
............................................................... 126 / 500 ( 25%)
............................................................... 189 / 500 ( 37%)
............................................................... 252 / 500 ( 50%)
............................................................... 315 / 500 ( 63%)
............................................................... 378 / 500 ( 75%)
............................................................... 441 / 500 ( 88%)
...........................................................

Time: 40 seconds, Memory: 51.25Mb

OK (500 tests, 500 assertions)
```
## tl;dr

Your test suite will use much less memory — 82% in this case.

```
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```
