### PR TITLE
[WebProfiler] Add default route to access the profiler more easily

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -32,4 +32,14 @@
         <default key="_controller">WebProfilerBundle:Profiler:panel</default>
     </route>
 
+    <route id="_profiler_redirect" pattern="/">
+        <default key="_controller">FrameworkBundle:Redirect:redirect</default>
+        <default key="route">_profiler_search_results</default>
+        <default key="token">empty</default>
+        <default key="ip"></default>
+        <default key="url"></default>
+        <default key="method"></default>
+        <default key="limit">10</default>
+    </route>
+
 </routes>


### PR DESCRIPTION
When you have the toolbar disabled, it's pretty annoying to reach the _profiler, I never remember what to type to get something except `/_profiler`. This shows the last ten runs which is quite useful.
