### PR TITLE
[HttpKernel] Fix call to Memcached::set() once again

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -67,7 +67,7 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
      */
     protected function setValue($key, $value, $expiration = 0)
     {
-        return $this->getMemcached()->set($key, $value, false, time() + $expiration);
+        return $this->getMemcached()->set($key, $value, time() + $expiration);
     }
 
     /**


### PR DESCRIPTION
I originally fixed this in #3358, but it appears #3363 (which touched the same line) was merged soon after.
