### PR TITLE
[DoctrineBridge] ContainerAwareEventManager class

### DIFF
--- a/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
+++ b/src/Symfony/Bridge/Doctrine/ContainerAwareEventManager.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\Common\EventManager;
+use Doctrine\Common\EventSubscriber;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Allows lazy loading of listener services.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ContainerAwareEventManager extends EventManager
+{
+    /**
+     * Map of registered listeners.
+     * <event> => <listeners>
+     *
+     * @var array
+     */
+    private $listeners = array();
+    private $initialized = array();
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * Dispatches an event to all registered listeners.
+     *
+     * @param string $eventName The name of the event to dispatch. The name of the event is
+     *                          the name of the method that is invoked on listeners.
+     * @param EventArgs $eventArgs The event arguments to pass to the event handlers/listeners.
+     *                             If not supplied, the single empty EventArgs instance is used.
+     * @return boolean
+     */
+    public function dispatchEvent($eventName, EventArgs $eventArgs = null)
+    {
+        if (isset($this->listeners[$eventName])) {
+            $eventArgs = $eventArgs === null ? EventArgs::getEmptyInstance() : $eventArgs;
+
+            $initialized = isset($this->initialized[$eventName]);
+
+            foreach ($this->listeners[$eventName] as $hash => $listener) {
+                if (!$initialized && is_string($listener)) {
+                    $this->listeners[$eventName][$hash] = $listener = $this->container->get($listener);
+                }
+
+                $listener->$eventName($eventArgs);
+            }
+            $this->initialized[$eventName] = true;
+        }
+    }
+
+    /**
+     * Gets the listeners of a specific event or all listeners.
+     *
+     * @param string $event The name of the event.
+     * @return array The event listeners for the specified event, or all event listeners.
+     */
+    public function getListeners($event = null)
+    {
+        return $event ? $this->listeners[$event] : $this->listeners;
+    }
+
+    /**
+     * Checks whether an event has any registered listeners.
+     *
+     * @param string $event
+     * @return boolean TRUE if the specified event has any listeners, FALSE otherwise.
+     */
+    public function hasListeners($event)
+    {
+        return isset($this->listeners[$event]) && $this->listeners[$event];
+    }
+
+    /**
+     * Adds an event listener that listens on the specified events.
+     *
+     * @param string|array $events The event(s) to listen on.
+     * @param object|string $listener The listener object.
+     */
+    public function addEventListener($events, $listener)
+    {
+        if (is_string($listener)) {
+            if ($this->initialized) {
+                throw new \RuntimeException('Adding lazy-loading listeners after construction is not supported.');
+            }
+
+            $hash = '_service_'.$listener;
+        } else {
+            // Picks the hash code related to that listener
+            $hash = spl_object_hash($listener);
+        }
+
+        foreach ((array) $events as $event) {
+            // Overrides listener if a previous one was associated already
+            // Prevents duplicate listeners on same event (same instance only)
+            $this->listeners[$event][$hash] = $listener;
+        }
+    }
+
+    /**
+     * Removes an event listener from the specified events.
+     *
+     * @param string|array $events
+     * @param object|string $listener
+     */
+    public function removeEventListener($events, $listener)
+    {
+        if (is_string($listener)) {
+            $hash = '_service_'.$listener;
+        } else {
+            // Picks the hash code related to that listener
+            $hash = spl_object_hash($listener);
+        }
+
+        foreach ((array) $events as $event) {
+            // Check if actually have this listener associated
+            if (isset($this->listeners[$event][$hash])) {
+                unset($this->listeners[$event][$hash]);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPass.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+class RegisterEventListenersAndSubscribersPass implements CompilerPassInterface
+{
+    private $connections;
+    private $container;
+    private $eventManagers;
+    private $managerTemplate;
+    private $tagPrefix;
+
+    /**
+     * Constructor.
+     *
+     * @param string $connections     Parameter ID for connections
+     * @param string $managerTemplate sprintf() template for generating the event
+     *                                manager's service ID for a connection name
+     * @param string $tagPrefix       Tag prefix for listeners and subscribers
+     */
+    public function __construct($connections, $managerTemplate, $tagPrefix)
+    {
+        $this->connections = $connections;
+        $this->managerTemplate = $managerTemplate;
+        $this->tagPrefix = $tagPrefix;
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter($this->connections)) {
+            return;
+        }
+
+        $this->container = $container;
+        $this->connections = $container->getParameter($this->connections);
+        $sortFunc = function($a, $b) {
+            $a = isset($a['priority']) ? $a['priority'] : 0;
+            $b = isset($b['priority']) ? $b['priority'] : 0;
+
+            return $a > $b ? -1 : 1;
+        };
+
+        $subscribersPerCon = $this->groupByConnection($container->findTaggedServiceIds($this->tagPrefix.'.event_subscriber'));
+        foreach ($subscribersPerCon as $con => $subscribers) {
+            $em = $this->getEventManager($con);
+
+            uasort($subscribers, $sortFunc);
+            foreach ($subscribers as $id => $instance) {
+                $em->addMethodCall('addEventSubscriber', array(new Reference($id)));
+            }
+        }
+
+        $listenersPerCon = $this->groupByConnection($container->findTaggedServiceIds($this->tagPrefix.'.event_listener'), true);
+        foreach ($listenersPerCon as $con => $listeners) {
+            $em = $this->getEventManager($con);
+
+            uasort($listeners, $sortFunc);
+            foreach ($listeners as $id => $instance) {
+                $em->addMethodCall('addEventListener', array(
+                    array_unique($instance['event']),
+                    isset($instance['lazy']) && $instance['lazy'] ? $id : new Reference($id),
+                ));
+            }
+        }
+    }
+
+    private function groupByConnection(array $services, $isListener = false)
+    {
+        $grouped = array();
+        foreach (array_keys($this->connections) as $con) {
+            $grouped[$con] = array();
+        }
+
+        foreach ($services as $id => $instances) {
+            foreach ($instances as $instance) {
+                $cons = isset($instance['connection']) ? array($instance['connection']) : array_keys($this->connections);
+                foreach ($cons as $con) {
+                    if (!isset($grouped[$con])) {
+                        throw new \RuntimeException(sprintf('The Doctrine connection "%s" referenced in service "%s" does not exist. Available connections names: %s', $con, $id, implode(', ', array_keys($this->connections))));
+                    }
+
+                    if ($isListener) {
+                        if (!isset($instance['event'])) {
+                            throw new \InvalidArgumentException(sprintf('Doctrine event listener "%s" must specify the "event" attribute.', $id));
+                        }
+                        $instance['event'] = array($instance['event']);
+
+                        if (isset($instance['lazy']) && $instance['lazy']) {
+                            $this->container->getDefinition($id)->setPublic(true);
+                        }
+
+                        if (isset($grouped[$con][$id])) {
+                            $grouped[$con][$id]['event'] = array_merge($grouped[$con][$id]['event'], $instance['event']);
+                            continue;
+                        }
+                    }
+
+                    $grouped[$con][$id] = $instance;
+                }
+            }
+        }
+
+        return $grouped;
+    }
+
+    private function getEventManager($name)
+    {
+        if (null === $this->eventManagers) {
+            $this->eventManagers = array();
+            foreach ($this->connections as $n => $id) {
+                $this->eventManagers[$n] = $this->container->getDefinition(sprintf($this->managerTemplate, $n));
+            }
+        }
+
+        return $this->eventManagers[$name];
+    }
+}

--- a/tests/Symfony/Tests/Bridge/Doctrine/ContainerAwareEventManagerTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/ContainerAwareEventManagerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\DoctrineBundle\Tests;
+
+use Symfony\Bridge\Doctrine\ContainerAwareEventManager;
+use Symfony\Component\DependencyInjection\Container;
+
+class ContainerAwareEventManagerTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->container = new Container();
+        $this->evm = new ContainerAwareEventManager($this->container);
+    }
+
+    public function testDispatchEvent()
+    {
+        $this->container->set('foobar', $listener1 = new MyListener());
+        $this->evm->addEventListener('foo', 'foobar');
+        $this->evm->addEventListener('foo', $listener2 = new MyListener());
+
+        $this->evm->dispatchEvent('foo');
+
+        $this->assertTrue($listener1->called);
+        $this->assertTrue($listener2->called);
+    }
+
+    public function testRemoveEventListener()
+    {
+        $this->evm->addEventListener('foo', 'bar');
+        $this->evm->addEventListener('foo', $listener = new MyListener());
+
+        $listeners = array('foo' => array('_service_bar' => 'bar', spl_object_hash($listener) => $listener));
+        $this->assertSame($listeners, $this->evm->getListeners());
+        $this->assertSame($listeners['foo'], $this->evm->getListeners('foo'));
+
+        $this->evm->removeEventListener('foo', $listener);
+        $this->assertSame(array('_service_bar' => 'bar'), $this->evm->getListeners('foo'));
+
+        $this->evm->removeEventListener('foo', 'bar');
+        $this->assertSame(array(), $this->evm->getListeners('foo'));
+    }
+}
+
+class MyListener
+{
+    public $called = false;
+
+    public function foo()
+    {
+        $this->called = true;
+    }
+}

--- a/tests/Symfony/Tests/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+*
+* (c) Fabien Potencier <fabien@symfony.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+namespace Symfony\Tests\Bridge\Doctrine\DependencyInjection\Compiler;
+
+use Symfony\Bridge\Doctrine\DependencyInjection\CompilerPass\RegisterEventListenersAndSubscribersPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterEventListenersAndSubscribersPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcessEventListenersWithPriorities()
+    {
+        $container = $this->createBuilder();
+
+        $container
+            ->register('a', 'stdClass')
+            ->addTag('doctrine.event_listener', array(
+                'event' => 'foo',
+                'priority' => -5,
+            ))
+            ->addTag('doctrine.event_listener', array(
+                'event' => 'bar',
+            ))
+        ;
+        $container
+            ->register('b', 'stdClass')
+            ->addTag('doctrine.event_listener', array(
+                'event' => 'foo',
+            ))
+        ;
+
+        $this->process($container);
+        $this->assertEquals(array('b', 'a'), $this->getServiceOrder($container, 'addEventListener'));
+
+        $calls = $container->getDefinition('doctrine.dbal.default_connection.event_manager')->getMethodCalls();
+        $this->assertEquals(array('foo', 'bar'), $calls[1][1][0]);
+    }
+
+    public function testProcessEventSubscribersWithPriorities()
+    {
+        $container = $this->createBuilder();
+
+        $container
+            ->register('a', 'stdClass')
+            ->addTag('doctrine.event_subscriber')
+        ;
+        $container
+            ->register('b', 'stdClass')
+            ->addTag('doctrine.event_subscriber', array(
+                'priority' => 5,
+            ))
+        ;
+        $container
+            ->register('c', 'stdClass')
+            ->addTag('doctrine.event_subscriber', array(
+                'priority' => 10,
+            ))
+        ;
+        $container
+            ->register('d', 'stdClass')
+            ->addTag('doctrine.event_subscriber', array(
+                'priority' => 10,
+            ))
+        ;
+        $container
+            ->register('e', 'stdClass')
+            ->addTag('doctrine.event_subscriber', array(
+                'priority' => 10,
+            ))
+        ;
+
+        $this->process($container);
+        $this->assertEquals(array('c', 'd', 'e', 'b', 'a'), $this->getServiceOrder($container, 'addEventSubscriber'));
+    }
+
+    private function process(ContainerBuilder $container)
+    {
+        $pass = new RegisterEventListenersAndSubscribersPass('doctrine.connections', 'doctrine.dbal.%s_connection.event_manager', 'doctrine');
+        $pass->process($container);
+    }
+
+    private function getServiceOrder(ContainerBuilder $container, $method)
+    {
+        $order = array();
+        foreach ($container->getDefinition('doctrine.dbal.default_connection.event_manager')->getMethodCalls() as $call) {
+            list($name, $arguments) = $call;
+            if ($method !== $name) {
+                continue;
+            }
+
+            if ('addEventListener' === $name) {
+                $order[] = (string) $arguments[1];
+                continue;
+            }
+
+            $order[] = (string) $arguments[0];
+        }
+
+        return $order;
+    }
+
+    private function createBuilder()
+    {
+        $container = new ContainerBuilder();
+        $container->register('doctrine.dbal.default_connection.event_manager', 'stdClass');
+        $container->register('doctrine.dbal.default_connection', 'stdClass');
+        $container->setParameter('doctrine.connections', array('default' => 'doctrine.dbal.default_connection'));
+
+        return $container;
+    }
+}


### PR DESCRIPTION
```
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```

[![Build Status](https://secure.travis-ci.org/jmikola/symfony.png?branch=doctrine-lazy-event-manager)](http://travis-ci.org/jmikola/symfony)

This allows services to be registered (and lazily loaded) with Doctrine Common's EventManager.

It is ported from @schmittjoh's previous commits here: doctrine/DoctrineBundle#23. I'd like to integrate this with DoctrineMongoDBBundle, so the Bridge once again seemed like an ideal alternative to duplicating code.
