### PR TITLE
[HttpKernel] Remove the _controller since it is not a route parameter part of the URL

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -61,6 +61,7 @@ class RouterListener implements EventSubscriberInterface
 
             $request->attributes->add($parameters);
             unset($parameters['_route']);
+            unset($parameters['_controller']);
             $request->attributes->set('_route_params', $parameters);
         } catch (ResourceNotFoundException $e) {
             $message = sprintf('No route found for "%s %s"', $request->getMethod(), $request->getPathInfo());


### PR DESCRIPTION
There is no reason for the _controller to be there, the whole idea behind this _route_params thing was to help re-generating the current page's URL, you can easily grab the _route + _route_params and reconstruct it without having lots of garbage as query parameters like `?_controller=Foo::..`
