### PR TITLE
Fix tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -231,7 +231,7 @@ abstract class FrameworkExtensionTest extends TestCase
 
         $xmlArgs = $container->getParameter('validator.mapping.loader.xml_files_loader.mapping_files');
         $this->assertCount(2, $xmlArgs);
-        $this->assertStringEndsWith('Component/Form/Resources/config/validation.xml', $xmlArgs[0]);
+        $this->assertStringEndsWith('Component/Form/Resources/config/validation.xml', strtr($xmlArgs[0], '\\', '/'));
         $this->assertStringEndsWith('TestBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'validation.xml', $xmlArgs[1]);
     }
 

--- a/tests/Symfony/Tests/Component/ClassLoader/ClassMapGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/ClassMapGeneratorTest.php
@@ -21,7 +21,7 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testCreateMap($directory, $expected)
     {
-        $this->assertEquals($expected, ClassMapGenerator::createMap($directory));
+        $this->assertEqualsNormalized($expected, ClassMapGenerator::createMap($directory));
     }
 
     public function getTestCreateMapTests()
@@ -65,9 +65,20 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
         $finder = new \Symfony\Component\Finder\Finder();
         $finder->files()->in(__DIR__ . '/Fixtures/beta/NamespaceCollision');
 
-        $this->assertEquals(array(
+        $this->assertEqualsNormalized(array(
             'NamespaceCollision\\A\\B\\Bar' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Bar.php',
             'NamespaceCollision\\A\\B\\Foo' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Foo.php',
         ), ClassMapGenerator::createMap($finder));
+    }
+
+    protected function assertEqualsNormalized($expected, $actual, $message = null)
+    {
+        foreach ($expected as $ns => $path) {
+            $expected[$ns] = strtr($path, '\\', '/');
+        }
+        foreach ($actual as $ns => $path) {
+            $actual[$ns] = strtr($path, '\\', '/');
+        }
+        $this->assertEquals($expected, $actual, $message);
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchEventTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchEventTest.php
@@ -66,10 +66,10 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
     {
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
-        usleep(10000);
+        usleep(20000);
         $event->stop();
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 9 && $total <= 20);
+        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
 
         $event = new StopwatchEvent(microtime(true) * 1000);
         $event->start();
@@ -79,7 +79,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         usleep(10000);
         $event->stop();
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 18 && $total <= 30);
+        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
     }
 
     /**
@@ -101,7 +101,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         usleep(10000);
         $event->ensureStopped();
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 27 && $total <= 40);
+        $this->assertTrue($total >= 21 && $total <= 39, $total.' should be 30 (between 21 and 39)');
     }
 
     public function testStartTime()
@@ -139,7 +139,7 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         usleep(10000);
         $event->stop();
         $end = $event->getEndTime();
-        $this->assertTrue($end >= 18 && $end <= 30);
+        $this->assertTrue($end > 10 && $end <= 29, $end.' should be 20 (between 10 and 29)');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Debug/StopwatchTest.php
@@ -33,12 +33,12 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
     {
         $stopwatch = new Stopwatch();
         $stopwatch->start('foo', 'cat');
-        usleep(10000);
+        usleep(20000);
         $event = $stopwatch->stop('foo');
 
         $this->assertInstanceof('Symfony\Component\HttpKernel\Debug\StopwatchEvent', $event);
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 9 && $total <= 20);
+        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
     }
 
     public function testLap()
@@ -52,7 +52,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\HttpKernel\Debug\StopwatchEvent', $event);
         $total = $event->getTotalTime();
-        $this->assertTrue($total >= 18 && $total <= 30);
+        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcacheProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcacheProfilerStorageTest.php
@@ -42,6 +42,10 @@ class MemcacheProfilerStorageTest extends \PHPUnit_Framework_TestCase
         self::$storage = new DummyMemcacheProfilerStorage('memcache://127.0.0.1/11211', '', '', 86400);
         try {
             self::$storage->getMemcache();
+            $stats = self::$storage->getMemcache()->getExtendedStats();
+            if (!isset($stats['127.0.0.1:11211']) || $stats['127.0.0.1:11211'] === false) {
+                throw new \Exception();
+            }
         } catch(\Exception $e) {
             $this->markTestSkipped('MemcacheProfilerStorageTest requires that there is a Memcache server present on localhost');
         }


### PR DESCRIPTION
- Some windows fixes
- Skip memcached for real when it's not there - by the way I think those tests are insane since they seem to run a purge() on the memcached server. If you run this by accident somewhere where it matters it could hurt. I think they should be put in a group disabled by default, I'll be happy to add that change if it's deemed useful.
- Fixed the timer tests for good on windows (which seems to be quite bad at `usleep`). I also documented them so you actually know how it failed when it does, the false instead of true wasn't super useful.
