### PR TITLE
[Finder] not searching in multiple dirs with sorting

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -502,7 +502,8 @@ class Finder implements \IteratorAggregate
         }
 
         if ($this->sort) {
-            $iterator = new Iterator\SortableIterator($iterator, $this->sort);
+            $iterator_aggregate = new Iterator\SortableIterator($iterator, $this->sort);
+            $iterator = $iterator_aggregate->getIterator();
         }
 
         return $iterator;

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -502,8 +502,8 @@ class Finder implements \IteratorAggregate
         }
 
         if ($this->sort) {
-            $iterator_aggregate = new Iterator\SortableIterator($iterator, $this->sort);
-            $iterator = $iterator_aggregate->getIterator();
+            $iteratorAggregate = new Iterator\SortableIterator($iterator, $this->sort);
+            $iterator = $iteratorAggregate->getIterator();
         }
 
         return $iterator;


### PR DESCRIPTION
I hit on a problem with **Finder, when using array of directories passed to ->in() together with sorting** (e.g. ->sortByName()):

_Catchable Fatal Error: Argument 1 passed to AppendIterator::append() must implement interface Iterator, instance of Symfony\Component\Finder\Iterator\SortableIterator given in ......\vendor\symfony\src\Symfony\Component\Finder\Finder.php line 421_

The problem is in Finder.php, line 419. When more than 1 directory is used, \AppendIterator is used to merge iterators for each directory. AppendIterator->append() accepts only objects implementing Iterator interface. But this is broken for SortableIterator, which implements IteratorAggregate and NOT Iterator.

My proposed solution retrieves an Iterator from IteratorAggregate, which is later valid as an input to AppendIterator->append()

(This solved the exception mentioned aboved in my testing project, not tested more.)
