### PR TITLE
[Validator]  Valid Constraint usage in AllValidator cause fatal error.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Constraints\Valid;
 
 /**
  * @api
@@ -50,7 +51,11 @@ class AllValidator extends ConstraintValidator
 
         foreach ($value as $key => $element) {
             foreach ($constraints as $constr) {
-                $walker->walkConstraint($constr, $element, $group, $propertyPath.'['.$key.']');
+                if ($constr instanceof Valid) {
+                    $walker->walkReference($element, $group, $propertyPath.'['.$key.']', $constr->traverse);
+                } else {
+                    $walker->walkConstraint($constr, $element, $group, $propertyPath.'['.$key.']');
+                }
             }
         }
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
@@ -102,7 +102,7 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->setGroup('MyGroup');
         $this->context->setPropertyPath('foo');
 
-        $constraint = new Valid;
+        $constraint = new Valid();
 
         foreach ($array as $key => $value) {
             $this->walker->expects($this->once())

--- a/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/AllValidatorTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Tests\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\ExecutionContext;
 use Symfony\Component\Validator\Constraints\Min;
+use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\AllValidator;
 
@@ -91,6 +92,25 @@ class AllValidatorTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertTrue($this->validator->isValid($array, new All($constraints)));
+    }
+
+    /**
+     * @dataProvider getValidArguments
+     */
+    public function testWalkSingleValidConstraint($array)
+    {
+        $this->context->setGroup('MyGroup');
+        $this->context->setPropertyPath('foo');
+
+        $constraint = new Valid;
+
+        foreach ($array as $key => $value) {
+            $this->walker->expects($this->once())
+                ->method('walkReference')
+                ->with($this->equalTo($value), $this->equalTo('MyGroup'), $this->equalTo('foo['.$key.']'), $this->equalTo($constraint->traverse));
+        }
+
+        $this->assertTrue($this->validator->isValid($array, new All($constraint)));
     }
 
     public function getValidArguments()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3428
Todo: -
