### PR TITLE
[DoctrineBridge] Simpler result checking in UniqueEntityValidator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -94,17 +94,11 @@ class UniqueEntityValidator extends ConstraintValidator
         $repository = $em->getRepository($className);
         $result = $repository->findBy($criteria);
 
-        // MongoDB will return a Cursor so we need to change it to an array
-        // so it is compatible with the orm returning an array
-        if ($result instanceof \Iterator && !$result instanceof \ArrayAccess) {
-            $result = iterator_to_array($result);
-        }
-
         /* If no entity matched the query criteria or a single entity matched,
          * which is the same as the entity being validated, the criteria is
          * unique.
          */
-        if (0 === count($result) || (1 === count($result) && $entity === reset($result))) {
+        if (0 === count($result) || (1 === count($result) && $entity === current($result))) {
             return true;
         }
 


### PR DESCRIPTION
In 928e352d09a6bb0b566e61bc7482ead1d4859442, support for MongoDB cursors was implemented by converting an Iterable, non-ArrayAccess object to an array. The ArrayAccess check didn't seem purposeful, since cursors are only Iterable and ORM returns real arrays. Since we only need to access the first element of the cursor (and only in cases where the count is exactly 1), we can simply use current() to handle Iterables and arrays.

@henrikbjorn: Any thoughts on this? I was testing @stof's work in doctrine/DoctrineMongoDBBundle#68 and our Symfony submodule was a bit old, so I fixed UniqueEntityValidator on my local machine before I realized you had come up with a solution a few weeks ago.
