### PR TITLE
[WIP] Refactored profiler tests including some storage fixes

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
@@ -79,7 +79,14 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
             --$limit;
         }
 
-        return array_values($result);
+        usort($result, function($a, $b) {
+            if ($a['time'] === $b['time']) {
+                return 0;
+            }
+            return ($a['time'] > $b['time']) ? -1 : 1;
+        });
+
+        return $result;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
@@ -83,7 +83,7 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
             if ($a['time'] === $b['time']) {
                 return 0;
             }
-            return ($a['time'] > $b['time']) ? -1 : 1;
+            return $a['time'] > $b['time'] ? -1 : 1;
         });
 
         return $result;

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -102,7 +102,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
             'time' => $profile->getTime()
         );
 
-        return $this->getMongo()->insert(array_filter($record, function ($v) { return !empty($v); }));
+        return $this->getMongo()->update(array('_id' => $profile->getToken()), array_filter($record, function ($v) { return !empty($v); }), array('upsert' => true));
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/AbstractProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/AbstractProfilerStorageTest.php
@@ -1,0 +1,190 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\HttpKernel\Profiler;
+
+use Symfony\Component\HttpKernel\Profiler\Profile;
+
+abstract class AbstractProfilerStorageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testStore()
+    {
+        for ($i = 0; $i < 10; $i ++) {
+            $profile = new Profile('token_'.$i);
+            $profile->setIp('127.0.0.1');
+            $profile->setUrl('http://foo.bar');
+            $profile->setMethod('GET');
+            $this->getStorage()->write($profile);
+        }
+        $this->assertCount(10, $this->getStorage()->find('127.0.0.1', 'http://foo.bar', 20, 'GET'), '->write() stores data in the storage');
+    }
+
+    public function testChildren()
+    {
+        $parentProfile = new Profile('token_parent');
+        $parentProfile->setIp('127.0.0.1');
+        $parentProfile->setUrl('http://foo.bar/parent');
+
+        $childProfile = new Profile('token_child');
+        $childProfile->setIp('127.0.0.1');
+        $childProfile->setUrl('http://foo.bar/child');
+
+        $parentProfile->addChild($childProfile);
+
+        $this->getStorage()->write($parentProfile);
+        $this->getStorage()->write($childProfile);
+
+        // Load them from storage
+        $parentProfile = $this->getStorage()->read('token_parent');
+        $childProfile  = $this->getStorage()->read('token_child');
+
+        // Check child has link to parent
+        $this->assertNotNull($childProfile->getParent());
+        $this->assertEquals($parentProfile->getToken(), $childProfile->getParentToken());
+
+        // Check parent has child
+        $children = $parentProfile->getChildren();
+        $this->assertCount(1, $children);
+        $this->assertEquals($childProfile->getToken(), $children[0]->getToken());
+    }
+
+    public function testStoreSpecialCharsInUrl()
+    {
+        // The storage accepts special characters in URLs (Even though URLs are not
+        // supposed to contain them)
+        $profile = new Profile('simple_quote');
+        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
+        $this->getStorage()->write($profile);
+        $this->assertTrue(false !== $this->getStorage()->read('simple_quote'), '->write() accepts single quotes in URL');
+
+        $profile = new Profile('double_quote');
+        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
+        $this->getStorage()->write($profile);
+        $this->assertTrue(false !== $this->getStorage()->read('double_quote'), '->write() accepts double quotes in URL');
+
+        $profile = new Profile('backslash');
+        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
+        $this->getStorage()->write($profile);
+        $this->assertTrue(false !== $this->getStorage()->read('backslash'), '->write() accepts backslash in URL');
+
+        $profile = new Profile('comma');
+        $profile->setUrl('127.0.0.1', 'http://foo.bar/,');
+        $this->getStorage()->write($profile);
+        $this->assertTrue(false !== $this->getStorage()->read('comma'), '->write() accepts comma in URL');
+    }
+
+    public function testStoreDuplicateToken()
+    {
+        $profile = new Profile('token');
+        $profile->setUrl('http://example.com/');
+
+        $this->assertTrue($this->getStorage()->write($profile), '->write() returns true when the token is unique');
+
+        $profile->setUrl('http://example.net/');
+
+        $this->assertTrue($this->getStorage()->write($profile), '->write() returns true when the token is already present in the storage');
+        $this->assertEquals('http://example.net/', $this->getStorage()->read('token')->getUrl(), '->write() overwrites the current profile data');
+
+        $this->assertCount(1, $this->getStorage()->find('', '', 1000, ''), '->find() does not return the same profile twice');
+    }
+
+    public function testRetrieveByIp()
+    {
+        $profile = new Profile('token');
+        $profile->setIp('127.0.0.1');
+        $profile->setMethod('GET');
+        $this->getStorage()->write($profile);
+
+        $this->assertCount(1, $this->getStorage()->find('127.0.0.1', '', 10, 'GET'), '->find() retrieve a record by IP');
+        $this->assertCount(0, $this->getStorage()->find('127.0.%.1', '', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the IP');
+        $this->assertCount(0, $this->getStorage()->find('127.0._.1', '', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the IP');
+    }
+
+    public function testRetrieveByUrl()
+    {
+        $profile = new Profile('simple_quote');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/\'');
+        $profile->setMethod('GET');
+        $this->getStorage()->write($profile);
+
+        $profile = new Profile('double_quote');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/"');
+        $profile->setMethod('GET');
+        $this->getStorage()->write($profile);
+
+        $profile = new Profile('backslash');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo\\bar/');
+        $profile->setMethod('GET');
+        $this->getStorage()->write($profile);
+
+        $profile = new Profile('percent');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/%');
+        $profile->setMethod('GET');
+        $this->getStorage()->write($profile);
+
+        $profile = new Profile('underscore');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/_');
+        $profile->setMethod('GET');
+        $this->getStorage()->write($profile);
+
+        $profile = new Profile('semicolon');
+        $profile->setIp('127.0.0.1');
+        $profile->setUrl('http://foo.bar/;');
+        $profile->setMethod('GET');
+        $this->getStorage()->write($profile);
+
+        $this->assertCount(1, $this->getStorage()->find('127.0.0.1', 'http://foo.bar/\'', 10, 'GET'), '->find() accepts single quotes in URLs');
+        $this->assertCount(1, $this->getStorage()->find('127.0.0.1', 'http://foo.bar/"', 10, 'GET'), '->find() accepts double quotes in URLs');
+        $this->assertCount(1, $this->getStorage()->find('127.0.0.1', 'http://foo\\bar/', 10, 'GET'), '->find() accepts backslash in URLs');
+        $this->assertCount(1, $this->getStorage()->find('127.0.0.1', 'http://foo.bar/;', 10, 'GET'), '->find() accepts semicolon in URLs');
+        $this->assertCount(1, $this->getStorage()->find('127.0.0.1', 'http://foo.bar/%', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the URL');
+        $this->assertCount(1, $this->getStorage()->find('127.0.0.1', 'http://foo.bar/_', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the URL');
+    }
+
+    public function testStoreTime()
+    {
+        $dt = new \DateTime('now');
+        for ($i = 0; $i < 3; $i++) {
+            $dt->modify('+1 minute');
+            $profile = new Profile('time_'.$i);
+            $profile->setIp('127.0.0.1');
+            $profile->setUrl('http://foo.bar');
+            $profile->setTime($dt->getTimestamp());
+            $profile->setMethod('GET');
+            $this->getStorage()->write($profile);
+        }
+        $records = $this->getStorage()->find('', '', 3, 'GET');
+        $this->assertCount(3, $records, '->find() returns all previously added records');
+        $this->assertEquals($records[0]['token'], 'time_2', '->find() returns records ordered by time in descendant order');
+        $this->assertEquals($records[1]['token'], 'time_1', '->find() returns records ordered by time in descendant order');
+        $this->assertEquals($records[2]['token'], 'time_0', '->find() returns records ordered by time in descendant order');
+    }
+
+    public function testRetrieveByEmptyUrlAndIp()
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $profile = new Profile('token_'.$i);
+            $profile->setMethod('GET');
+            $this->getStorage()->write($profile);
+        }
+        $this->assertCount(5, $this->getStorage()->find('', '', 10, 'GET'), '->find() returns all previously added records');
+        $this->getStorage()->purge();
+    }
+
+    /**
+     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
+     */
+    abstract protected function getStorage();
+}

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/AbstractProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/AbstractProfilerStorageTest.php
@@ -60,22 +60,22 @@ abstract class AbstractProfilerStorageTest extends \PHPUnit_Framework_TestCase
         // The storage accepts special characters in URLs (Even though URLs are not
         // supposed to contain them)
         $profile = new Profile('simple_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
+        $profile->setUrl('http://foo.bar/\'');
         $this->getStorage()->write($profile);
         $this->assertTrue(false !== $this->getStorage()->read('simple_quote'), '->write() accepts single quotes in URL');
 
         $profile = new Profile('double_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
+        $profile->setUrl('http://foo.bar/"');
         $this->getStorage()->write($profile);
         $this->assertTrue(false !== $this->getStorage()->read('double_quote'), '->write() accepts double quotes in URL');
 
         $profile = new Profile('backslash');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
+        $profile->setUrl('http://foo.bar/\\');
         $this->getStorage()->write($profile);
         $this->assertTrue(false !== $this->getStorage()->read('backslash'), '->write() accepts backslash in URL');
 
         $profile = new Profile('comma');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/,');
+        $profile->setUrl('http://foo.bar/,');
         $this->getStorage()->write($profile);
         $this->assertTrue(false !== $this->getStorage()->read('comma'), '->write() accepts comma in URL');
     }

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/FileProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/FileProfilerStorageTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Tests\Component\HttpKernel\Profiler;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
-class FileProfilerStorageTest extends \PHPUnit_Framework_TestCase
+class FileProfilerStorageTest extends AbstractProfilerStorageTest
 {
     protected static $tmpDir;
     protected static $storage;
@@ -38,7 +38,7 @@ class FileProfilerStorageTest extends \PHPUnit_Framework_TestCase
         if (is_dir(self::$tmpDir)) {
             self::cleanDir();
         }
-        self::$storage = new FileProfilerStorage('file:'.self::$tmpDir);
+        self::$storage = new FileProfilerStorage('file:' . self::$tmpDir);
     }
 
     public static function tearDownAfterClass()
@@ -51,138 +51,11 @@ class FileProfilerStorageTest extends \PHPUnit_Framework_TestCase
         self::$storage->purge();
     }
 
-    public function testStore()
+    /**
+     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
+     */
+    protected function getStorage()
     {
-        for ($i = 0; $i < 10; $i ++) {
-            $profile = new Profile('token_'.$i);
-            $profile->setIp('127.0.0.1');
-            $profile->setUrl('http://foo.bar');
-            $profile->setMethod('GET');
-            self::$storage->write($profile);
-        }
-        $this->assertCount(10, self::$storage->find('127.0.0.1', 'http://foo.bar', 20, 'GET'), '->write() stores data in the database');
-    }
-
-    public function testChildren()
-    {
-        $parentProfile = new Profile('token_parent');
-        $parentProfile->setIp('127.0.0.1');
-        $parentProfile->setUrl('http://foo.bar/parent');
-
-        $childProfile = new Profile('token_child');
-        $childProfile->setIp('127.0.0.1');
-        $childProfile->setUrl('http://foo.bar/child');
-
-        $parentProfile->addChild($childProfile);
-
-        self::$storage->write($parentProfile);
-        self::$storage->write($childProfile);
-
-        // Load them from storage
-        $parentProfile = self::$storage->read('token_parent');
-        $childProfile  = self::$storage->read('token_child');
-
-        // Check child has link to parent
-        $this->assertNotNull($childProfile->getParent());
-        $this->assertEquals($parentProfile->getToken(), $childProfile->getParentToken());
-
-        // Check parent has child
-        $children = $parentProfile->getChildren();
-        $this->assertCount(1, $children);
-        $this->assertEquals($childProfile->getToken(), $children[0]->getToken());
-    }
-
-    public function testStoreSpecialCharsInUrl()
-    {
-        // The SQLite storage accepts special characters in URLs (Even though URLs are not
-        // supposed to contain them)
-        $profile = new Profile('simple_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('simple_quote'), '->write() accepts single quotes in URL');
-
-        $profile = new Profile('double_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('double_quote'), '->write() accepts double quotes in URL');
-
-        $profile = new Profile('backslash');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('backslash'), '->write() accepts backslash in URL');
-
-        $profile = new Profile('comma');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/,');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('comma'), '->write() accepts comma in URL');
-    }
-
-    public function testStoreDuplicateToken()
-    {
-        $profile = new Profile('token');
-
-        $this->assertTrue(self::$storage->write($profile), '->write() returns true when the token is unique');
-        $this->assertTrue(self::$storage->write($profile), '->write() overwrites when the token is already present in the DB');
-
-        $this->assertCount(1, self::$storage->find('', '', 1000, ''), '->find() does not return the same profile twice');
-    }
-
-    public function testRetrieveByIp()
-    {
-        $profile = new Profile('token');
-        $profile->setIp('127.0.0.1');
-        $profile->setMethod('GET');
-
-        self::$storage->write($profile);
-
-        $this->assertCount(1, self::$storage->find('127.0.0.1', '', 10, 'GET'), '->find() retrieve a record by IP');
-        $this->assertCount(0, self::$storage->find('127.0.%.1', '', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the IP');
-        $this->assertCount(0, self::$storage->find('127.0._.1', '', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the IP');
-    }
-
-    public function testRetrieveByUrl()
-    {
-        $profile = new Profile('simple_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/\'');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('double_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/"');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('backslash');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo\\bar/');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('percent');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/%');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('underscore');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/_');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('semicolon');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/;');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10, 'GET'), '->find() accepts single quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10, 'GET'), '->find() accepts double quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10, 'GET'), '->find() accepts backslash in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/;', 10, 'GET'), '->find() accepts semicolon in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the URL');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the URL');
+        return self::$storage;
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/FileProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/FileProfilerStorageTest.php
@@ -38,7 +38,7 @@ class FileProfilerStorageTest extends AbstractProfilerStorageTest
         if (is_dir(self::$tmpDir)) {
             self::cleanDir();
         }
-        self::$storage = new FileProfilerStorage('file:' . self::$tmpDir);
+        self::$storage = new FileProfilerStorage('file:'.self::$tmpDir);
     }
 
     public static function tearDownAfterClass()

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcacheProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcacheProfilerStorageTest.php
@@ -22,7 +22,7 @@ class DummyMemcacheProfilerStorage extends MemcacheProfilerStorage
     }
 }
 
-class MemcacheProfilerStorageTest extends \PHPUnit_Framework_TestCase
+class MemcacheProfilerStorageTest extends AbstractProfilerStorageTest
 {
     protected static $storage;
 
@@ -46,7 +46,7 @@ class MemcacheProfilerStorageTest extends \PHPUnit_Framework_TestCase
             if (!isset($stats['127.0.0.1:11211']) || $stats['127.0.0.1:11211'] === false) {
                 throw new \Exception();
             }
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $this->markTestSkipped('MemcacheProfilerStorageTest requires that there is a Memcache server present on localhost');
         }
 
@@ -55,144 +55,11 @@ class MemcacheProfilerStorageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testStore()
+    /**
+     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
+     */
+    protected function getStorage()
     {
-        for ($i = 0; $i < 10; $i ++) {
-            $profile = new Profile('token_'.$i);
-            $profile->setIp('127.0.0.1');
-            $profile->setUrl('http://foo.bar');
-            $profile->setMethod('GET');
-            self::$storage->write($profile);
-        }
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar', 20, 'GET')), 10, '->write() stores data in the Memcache');
-    }
-
-
-    public function testChildren()
-    {
-        $parentProfile = new Profile('token_parent');
-        $parentProfile->setIp('127.0.0.1');
-        $parentProfile->setUrl('http://foo.bar/parent');
-
-        $childProfile = new Profile('token_child');
-        $childProfile->setIp('127.0.0.1');
-        $childProfile->setUrl('http://foo.bar/child');
-
-        $parentProfile->addChild($childProfile);
-
-        self::$storage->write($parentProfile);
-        self::$storage->write($childProfile);
-
-        // Load them from storage
-        $parentProfile = self::$storage->read('token_parent');
-        $childProfile  = self::$storage->read('token_child');
-
-        // Check child has link to parent
-        $this->assertNotNull($childProfile->getParent());
-        $this->assertEquals($parentProfile->getToken(), $childProfile->getParentToken());
-
-        // Check parent has child
-        $children = $parentProfile->getChildren();
-        $this->assertEquals(1, count($children));
-        $this->assertEquals($childProfile->getToken(), $children[0]->getToken());
-    }
-
-    public function testStoreSpecialCharsInUrl()
-    {
-        // The SQLite storage accepts special characters in URLs (Even though URLs are not
-        // supposed to contain them)
-        $profile = new Profile('simple_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('simple_quote'), '->write() accepts single quotes in URL');
-
-        $profile = new Profile('double_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('double_quote'), '->write() accepts double quotes in URL');
-
-        $profile = new Profile('backslash');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('backslash'), '->write() accepts backslash in URL');
-
-        $profile = new Profile('comma');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/,');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('comma'), '->write() accepts comma in URL');
-    }
-
-    public function testStoreDuplicateToken()
-    {
-        $profile = new Profile('token');
-        $profile->setUrl('http://example.com/');
-
-        $this->assertTrue(self::$storage->write($profile), '->write() returns true when the token is unique');
-
-        $profile->setUrl('http://example.net/');
-
-        $this->assertTrue(self::$storage->write($profile), '->write() returns true when the token is already present in the Memcache');
-        $this->assertEquals('http://example.net/', self::$storage->read('token')->getUrl(), '->write() overwrites the current profile data');
-
-        $this->assertCount(1, self::$storage->find('', '', 1000, ''), '->find() does not return the same profile twice');
-    }
-
-    public function testRetrieveByIp()
-    {
-        $profile = new Profile('token');
-        $profile->setIp('127.0.0.1');
-        $profile->setMethod('GET');
-
-        self::$storage->write($profile);
-
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', '', 10, 'GET')), 1, '->find() retrieve a record by IP');
-        $this->assertEquals(count(self::$storage->find('127.0.%.1', '', 10, 'GET')), 0, '->find() does not interpret a "%" as a wildcard in the IP');
-        $this->assertEquals(count(self::$storage->find('127.0._.1', '', 10, 'GET')), 0, '->find() does not interpret a "_" as a wildcard in the IP');
-    }
-
-    public function testRetrieveByUrl()
-    {
-        $profile = new Profile('simple_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/\'');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('double_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/"');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('backslash');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo\\bar/');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('percent');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/%');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('underscore');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/_');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('semicolon');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/;');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10, 'GET')), 1, '->find() accepts single quotes in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10, 'GET')), 1, '->find() accepts double quotes in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10, 'GET')), 1, '->find() accepts backslash in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/;', 10, 'GET')), 1, '->find() accepts semicolon in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10, 'GET')), 1, '->find() does not interpret a "%" as a wildcard in the URL');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10, 'GET')), 1, '->find() does not interpret a "_" as a wildcard in the URL');
+        return self::$storage;
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcachedProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcachedProfilerStorageTest.php
@@ -22,7 +22,7 @@ class DummyMemcachedProfilerStorage extends MemcachedProfilerStorage
     }
 }
 
-class MemcachedProfilerStorageTest extends \PHPUnit_Framework_TestCase
+class MemcachedProfilerStorageTest extends AbstractProfilerStorageTest
 {
     protected static $storage;
 
@@ -42,7 +42,7 @@ class MemcachedProfilerStorageTest extends \PHPUnit_Framework_TestCase
         self::$storage = new DummyMemcachedProfilerStorage('memcached://127.0.0.1/11211', '', '', 86400);
         try {
             self::$storage->getMemcached();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             $this->markTestSkipped('MemcachedProfilerStorageTest requires that there is a Memcache server present on localhost');
         }
 
@@ -51,144 +51,11 @@ class MemcachedProfilerStorageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testStore()
+    /**
+     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
+     */
+    protected function getStorage()
     {
-        for ($i = 0; $i < 10; $i ++) {
-            $profile = new Profile('token_'.$i);
-            $profile->setIp('127.0.0.1');
-            $profile->setUrl('http://foo.bar');
-            $profile->setMethod('GET');
-            self::$storage->write($profile);
-        }
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar', 20, 'GET')), 10, '->write() stores data in the Memcache');
-    }
-
-
-    public function testChildren()
-    {
-        $parentProfile = new Profile('token_parent');
-        $parentProfile->setIp('127.0.0.1');
-        $parentProfile->setUrl('http://foo.bar/parent');
-
-        $childProfile = new Profile('token_child');
-        $childProfile->setIp('127.0.0.1');
-        $childProfile->setUrl('http://foo.bar/child');
-
-        $parentProfile->addChild($childProfile);
-
-        self::$storage->write($parentProfile);
-        self::$storage->write($childProfile);
-
-        // Load them from storage
-        $parentProfile = self::$storage->read('token_parent');
-        $childProfile  = self::$storage->read('token_child');
-
-        // Check child has link to parent
-        $this->assertNotNull($childProfile->getParent());
-        $this->assertEquals($parentProfile->getToken(), $childProfile->getParentToken());
-
-        // Check parent has child
-        $children = $parentProfile->getChildren();
-        $this->assertEquals(1, count($children));
-        $this->assertEquals($childProfile->getToken(), $children[0]->getToken());
-    }
-
-    public function testStoreSpecialCharsInUrl()
-    {
-        // The SQLite storage accepts special characters in URLs (Even though URLs are not
-        // supposed to contain them)
-        $profile = new Profile('simple_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('simple_quote'), '->write() accepts single quotes in URL');
-
-        $profile = new Profile('double_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('double_quote'), '->write() accepts double quotes in URL');
-
-        $profile = new Profile('backslash');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('backslash'), '->write() accepts backslash in URL');
-
-        $profile = new Profile('comma');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/,');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('comma'), '->write() accepts comma in URL');
-    }
-
-    public function testStoreDuplicateToken()
-    {
-        $profile = new Profile('token');
-        $profile->setUrl('http://example.com/');
-
-        $this->assertTrue(self::$storage->write($profile), '->write() returns true when the token is unique');
-
-        $profile->setUrl('http://example.net/');
-
-        $this->assertTrue(self::$storage->write($profile), '->write() returns true when the token is already present in the Memcache');
-        $this->assertEquals('http://example.net/', self::$storage->read('token')->getUrl(), '->write() overwrites the current profile data');
-
-        $this->assertCount(1, self::$storage->find('', '', 1000, ''), '->find() does not return the same profile twice');
-    }
-
-    public function testRetrieveByIp()
-    {
-        $profile = new Profile('token');
-        $profile->setIp('127.0.0.1');
-        $profile->setMethod('GET');
-
-        self::$storage->write($profile);
-
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', '', 10, 'GET')), 1, '->find() retrieve a record by IP');
-        $this->assertEquals(count(self::$storage->find('127.0.%.1', '', 10, 'GET')), 0, '->find() does not interpret a "%" as a wildcard in the IP');
-        $this->assertEquals(count(self::$storage->find('127.0._.1', '', 10, 'GET')), 0, '->find() does not interpret a "_" as a wildcard in the IP');
-    }
-
-    public function testRetrieveByUrl()
-    {
-        $profile = new Profile('simple_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/\'');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('double_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/"');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('backslash');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo\\bar/');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('percent');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/%');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('underscore');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/_');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('semicolon');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/;');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10, 'GET')), 1, '->find() accepts single quotes in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10, 'GET')), 1, '->find() accepts double quotes in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10, 'GET')), 1, '->find() accepts backslash in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/;', 10, 'GET')), 1, '->find() accepts semicolon in URLs');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10, 'GET')), 1, '->find() does not interpret a "%" as a wildcard in the URL');
-        $this->assertEquals(count(self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10, 'GET')), 1, '->find() does not interpret a "_" as a wildcard in the URL');
+        return self::$storage;
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the Symfony package.
  *
@@ -13,15 +14,24 @@ namespace Symfony\Tests\Component\HttpKernel\Profiler;
 use Symfony\Component\HttpKernel\Profiler\MongoDbProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
-class DummyMongoDbProfilerStorage extends MongoDbProfilerStorage {
-    public function getMongo() {
+class DummyMongoDbProfilerStorage extends MongoDbProfilerStorage
+{
+    public function getMongo()
+    {
         return parent::getMongo();
     }
 }
 
-class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
+class MongoDbProfilerStorageTest extends AbstractProfilerStorageTest
 {
     protected static $storage;
+
+    public static function tearDownAfterClass()
+    {
+        if (self::$storage) {
+            self::$storage->purge();
+        }
+    }
 
     protected function setUp()
     {
@@ -29,138 +39,13 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
             self::$storage = new DummyMongoDbProfilerStorage('mongodb://localhost/symfony_tests/profiler_data', '', '', 86400);
             try {
                 self::$storage->getMongo();
-            } catch(\MongoConnectionException $e) {
+                self::$storage->purge();
+            } catch (\MongoConnectionException $e) {
                 $this->markTestSkipped('MongoDbProfilerStorageTest requires that there is a MongoDB server present on localhost');
             }
-            self::$storage->purge();
         } else {
             $this->markTestSkipped('MongoDbProfilerStorageTest requires that the extension mongo is loaded');
         }
-    }
-
-    public function testStore()
-    {
-        for ($i = 0; $i < 10; $i++) {
-            $profile = new Profile('token_'.$i);
-            $profile->setIp('127.0.0.1');
-            $profile->setUrl('http://foo.bar');
-            $profile->setMethod('GET');
-            self::$storage->write($profile);
-        }
-        $this->assertCount(10, self::$storage->find('127.0.0.1', 'http://foo.bar', 20, 'GET'), '->write() stores data in the database');
-        self::$storage->purge();
-    }
-
-    public function testStoreSpecialCharsInUrl()
-    {
-        // The storage accepts special characters in URLs (Even though URLs are not
-        // supposed to contain them)
-        $profile = new Profile('simple_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('simple_quote'), '->write() accepts single quotes in URL');
-
-        $profile = new Profile('double_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('double_quote'), '->write() accepts double quotes in URL');
-
-        $profile = new Profile('backslash');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('backslash'), '->write() accpets backslash in URL');
-
-        self::$storage->purge();
-    }
-
-    public function testStoreTime()
-    {
-        $dt = new \DateTime('now');
-        for ($i = 0; $i < 3; $i++) {
-            $dt->modify('+1 minute');
-            $profile = new Profile('time_'.$i);
-            $profile->setIp('127.0.0.1');
-            $profile->setUrl('http://foo.bar');
-            $profile->setTime($dt->getTimestamp());
-            $profile->setMethod('GET');
-            self::$storage->write($profile);
-        }
-        $records = self::$storage->find('', '', 3, 'GET');
-        $this->assertCount(3, $records, '->find() returns all previously added records');
-        $this->assertEquals($records[0]['token'], 'time_2', '->find() returns records ordered by time in descendant order');
-        $this->assertEquals($records[1]['token'], 'time_1', '->find() returns records ordered by time in descendant order');
-        $this->assertEquals($records[2]['token'], 'time_0', '->find() returns records ordered by time in descendant order');
-        self::$storage->purge();
-    }
-
-    public function testRetrieveByIp()
-    {
-        $profile = new Profile('token');
-        $profile->setIp('127.0.0.1');
-        $profile->setMethod('GET');
-
-        self::$storage->write($profile);
-
-        $this->assertCount(1, self::$storage->find('127.0.0.1', '', 10, 'GET'), '->find() retrieve a record by IP');
-        $this->assertCount(0, self::$storage->find('127.0.%.1', '', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the IP');
-        $this->assertCount(0, self::$storage->find('127.0._.1', '', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the IP');
-
-        self::$storage->purge();
-    }
-
-    public function testRetrieveByUrl()
-    {
-        $profile = new Profile('simple_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/\'');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('double_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/"');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('backslash');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo\\bar/');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('percent');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/%');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('underscore');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/_');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10, 'GET'), '->find() accepts single quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10, 'GET'), '->find() accepts double quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10, 'GET'), '->find() accepts backslash in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the URL');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the URL');
-
-        self::$storage->purge();
-    }
-
-    public function testRetrieveByEmptyUrlAndIp()
-    {
-        for ($i = 0; $i < 5; $i++) {
-            $profile = new Profile('token_'.$i);
-            $profile->setMethod('GET');
-            self::$storage->write($profile);
-        }
-        $this->assertCount(5, self::$storage->find('', '', 10, 'GET'), '->find() returns all previously added records');
-        self::$storage->purge();
     }
 
     public function testCleanup()
@@ -168,7 +53,7 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
         $dt = new \DateTime('-2 day');
         for ($i = 0; $i < 3; $i++) {
             $dt->modify('-1 day');
-            $profile = new Profile('time_'.$i);
+            $profile = new Profile('time_' . $i);
             $profile->setTime($dt->getTimestamp());
             $profile->setMethod('GET');
             self::$storage->write($profile);
@@ -177,5 +62,13 @@ class MongoDbProfilerStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $records, '->find() returns only one record');
         $this->assertEquals($records[0]['token'], 'time_2', '->find() returns the latest added record');
         self::$storage->purge();
+    }
+
+    /**
+     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
+     */
+    protected function getStorage()
+    {
+        return self::$storage;
     }
 }

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php
@@ -53,7 +53,7 @@ class MongoDbProfilerStorageTest extends AbstractProfilerStorageTest
         $dt = new \DateTime('-2 day');
         for ($i = 0; $i < 3; $i++) {
             $dt->modify('-1 day');
-            $profile = new Profile('time_' . $i);
+            $profile = new Profile('time_'.$i);
             $profile->setTime($dt->getTimestamp());
             $profile->setMethod('GET');
             self::$storage->write($profile);

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/SqliteProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/SqliteProfilerStorageTest.php
@@ -25,7 +25,7 @@ class SqliteProfilerStorageTest extends AbstractProfilerStorageTest
         if (file_exists(self::$dbFile)) {
             @unlink(self::$dbFile);
         }
-        self::$storage = new SqliteProfilerStorage('sqlite:' . self::$dbFile);
+        self::$storage = new SqliteProfilerStorage('sqlite:'.self::$dbFile);
     }
 
     public static function tearDownAfterClass()

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/SqliteProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/SqliteProfilerStorageTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Tests\Component\HttpKernel\Profiler;
 use Symfony\Component\HttpKernel\Profiler\SqliteProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 
-class SqliteProfilerStorageTest extends \PHPUnit_Framework_TestCase
+class SqliteProfilerStorageTest extends AbstractProfilerStorageTest
 {
     protected static $dbFile;
     protected static $storage;
@@ -25,7 +25,7 @@ class SqliteProfilerStorageTest extends \PHPUnit_Framework_TestCase
         if (file_exists(self::$dbFile)) {
             @unlink(self::$dbFile);
         }
-        self::$storage = new SqliteProfilerStorage('sqlite:'.self::$dbFile);
+        self::$storage = new SqliteProfilerStorage('sqlite:' . self::$dbFile);
     }
 
     public static function tearDownAfterClass()
@@ -41,101 +41,11 @@ class SqliteProfilerStorageTest extends \PHPUnit_Framework_TestCase
         self::$storage->purge();
     }
 
-    public function testStore()
+    /**
+     * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
+     */
+    protected function getStorage()
     {
-        for ($i = 0; $i < 10; $i ++) {
-            $profile = new Profile('token_'.$i);
-            $profile->setIp('127.0.0.1');
-            $profile->setUrl('http://foo.bar');
-            $profile->setMethod('GET');
-            self::$storage->write($profile);
-        }
-
-        $this->assertCount(10, self::$storage->find('127.0.0.1', 'http://foo.bar', 20, 'GET'), '->write() stores data in the database');
-    }
-
-    public function testStoreSpecialCharsInUrl()
-    {
-        // The SQLite storage accepts special characters in URLs (Even though URLs are not
-        // supposed to contain them)
-        $profile = new Profile('simple_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\'');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('simple_quote'), '->write() accepts single quotes in URL');
-
-        $profile = new Profile('double_quote');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/"');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('double_quote'), '->write() accepts double quotes in URL');
-
-        $profile = new Profile('backslash');
-        $profile->setUrl('127.0.0.1', 'http://foo.bar/\\');
-        self::$storage->write($profile);
-        $this->assertTrue(false !== self::$storage->read('backslash'), '->write() accpets backslash in URL');
-    }
-
-    public function testStoreDuplicateToken()
-    {
-        $profile = new Profile('token');
-        $profile->setUrl('http://example.com/');
-
-        $this->assertTrue(self::$storage->write($profile), '->write() returns true when the token is unique');
-
-        $profile->setUrl('http://example.net/');
-
-        $this->assertTrue(self::$storage->write($profile), '->write() returns true when the token is already present in the DB');
-        $this->assertEquals('http://example.net/', self::$storage->read('token')->getUrl(), '->write() overwrites the current profile data');
-    }
-
-    public function testRetrieveByIp()
-    {
-        $profile = new Profile('token');
-        $profile->setIp('127.0.0.1');
-        $profile->setMethod('GET');
-
-        self::$storage->write($profile);
-
-        $this->assertCount(1, self::$storage->find('127.0.0.1', '', 10, 'GET'), '->find() retrieve a record by IP');
-        $this->assertCount(0, self::$storage->find('127.0.%.1', '', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the IP');
-        $this->assertCount(0, self::$storage->find('127.0._.1', '', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the IP');
-    }
-
-    public function testRetrieveByUrl()
-    {
-        $profile = new Profile('simple_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/\'');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('double_quote');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/"');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('backslash');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo\\bar/');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('percent');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/%');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $profile = new Profile('underscore');
-        $profile->setIp('127.0.0.1');
-        $profile->setUrl('http://foo.bar/_');
-        $profile->setMethod('GET');
-        self::$storage->write($profile);
-
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/\'', 10, 'GET'), '->find() accepts single quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/"', 10, 'GET'), '->find() accepts double quotes in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo\\bar/', 10, 'GET'), '->find() accepts backslash in URLs');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/%', 10, 'GET'), '->find() does not interpret a "%" as a wildcard in the URL');
-        $this->assertCount(1, self::$storage->find('127.0.0.1', 'http://foo.bar/_', 10, 'GET'), '->find() does not interpret a "_" as a wildcard in the URL');
+        return self::$storage;
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

While refactoring the tests I came across some inconsistencies. Two of them are already fixed in this PR.

One thing left is the [MongoDbProfilerStorageTest::testCleanup()](https://github.com/snc/symfony/blob/9d8e3f2da4bea58316e32ef41d4e856a0cfdc872/tests/Symfony/Tests/Component/HttpKernel/Profiler/MongoDbProfilerStorageTest.php#L51) test which fails in all other storage implementations. The mongodb implementation uses the `time` value from the profiler data to clean up the storage while the others additionally save a `created_at` value which is then used. For me this `created_at` value does not make any sense and I would suggest to change the other implementations to use the `time` value for cleaning up. What do you think?
