### PR TITLE
Add branch-alias for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,6 @@
     "description": "The Symfony PHP framework",
     "keywords": ["framework"],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,10 @@
             "Symfony": "src/",
             "SessionHandlerInterface": "src/Symfony/Component/HttpFoundation/Resources/stub"
         }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
     }
 }

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Doctrine Bridge",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -32,5 +32,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Doctrine": "" }
     },
-    "target-dir": "Symfony/Bridge/Doctrine"
+    "target-dir": "Symfony/Bridge/Doctrine",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Monolog Bridge",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -24,5 +24,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Monolog": "" }
     },
-    "target-dir": "Symfony/Bridge/Monolog"
+    "target-dir": "Symfony/Bridge/Monolog",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Swiftmailer Bridge",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -26,5 +26,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Swiftmailer": "" }
     },
-    "target-dir": "Symfony/Bridge/Swiftmailer"
+    "target-dir": "Symfony/Bridge/Swiftmailer",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -29,5 +29,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Twig": "" }
     },
-    "target-dir": "Symfony/Bridge/Twig"
+    "target-dir": "Symfony/Bridge/Twig",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Twig Bridge",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony FrameworkBundle",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -37,5 +37,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\FrameworkBundle": "" }
     },
-    "target-dir": "Symfony/Bundle/FrameworkBundle"
+    "target-dir": "Symfony/Bundle/FrameworkBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -23,5 +23,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\SecurityBundle": "" }
     },
-    "target-dir": "Symfony/Bundle/SecurityBundle"
+    "target-dir": "Symfony/Bundle/SecurityBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony SecurityBundle",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony TwigBundle",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -23,5 +23,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\TwigBundle": "" }
     },
-    "target-dir": "Symfony/Bundle/TwigBundle"
+    "target-dir": "Symfony/Bundle/TwigBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -23,5 +23,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\WebProfilerBundle": "" }
     },
-    "target-dir": "Symfony/Bundle/WebProfilerBundle"
+    "target-dir": "Symfony/Bundle/WebProfilerBundle",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony WebProfilerBundle",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony BrowserKit Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -26,5 +26,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\BrowserKit": "" }
     },
-    "target-dir": "Symfony/Component/BrowserKit"
+    "target-dir": "Symfony/Component/BrowserKit",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony ClassLoader Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\ClassLoader": "" }
     },
-    "target-dir": "Symfony/Component/ClassLoader"
+    "target-dir": "Symfony/Component/ClassLoader",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Config": "" }
     },
-    "target-dir": "Symfony/Component/Config"
+    "target-dir": "Symfony/Component/Config",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Config Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Console": "" }
     },
-    "target-dir": "Symfony/Component/Console"
+    "target-dir": "Symfony/Component/Console",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Console Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony CssSelector Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\CssSelector": "" }
     },
-    "target-dir": "Symfony/Component/CssSelector"
+    "target-dir": "Symfony/Component/CssSelector",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony DependencyInjection Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -28,5 +28,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\DependencyInjection": "" }
     },
-    "target-dir": "Symfony/Component/DependencyInjection"
+    "target-dir": "Symfony/Component/DependencyInjection",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -25,5 +25,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\DomCrawler": "" }
     },
-    "target-dir": "Symfony/Component/DomCrawler"
+    "target-dir": "Symfony/Component/DomCrawler",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony DomCrawler Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\EventDispatcher": "" }
     },
-    "target-dir": "Symfony/Component/EventDispatcher"
+    "target-dir": "Symfony/Component/EventDispatcher",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony EventDispatcher Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Filesystem": "" }
     },
-    "target-dir": "Symfony/Component/Filesystem"
+    "target-dir": "Symfony/Component/Filesystem",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Filesystem Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Finder": "" }
     },
-    "target-dir": "Symfony/Component/Finder"
+    "target-dir": "Symfony/Component/Finder",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Finder Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -28,5 +28,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Form": "" }
     },
-    "target-dir": "Symfony/Component/Form"
+    "target-dir": "Symfony/Component/Form",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Form Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -25,5 +25,10 @@
             "SessionHandlerInterface": "Symfony/Component/HttpFoundation/Resources/stub"
         }
     },
-    "target-dir": "Symfony/Component/HttpFoundation"
+    "target-dir": "Symfony/Component/HttpFoundation",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony HttpFoundation Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony HttpKernel Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -32,5 +32,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\HttpKernel": "" }
     },
-    "target-dir": "Symfony/Component/HttpKernel"
+    "target-dir": "Symfony/Component/HttpKernel",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Locale Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -25,5 +25,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Locale": "" }
     },
-    "target-dir": "Symfony/Component/Locale"
+    "target-dir": "Symfony/Component/Locale",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Process": "" }
     },
-    "target-dir": "Symfony/Component/Process"
+    "target-dir": "Symfony/Component/Process",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Process Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Routing Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -26,5 +26,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Routing": "" }
     },
-    "target-dir": "Symfony/Component/Routing"
+    "target-dir": "Symfony/Component/Routing",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Security Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -31,5 +31,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Security": "" }
     },
-    "target-dir": "Symfony/Component/Security"
+    "target-dir": "Symfony/Component/Security",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Serializer Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Serializer": "" }
     },
-    "target-dir": "Symfony/Component/Serializer"
+    "target-dir": "Symfony/Component/Serializer",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Templating Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Templating": "" }
     },
-    "target-dir": "Symfony/Component/Templating"
+    "target-dir": "Symfony/Component/Templating",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -26,5 +26,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Translation": "" }
     },
-    "target-dir": "Symfony/Component/Translation"
+    "target-dir": "Symfony/Component/Translation",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Translation Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -27,5 +27,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Validator": "" }
     },
-    "target-dir": "Symfony/Component/Validator"
+    "target-dir": "Symfony/Component/Validator",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Validator Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -22,5 +22,10 @@
     "autoload": {
         "psr-0": { "Symfony\\Component\\Yaml": "" }
     },
-    "target-dir": "Symfony/Component/Yaml"
+    "target-dir": "Symfony/Component/Yaml",
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.1-dev"
+        }
+    }
 }

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -4,7 +4,6 @@
     "description": "Symfony Yaml Component",
     "keywords": [],
     "homepage": "http://symfony.com",
-    "version": "2.1.0",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
This should restore the 2.1-dev version (as an alias of dev-master) so that `2.*` or `2.1.*` constraints work again. I'll adjust packagist soon to also display those aliases.
