### PR TITLE
fixed providers conflict in remember me service

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -221,21 +221,11 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
      */
     abstract protected function onLoginSuccess(Request $request, Response $response, TokenInterface $token);
 
-    protected final function getUserProvider($class)
+    protected final function getUserProviders()
     {
-		foreach ($this->userProviders as $provider){
-			$_user = null;
-			try{
-					$_user = $provider->loadUserByUsername($username);
-			} catch (\Exception $ex) {}
-			if($_user){
-				return $provider;
-			}
-		}
-
-        throw new UnsupportedUserException(sprintf('There is no user provider that supports class "%s".', $class));
+		return $this->userProviders;
     }
-
+    
     /**
      * Decodes the raw cookie value
      *

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -223,7 +223,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
 
     protected final function getUserProvider($class)
     {
-		foreach ($this->getUserProvider($class) as $provider){
+		foreach ($this->userProviders as $provider){
 			$_user = null;
 			try{
 					$_user = $provider->loadUserByUsername($username);

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -223,11 +223,15 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
 
     protected final function getUserProvider($class)
     {
-        foreach ($this->userProviders as $provider) {
-            if ($provider->supportsClass($class)) {
-                return $provider;
-            }
-        }
+		foreach ($this->getUserProvider($class) as $provider){
+			$_user = null;
+			try{
+					$_user = $provider->loadUserByUsername($username);
+			} catch (\Exception $ex) {}
+			if($_user){
+				return $provider;
+			}
+		}
 
         throw new UnsupportedUserException(sprintf('There is no user provider that supports class "%s".', $class));
     }

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -40,7 +40,18 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
             throw new AuthenticationException('$username contains a character from outside the base64 alphabet.');
         }
         try {
-            $user = $this->getUserProvider($class)->loadUserByUsername($username);
+			foreach ($this->getUserProviders() as $provider){
+				$_user = null;
+				try{
+						$_user = $provider->loadUserByUsername($username);
+				} catch (\Exception $ex) {}
+				if($_user){
+					$user = $_user;
+				}
+			}
+			if(!$user){
+				throw new AuthenticationException('No user in database');
+			}
         } catch (\Exception $ex) {
             if (!$ex instanceof AuthenticationException) {
                 $ex = new AuthenticationException($ex->getMessage(), null, $ex->getCode(), $ex);


### PR DESCRIPTION
Function getUserProvider from src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php  doesn't work properly - returns first provider that is in a collection of providers.
