### PR TITLE
[AbstractRememberMeServices] add support for the remember_me parameter in the query

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -283,7 +283,11 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             return true;
         }
 
-        $parameter = $request->request->get($this->options['remember_me_parameter'], null, true);
+        $parameter = $request->request->get(
+                $this->options['remember_me_parameter'],
+                $request->query->get($this->options['remember_me_parameter'], null),
+                true
+        );
 
         if ($parameter === null && null !== $this->logger) {
             $this->logger->debug(sprintf('Did not send remember-me cookie (remember-me parameter "%s" was not sent).', $this->options['remember_me_parameter']));


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no

I found myself having to pass the _remember_me parameter in the query instead of as a POST parameter, because I use OpenID which don't support POSTing, and I think it could be helpfull and harmless feature.
