### PR TITLE
[DoctrineBridge] Add tests for data fixture ContainerAwareLoader

### DIFF
--- a/tests/Symfony/Tests/Bridge/Doctrine/DataFixtures/ContainerAwareLoaderTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/DataFixtures/ContainerAwareLoaderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Bridge\Doctrine\DataFixtures;
+
+use Symfony\Bridge\Doctrine\DataFixtures\ContainerAwareLoader;
+use Symfony\Tests\Bridge\Doctrine\Fixtures\ContainerAwareFixture;
+
+class ContainerAwareLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Doctrine\Common\DataFixtures\Loader')) {
+            $this->markTestSkipped('Doctrine Data Fixtures is not available.');
+        }
+    }
+
+    public function testShouldSetContainerOnContainerAwareFixture()
+    {
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $loader    = new ContainerAwareLoader($container);
+        $fixture   = new ContainerAwareFixture();
+
+        $loader->addFixture($fixture);
+
+        $this->assertSame($container, $fixture->container);
+    }
+}

--- a/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/ContainerAwareFixture.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Fixtures/ContainerAwareFixture.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Tests\Bridge\Doctrine\Fixtures;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+
+class ContainerAwareFixture implements FixtureInterface, ContainerAwareInterface
+{
+    public $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    public function load(ObjectManager $manager)
+    {
+    }
+}


### PR DESCRIPTION
```
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3328 (PR was missing this test)
Todo: -
```

The test is skipped unless the optional `doctrine/data-fixtures` is available. I confirmed that it passes with it installed. Once this is merged, the DoctrineFixturesBundle will contain nothing more than a console command, which can be merged into DoctrineBundle.
