### PR TITLE
[FrameworkBundle] Added server:run command (PHP 5.4 built-in web server)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -28,7 +28,7 @@ class ServerRunCommand extends ContainerAwareCommand
      */
     public function isEnabled()
     {
-        if (PHP_VERSION_ID < 50400) {
+        if (version_compare(phpversion(), '5.4.0', '<')) {
             return false;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -47,9 +47,9 @@ class ServerRunCommand extends ContainerAwareCommand
                 new InputOption('router', 'r', InputOption::VALUE_REQUIRED, 'Path to custom router script'),
             ))
             ->setName('server:run')
-            ->setDescription('Runs Symfony2 application using PHP built-in web server')
+            ->setDescription('Runs PHP built-in web server')
             ->setHelp(<<<EOF
-The <info>%command.name%</info> runs Symfony2 application using PHP built-in web server:
+The <info>%command.name%</info> runs PHP built-in web server:
 
   <info>%command.full_name%</info>
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -94,8 +94,8 @@ EOF
         $builder->setWorkingDirectory($input->getOption('docroot'));
         $builder->setTimeout(null);
 
-        $process = $builder->getProcess()->run(function ($type, $buffer) {
-            echo $buffer;
+        $builder->getProcess()->run(function ($type, $buffer) use ($output) {
+            $output->write($buffer);
         });
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ServerRunCommand.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Runs Symfony2 application using PHP built-in web server
+ *
+ * @author Michał Pipa <michal.pipa.xsolve@gmail.com>
+ */
+class ServerRunCommand extends ContainerAwareCommand
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function isEnabled()
+    {
+        if (PHP_VERSION_ID < 50400) {
+            return false;
+        }
+
+        return parent::isEnabled();
+    }
+
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setDefinition(array(
+                new InputArgument('address', InputArgument::OPTIONAL, 'Address:port', 'localhost:8000'),
+                new InputOption('docroot', 'd', InputOption::VALUE_REQUIRED, 'Document root', 'web/'),
+                new InputOption('router', 'r', InputOption::VALUE_REQUIRED, 'Path to custom router script'),
+            ))
+            ->setName('server:run')
+            ->setDescription('Runs Symfony2 application using PHP built-in web server')
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> runs Symfony2 application using PHP built-in web server:
+
+  <info>%command.full_name%</info>
+
+To change default bind address and port use the <info>address</info> argument:
+
+  <info>%command.full_name% 127.0.0.1:8080</info>
+
+To change default docroot directory use the <info>--docroot</info> option:
+
+  <info>%command.full_name% --docroot=htdocs/</info>
+
+If you have custom docroot directory layout, you can specify your own
+router script using <info>--router</info> option:
+
+  <info>%command.full_name% --router=app/config/router.php</info>
+
+See also: http://www.php.net/manual/en/features.commandline.webserver.php
+EOF
+            )
+        ;
+    }
+
+    /**
+     * @see Command
+     *
+     * @throws \InvalidArgumentException When the docroot directory does not exist
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $docroot = $input->getOption('docroot');
+
+        if (@!chdir($docroot)) {
+            throw new \InvalidArgumentException(sprintf(
+                'Unable to change directory to %s',
+                $docroot
+            ));
+        }
+
+        $router = $input->getOption('router') ?: $this
+            ->getContainer()
+            ->get('kernel')
+            ->locateResource('@FrameworkBundle/Resources/config/router.php')
+        ;
+
+        $command = escapeshellcmd(
+            sprintf(
+                '%s -S %s %s',
+                PHP_BINARY,
+                $input->getArgument('address'),
+                $router
+            )
+        );
+
+        proc_open(
+            $command,
+            array(
+                0 => STDIN,
+                1 => STDOUT,
+                2 => STDERR
+            ),
+            $pipes
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
@@ -23,5 +23,12 @@
 if (isset($_SERVER['SCRIPT_FILENAME'])) {
     return false;
 } else {
-    require 'app.php';
+    $controller = 'app.php';
+
+    $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT']
+        . DIRECTORY_SEPARATOR
+        . $controller
+    ;
+
+    require $controller;
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/*
+ * This file implements rewrite rules for PHP built-in web server.
+ *
+ * See: http://www.php.net/manual/en/features.commandline.webserver.php
+ *
+ * If you have custom directory layout, then you have to write your own router
+ * and pass it as a value to 'router' option of server:run command.
+ *
+ * @author: Michał Pipa <michal.pipa.xsolve@gmail.com>
+ */
+
+if (isset($_SERVER['SCRIPT_FILENAME'])) {
+    return false;
+} else {
+    require 'app.php';
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
@@ -23,12 +23,10 @@
 if (isset($_SERVER['SCRIPT_FILENAME'])) {
     return false;
 } else {
-    $controller = 'app.php';
-
     $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT']
         . DIRECTORY_SEPARATOR
-        . $controller
+        . 'app.php'
     ;
 
-    require $controller;
+    require 'app.php';
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/michal-pipa/symfony.png?branch=server)](http://travis-ci.org/michal-pipa/symfony)
Fixes the following tickets: -
Todo: -

PHP 5.4 comes with [built-in web server](http://www.php.net/manual/en/features.commandline.webserver.php). I've created command which allows to easily run Symfony2 application using this new feature.

```
Usage:
 server:run [-d|--docroot="..."] [-r|--router="..."] [address]

Arguments:
 address        Address:port (default: 'localhost:8000')

Options:
 --docroot (-d) Document root (default: 'web/')
 --router (-r)  Path to custom router script

Help:
 The server:run runs Symfony2 application using PHP built-in web server:

   app/console server:run

 To change default bind address and port use the address argument:

   app/console server:run 127.0.0.1:8080

 To change default docroot directory use the --docroot option:

   app/console server:run --docroot=htdocs/

 If you have custom docroot directory layout, you can specify your own
 router script using --router option:

   app/console server:run --router=app/config/router.php

 See also: http://www.php.net/manual/en/features.commandline.webserver.php
```

It requires PHP 5.4, otherwise this command will be disabled.

I think that this is very convenient (especially for new users). All you have to do is download Symfony, install vendors and run this command. You don't have to configure "real" web server, in fact any other server is not required. You don't have cache and logs permission problem, because server runs with your local user permissions.
