### PR TITLE
[Form] When there are no choices it should give back an empty array.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoader.php
@@ -69,6 +69,10 @@ class ORMQueryBuilderLoader implements EntityLoaderInterface
      */
     public function getEntitiesByIds($identifier, array $values)
     {
+        if (empty($values)) {
+            return array();
+        }
+
         $qb = clone ($this->queryBuilder);
         $alias = current($qb->getRootAliases());
         $parameter = 'ORMQueryBuilderLoader_getEntitiesByIds_'.$identifier;

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -51,10 +51,6 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($array, 'array');
         }
 
-        if (empty($array)){
-            return array();
-        }
-
         return $this->choiceList->getValuesForChoices($array);
     }
 
@@ -73,10 +69,6 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
 
         if (!is_array($array)) {
             throw new UnexpectedTypeException($array, 'array');
-        }
-        
-        if (empty($array)){
-            return array();
         }
 
         $choices = $this->choiceList->getChoicesForValues($array);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -63,7 +63,7 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
      */
     public function reverseTransform($array)
     {
-        if (null === $array) {
+        if (null === $array || empty($array)) {
             return array();
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -51,6 +51,10 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
             throw new UnexpectedTypeException($array, 'array');
         }
 
+        if (empty($array)){
+            return array();
+        }
+
         return $this->choiceList->getValuesForChoices($array);
     }
 
@@ -63,12 +67,16 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
      */
     public function reverseTransform($array)
     {
-        if (null === $array || empty($array)) {
+        if (null === $array) {
             return array();
         }
 
         if (!is_array($array)) {
             throw new UnexpectedTypeException($array, 'array');
+        }
+        
+        if (empty($array)){
+            return array();
         }
 
         $choices = $this->choiceList->getChoicesForValues($array);

--- a/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
+++ b/tests/Symfony/Tests/Bridge/Doctrine/Form/ChoiceList/ORMQueryBuilderLoaderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Bridge\Doctrine\Form\ChoiceList;
+
+require_once __DIR__.'/../../DoctrineOrmTestCase.php';
+require_once __DIR__.'/../../Fixtures/ItemGroupEntity.php';
+require_once __DIR__.'/../../Fixtures/SingleIdentEntity.php';
+require_once __DIR__.'/../../Fixtures/NoToStringSingleIdentEntity.php';
+
+use Symfony\Tests\Bridge\Doctrine\DoctrineOrmTestCase;
+use Symfony\Tests\Bridge\Doctrine\Fixtures\ItemGroupEntity;
+use Symfony\Tests\Bridge\Doctrine\Fixtures\SingleIdentEntity;
+use Symfony\Tests\Bridge\Doctrine\Fixtures\NoToStringSingleIdentEntity;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
+use Symfony\Bridge\Doctrine\Form\ChoiceList\ORMQueryBuilderLoader;
+use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+use Doctrine\ORM\Tools\SchemaTool;
+
+class ORMQueryBuilderLoaderTest extends DoctrineOrmTestCase
+{
+    const SINGLE_IDENT_CLASS = 'Symfony\Tests\Bridge\Doctrine\Fixtures\SingleIdentEntity';
+
+    public function testValues()
+    {
+        $class = self::SINGLE_IDENT_CLASS;
+
+        $em = $this->createTestEntityManager();
+        $this->createSchema($em,$class);
+
+        $entity = new $class(1, 1, 'user1');
+
+        $em->persist($entity);
+        $em->flush();
+
+        $repository = $em->getRepository(self::SINGLE_IDENT_CLASS);
+
+        $loader = new ORMQueryBuilderLoader(
+            $repository->createQueryBuilder('o'),
+            $em,
+            self::SINGLE_IDENT_CLASS
+        );
+
+        $this->assertEquals(array($entity), $loader->getEntitiesByIds('id',array(1)));
+    }
+
+    public function testEmptyValues()
+    {
+        $class = self::SINGLE_IDENT_CLASS;
+        $em = $this->createTestEntityManager();
+        $this->createSchema($em,$class);
+
+        $repository = $em->getRepository(self::SINGLE_IDENT_CLASS);
+
+        $loader = new ORMQueryBuilderLoader(
+            $repository->createQueryBuilder('o'),
+            $em,
+            self::SINGLE_IDENT_CLASS
+        );
+
+        $this->assertEquals(array(), $loader->getEntitiesByIds('id',array()));
+    }
+
+    private function createSchema($em,$class)
+    {
+        $schemaTool = new SchemaTool($em);
+        $schemaTool->createSchema(array(
+            $em->getClassMetadata($class),
+        ));
+    }
+}


### PR DESCRIPTION
It's causing problems otherwise.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
