### PR TITLE
[FrameworkBundle] Fixed test on Ubuntu 10.04 LTS

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/HttpKernelTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/HttpKernelTest.php
@@ -169,8 +169,8 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
 
     public function testExceptionInSubRequestsDoesNotMangleOutputBuffers()
     {
-        if (version_compare(phpversion(), "5.3.2", "<=")) {
-            $this->markTestSkipped('Test fails with PHP5.3.2 due to https://bugs.php.net/bug.php?id=50563');
+        if (version_compare(phpversion(), '5.3.3', '<')) {
+            $this->markTestSkipped('Test fails with PHP 5.3.2 due to https://bugs.php.net/bug.php?id=50563');
         }
 
         $request = new Request();


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/michal-pipa/symfony.png?branch=test-fix)](http://travis-ci.org/michal-pipa/symfony)
Fixes the following tickets: -
Todo: -

Test was failing on Ubuntu 10.04 LTS because Ubuntu adds it's own PHP extra version number, which was greater than 5.3.2.

The same bug exist in master branch.
