### PR TITLE
Allow people to set the error level, this is especially important when d...

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -56,6 +56,7 @@ abstract class Kernel implements KernelInterface
     protected $name;
     protected $startTime;
     protected $classes;
+    protected $errorReportingLevel;
 
     const VERSION = '2.0.11';
 
@@ -90,7 +91,7 @@ abstract class Kernel implements KernelInterface
             error_reporting(-1);
 
             DebugUniversalClassLoader::enable();
-            ErrorHandler::register();
+            ErrorHandler::register($this->errorReportingLevel);
             if ('cli' !== php_sapi_name()) {
                 ExceptionHandler::register();
             }


### PR DESCRIPTION
...ealing with misbehaving libraries as part of legacy integrations.

Usage would be to extend the Kernel, and set the errorReportingLevel prior to calling parent::__construct(). Not ideal, but this doesn't break BC and allows the user to defer the decision as late as possible. This can/should be handled better in 2.1.x
