### PR TITLE
[Form] label path in ObjectChoiceList can also be callable

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -73,7 +73,7 @@ class ObjectChoiceList extends ChoiceList
      *                          for the choice labels. The value is obtained
      *                          by calling the getter on the object. You can
      *                          also pass any callable. When callable will be
-     *                          executed it wil get the choice parameter passed.
+     *                          executed it will get the choice parameter passed.
      *                          If the path is NULL, the object's __toString()
      *                          method is used instead.
      * @param array $preferredChoices A flat array of choices that should be
@@ -200,8 +200,6 @@ class ObjectChoiceList extends ChoiceList
 
     private function extractLabels($choices, array &$labels)
     {
-        $callable = is_callable($this->labelPath) ? $this->labelPath : false;
-
         foreach ($choices as $i => $choice) {
             if (is_array($choice) || $choice instanceof \Traversable) {
                 $labels[$i] = array();
@@ -209,7 +207,7 @@ class ObjectChoiceList extends ChoiceList
             } elseif ($this->labelPath instanceof PropertyPath) {
                 $labels[$i] = $this->labelPath->getValue($choice);
             } elseif (is_callable($this->labelPath)) {
-                $labels[$i] = $callable($choice);
+                $labels[$i] = call_user_func($this->labelPath, $choice);
             } elseif (method_exists($choice, '__toString')) {
                 $labels[$i] = (string) $choice;
             } else {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
@@ -45,10 +45,10 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
     {
         parent::setUp();
 
-        $this->obj1 = (object) array('name' => 'A');
-        $this->obj2 = (object) array('name' => 'B');
-        $this->obj3 = (object) array('name' => 'C');
-        $this->obj4 = (object) array('name' => 'D');
+        $this->obj1 = (object) array('name' => 'A', 'number' => 1);
+        $this->obj2 = (object) array('name' => 'B', 'number' => 2);
+        $this->obj3 = (object) array('name' => 'C', 'number' => 3);
+        $this->obj4 = (object) array('name' => 'D', 'number' => 4);
 
         $this->list = new ObjectChoiceList(
             array(
@@ -227,5 +227,17 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
         new ObjectChoiceList(
             array($this->obj1, $this->obj2, $this->obj3, $this->obj4)
         );
+    }
+
+    public function testCallableArray()
+    {
+        $this->list = new ObjectChoiceList(
+            array($this->obj1, $this->obj2, $this->obj3, $this->obj4),
+            function ($choice) {
+                return $choice->name . $choice->number;
+            }
+        );
+
+        $this->assertEquals(array(0 => new ChoiceView('0', 'A1'), 1 => new ChoiceView('1', 'B2'), 2 => new ChoiceView('2', 'C3'), 3 => new ChoiceView('3', 'D4')), $this->list->getRemainingViews());
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

This PR adds a callback support as additional option to label path in ObjectChoiceList class.

Right now you either have to set a property path to a property or a getter or implement __toString method in the objects you pass as choices to get the choice label. Usually this is ok, but sometimes you need to have different labels depending on where the choice filed is displayed, or __toString is used elsewhere for different purposes.

Usage example:

``` php
        $builder
            ->add('account', 'entity', array(
                'class' => 'xxx\Entity\Account',
                'property' => function ($entity) {
                    /** @var $entity xxx\Entity\Account */
                    $ret = '';
                    $ret .= $entity->getFirstName() . ' ';
                    $ret .= $entity->getLastName();

                    $ret .= $entity->getCompany() ? ' @ ' . $entity->getCompany() : '';

                    return $ret;

                },
            ))
```
