### PR TITLE
[WebProfilerBundle] Router panel: take the request method into account

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -41,7 +41,10 @@ class RouterController extends ContainerAware
 
         $profile = $profiler->loadProfile($token);
 
-        $matcher = new TraceableUrlMatcher($router->getRouteCollection(), $router->getContext());
+        $context = $router->getContext();
+        $context->setMethod($profile->getMethod());
+        $matcher = new TraceableUrlMatcher($router->getRouteCollection(), $context);
+        
         $request = $profile->getCollector('request');
 
         return $this->container->get('templating')->renderResponse('WebProfilerBundle:Router:panel.html.twig', array(


### PR DESCRIPTION
Before this change we were always using the default method (i.e. 'GET').
