### PR TITLE
[Process] PHP_BINARY only return the current sapi process

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -33,7 +33,8 @@ class PhpExecutableFinder
      */
     public function find()
     {
-        if (defined('PHP_BINARY') && PHP_BINARY && ('php' === pathinfo(PHP_BINARY, PATHINFO_FILENAME))) {
+        // PHP_BINARY return the current sapi executable
+        if (defined('PHP_BINARY') && PHP_BINARY && ('cli' === PHP_SAPI)) {
             return PHP_BINARY;
         }
 

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -33,7 +33,7 @@ class PhpExecutableFinder
      */
     public function find()
     {
-        if (defined('PHP_BINARY') && PHP_BINARY) {
+        if (defined('PHP_BINARY') && PHP_BINARY && ('php' === pathinfo(PHP_BINARY, PATHINFO_FILENAME))) {
             return PHP_BINARY;
         }
 


### PR DESCRIPTION
```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```

PHP_BINARY return the current process, so under the apache module I get (on Windows) `httpd.exe`
