### PR TITLE
[HttpKernel] Bundle meta for extensions and compiler passes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -519,10 +519,11 @@ class FrameworkExtension extends Extension
 
             // Discover translation directories
             $dirs = array();
-            foreach ($container->getParameter('kernel.bundles') as $bundle) {
-                $reflection = new \ReflectionClass($bundle);
-                if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/translations')) {
-                    $dirs[] = $dir;
+            $bundlesMeta = $container->getParameter('kernel.bundles_meta');
+            foreach ($container->getParameter('kernel.bundles') as $name => $bundle) {
+                $bundleMeta = $bundlesMeta[$name];
+                if (isset($bundleMeta['translations_path']) && is_dir($bundleMeta['translations_path'])) {
+                    $dirs[] = $bundleMeta['translations_path'];
                 }
             }
             if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/translations')) {
@@ -582,9 +583,10 @@ class FrameworkExtension extends Extension
         $files = array(dirname($reflClass->getFileName()).'/Resources/config/validation.xml');
         $container->addResource(new FileResource($files[0]));
 
-        foreach ($container->getParameter('kernel.bundles') as $bundle) {
-            $reflection = new \ReflectionClass($bundle);
-            if (is_file($file = dirname($reflection->getFilename()).'/Resources/config/validation.xml')) {
+        $bundlesMeta = $container->getParameter('kernel.bundles_meta');
+        foreach ($container->getParameter('kernel.bundles') as $name => $bundle) {
+            $bundleMeta = $bundlesMeta[$name];
+            if (isset($bundleMeta['config_path']) && is_file($file = $bundleMeta['config_path'].'/validation.xml')) {
                 $files[] = realpath($file);
                 $container->addResource(new FileResource($file));
             }
@@ -597,9 +599,10 @@ class FrameworkExtension extends Extension
     {
         $files = array();
 
-        foreach ($container->getParameter('kernel.bundles') as $bundle) {
-            $reflection = new \ReflectionClass($bundle);
-            if (is_file($file = dirname($reflection->getFilename()).'/Resources/config/validation.yml')) {
+        $bundlesMeta = $container->getParameter('kernel.bundles_meta');
+        foreach ($container->getParameter('kernel.bundles') as $name => $bundle) {
+            $bundleMeta = $bundlesMeta[$name];
+            if (isset($bundleMeta['config_path']) && is_file($file = $bundleMeta['config_path'].'/validation.yml')) {
                 $files[] = realpath($file);
                 $container->addResource(new FileResource($file));
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -251,8 +251,11 @@ abstract class FrameworkExtensionTest extends TestCase
     {
         require_once __DIR__."/Fixtures/TestBundle/TestBundle.php";
 
+        $bundle = new \Symfony\Bundle\FrameworkBundle\Tests\TestBundle();
+
         $container = $this->createContainerFromFile('validation_annotations', array(
             'kernel.bundles' => array('TestBundle' => 'Symfony\Bundle\FrameworkBundle\Tests\TestBundle'),
+            'kernel.bundles_meta' => array('TestBundle' => $bundle->getMeta())
         ));
 
         $yamlArgs = $container->getParameter('validator.mapping.loader.yaml_files_loader.mapping_files');
@@ -267,8 +270,13 @@ abstract class FrameworkExtensionTest extends TestCase
 
     protected function createContainer(array $data = array())
     {
+        $bundle = new \Symfony\Bundle\FrameworkBundle\FrameworkBundle();
+
         return new ContainerBuilder(new ParameterBag(array_merge(array(
             'kernel.bundles'          => array('FrameworkBundle' => 'Symfony\\Bundle\\FrameworkBundle\\FrameworkBundle'),
+            'kernel.bundles_meta'     => array(
+                'FrameworkBundle' => $bundle->getMeta(),
+            ),
             'kernel.cache_dir'        => __DIR__,
             'kernel.compiled_classes' => array(),
             'kernel.debug'            => false,

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -130,6 +130,27 @@ abstract class Bundle extends ContainerAware implements BundleInterface
     }
 
     /**
+     * Gets the Bundle meta array.
+     *
+     * @return array The Bundle meta information hash
+     *
+     * @api
+     */
+    public function getMeta()
+    {
+        return array(
+            'bundle_path'       => $this->getPath(),
+            'resources_path'    => $this->getPath().'/Resources',
+            'meta_path'         => $this->getPath().'/Resources/meta',
+            'config_path'       => $this->getPath().'/Resources/config',
+            'doc_path'          => $this->getPath().'/Resources/doc',
+            'translations_path' => $this->getPath().'/Resources/translations',
+            'views_path'        => $this->getPath().'/Resources/views',
+            'public_path'       => $this->getPath().'/Resources/public'
+        );
+    }
+
+    /**
      * Returns the bundle parent name.
      *
      * @return string The Bundle parent name it overrides or null if no parent

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -93,4 +93,13 @@ interface BundleInterface
      * @api
      */
     function getPath();
+
+    /**
+     * Gets the Bundle meta information, that could be used in extensions and compiler passes.
+     *
+     * @return array The Bundle meta information hash
+     *
+     * @api
+     */
+    function getMeta();
 }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -583,8 +583,10 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected function getKernelParameters()
     {
         $bundles = array();
+        $bundlesMeta = array();
         foreach ($this->bundles as $name => $bundle) {
             $bundles[$name] = get_class($bundle);
+            $bundlesMeta[$name] = $bundle->getMeta();
         }
 
         return array_merge(
@@ -596,6 +598,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 'kernel.cache_dir'       => $this->getCacheDir(),
                 'kernel.logs_dir'        => $this->getLogDir(),
                 'kernel.bundles'         => $bundles,
+                'kernel.bundles_meta'    => $bundlesMeta,
                 'kernel.charset'         => 'UTF-8',
                 'kernel.container_class' => $this->getContainerClass(),
             ),


### PR DESCRIPTION
```
Bug fix: no
Feature addition: no
Backwards compatibility break: yes (only if someone used `BundleInterface` instead of extending base `Bundle` class)
Symfony2 tests pass: yes
```

This PR introduces new method to the `BundleInterface` - `getMeta()`.
This method returns meta information related to bundle, like `resources_path` or `translations_path`,
that could be used inside extension or compiler pass classes as `Kernel::getParameters()` now
returns special `kernel.bundles_meta` array in addition to `kernel.bundles`.

Before this change, there was no ability to get predefined in `getPath()` bundle path in extensions or
compiler passes, so bundle developers finished doing something like this:
https://github.com/symfony/AsseticBundle/blob/master/DependencyInjection/Compiler/TemplateResourcesPass.php#L35-42
https://github.com/symfony/FrameworkBundle/blob/master/DependencyInjection/FrameworkExtension.php#L515-518

We had hardcoded paths to the bundle resources and even worse, restricted bundle class to live
inside bundle folder. But in some cases, it's not an option (RadBundle ?).

Anyway, we think that this change will lead to much cleaner and extensible bundles interface
in future.

If this PR will be accepted, i will adapt 3rd-party bundles to this new `kernel.bundles_meta`
stuff.
