### PR TITLE
[Form] Stop automatic left '0' str_padding on the 'days' field on a date choice widget.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -83,7 +83,7 @@ class DateType extends AbstractType
                     $months[$month] = str_pad($month, 2, '0', STR_PAD_LEFT);
                 }
                 foreach ($options['days'] as $day) {
-                    $days[$day] = str_pad($day, 2, '0', STR_PAD_LEFT);
+                    $days[$day] = str_pad($day, 0, '0', STR_PAD_LEFT);
                 }
 
                 // Only pass a subset of the options to children


### PR DESCRIPTION
Can't see of any other way of disabling this otherwise?

(Doesn't respect format=>'MMMM-d-y' like date 'single_text' widget, although it probably should...?)
