### PR TITLE
[HttpKernel] Modified Memcache(d)ProfilerStorage dsn to be more intuitive

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -34,7 +34,7 @@ class FileProfilerStorage implements ProfilerStorageInterface
     public function __construct($dsn)
     {
         if (0 !== strpos($dsn, 'file:')) {
-            throw new \InvalidArgumentException("FileStorage DSN must start with file:");
+            throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use FileStorage with an invalid dsn "%s". The expected format is "file:/path/to/the/storage/folder".', $this->dsn));
         }
         $this->folder = substr($dsn, 5);
 

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -34,12 +34,12 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
     protected function getMemcache()
     {
         if (null === $this->memcache) {
-            if (!preg_match('#^memcache://(.*)/(.*)$#', $this->dsn, $matches)) {
-                throw new \RuntimeException('Please check your configuration. You are trying to use Memcache with an invalid dsn. "' . $this->dsn . '"');
+            if (!preg_match('#^memcache://(?(?=\[.*\])\[(.*)\]|(.*)):(.*)$#', $this->dsn, $matches)) {
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Memcache with an invalid dsn "%s". The expected format is "memcache://[host]:port".', $this->dsn));
             }
 
-            $host = $matches[1];
-            $port = $matches[2];
+            $host = $matches[1] ?: $matches[2];
+            $port = $matches[3];
 
             $memcache = new Memcache;
             $memcache->addServer($host, $port);

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -34,12 +34,12 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
     protected function getMemcached()
     {
         if (null === $this->memcached) {
-            if (!preg_match('#^memcached://(.*)/(.*)$#', $this->dsn, $matches)) {
-                throw new \RuntimeException('Please check your configuration. You are trying to use Memcached with an invalid dsn. "' . $this->dsn . '"');
+            if (!preg_match('#^memcached://(?(?=\[.*\])\[(.*)\]|(.*)):(.*)$#', $this->dsn, $matches)) {
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Memcached with an invalid dsn "%s". The expected format is "memcached://[host]:port".', $this->dsn));
             }
 
-            $host = $matches[1];
-            $port = $matches[2];
+            $host = $matches[1] ?: $matches[2];
+            $port = $matches[3];
 
             $memcached = new Memcached;
 

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -119,7 +119,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
                 $collection = $matches[3];
                 $this->mongo = $mongo->selectCollection($database, $collection);
             } else {
-                throw new \RuntimeException('Please check your configuration. You are trying to use MongoDB with an invalid dsn. "'.$this->dsn.'"');
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use MongoDB with an invalid dsn "%s". The expected format is "mongodb://user:pass@location/database/collection"', $this->dsn));
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/MysqlProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MysqlProfilerStorage.php
@@ -25,7 +25,7 @@ class MysqlProfilerStorage extends PdoProfilerStorage
     {
         if (null === $this->db) {
             if (0 !== strpos($this->dsn, 'mysql')) {
-                throw new \RuntimeException('Please check your configuration. You are trying to use Mysql with a wrong dsn. "'.$this->dsn.'"');
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Mysql with an invalid dsn "%s". The expected format is "mysql:dbname=database_name;host=host_name".', $this->dsn));
             }
 
             if (!class_exists('PDO') || !in_array('mysql', \PDO::getAvailableDrivers(), true)) {

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -190,7 +190,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     {
         if (null === $this->redis) {
             if (!preg_match('#^redis://(?(?=\[.*\])\[(.*)\]|(.*)):(.*)$#', $this->dsn, $matches)) {
-                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Redis with an invalid dsn. "%s". The expected format is redis://host:port, redis://127.0.0.1:port, redis://[::1]:port', $this->dsn));
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Redis with an invalid dsn "%s". The expected format is "redis://[host]:port".', $this->dsn));
             }
 
             $host = $matches[1] ?: $matches[2];

--- a/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/SqliteProfilerStorage.php
@@ -26,7 +26,7 @@ class SqliteProfilerStorage extends PdoProfilerStorage
     {
         if (null === $this->db || $this->db instanceof \SQLite3) {
             if (0 !== strpos($this->dsn, 'sqlite')) {
-                throw new \RuntimeException('You are trying to use Sqlite with a wrong dsn. "'.$this->dsn.'"');
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Sqlite with an invalid dsn "%s". The expected format is "sqlite:/path/to/the/db/file".', $this->dsn));
             }
             if (class_exists('SQLite3')) {
                 $db = new \SQLite3(substr($this->dsn, 7, strlen($this->dsn)), \SQLITE3_OPEN_READWRITE | \SQLITE3_OPEN_CREATE);

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcacheProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcacheProfilerStorageTest.php
@@ -42,7 +42,7 @@ class MemcacheProfilerStorageTest extends AbstractProfilerStorageTest
             $this->markTestSkipped('MemcacheProfilerStorageTest requires that the extension memcache is loaded');
         }
 
-        self::$storage = new DummyMemcacheProfilerStorage('memcache://127.0.0.1/11211', '', '', 86400);
+        self::$storage = new DummyMemcacheProfilerStorage('memcache://127.0.0.1:11211', '', '', 86400);
         try {
             self::$storage->getMemcache();
             $stats = self::$storage->getMemcache()->getExtendedStats();

--- a/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcachedProfilerStorageTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/Profiler/MemcachedProfilerStorageTest.php
@@ -42,7 +42,7 @@ class MemcachedProfilerStorageTest extends AbstractProfilerStorageTest
             $this->markTestSkipped('MemcachedProfilerStorageTest requires that the extension memcached is loaded');
         }
 
-        self::$storage = new DummyMemcachedProfilerStorage('memcached://127.0.0.1/11211', '', '', 86400);
+        self::$storage = new DummyMemcachedProfilerStorage('memcached://127.0.0.1:11211', '', '', 86400);
         try {
             self::$storage->getMemcached();
         } catch (\Exception $e) {


### PR DESCRIPTION
Bug fix: no
Feature addition: -
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Before:

```
#app/config/config_dev.yml
...
framework:
    ...
    profiler:
        ...
        dsn: memcache://127.0.0.1/11211
...
```

Now:

```
#app/config/config_dev.yml
...
framework:
    ...
    profiler:
        ...
        dsn: memcache://127.0.0.1:11211
...
```

If Memcache host is IPv6 address:

```
#app/config/config_dev.yml
...
framework:
    ...
    profiler:
        ...
        dsn: memcache://[::1]:11211
...
```

I changed texts of some exceptions to be more consistent, too.
