### PR TITLE
Fix form get parent default options 2 0

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -220,15 +220,20 @@ class FormFactory implements FormFactoryInterface
 
         while (null !== $type) {
             if ($type instanceof FormTypeInterface) {
-                if ($type->getName() == $type->getParent($options)) {
-                    throw new FormException(sprintf('The form type name "%s" for class "%s" cannot be the same as the parent type.', $type->getName(), get_class($type)));
-                }
-
                 $this->addType($type);
             } elseif (is_string($type)) {
                 $type = $this->getType($type);
             } else {
                 throw new UnexpectedTypeException($type, 'string or Symfony\Component\Form\FormTypeInterface');
+            }
+
+            $options = array_replace($type->getDefaultOptions($options), $options);
+            foreach ($type->getExtensions() as $typeExtension) {
+                $options = array_replace($options, $typeExtension->getDefaultOptions($options));
+            }
+
+            if ($type->getName() == $type->getParent($options)) {
+                throw new FormException(sprintf('The form type name "%s" for class "%s" cannot be the same as the parent type.', $type->getName(), get_class($type)));
             }
 
             $defaultOptions = $type->getDefaultOptions($options);

--- a/tests/Symfony/Tests/Component/Form/Fixtures/FooChildType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/FooChildType.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FooChildType extends AbstractType
+{
+    public function getName()
+    {
+        return 'foo_child';
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        return array(
+            'parent' => new FooParentType(),
+        );
+    }
+
+    public function getParent(array $options)
+    {
+        return new FooType();
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Fixtures/FooParentType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/FooParentType.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FooParentType extends AbstractType
+{
+    public function getName()
+    {
+        return 'foo_parent';
+    }
+
+    public function getParent(array $options)
+    {
+        return null;
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Fixtures/FooType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/FooType.php
@@ -32,6 +32,7 @@ class FooType extends AbstractType
             'required' => false,
             'max_length' => null,
             'a_or_b' => 'a',
+            'parent' => null
         );
     }
 
@@ -44,6 +45,6 @@ class FooType extends AbstractType
 
     public function getParent(array $options)
     {
-        return null;
+        return $options['parent'];
     }
 }

--- a/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Tests\Component\Form\Fixtures\TestExtension;
 use Symfony\Tests\Component\Form\Fixtures\FooType;
+use Symfony\Tests\Component\Form\Fixtures\FooChildType;
 use Symfony\Tests\Component\Form\Fixtures\FooTypeBarExtension;
 use Symfony\Tests\Component\Form\Fixtures\FooTypeBazExtension;
 
@@ -482,6 +483,17 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals('builderInstance', $builder);
+    }
+
+    public function testChildDefaultOptionIsPassedToChildsGetParentMethod()
+    {
+        $type = new FooChildType();
+
+        $builder = $this->factory->createNamedBuilder($type, 'foo_child');
+        $this->assertEquals(3, count($builder->getTypes()));
+
+        $builder = $this->factory->createNamedBuilder($type, 'foo_child', null, array('parent'=>null));
+        $this->assertEquals(2, count($builder->getTypes()));
     }
 
     private function createMockFactory(array $methods = array())


### PR DESCRIPTION
...alling the parent's getParent() method

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: Yes
Fixes the following tickets: -

I ran into the following situation:

I defined a new Form Type, which extends the choice type. Since this new Form Type always needs to be expanded and multiple, I overrode these options in the getDefaultOptionsMethod().

These options were passed into the buildForm method of the choice type just fine, but not into the getParent() method of the choice type.

The result of this was that the parent of the choice type became "field" rather than "form", and even though the checkbox list is rendered fine, and even posts the correct values on submit, the checkbox list is not actually filled before show - all checkboxes are empty. This is because the datamapper on this specific form is not set, since this only happens for types with parent 'form'.

This PR makes sure the default options of the child type are passed to the getParent() method of the parent type.
