### PR TITLE
[SecurityBundle] Avoid direct request dependency in LogoutUrlHelper

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/templating_php.xml
@@ -12,7 +12,7 @@
     <services>
         <service id="templating.helper.logout_url" class="%templating.helper.logout_url.class%">
             <tag name="templating.helper" alias="logout_url" />
-            <argument type="service" id="request" strict="false" />
+            <argument type="service" id="service_container" />
             <argument type="service" id="router" />
         </service>
 

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Bundle\SecurityBundle\Templating\Helper;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Templating\Helper\Helper;
 
@@ -23,19 +23,19 @@ use Symfony\Component\Templating\Helper\Helper;
  */
 class LogoutUrlHelper extends Helper
 {
+    private $container;
     private $listeners;
-    private $request;
     private $router;
 
     /**
      * Constructor.
      *
-     * @param Request               $request A request instance
-     * @param UrlGeneratorInterface $router  A Router instance
+     * @param ContainerInterface    $container A ContainerInterface instance
+     * @param UrlGeneratorInterface $router    A Router instance
      */
-    public function __construct(Request $request, UrlGeneratorInterface $router)
+    public function __construct(ContainerInterface $container, UrlGeneratorInterface $router)
     {
-        $this->request = $request;
+        $this->container = $container;
         $this->router = $router;
         $this->listeners = array();
     }
@@ -95,7 +95,9 @@ class LogoutUrlHelper extends Helper
         $parameters = null !== $csrfProvider ? array($csrfParameter => $csrfProvider->generateCsrfToken($intention)) : array();
 
         if ('/' === $logoutPath[0]) {
-            $url = ($absolute ? $this->request->getUriForPath($logoutPath) : $this->request->getBasePath() . $logoutPath);
+            $request = $this->container->get('request');
+
+            $url = ($absolute ? $request->getUriForPath($logoutPath) : $request->getBasePath() . $logoutPath);
 
             if (!empty($parameters)) {
                 $url .= '?' . http_build_query($parameters);


### PR DESCRIPTION
This quickly addresses the problem when the helper is constructed in a console environment without request scope. Ideally, the helper should be able to construct the absolute logout URL using data already available in the UrlGenerator's RequestContext and the $_SERVER environment variable; however, that will require copying some code from the Request class to create a base URI and path.

Fixes #3508

[![Build Status](https://secure.travis-ci.org/jmikola/symfony.png?branch=master)](http://travis-ci.org/jmikola/symfony)
