### PR TITLE
[Form] made sure the child type default options are passed to the parent when...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -51,6 +51,7 @@ abstract class DoctrineType extends AbstractType
             'query_builder'     => null,
             'loader'            => null,
             'group_by'          => null,
+            'choices'           => null,
         );
 
         $options = array_replace($defaultOptions, $options);

--- a/tests/Symfony/Tests/Component/Form/Fixtures/FooChildType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/FooChildType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FooChildType extends AbstractType
+{
+
+    public function getName()
+    {
+        return 'foo_child';
+    }
+
+    public function getParent(array $options)
+    {
+        return new FooType();
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        return array(
+            'parent' => new FooParentType()
+        );
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Fixtures/FooParentType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/FooParentType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FooParentType extends AbstractType
+{
+
+    public function getName()
+    {
+        return 'foo_parent';
+    }
+    
+    public function getParent(array $options)
+    {
+        return null;
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/Fixtures/FooType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/FooType.php
@@ -32,6 +32,7 @@ class FooType extends AbstractType
             'required' => false,
             'max_length' => null,
             'a_or_b' => 'a',
+            'parent' => null
         );
     }
 
@@ -44,6 +45,6 @@ class FooType extends AbstractType
 
     public function getParent(array $options)
     {
-        return null;
+        return $options['parent'];
     }
 }

--- a/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Form\Guess\TypeGuess;
 use Symfony\Tests\Component\Form\Fixtures\TestExtension;
 use Symfony\Tests\Component\Form\Fixtures\FooType;
+use Symfony\Tests\Component\Form\Fixtures\FooChildType;
 use Symfony\Tests\Component\Form\Fixtures\FooTypeBarExtension;
 use Symfony\Tests\Component\Form\Fixtures\FooTypeBazExtension;
 
@@ -529,6 +530,17 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             '"translation_domain", "empty_data"'
         );
         $factory->createNamedBuilder($type, "text", "value", array("unknown" => "opt"));
+    }
+    
+    public function testChildDefaultOptionIsPassedToChildsGetParentMethod()
+    {
+        $type = new FooChildType();
+
+        $builder = $this->factory->createNamedBuilder($type, 'foo_child');
+        $this->assertEquals(3, count($builder->getTypes()));
+
+        $builder = $this->factory->createNamedBuilder($type, 'foo_child', null, array('parent'=>null));
+        $this->assertEquals(2, count($builder->getTypes()));
     }
 
     private function createMockFactory(array $methods = array())


### PR DESCRIPTION
...calling the parent's getParent() method

Bug fix: Yes
Feature addition: No
Backwards compatibility break: Reverts an older BC-break
Symfony2 tests pass: Yes
Fixes the following tickets: #3694, #3354, #3753

With the merge of 88ef52d2, a bug was introduced which I keep running into and also generated some issues: #3694, #3354, #3753

A good example of the bug is when you define a new Form Type which defines 'choice' as its parent and have it return 'expanded'=true and 'multiple'=true from the getDefaultOptions() method.

The buildForm of ChoiceType receives these options as expected and therefore adds a list of checkboxes to itself. The getParent method, on the other hand, does not receive these options. In fact, it doesn't receive a value for 'expanded' at all, so it just "guesses" the value to be false, after which it returns 'field' rather than 'form' as its parent. Because of this, a datamapper is never set to the form element, causing all the checkboxes to remain empty, even if you pass a value to it.

Other cases can be found in the issues mentioned above.

Basically the only workaround is to explicitly pass these options to the builder from within every controller and builder this type is used in, which of course results in a lot of non-DRY code.

This PR makes sure the options return from getDefaultOptions are passed to the getParent() method of the parent type and that all getDefaultOptions() methods get the default options of their children merged with the passed options, rather than its parents default options merged with passed options.
