### PR TITLE
[Form] Make transform methods public

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -947,7 +947,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @return string
      */
-    private function appToNorm($value)
+    public function appToNorm($value)
     {
         foreach ($this->normTransformers as $transformer) {
             $value = $transformer->transform($value);
@@ -963,7 +963,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @return mixed
      */
-    private function normToApp($value)
+    public function normToApp($value)
     {
         for ($i = count($this->normTransformers) - 1; $i >= 0; --$i) {
             $value = $this->normTransformers[$i]->reverseTransform($value);
@@ -979,7 +979,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @return string
      */
-    private function normToClient($value)
+    public function normToClient($value)
     {
         if (!$this->clientTransformers) {
             // Scalar values should always be converted to strings to
@@ -1001,7 +1001,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @return mixed
      */
-    private function clientToNorm($value)
+    public function clientToNorm($value)
     {
         if (!$this->clientTransformers) {
             return '' === $value ? null : $value;


### PR DESCRIPTION
Bug fix: No
Feature addition: Yes
Backwards compatibility break: No
Symfony2 tests pass: Yes
Fixes the following tickets: -

Especially when using the PRE_BIND and BIND_CLIENT_DATA listeners, it is very convenient to be use the transformers. I can fetch them using $form->getClientTransformers() and them looping over them, but that's just code duplication of what the form defines in it's private functions.

For example, someone enters country with ID 12, I fetch this in my listener, and want to create a new form element with a list of states in this country. I'd either have to inject the EntityManager into the listener, or use the transformers, to get the Country entity in order to fetch the states from it. The latter, IMO, is the best option, but since the transform methods are private, i have to rewrite them within my listener instead of being able to reuse Component code
