### PR TITLE
[DependencyInjection] Allow parsing of parameters near escaped percent signs

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -212,7 +212,12 @@ class ParameterBag implements ParameterBagInterface
 
         $self = $this;
 
-        return preg_replace_callback('/(?<!%)%([^%\s]+)%/', function ($match) use ($self, $resolving, $value) {
+        return preg_replace_callback('/%%|%([^%\s]+)%/', function ($match) use ($self, $resolving, $value) {
+            // skip %%
+            if (!isset($match[1])) {
+                return '%%';
+            }
+
             $key = strtolower($match[1]);
             if (isset($resolving[$key])) {
                 throw new ParameterCircularReferenceException(array_keys($resolving));

--- a/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/ParameterBag/ParameterBagTest.php
@@ -101,6 +101,12 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $bag = new ParameterBag(array('foo' => null));
         $this->assertSame(null, $bag->resolveValue('%foo%'), '->resolveValue() replaces arguments that are just a placeholder by their value without casting them to strings');
 
+        $bag = new ParameterBag(array('foo' => 'bar', 'baz' => '%%%foo% %foo%%% %%foo%% %%%foo%%%'));
+        $this->assertEquals('%%bar bar%% %%foo%% %%bar%%', $bag->resolveValue('%baz%'), '->resolveValue() replaces params placed besides escaped %');
+
+        $bag = new ParameterBag(array('baz' => '%%s?%%s'));
+        $this->assertEquals('%%s?%%s', $bag->resolveValue('%baz%'), '->resolveValue() is not replacing greedily');
+
         $bag = new ParameterBag(array());
         try {
             $bag->resolveValue('%foobar%');
@@ -169,7 +175,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolve
      */
-    public function testResolveUnespacesValue()
+    public function testResolveUnescapesValue()
     {
         $bag = new ParameterBag(array(
             'foo' => array('bar' => array('ding' => 'I\'m a bar %%foo %%bar')),


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no (unless someone relied on the buggy behavior..)
Symfony2 tests pass: yes
