### PR TITLE
[HttpFoundation] SPL on ParameterBag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\HttpFoundation;
  *
  * @api
  */
-class HeaderBag
+class HeaderBag implements \IteratorAggregate, \Countable
 {
     protected $headers;
     protected $cacheControl;
@@ -265,6 +265,26 @@ class HeaderBag
         unset($this->cacheControl[$key]);
 
         $this->set('Cache-Control', $this->getCacheControlHeader());
+    }
+
+    /**
+     * IteratorAggregate method for looping the instance
+     *
+     * @return array An array of parameters
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->headers);
+    }
+
+    /**
+     * Countable method returning the number of headers
+     *
+     * @return int Number of parameters held in the bag
+     */
+    public function count()
+    {
+        return count($this->headers);
     }
 
     protected function getCacheControlHeader()

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\HttpFoundation;
  *
  * @api
  */
-class ParameterBag
+class ParameterBag implements \IteratorAggregate, \Countable
 {
     /**
      * Parameter storage.
@@ -277,5 +277,25 @@ class ParameterBag
         }
 
         return filter_var($value, $filter, $options);
+    }
+
+    /**
+     * IteratorAggregate method for looping the instance
+     *
+     * @return array An array of parameters
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->parameters);
+    }
+
+    /**
+     * Countable method returning the number of key/val pairings
+     *
+     * @return int Number of parameters held in the bag
+     */
+    public function count()
+    {
+        return count($this->parameters);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -282,7 +282,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * IteratorAggregate method for looping the instance
      *
-     * @return array An array of parameters
+     * @return ArrayIterator An array of parameters wrapped in an ArrayIterator
      */
     public function getIterator()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBag.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\HttpFoundation\Session\Attribute;
 /**
  * This class relates to session attribute storage
  */
-class AttributeBag implements AttributeBagInterface
+class AttributeBag implements AttributeBagInterface, \IteratorAggregate, \Countable
 {
     private $name = 'attributes';
 
@@ -133,5 +133,25 @@ class AttributeBag implements AttributeBagInterface
         $this->attributes = array();
 
         return $return;
+    }
+
+    /**
+     *
+     *
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->attributes);
+    }
+
+    /**
+     *
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->attributes);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\HttpFoundation\Session\Flash;
  *
  * @author Drak <drak@zikula.org>
  */
-class FlashBag implements FlashBagInterface
+class FlashBag implements FlashBagInterface, \IteratorAggregate, \Countable
 {
     private $name = 'flashes';
 
@@ -154,5 +154,25 @@ class FlashBag implements FlashBagInterface
     public function clear()
     {
         return $this->all();
+    }
+
+    /**
+     * IteratorAggregate 
+     *
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->all());
+    }
+
+    /**
+     * 
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return count($this->flashes);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
  *
  * @api
  */
-class Session implements SessionInterface
+class Session implements SessionInterface, \IteratorAggregate, \Countable
 {
     /**
      * Storage driver.
@@ -259,5 +259,25 @@ class Session implements SessionInterface
     public function clearFlashes()
     {
        return $this->getBag('flashes')->clear();
+    }
+
+    /**
+     * IteratorAggregate method for looping through the session attributes
+     *
+     * @return ArrayIterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->storage->getBag('attributes')->all());
+    }
+
+    /**
+     * Get the number of attributes in the session
+     *
+     * @return int Number of attributes
+     */
+    public function count()
+    {
+        return count($this->storage->getBag('attributes')->all());
     }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/HeaderBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/HeaderBagTest.php
@@ -127,4 +127,32 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($bag->hasCacheControlDirective('max-age'));
         $this->assertEquals(10, $bag->getCacheControlDirective('max-age'));
     }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\HeaderBag::getIterator
+     */
+    public function testGetIterator()
+    {
+        $headers   = array('foo' => 'bar', 'hello' => 'world', 'third' => 'charm');
+        $headerBag = new HeaderBag($headers);
+
+        $i = 0;
+        foreach ($headerBag as $key => $val) {
+            $i++;
+            $this->assertEquals(array($headers[$key]), $val);
+        }
+
+        $this->assertEquals(count($headers), $i);
+    }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\HeaderBag::count
+     */
+    public function testCount()
+    {
+        $headers   = array('foo' => 'bar', 'HELLO' => 'WORLD');
+        $headerBag = new HeaderBag($headers);
+
+        $this->assertEquals(count($headers), count($headerBag));
+    }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/ParameterBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ParameterBagTest.php
@@ -202,4 +202,32 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
 
 
     }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\ParameterBag::getIterator
+     */
+    public function testGetIterator()
+    {
+        $parameters = array('foo' => 'bar', 'hello' => 'world');
+        $bag = new ParameterBag($parameters);
+
+        $i = 0;
+        foreach ($bag as $key => $val) {
+            $i++;
+            $this->assertEquals($parameters[$key], $val);
+        }
+
+        $this->assertEquals(count($parameters), $i);
+    }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\ParameterBag::count
+     */
+    public function testCount()
+    {
+        $parameters = array('foo' => 'bar', 'hello' => 'world');
+        $bag = new ParameterBag($parameters);
+
+        $this->assertEquals(count($parameters), count($bag));
+    }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/Session/Attribute/AttributeBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/Session/Attribute/AttributeBagTest.php
@@ -159,4 +159,26 @@ class AttributeBagTest extends \PHPUnit_Framework_TestCase
             array('bye/for/now', null, false),
         );
     }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag::getIterator
+     */
+    public function testGetIterator()
+    {
+        $i = 0;
+        foreach ($this->bag as $key => $val) {
+            $this->assertEquals($this->array[$key], $val);
+            $i++;
+        }
+
+        $this->assertEquals(count($this->array), $i);
+    }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag::count
+     */
+    public function testCount()
+    {
+        $this->assertEquals(count($this->array), count($this->bag));
+    }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/Session/Flash/FlashBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/Session/Flash/FlashBagTest.php
@@ -132,4 +132,37 @@ class FlashBagTest extends \PHPUnit_Framework_TestCase
             ), $this->bag->peekAll()
         );
     }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\Session\Flash\FlashBag::count
+     */
+    public function testCount()
+    {
+        $flashes = array('hello' => 'world', 'beep' => 'boop', 'notice' => 'nope');
+        foreach ($flashes as $key => $val) {
+            $this->bag->set($key, $val);
+        }
+
+        $this->assertEquals(count($flashes), count($this->bag));
+    }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\Session\Flash\FlashBag::getIterator
+     */
+    public function testGetIterator()
+    {
+        $flashes = array('hello' => 'world', 'beep' => 'boop', 'notice' => 'nope');
+        foreach ($flashes as $key => $val) {
+            $this->bag->set($key, $val);
+        }
+
+        $i = 0;
+        foreach ($this->bag as $key => $val) {
+            $this->assertEquals($flashes[$key], $val);
+            $i++;
+        }
+
+        $this->assertEquals(count($flashes), $i);
+        $this->assertEquals(0, count($this->bag));
+    }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/Session/SessionTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/Session/SessionTest.php
@@ -215,4 +215,34 @@ class SessionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->session->hasFlash('notice'));
         $this->assertFalse($this->session->hasFlash('error'));
     }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\Session\Session::getIterator
+     */
+    public function testGetIterator()
+    {
+        $attributes = array('hello' => 'world', 'symfony2' => 'rocks');
+        foreach ($attributes as $key => $val) {
+            $this->session->set($key, $val);
+        }
+
+        $i = 0;
+        foreach ($this->session as $key => $val) {
+            $this->assertEquals($attributes[$key], $val);
+            $i++;
+        }
+
+        $this->assertEquals(count($attributes), $i);
+    }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\Session\Session::count
+     */
+    public function testGetCount()
+    {
+        $this->session->set('hello', 'world');
+        $this->session->set('symfony2', 'rocks');
+
+        $this->assertEquals(2, count($this->session));
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

Added a couple SPL interfaces to ParameterBag, added shortcuts to working with the parameters.  For example:

``` php
<?php
    $post = Request::createFromGlobal()->request;
    echo "There are {count($post)} POST variables\n";

    foreach ($post as $key => $val) {
        echo "{$key}: {$val}\n";
    }
```

Thoughts?
