### PR TITLE
[FrameworkBundle, Console] Changed help text for container:debug command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -41,7 +41,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
     {
         $this
             ->setDefinition(array(
-                new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)  or search (foo*)'),
+                new InputArgument('name', InputArgument::OPTIONAL, 'A service name (foo)'),
                 new InputOption('show-private', null, InputOption::VALUE_NONE, 'Use to show public *and* private services'),
             ))
             ->setName('container:debug')


### PR DESCRIPTION
Fixed help for "name" argument as search for services with wildcards is not implemented in ContainerDebugCommand
