### PR TITLE
[DoctrineBridge] Iterator->current() is not the same as current(Iterator)

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -106,7 +106,7 @@ class UniqueEntityValidator extends ConstraintValidator
          * which is the same as the entity being validated, the criteria is
          * unique.
          */
-        if (0 === count($result) || (1 === count($result) && $entity === current($result))) {
+        if (0 === count($result) || (1 === count($result) && $entity === ($result instanceof \Iterator ? $result->current() : current($result)))) {
             return true;
         }
 


### PR DESCRIPTION
More lively discussion from: doctrine/DoctrineMongoDBBundle#84.
