### PR TITLE
[HttpFoundation] Complete HTTP status code translation table (fix #2552)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -53,11 +53,18 @@ class Response
     /**
      * Status codes translation table.
      *
+     * The list of codes is complete according to the
+     * {@link http://www.iana.org/assignments/http-status-codes/ Hypertext Transfer Protocol (HTTP) Status Code Registry}
+     * (last updated 2012-02-13).
+     *
+     * Unless otherwise noted, the status code is defined in RFC2616.
+     *
      * @var array
      */
     static public $statusTexts = array(
         100 => 'Continue',
         101 => 'Switching Protocols',
+        102 => 'Processing',            // RFC2518
         200 => 'OK',
         201 => 'Created',
         202 => 'Accepted',
@@ -65,12 +72,16 @@ class Response
         204 => 'No Content',
         205 => 'Reset Content',
         206 => 'Partial Content',
+        207 => 'Multi-Status',          // RFC4918
+        208 => 'Already Reported',      // RFC5842
+        226 => 'IM Used',               // RFC3229
         300 => 'Multiple Choices',
         301 => 'Moved Permanently',
         302 => 'Found',
         303 => 'See Other',
         304 => 'Not Modified',
         305 => 'Use Proxy',
+        306 => 'Reserved',
         307 => 'Temporary Redirect',
         400 => 'Bad Request',
         401 => 'Unauthorized',
@@ -90,13 +101,25 @@ class Response
         415 => 'Unsupported Media Type',
         416 => 'Requested Range Not Satisfiable',
         417 => 'Expectation Failed',
-        418 => 'I\'m a teapot',
+        422 => 'Unprocessable Entity',  // RFC4918
+        423 => 'Locked',                // RFC4918
+        424 => 'Failed Dependency',     // RFC4918
+        425 => 'Reserved for WebDAV advanced collections expired proposal',   // RFC2817
+        426 => 'Upgrade Required',      // RFC2817
+        428 => 'Precondition Required', // RFC-nottingham-http-new-status-04
+        429 => 'Too Many Requests',     // RFC-nottingham-http-new-status-04
+        431 => 'Request Header Fields Too Large',   // RFC-nottingham-http-new-status-04
         500 => 'Internal Server Error',
         501 => 'Not Implemented',
         502 => 'Bad Gateway',
         503 => 'Service Unavailable',
         504 => 'Gateway Timeout',
         505 => 'HTTP Version Not Supported',
+        506 => 'Variant Also Negotiates (Experimental)', // [RFC2295]
+        507 => 'Insufficient Storage',  // RFC4918
+        508 => 'Loop Detected',         // RFC5842
+        510 => 'Not Extended',          // RFC2774
+        511 => 'Network Authentication Required',   // RFC-nottingham-http-new-status-04
     );
 
     /**


### PR DESCRIPTION
The HTTP status code translation table was updated to include all HTTP status codes as defined by the IANA Hypertext Transfer Protocol (HTTP) Status Code Registry (http://www.iana.org/assignments/http-status-codes/). This fixes #2552.
