### PR TITLE
[Form] Give PropertyPath ability to read hassers

### DIFF
--- a/src/Symfony/Component/Form/Tests/Fixtures/Author.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Author.php
@@ -17,6 +17,7 @@ class Author
     private $lastName;
     private $australian;
     public $child;
+    private $readPermissions;
 
     private $privateProperty;
 
@@ -43,6 +44,16 @@ class Author
     public function isAustralian()
     {
         return $this->australian;
+    }
+
+    public function setReadPermissions($bool)
+    {
+        $this->readPermissions = $bool;
+    }
+
+    public function hasReadPermissions()
+    {
+        return $this->readPermissions;
     }
 
     private function isPrivateIsser()

--- a/src/Symfony/Component/Form/Tests/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/PropertyPathTest.php
@@ -169,6 +169,16 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($path->getValue($object));
     }
 
+    public function testGetValueReadHassers()
+    {
+        $path = new PropertyPath('read_permissions');
+
+        $object = new Author();
+        $object->setReadPermissions(true);
+
+        $this->assertTrue($path->getValue($object));
+    }
+
     public function testGetValueReadsMagicGet()
     {
         $path = new PropertyPath('magicProperty');

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -216,12 +216,12 @@ class PropertyPath implements \IteratorAggregate
      *
      * This method first tries to find a public getter for each property in the
      * path. The name of the getter must be the camel-cased property name
-     * prefixed with "get" or "is".
+     * prefixed with "get", "is", or "has".
      *
      * If the getter does not exist, this method tries to find a public
      * property. The value of the property is then returned.
      *
-     * If neither is found, an exception is thrown.
+     * If none of them are found, an exception is thrown.
      *
      * @param  object|array $objectOrArray   The object or array to traverse
      *
@@ -332,6 +332,7 @@ class PropertyPath implements \IteratorAggregate
             $reflClass = new \ReflectionClass($object);
             $getter = 'get'.$camelProp;
             $isser = 'is'.$camelProp;
+            $hasser = 'has'.$camelProp;
 
             if ($reflClass->hasMethod($getter)) {
                 if (!$reflClass->getMethod($getter)->isPublic()) {
@@ -345,6 +346,12 @@ class PropertyPath implements \IteratorAggregate
                 }
 
                 return $object->$isser();
+            } elseif ($reflClass->hasMethod($hasser)) {
+                if (!$reflClass->getMethod($hasser)->isPublic()) {
+                    throw new PropertyAccessDeniedException(sprintf('Method "%s()" is not public in class "%s"', $hasser, $reflClass->getName()));
+                }
+
+                return $object->$hasser();
             } elseif ($reflClass->hasMethod('__get')) {
                 // needed to support magic method __get
                 return $object->$property;


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Using a `hasser` instead of `isser` for Boolean values is pretty common. I've found myself using `issers` a handful of times just to make an interface play nice with the form component, but the code reads funny now. I don't think we should be accounting for every possible `getter` variation, but I think this one is common enough that it warrants a discussion. 
