### PR TITLE
[BrowserKit] Client->back/forward/reload() is not keeping all request attributes

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -484,6 +484,6 @@ abstract class Client
      */
     protected function requestFromRequest(Request $request, $changeHistory = true)
     {
-        return $this->request($request->getMethod(), $request->getUri(), $request->getParameters(), array(), $request->getFiles(), $request->getServer(), $request->getContent(), $changeHistory);
+        return $this->request($request->getMethod(), $request->getUri(), $request->getParameters(), $request->getFiles(), $request->getServer(), $request->getContent(), $changeHistory);
     }
 }

--- a/tests/Symfony/Tests/Component/BrowserKit/ClientTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/ClientTest.php
@@ -270,28 +270,61 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     public function testBack()
     {
         $client = new TestClient();
-        $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        $parameters = array('foo' => 'bar');
+        $files = array('myfile.foo' => 'baz');
+        $server = array('X_TEST_FOO' => 'bazbar');
+        $content = 'foobarbaz';
+
+        $client->request('GET', 'http://www.example.com/foo/foobar', $parameters, $files, $server, $content);
         $client->request('GET', 'http://www.example.com/foo');
         $client->back();
+        
         $this->assertEquals('http://www.example.com/foo/foobar', $client->getRequest()->getUri(), '->back() goes back in the history');
+        $this->assertArrayHasKey('foo', $client->getRequest()->getParameters(), '->back() keeps parameters');
+        $this->assertArrayHasKey('myfile.foo', $client->getRequest()->getFiles(), '->back() keeps files');
+        $this->assertArrayHasKey('X_TEST_FOO', $client->getRequest()->getServer(), '->back() keeps $_SERVER');
+        $this->assertEquals($content, $client->getRequest()->getContent(), '->back() keeps content');
     }
 
     public function testForward()
     {
         $client = new TestClient();
+
+        $parameters = array('foo' => 'bar');
+        $files = array('myfile.foo' => 'baz');
+        $server = array('X_TEST_FOO' => 'bazbar');
+        $content = 'foobarbaz';
+
         $client->request('GET', 'http://www.example.com/foo/foobar');
-        $client->request('GET', 'http://www.example.com/foo');
+        $client->request('GET', 'http://www.example.com/foo', $parameters, $files, $server, $content);
         $client->back();
         $client->forward();
+
         $this->assertEquals('http://www.example.com/foo', $client->getRequest()->getUri(), '->forward() goes forward in the history');
+        $this->assertArrayHasKey('foo', $client->getRequest()->getParameters(), '->forward() keeps parameters');
+        $this->assertArrayHasKey('myfile.foo', $client->getRequest()->getFiles(), '->forward() keeps files');
+        $this->assertArrayHasKey('X_TEST_FOO', $client->getRequest()->getServer(), '->forward() keeps $_SERVER');
+        $this->assertEquals($content, $client->getRequest()->getContent(), '->forward() keeps content');
     }
 
     public function testReload()
     {
         $client = new TestClient();
-        $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        $parameters = array('foo' => 'bar');
+        $files = array('myfile.foo' => 'baz');
+        $server = array('X_TEST_FOO' => 'bazbar');
+        $content = 'foobarbaz';
+
+        $client->request('GET', 'http://www.example.com/foo/foobar', $parameters, $files, $server, $content);
         $client->reload();
-        $this->assertEquals('http://www.example.com/foo/foobar', $client->getRequest()->getUri(), '->forward() reloads the current page');
+
+        $this->assertEquals('http://www.example.com/foo/foobar', $client->getRequest()->getUri(), '->reload() reloads the current page');
+        $this->assertArrayHasKey('foo', $client->getRequest()->getParameters(), '->reload() keeps parameters');
+        $this->assertArrayHasKey('myfile.foo', $client->getRequest()->getFiles(), '->reload() keeps files');
+        $this->assertArrayHasKey('X_TEST_FOO', $client->getRequest()->getServer(), '->reload() keeps $_SERVER');
+        $this->assertEquals($content, $client->getRequest()->getContent(), '->reload() keeps content');
     }
 
     public function testRestart()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: ![Travis CI icon](https://secure.travis-ci.org/clemherreman/symfony.png?branch=fix-browserkit_client-history)
Fixes the following tickets: This one
Todo: - 

<hr>

Hello

While using the BrowserKit component with Behat, I noticed that some request attributes, such as files or body, disappeared when using `Symfony\Component\BrowserKit\Client->back/forward/reload()`.

The method used internally in these methods, Client->#requestFromRequest was badly passing the old request parameters to the new request. See the diff.
