### PR TITLE
Composer deps

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": "2.1.*"
+        "doctrine/common": ">=2.1,<2.3"
     },
     "recommend": {
-        "doctrine/dbal": ">=2.1",
-        "doctrine/orm": ">=2.1"
+        "doctrine/dbal": ">=2.1,<2.3",
+        "doctrine/orm": ">=2.1,<2.3"
     },
     "suggest": {
         "symfony/form": "self.version",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -18,10 +18,10 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/event-dispatcher": "self.version",
-        "symfony/locale": "self.version",
-        "symfony/validator": "self.version"
+        "symfony/locale": "self.version"
     },
     "suggest": {
+        "symfony/validator": "self.version",
         "symfony/http-foundation": "self.version"
     },
     "autoload": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.1"
+        "doctrine/common": ">=2.1,<2.3"
     },
     "suggest": {
         "symfony/http-foundation": "self.version",


### PR DESCRIPTION
There is no hard dependency to the Validator component in the Form, as said on Twitter when @harikt tried to use it. I kept the Locale component as a requirement as it is used by the LanguageTyep, CountryType and LocaleType which will be registered when using the CoreExtension.

The constraints for Doctrine deps are fixed too: adding an upper bound everywhere as we don't know the future to guarantee the compatibility (and for instance, 2.0.9 and lower were not compatible with ORM 2.2 as we had to fix the bundle), and the bridge is compatible with Common 2.2 too, not only with 2.1.

I found 2 other places where the dependencies should be discussed:
- the Validator component marks a hard dependency to Doctrine Common for its annotation reader. There is a dependency only when using annotation so it should not be a hard requirement IMO but a suggestion. the issue is that the [ValidatorFactory](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Validator/ValidatorFactory.php) (not used by the framework itself) will add an annotation loader when relying on the default value of the arguments, which means that people that don't take care will need Common. Would it make sense to change the default so that Common is needed only when the user explicitly asks to use annotations ? Moving Common from require to suggest would make it easier for people using the Validator component standalone if they don't use annotations
- the Security component suggests the Finder and ClassLoader components. But these ones are only used by the [dev script](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Security/Acl/Resources/bin/generateSql.php) used to generate the SQL schema shipped in the component. Does it really make sense to list them as people cloning the component should probably never use this script (which alters the files in the component) ?
