### PR TITLE
[DependencyInjection] IntrospectableContainerInterface::initialized()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -59,7 +59,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  *
  * @api
  */
-class Container implements ContainerInterface
+class Container implements IntrospectableContainerInterface
 {
     protected $parameterBag;
     protected $services;
@@ -264,6 +264,18 @@ class Container implements ContainerInterface
         if (self::EXCEPTION_ON_INVALID_REFERENCE === $invalidBehavior) {
             throw new ServiceNotFoundException($id);
         }
+    }
+    
+    /**
+     * Returns true if the given service has actually been initialized
+     *
+     * @param string $id          The service identifier
+     *
+     * @return Boolean true if service has already been initialized, false otherwise
+     */
+    public function initialized($id)
+    {
+        return isset($this->services[strtolower($id)]);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection;
+
+/**
+ * IntrospectableContainerInterface defines additional introspection functionality
+ * for containers, allowing logic to be implemented based on a Container's state.
+ *
+ * @author Evan Villemez <evillemez@gmail.com>
+ *
+ */
+interface IntrospectableContainerInterface extends ContainerInterface
+{
+    /**
+     * Check for whether or not a service has been initialized.
+     *
+     * @param string $id
+     * 
+     * @return Boolean true if the service has been initialized, false otherwise
+     *
+     */
+    function initialized($id);
+    
+}

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -193,6 +193,18 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($sc->has('foo.baz'), '->has() returns true if a get*Method() is defined');
     }
 
+    /**
+     * @covers Symfony\Component\DependencyInjection\Container::initialized
+     */
+    public function testInitialized()
+    {
+        $sc = new ProjectServiceContainer();
+        $sc->set('foo', new \stdClass());
+        $this->assertTrue($sc->initialized('foo'), '->initialized() returns true if service is loaded');
+        $this->assertFalse($sc->initialized('foo1'), '->initialized() returns false if service is not loaded');
+        $this->assertFalse($sc->initialized('bar'), '->initialized() returns false if a service is defined, but not currently loaded');
+    }
+
     public function testEnterLeaveCurrentScope()
     {
         $container = new ProjectServiceContainer();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

Added, implemented and tested `IntrospectableContainerInterface::initialized()`, which allows checking for whether or not a service id has actually been loaded, without forcing it to load.  This could be implemented in several places to prevent loading a service when it's only needed if it has been previously loaded - for example the SwiftmailBundle's event listener for the `kernel.terminate` event, which currently forces Swiftmail to load on every request to check for messages to send, even if it was not previously loaded.
