### PR TITLE
prevent infinite loops when normalizing with GetSetMethodNormalizer

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -57,7 +57,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
                         'Symfony\Component\Serializer\Normalizer\NoNormalizer'
                     );
                     if ($annotation !== NULL) {
-                        continue ;
+                        continue;
                     } else if (!is_scalar($attributeValue)) {
                         $attributeValue = $this->serializer->normalize($attributeValue, $format);
                     }

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -3,6 +3,7 @@
 namespace Symfony\Component\Serializer\Normalizer;
 
 use Symfony\Component\Serializer\Exception\RuntimeException;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /*
  * This file is part of the Symfony framework.
@@ -42,6 +43,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
     {
         $reflectionObject = new \ReflectionObject($object);
         $reflectionMethods = $reflectionObject->getMethods(\ReflectionMethod::IS_PUBLIC);
+        $reader = new AnnotationReader();
 
         $attributes = array();
         foreach ($reflectionMethods as $method) {
@@ -49,8 +51,16 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
                 $attributeName = lcfirst(substr($method->getName(), 3));
 
                 $attributeValue = $method->invoke($object);
-                if (null !== $attributeValue && !is_scalar($attributeValue)) {
-                    $attributeValue = $this->serializer->normalize($attributeValue, $format);
+                if (null !== $attributeValue) {
+                    $annotation = $reader->getMethodAnnotation(
+                        $method,
+                        'Symfony\Component\Serializer\Normalizer\NoNormalizer'
+                    );
+                    if ($annotation !== NULL) {
+                        continue ;
+                    } else if (!is_scalar($attributeValue)) {
+                        $attributeValue = $this->serializer->normalize($attributeValue, $format);
+                    }
                 }
 
                 $attributes[$attributeName] = $attributeValue;

--- a/src/Symfony/Component/Serializer/Normalizer/NoNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NoNormalizer.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\Serializer\Normalizer;
+
+use Doctrine\Common\Annotations\Annotation;
+
+class NoNormalizer extends Annotation {}


### PR DESCRIPTION
I would like to use the GetSetMethodNormalizer on an entity array. The problem is that the entities refer to each other. So, there is an infinite loop when normalising. To solve this, I created an annotation 'NoNormalizer', than I can add on my entity's get methods when I don't want them to be normalized. The GetSetNormalizer checks for this annotation.

My (stripped down) entity, to demonstrate the concept:

```
use Symfony\Component\Serializer\Normalizer as NormalizerStrategy;
class Author
{
    /**
     * Get books
     * @NormalizerStrategy\NoNormalizer
     *
     * @return \Doctrine\Common\Collections\Collection
     */
    public function getBooks()
    {
        return $this->books;
    }
}
```

This solves my problem. What do you thing of this solution?

In addition, I was thinking about changing 'NoNormalizer' into a 'NormalizerStrategy' that has a type property. For example 'none' (which skips the getter), 'lazy' (which does a getId() on the returned value). This is not in this pull request yet. But again, to show you an example of 'lazy':

```
use Symfony\Component\Serializer\Normalizer\NormalizerStrategy;
class Book
{
    /**
     * Get author
     * @NormalizerStrategy(type="lazy")
     *
     * @return Author
     */
    public function getAuthor()
    {
        return $this->author;
    }
}
```

The GetSetMethodNormalizer would look something like this:

```
$attributeValue = $method->invoke($object);
if (null !== $attributeValue) {
    $annotation = $reader->getMethodAnnotation(
        $method,
        'Symfony\Component\Serializer\Normalizer\NormalizerStrategy'
    );
    if ($annotation !== NULL) {
        switch ($annotation->type) {
            case 'lazy':
                $attributeValue = $attributeValue->getId();
                break;
            case 'none':
                continue 2;
    } else if (!is_scalar($attributeValue)) {
        $attributeValue = $this->serializer->normalize($attributeValue, $format);
    }
}
```
