### PR TITLE
[Console] Xml output fix

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -299,6 +299,19 @@ class Command
     }
 
     /**
+     * Gets the InputDefinition to be used to create XML and Text representations of this Command.
+     *
+     * Can be overridden to provide the original command representation when it would otherwise
+     * be changed by merging with the application InputDefinition.
+     *
+     * @return InputDefinition An InputDefinition instance
+     */
+    protected function getNativeDefinition()
+    {
+        return $this->getDefinition();
+    }
+
+    /**
      * Adds an argument.
      *
      * @param string  $name        The argument name
@@ -531,7 +544,7 @@ class Command
             $messages[] = '<comment>Aliases:</comment> <info>'.implode(', ', $this->getAliases()).'</info>';
         }
 
-        $messages[] = $this->definition->asText();
+        $messages[] = $this->getNativeDefinition()->asText();
 
         if ($help = $this->getProcessedHelp()) {
             $messages[] = '<comment>Help:</comment>';
@@ -572,7 +585,7 @@ class Command
             $aliasXML->appendChild($dom->createTextNode($alias));
         }
 
-        $definition = $this->definition->asXml(true);
+        $definition = $this->getNativeDefinition()->asXml(true);
         $commandXML->appendChild($dom->importNode($definition->getElementsByTagName('arguments')->item(0), true));
         $commandXML->appendChild($dom->importNode($definition->getElementsByTagName('options')->item(0), true));
 

--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -17,6 +17,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputDefinition;
 
 /**
  * ListCommand displays the list of all available commands for the application.
@@ -31,10 +32,7 @@ class ListCommand extends Command
     protected function configure()
     {
         $this
-            ->setDefinition(array(
-                new InputArgument('namespace', InputArgument::OPTIONAL, 'The namespace name'),
-                new InputOption('xml', null, InputOption::VALUE_NONE, 'To output help as XML'),
-            ))
+            ->setDefinition($this->createDefinition())
             ->setName('list')
             ->setDescription('Lists commands')
             ->setHelp(<<<EOF
@@ -56,6 +54,14 @@ EOF
     /**
      * {@inheritdoc}
      */
+    protected function getNativeDefinition()
+    {
+        return $this->createDefinition();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if ($input->getOption('xml')) {
@@ -63,5 +69,13 @@ EOF
         } else {
             $output->writeln($this->getApplication()->asText($input->getArgument('namespace')));
         }
+    }
+
+    private function createDefinition()
+    {
+        return new InputDefinition(array(
+            new InputArgument('namespace', InputArgument::OPTIONAL, 'The namespace name'),
+            new InputOption('xml', null, InputOption::VALUE_NONE, 'To output help as XML'),
+        ));
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2667
Todo: add specific test

As per my comment [here](https://github.com/symfony/symfony/issues/2667#issuecomment-4431944), added the ability to provide an InputDefinition that will not be changed by merging with the Application InputDefinition..
