### PR TITLE
Fixed Timezone bug in DateTimeToTimeStampDataTransformer

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -73,7 +73,9 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
         }
 
         try {
-            $dateTime = new \DateTime(sprintf("@%s %s", $value, $this->outputTimezone));
+            $dateTime = new \DateTime();
+            $dateTime->setTimezone(new \DateTimeZone($this->outputTimezone));
+            $dateTime->setTimestamp($value);
 
             if ($this->inputTimezone !== $this->outputTimezone) {
                 $dateTime->setTimezone(new \DateTimeZone($this->inputTimezone));


### PR DESCRIPTION
After several trials, I found out that the original code

``` php
$dateTime = new \DateTime(sprintf("@%s %s", $value, $this->outputTimezone));
```

would create a DateTime object with timezone being '0000', even though $this->outputTimezone is set to my local timezone.

so I expanded the code a bit and it's working now.

PHP Test code,

``` PHP
$d = new DateTime("@1234567890 Asia/Tokyo");
echo date_format($d, 'Y/m/d H:i:s')."\n";
echo $d->getTimezone()->getName()."\n";

$d = new DateTime("now Asia/Hong_Kong");
echo date_format($d, 'Y/m/d H:i:s')."\n";
echo $d->getTimezone()->getName()."\n";
```

The output is as followed:
2009/02/13 23:31:30
+00:00
2012/03/13 03:35:55
Asia/Hong_Kong

This could be a bug of PHP,
