### PR TITLE
[Form] Alternate syntax for form_theme

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -54,12 +54,12 @@ class FormExtension extends \Twig_Extension
     /**
      * Sets a theme for a given view.
      *
-     * @param FormView $view      A FormView instance
-     * @param array    $resources An array of resources
+     * @param FormView     $view      A FormView instance
+     * @param array|string $resources An array of resource names|a resource name
      */
-    public function setTheme(FormView $view, array $resources)
+    public function setTheme(FormView $view, $resources)
     {
-        $this->themes->attach($view, $resources);
+        $this->themes->attach($view, (array) $resources);
         $this->blocks = new \SplObjectStorage();
     }
 

--- a/src/Symfony/Bridge/Twig/Node/FormThemeNode.php
+++ b/src/Symfony/Bridge/Twig/Node/FormThemeNode.php
@@ -32,16 +32,9 @@ class FormThemeNode extends \Twig_Node
             ->addDebugInfo($this)
             ->write('echo $this->env->getExtension(\'form\')->setTheme(')
             ->subcompile($this->getNode('form'))
-            ->raw(', array(')
+            ->raw(', ')
+            ->subcompile($this->getNode('resources'))
+            ->raw(");\n");
         ;
-
-        foreach ($this->getNode('resources') as $resource) {
-            $compiler
-                ->subcompile($resource)
-                ->raw(', ')
-            ;
-        }
-
-        $compiler->raw("));\n");
     }
 }

--- a/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/FormThemeTokenParser.php
@@ -33,14 +33,20 @@ class FormThemeTokenParser extends \Twig_TokenParser
         $stream = $this->parser->getStream();
 
         $form = $this->parser->getExpressionParser()->parseExpression();
-        $resources = array();
-        do {
-            $resources[] = $this->parser->getExpressionParser()->parseExpression();
-        } while (!$stream->test(\Twig_Token::BLOCK_END_TYPE));
+
+        if ($this->parser->getStream()->test(\Twig_Token::NAME_TYPE, 'with')) {
+            $this->parser->getStream()->next();
+            $resources = $this->parser->getExpressionParser()->parseExpression();
+        } else {
+            $resources = new \Twig_Node_Expression_Array(array(), $stream->getCurrent()->getLine());
+            do {
+                $resources->addElement($this->parser->getExpressionParser()->parseExpression());
+            } while (!$stream->test(\Twig_Token::BLOCK_END_TYPE));
+        }
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        return new FormThemeNode($form, new \Twig_Node($resources), $lineno, $this->getTag());
+        return new FormThemeNode($form, $resources, $lineno, $this->getTag());
     }
 
     /**

--- a/tests/Symfony/Tests/Bridge/Twig/Node/FormThemeTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/Node/FormThemeTest.php
@@ -42,10 +42,12 @@ class FormThemeTest extends TestCase
     public function testCompile()
     {
         $form = new \Twig_Node_Expression_Name('form', 0);
-        $resources = new \Twig_Node(array(
+        $resources = new \Twig_Node_Expression_Array(array(
+            new \Twig_Node_Expression_Constant(0, 0),
             new \Twig_Node_Expression_Constant('tpl1', 0),
+            new \Twig_Node_Expression_Constant(1, 0),
             new \Twig_Node_Expression_Constant('tpl2', 0)
-        ));
+        ), 0);
 
         $node = new FormThemeNode($form, $resources, 0);
 
@@ -53,7 +55,19 @@ class FormThemeTest extends TestCase
 
         $this->assertEquals(
             sprintf(
-                'echo $this->env->getExtension(\'form\')->setTheme(%s, array("tpl1", "tpl2", ));',
+                'echo $this->env->getExtension(\'form\')->setTheme(%s, array(0 => "tpl1", 1 => "tpl2"));',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+
+        $resources = new \Twig_Node_Expression_Constant('tpl1', 0);
+
+        $node = new FormThemeNode($form, $resources, 0);
+
+        $this->assertEquals(
+            sprintf(
+                'echo $this->env->getExtension(\'form\')->setTheme(%s, "tpl1");',
                 $this->getVariableGetter('form')
              ),
             trim($compiler->compile($node)->getSource())

--- a/tests/Symfony/Tests/Bridge/Twig/TokenParser/FormThemeTokenParserTest.php
+++ b/tests/Symfony/Tests/Bridge/Twig/TokenParser/FormThemeTokenParserTest.php
@@ -46,9 +46,10 @@ class FormThemeTokenParserTest extends TestCase
                 '{% form_theme form "tpl1" %}',
                 new FormThemeNode(
                     new \Twig_Node_Expression_Name('form', 1),
-                    new \Twig_Node(array(
+                    new \Twig_Node_Expression_Array(array(
+                        new \Twig_Node_Expression_Constant(0, 1),
                         new \Twig_Node_Expression_Constant('tpl1', 1),
-                    )),
+                    ), 1),
                     1,
                     'form_theme'
                 )
@@ -57,10 +58,47 @@ class FormThemeTokenParserTest extends TestCase
                 '{% form_theme form "tpl1" "tpl2" %}',
                 new FormThemeNode(
                     new \Twig_Node_Expression_Name('form', 1),
-                    new \Twig_Node(array(
+                    new \Twig_Node_Expression_Array(array(
+                        new \Twig_Node_Expression_Constant(0, 1),
                         new \Twig_Node_Expression_Constant('tpl1', 1),
+                        new \Twig_Node_Expression_Constant(1, 1),
                         new \Twig_Node_Expression_Constant('tpl2', 1)
-                    )),
+                    ), 1),
+                    1,
+                    'form_theme'
+                )
+            ),
+            array(
+                '{% form_theme form with "tpl1" %}',
+                new FormThemeNode(
+                    new \Twig_Node_Expression_Name('form', 1),
+                    new \Twig_Node_Expression_Constant('tpl1', 1),
+                    1,
+                    'form_theme'
+                )
+            ),
+            array(
+                '{% form_theme form with ["tpl1"] %}',
+                new FormThemeNode(
+                    new \Twig_Node_Expression_Name('form', 1),
+                    new \Twig_Node_Expression_Array(array(
+                        new \Twig_Node_Expression_Constant(0, 1),
+                        new \Twig_Node_Expression_Constant('tpl1', 1),
+                    ), 1),
+                    1,
+                    'form_theme'
+                )
+            ),
+            array(
+                '{% form_theme form with ["tpl1", "tpl2"] %}',
+                new FormThemeNode(
+                    new \Twig_Node_Expression_Name('form', 1),
+                    new \Twig_Node_Expression_Array(array(
+                        new \Twig_Node_Expression_Constant(0, 1),
+                        new \Twig_Node_Expression_Constant('tpl1', 1),
+                        new \Twig_Node_Expression_Constant(1, 1),
+                        new \Twig_Node_Expression_Constant('tpl2', 1)
+                    ), 1),
                     1,
                     'form_theme'
                 )


### PR DESCRIPTION
before
`{% form_theme form _self "::base.html.twig" %}`

after
`{% form_theme form with "::base.html.twig" %}`
`{% form_theme form with varTheme %}`
`{% form_theme form with [_self, "::base.html.twig"] %}`

_the former syntax is still supported_
