### PR TITLE
[Security] Disabled exception when switching to the user that is already impersonated

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/SwitchUserTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Tests\Functional;
+
+/**
+ * @group functional
+ */
+class SwitchUserTest extends WebTestCase
+{
+    /**
+     * @dataProvider getTestParameters
+     */
+    public function testSwitchUser($originalUser, $targetUser, $expectedUser, $expectedStatus)
+    {
+        $client = $this->createAuthenticatedClient($originalUser);
+
+        $client->request('GET', '/profile?_switch_user=' . $targetUser);
+
+        $this->assertEquals($expectedStatus, $client->getResponse()->getStatusCode());
+        $this->assertEquals($expectedUser, $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testSwitchedUserCannotSwitchToOther()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch');
+
+        $client->request('GET', '/profile?_switch_user=user_cannot_switch_1');
+        $client->request('GET', '/profile?_switch_user=user_cannot_switch_2');
+
+        $this->assertEquals(500, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_cannot_switch_1', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function testSwitchedUserExit()
+    {
+        $client = $this->createAuthenticatedClient('user_can_switch');
+
+        $client->request('GET', '/profile?_switch_user=user_cannot_switch_1');
+        $client->request('GET', '/profile?_switch_user=_exit');
+
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        $this->assertEquals('user_can_switch', $client->getProfile()->getCollector('security')->getUser());
+    }
+
+    public function getTestParameters()
+    {
+        return array(
+            'unauthorized_user_cannot_switch'               => array('user_cannot_switch_1', 'user_cannot_switch_1', 'user_cannot_switch_1', 403),
+            'authorized_user_can_switch'                    => array('user_can_switch', 'user_cannot_switch_1', 'user_cannot_switch_1', 200),
+            'authorized_user_cannot_switch_to_non_existent' => array('user_can_switch', 'user_does_not_exist', 'user_can_switch', 500),
+            'authorized_user_can_switch_to_himself'         => array('user_can_switch', 'user_can_switch', 'user_can_switch', 200),
+        );
+    }
+
+    protected function createAuthenticatedClient($username)
+    {
+        $client = $this->createClient(array('test_case' => 'StandardFormLogin', 'root_config' => 'switchuser.yml'));
+        $client->followRedirects(true);
+        $client->insulate();
+
+        $form = $client->request('GET', '/login')->selectButton('login')->form();
+        $form['_username'] = $username;
+        $form['_password'] = 'test';
+        $client->submit($form);
+
+        return $client;
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->deleteTmpDir('StandardFormLogin');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->deleteTmpDir('StandardFormLogin');
+    }
+}

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
@@ -1,0 +1,17 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    profiler: { only_exceptions: false }
+
+security:
+    providers:
+        in_memory:
+            memory:
+                users:
+                    user_can_switch:      { password: test, roles: [ROLE_USER, ROLE_ALLOWED_TO_SWITCH] }
+                    user_cannot_switch_1: { password: test, roles: [ROLE_USER] }
+                    user_cannot_switch_2: { password: test, roles: [ROLE_USER] }
+    firewalls:
+        default:
+            switch_user: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/StandardFormLogin/switchuser.yml
@@ -1,8 +1,5 @@
 imports:
-    - { resource: config.yml }
-
-framework:
-    profiler: { only_exceptions: false }
+    - { resource: ./config.yml }
 
 security:
     providers:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -11,6 +11,7 @@ framework:
     session:
         auto_start:     true
         storage_id:     session.storage.mock_file
+    profiler: { only_exceptions: false }
 
 services:
     logger: { class: Symfony\Component\HttpKernel\Log\NullLogger }


### PR DESCRIPTION
Bug fix: yes-ish
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #2554
Todo: -
