### PR TITLE
[Config] Fixed an "Array to string conversion" warning when using PHP 5.4

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -267,7 +267,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         if (count($value) && !$this->ignoreExtraKeys) {
             $msg = sprintf('Unrecognized options "%s" under "%s"', implode(', ', array_keys($value)), $this->getPath());
             $ex = new InvalidConfigurationException($msg);
-            $ex->setPath($this->getPath().'.'.reset($value));
+            $ex->setPath($this->getPath());
 
             throw $ex;
         }


### PR DESCRIPTION
This also affects Symfony2 master
