### PR TITLE
Correct bad HttpCache behaviour when waiting for unlock.

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -516,7 +516,8 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             // wait for the lock to be released
             $wait = 0;
             while (is_file($lock) && $wait < 5000000) {
-                usleep($wait += 50000);
+                usleep(50000);
+                $wait += 50000;
             }
 
             if ($wait < 2000000) {


### PR DESCRIPTION
I read the class Symfony\Component\HttpKernel\HttpCache\HttpCache and I found something which looks like a bug lines 518-520 (in _lock_ method) :
$wait = 0;
while (is_file($lock) && $wait < 5000000) {
    usleep($wait += 50000);
}
This code can wait at maximum 50000+100000+150000+.... 4950000 µs = more than 250 seconds !

I corrected like that :
$wait = 0;
while (is_file($lock) && $wait < 5000000) {
    usleep(50000);
    $wait += 50000
}

This code will wait 5 sec maximum. 

This is more coherent if we read the following lines of this method.
