### PR TITLE
Branch 2.0 - Correct bad HttpCache behaviour when waiting for unlock.

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -36,6 +36,19 @@ class TwigExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('twig.xml');
 
+        foreach ($configs as &$config) {
+            if (isset($config['globals'])) {
+                foreach ($config['globals'] as $name => $value) {
+                    if (is_array($value) && isset($value['key'])) {
+                        $config['globals'][$name] = array(
+                            'key'   => $name,
+                            'value' => $config['globals'][$name]
+                        );
+                    }
+                }
+            }
+        }
+
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -9,6 +9,7 @@ $container->loadFromExtension('twig', array(
      'globals' => array(
          'foo' => '@bar',
          'pi'  => 3.14,
+         'bad' => array('key' => 'foo'),
      ),
      'auto_reload'         => true,
      'autoescape'          => true,

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -3,8 +3,9 @@ twig:
         resources:
             - MyBundle::form.html.twig
     globals:
-        foo: @bar
+        foo: "@bar"
         pi:  3.14
+        bad: {key: foo}
     auto_reload:         true
     autoescape:          true
     base_template_class: stdClass

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -64,6 +64,12 @@ class TwigExtensionTest extends TestCase
         $this->assertEquals('pi', $calls[1][1][0], '->load() registers variables as Twig globals');
         $this->assertEquals(3.14, $calls[1][1][1], '->load() registers variables as Twig globals');
 
+        // Yaml and Php specific configs
+        if (in_array($format, array('yml', 'php'))) {
+            $this->assertEquals('bad', $calls[2][1][0], '->load() registers variables as Twig globals');
+            $this->assertEquals(array('key' => 'foo'), $calls[2][1][1], '->load() registers variables as Twig globals');
+        }
+
         // Twig options
         $options = $container->getParameter('twig.options');
         $this->assertTrue($options['auto_reload'], '->load() sets the auto_reload option');

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -503,7 +503,8 @@ class HttpCache implements HttpKernelInterface
             // wait for the lock to be released
             $wait = 0;
             while (file_exists($lock) && $wait < 5000000) {
-                usleep($wait += 50000);
+                usleep(50000);
+                $wait += 50000;
             }
 
             if ($wait < 2000000) {


### PR DESCRIPTION
I read the class Symfony\Component\HttpKernel\HttpCache\HttpCache and I found something which looks like a bug lines 518-520 (in lock method) :
$wait = 0;
while (is_file($lock) && $wait < 5000000) {
usleep($wait += 50000);
}
This code can wait at maximum 50000+100000+150000+.... 4950000 µs = more than 250 seconds !

I corrected like that :
$wait = 0;
while (is_file($lock) && $wait < 5000000) {
usleep(50000);
$wait += 50000
}

This code will wait 5 sec maximum.

This is more coherent if we read the following lines of this method.
