### PR TITLE
Fixed profiler report under an exception of a sub-request

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -199,7 +199,7 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
         $profile->setCollectors(unserialize(base64_decode($data['data'])));
 
         // Under sub-requests, $data['parent'] === $token in an exception situation
-        if ( ! $parent && isset($data['parent']) && $data['parent'] && $data['parent'] !== $token) {
+        if (!$parent && isset($data['parent']) && $data['parent'] && $data['parent'] !== $token) {
             $parent = $this->read($data['parent']);
         }
 
@@ -208,7 +208,7 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
         }
 
         // Avoid inspecting children under sub-request exception
-        if ( ! $parent || $parent->getToken() !== $token) {
+        if (!$parent || $parent->getToken() !== $token) {
             $profile->setChildren($this->readChildren($token, $profile));
         }
 


### PR DESCRIPTION
When a sub-request contains an exception, PdoProfilerStorage was entering in an infinite loop.
Fixed by preventing the read/createProfileFromData recursion.
