### PR TITLE
[Console] Fixes formatter nested style appliance.

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -147,15 +147,11 @@ class OutputFormatter implements OutputFormatterInterface
      */
     private function replaceStyle($match)
     {
-        if (!$this->isDecorated()) {
-            return '';
-        }
-
         // Special "</>" tag resets all styles.
         if (!isset($match[2])) {
             $this->styleStack->reset();
 
-            return "\033[0m";
+            return $this->isDecorated() ? "\033[0m" : '';
         }
 
         if (isset($this->styles[strtolower($match[2])])) {
@@ -174,7 +170,7 @@ class OutputFormatter implements OutputFormatterInterface
             $this->styleStack->pushStyle($style);
         }
 
-        return $this->styleStack->getCurrentStyle()->getTerminalSequence();
+        return $this->isDecorated() ? $this->styleStack->getCurrentStyle()->getTerminalSequence() : '';
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -166,7 +166,7 @@ class OutputFormatter implements OutputFormatterInterface
      *
      * @param   string  $string
      *
-     * @return  Symfony\Component\Console\Format\FormatterStyle|Boolean false if string is not format string
+     * @return  \Symfony\Component\Console\Formatter\OutputFormatterStyle|Boolean false if string is not format string
      */
     private function createStyleFromString($string)
     {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -23,10 +23,11 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * The pattern to phrase the format.
      */
-    const FORMAT_PATTERN = '#<([a-z][a-z0-9_=;-]+)>(.*?)</\\1?>#is';
+    const FORMAT_PATTERN = '#<(/?)([a-z][a-z0-9_=;-]+)?>#is';
 
     private $decorated;
     private $styles = array();
+    private $styleStack;
 
     /**
      * Initializes console output formatter.
@@ -48,6 +49,8 @@ class OutputFormatter implements OutputFormatterInterface
         foreach ($styles as $name => $style) {
             $this->setStyle($name, $style);
         }
+
+        $this->styleStack = new OutputFormatterStyleStack();
     }
 
     /**
@@ -145,20 +148,33 @@ class OutputFormatter implements OutputFormatterInterface
     private function replaceStyle($match)
     {
         if (!$this->isDecorated()) {
-            return $match[2];
+            return '';
         }
 
-        if (isset($this->styles[strtolower($match[1])])) {
-            $style = $this->styles[strtolower($match[1])];
+        // Special "</>" tag resets all styles.
+        if (!isset($match[2])) {
+            $this->styleStack->reset();
+
+            return "\033[0m";
+        }
+
+        if (isset($this->styles[strtolower($match[2])])) {
+            $style = $this->styles[strtolower($match[2])];
         } else {
-            $style = $this->createStyleFromString($match[1]);
+            $style = $this->createStyleFromString($match[2]);
 
             if (false === $style) {
-                return $match[0];
+                return '';
             }
         }
 
-        return $style->apply($this->format($match[2]));
+        if ('/' === $match[1]) {
+            $this->styleStack->popStyle($style);
+        } else {
+            $this->styleStack->pushStyle($style);
+        }
+
+        return $this->styleStack->getCurrentStyle()->getTerminalSequence();
     }
 
     /**

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -103,6 +103,22 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
+     * Gets style foreground color.
+     *
+     * @return string|null
+     */
+    public function getForeground()
+    {
+        if (null === $this->foreground) {
+            return null;
+        }
+
+        $names = array_flip(static::$availableForegroundColors);
+
+        return $names[$this->foreground];
+    }
+
+    /**
      * Sets style background color.
      *
      * @param   string  $color  color name
@@ -128,6 +144,22 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         }
 
         $this->background = static::$availableBackgroundColors[$color];
+    }
+
+    /**
+     * Gets style background color.
+     *
+     * @return string|null
+     */
+    public function getBackground()
+    {
+        if (null === $this->background) {
+            return null;
+        }
+
+        $names = array_flip(static::$availableBackgroundColors);
+
+        return $names[$this->background];
     }
 
     /**
@@ -193,6 +225,23 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
     }
 
     /**
+     * Gets specific style options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        $names   = array_flip(static::$availableOptions);
+        $options = array();
+
+        foreach ($this->options as $code) {
+            $options[] = $names[$code];
+        }
+
+        return $options;
+    }
+
+    /**
      * Applies the style to a given text.
      *
      * @param string $text The text to style
@@ -200,6 +249,16 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
      * @return string
      */
     public function apply($text)
+    {
+        return sprintf("%s%s\033[0m", $this->getTerminalSequence(), $text);
+    }
+
+    /**
+     * Gets terminal colorization sequence.
+     *
+     * @return string
+     */
+    public function getTerminalSequence()
     {
         $codes = array();
 
@@ -216,6 +275,6 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
             $codes = array(0);
         }
 
-        return sprintf("\033[%sm%s\033[0m", implode(';', $codes), $text);
+        return sprintf("\033[%sm", implode(';', $codes));
     }
 }

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyle.php
@@ -212,6 +212,9 @@ class OutputFormatterStyle implements OutputFormatterStyleInterface
         if (count($this->options)) {
             $codes = array_merge($codes, $this->options);
         }
+        if (0 === count($codes)) {
+            $codes = array(0);
+        }
 
         return sprintf("\033[%sm%s\033[0m", implode(';', $codes), $text);
     }

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
@@ -30,13 +30,6 @@ interface OutputFormatterStyleInterface
     function setForeground($color = null);
 
     /**
-     * Gets style foreground color.
-     *
-     * @return string|null
-     */
-    function getForeground();
-
-    /**
      * Sets style background color.
      *
      * @param   string  $color  color name
@@ -44,13 +37,6 @@ interface OutputFormatterStyleInterface
      * @api
      */
     function setBackground($color = null);
-
-    /**
-     * Gets style background color.
-     *
-     * @return string|null
-     */
-    function getBackground();
 
     /**
      * Sets some specific style option.
@@ -74,20 +60,6 @@ interface OutputFormatterStyleInterface
      * @param   array   $options
      */
     function setOptions(array $options);
-
-    /**
-     * Gets specific style options.
-     *
-     * @return array
-     */
-    function getOptions();
-
-    /**
-     * Gets terminal colorization sequence.
-     *
-     * @return string
-     */
-    function getTerminalSequence();
 
     /**
      * Applies the style to a given text.

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleInterface.php
@@ -30,6 +30,13 @@ interface OutputFormatterStyleInterface
     function setForeground($color = null);
 
     /**
+     * Gets style foreground color.
+     *
+     * @return string|null
+     */
+    function getForeground();
+
+    /**
      * Sets style background color.
      *
      * @param   string  $color  color name
@@ -37,6 +44,13 @@ interface OutputFormatterStyleInterface
      * @api
      */
     function setBackground($color = null);
+
+    /**
+     * Gets style background color.
+     *
+     * @return string|null
+     */
+    function getBackground();
 
     /**
      * Sets some specific style option.
@@ -60,6 +74,20 @@ interface OutputFormatterStyleInterface
      * @param   array   $options
      */
     function setOptions(array $options);
+
+    /**
+     * Gets specific style options.
+     *
+     * @return array
+     */
+    function getOptions();
+
+    /**
+     * Gets terminal colorization sequence.
+     *
+     * @return string
+     */
+    function getTerminalSequence();
 
     /**
      * Applies the style to a given text.

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -52,9 +52,9 @@ class OutputFormatterStyleStack
     /**
      * Pushes a style in the stack.
      *
-     * @param OutputFormatterStyleInterface $style
+     * @param OutputFormatterStyle $style
      */
-    public function pushStyle(OutputFormatterStyleInterface $style)
+    public function pushStyle(OutputFormatterStyle $style)
     {
         $foreground = $style->getForeground();
         if (null !== $foreground) {
@@ -77,11 +77,11 @@ class OutputFormatterStyleStack
     /**
      * Pops a style from the stack.
      *
-     * @param OutputFormatterStyleInterface $style
+     * @param OutputFormatterStyle $style
      *
      * @throws \InvalidArgumentException  When style tags incorrectly nested
      */
-    public function popStyle(OutputFormatterStyleInterface $style)
+    public function popStyle(OutputFormatterStyle $style)
     {
         $this->popArrayCode($this->foregrounds, $style->getForeground());
         $this->popArrayCode($this->backgrounds, $style->getBackground());
@@ -115,8 +115,8 @@ class OutputFormatterStyleStack
     /**
      * Pops a color from a stack.
      *
-     * @param array $stack  An array of color names
-     * @param int   $color  A color name
+     * @param array  $stack  An array of color names
+     * @param string $color  A color name
      *
      * @throws \InvalidArgumentException  When poped color is not the expected one
      */

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Formatter;
+
+/**
+ * @author: Jean-François Simon <contact@jfsimon.fr>
+ */
+class OutputFormatterStyleStack
+{
+    /**
+     * @var array
+     */
+    private $foregrounds;
+
+    /**
+     * @var array
+     */
+    private $backgrounds;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->reset();
+    }
+
+    /**
+     * Resets stack (ie. empty internal arrays).
+     */
+    public function reset()
+    {
+        $this->foregrounds = array();
+        $this->backgrounds = array();
+        $this->options     = array();
+    }
+
+    /**
+     * Pushes a style in the stack.
+     *
+     * @param OutputFormatterStyleInterface $style
+     */
+    public function pushStyle(OutputFormatterStyleInterface $style)
+    {
+        $foreground = $style->getForeground();
+        if (null !== $foreground) {
+            $this->foregrounds[] = $foreground;
+        }
+
+        $background = $style->getBackground();
+        if (null !== $background) {
+            $this->backgrounds[] = $background;
+        }
+
+        foreach ($style->getOptions() as $option) {
+            if (!isset($this->options[$option])) {
+                $this->options[$option] = 0;
+            }
+            $this->options[$option] += 1;
+        }
+    }
+
+    /**
+     * Pops a style from the stack.
+     *
+     * @param OutputFormatterStyleInterface $style
+     *
+     * @throws \InvalidArgumentException  When style tags incorrectly nested
+     */
+    public function popStyle(OutputFormatterStyleInterface $style)
+    {
+        $this->popArrayCode($this->foregrounds, $style->getForeground());
+        $this->popArrayCode($this->backgrounds, $style->getBackground());
+
+        foreach ($style->getOptions() as $option) {
+            if (!isset($this->options[$option])) {
+                throw new \InvalidArgumentException('Unexpected style "'.$option.'" option end.');
+            }
+
+            $this->options[$option] -= 1;
+            if (0 === $this->options[$option]) {
+                unset($this->options[$option]);
+            }
+        }
+    }
+
+    /**
+     * Computes current style with stacks top codes.
+     *
+     * @return OutputFormatterStyle
+     */
+    public function getCurrentStyle()
+    {
+        return new OutputFormatterStyle(
+            end($this->foregrounds) ?: null,
+            end($this->backgrounds) ?: null,
+            array_keys($this->options)
+        );
+    }
+
+    /**
+     * Pops a color from a stack.
+     *
+     * @param array $stack  An array of color names
+     * @param int   $color  A color name
+     *
+     * @throws \InvalidArgumentException  When poped color is not the expected one
+     */
+    private function popArrayCode(&$stack, $color)
+    {
+        if (null === $color) {
+            return;
+        }
+
+        $current = end($stack);
+        if ($current !== $color) {
+            throw new \InvalidArgumentException('Expected style "'.$current.'" color end but "'.$color.'" end found.');
+        }
+
+        array_pop($stack);
+    }
+}

--- a/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterStyleStackTest.php
+++ b/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterStyleStackTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Console\Formatter;
+
+use Symfony\Component\Console\Formatter\OutputFormatterStyleStack;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
+
+class OutputFormatterStyleStackTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPush()
+    {
+        $stack = new OutputFormatterStyleStack();
+        $stack->pushStyle(new OutputFormatterStyle('white'));
+        $stack->pushStyle(new OutputFormatterStyle(null, 'black'));
+        $stack->pushStyle(new OutputFormatterStyle(null, null, array('bold')));
+
+        $style = $stack->getCurrentStyle();
+        $this->assertEquals('white', $style->getForeground());
+        $this->assertEquals('black', $style->getBackground());
+        $this->assertEquals(array('bold'), $style->getOptions());
+
+        $stack->pushStyle(new OutputFormatterStyle('yellow', null, array('blink')));
+
+        $style = $stack->getCurrentStyle();
+        $this->assertEquals('yellow', $style->getForeground());
+        $this->assertEquals('black', $style->getBackground());
+        $this->assertEquals(array('bold', 'blink'), $style->getOptions());
+    }
+
+    public function testPop()
+    {
+        $stack = new OutputFormatterStyleStack();
+        $stack->pushStyle(new OutputFormatterStyle('white', 'black', array('blink', 'bold')));
+        $stack->pushStyle(new OutputFormatterStyle('yellow', 'blue'));
+
+        $style = $stack->getCurrentStyle();
+        $this->assertEquals('yellow', $style->getForeground());
+        $this->assertEquals('blue', $style->getBackground());
+        $this->assertEquals(array('blink', 'bold'), $style->getOptions());
+
+        $stack->popStyle(new OutputFormatterStyle(null, 'blue', array('blink')));
+
+        $style = $stack->getCurrentStyle();
+        $this->assertEquals('yellow', $style->getForeground());
+        $this->assertEquals('black', $style->getBackground());
+        $this->assertEquals(array('bold'), $style->getOptions());
+
+        $stack->popStyle(new OutputFormatterStyle('yellow', 'black', array('bold')));
+
+        $style = $stack->getCurrentStyle();
+        $this->assertEquals('white', $style->getForeground());
+        $this->assertEquals(null, $style->getBackground());
+        $this->assertEquals(array(), $style->getOptions());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidPop()
+    {
+        $stack = new OutputFormatterStyleStack();
+        $stack->pushStyle(new OutputFormatterStyle('white', 'black', array('blink', 'bold')));
+        $stack->popStyle(new OutputFormatterStyle('yellow'));
+    }
+}

--- a/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
@@ -43,7 +43,7 @@ class FormatterStyleTest extends \PHPUnit_Framework_TestCase
         $formatter = new OutputFormatter(true);
 
         $this->assertEquals(
-            "\033[37;41msome \033[32msome info\033[0m error\033[0m", $formatter->format('<error>some <info>some info</info> error</error>')
+            "\033[37;41msome \033[32;41msome info\033[37;41m error\033[0m", $formatter->format('<error>some <info>some info</info> error</error>')
         );
     }
 

--- a/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Tests\Component\Console\Formatter;
 
 use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 
 class FormatterStyleTest extends \PHPUnit_Framework_TestCase
 {
@@ -51,36 +52,23 @@ class FormatterStyleTest extends \PHPUnit_Framework_TestCase
     {
         $formatter = new OutputFormatter(true);
 
-        $style = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterStyleInterface')->getMock();
+        $style = new OutputFormatterStyle('red', 'blue');
         $formatter->setStyle('test', $style);
 
         $this->assertEquals($style, $formatter->getStyle('test'));
         $this->assertNotEquals($style, $formatter->getStyle('info'));
 
-        $style
-            ->expects($this->once())
-            ->method('apply')
-            ->will($this->returnValue('[STYLE_BEG]some custom msg[STYLE_END]'));
-
-        $this->assertEquals("[STYLE_BEG]some custom msg[STYLE_END]", $formatter->format('<test>some custom msg</test>'));
+        $this->assertEquals("\033[31;44msome custom msg\033[0m", $formatter->format('<test>some custom msg</test>'));
     }
 
     public function testRedefineStyle()
     {
         $formatter = new OutputFormatter(true);
 
-        $style = $this->getMockBuilder('Symfony\Component\Console\Formatter\OutputFormatterStyleInterface')
-            ->getMock();
+        $style = new OutputFormatterStyle('red', 'blue');
         $formatter->setStyle('info', $style);
 
-        $style
-            ->expects($this->once())
-            ->method('apply')
-            ->will($this->returnValue('[STYLE_BEG]some custom msg[STYLE_END]'));
-
-        $this->assertEquals(
-            "[STYLE_BEG]some custom msg[STYLE_END]", $formatter->format('<info>some custom msg</info>')
-        );
+        $this->assertEquals("\033[31;44msome custom msg\033[0m", $formatter->format('<info>some custom msg</info>'));
     }
 
     public function testInlineStyle()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

When outputing styled text in the console, you sometimes face to a confusing behavior: style tags cannot be nested. If tou try something like `<fg=blue>Hello <fg=red>world</fg=red>!</fg=blue>`, the trailing `!` will not be styled.

This PR introduce a new FormatterOutputStyleStack to keep open/closed styles informations up-to-date. It slightly changes OutputFormatter implementation which no longer uses `OutputFormatterStyle::apply()` method, but the new `OutputFormatterStyle::getTerminalSequence()`.

**Question:** I don't une `OutputFormatterStyleInterface` but `OutputFormatterStyle` to type `OutputFormatterStyleStack` methods arguments (to avoid BC break on the interface). Do you think it's right?

**Notice:** I also needed to fix some tests broken by new implementation.
