### PR TITLE
Made assets:install output copy mode its using

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -83,6 +83,9 @@ EOT
         // Create the bundles directory otherwise symlink will fail.
         $filesystem->mkdir($targetArg.'/bundles/', 0777);
 
+        $copyMethod = ($input->getOption('symlink')) ? "symlink":"hard copy";
+        $output->writeln(sprintf("Installing assets using <comment>%s</comment> option", $copyMethod));
+
         foreach ($this->getContainer()->get('kernel')->getBundles() as $bundle) {
             if (is_dir($originDir = $bundle->getPath().'/Resources/public')) {
                 $bundlesDir = $targetArg.'/bundles/';


### PR DESCRIPTION
Made option to use symlink explicit in the output. This can clear up any issues for example when running composer update to know if assets:install did a symlink or hard copy.

On a general it just makes communication a bit clearer on what is being executed.

Further improvement is to make Composer install use the same process as was previously used on that server.
