### PR TITLE
Add connection name in the propel data collector

### DIFF
--- a/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
+++ b/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
@@ -119,13 +119,15 @@ class PropelDataCollector extends DataCollector
             $parts     = explode($outerGlue, $q);
 
             $times     = explode($innerGlue, $parts[0]);
+            $con       = explode($innerGlue, $parts[2]);
             $memories  = explode($innerGlue, $parts[1]);
 
-            $sql       = trim($parts[2]);
+            $sql       = trim($parts[3]);
+            $con       = trim($con[1]);
             $time      = trim($times[1]);
             $memory    = trim($memories[1]);
 
-            $queries[] = array('sql' => $sql, 'time' => $time, 'memory' => $memory);
+            $queries[] = array('connection' => $con, 'sql' => $sql, 'time' => $time, 'memory' => $memory);
         }
 
         return $queries;

--- a/tests/Symfony/Tests/Bridge/Propel1/DataCollector/PropelDataCollectorTest.php
+++ b/tests/Symfony/Tests/Bridge/Propel1/DataCollector/PropelDataCollectorTest.php
@@ -30,7 +30,7 @@ class PropelDataCollectorTest extends Propel1TestCase
     public function testCollectWithData()
     {
         $queries = array(
-            "time: 0.000 sec | mem: 1.4 MB | SET NAMES 'utf8'",
+            "time: 0.000 sec | mem: 1.4 MB | connection: default | SET NAMES 'utf8'",
         );
 
         $c = $this->createCollector($queries);
@@ -40,6 +40,7 @@ class PropelDataCollectorTest extends Propel1TestCase
             array(
                 'sql'       => "SET NAMES 'utf8'",
                 'time'      => '0.000 sec',
+                'connection'=> 'default',
                 'memory'    => '1.4 MB'
             )
         ), $c->getQueries());
@@ -49,8 +50,8 @@ class PropelDataCollectorTest extends Propel1TestCase
     public function testCollectWithMultipleData()
     {
         $queries = array(
-            "time: 0.000 sec | mem: 1.4 MB | SET NAMES 'utf8'",
-            "time: 0.012 sec | mem: 2.4 MB | SELECT tags.NAME, image.FILENAME FROM tags LEFT JOIN image ON tags.IMAGEID = image.ID WHERE image.ID = 12"
+            "time: 0.000 sec | mem: 1.4 MB | connection: default | SET NAMES 'utf8'",
+            "time: 0.012 sec | mem: 2.4 MB | connection: default | SELECT tags.NAME, image.FILENAME FROM tags LEFT JOIN image ON tags.IMAGEID = image.ID WHERE image.ID = 12"
         );
 
         $c = $this->createCollector($queries);
@@ -60,11 +61,13 @@ class PropelDataCollectorTest extends Propel1TestCase
             array(
                 'sql'       => "SET NAMES 'utf8'",
                 'time'      => '0.000 sec',
+                'connection'=> 'default',
                 'memory'    => '1.4 MB'
             ),
             array(
                 'sql'       => "SELECT tags.NAME, image.FILENAME FROM tags LEFT JOIN image ON tags.IMAGEID = image.ID WHERE image.ID = 12",
                 'time'      => '0.012 sec',
+                'connection'=> 'default',
                 'memory'    => '2.4 MB'
             )
         ), $c->getQueries());


### PR DESCRIPTION
Bug fix: no
Feature addition: yes, This will allow to explain a propel query on a specific connection
Backwards compatibility break: no
Symfony2 tests pass: yes
- Require PR propelorm/Propel#315
- Related to PR propelorm/PropelBundle#129

cc @willdurand
