### PR TITLE
fixed code coverage raport generation

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -9,6 +9,7 @@ $loader = new UniversalClassLoader();
 $loader->registerNamespaces(array(
     'Symfony\\Tests'   => __DIR__.'/tests',
     'Symfony'          => __DIR__.'/src',
+    'Doctrine\\Common\\DataFixtures' => __DIR__.'/vendor/doctrine-fixtures/lib',
     'Doctrine\\Common' => __DIR__.'/vendor/doctrine-common/lib',
     'Doctrine\\DBAL'   => __DIR__.'/vendor/doctrine-dbal/lib',
     'Doctrine'         => __DIR__.'/vendor/doctrine/lib',

--- a/vendors.php
+++ b/vendors.php
@@ -34,9 +34,11 @@ if (isset($argv[1]) && in_array($argv[1], array('--transport=http', '--transport
 $deps = array(
     array('doctrine', 'http://github.com/doctrine/doctrine2.git', 'origin/master'),
     array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', 'origin/master'),
+    array('doctrine-fixtures', 'https://github.com/doctrine/data-fixtures.git', 'origin/master'),
     array('doctrine-common', 'http://github.com/doctrine/common.git', 'origin/master'),
     array('twig', 'http://github.com/fabpot/Twig.git', 'origin/master'),
     array('propel', 'http://github.com/propelorm/Propel.git', 'origin/master'),
+    array('monolog', 'https://github.com/Seldaek/monolog.git', 'origin/master'),
 );
 
 foreach ($deps as $dep) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no (tests were already broken)
Fixes the following tickets: -
Todo: -

I wanted to run the test coverage for Symfony2.1. 
I installed vendors using composer but code coverage script failed (running unit tests failed too).
After installing vendors using vendors.php I got errors about missing classes:
`Class 'Doctrine\Common\DataFixtures\Loader' not found`
and later: `Class 'Monolog\Handler\ChromePHPHandler' not found.`

The changes made it possible to run the code coverage script.
Monolog was already present in autoload.php.dist but was not present in vendors.php script, doctrine fixtures were not included in both.
