### PR TITLE
Fixed profiler report under an exception of a sub-request

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -201,7 +201,8 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
         $profile->setTime($data['time']);
         $profile->setCollectors(unserialize(base64_decode($data['data'])));
 
-        if (!$parent && isset($data['parent']) && $data['parent']) {
+        // Under sub-requests, $data['parent'] === $token in an exception situation
+        if (!$parent && isset($data['parent']) && $data['parent'] && $data['parent'] !== $token) {
             $parent = $this->read($data['parent']);
         }
 
@@ -209,7 +210,10 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
             $profile->setParent($parent);
         }
 
-        $profile->setChildren($this->readChildren($token, $profile));
+        // Avoid inspecting children under sub-request exception
+        if (!$parent || $parent->getToken() !== $token) {
+            $profile->setChildren($this->readChildren($token, $profile));
+        }
 
         return $profile;
     }


### PR DESCRIPTION
When a sub-request contains an exception, PdoProfilerStorage was entering in an infinite loop.
Fixed by preventing the read/createProfileFromData recursion.

I experienced this situation when I was trying to consume an undefined variable in a twig template which was part of a sub-request (ESI template).

Associated issue: https://github.com/symfony/symfony/issues/3620

This is a PR against 2.0 branch from original PR 3609 https://github.com/symfony/symfony/pull/3609
