### PR TITLE
Autoloader

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -6,24 +6,22 @@ use Symfony\Component\ClassLoader\UniversalClassLoader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
 $loader = new UniversalClassLoader();
-$loader->registerNamespaces(array(
-    'Symfony\\Tests'   => __DIR__.'/tests',
-    'Symfony'          => __DIR__.'/src',
-    'Doctrine\\Common' => __DIR__.'/vendor/doctrine-common/lib',
-    'Doctrine\\DBAL'   => __DIR__.'/vendor/doctrine-dbal/lib',
-    'Doctrine'         => __DIR__.'/vendor/doctrine/lib',
-    'Monolog'          => __DIR__.'/vendor/monolog/src',
-));
-$loader->registerPrefixes(array(
+$loader->addAll(array(
+    'Symfony\\Tests\\'   => __DIR__.'/tests',
+    'Symfony\\'          => __DIR__.'/src',
+    'Doctrine\\Common\\' => __DIR__.'/vendor/doctrine-common/lib',
+    'Doctrine\\DBAL\\'   => __DIR__.'/vendor/doctrine-dbal/lib',
+    'Doctrine\\ORM\\'    => __DIR__.'/vendor/doctrine/lib',
+    'Monolog\\'          => __DIR__.'/vendor/monolog/src',
     'Twig_' => __DIR__.'/vendor/twig/lib',
 ));
 if (!function_exists('intl_get_error_code')) {
     require_once __DIR__.'/src/Symfony/Component/Locale/Resources/stubs/functions.php';
 
-    $loader->registerPrefixFallback(__DIR__.'/src/Symfony/Component/Locale/Resources/stubs');
+    $loader->addFallback(__DIR__.'/src/Symfony/Component/Locale/Resources/stubs');
 }
 if (!interface_exists('SessionHandlerInterface', false)) {
-    $loader->registerPrefix('SessionHandlerInterface', __DIR__.'/src/Symfony/Component/HttpFoundation/Resources/stubs');
+    $loader->add('SessionHandlerInterface', __DIR__.'/src/Symfony/Component/HttpFoundation/Resources/stubs');
 }
 $loader->register();
 

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -34,10 +34,8 @@ class DebugUniversalClassLoader extends UniversalClassLoader
         foreach ($functions as $function) {
             if (is_array($function) && $function[0] instanceof UniversalClassLoader) {
                 $loader = new static();
-                $loader->registerNamespaceFallbacks($function[0]->getNamespaceFallbacks());
-                $loader->registerPrefixFallbacks($function[0]->getPrefixFallbacks());
-                $loader->registerNamespaces($function[0]->getNamespaces());
-                $loader->registerPrefixes($function[0]->getPrefixes());
+                $loader->addFallbacks($function[0]->getFallbacks());
+                $loader->addAll($function[0]->getPrefixes());
                 $loader->useIncludePath($function[0]->getUseIncludePath());
 
                 $function[0] = $loader;

--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -60,10 +60,8 @@ namespace Symfony\Component\ClassLoader;
  */
 class UniversalClassLoader
 {
-    private $namespaces = array();
     private $prefixes = array();
-    private $namespaceFallbacks = array();
-    private $prefixFallbacks = array();
+    private $fallbacks = array();
     private $useIncludePath = false;
 
     /**
@@ -92,10 +90,13 @@ class UniversalClassLoader
      * Gets the configured namespaces.
      *
      * @return array A hash with namespaces as keys and directories as values
+     *
+     * @see getPrefixes()
+     * @deprecated
      */
     public function getNamespaces()
     {
-        return $this->namespaces;
+        return $this->prefixes;
     }
 
     /**
@@ -109,23 +110,39 @@ class UniversalClassLoader
     }
 
     /**
-     * Gets the directory(ies) to use as a fallback for namespaces.
+     * Gets the directory(ies) to use as a fallback.
      *
      * @return array An array of directories
      */
+    public function getFallbacks()
+    {
+        return $this->fallbacks;
+    }
+
+    /**
+     * Gets the directory(ies) to use as a fallback for namespaces.
+     *
+     * @return array An array of directories
+     *
+     * @see getFallbacks()
+     * @deprecated
+     */
     public function getNamespaceFallbacks()
     {
-        return $this->namespaceFallbacks;
+        return $this->fallbacks;
     }
 
     /**
      * Gets the directory(ies) to use as a fallback for class prefixes.
      *
      * @return array An array of directories
+     *
+     * @see getFallbacks()
+     * @deprecated
      */
     public function getPrefixFallbacks()
     {
-        return $this->prefixFallbacks;
+        return $this->fallbacks;
     }
 
     /**
@@ -133,21 +150,25 @@ class UniversalClassLoader
      *
      * @param array $dirs An array of directories
      *
-     * @api
+     * @see addFallbacks()
+     * @deprecated
      */
     public function registerNamespaceFallbacks(array $dirs)
     {
-        $this->namespaceFallbacks = $dirs;
+        $this->addFallbacks($dirs);
     }
 
     /**
      * Registers a directory to use as a fallback for namespaces.
      *
      * @param string $dir A directory
+     *
+     * @see addFallback()
+     * @deprecated
      */
     public function registerNamespaceFallback($dir)
     {
-        $this->namespaceFallbacks[] = $dir;
+        $this->fallbacks[] = $dir;
     }
 
     /**
@@ -155,11 +176,55 @@ class UniversalClassLoader
      *
      * @param array $dirs An array of directories
      *
-     * @api
+     * @see addFallbacks()
+     * @deprecated
      */
     public function registerPrefixFallbacks(array $dirs)
     {
-        $this->prefixFallbacks = $dirs;
+        $this->addFallbacks($dirs);
+    }
+
+    /**
+     * Registers a directory to use as a fallback for class prefixes.
+     *
+     * @param string $dir A directory
+     *
+     * @see addFallback()
+     * @deprecated
+     */
+    public function registerPrefixFallback($dir)
+    {
+        $this->fallbacks[] = $dir;
+    }
+
+    /**
+     * Registers an array of prefixes
+     *
+     * @param array $prefixes An array of prefixes (prefixes as keys and locations as values)
+     */
+    public function addAll(array $prefixes)
+    {
+        foreach ($prefixes as $prefix => $paths) {
+            $this->add($prefix, $paths);
+        }
+    }
+
+    /**
+     * Registers a class prefix
+     *
+     * @param string       $prefix  The class prefix
+     * @param array|string $paths   The location(s) of the classes
+     */
+    public function add($prefix, $paths)
+    {
+        if (isset($this->prefixes[$prefix])) {
+            $this->prefixes[$prefix] = array_merge(
+                $this->prefixes[$prefix],
+                (array) $paths
+            );
+        } else {
+            $this->prefixes[$prefix] = (array) $paths;
+        }
     }
 
     /**
@@ -167,9 +232,19 @@ class UniversalClassLoader
      *
      * @param string $dir A directory
      */
-    public function registerPrefixFallback($dir)
+    public function addFallback($dir)
     {
-        $this->prefixFallbacks[] = $dir;
+        $this->fallbacks[] = $dir;
+    }
+
+    /**
+     * Registers a set of directories to use as a fallback for class prefixes.
+     *
+     * @param array $dirs A set of directories
+     */
+    public function addFallbacks(array $dirs)
+    {
+        $this->fallbacks = array_merge($this->fallbacks, $dirs);
     }
 
     /**
@@ -177,13 +252,12 @@ class UniversalClassLoader
      *
      * @param array $namespaces An array of namespaces (namespaces as keys and locations as values)
      *
-     * @api
+     * @see addAll()
+     * @deprecated
      */
     public function registerNamespaces(array $namespaces)
     {
-        foreach ($namespaces as $namespace => $locations) {
-            $this->namespaces[$namespace] = (array) $locations;
-        }
+        $this->addAll($namespaces);
     }
 
     /**
@@ -192,11 +266,12 @@ class UniversalClassLoader
      * @param string       $namespace The namespace
      * @param array|string $paths     The location(s) of the namespace
      *
-     * @api
+     * @see add()
+     * @deprecated
      */
     public function registerNamespace($namespace, $paths)
     {
-        $this->namespaces[$namespace] = (array) $paths;
+        $this->add($namespace, $paths);
     }
 
     /**
@@ -204,13 +279,12 @@ class UniversalClassLoader
      *
      * @param array $classes An array of classes (prefixes as keys and locations as values)
      *
-     * @api
+     * @see addAll()
+     * @deprecated
      */
     public function registerPrefixes(array $classes)
     {
-        foreach ($classes as $prefix => $locations) {
-            $this->prefixes[$prefix] = (array) $locations;
-        }
+        $this->addAll($classes);
     }
 
     /**
@@ -219,11 +293,12 @@ class UniversalClassLoader
      * @param string       $prefix  The classes prefix
      * @param array|string $paths   The location(s) of the classes
      *
-     * @api
+     * @see add()
+     * @deprecated
      */
     public function registerPrefix($prefix, $paths)
     {
-        $this->prefixes[$prefix] = (array) $paths;
+        $this->add($prefix, $paths);
     }
 
     /**
@@ -265,54 +340,36 @@ class UniversalClassLoader
 
         if (false !== $pos = strrpos($class, '\\')) {
             // namespaced class name
-            $namespace = substr($class, 0, $pos);
+            $classPath = str_replace('\\', DIRECTORY_SEPARATOR, substr($class, 0, $pos)) . DIRECTORY_SEPARATOR;
             $className = substr($class, $pos + 1);
-            $normalizedClass = str_replace('\\', DIRECTORY_SEPARATOR, $namespace).DIRECTORY_SEPARATOR.str_replace('_', DIRECTORY_SEPARATOR, $className).'.php';
-            foreach ($this->namespaces as $ns => $dirs) {
-                if (0 !== strpos($namespace, $ns)) {
-                    continue;
-                }
-
-                foreach ($dirs as $dir) {
-                    $file = $dir.DIRECTORY_SEPARATOR.$normalizedClass;
-                    if (is_file($file)) {
-                        return $file;
-                    }
-                }
-            }
-
-            foreach ($this->namespaceFallbacks as $dir) {
-                $file = $dir.DIRECTORY_SEPARATOR.$normalizedClass;
-                if (is_file($file)) {
-                    return $file;
-                }
-            }
-
         } else {
             // PEAR-like class name
-            $normalizedClass = str_replace('_', DIRECTORY_SEPARATOR, $class).'.php';
-            foreach ($this->prefixes as $prefix => $dirs) {
-                if (0 !== strpos($class, $prefix)) {
-                    continue;
-                }
+            $classPath = null;
+            $className = $class;
+        }
+        $classPath .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
-                foreach ($dirs as $dir) {
-                    $file = $dir.DIRECTORY_SEPARATOR.$normalizedClass;
-                    if (is_file($file)) {
-                        return $file;
-                    }
-                }
+        foreach ($this->prefixes as $prefix => $dirs) {
+            if (0 !== strpos($class, $prefix)) {
+                continue;
             }
 
-            foreach ($this->prefixFallbacks as $dir) {
-                $file = $dir.DIRECTORY_SEPARATOR.$normalizedClass;
+            foreach ($dirs as $dir) {
+                $file = $dir.DIRECTORY_SEPARATOR.$classPath;
                 if (is_file($file)) {
                     return $file;
                 }
             }
         }
 
-        if ($this->useIncludePath && $file = stream_resolve_include_path($normalizedClass)) {
+        foreach ($this->fallbacks as $dir) {
+            $file = $dir.DIRECTORY_SEPARATOR.$classPath;
+            if (is_file($file)) {
+                return $file;
+            }
+        }
+
+        if ($this->useIncludePath && $file = stream_resolve_include_path($classPath)) {
             return $file;
         }
     }

--- a/tests/Symfony/Tests/Component/ClassLoader/UniversalClassLoaderTest.php
+++ b/tests/Symfony/Tests/Component/ClassLoader/UniversalClassLoaderTest.php
@@ -21,8 +21,8 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClass($className, $testClassName, $message)
     {
         $loader = new UniversalClassLoader();
-        $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
-        $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->add('Namespaced\\', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->add('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
         $loader->loadClass($testClassName);
         $this->assertTrue(class_exists($className), $message);
     }
@@ -62,10 +62,9 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassFromFallback($className, $testClassName, $message)
     {
         $loader = new UniversalClassLoader();
-        $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
-        $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
-        $loader->registerNamespaceFallbacks(array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'));
-        $loader->registerPrefixFallbacks(array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'));
+        $loader->add('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->add('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->addFallbacks(array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'));
         $loader->loadClass($testClassName);
         $this->assertTrue(class_exists($className), $message);
     }
@@ -83,8 +82,8 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     public function testRegisterPrefixFallback()
     {
         $loader = new UniversalClassLoader();
-        $loader->registerPrefixFallback(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback');
-        $this->assertEquals(array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'), $loader->getPrefixFallbacks());
+        $loader->addFallback(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback');
+        $this->assertEquals(array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'), $loader->getFallbacks());
     }
 
     public function testRegisterNamespaceFallback()
@@ -100,7 +99,7 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassNamespaceCollision($namespaces, $className, $message)
     {
         $loader = new UniversalClassLoader();
-        $loader->registerNamespaces($namespaces);
+        $loader->addAll($namespaces);
 
         $loader->loadClass($className);
         $this->assertTrue(class_exists($className), $message);
@@ -150,7 +149,7 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadClassPrefixCollision($prefixes, $className, $message)
     {
         $loader = new UniversalClassLoader();
-        $loader->registerPrefixes($prefixes);
+        $loader->addAll($prefixes);
 
         $loader->loadClass($className);
         $this->assertTrue(class_exists($className), $message);


### PR DESCRIPTION
As discussed on #3570, this refactors the UniversalClassLoader to remove the distinction between namespaced classes and PEAR-like classes. This distinction was unnecessary as the PEAR convention is a subset of PSR-0

Currently, I kept a separate method to register the fallbacks (`addFallback` vc `add`) but I'm wondering if it wouldn't be better to specify an empty string as prefix in `add` to register a fallback, thus allowing us to use the namespace map generated by Composer directly (as this is how prefixes are handled by Composer). What do you think about it ?

The refactoring is BC as old methods have been kept (and rewritten internally to use the new logic).
