### PR TITLE
[Console] Stop parsing options after encountering "--" token

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -168,6 +168,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * made the defaults (helper set, commands, input definition) in Application more easily customizable
  * added support for the shell even if readline is not available
  * added support for process isolation in Symfony shell via `--process-isolation` switch
+ * added support for `--`, which disables options parsing after that point (tokens will be parsed as arguments)
 
 ### ClassLoader
 

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -75,11 +75,14 @@ class ArgvInput extends Input
      */
     protected function parse()
     {
+        $parseOptions = true;
         $this->parsed = $this->tokens;
         while (null !== $token = array_shift($this->parsed)) {
-            if (0 === strpos($token, '--')) {
+            if ($parseOptions && '--' == $token) {
+                $parseOptions = false;
+            } elseif ($parseOptions && 0 === strpos($token, '--')) {
                 $this->parseLongOption($token);
-            } elseif ('-' === $token[0]) {
+            } elseif ($parseOptions && '-' === $token[0]) {
                 $this->parseShortOption($token);
             } else {
                 $this->parseArgument($token);


### PR DESCRIPTION
This enables support for arguments with leading dashes (e.g. "-1"), as supported by getopt in other languages.

[![Build Status](https://secure.travis-ci.org/jmikola/symfony.png?branch=double-dash)](http://travis-ci.org/jmikola/symfony)

The test suite currently fails due to 7a54fe41caf66f468e80c103092b3534348c486a. ArgvInputTest passes, and these changes don't appear to break anything else.

![](http://media.giantbomb.com/uploads/2/27528/1061704-mario_kart_double_dash___title_screen_super.jpg)

Aside: This got me thinking about how one would pass an option value of "-1". I suppose for input options with `VALUE_OPTIONAL`, it would be ambiguous if "-1" followed; however, `VALUE_REQUIRED` should probably require that the next token is captured as the option value. In my tests, a required option value with a leading dash was interpreted as another option. The workaround for all of this is to use the space-less syntax (e.g. `-f=-1`).
