### PR TITLE
[Locale] DateTimeZone called incorrectly by default

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
@@ -39,7 +39,7 @@ class MonthChoiceList extends PaddedChoiceList
         $pattern = $this->formatter->getPattern();
         $timezone = $this->formatter->getTimezoneId();
 
-        $this->formatter->setTimezoneId(\DateTimeZone::UTC);
+        $this->formatter->setTimezoneId('UTC');
 
         if (preg_match('/M+/', $pattern, $matches)) {
             $this->formatter->setPattern($matches[0]);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -57,7 +57,7 @@ class DateType extends AbstractType
             \Locale::getDefault(),
             $format,
             \IntlDateFormatter::NONE,
-            \DateTimeZone::UTC,
+            'UTC',
             \IntlDateFormatter::GREGORIAN,
             $pattern
         );

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/ChoiceList/MonthChoiceListTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/ChoiceList/MonthChoiceListTest.php
@@ -31,7 +31,7 @@ class MonthChoiceListTest extends \PHPUnit_Framework_TestCase
             \Locale::getDefault(),
             \IntlDateFormatter::SHORT,
             \IntlDateFormatter::NONE,
-            \DateTimeZone::UTC
+            'UTC'
         );
     }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no (there were two tests that were failing previously, that still fail)
Fixes the following tickets: none
Todo: none

While running, a warning throws every single time when the code 

``` php
new \DateTimeZone(\DateTimeZone::UTC);
```

is encountered. It is normally caught as a thrown exception and then corrected here:

``` php
// src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php:442
        try {
            $this->dateTimeZone = new \DateTimeZone($timeZoneId);
        } catch (\Exception $e) {
            $this->dateTimeZone = new \DateTimeZone('UTC');
        }
```

However in my particular infrastructure, for whatever reason in production only, it causes an error to appear on shutdown in the logs. As ultimately the constant can NEVER pass, it should not be attempted with the constant. Instead, the correct 'UTC' should be passed in (as done in the catch statement).
