### PR TITLE
Updated .gitignore to ignore some usual IDE directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 phpunit.xml
 autoload.php
 /vendor/
+.idea
+.buildpath
+.project
+.settings
+atlassian-ide-plugin.xml


### PR DESCRIPTION
I work with PHPStorm on a daily basis and I think it's a good idea to have the .gitignore ignore most of the usual IDE directories in order to avoid mistakes when commiting files to the project.

I've also added the default file added by Atlassian Bamboo server.
