### PR TITLE
[WIP][Routing] Added unicode support

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -21,3 +21,4 @@ CHANGELOG
    been used anyway without creating inconsistencies
  * [BC BREAK] RouteCollection::remove also removes a route from parent
    collections (not only from its children)
+ * Routing component now supports unicode routes

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -124,7 +124,7 @@ class UrlGenerator implements UrlGeneratorInterface
                     $optional = false;
                 }
             } elseif ('text' === $token[0]) {
-                $url = $token[1].$url;
+                $url = str_replace(array_keys($this->decodedChars), $this->decodedChars, rawurlencode($token[1])).$url;
                 $optional = false;
             }
         }

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -85,7 +85,7 @@ class RouteCompiler implements RouteCompilerInterface
         return new CompiledRoute(
             $route,
             'text' === $tokens[0][0] ? $tokens[0][1] : '',
-            self::REGEX_DELIMITER.'^'.$regexp.'$'.self::REGEX_DELIMITER.'s',
+            self::REGEX_DELIMITER.'^'.$regexp.'$'.self::REGEX_DELIMITER.'su',
             array_reverse($tokens),
             $variables
         );

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.apache
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.apache
@@ -6,6 +6,10 @@ RewriteRule .* - [QSA,L]
 RewriteCond %{REQUEST_URI} ^/foo/(baz|symfony)$
 RewriteRule .* app.php [QSA,L,E=_ROUTING__route:foo,E=_ROUTING_bar:%1,E=_ROUTING_def:test]
 
+# foo_unicode
+RewriteCond %{REQUEST_URI} ^/Жени/(baz|symfony)$
+RewriteRule .* app.php [QSA,L,E=_ROUTING__route:foo_unicode,E=_ROUTING_bar:%1,E=_ROUTING_def:test]
+
 # bar
 RewriteCond %{REQUEST_URI} ^/bar/([^/]+?)$
 RewriteCond %{REQUEST_METHOD} !^(GET|HEAD)$ [NC]

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -26,12 +26,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         $pathinfo = rawurldecode($pathinfo);
 
         // foo
-        if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?<bar>baz|symfony)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?<bar>baz|symfony)$#su', $pathinfo, $matches)) {
             return array_merge($this->mergeDefaults($matches, array (  'def' => 'test',)), array('_route' => 'foo'));
         }
 
+        // foo_unicode
+        if (0 === strpos($pathinfo, '/Жени') && preg_match('#^/Жени/(?<bar>baz|symfony)$#su', $pathinfo, $matches)) {
+            return array_merge($this->mergeDefaults($matches, array (  'def' => 'test',)), array('_route' => 'foo_unicode'));
+        }
+
         // bar
-        if (0 === strpos($pathinfo, '/bar') && preg_match('#^/bar/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/bar') && preg_match('#^/bar/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
                 $allow = array_merge($allow, array('GET', 'HEAD'));
                 goto not_bar;
@@ -42,7 +47,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         not_bar:
 
         // barhead
-        if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
                 $allow = array_merge($allow, array('GET', 'HEAD'));
                 goto not_barhead;
@@ -68,13 +73,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // baz4
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'baz4';
             return $matches;
         }
 
         // baz5
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#su', $pathinfo, $matches)) {
             if ($this->context->getMethod() != 'POST') {
                 $allow[] = 'POST';
                 goto not_baz5;
@@ -85,7 +90,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         not_baz5:
 
         // baz.baz6
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#su', $pathinfo, $matches)) {
             if ($this->context->getMethod() != 'PUT') {
                 $allow[] = 'PUT';
                 goto not_bazbaz6;
@@ -101,7 +106,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // quoter
-        if (preg_match('#^/(?<quoter>[\']+)$#s', $pathinfo, $matches)) {
+        if (preg_match('#^/(?<quoter>[\']+)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'quoter';
             return $matches;
         }
@@ -114,13 +119,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (0 === strpos($pathinfo, '/a')) {
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo1
-                if (preg_match('#^/a/b\'b/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'foo1';
                     return $matches;
                 }
 
                 // bar1
-                if (preg_match('#^/a/b\'b/(?<bar>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<bar>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'bar1';
                     return $matches;
                 }
@@ -128,20 +133,20 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             }
 
             // overriden
-            if (preg_match('#^/a/(?<var>.*)$#s', $pathinfo, $matches)) {
+            if (preg_match('#^/a/(?<var>.*)$#su', $pathinfo, $matches)) {
                 $matches['_route'] = 'overriden';
                 return $matches;
             }
 
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
-                if (preg_match('#^/a/b\'b/(?<foo1>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<foo1>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'foo2';
                     return $matches;
                 }
 
                 // bar2
-                if (preg_match('#^/a/b\'b/(?<bar1>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<bar1>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'bar2';
                     return $matches;
                 }
@@ -152,7 +157,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
         if (0 === strpos($pathinfo, '/multi')) {
             // helloWorld
-            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?<who>[^/]+?))?$#s', $pathinfo, $matches)) {
+            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?<who>[^/]+?))?$#su', $pathinfo, $matches)) {
                 return array_merge($this->mergeDefaults($matches, array (  'who' => 'World!',)), array('_route' => 'helloWorld'));
             }
 
@@ -169,13 +174,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // foo3
-        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'foo3';
             return $matches;
         }
 
         // bar3
-        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<bar>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<bar>[^/]+?)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'bar3';
             return $matches;
         }
@@ -186,7 +191,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         }
 
         // foo4
-        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'foo4';
             return $matches;
         }
@@ -199,13 +204,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
 
             if (0 === strpos($pathinfo, '/a/b')) {
                 // b
-                if (preg_match('#^/a/b/(?<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b/(?<var>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'b';
                     return $matches;
                 }
 
                 // c
-                if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?<var>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'c';
                     return $matches;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -26,12 +26,17 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         $pathinfo = rawurldecode($pathinfo);
 
         // foo
-        if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?<bar>baz|symfony)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?<bar>baz|symfony)$#su', $pathinfo, $matches)) {
             return array_merge($this->mergeDefaults($matches, array (  'def' => 'test',)), array('_route' => 'foo'));
         }
 
+        // foo_unicode
+        if (0 === strpos($pathinfo, '/Жени') && preg_match('#^/Жени/(?<bar>baz|symfony)$#su', $pathinfo, $matches)) {
+            return array_merge($this->mergeDefaults($matches, array (  'def' => 'test',)), array('_route' => 'foo_unicode'));
+        }
+
         // bar
-        if (0 === strpos($pathinfo, '/bar') && preg_match('#^/bar/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/bar') && preg_match('#^/bar/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
                 $allow = array_merge($allow, array('GET', 'HEAD'));
                 goto not_bar;
@@ -42,7 +47,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         not_bar:
 
         // barhead
-        if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
                 $allow = array_merge($allow, array('GET', 'HEAD'));
                 goto not_barhead;
@@ -71,7 +76,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // baz4
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/?$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/?$#su', $pathinfo, $matches)) {
             if (substr($pathinfo, -1) !== '/') {
                 return $this->redirect($pathinfo.'/', 'baz4');
             }
@@ -80,7 +85,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // baz5
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#su', $pathinfo, $matches)) {
             if ($this->context->getMethod() != 'POST') {
                 $allow[] = 'POST';
                 goto not_baz5;
@@ -91,7 +96,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         not_baz5:
 
         // baz.baz6
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]+?)/$#su', $pathinfo, $matches)) {
             if ($this->context->getMethod() != 'PUT') {
                 $allow[] = 'PUT';
                 goto not_bazbaz6;
@@ -107,7 +112,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // quoter
-        if (preg_match('#^/(?<quoter>[\']+)$#s', $pathinfo, $matches)) {
+        if (preg_match('#^/(?<quoter>[\']+)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'quoter';
             return $matches;
         }
@@ -120,13 +125,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (0 === strpos($pathinfo, '/a')) {
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo1
-                if (preg_match('#^/a/b\'b/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'foo1';
                     return $matches;
                 }
 
                 // bar1
-                if (preg_match('#^/a/b\'b/(?<bar>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<bar>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'bar1';
                     return $matches;
                 }
@@ -134,20 +139,20 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             }
 
             // overriden
-            if (preg_match('#^/a/(?<var>.*)$#s', $pathinfo, $matches)) {
+            if (preg_match('#^/a/(?<var>.*)$#su', $pathinfo, $matches)) {
                 $matches['_route'] = 'overriden';
                 return $matches;
             }
 
             if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
-                if (preg_match('#^/a/b\'b/(?<foo1>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<foo1>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'foo2';
                     return $matches;
                 }
 
                 // bar2
-                if (preg_match('#^/a/b\'b/(?<bar1>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b\'b/(?<bar1>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'bar2';
                     return $matches;
                 }
@@ -158,7 +163,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
         if (0 === strpos($pathinfo, '/multi')) {
             // helloWorld
-            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?<who>[^/]+?))?$#s', $pathinfo, $matches)) {
+            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?<who>[^/]+?))?$#su', $pathinfo, $matches)) {
                 return array_merge($this->mergeDefaults($matches, array (  'who' => 'World!',)), array('_route' => 'helloWorld'));
             }
 
@@ -178,13 +183,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // foo3
-        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'foo3';
             return $matches;
         }
 
         // bar3
-        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<bar>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (preg_match('#^/(?<_locale>[^/]+?)/b/(?<bar>[^/]+?)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'bar3';
             return $matches;
         }
@@ -195,7 +200,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         }
 
         // foo4
-        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?<foo>[^/]+?)$#su', $pathinfo, $matches)) {
             $matches['_route'] = 'foo4';
             return $matches;
         }
@@ -208,13 +213,13 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
 
             if (0 === strpos($pathinfo, '/a/b')) {
                 // b
-                if (preg_match('#^/a/b/(?<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (preg_match('#^/a/b/(?<var>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'b';
                     return $matches;
                 }
 
                 // c
-                if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?<var>[^/]+?)$#su', $pathinfo, $matches)) {
                     $matches['_route'] = 'c';
                     return $matches;
                 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -32,7 +32,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             }
 
             // dynamic
-            if (preg_match('#^/rootprefix/(?<var>[^/]+?)$#s', $pathinfo, $matches)) {
+            if (preg_match('#^/rootprefix/(?<var>[^/]+?)$#su', $pathinfo, $matches)) {
                 $matches['_route'] = 'dynamic';
                 return $matches;
             }

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -42,6 +42,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost:8080/app.php/testing', $url);
     }
 
+    public function testAbsoluteUrlUnicodeWithNonStandardPort()
+    {
+        $routes = $this->getRoutes('test', new Route('/Жени'));
+        $url = $this->getGenerator($routes, array('httpPort' => 8080))->generate('test', array(), true);
+
+        $this->assertEquals('http://localhost:8080/app.php/Жени', $url);
+    }
+
     public function testAbsoluteSecureUrlWithNonStandardPort()
     {
         $routes = $this->getRoutes('test', new Route('/testing'));
@@ -96,6 +104,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), false);
 
         $this->assertEquals('/app.php/testing?foo=bar', $url);
+    }
+
+    public function testRelativeUrlUnicodeWithExtraParameters()
+    {
+        $routes = $this->getRoutes('test', new Route('/Жени'));
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), false);
+
+        $this->assertEquals('/app.php/Жени?foo=bar', $url);
     }
 
     public function testAbsoluteUrlWithExtraParameters()
@@ -197,6 +213,13 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes = $this->getRoutes('test', new Route('/category/{slug1}/{slug2}/{slug3}', array('slug2' => null, 'slug3' => null)));
 
         $this->assertEquals('/app.php/category/foo', $this->getGenerator($routes)->generate('test', array('slug1' => 'foo')));
+    }
+
+    public function testUnicodeNoTrailingSlashForMultipleOptionalParameters()
+    {
+        $routes = $this->getRoutes('test', new Route('/Жени/{slug1}/{slug2}/{slug3}', array('slug2' => null, 'slug3' => null)));
+
+        $this->assertEquals('/app.php/Жени/%D0%96%D0%B5%D0%BD%D0%B8', $this->getGenerator($routes)->generate('test', array('slug1' => 'Жени')));
     }
 
     public function testWithAnIntegerAsADefaultValue()

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -47,7 +47,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes = $this->getRoutes('test', new Route('/Жени'));
         $url = $this->getGenerator($routes, array('httpPort' => 8080))->generate('test', array(), true);
 
-        $this->assertEquals('http://localhost:8080/app.php/Жени', $url);
+        $this->assertEquals('http://localhost:8080/app.php/%D0%96%D0%B5%D0%BD%D0%B8', $url);
     }
 
     public function testAbsoluteSecureUrlWithNonStandardPort()
@@ -111,7 +111,15 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes = $this->getRoutes('test', new Route('/Жени'));
         $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), false);
 
-        $this->assertEquals('/app.php/Жени?foo=bar', $url);
+        $this->assertEquals('/app.php/%D0%96%D0%B5%D0%BD%D0%B8?foo=bar', $url);
+    }
+
+    public function testRelativeUrlUnicodeWithExtraUnicodeParameters()
+    {
+        $routes = $this->getRoutes('test', new Route('/Жени'));
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'शाम'), false);
+
+        $this->assertEquals('/app.php/%D0%96%D0%B5%D0%BD%D0%B8?foo=%E0%A4%B6%E0%A4%BE%E0%A4%AE', $url);
     }
 
     public function testAbsoluteUrlWithExtraParameters()
@@ -152,6 +160,18 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $url = $generator->generate('test', array());
 
         $this->assertEquals('/app.php/testing/bar', $url);
+    }
+
+    public function testUrlWithGlobalUnicodeParameter()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing/{foo}'));
+        $generator = $this->getGenerator($routes);
+        $context = new RequestContext('/app.php');
+        $context->setParameter('foo', 'Жени');
+        $generator->setContext($context);
+        $url = $generator->generate('test', array());
+
+        $this->assertEquals('/app.php/testing/%D0%96%D0%B5%D0%BD%D0%B8', $url);
     }
 
     /**
@@ -218,35 +238,31 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     public function testUnicodeNoTrailingSlashForMultipleOptionalParameters()
     {
         $routes = $this->getRoutes('test', new Route('/Жени/{bulgarian}/{slug2}/{slug3}', array('bulgarian' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/Жени/Жени', $this->getGenerator($routes)->generate('test', array('bulgarian' => 'Жени')));
+        $this->assertEquals('/app.php/%D0%96%D0%B5%D0%BD%D0%B8/%D0%96%D0%B5%D0%BD%D0%B8', $this->getGenerator($routes)->generate('test', array('bulgarian' => 'Жени')));
 
         $routes = $this->getRoutes('test', new Route('/शाम/{hindi}/{slug2}/{slug3}', array('hindi' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/शाम/शाम', $this->getGenerator($routes)->generate('test', array('hindi' => 'शाम')));
+        $this->assertEquals('/app.php/%E0%A4%B6%E0%A4%BE%E0%A4%AE/%E0%A4%B6%E0%A4%BE%E0%A4%AE', $this->getGenerator($routes)->generate('test', array('hindi' => 'शाम')));
 
         $routes = $this->getRoutes('test', new Route('/مساء/{arabic}/{slug2}/{slug3}', array('arabic' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/مساء/مساء', $this->getGenerator($routes)->generate('test', array('arabic' => 'مساء')));
+        $this->assertEquals('/app.php/%D9%85%D8%B3%D8%A7%D8%A1/%D9%85%D8%B3%D8%A7%D8%A1', $this->getGenerator($routes)->generate('test', array('arabic' => 'مساء')));
 
         $routes = $this->getRoutes('test', new Route('/երեկո/{armenian}/{slug2}/{slug3}', array('armenian' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/երեկո/երեկո', $this->getGenerator($routes)->generate('test', array('armenian' => 'երեկո')));
+        $this->assertEquals('/app.php/%D5%A5%D6%80%D5%A5%D5%AF%D5%B8/%D5%A5%D6%80%D5%A5%D5%AF%D5%B8', $this->getGenerator($routes)->generate('test', array('armenian' => 'երեկո')));
 
         $routes = $this->getRoutes('test', new Route('/黄昏/{chineseSimplified}/{slug2}/{slug3}', array('chineseSimplified' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/黄昏/黄昏', $this->getGenerator($routes)->generate('test', array('chineseSimplified' => '黄昏')));
+        $this->assertEquals('/app.php/%E9%BB%84%E6%98%8F/%E9%BB%84%E6%98%8F', $this->getGenerator($routes)->generate('test', array('chineseSimplified' => '黄昏')));
 
         $routes = $this->getRoutes('test', new Route('/黃昏/{chineseTraditional}/{slug2}/{slug3}', array('chineseTraditional' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/黃昏/黃昏', $this->getGenerator($routes)->generate('test', array('chineseTraditional' => '黃昏')));
+        $this->assertEquals('/app.php/%E9%BB%83%E6%98%8F/%E9%BB%83%E6%98%8F', $this->getGenerator($routes)->generate('test', array('chineseTraditional' => '黃昏')));
 
         $routes = $this->getRoutes('test', new Route('/вечер/{macedonian}/{slug2}/{slug3}', array('macedonian' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/вечер/вечер', $this->getGenerator($routes)->generate('test', array('macedonian' => 'вечер')));
+        $this->assertEquals('/app.php/%D0%B2%D0%B5%D1%87%D0%B5%D1%80/%D0%B2%D0%B5%D1%87%D0%B5%D1%80', $this->getGenerator($routes)->generate('test', array('macedonian' => 'вечер')));
 
         $routes = $this->getRoutes('test', new Route('/ตอนเย็น/{thai}/{slug2}/{slug3}', array('thai' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/ตอนเย็น/ตอนเย็น', $this->getGenerator($routes)->generate('test', array('thai' => 'ตอนเย็น')));
+        $this->assertEquals('/app.php/%E0%B8%95%E0%B8%AD%E0%B8%99%E0%B9%80%E0%B8%A2%E0%B9%87%E0%B8%99/%E0%B8%95%E0%B8%AD%E0%B8%99%E0%B9%80%E0%B8%A2%E0%B9%87%E0%B8%99', $this->getGenerator($routes)->generate('test', array('thai' => 'ตอนเย็น')));
 
         $routes = $this->getRoutes('test', new Route('/buổi tối/{vietnamese}/{slug2}/{slug3}', array('vietnamese' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/buổi tối/buổi tối', $this->getGenerator($routes)->generate('test', array('vietnamese' => 'buổi tối')));
-
-        $routes = $this->getRoutes('test', new Route('/buổi tối/{vietnamese}/{slug2}/{slug3}', array('vietnamese' => null, 'slug2' => null, 'slug3' => null)));
-        $this->assertEquals('/app.php/buổi tối/buổi tối', $this->getGenerator($routes)->generate('test', array('vietnamese' => 'buổi tối')));
-
+        $this->assertEquals('/app.php/bu%E1%BB%95i%20t%E1%BB%91i/bu%E1%BB%95i%20t%E1%BB%91i', $this->getGenerator($routes)->generate('test', array('vietnamese' => 'buổi tối')));
     }
 
     public function testWithAnIntegerAsADefaultValue()

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -217,9 +217,36 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testUnicodeNoTrailingSlashForMultipleOptionalParameters()
     {
-        $routes = $this->getRoutes('test', new Route('/Жени/{slug1}/{slug2}/{slug3}', array('slug2' => null, 'slug3' => null)));
+        $routes = $this->getRoutes('test', new Route('/Жени/{bulgarian}/{slug2}/{slug3}', array('bulgarian' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/Жени/Жени', $this->getGenerator($routes)->generate('test', array('bulgarian' => 'Жени')));
 
-        $this->assertEquals('/app.php/Жени/%D0%96%D0%B5%D0%BD%D0%B8', $this->getGenerator($routes)->generate('test', array('slug1' => 'Жени')));
+        $routes = $this->getRoutes('test', new Route('/शाम/{hindi}/{slug2}/{slug3}', array('hindi' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/शाम/शाम', $this->getGenerator($routes)->generate('test', array('hindi' => 'शाम')));
+
+        $routes = $this->getRoutes('test', new Route('/مساء/{arabic}/{slug2}/{slug3}', array('arabic' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/مساء/مساء', $this->getGenerator($routes)->generate('test', array('arabic' => 'مساء')));
+
+        $routes = $this->getRoutes('test', new Route('/երեկո/{armenian}/{slug2}/{slug3}', array('armenian' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/երեկո/երեկո', $this->getGenerator($routes)->generate('test', array('armenian' => 'երեկո')));
+
+        $routes = $this->getRoutes('test', new Route('/黄昏/{chineseSimplified}/{slug2}/{slug3}', array('chineseSimplified' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/黄昏/黄昏', $this->getGenerator($routes)->generate('test', array('chineseSimplified' => '黄昏')));
+
+        $routes = $this->getRoutes('test', new Route('/黃昏/{chineseTraditional}/{slug2}/{slug3}', array('chineseTraditional' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/黃昏/黃昏', $this->getGenerator($routes)->generate('test', array('chineseTraditional' => '黃昏')));
+
+        $routes = $this->getRoutes('test', new Route('/вечер/{macedonian}/{slug2}/{slug3}', array('macedonian' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/вечер/вечер', $this->getGenerator($routes)->generate('test', array('macedonian' => 'вечер')));
+
+        $routes = $this->getRoutes('test', new Route('/ตอนเย็น/{thai}/{slug2}/{slug3}', array('thai' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/ตอนเย็น/ตอนเย็น', $this->getGenerator($routes)->generate('test', array('thai' => 'ตอนเย็น')));
+
+        $routes = $this->getRoutes('test', new Route('/buổi tối/{vietnamese}/{slug2}/{slug3}', array('vietnamese' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/buổi tối/buổi tối', $this->getGenerator($routes)->generate('test', array('vietnamese' => 'buổi tối')));
+
+        $routes = $this->getRoutes('test', new Route('/buổi tối/{vietnamese}/{slug2}/{slug3}', array('vietnamese' => null, 'slug2' => null, 'slug3' => null)));
+        $this->assertEquals('/app.php/buổi tối/buổi tối', $this->getGenerator($routes)->generate('test', array('vietnamese' => 'buổi tối')));
+
     }
 
     public function testWithAnIntegerAsADefaultValue()

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/ApacheMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/ApacheMatcherDumperTest.php
@@ -70,6 +70,11 @@ class ApacheMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array('def' => 'test'),
             array('bar' => 'baz|symfony')
         ));
+        $collection->add('foo_unicode', new Route(
+            '/Жени/{bar}',
+            array('def' => 'test'),
+            array('bar' => 'baz|symfony')
+        ));
         // method requirement
         $collection->add('bar', new Route(
             '/bar/{foo}',

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -59,6 +59,11 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array('def' => 'test'),
             array('bar' => 'baz|symfony')
         ));
+        $collection->add('foo_unicode', new Route(
+            '/Жени/{bar}',
+            array('def' => 'test'),
+            array('bar' => 'baz|symfony')
+        ));
         // method requirement
         $collection->add('bar', new Route(
             '/bar/{foo}',

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -36,22 +36,30 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Static route',
                 array('/foo'),
-                '/foo', '#^/foo$#s', array(), array(
+                '/foo', '#^/foo$#su', array(), array(
                     array('text', '/foo'),
                 )),
 
             array(
                 'Route with a variable',
                 array('/foo/{bar}'),
-                '/foo', '#^/foo/(?<bar>[^/]+?)$#s', array('bar'), array(
+                '/foo', '#^/foo/(?<bar>[^/]+?)$#su', array('bar'), array(
                     array('variable', '/', '[^/]+?', 'bar'),
                     array('text', '/foo'),
                 )),
 
             array(
+                'Unicode route with a variable',
+                array('/Жени/{bar}'),
+                '/Жени', '#^/Жени/(?<bar>[^/]+?)$#su', array('bar'), array(
+                    array('variable', '/', '[^/]+?', 'bar'),
+                    array('text', '/Жени'),
+                )),
+
+            array(
                 'Route with a variable that has a default value',
                 array('/foo/{bar}', array('bar' => 'bar')),
-                '/foo', '#^/foo(?:/(?<bar>[^/]+?))?$#s', array('bar'), array(
+                '/foo', '#^/foo(?:/(?<bar>[^/]+?))?$#su', array('bar'), array(
                     array('variable', '/', '[^/]+?', 'bar'),
                     array('text', '/foo'),
                 )),
@@ -59,7 +67,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables',
                 array('/foo/{bar}/{foobar}'),
-                '/foo', '#^/foo/(?<bar>[^/]+?)/(?<foobar>[^/]+?)$#s', array('bar', 'foobar'), array(
+                '/foo', '#^/foo/(?<bar>[^/]+?)/(?<foobar>[^/]+?)$#su', array('bar', 'foobar'), array(
                     array('variable', '/', '[^/]+?', 'foobar'),
                     array('variable', '/', '[^/]+?', 'bar'),
                     array('text', '/foo'),
@@ -68,7 +76,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables that have default values',
                 array('/foo/{bar}/{foobar}', array('bar' => 'bar', 'foobar' => '')),
-                '/foo', '#^/foo(?:/(?<bar>[^/]+?)(?:/(?<foobar>[^/]+?))?)?$#s', array('bar', 'foobar'), array(
+                '/foo', '#^/foo(?:/(?<bar>[^/]+?)(?:/(?<foobar>[^/]+?))?)?$#su', array('bar', 'foobar'), array(
                     array('variable', '/', '[^/]+?', 'foobar'),
                     array('variable', '/', '[^/]+?', 'bar'),
                     array('text', '/foo'),
@@ -77,7 +85,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables but some of them have no default values',
                 array('/foo/{bar}/{foobar}', array('bar' => 'bar')),
-                '/foo', '#^/foo/(?<bar>[^/]+?)/(?<foobar>[^/]+?)$#s', array('bar', 'foobar'), array(
+                '/foo', '#^/foo/(?<bar>[^/]+?)/(?<foobar>[^/]+?)$#su', array('bar', 'foobar'), array(
                     array('variable', '/', '[^/]+?', 'foobar'),
                     array('variable', '/', '[^/]+?', 'bar'),
                     array('text', '/foo'),
@@ -86,14 +94,14 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with an optional variable as the first segment',
                 array('/{bar}', array('bar' => 'bar')),
-                '', '#^/(?<bar>[^/]+?)?$#s', array('bar'), array(
+                '', '#^/(?<bar>[^/]+?)?$#su', array('bar'), array(
                     array('variable', '/', '[^/]+?', 'bar'),
                 )),
 
             array(
                 'Route with an optional variable as the first segment with requirements',
                 array('/{bar}', array('bar' => 'bar'), array('bar' => '(foo|bar)')),
-                '', '#^/(?<bar>(foo|bar))?$#s', array('bar'), array(
+                '', '#^/(?<bar>(foo|bar))?$#su', array('bar'), array(
                     array('variable', '/', '(foo|bar)', 'bar'),
                 )),
         );


### PR DESCRIPTION
Bug fix: yes
Feature addition: not sure
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/dlsniper/symfony.png?branch=unicode-routes)](http://travis-ci.org/dlsniper/symfony)
Fixes the following tickets: #4166
Todo: -

This is PR started when the Routing component didn't had support for unicode routes but the latest changes to it seems to have changed its state.
I've basically just added some missing tests for this feature and noted the change in the changelog as it seems pretty nice to know about.
