### PR TITLE
[WIP][Locale] Fix StubIntl test

### DIFF
--- a/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
@@ -16,6 +16,7 @@ require_once __DIR__.'/../TestCase.php';
 use Symfony\Component\Locale\Locale;
 use Symfony\Component\Locale\Stub\StubIntl;
 use Symfony\Component\Locale\Stub\StubIntlDateFormatter;
+use Symfony\Component\Locale\Stub\StubIntlDateFormatter as IntlDateFormatter;
 use Symfony\Tests\Component\Locale\TestCase as LocaleTestCase;
 
 class StubIntlDateFormatterTest extends LocaleTestCase
@@ -392,7 +393,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $this->skipIfIntlExtensionIsNotLoaded();
         $this->skipIfICUVersionIsTooOld();
-        $formatter = new \IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
+        $formatter = new IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
         $formatter->setPattern('yyyy-MM-dd HH:mm:ss');
 
         $this->assertEquals(


### PR DESCRIPTION
Bug fix: yes / no (I'm really not sure of it, see below)
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: see below/provide a actual fix for the issue.

Hello,

I'm not sure how to address this as the test seem to be failing only on my machine... Ubuntu 11.10, Intl + ICU, default repos from Canonical, nothing else customized. Settings done in cli/php.ini with date.timezone = UTC.
app/check.php passes with flying colors.

1) Symfony\Tests\Component\Locale\Stub\StubIntlDateFormatterTest::testFormatWithDefaultTimezoneIntl
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'1970-01-01 00:00:00'
+'1970-01-01 02:00:00'

The problem is that I see all kinds of reference to the \IntlDateFormatter in which case this PR doesn't fix them all, I've just fixed the test that was failing on my computer. 

I'm really confused about this one but I do know that either this fix or $formatter->setTimeZoneId('UTC') fixes the test for me.

Any thoughts on this one?
