### PR TITLE
[Process] Fix command escaping

### DIFF
--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -103,13 +103,7 @@ class ProcessBuilder
 
         $options = $this->options;
 
-        $arguments = $this->arguments;
-        $command = array_shift($arguments);
-
-        $script = escapeshellcmd($command);
-        if ($arguments) {
-            $script .= ' '.implode(' ', array_map('escapeshellarg', $arguments));
-        }
+        $script = implode(' ', array_map('escapeshellarg', $this->arguments));
 
         if ($this->inheritEnv) {
             $env = $this->env ? $this->env + $_ENV : null;


### PR DESCRIPTION
My bad, I misunderstood what escapeshellcmd was good for. This fixes it by properly escaping all args.

The test suite hangs here but it already did before, so I'm not sure if all tests pass.
