### PR TITLE
Improved feedback for Upload Validator to cover all PHP error states.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -27,7 +27,12 @@ class File extends Constraint
     public $maxSizeMessage = 'The file is too large ({{ size }}). Allowed maximum size is {{ limit }}';
     public $mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}';
 
-    public $uploadIniSizeErrorMessage = 'The file is too large. Allowed maximum size is {{ limit }}';
-    public $uploadFormSizeErrorMessage = 'The file is too large';
-    public $uploadErrorMessage = 'The file could not be uploaded';
+    public $uploadIniSizeErrorMessage   = 'The file is too large. Allowed maximum size is {{ limit }}';
+    public $uploadFormSizeErrorMessage  = 'The file is too large';
+    public $uploadPartialErrorMessage   = 'The file was only partially uploaded';
+    public $uploadNoFileErrorMessage    = 'No file was uploaded';
+    public $uploadNoTmpDirErrorMessage  = 'No temporary folder was configured in php.ini';
+    public $uploadCantWriteErrorMessage = 'Cannot write temporary file to disk';
+    public $uploadExtensionErrorMessage = 'A PHP extension cause the upload to fail';
+    public $uploadErrorMessage          = 'The file could not be uploaded';
 }

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -33,6 +33,6 @@ class File extends Constraint
     public $uploadNoFileErrorMessage    = 'No file was uploaded';
     public $uploadNoTmpDirErrorMessage  = 'No temporary folder was configured in php.ini';
     public $uploadCantWriteErrorMessage = 'Cannot write temporary file to disk';
-    public $uploadExtensionErrorMessage = 'A PHP extension cause the upload to fail';
+    public $uploadExtensionErrorMessage = 'A PHP extension caused the upload to fail';
     public $uploadErrorMessage          = 'The file could not be uploaded';
 }

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -51,6 +51,26 @@ class FileValidator extends ConstraintValidator
                     $this->context->addViolation($constraint->uploadFormSizeErrorMessage);
 
                     return false;
+                case UPLOAD_ERR_PARTIAL:
+                    $this->context->addViolation($constraint->uploadPartialErrorMessage);
+
+                    return false;
+                case UPLOAD_ERR_NO_FILE:
+                    $this->context->addViolation($constraint->uploadNoFileErrorMessage);
+
+                    return false;
+                case UPLOAD_ERR_NO_TMP_DIR:
+                    $this->context->addViolation($constraint->uploadNoTmpDirErrorMessage);
+
+                    return false;
+                case UPLOAD_ERR_CANT_WRITE:
+                    $this->context->addViolation($constraint->uploadCantWriteErrorMessage);
+
+                    return false;
+                case UPLOAD_ERR_EXTENSION:
+                    $this->context->addViolation($constraint->uploadExtensionErrorMessage);
+
+                    return false;
                 default:
                     $this->context->addViolation($constraint->uploadErrorMessage);
 

--- a/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Constraints/FileValidatorTest.php
@@ -303,9 +303,11 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         return array(
             array(UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', array('{{ limit }}' => UploadedFile::getMaxFilesize() . ' bytes')),
             array(UPLOAD_ERR_FORM_SIZE, 'uploadFormSizeErrorMessage'),
-            array(UPLOAD_ERR_PARTIAL, 'uploadErrorMessage'),
-            array(UPLOAD_ERR_NO_TMP_DIR, 'uploadErrorMessage'),
-            array(UPLOAD_ERR_EXTENSION, 'uploadErrorMessage'),
+            array(UPLOAD_ERR_PARTIAL, 'uploadPartialErrorMessage'),
+            array(UPLOAD_ERR_NO_FILE, 'uploadNoFileErrorMessage'),
+            array(UPLOAD_ERR_NO_TMP_DIR, 'uploadNoTmpDirErrorMessage'),
+            array(UPLOAD_ERR_CANT_WRITE, 'uploadCantWriteErrorMessage'),
+            array(UPLOAD_ERR_EXTENSION, 'uploadExtensionErrorMessage'),
         );
     }
 


### PR DESCRIPTION
The upload validator only sets individual messages for 2 out of the 7 error states PHP suports for uploading files. Which means when you have any of those 5 stats you get a standard error message and have to really dig into the code to read the error state.

I added messages for every state, so that you will always get a detailed message.
