### PR TITLE
[RFC] Fix issues with url decoding

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1137,14 +1137,14 @@ class Request
         // Does the baseUrl have anything in common with the request_uri?
         $requestUri = $this->getRequestUri();
 
-        if ($baseUrl && 0 === strpos($requestUri, $baseUrl)) {
+        if ($baseUrl && false !== $prefix = $this->getUrlencodedPrefix($requestUri, $baseUrl)) {
             // full $baseUrl matches
-            return $baseUrl;
+            return $prefix;
         }
 
-        if ($baseUrl && 0 === strpos($requestUri, dirname($baseUrl))) {
+        if ($baseUrl && false !== $prefix = $this->getUrlencodedPrefix($requestUri, dirname($baseUrl))) {
             // directory portion of $baseUrl matches
-            return rtrim(dirname($baseUrl), '/');
+            return rtrim($prefix, '/');
         }
 
         $truncatedRequestUri = $requestUri;
@@ -1153,7 +1153,7 @@ class Request
         }
 
         $basename = basename($baseUrl);
-        if (empty($basename) || !strpos($truncatedRequestUri, $basename)) {
+        if (empty($basename) || !strpos(urldecode($truncatedRequestUri), $basename)) {
             // no match whatsoever; set it blank
             return '';
         }
@@ -1214,14 +1214,14 @@ class Request
             $requestUri = substr($requestUri, 0, $pos);
         }
 
-        if ((null !== $baseUrl) && (false === ($pathInfo = substr(urldecode($requestUri), strlen(urldecode($baseUrl)))))) {
+        if ((null !== $baseUrl) && (false === ($pathInfo = substr($requestUri, strlen($baseUrl))))) {
             // If substr() returns false then PATH_INFO is set to an empty string
             return '/';
         } elseif (null === $baseUrl) {
             return $requestUri;
         }
 
-        return (string) $pathInfo;
+        return rawurldecode((string) $pathInfo);
     }
 
     /**
@@ -1239,5 +1239,29 @@ class Request
             'rdf'  => array('application/rdf+xml'),
             'atom' => array('application/atom+xml'),
         );
+    }
+
+    /**
+     * Returns the prefix as encoded in the string when the string starts with
+     * the given prefix, false otherwise.
+     *
+     * @param string $string The urlencoded string
+     * @param string $prefix The prefix not encoded
+     *
+     * @return string|false The prefix as it is encoded in $string, or false
+     */
+    private function getUrlencodedPrefix($string, $prefix)
+    {
+        if (0 !== strpos(rawurldecode($string), $prefix)) {
+            return false;
+        }
+
+        $len = strlen($prefix);
+
+        if (preg_match("#^(%[[:xdigit:]]{2}|.){{$len}}#", $string, $match)) {
+            return $match[0];
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1221,7 +1221,7 @@ class Request
             return $requestUri;
         }
 
-        return rawurldecode((string) $pathInfo);
+        return (string) $pathInfo;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1153,7 +1153,7 @@ class Request
         }
 
         $basename = basename($baseUrl);
-        if (empty($basename) || !strpos(urldecode($truncatedRequestUri), $basename)) {
+        if (empty($basename) || !strpos(rawurldecode($truncatedRequestUri), $basename)) {
             // no match whatsoever; set it blank
             return '';
         }

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -62,6 +62,7 @@ class PhpMatcherDumper extends MatcherDumper
     public function match(\$pathinfo)
     {
         \$allow = array();
+        \$pathinfo = rawurldecode(\$pathinfo);
 
 $code
         throw 0 < count(\$allow) ? new MethodNotAllowedException(array_unique(\$allow)) : new ResourceNotFoundException();

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -62,7 +62,6 @@ class PhpMatcherDumper extends MatcherDumper
     public function match(\$pathinfo)
     {
         \$allow = array();
-        \$pathinfo = urldecode(\$pathinfo);
 
 $code
         throw 0 < count(\$allow) ? new MethodNotAllowedException(array_unique(\$allow)) : new ResourceNotFoundException();

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -93,8 +93,6 @@ class UrlMatcher implements UrlMatcherInterface
 
     protected function matchCollection($pathinfo, RouteCollection $routes)
     {
-        $pathinfo = urldecode($pathinfo);
-
         foreach ($routes as $name => $route) {
             if ($route instanceof RouteCollection) {
                 if (false === strpos($route->getPrefix(), '{') && $route->getPrefix() !== substr($pathinfo, 0, strlen($route->getPrefix()))) {
@@ -142,7 +140,7 @@ class UrlMatcher implements UrlMatcherInterface
         $parameters = $defaults;
         foreach ($params as $key => $value) {
             if (!is_int($key)) {
-                $parameters[$key] = rawurldecode($value);
+                $parameters[$key] = $value;
             }
         }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -69,7 +69,7 @@ class UrlMatcher implements UrlMatcherInterface
     /**
      * Tries to match a URL with a set of routes.
      *
-     * @param  string $pathinfo The path info to be parsed
+     * @param  string $pathinfo The path info to be parsed (must no be decoded)
      *
      * @return array An array of parameters
      *
@@ -82,7 +82,7 @@ class UrlMatcher implements UrlMatcherInterface
     {
         $this->allow = array();
 
-        if ($ret = $this->matchCollection($pathinfo, $this->routes)) {
+        if ($ret = $this->matchCollection(rawurldecode($pathinfo), $this->routes)) {
             return $ret;
         }
 

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -705,7 +705,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $server['REQUEST_URI'] = '/path%20test/info';
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
-        $this->assertEquals('/path%20test/info', $request->getPathInfo());
+        $this->assertEquals('/path test/info', $request->getPathInfo());
     }
 
     public function testGetPreferredLanguage()

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -702,17 +702,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/path/info', $request->getPathInfo());
 
         $server = array();
-        $server['REQUEST_URI'] = '/path test/info';
-        $request->initialize(array(), array(), array(), array(), array(), $server);
-
-        $this->assertEquals('/path test/info', $request->getPathInfo());
-
-        $server = array();
         $server['REQUEST_URI'] = '/path%20test/info';
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
-        $this->assertEquals('/path test/info', $request->getPathInfo());
-
+        $this->assertEquals('/path%20test/info', $request->getPathInfo());
     }
 
     public function testGetPreferredLanguage()
@@ -862,6 +855,100 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('text/html,application/xhtml+xml;q=0.9,*/*;q=0.8; foo=bar', array('text/html' => 1, 'application/xhtml+xml' => 0.9, '*/*' => 0.8)),
             array('text/html,application/xhtml+xml;charset=utf-8;q=0.9; foo=bar,*/*', array('text/html' => 1, '*/*' => 1, 'application/xhtml+xml;charset=utf-8' => 0.9)),
             array('text/html,application/xhtml+xml', array('application/xhtml+xml' => 1, 'text/html' => 1)),
+        );
+    }
+
+    /**
+     * @dataProvider getBaseUrlData
+     */
+    public function testGetBaseUrl($uri, $server, $expectedBaseUrl, $expectedPathInfo)
+    {
+        $request = Request::create($uri, 'GET', array(), array(), array(), $server);
+
+        $this->assertSame($expectedBaseUrl, $request->getBaseUrl(), 'baseUrl');
+        $this->assertSame($expectedPathInfo, $request->getPathInfo(), 'pathInfo');
+    }
+
+    public function getBaseUrlData()
+    {
+        return array(
+            array(
+                '/foo%20bar',
+                array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME'     => '/foo bar/app.php',
+                    'PHP_SELF'        => '/foo bar/app.php',
+                ),
+                '/foo%20bar',
+                '/',
+            ),
+            array(
+                '/foo%20bar/home',
+                array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME'     => '/foo bar/app.php',
+                    'PHP_SELF'        => '/foo bar/app.php',
+                ),
+                '/foo%20bar',
+                '/home',
+            ),
+            array(
+                '/foo%20bar/app.php/home',
+                array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME'     => '/foo bar/app.php',
+                    'PHP_SELF'        => '/foo bar/app.php',
+                ),
+                '/foo%20bar/app.php',
+                '/home',
+            ),
+            array(
+                '/foo%20bar/app.php/home%2Fbaz',
+                array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
+                    'SCRIPT_NAME'     => '/foo bar/app.php',
+                    'PHP_SELF'        => '/foo bar/app.php',
+                ),
+                '/foo%20bar/app.php',
+                '/home%2Fbaz',
+            ),
+            array(
+                '/foo/bar+baz',
+                array(
+                    'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo/app.php',
+                    'SCRIPT_NAME'     => '/foo/app.php',
+                    'PHP_SELF'        => '/foo/app.php',
+                ),
+                '/foo',
+                '/bar+baz',
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider urlencodedStringPrefixData
+     */
+    public function testUrlencodedStringPrefix($string, $prefix, $expect)
+    {
+        $request = new Request;
+
+        $me = new \ReflectionMethod($request, 'getUrlencodedPrefix');
+        $me->setAccessible(true);
+
+        $this->assertSame($expect, $me->invoke($request, $string, $prefix));
+    }
+
+    public function urlencodedStringPrefixData()
+    {
+        return array(
+            array('foo', 'foo', 'foo'),
+            array('fo%6f', 'foo', 'fo%6f'),
+            array('foo/bar', 'foo', 'foo'),
+            array('fo%6f/bar', 'foo', 'fo%6f'),
+            array('f%6f%6f/bar', 'foo', 'f%6f%6f'),
+            array('%66%6F%6F/bar', 'foo', '%66%6F%6F'),
+            array('fo+o/bar', 'fo+o', 'fo+o'),
+            array('fo%2Bo/bar', 'fo+o', 'fo%2Bo'),
         );
     }
 }

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -287,6 +287,27 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
         $this->assertEquals('http://servername/path/info?query=string', $request->getUri(), '->getUri() with rewrite, default port without HOST_HEADER');
+
+        // With encoded characters
+
+        $server = array(
+            'HTTP_HOST'       => 'hostname:8080',
+            'SERVER_NAME'     => 'servername',
+            'SERVER_PORT'     => '8080',
+            'QUERY_STRING'    => 'query=string',
+            'REQUEST_URI'     => '/ba%20se/index_dev.php/foo%20bar/in+fo?query=string',
+            'SCRIPT_NAME'     => '/ba se/index_dev.php',
+            'PATH_TRANSLATED' => 'redirect:/index.php/foo bar/in+fo',
+            'PHP_SELF'        => '/ba se/index_dev.php/path/info',
+            'SCRIPT_FILENAME' => '/some/where/ba se/index_dev.php',
+        );
+
+        $request->initialize(array(), array(), array(), array(), array(), $server);
+
+        $this->assertEquals(
+            'http://hostname:8080/ba%20se/index_dev.php/foo%20bar/in+fo?query=string',
+            $request->getUri()
+        );
    }
 
     /**
@@ -705,7 +726,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $server['REQUEST_URI'] = '/path%20test/info';
         $request->initialize(array(), array(), array(), array(), array(), $server);
 
-        $this->assertEquals('/path test/info', $request->getPathInfo());
+        $this->assertEquals('/path%20test/info', $request->getPathInfo());
     }
 
     public function testGetPreferredLanguage()
@@ -910,7 +931,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                     'PHP_SELF'        => '/foo bar/app.php',
                 ),
                 '/foo%20bar/app.php',
-                '/home=baz',
+                '/home%3Dbaz',
             ),
             array(
                 '/foo/bar+baz',

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -903,14 +903,14 @@ class RequestTest extends \PHPUnit_Framework_TestCase
                 '/home',
             ),
             array(
-                '/foo%20bar/app.php/home%2Fbaz',
+                '/foo%20bar/app.php/home%3Dbaz',
                 array(
                     'SCRIPT_FILENAME' => '/home/John Doe/public_html/foo bar/app.php',
                     'SCRIPT_NAME'     => '/foo bar/app.php',
                     'PHP_SELF'        => '/foo bar/app.php',
                 ),
                 '/foo%20bar/app.php',
-                '/home%2Fbaz',
+                '/home=baz',
             ),
             array(
                 '/foo/bar+baz',

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
@@ -23,7 +23,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = urldecode($pathinfo);
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#xs', $pathinfo, $matches)) {

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher1.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     public function match($pathinfo)
     {
         $allow = array();
+        $pathinfo = rawurldecode($pathinfo);
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#xs', $pathinfo, $matches)) {

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher2.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher2.php
@@ -23,7 +23,6 @@ class ProjectUrlMatcher extends Symfony\Tests\Component\Routing\Fixtures\Redirec
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = urldecode($pathinfo);
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#xs', $pathinfo, $matches)) {

--- a/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher2.php
+++ b/tests/Symfony/Tests/Component/Routing/Fixtures/dumper/url_matcher2.php
@@ -23,6 +23,7 @@ class ProjectUrlMatcher extends Symfony\Tests\Component\Routing\Fixtures\Redirec
     public function match($pathinfo)
     {
         $allow = array();
+        $pathinfo = rawurldecode($pathinfo);
 
         // foo
         if (0 === strpos($pathinfo, '/foo') && preg_match('#^/foo/(?P<bar>baz|symfony)$#xs', $pathinfo, $matches)) {

--- a/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
@@ -205,4 +205,14 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         } catch (ResourceNotFoundException $e) {
         }
     }
+
+    public function testDoNotDecodeUrl()
+    {
+        $coll = new RouteCollection();
+        $coll->add('foo', new Route('/foo/{foo}'));
+
+        $matcher = new UrlMatcher($coll, new RequestContext());
+        $this->assertEquals(array('foo' => 'bar%23', '_route' => 'foo'), $matcher->match('/foo/bar%23'));
+    }
+
 }

--- a/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
@@ -157,8 +157,8 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '['.preg_quote($chars).']+')));
 
         $matcher = new UrlMatcher($collection, new RequestContext(), array());
-        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.urlencode($chars).'/bar'));
-        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.strtr($chars, array('%' => '%25', '+' => '%2B')).'/bar'));
+        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.rawurlencode($chars).'/bar'));
+        $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.strtr($chars, array('%' => '%25')).'/bar'));
     }
 
     public function testMatchWithDotMetacharacterInRequirements()
@@ -206,13 +206,13 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function testDoNotDecodeUrl()
+    public function testDecodeOnce()
     {
         $coll = new RouteCollection();
         $coll->add('foo', new Route('/foo/{foo}'));
 
         $matcher = new UrlMatcher($coll, new RequestContext());
-        $this->assertEquals(array('foo' => 'bar%23', '_route' => 'foo'), $matcher->match('/foo/bar%23'));
+        $this->assertEquals(array('foo' => 'bar#', '_route' => 'foo'), $matcher->match('/foo/bar%23'));
     }
 
 }


### PR DESCRIPTION
Related: #2324, #2963, #2962, #2579

This PR fixes two issues:
- `+` in paths were turned to " " by `urldecode()`
- `urldecode()` was called a few times (and a different number of times according to which part of the path was handled, see #2962 for details).

Notes:
- @arnaud-lb, the first commit is based on your #2962 so I put your name fot the commit,
- `Request::getPathInfo()` returns the decoded path in order to minimize BC (see [this comment](https://github.com/symfony/symfony/pull/2963#issuecomment-3274617) from @Seldaek) - however the decoding is now done with `rawurldecode()` instead of `urldecode()` in order to avoid loosing `+` chars,
- As the path is already decoded in `Request::getPathInfo()` it is no more decoded by the matchers (see `UrlMatcher` and `PhpMatcherDumper`). This could be considered as a BC or as a fixed (`UrlMatcher` was not consistent with `PhpUrlMatcher` and the path was decoded multiple times).

Any thoughts ?
