### PR TITLE
[DependencyInjection] Trim class & method names (fix #3644)

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -71,7 +71,7 @@ class Definition
      */
     public function setFactoryClass($factoryClass)
     {
-        $this->factoryClass = $factoryClass;
+        $this->factoryClass = trim($factoryClass);
 
         return $this;
     }
@@ -99,7 +99,7 @@ class Definition
      */
     public function setFactoryMethod($factoryMethod)
     {
-        $this->factoryMethod = $factoryMethod;
+        $this->factoryMethod = trim($factoryMethod);
 
         return $this;
     }
@@ -155,7 +155,7 @@ class Definition
      */
     public function setClass($class)
     {
-        $this->class = $class;
+        $this->class = trim($class);
 
         return $this;
     }

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -316,6 +316,7 @@ class Definition
      */
     public function addMethodCall($method, array $arguments = array())
     {
+        $method = trim($method);
         if (empty($method)) {
             throw new InvalidArgumentException(sprintf('Method name cannot be empty.'));
         }
@@ -335,6 +336,7 @@ class Definition
      */
     public function removeMethodCall($method)
     {
+        $method = trim($method);
         foreach ($this->calls as $i => $call) {
             if ($call[0] === $method) {
                 unset($this->calls[$i]);
@@ -356,6 +358,7 @@ class Definition
      */
     public function hasMethodCall($method)
     {
+        $method = trim($method);
         foreach ($this->calls as $call) {
             if ($call[0] === $method) {
                 return true;

--- a/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/DefinitionTest.php
@@ -33,6 +33,8 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($def->getFactoryClass());
         $this->assertSame($def, $def->setFactoryClass('stdClass2'), "->setFactoryClass() implements a fluent interface.");
         $this->assertEquals('stdClass2', $def->getFactoryClass(), "->getFactoryClass() returns current class to construct this service.");
+        $def->setFactoryClass("   stdClass3  \t\n");
+        $this->assertEquals('stdClass3', $def->getFactoryClass(), "->getFactoryClass() returns a trimmed class name");
     }
 
     public function testSetGetFactoryMethod()
@@ -60,6 +62,8 @@ class DefinitionTest extends \PHPUnit_Framework_TestCase
         $def = new Definition('stdClass');
         $this->assertSame($def, $def->setClass('foo'), '->setClass() implements a fluent interface');
         $this->assertEquals('foo', $def->getClass(), '->getClass() returns the class name');
+        $def->setClass("\t\n  bar ");
+        $this->assertEquals('bar', $def->getClass(), '->getClass() returns the trimmed class name');
     }
 
     /**


### PR DESCRIPTION
Class and method names needs to be trimmed in some cases, see #3644.

Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes (DIC)
Fixes the following tickets: #3644
