### PR TITLE
[Form] Allow to inherit translation domain for all elements of a form

### DIFF
--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -296,6 +296,10 @@ class FormFactory implements FormFactoryInterface
             }
         }
 
+        if (!isset($passedOptions['translation_domain']) && null !== $parent && $parent->hasAttribute('translation_domain')) {
+            $options['translation_domain'] = $parent->getAttribute('translation_domain');
+        }
+
         for ($i = 0, $l = count($types); $i < $l && !$builder; ++$i) {
             $builder = $types[$i]->createBuilder($name, $this, $options);
         }

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestTranslationType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestTranslationType.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symfony\Tests\Component\Form\Fixtures;
+namespace Symfony\Component\Form\Tests\Fixtures;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilder;

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -535,6 +535,19 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $factory->createNamedBuilder($type, "text", "value", array("unknown" => "opt"));
     }
 
+    public function testInheritTranslationDomain()
+    {
+        $type = new \Symfony\Tests\Component\Form\Fixtures\TestTranslationType();
+        $factory = new FormFactory(array(new \Symfony\Component\Form\Extension\Core\CoreExtension()));
+
+        $builder = $factory->createNamedBuilder($type, 'test');
+        $view = $builder->getForm()->createView();
+
+        $this->assertSame('test', $view->get('translation_domain'));
+        $this->assertSame('field1', $view->getChild('field1')->get('translation_domain'));
+        $this->assertSame('test', $view->getChild('field2')->get('translation_domain'));
+    }
+
     private function createMockFactory(array $methods = array())
     {
         return $this->getMockBuilder('Symfony\Component\Form\FormFactory')

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -537,7 +537,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
     public function testInheritTranslationDomain()
     {
-        $type = new \Symfony\Tests\Component\Form\Fixtures\TestTranslationType();
+        $type = new \Symfony\Component\Form\Tests\Fixtures\TestTranslationType();
         $factory = new FormFactory(array(new \Symfony\Component\Form\Extension\Core\CoreExtension()));
 
         $builder = $factory->createNamedBuilder($type, 'test');

--- a/tests/Symfony/Tests/Component/Form/Fixtures/TestTranslationType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/TestTranslationType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilder;
+
+class TestTranslationType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder->add('field1', 'choice', array(
+            'choices' => array('1' => 'choice.1', '2' => 'choice.2'),
+            'required' => true,
+            'expanded' => true,
+            'translation_domain' => 'field1'
+        ));
+        $builder->add('field2', 'checkbox', array('required' => true));
+        $builder->add('field3', 'text');
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        return array('translation_domain' => 'test');
+    }
+
+    public function getName()
+    {
+        return 'test_translation_type';
+    }
+}


### PR DESCRIPTION
Currently I can set a translation_domain on each field of a form, but there is no simple way to do it once for a complete form. This change passes on the translation_domain from the form to its elements if translation_domain is not explicitly set on a field. 
