### PR TITLE
[WIP][Session] Added auto-extend capability

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -167,6 +167,7 @@ class Configuration implements ConfigurationInterface
                     ->canBeUnset()
                     ->children()
                         ->booleanNode('auto_start')->defaultFalse()->end()
+                        ->booleanNode('auto_extend')->defaultFalse()->end()
                         ->scalarNode('storage_id')->defaultValue('session.storage.native')->end()
                         ->scalarNode('handler_id')->defaultValue('session.handler.native_file')->end()
                         ->scalarNode('name')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -295,7 +295,7 @@ class FrameworkExtension extends Extension
         // session storage
         $container->setAlias('session.storage', $config['storage_id']);
         $options = array();
-        foreach (array('name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'auto_start') as $key) {
+        foreach (array('name', 'cookie_lifetime', 'cookie_path', 'cookie_domain', 'cookie_secure', 'cookie_httponly', 'auto_start' , 'auto_extend') as $key) {
             if (isset($config[$key])) {
                 $options[$key] = $config[$key];
             }

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -71,7 +71,12 @@ class Session implements SessionInterface
      */
     public function start()
     {
-        return $this->storage->start();
+        $couldStart = $this->storage->start();
+        if ($couldStart && $this->storage->getAutoExtend()) {
+            $this->migrate();
+        }
+
+        return $couldStart;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -40,6 +40,11 @@ class MockArraySessionStorage implements SessionStorageInterface
     /**
      * @var boolean
      */
+    protected $autoExtend;
+
+    /**
+     * @var boolean
+     */
     protected $started = false;
 
     /**
@@ -189,6 +194,14 @@ class MockArraySessionStorage implements SessionStorageInterface
         }
 
         return $this->bags[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAutoExtend()
+    {
+        return $this->autoExtend;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -41,6 +41,11 @@ class NativeSessionStorage implements SessionStorageInterface
     protected $closed = false;
 
     /**
+     * @var boolean
+     */
+    protected $autoExtend = false;
+
+    /**
      * @var AbstractProxy
      */
     protected $saveHandler;
@@ -56,6 +61,7 @@ class NativeSessionStorage implements SessionStorageInterface
      * but we omit 'session.' from the beginning of the keys for convenience.
      *
      * auto_start, "0"
+     * auto_extend, false
      * cache_limiter, "nocache" (use "0" to prevent headers from being sent entirely).
      * cookie_domain, ""
      * cookie_httponly, ""
@@ -250,6 +256,14 @@ class NativeSessionStorage implements SessionStorageInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getAutoExtend()
+    {
+        return $this->autoExtend;
+    }
+
+    /**
      * Sets session.* ini variables.
      *
      * For convenience we omit 'session.' from the beginning of the keys.
@@ -273,6 +287,8 @@ class NativeSessionStorage implements SessionStorageInterface
                 'upload_progress.cleanup', 'upload_progress.prefix', 'upload_progress.name',
                 'upload_progress.freq', 'upload_progress.min-freq', 'url_rewriter.tags'))) {
                 ini_set('session.'.$key, $value);
+            } elseif ('auto_extend' == $key) {
+                $this->autoExtend = $value;
             }
         }
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -123,4 +123,11 @@ interface SessionStorageInterface
      * @param SessionBagInterface $bag
      */
     function registerBag(SessionBagInterface $bag);
+
+    /**
+     * Returns if the session should be automatically extended on start
+     *
+     * @return Boolean True if automatic extension is needed, false if not
+     */
+    function getAutoExtend();
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/dlsniper/symfony.png?branch=session-regen)](http://travis-ci.org/dlsniper/symfony)Fixes the following tickets: #2171
Todo: Seems that this implementation breaks CSRF tokens so this will need to be fixed.

I think this should allow you to define an entry called: auto_extend in the parameters of a session in order to make the session automatically extend on each start.

ping @Drak to see if this is the way of doing it.
