### PR TITLE
[Filesystem] Add exists function

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -19,6 +19,18 @@ namespace Symfony\Component\Filesystem;
 class Filesystem
 {
     /**
+     * Checks whether a file or directory exists.
+     *
+     * @param string $file The filename
+     *
+     * @return Boolean true if the file or directory exists, false otherwise
+     */
+    public function exists($file)
+    {
+        return file_exists($file);
+    }
+
+    /**
      * Copies a file.
      *
      * This method only copies the file if the origin file is newer than the target file.


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=filesystem-exists)](http://travis-ci.org/asm89/symfony)
Fixes the following tickets: -
Todo: -

The function itself is very trivial. I think it's still useful in the filesystem component, because it will be easier to mock the filesystem for classes that depend on it (instead of using the `Filesystem#remove` etc functions, but then falling back to `file_exists`, which can't be mocked (easily)).
