### PR TITLE
[FrameworkBundle] Subrequests should always use GET method

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -140,6 +140,7 @@ class HttpKernel extends BaseHttpKernel
 
             $options['attributes']['_route'] = '_internal';
             $subRequest = $request->duplicate($options['query'], null, $options['attributes']);
+            $subRequest->setMethod('GET');
         }
 
         $level = ob_get_level();


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: maybe?
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=subrequest-request-method)](http://travis-ci.org/asm89/symfony)
Fixes the following tickets: -
Todo: -

When generating a subrequest using the bundle/controller notation instead of a url, the method of the duplicated subrequest isn't set to GET, while this does happen in the other case (see [here](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php#L143)). This causes weird behavior when embedding actions with forms on a page that is already reached through a POST request (since most forms check if POST was the request method before binding to the request).
