### PR TITLE
Use Flash Messages for avoid wrong redirect after login

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Controller/LoginController.php
@@ -27,6 +27,11 @@ class LoginController extends ContainerAware
             $error = $this->container->get('request')->getSession()->get(SecurityContext::AUTHENTICATION_ERROR);
         }
 
+        $session = $this->container->get('request')->getSession();
+        if ($targetUrl = $session->getFlash('_security.target_path')) {
+            $session->setFlash('_security.target_path', $targetUrl);
+        }
+
         return $this->container->get('templating')->renderResponse('FormLoginBundle:Login:login.html.twig', array(
             // last username entered by the user
             'last_username' => $this->container->get('request')->getSession()->get(SecurityContext::LAST_USERNAME),

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -271,9 +271,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
         }
 
         $session = $request->getSession();
-        if ($targetUrl = $session->get('_security.target_path')) {
-            $session->remove('_security.target_path');
-
+        if ($targetUrl = $session->getFlash('_security.target_path')) {
             return $targetUrl;
         }
 

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -131,6 +131,11 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
             throw new \RuntimeException('This authentication method requires a session.');
         }
 
+        $session = $request->getSession();
+        if ($targetUrl = $session->getFlash('_security.target_path')) {
+            $session->setFlash('_security.target_path', $targetUrl);
+        }
+
         try {
             if (!$request->hasPreviousSession()) {
                 throw new SessionUnavailableException('Your session has timed-out, or you have disabled cookies.');

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -180,7 +180,7 @@ class ExceptionListener
     {
         // session isn't required when using http basic authentication mechanism for example
         if ($request->hasSession()) {
-            $request->getSession()->set('_security.target_path', $request->getUri());
+            $request->getSession()->setFlash('_security.target_path', $request->getUri());
         }
     }
 }


### PR DESCRIPTION
This pull tries to fix a problem in firewall in which the user is not redirected properly.

Assuming that we have the following rules:
    access_control:
        - { path: ^/A, role: IS_AUTHENTICATED_ANONYMOUSLY }
        - { path: ^/B, role: ROLE_USER }

A user goes to page /B and is forwarder/redirected to /login page.
If he does NOT login and choose to go to page /A and then again to page /login, 
then, after a successfull login he will be redirected to /B instead of /A which was the last visited page.
