### PR TITLE
Let Request know about response and vice versa

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -139,6 +139,11 @@ class Request
     protected $defaultLocale = 'en';
 
     /**
+     * @var Response
+     */
+    protected $response;
+
+    /**
      * @var string
      */
     static protected $formats;
@@ -1013,6 +1018,29 @@ class Request
     public function getLocale()
     {
         return null === $this->locale ? $this->defaultLocale : $this->locale;
+    }
+
+    /**
+     * @param Response $response
+     * @return Request
+     */
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
+
+        if ($this !== $response->getRequest()) {
+            $response->setRequest($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Response|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -51,6 +51,11 @@ class Response
     protected $charset;
 
     /**
+     * @var Request
+     */
+    protected $request;
+
+    /**
      * Status codes translation table.
      *
      * The list of codes is complete according to the
@@ -943,6 +948,29 @@ class Response
         $this->headers->set('Vary', $headers, $replace);
 
         return $this;
+    }
+
+    /**
+     * @param Request $request
+     * @return Response
+     */
+    public function setRequest(Request $request)
+    {
+        $this->request = $request;
+
+        if ($this !== $request->getResponse()) {
+            $request->setResponse($this);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return Request|null
+     */
+    public function getRequest()
+    {
+        return $this->request;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/RequestTest.php
@@ -15,6 +15,7 @@ namespace Symfony\Tests\Component\HttpFoundation;
 use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class RequestTest extends \PHPUnit_Framework_TestCase
 {
@@ -923,6 +924,17 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(Request::isProxyTrusted());
         $this->stopTrustingProxyData();
         $this->assertFalse(Request::isProxyTrusted());
+    }
+
+    public function testSetRequest()
+    {
+        $request = new Request();
+        $response = new Response();
+
+        $request->setResponse($response);
+
+        $this->assertSame($response, $request->getResponse());
+        $this->assertSame($request, $response->getRequest());
     }
 
     private function startTrustingProxyData()


### PR DESCRIPTION
```
Bug fix: [no]
Feature addition: [yes]
Backwards compatibility break: [no]
Symfony2 tests pass: [yes] (actualy I got some not related to this pull request errors as described here: https://groups.google.com/forum/#!topic/symfony-devs/EFDgwVSUcpw)
Fixes the following tickets: -
Todo: -
```

Hi!

This pull request is to add some extra abilities to the `Request` and `Reponse` classes. Those are the `Request::setResponse` and `Response::setRequest` methods and the corresponding getters

This was done to allow even more intuitive syntax in my pull request to SensioFrameworkExtraBundle: https://github.com/sensio/SensioFrameworkExtraBundle/pull/105

After this merge it would be possible to write `$this->getRequest()->getResponse()->headers->setCookie(new Cookie('test', 123))`
there. Also it is logical to let request know about the related response and vice versa since this pair always acts together.

I also suggest adding `getResponse($streamed = false)` to default Controller class so that if no response is generated in an Action - an empty new one would be generated (and to keep track of it) (FYI: it's already created in `Controller::stream()` and when `Controller::render()` is called). I can add such changes into this pull request as well if nobody is against it.
