### PR TITLE
[Translation] Ignore xliff entries with no "target" node

### DIFF
--- a/resources-clean.xlf
+++ b/resources-clean.xlf
@@ -7,9 +7,6 @@
         <target>bar</target>
       </trans-unit>
       <trans-unit id="2">
-        <source>extra</source>
-      </trans-unit>
-      <trans-unit id="3">
         <source>key</source>
         <target></target>
       </trans-unit>

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -39,6 +39,9 @@ class XliffFileLoader implements LoaderInterface
 
         $catalogue = new MessageCatalogue($locale);
         foreach ($xml->xpath('//xliff:trans-unit') as $translation) {
+            if (2 !== count($translation)) {
+                continue;
+            }
             $catalogue->set((string) $translation->source, (string) $translation->target, $domain);
         }
         $catalogue->addResource(new FileResource($resource));

--- a/tests/Symfony/Tests/Component/Translation/Dumper/XliffFileDumperTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Dumper/XliffFileDumperTest.php
@@ -19,13 +19,13 @@ class XliffFileDumperTest extends \PHPUnit_Framework_TestCase
     public function testDump()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->add(array('foo' => 'bar'));
+        $catalogue->add(array('foo' => 'bar', 'key' => ''));
 
         $tempDir = sys_get_temp_dir();
         $dumper = new XliffFileDumper();
         $dumperString = $dumper->dump($catalogue, array('path' => $tempDir));
 
-        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources.xlf'), file_get_contents($tempDir.'/messages.en.xlf'));
+        $this->assertEquals(file_get_contents(__DIR__.'/../fixtures/resources-clean.xlf'), file_get_contents($tempDir.'/messages.en.xlf'));
 
         unlink($tempDir.'/messages.en.xlf');
     }

--- a/tests/Symfony/Tests/Component/Translation/Loader/XliffFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Translation/Loader/XliffFileLoaderTest.php
@@ -22,9 +22,17 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
         $resource = __DIR__.'/../fixtures/resources.xlf';
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
-        $this->assertEquals(array('foo' => 'bar'), $catalogue->all('domain1'));
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
+    }
+
+    public function testIncompleteResource()
+    {
+        $loader = new XliffFileLoader();
+        $catalogue = $loader->load(__DIR__.'/../fixtures/resources.xlf', 'en', 'domain1');
+
+        $this->assertEquals(array('foo' => 'bar', 'key' => ''), $catalogue->all('domain1'));
+        $this->assertFalse($catalogue->has('extra', 'domain1'));
     }
 
     /**


### PR DESCRIPTION
This PR will ignore some entries with no "target" node when a xliff file is loaded.

``` xml
<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
  <file source-language="en" datatype="plaintext" original="file.ext">
    <body>
      <trans-unit id="1">
        <source>foo</source>
        <target>bar</target>
      </trans-unit>
      <trans-unit id="2">
        <source>extra</source>
      </trans-unit>
    </body>
  </file>
</xliff>
```

Before:

``` php
array(
    'foo'   => 'bar',
    'extra' => ''
);
```

After:

``` php
array(
    'foo' => 'bar'
);
```
