### PR TITLE
[TwigBundle] Changed getAndCleanOutputBuffering() handling of systems where ob_get_level() never returns 0

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -61,13 +61,15 @@ class ExceptionController extends ContainerAware
 
     protected function getAndCleanOutputBuffering()
     {
-        // the count variable avoids an infinite loop on
-        // some Windows configurations where ob_get_level()
-        // never reaches 0
-        $count = 100;
+        // ob_get_level() never returns 0 on some Windows configurations, so if
+        // the level is the same two times in a row, the loop should be stopped.
+        $previousObLevel = null;
         $startObLevel = $this->container->get('request')->headers->get('X-Php-Ob-Level', -1);
+
         $currentContent = '';
-        while (ob_get_level() > $startObLevel && --$count) {
+
+        while (($obLevel = ob_get_level()) > $startObLevel && $obLevel !== $previousObLevel) {
+            $previousObLevel = $obLevel;
             $currentContent .= ob_get_clean();
         }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/lencioni/symfony.png)](http://travis-ci.org/lencioni/symfony)
Fixes the following tickets: -
Todo: -

Relying on decrementing a counter has two problems. First, and most importantly, if the output buffering nesting level is greater than the counter, the function does not perform the expected task. Secondly, on systems where the counter is needed, a lot of unnecessary extra loops would potentially occur.

This approach checks to see if the level has stayed the same from the previous iteration and if it has it stops looping.
