### PR TITLE
Fixed typo in CHANGELOG-2.1.md and UPGRADE-2.1.md

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -263,8 +263,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * added ResponseHeaderBag::makeDisposition() (implements RFC 6266)
  * made mimetype to extension conversion configurable
  * [BC BREAK] Moved all session related classes and interfaces into own namespace, as
-   `Symfony\Component\HttpFoudation\Session` and renamed classes accordingly.
-   Session handlers are located in the subnamespace `Symfony\Component\HttpFoudation\Session\Handler`.
+   `Symfony\Component\HttpFoundation\Session` and renamed classes accordingly.
+   Session handlers are located in the subnamespace `Symfony\Component\HttpFoundation\Session\Handler`.
  * SessionHandlers must implement `\SessionHandlerInterface` or extend from the
    `Symfony\Component\HttpFoundation\Storage\Handler\NativeSessionHandler` base class.
  * Added internal storage driver proxy mechanism for forward compatibility with

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -335,7 +335,7 @@ UPGRADE FROM 2.0 to 2.1
     ```
 
   * Session handler drivers should implement `\SessionHandlerInterface` or extend from
-    `Symfony\Component\HttpFoudation\Session\Storage\Handler\NativeHandlerInterface` base class and renamed
+    `Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeHandlerInterface` base class and renamed
     to `Handler\FooSessionHandler`.  E.g. `PdoSessionStorage` becomes `Handler\PdoSessionHandler`.
 
   * Refactor code using `$session->*flash*()` methods to use `$session->getFlashBag()->*()`.


### PR DESCRIPTION
changed "Foudation" to "Foundation".
