### PR TITLE
[Process] Added support for non-blocking process control

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -159,7 +159,8 @@ class Process
 
     /**
      * Starts the process and returns after sending the stdin.
-     * This method blocks until all stdin data is sent to the process then it returns while the pricess runs in the background.
+     * 
+     * This method blocks until all stdin data is sent to the process then it returns while the process runs in the background.
      * The termination of the process can be awaited with waitForTermination
      *
      * The callback receives the type of output (out or err) and
@@ -176,7 +177,7 @@ class Process
      */
     public function start($callback = null)
     {
-        if($this->isRunning()) {
+        if ($this->isRunning()) {
             throw new \RuntimeException('Process is already running');
         }
         $this->stdout = '';
@@ -204,7 +205,7 @@ class Process
             stream_set_blocking($pipe, false);
         }
 
-        if(null === $this->stdin) {
+        if (null === $this->stdin) {
             fclose($this->pipes[0]);
 
             return;
@@ -265,7 +266,6 @@ class Process
      * from the independent process during execution.
      *
      * @param Closure|string|array $callback
-     * @param boolean $invokeCallbackWithStartData
      * @return int the exitcode of the process
      * @throws \RuntimeException
      */
@@ -282,7 +282,8 @@ class Process
 
             if (false === $n) {
                 break;
-            } elseif ($n === 0) {
+            } 
+            if (0 === $n) {
                 proc_terminate($this->process);
 
                 throw new \RuntimeException('The process timed out.');
@@ -302,7 +303,7 @@ class Process
         }
         $this->updateStatus();
         if ($this->processInformation['signaled']) {
-                throw new \RuntimeException(sprintf('The process stopped because of a "%s" signal.', $this->processInformation['stopsig']));
+            throw new \RuntimeException(sprintf('The process stopped because of a "%s" signal.', $this->processInformation['stopsig']));
         }
 
         $time = 0;
@@ -461,8 +462,9 @@ class Process
      * Returns if the process is currently running
      * @return boolean
      */
-    public function isRunning() {
-        if(self::STATUS_STARTED === $this->status) {
+    public function isRunning() 
+    {
+        if (self::STATUS_STARTED === $this->status) {
             $this->updateStatus();
             if($this->processInformation['running'] === false) {
                 $this->status = self::STATUS_TERMINATED;
@@ -480,9 +482,10 @@ class Process
      * @return int the exitcode of the process
      * @throws \RuntimeException if the process got signaled
      */
-    public function stop($timeout=10) {
+    public function stop($timeout=10) 
+    {
         $timeoutMicro = (int) $timeout*10E6;
-        if($this->isRunning()) {
+        if ($this->isRunning()) {
             proc_terminate($this->process);
             $time = 0;
             while (1 == $this->isRunning() && $time < $timeoutMicro) {
@@ -608,11 +611,11 @@ class Process
      */
     protected function updateStatus()
     {
-        if(self::STATUS_STARTED === $this->status) {
+        if (self::STATUS_STARTED === $this->status) {
             $this->processInformation = proc_get_status($this->process);
-            if(!$this->processInformation['running']) {
+            if (!$this->processInformation['running']) {
                 $this->status = self::STATUS_TERMINATED;
-                if(-1 !== $this->processInformation['exitcode']) {
+                if (-1 !== $this->processInformation['exitcode']) {
                     $this->exitcode = $this->processInformation['exitcode'];
                 }
             }
@@ -620,13 +623,13 @@ class Process
     }
 
     protected function updateErrorOutput() {
-        if(isset($this->pipes[self::STDERR]) && is_resource($this->pipes[self::STDERR])) {
+        if (isset($this->pipes[self::STDERR]) && is_resource($this->pipes[self::STDERR])) {
             $this->addErrorOutput(stream_get_contents($this->pipes[self::STDERR]));
         }
     }
 
     protected function updateOutput() {
-        if(isset($this->pipes[self::STDOUT]) && is_resource($this->pipes[self::STDOUT])) {
+        if (isset($this->pipes[self::STDOUT]) && is_resource($this->pipes[self::STDOUT])) {
             $this->addOutput(stream_get_contents($this->pipes[self::STDOUT]));
         }
     }

--- a/tests/Symfony/Tests/Component/Process/ProcessTest.php
+++ b/tests/Symfony/Tests/Component/Process/ProcessTest.php
@@ -79,6 +79,41 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Misuse of shell builtins', $process->getExitCodeText());
     }
 
+    public function testStartIsNonBlocking()
+    {
+        $process = new Process('php -r "sleep(4);"');
+        $start = microtime(true);
+        $process->start();
+        $end = microtime(true);
+        $this->assertLessThan(1 , $end-$start);
+    }
+
+    public function testUpdateStatus() {
+        $process = new Process('php -h');
+        $process->start();
+        usleep(0.05E6); //wait for output
+        $this->assertEquals(0, $process->getExitCode());
+        $this->assertTrue(strlen($process->getOutput()) > 0 );
+    }
+
+    public function testIsRunning() {
+        $process = new Process('php -r "sleep(1);"');
+        $this->assertFalse($process->isRunning());
+        $process->start();
+        $this->assertTrue($process->isRunning());
+        $process->waitForTermination();
+        $this->assertFalse($process->isRunning());
+    }
+
+    public function testStop() {
+        $process = new Process('php -r "while(true){}"');
+        $process->start();
+        $this->assertTrue($process->isRunning());
+        $process->stop();
+        $this->assertFalse($process->isRunning());
+        $this->assertTrue($process->hasBeenSignaled());
+    }
+
     public function responsesCodeProvider()
     {
         return array(


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/drak3/symfony.png?branch=process-control)](http://travis-ci.org/drak3/symfony)
Fixes the following tickets: #1049
Todo: -

Added methods to control long running processes (as described in issue #1049) to the Process class:
- A non blocking start method to startup a process and return
  immediately
- A blocking waitForTermination method to wait for the processes
  termination
- A stop method to stop a process started with start
  All status-getters like getOutput were changed to return real-time data
