### PR TITLE
[Security] Log file/line that triggered the AccessDeniedException

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -98,7 +98,7 @@ class ExceptionListener
             $token = $this->context->getToken();
             if (!$this->authenticationTrustResolver->isFullFledged($token)) {
                 if (null !== $this->logger) {
-                    $this->logger->debug('Access denied (user is not fully authenticated); redirecting to authentication entry point');
+                    $this->logger->debug('Access is denied (user is not fully authenticated) by '.$exception->getFile().' at line '.$exception->getLine().'; redirecting to authentication entry point');
                 }
 
                 try {
@@ -110,7 +110,7 @@ class ExceptionListener
                 }
             } else {
                 if (null !== $this->logger) {
-                    $this->logger->debug('Access is denied (and user is neither anonymous, nor remember-me)');
+                    $this->logger->debug('Access is denied (and user is neither anonymous, nor remember-me) by '.$exception->getFile().' at line '.$exception->getLine());
                 }
 
                 try {


### PR DESCRIPTION
I had to debug some strange issue in a complex system and with all the nested requests and such, knowing exactly what was triggering the login page to show up wasn't so easy. This helps (unless you use annotations, but the JMSSecurityExtra bundle could use a custom exception class that overrides getLine/getFile and makes it point to the annotation line).
