### PR TITLE
[Validator] Fix form type guesser 

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -193,6 +193,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {
                         return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
                 }
+                break;
 
             case 'Symfony\Component\Validator\Constraints\Max':
                 return new ValueGuess(strlen((string) $constraint->limit), Guess::LOW_CONFIDENCE);
@@ -222,6 +223,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {
                         return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);
                 }
+                break;
 
             case 'Symfony\Component\Validator\Constraints\Min':
                 return new ValueGuess(strlen((string) $constraint->limit), Guess::LOW_CONFIDENCE);


### PR DESCRIPTION
[Validator] Fix switch breaking in max/min length for constraint guesser, when a "Symfony\Component\Validator\Constraints\Type" constraint type is not in numeric types array
