### PR TITLE
[Form] Failing test for empty_data option BC break

### DIFF
--- a/tests/Symfony/Tests/Component/Form/Fixtures/AuthorType.php
+++ b/tests/Symfony/Tests/Component/Form/Fixtures/AuthorType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Symfony\Tests\Component\Form\Fixtures;
+
+use Symfony\Component\Form\FormInterface;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilder;
+
+class AuthorType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder
+            ->add('firstName')
+            ->add('lastName')
+        ;
+    }
+
+    public function getName()
+    {
+        return 'author';
+    }
+
+    public function getDefaultOptions(array $options)
+    {
+        return array(
+            'data_class' => 'Symfony\Tests\Component\Form\Fixtures\Author',
+        );
+    }
+}

--- a/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
+++ b/tests/Symfony/Tests/Component/Form/FormFactoryTest.php
@@ -16,6 +16,8 @@ use Symfony\Component\Form\FormFactory;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\ValueGuess;
 use Symfony\Component\Form\Guess\TypeGuess;
+use Symfony\Tests\Component\Form\Fixtures\Author;
+use Symfony\Tests\Component\Form\Fixtures\AuthorType;
 use Symfony\Tests\Component\Form\Fixtures\TestExtension;
 use Symfony\Tests\Component\Form\Fixtures\FooType;
 use Symfony\Tests\Component\Form\Fixtures\FooTypeBarExtension;
@@ -529,6 +531,20 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             '"translation_domain", "empty_data"'
         );
         $factory->createNamedBuilder($type, "text", "value", array("unknown" => "opt"));
+    }
+
+    public function testFieldTypeCreatesDefaultValueForEmptyDataOption()
+    {
+        $factory = new FormFactory(array(new \Symfony\Component\Form\Extension\Core\CoreExtension()));
+
+        $form = $factory->createNamedBuilder(new AuthorType(), 'author')->getForm();
+        $form->bind(array('firstName' => 'John', 'lastName' => 'Smith'));
+
+        $author = new Author();
+        $author->firstName = 'John';
+        $author->setLastName('Smith');
+
+        $this->assertEquals($author, $form->getData());
     }
 
     private function createMockFactory(array $methods = array())


### PR DESCRIPTION
This demonstrates the issue described in symfony/symfony#3354. FieldType no longer has access to the child type's data_class option, which makes it unable to create the default closure for empty_data.

We're still waiting for @bschussek to chime in on #3354, so there is no rush to merge this. Most users are expecting `data_class` to be all that's necessary to facilitate creation of a new form data object -- it's not clear if that is still the intended functionality after the recent form BC breaks, or if those breaks were an oversight.

If it is to remain intended functionality, I think we can keep this test around after the issue is resolved.
