### PR TITLE
[FrameworkBundle] Add support for full URLs to redirect controller

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -70,6 +70,13 @@ class RedirectController extends ContainerAware
             return new Response(null, 410);
         }
 
+        $statusCode = $permanent ? 301 : 302;
+
+        // redirect if the path is a full URL
+        if (parse_url($path, PHP_URL_SCHEME)) {
+            return new RedirectResponse($path, $statusCode);
+        }
+
         $request = $this->container->get('request');
         if (null === $scheme) {
             $scheme = $request->getScheme();
@@ -89,6 +96,6 @@ class RedirectController extends ContainerAware
 
         $url = $scheme.'://'.$request->getHost().$port.$request->getBaseUrl().$path.$qs;
 
-        return new RedirectResponse($url, $permanent ? 301 : 302);
+        return new RedirectResponse($url, $statusCode);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -92,15 +92,22 @@ class RedirectControllerTest extends TestCase
 
     public function testEmptyPath()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-
         $controller = new RedirectController();
-        $controller->setContainer($container);
-
         $returnResponse = $controller->urlRedirectAction('');
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
 
         $this->assertEquals(410, $returnResponse->getStatusCode());
+    }
+
+    public function testFullURL()
+    {
+        $controller = new RedirectController();
+        $returnResponse = $controller->urlRedirectAction('http://foo.bar/');
+
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
+
+        $this->assertEquals('http://foo.bar/', $returnResponse->headers->get('Location'));
+        $this->assertEquals(302, $returnResponse->getStatusCode());
     }
 }


### PR DESCRIPTION
I'd consider this a bugfix since at the moment using an URL just redirects to `/current/pathhttp://example.org`.
