### PR TITLE
add limit to logger explosion

### DIFF
--- a/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
+++ b/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
@@ -116,7 +116,7 @@ class PropelDataCollector extends DataCollector
         $innerGlue = $this->propelConfiguration->getParameter('debugpdo.logging.innerglue', ': ');
 
         foreach ($this->logger->getQueries() as $q) {
-            $parts     = explode($outerGlue, $q);
+            $parts     = explode($outerGlue, $q, 4);
 
             $times     = explode($innerGlue, $parts[0]);
             $con       = explode($innerGlue, $parts[2]);

--- a/tests/Symfony/Tests/Bridge/Propel1/DataCollector/PropelDataCollectorTest.php
+++ b/tests/Symfony/Tests/Bridge/Propel1/DataCollector/PropelDataCollectorTest.php
@@ -51,7 +51,8 @@ class PropelDataCollectorTest extends Propel1TestCase
     {
         $queries = array(
             "time: 0.000 sec | mem: 1.4 MB | connection: default | SET NAMES 'utf8'",
-            "time: 0.012 sec | mem: 2.4 MB | connection: default | SELECT tags.NAME, image.FILENAME FROM tags LEFT JOIN image ON tags.IMAGEID = image.ID WHERE image.ID = 12"
+            "time: 0.012 sec | mem: 2.4 MB | connection: default | SELECT tags.NAME, image.FILENAME FROM tags LEFT JOIN image ON tags.IMAGEID = image.ID WHERE image.ID = 12",
+            "time: 0.012 sec | mem: 2.4 MB | connection: default | INSERT INTO `table` (`some_array`) VALUES ('| 1 | 2 | 3 |')",
         );
 
         $c = $this->createCollector($queries);
@@ -69,10 +70,16 @@ class PropelDataCollectorTest extends Propel1TestCase
                 'time'      => '0.012 sec',
                 'connection'=> 'default',
                 'memory'    => '2.4 MB'
-            )
+            ),
+            array(
+                'sql'       => "INSERT INTO `table` (`some_array`) VALUES ('| 1 | 2 | 3 |')",
+                'time'      => '0.012 sec',
+                'connection'=> 'default',
+                'memory'    => '2.4 MB'
+            ),
         ), $c->getQueries());
-        $this->assertEquals(2, $c->getQueryCount());
-        $this->assertEquals(0.012, $c->getTime());
+        $this->assertEquals(3, $c->getQueryCount());
+        $this->assertEquals(0.024, $c->getTime());
     }
 
     private function createCollector($queries)


### PR DESCRIPTION
This limit is required to display complete query with e.g. "array" type in it.

ping @willdurand
