### PR TITLE
[FrameworkBundle] WebTestCase createClient doesn't check if static:kernel was already allocated

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -35,6 +35,10 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
      */
     static protected function createClient(array $options = array(), array $server = array())
     {
+        if (null !== static::$kernel) {
+            static::$kernel->shutdown();
+        }
+
         static::$kernel = static::createKernel($options);
         static::$kernel->boot();
 


### PR DESCRIPTION
with this little fix CreateClient shuts down the kernel before booting again.

If you add an echo after the "if" on the line number 38 
and run the test you would see that sometime the kernel is not properly umounted. 

Bug fix: [no]
Feature addition: [no]
Backwards compatibility break: [no]
Symfony2 tests pass: [yes]
