### PR TITLE
[HttpKernel] Throw exception if TimeDataCollector has no last event

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -69,12 +69,18 @@ class TimeDataCollector extends DataCollector
      * Gets the request elapsed time.
      *
      * @return float The elapsed time
+     *
+     * @throws \UnexpectedValueException When the last event is not available
      */
     public function getTotalTime()
     {
+        if (!isset($this->data['events']['__section__'])) {
+            throw new \UnexpectedValueException('The last event is not available. Are you sure that debugging is enabled in the kernel?');
+        }
+
         $lastEvent = $this->data['events']['__section__'];
 
-        return $lastEvent->getOrigin() + $lastEvent->getTotalTime() - $this->data['start_time'];
+        return $lastEvent->getOrigin() + $lastEvent->getTotalTime() - $this->getStartTime();
     }
 
     /**
@@ -83,9 +89,15 @@ class TimeDataCollector extends DataCollector
      * This is the time spent until the beginning of the request handling.
      *
      * @return float The elapsed time
+     *
+     * @throws \UnexpectedValueException When the last event is not available
      */
     public function getInitTime()
     {
+        if (!isset($this->data['events']['__section__'])) {
+            throw new \UnexpectedValueException('The last event is not available. Are you sure that debugging is enabled in the kernel?');
+        }
+
         return $this->data['events']['__section__']->getOrigin() - $this->getStartTime();
     }
 


### PR DESCRIPTION
This fixes an NPE I receive at times when enabling the WDT on production (on rare occasions I need to debug something live). I often find the following errors in the logs whenever the WDT is rendered:

> PHP Fatal error:  Call to a member function getOrigin() on a non-object in /data/site/vendor/symfony/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php on line 78

My mistake is enabled profiling and the WDT bundle but forgetting to flip the debugging kernel argument to `true`. This prevents the TraceableEventDispatcher from being used, which in turn means that no events are ever set on the TimeDataCollector. Adding an `isset()` check and throwing an exception with a helpful error message seems helpful here. No we'll get:

> PHP Fatal error:  Uncaught exception 'UnexpectedValueException' with message 'The last event is not available. Are you sure that debugging is enabled in the kernel?' in /data/site/vendor/symfony/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php:78

I'm not encouraging anyone to use WDT on production here, but I think we'd do well to avoid any change of NPE's in the code.
