### PR TITLE
Fixes JS profiler load error on IE7

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/base_js.html.twig
@@ -17,6 +17,13 @@
                 };
                 xhr.send(payload || '');
             },
+            getElement = function(selector) {
+                if (document.querySelector) {
+                    return document.querySelector(selector);
+                }
+
+                return false;
+            },
             hasClass = function(el, klass) {
                 return el.className.match(new RegExp('\\b' + klass + '\\b'));
             },
@@ -28,12 +35,13 @@
             };
 
         return {
+            getElement: getElement,
             hasClass: hasClass,
             removeClass: removeClass,
             addClass: addClass,
             request: request,
             load: function(selector, url, onSuccess, onError, options) {
-                var el = document.querySelector(selector);
+                var el = getElement(selector);
                 if (el && el.getAttribute('data-sfurl') !== url) {
                     request(
                         url,


### PR DESCRIPTION
I haven't found any documentation pointing towards browser support of the Symfony2 profiler, so these notes might not be totally accurate.

During JS debugging sessions on IE7, it's very complicated to detect and fix application specific JS code since the profiler throws a JS error on every page. One could work in non debug mode, but usually this is already configured for assetic to dump the assets, which complicates debugging even more.

This patch fixes the profiler JS error on IE7 but does it in a silent way. However, I wonder if we should adopt another approach:
1. Keep the vanilla JS version and only support "modern" browsers (IE8 has querySelector support but only for CSS 2.1 selectors) - this means we would have to at least silently fail on older browsers (ideally it would be gracefully too, including some support messages, for instance).
2. Keep the vanilla JS version but load polyfills: querySelector/querySelectorAll can be injected in the document using a polyfill targeted for browsers that do not support these DOM methods.
3. Keep the vanilla JS version but simplify/dumb down the code: I've noticed that most of the selectors are ID's, which means `getElementById` would work just fine on all browsers, without the need for `querySelector`. The `querySelectorAll` method could be replaced by `getElementsByClassName` and only classes would be used, for example.
4. Load a micro JS framework like `Ender.js` to provide basic support for all browsers - ender.js supports loading modules, which means we can keep it very slim by only loading the selector (_qwery_) and the ajax engines.

Also, I did not patch the querySelectorAll method on the `toggle` method since toggling the queries on the DB collector (`explain`) throws other errors which can only be fixed after one of the proposed approaches is used (the error is originated by `elem.dataset` which is not supported on IE, hence `getAttribute` would have to be used) - we can choose to not toggle, allow the user to visit the href instead of loading it by ajax, etc).
