### PR TITLE
[FrameworkBundle] make http_cache dir extensible

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -28,11 +28,17 @@ abstract class HttpCache extends BaseHttpCache
     /**
      * Constructor.
      *
-     * @param HttpKernelInterface $kernel An HttpKernelInterface instance
+     * @param HttpKernelInterface $kernel   An HttpKernelInterface instance
+     * @param String              $cacheDir The cache directory (default used if null)
      */
-    public function __construct(HttpKernelInterface $kernel)
+    public function __construct(HttpKernelInterface $kernel, $cacheDir = null)
     {
-        $store = new Store($kernel->getCacheDir().'/http_cache');
+        if ($cacheDir) {
+            $store = new Store($cacheDir);
+        } else {
+            $store = new Store($kernel->getCacheDir().'/http_cache');
+        }
+
         $esi = new Esi();
 
         parent::__construct($kernel, $store, $esi, array_merge(array('debug' => $kernel->isDebug()), $this->getOptions()));

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -33,12 +33,7 @@ abstract class HttpCache extends BaseHttpCache
      */
     public function __construct(HttpKernelInterface $kernel, $cacheDir = null)
     {
-        if ($cacheDir) {
-            $store = new Store($cacheDir);
-        } else {
-            $store = new Store($kernel->getCacheDir().'/http_cache');
-        }
-
+        $store = new Store($cacheDir ?: $kernel->getCacheDir().'/http_cache');
         $esi = new Esi();
 
         parent::__construct($kernel, $store, $esi, array_merge(array('debug' => $kernel->isDebug()), $this->getOptions()));


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

I have a use case where I don't want the httpcache cleared on `cache:clear`.  Currently, it is awkward to change this directory.

[![Build Status](https://secure.travis-ci.org/kbond/symfony.png?branch=extensible-httpcache)](http://travis-ci.org/kbond/symfony)
