### PR TITLE
Run built-in server on dev environment

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
@@ -24,6 +24,6 @@ if (isset($_SERVER['SCRIPT_FILENAME'])) {
     return false;
 }
 
-$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app.php';
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app_dev.php';
 
-require 'app.php';
+require 'app_dev.php';


### PR DESCRIPTION
Bug fix: yes?
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Change the router of the built-in server command to run on dev environment.

The symfony standard edition doesn't have any `/` route by default (it's only available to dev), so by default, when ran, it gives a `404`, unless you explicitely add the `app_dev.php` front controller to the route.

Also, this server is meant to be run on dev only, so no need to run it with the prod front controller by default.
