### PR TITLE
[HttpFoundation] Added support for 308 / Permanent Redirect

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -83,7 +83,7 @@ class Response
         305 => 'Use Proxy',
         306 => 'Reserved',
         307 => 'Temporary Redirect',
-        308 => 'Permanent Redirect',
+        308 => 'Permanent Redirect',    // RFC-reschke-http-status-308-07
         400 => 'Bad Request',
         401 => 'Unauthorized',
         402 => 'Payment Required',

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -83,6 +83,7 @@ class Response
         305 => 'Use Proxy',
         306 => 'Reserved',
         307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',
         400 => 'Bad Request',
         401 => 'Unauthorized',
         402 => 'Payment Required',


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes (i guess) [![Build Status](https://secure.travis-ci.org/lyrixx/symfony.png?branch=patch-1)](http://travis-ci.org/lyrixx/symfony)
Fixes the following tickets: -
Todo: -

I know this is still a draft, but it is already implemented in Firefox.

See : 
- http://tools.ietf.org/html/draft-reschke-http-status-308-07
- https://developer.mozilla.org/en/HTTP/HTTP_response_codes#308
