### PR TITLE
[Form] [Doctrine-bridge] Wrong value transformation raises exception

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToValuesTransformer.php
@@ -63,7 +63,7 @@ class ChoicesToValuesTransformer implements DataTransformerInterface
      */
     public function reverseTransform($array)
     {
-        if (null === $array) {
+        if (empty($array)) {
             return array();
         }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3446
Todo: Add a unit test
# Steps

Calling `Symfony\Component\Form\Extension\Core\DataTransformer\ChoicesToValuesTransformer::reverseTransform()` with an empty array as a parameter, when the `ChoicesToValuesTransformer::$choiceList` is a `Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList`.
# Expected behavior

The method returns an empty array.
# Observed behavior

A php warning is raised, thus throwing a 500 error

> Warning: array_fill(): Number of elements must be positive in /var/www/widop/divosea.local/vendor/doctrine/dbal/lib/Doctrine/DBAL/SQLParserUtils.php line 127
# Notes

I didn't write a test because I didn't know where to add it, as the `ChoicesToValuesTransformer` belongs to the Form component, and the `EntityChoiceList` belongs to the Doctrine bridge.

Also, all the unit test of `ChoicesToValuesTransformer` are made on a `Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList`, not all the classes implementing `Symfony\Component\Form\Extension\Core\ChoiceList\ChoiceList`. I think this could be improved so the tests would be more robust, maybe with a PHPUnit provider.

Thanks for your time :)
