### PR TITLE
[Monolog] Fixed Fire PHPHandler. Defined sendHeaders property

### DIFF
--- a/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/FirePHPHandler.php
@@ -34,6 +34,11 @@ class FirePHPHandler extends BaseFirePHPHandler
     private $response;
 
     /**
+     * @var boolean
+     */
+     private $sendHeaders;
+
+    /**
      * Adds the headers to the response once it's created
      */
     public function onKernelResponse(FilterResponseEvent $event)


### PR DESCRIPTION
Property sendHeaders was not defined and it caused notice
