### PR TITLE
updated reference to tests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/README.md
+++ b/src/Symfony/Component/HttpFoundation/README.md
@@ -38,10 +38,9 @@ If you are using PHP 5.3.x you must add the following to your autoloader:
         $loader->registerPrefixFallback(__DIR__.'/../vendor/symfony/src/Symfony/Component/HttpFoundation/Resources/stubs');
     }
 
-
 Resources
 ---------
 
-Unit tests:
+You can run the unit tests with the following command:
 
-https://github.com/symfony/symfony/tree/master/tests/Symfony/Tests/Component/HttpFoundation
+    phpunit -c src/Symfony/Component/HttpFoundation/


### PR DESCRIPTION
this is basically the format used in all other components.

however i am not sure if it really makes sense to list `phpunit -c src/Symfony/Component/HttpFoundation/`, since this relative path could be confusing for anyone using the standalone components. But even if using `symfony/symfony` the path is wrong relative to the location of the README.md.
