### PR TITLE
[WIP] [Locale] Fixes NumberFormatter tests failing when using ICU 4.8 or 4.8.1.1

### DIFF
--- a/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
@@ -144,14 +144,6 @@ class StubNumberFormatterTest extends LocaleTestCase
             array(-100, 'ALL', '(ALL100)'),
             array(1000.12, 'ALL', 'ALL1,000'),
 
-            array(100, 'BRL', 'R$100.00'),
-            array(-100, 'BRL', '(R$100.00)'),
-            array(1000.12, 'BRL', 'R$1,000.12'),
-
-            array(100, 'CRC', '₡100'),
-            array(-100, 'CRC', '(₡100)'),
-            array(1000.12, 'CRC', '₡1,000'),
-
             array(100, 'JPY', '¥100'),
             array(-100, 'JPY', '(¥100)'),
             array(1000.12, 'JPY', '¥1,000'),
@@ -159,15 +151,77 @@ class StubNumberFormatterTest extends LocaleTestCase
             array(100, 'EUR', '€100.00'),
             array(-100, 'EUR', '(€100.00)'),
             array(1000.12, 'EUR', '€1,000.12'),
+        );
+    }
+
+    /**
+     * @dataProvider formatCurrencyWithCurrencyStyleCostaRicanColonsRoundingProvider
+     */
+    public function testFormatCurrencyWithCurrencyStyleCostaRicanColonsRoundingStub($value, $currency, $symbol, $expected)
+    {
+        $formatter = $this->getStubFormatterWithCurrencyStyle();
+        $this->assertEquals(sprintf($expected, '₡'), $formatter->formatCurrency($value, $currency));
+    }
+
+    /**
+     * @dataProvider formatCurrencyWithCurrencyStyleCostaRicanColonsRoundingProvider
+     */
+    public function testFormatCurrencyWithCurrencyStyleCostaRicanColonsRoundingIntl($value, $currency, $symbol, $expected)
+    {
+        $this->skipIfIntlExtensionIsNotLoaded();
+        $this->skipIfICUVersionIsTooOld();
+        $formatter = $this->getIntlFormatterWithCurrencyStyle();
+        $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
+    }
+
+    public function formatCurrencyWithCurrencyStyleCostaRicanColonsRoundingProvider()
+    {
+        $crc = $this->isIntlExtensionLoaded() && $this->isSameAsIcuVersion('4.8') ? 'CRC' : '₡';
+
+        return array(
+            array(100, 'CRC', $crc, '%s100'),
+            array(-100, 'CRC', $crc, '(%s100)'),
+            array(1000.12, 'CRC', $crc, '%s1,000'),
+        );
+    }
+
+    /**
+     * @dataProvider formatCurrencyWithCurrencyStyleBrazilianRealRoundingProvider
+     */
+    public function testFormatCurrencyWithCurrencyStyleBrazilianRealRoundingStub($value, $currency, $symbol, $expected)
+    {
+        $formatter = $this->getStubFormatterWithCurrencyStyle();
+        $this->assertEquals(sprintf($expected, 'R'), $formatter->formatCurrency($value, $currency));
+    }
+
+    /**
+     * @dataProvider formatCurrencyWithCurrencyStyleBrazilianRealRoundingProvider
+     */
+    public function testFormatCurrencyWithCurrencyStyleBrazilianRealRoundingIntl($value, $currency, $symbol, $expected)
+    {
+        $this->skipIfIntlExtensionIsNotLoaded();
+        $this->skipIfICUVersionIsTooOld();
+        $formatter = $this->getIntlFormatterWithCurrencyStyle();
+        $this->assertEquals(sprintf($expected, $symbol), $formatter->formatCurrency($value, $currency));
+    }
+
+    public function formatCurrencyWithCurrencyStyleBrazilianRealRoundingProvider()
+    {
+        $brl = $this->isIntlExtensionLoaded() && $this->isSameAsIcuVersion('4.8') ? 'BR' : 'R';
+
+        return array(
+            array(100, 'BRL', $brl, '%s$100.00'),
+            array(-100, 'BRL', $brl, '(%s$100.00)'),
+            array(1000.12, 'BRL', $brl, '%s$1,000.12'),
 
             // Rounding checks
-            array(1000.121, 'BRL', 'R$1,000.12'),
-            array(1000.123, 'BRL', 'R$1,000.12'),
-            array(1000.125, 'BRL', 'R$1,000.12'),
-            array(1000.127, 'BRL', 'R$1,000.13'),
-            array(1000.129, 'BRL', 'R$1,000.13'),
-            array(11.50999, 'BRL', 'R$11.51'),
-            array(11.9999464, 'BRL', 'R$12.00')
+            array(1000.121, 'BRL', $brl, '%s$1,000.12'),
+            array(1000.123, 'BRL', $brl, '%s$1,000.12'),
+            array(1000.125, 'BRL', $brl, '%s$1,000.12'),
+            array(1000.127, 'BRL', $brl, '%s$1,000.13'),
+            array(1000.129, 'BRL', $brl, '%s$1,000.13'),
+            array(11.50999, 'BRL', $brl, '%s$11.51'),
+            array(11.9999464, 'BRL', $brl, '%s$12.00')
         );
     }
 

--- a/src/Symfony/Component/Locale/Tests/TestCase.php
+++ b/src/Symfony/Component/Locale/Tests/TestCase.php
@@ -66,6 +66,13 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         return $icuVersion >= $version;
     }
 
+    protected function isSameAsIcuVersion($version) {
+        $version = $this->normalizeIcuVersion($version);
+        $icuVersion = $this->normalizeIcuVersion($this->getIntlExtensionIcuVersion());
+
+        return $icuVersion === $version;
+    }
+
     protected function isLowerThanIcuVersion($version)
     {
         $version = $this->normalizeIcuVersion($version);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no
Todo: fix DateFormatter

The ICU CLDR 2.0 data has been updated on ICU 4.8 and the same data set is used on version 4.8.1.1. The problem is related to [this commit](http://bugs.icu-project.org/trac/changeset?reponame=&new=31307%40icu%2Ftrunk%2Fsource%2Fdata%2Fcurr%2Fen.txt&old=31074%40icu%2Ftrunk%2Fsource%2Fdata%2Fcurr%2Fen.txt) which has since been updated with new data and subsequently shipped with version 49.

The `DateFormatter` tests are still failing - see this [gist](https://gist.github.com/2004d40e5167286028ea). Suggestions are welcomed on how to handle this part.

Test results with PHP 5.4.0 with ICU 4.8.1.1 on OSX:

```
FAILURES!
Tests: 5917, Assertions: 12749, Failures: 26, Incomplete: 11, Skipped: 47.
```

with this WIP patch:

```
FAILURES!
Tests: 5917, Assertions: 12749, Failures: 13, Incomplete: 11, Skipped: 47.
```
