### PR TITLE
[DoctrineBridge] Added connection name to the Doctrine Collector

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
+++ b/src/Symfony/Bridge/Doctrine/DataCollector/DoctrineDataCollector.php
@@ -116,6 +116,7 @@ class DoctrineDataCollector extends DataCollector
 
     private function sanitizeQuery($connectionName, $query)
     {
+        $query['connectionName'] = $connectionName;
         $query['explainable'] = true;
         $query['params'] = (array) $query['params'];
         foreach ($query['params'] as $j => &$param) {


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/dlsniper/symfony.png?branch=add-connection-name-to-doctrine-collector)](http://travis-ci.org/dlsniper/symfony) Fixes the following tickets: -
Todo: -

This adds the connection name to the collector in order to provide more debug info to the users.
It should be merged in order for doctrine/DoctrineBundle#43 and doctrine/DoctrineBundle#51 to be 'fixed'.
