### PR TITLE
[HttpFoundation] Added AJAX request to header bag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -35,6 +35,10 @@ class ServerBag extends ParameterBag
             elseif (in_array($key, array('CONTENT_LENGTH', 'CONTENT_MD5', 'CONTENT_TYPE'))) {
                 $headers[$key] = $this->parameters[$key];
             }
+
+            elseif (isset($this->parameters['X-Requested-With']))  {
+                $headers['X-Requested-With'] = 'XMLHttpRequest';
+            }
         }
 
         // PHP_AUTH_USER/PHP_AUTH_PW

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -31,6 +31,8 @@ class ServerBagTest extends \PHPUnit_Framework_TestCase
             'HTTP_ETAG' => 'asdf',
             'PHP_AUTH_USER' => 'foo',
             'PHP_AUTH_PW' => 'bar',
+            'X-Requested-With' =>  'XMLHttpRequest'
+
         );
 
         $bag = new ServerBag($server);
@@ -40,6 +42,8 @@ class ServerBagTest extends \PHPUnit_Framework_TestCase
             'CONTENT_LENGTH' => '0',
             'ETAG' => 'asdf',
             'AUTHORIZATION' => 'Basic '.base64_encode('foo:bar'),
+            'X-Requested-With' =>  'XMLHttpRequest',
+
         ), $bag->getHeaders());
     }
 


### PR DESCRIPTION
Added the XMLHttpRequest header to getHeaders functions. I think it will be usefull to test ajax calls and adding the ajax header to client on tests. 
