### PR TITLE
[Routing] fixed several bugs and applied improvements

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -363,9 +363,11 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * added a TraceableUrlMatcher
  * added the possibility to define options, default values and requirements for placeholders in prefix, including imported routes
  * added RouterInterface::getRouteCollection
- * [BC BREAK] the UrlMatcher urldecodes the route parameters only once, they were
-   decoded twice before. Note that the `urldecode()` calls have been change for a
-   single `rawurldecode()` in order to support `+` for input paths.
+ * [BC BREAK] the UrlMatcher urldecodes the route parameters only once, they were decoded twice before.
+   Note that the `urldecode()` calls have been changed for a single `rawurldecode()` in order to support `+` for input paths.
+ * added RouteCollection::getRoot method to retrieve the root of a RouteCollection tree
+ * [BC BREAK] made RouteCollection::setParent private which could not have been used anyway without creating inconsistencies
+ * [BC BREAK] RouteCollection::remove also removes a route from parent collections (not only from its children)
 
 ### Security
 

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -79,9 +79,11 @@ class Route
         $this->pattern = trim($pattern);
 
         // a route must start with a slash
-        if (empty($this->pattern) || '/' !== $this->pattern[0]) {
+        if ('' === $this->pattern || '/' !== $this->pattern[0]) {
             $this->pattern = '/'.$this->pattern;
         }
+
+        $this->compiled = null;
 
         return $this;
     }
@@ -128,6 +130,7 @@ class Route
         foreach ($options as $name => $option) {
             $this->options[(string) $name] = $option;
         }
+        $this->compiled = null;
 
         return $this;
     }
@@ -147,6 +150,7 @@ class Route
     public function setOption($name, $value)
     {
         $this->options[$name] = $value;
+        $this->compiled = null;
 
         return $this;
     }
@@ -203,6 +207,7 @@ class Route
         foreach ($defaults as $name => $default) {
             $this->defaults[(string) $name] = $default;
         }
+        $this->compiled = null;
 
         return $this;
     }
@@ -244,6 +249,7 @@ class Route
     public function setDefault($name, $default)
     {
         $this->defaults[(string) $name] = $default;
+        $this->compiled = null;
 
         return $this;
     }
@@ -288,6 +294,7 @@ class Route
         foreach ($requirements as $key => $regex) {
             $this->requirements[$key] = $this->sanitizeRequirement($key, $regex);
         }
+        $this->compiled = null;
 
         return $this;
     }
@@ -317,6 +324,7 @@ class Route
     public function setRequirement($key, $regex)
     {
         $this->requirements[$key] = $this->sanitizeRequirement($key, $regex);
+        $this->compiled = null;
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -343,15 +343,19 @@ class Route
 
     private function sanitizeRequirement($key, $regex)
     {
-        if (is_array($regex)) {
-            throw new \InvalidArgumentException(sprintf('Routing requirements must be a string, array given for "%s"', $key));
+        if (!is_string($regex)) {
+            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" must be a string', $key));
         }
 
-        if ('^' == $regex[0]) {
+        if ('' === $regex) {
+            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" cannot be empty', $key));
+        }
+
+        if ('^' === $regex[0]) {
             $regex = substr($regex, 1);
         }
 
-        if ('$' == substr($regex, -1)) {
+        if ('$' === substr($regex, -1)) {
             $regex = substr($regex, 0, -1);
         }
 

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -215,6 +215,10 @@ class RouteCollection implements \IteratorAggregate
         // a prefix must not end with a slash
         $prefix = rtrim($prefix, '/');
 
+        if ('' === $prefix && empty($defaults) && empty($requirements) && empty($options)) {
+            return;
+        }
+
         // a prefix must start with a slash
         if ('' !== $prefix && '/' !== $prefix[0]) {
             $prefix = '/'.$prefix;

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -131,9 +131,9 @@ class RouteCollection implements \IteratorAggregate
     /**
      * Gets a route by name defined in this collection or its children.
      *
-     * @param  string      $name  The route name
+     * @param string $name The route name
      *
-     * @return Route|null  $route A Route instance or null when not found
+     * @return Route|null A Route instance or null when not found
      */
     public function get($name)
     {
@@ -160,12 +160,8 @@ class RouteCollection implements \IteratorAggregate
     {
         $root = $this->getRoot();
 
-        if (is_array($name)) {
-            foreach ($name as $n) {
-                $root->removeRecursively($n);
-            }
-        } else {
-            $root->removeRecursively($name);
+        foreach ((array) $name as $n) {
+            $root->removeRecursively($n);
         }
     }
 
@@ -186,7 +182,7 @@ class RouteCollection implements \IteratorAggregate
     {
         // prevent infinite loops by recursive referencing
         $root = $this->getRoot();
-        if ($root === $collection || $root->existsSubCollection($collection)) {
+        if ($root === $collection || $root->hasCollection($collection)) {
             throw new \InvalidArgumentException('The RouteCollection already exists in the tree.');
         }
 
@@ -321,13 +317,10 @@ class RouteCollection implements \IteratorAggregate
      *
      * @return Boolean
      */
-    private function existsSubCollection(RouteCollection $collection)
+    private function hasCollection(RouteCollection $collection)
     {
         foreach ($this->routes as $routes) {
-            if ($routes === $collection) {
-                return true;
-            }
-            if ($routes instanceof RouteCollection && $routes->existsSubCollection($collection)) {
+            if ($routes === $collection || $routes instanceof RouteCollection && $routes->hasCollection($collection)) {
                 return true;
             }
         }

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -194,9 +194,9 @@ class RouteCollection implements \IteratorAggregate
         $this->remove(array_keys($collection->all()));
 
         $collection->setParent($this);
-        // the sub-collection must have the prefix of the parent (current instance) prepended because it it does not
+        // the sub-collection must have the prefix of the parent (current instance) prepended because it does not
         // necessarily already have it applied (depending on the order RouteCollections are added to each other)
-        $collection->addPrefix($this->getPrefix() . $prefix, $defaults, $requirements);
+        $collection->addPrefix($this->getPrefix() . $prefix, $defaults, $requirements, $options);
         $this->routes[] = $collection;
     }
 
@@ -302,10 +302,8 @@ class RouteCollection implements \IteratorAggregate
         }
 
         foreach ($this->routes as $routes) {
-            if ($routes instanceof RouteCollection) {
-                if ($routes->removeRecursively($name)) {
-                    return true;
-                }
+            if ($routes instanceof RouteCollection && $routes->removeRecursively($name)) {
+                return true;
             }
         }
 
@@ -315,7 +313,7 @@ class RouteCollection implements \IteratorAggregate
     /**
      * Checks whether the given RouteCollection is already set in any child of the current instance.
      *
-     * @param RouteCollection $collection   A RouteCollection instance
+     * @param RouteCollection $collection A RouteCollection instance
      *
      * @return Boolean
      */
@@ -324,10 +322,9 @@ class RouteCollection implements \IteratorAggregate
         foreach ($this->routes as $routes) {
             if ($routes === $collection) {
                 return true;
-            } elseif ($routes instanceof RouteCollection) {
-                if ($routes->existsSubCollection($collection)) {
-                    return true;
-                }
+            }
+            if ($routes instanceof RouteCollection && $routes->existsSubCollection($collection)) {
+                return true;
             }
         }
 

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -17,9 +17,10 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  * A RouteCollection represents a set of Route instances.
  *
  * When adding a route, it overrides existing routes with the
- * same name defined in theinstance or its children and parents.
+ * same name defined in the instance or its children and parents.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Tobias Schultze <http://tobion.de>
  *
  * @api
  */
@@ -55,7 +56,7 @@ class RouteCollection implements \IteratorAggregate
     /**
      * Gets the parent RouteCollection.
      *
-     * @return RouteCollection The parent RouteCollection
+     * @return RouteCollection|null The parent RouteCollection or null when it's the root
      */
     public function getParent()
     {
@@ -98,20 +99,13 @@ class RouteCollection implements \IteratorAggregate
             throw new \InvalidArgumentException(sprintf('The provided route name "%s" contains non valid characters. A route name must only contain digits (0-9), letters (a-z and A-Z), underscores (_) and dots (.).', $name));
         }
 
-        $parent = $this;
-        while ($parent->getParent()) {
-            $parent = $parent->getParent();
-        }
-
-        if ($parent) {
-            $parent->remove($name);
-        }
+        $this->removeCompletely($name);
 
         $this->routes[$name] = $route;
     }
 
     /**
-     * Returns the array of routes.
+     * Returns all routes in this collection and its children.
      *
      * @return array An array of routes
      */
@@ -130,44 +124,58 @@ class RouteCollection implements \IteratorAggregate
     }
 
     /**
-     * Gets a route by name.
+     * Gets a route by name defined in this collection or its children.
      *
-     * @param  string $name  The route name
+     * @param  string      $name  The route name
      *
-     * @return Route  $route A Route instance
+     * @return Route|null  $route A Route instance or null when not found
      */
     public function get($name)
     {
-        // get the latest defined route
-        foreach (array_reverse($this->routes) as $routes) {
-            if (!$routes instanceof RouteCollection) {
-                continue;
-            }
-
-            if (null !== $route = $routes->get($name)) {
-                return $route;
-            }
-        }
-
         if (isset($this->routes[$name])) {
             return $this->routes[$name];
+        } else {
+            foreach ($this->routes as $routes) {
+                if ($routes instanceof RouteCollection && null !== $route = $routes->get($name)) {
+                    return $route;
+                }
+            }
         }
+        
+        return null;
     }
 
     /**
-     * Removes a route by name.
+     * Removes a route by name from all connected collections (this instance and all parents and children).
+     *
+     * @param string $name The route name
+     */
+    public function removeCompletely($name)
+    {
+        $parent = $this;
+        while ($parent->getParent()) {
+            $parent = $parent->getParent();
+        }
+
+        $parent->remove($name);
+    }
+    
+    /**
+     * Removes a route by name from this collection and its children.
      *
      * @param string $name The route name
      */
     public function remove($name)
     {
+        // the route can only be in this RouteCollection or one of its children (not both) because the
+        // adders (->add and ->addCollection) make sure there is only one route per name in all collections     
         if (isset($this->routes[$name])) {
             unset($this->routes[$name]);
-        }
-
-        foreach ($this->routes as $routes) {
-            if ($routes instanceof RouteCollection) {
-                $routes->remove($name);
+        } else {
+            foreach ($this->routes as $routes) {
+                if ($routes instanceof RouteCollection) {
+                    $routes->remove($name);
+                }
             }
         }
     }
@@ -190,7 +198,7 @@ class RouteCollection implements \IteratorAggregate
 
         // remove all routes with the same name in all existing collections
         foreach (array_keys($collection->all()) as $name) {
-            $this->remove($name);
+            $this->removeCompletely($name);
         }
 
         $this->routes[] = $collection;
@@ -212,7 +220,7 @@ class RouteCollection implements \IteratorAggregate
         $prefix = rtrim($prefix, '/');
 
         // a prefix must start with a slash
-        if ($prefix && '/' !== $prefix[0]) {
+        if ('' !== $prefix && '/' !== $prefix[0]) {
             $prefix = '/'.$prefix;
         }
 
@@ -230,6 +238,12 @@ class RouteCollection implements \IteratorAggregate
         }
     }
 
+    /**
+     * Returns the prefix that may contain placeholders. 
+     * When given, it must start with a slash and must not end with a slash.
+     *
+     * @return string The prefix
+     */
     public function getPrefix()
     {
         return $this->prefix;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -124,6 +124,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     $matches['_route'] = 'bar1';
                     return $matches;
                 }
+
             }
 
             // overriden
@@ -144,7 +145,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     $matches['_route'] = 'bar2';
                     return $matches;
                 }
+
             }
+
         }
 
         if (0 === strpos($pathinfo, '/multi')) {
@@ -162,6 +165,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             if ($pathinfo === '/multi/hey/') {
                 return array('_route' => 'hey');
             }
+
         }
 
         // foo3
@@ -205,7 +209,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     $matches['_route'] = 'c';
                     return $matches;
                 }
+
             }
+
         }
 
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -124,7 +124,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     $matches['_route'] = 'bar1';
                     return $matches;
                 }
+            }
 
+            // overriden
+            if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
+                $matches['_route'] = 'overriden';
+                return $matches;
+            }
+
+            if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
                 if (preg_match('#^/a/b\'b/(?P<foo1>[^/]+?)$#s', $pathinfo, $matches)) {
                     $matches['_route'] = 'foo2';
@@ -137,21 +145,22 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     return $matches;
                 }
             }
+        }
 
-            // overriden
-            if ($pathinfo === '/a/overriden2') {
-                return array('_route' => 'overriden');
+        if (0 === strpos($pathinfo, '/multi')) {
+            // helloWorld
+            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]+?))?$#s', $pathinfo, $matches)) {
+                return array_merge($this->mergeDefaults($matches, array (  'who' => 'World!',)), array('_route' => 'helloWorld'));
             }
 
-            // ababa
-            if ($pathinfo === '/ababa') {
-                return array('_route' => 'ababa');
+            // overriden2
+            if ($pathinfo === '/multi/new') {
+                return array('_route' => 'overriden2');
             }
 
-            // foo4
-            if (preg_match('#^/aba/(?P<foo>[^/]+?)$#s', $pathinfo, $matches)) {
-                $matches['_route'] = 'foo4';
-                return $matches;
+            // hey
+            if ($pathinfo === '/multi/hey/') {
+                return array('_route' => 'hey');
             }
         }
 
@@ -165,6 +174,38 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
         if (preg_match('#^/(?P<_locale>[^/]+?)/b/(?P<bar>[^/]+?)$#s', $pathinfo, $matches)) {
             $matches['_route'] = 'bar3';
             return $matches;
+        }
+
+        // ababa
+        if ($pathinfo === '/ababa') {
+            return array('_route' => 'ababa');
+        }
+
+        // foo4
+        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?P<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+            $matches['_route'] = 'foo4';
+            return $matches;
+        }
+
+        if (0 === strpos($pathinfo, '/a')) {
+            // a
+            if ($pathinfo === '/a/a...') {
+                return array('_route' => 'a');
+            }
+
+            if (0 === strpos($pathinfo, '/a/b')) {
+                // b
+                if (preg_match('#^/a/b/(?P<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                    $matches['_route'] = 'b';
+                    return $matches;
+                }
+
+                // c
+                if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                    $matches['_route'] = 'c';
+                    return $matches;
+                }
+            }
         }
 
         throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -130,7 +130,15 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     $matches['_route'] = 'bar1';
                     return $matches;
                 }
+            }
 
+            // overriden
+            if (preg_match('#^/a/(?P<var>.*)$#s', $pathinfo, $matches)) {
+                $matches['_route'] = 'overriden';
+                return $matches;
+            }
+
+            if (0 === strpos($pathinfo, '/a/b\'b')) {
                 // foo2
                 if (preg_match('#^/a/b\'b/(?P<foo1>[^/]+?)$#s', $pathinfo, $matches)) {
                     $matches['_route'] = 'foo2';
@@ -143,21 +151,25 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     return $matches;
                 }
             }
+        }
 
-            // overriden
-            if ($pathinfo === '/a/overriden2') {
-                return array('_route' => 'overriden');
+        if (0 === strpos($pathinfo, '/multi')) {
+            // helloWorld
+            if (0 === strpos($pathinfo, '/multi/hello') && preg_match('#^/multi/hello(?:/(?P<who>[^/]+?))?$#s', $pathinfo, $matches)) {
+                return array_merge($this->mergeDefaults($matches, array (  'who' => 'World!',)), array('_route' => 'helloWorld'));
             }
 
-            // ababa
-            if ($pathinfo === '/ababa') {
-                return array('_route' => 'ababa');
+            // overriden2
+            if ($pathinfo === '/multi/new') {
+                return array('_route' => 'overriden2');
             }
 
-            // foo4
-            if (preg_match('#^/aba/(?P<foo>[^/]+?)$#s', $pathinfo, $matches)) {
-                $matches['_route'] = 'foo4';
-                return $matches;
+            // hey
+            if (rtrim($pathinfo, '/') === '/multi/hey') {
+                if (substr($pathinfo, -1) !== '/') {
+                    return $this->redirect($pathinfo.'/', 'hey');
+                }
+                return array('_route' => 'hey');
             }
         }
 
@@ -171,6 +183,38 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
         if (preg_match('#^/(?P<_locale>[^/]+?)/b/(?P<bar>[^/]+?)$#s', $pathinfo, $matches)) {
             $matches['_route'] = 'bar3';
             return $matches;
+        }
+
+        // ababa
+        if ($pathinfo === '/ababa') {
+            return array('_route' => 'ababa');
+        }
+
+        // foo4
+        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?P<foo>[^/]+?)$#s', $pathinfo, $matches)) {
+            $matches['_route'] = 'foo4';
+            return $matches;
+        }
+
+        if (0 === strpos($pathinfo, '/a')) {
+            // a
+            if ($pathinfo === '/a/a...') {
+                return array('_route' => 'a');
+            }
+
+            if (0 === strpos($pathinfo, '/a/b')) {
+                // b
+                if (preg_match('#^/a/b/(?P<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                    $matches['_route'] = 'b';
+                    return $matches;
+                }
+
+                // c
+                if (0 === strpos($pathinfo, '/a/b/c') && preg_match('#^/a/b/c/(?P<var>[^/]+?)$#s', $pathinfo, $matches)) {
+                    $matches['_route'] = 'c';
+                    return $matches;
+                }
+            }
         }
 
         // secure

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -130,6 +130,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     $matches['_route'] = 'bar1';
                     return $matches;
                 }
+
             }
 
             // overriden
@@ -150,7 +151,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     $matches['_route'] = 'bar2';
                     return $matches;
                 }
+
             }
+
         }
 
         if (0 === strpos($pathinfo, '/multi')) {
@@ -171,6 +174,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 }
                 return array('_route' => 'hey');
             }
+
         }
 
         // foo3
@@ -214,7 +218,9 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     $matches['_route'] = 'c';
                     return $matches;
                 }
+
             }
+
         }
 
         // secure

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -23,7 +23,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
     public function match($pathinfo)
     {
         $allow = array();
-        $pathinfo = urldecode($pathinfo);
+        $pathinfo = rawurldecode($pathinfo);
 
         if (0 === strpos($pathinfo, '/rootprefix')) {
             // static
@@ -32,7 +32,7 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             }
 
             // dynamic
-            if (preg_match('#^/rootprefix/(?P<var>[^/]+?)$#xs', $pathinfo, $matches)) {
+            if (preg_match('#^/rootprefix/(?P<var>[^/]+?)$#s', $pathinfo, $matches)) {
                 $matches['_route'] = 'dynamic';
                 return $matches;
             }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher3.php
@@ -1,0 +1,44 @@
+<?php
+
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * ProjectUrlMatcher
+ *
+ * This class has been auto-generated
+ * by the Symfony Routing Component.
+ */
+class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function match($pathinfo)
+    {
+        $allow = array();
+        $pathinfo = urldecode($pathinfo);
+
+        if (0 === strpos($pathinfo, '/rootprefix')) {
+            // static
+            if ($pathinfo === '/rootprefix/test') {
+                return array('_route' => 'static');
+            }
+
+            // dynamic
+            if (preg_match('#^/rootprefix/(?P<var>[^/]+?)$#xs', $pathinfo, $matches)) {
+                $matches['_route'] = 'dynamic';
+                return $matches;
+            }
+
+        }
+
+        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -135,12 +135,24 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
         $collection1->add('bar1', new Route('/{bar}'));
         $collection2 = new RouteCollection();
         $collection2->addCollection($collection1, '/b\'b');
-        $collection2->add('overriden', new Route('/overriden2'));
+        $collection2->add('overriden', new Route('/{var}', array(), array('var' => '.*')));
         $collection1 = new RouteCollection();
         $collection1->add('foo2', new Route('/{foo1}'));
         $collection1->add('bar2', new Route('/{bar1}'));
         $collection2->addCollection($collection1, '/b\'b');
         $collection->addCollection($collection2, '/a');
+
+        // overriden through addCollection() and multiple sub-collections with no own prefix
+        $collection1 = new RouteCollection();
+        $collection1->add('overriden2', new Route('/old'));
+        $collection1->add('helloWorld', new Route('/hello/{who}', array('who' => 'World!')));
+        $collection2 = new RouteCollection();
+        $collection3 = new RouteCollection();
+        $collection3->add('overriden2', new Route('/new'));
+        $collection3->add('hey', new Route('/hey/'));
+        $collection1->addCollection($collection2);
+        $collection2->addCollection($collection3);
+        $collection->addCollection($collection1, '/multi');
 
         // "dynamic" prefix
         $collection1 = new RouteCollection();
@@ -150,12 +162,25 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
         $collection2->addCollection($collection1, '/b');
         $collection->addCollection($collection2, '/{_locale}');
 
+        // route between collections
         $collection->add('ababa', new Route('/ababa'));
 
-        // some more prefixes
+        // collection with static prefix but only one route
         $collection1 = new RouteCollection();
         $collection1->add('foo4', new Route('/{foo}'));
         $collection->addCollection($collection1, '/aba');
+
+        // multiple sub-collections with a single route and a prefix each
+        $collection1 = new RouteCollection();
+        $collection1->add('a', new Route('/a...'));
+        $collection2 = new RouteCollection();
+        $collection2->add('b', new Route('/{var}'));
+        $collection3 = new RouteCollection();
+        $collection3->add('c', new Route('/{var}'));
+
+        $collection1->addCollection($collection2, '/b');
+        $collection2->addCollection($collection3, '/c');
+        $collection->addCollection($collection1, '/a');
 
         return $collection;
     }

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -188,14 +188,12 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array('_scheme' => 'http')
         ));
 
-
         /* test case 3 */
 
         $rootprefixCollection = new RouteCollection();
         $rootprefixCollection->add('static', new Route('/test'));
         $rootprefixCollection->add('dynamic', new Route('/{var}'));
         $rootprefixCollection->addPrefix('rootprefix');
-
 
         return array(
            array($collection, 'url_matcher1.php', array()),

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -71,7 +71,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
     public function testMatch()
     {
-        // test the patterns are matched are parameters are returned
+        // test the patterns are matched and parameters are returned
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo/{bar}'));
         $matcher = new UrlMatcher($collection, new RequestContext(), array());

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -186,7 +186,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     public function testUniqueRouteWithGivenName()
     {
         $collection1 = new RouteCollection();
-        $collection1->add('foo', $old = new Route('/old'));
+        $collection1->add('foo', new Route('/old'));
         $collection2 = new RouteCollection();
         $collection3 = new RouteCollection();
         $collection3->add('foo', $new = new Route('/new'));
@@ -194,11 +194,16 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $collection1->addCollection($collection2);
         $collection2->addCollection($collection3);
 
+        $collection1->add('stay', new Route('/stay'));
+
+        $iterator = $collection1->getIterator();
+
         $this->assertSame($new, $collection1->get('foo'), '->get() returns new route that overrode previous one');
-        $p = new \ReflectionProperty('Symfony\Component\Routing\RouteCollection', 'routes');
-        $p->setAccessible(true);
-        // size of 1 because collection1 contains collection2 but not $old anymore
-        $this->assertCount(1, $p->getValue($collection1), '->addCollection() removes previous routes when adding new routes with the same name');
+        // size of 2 because collection1 contains collection2 and /stay but not /old anymore
+        $this->assertCount(2, $iterator, '->addCollection() removes previous routes when adding new routes with the same name');
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $iterator->current(), '->getIterator returns both Routes and RouteCollections');
+        $iterator->next();
+        $this->assertInstanceOf('Symfony\Component\Routing\Route', $iterator->current(), '->getIterator returns both Routes and RouteCollections');
     }
 
     public function testGet()
@@ -267,10 +272,8 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $collection2->addCollection($collection3, '/c');
         $rootCollection_B->addCollection($collection1, '/a');
 
-        // test it
+        // test it now
 
-        $p = new \ReflectionProperty('Symfony\Component\Routing\RouteCollection', 'routes');
-        $p->setAccessible(true);
-        $this->assertEquals($p->getValue($rootCollection_A), $p->getValue($rootCollection_B));
+        $this->assertEquals($rootCollection_A, $rootCollection_B);
     }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -28,7 +28,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException InvalidArgumentException
+     * @expectedException \InvalidArgumentException
      */
     public function testAddInvalidRoute()
     {
@@ -183,7 +183,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($foo), $collection->getResources(), '->addResources() adds a resource');
     }
 
-    public function testSingleRouteWithGivenName()
+    public function testUniqueRouteWithGivenName()
     {
         $collection1 = new RouteCollection();
         $collection1->add('foo', $old = new Route('/old'));
@@ -204,10 +204,73 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     public function testGet()
     {
         $collection1 = new RouteCollection();
+        $collection1->add('a', $a = new Route('/a'));
         $collection2 = new RouteCollection();
+        $collection2->add('b', $b = new Route('/b'));
         $collection1->addCollection($collection2);
 
+        $this->assertSame($b, $collection1->get('b'), '->get() returns correct route in child collection');
+        $this->assertNull($collection2->get('a'), '->get() does not return the route defined in parent collection');
         $this->assertNull($collection1->get('non-existent'), '->get() returns null when route does not exist');
         $this->assertNull($collection1->get(0), '->get() does not disclose internal child RouteCollection');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCannotSelfJoinCollection()
+    {
+        $collection = new RouteCollection();
+
+        $collection->addCollection($collection);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCannotAddExistingCollectionToTree()
+    {
+        $collection1 = new RouteCollection();
+        $collection2 = new RouteCollection();
+        $collection3 = new RouteCollection();
+
+        $collection1->addCollection($collection2);
+        $collection1->addCollection($collection3);
+        $collection2->addCollection($collection3);
+    }
+
+    public function testDefinitionOrderDoesNotMatter()
+    {
+        $collection1 = new RouteCollection();
+        $collection1->add('a', new Route('/a...'));
+        $collection2 = new RouteCollection();
+        $collection2->add('b', new Route('/b...'));
+        $collection3 = new RouteCollection();
+        $collection3->add('c', new Route('/c...'));
+
+        $rootCollection_A = new RouteCollection();
+        $collection2->addCollection($collection3, '/c');
+        $collection1->addCollection($collection2, '/b');
+        $rootCollection_A->addCollection($collection1, '/a');
+
+        // above should mean the same as below
+
+        $collection1 = new RouteCollection();
+        $collection1->add('a', new Route('/a...'));
+        $collection2 = new RouteCollection();
+        $collection2->add('b', new Route('/b...'));
+        $collection3 = new RouteCollection();
+        $collection3->add('c', new Route('/c...'));
+
+        $rootCollection_B = new RouteCollection();
+        $collection1->addCollection($collection2, '/b');
+        $collection2->addCollection($collection3, '/c');
+        $rootCollection_B->addCollection($collection1, '/a');
+
+        // test it
+
+        $p = new \ReflectionProperty('Symfony\Component\Routing\RouteCollection', 'routes');
+        $p->setAccessible(true);
+        $this->assertEquals($p->getValue($rootCollection_A), $p->getValue($rootCollection_B));
     }
 }

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -98,6 +98,24 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('\d+', $route->getRequirement('foo'), '->setRequirement() removes ^ and $ from the pattern');
     }
 
+    /**
+     * @dataProvider getInvalidRequirements
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetInvalidRequirement($req)
+    {
+        $route = new Route('/{foo}');
+        $route->setRequirement('foo', $req);
+    }
+
+    public function getInvalidRequirements()
+    {
+        return array(
+           array(''),
+           array(array())
+        );
+    }
+
     public function testCompile()
     {
         $route = new Route('/{foo}');

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -119,7 +119,9 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     public function testCompile()
     {
         $route = new Route('/{foo}');
-        $this->assertEquals('Symfony\\Component\\Routing\\CompiledRoute', get_class($compiled = $route->compile()), '->compile() returns a compiled route');
-        $this->assertEquals($compiled, $route->compile(), '->compile() only compiled the route once');
+        $this->assertInstanceOf('Symfony\Component\Routing\CompiledRoute', $compiled = $route->compile(), '->compile() returns a compiled route');
+        $this->assertSame($compiled, $route->compile(), '->compile() only compiled the route once if unchanged');
+        $route->setRequirement('foo', '.*');
+        $this->assertNotSame($compiled, $route->compile(), '->compile() recompiles if the route was modified');
     }
 }


### PR DESCRIPTION
Ok this PR was hard because stuff was tricky to understand and there was much room for improvement. Here a list of what is fixed. Tests pass.
1. The `RouteCollection` states
   
   > it overrides existing routes with the same name defined in the instance or its children and parents.
   
   But this is not true for `->addCollection()` but only for `->add()`. addCollection does not remove routes with the same name in its parents (only in its children). I don't think this is on purpose.
   So I fixed it by making sure there can only be one route per name in all connected collections. This way we can also simplify `->get()` and `->remove()` and improve performance since we can stop iterating recursively when we found the first and only route with a given name.
   See `testUniqueRouteWithGivenName` that fails in the old code but works now.
2. There was an bug with `$collection->addPrefix('0');` that didn't apply the starting slash. Fixed and test case added.
3. There is an issue with `->get()` that I also think is not intended. Currently it allows to access a sub-RouteCollection by specifing $name as array integer index. But according to the PHPdoc you should only be allowed to receive a Route instance and not a RouteCollection.
   See `testGet` that has a failing test case. I fixed this behavior.
4. Then I recognized that `->addCollection` depended on the order of applying them. So
   
   ```
   $collection1->addCollection($collection2, '/b');
   $collection2->addCollection($collection3, '/c');
   $rootCollection->addCollection($collection1, '/a');
   ```
   
   had a different pattern result from 
   
   ```
   $collection2->addCollection($collection3, '/c');
   $collection1->addCollection($collection2, '/b');
   $rootCollection->addCollection($collection1, '/a');
   ```
   
   Fixed and test case added. See `testDefinitionOrderDoesNotMatter`.
5. PHP could have ended in an infinite loop when one tried to add an existing RouteCollection to the tree. Fixed by throwing an exception when this situation is detected. See tests `testCannotSelfJoinCollection` and `testCannotAddExistingCollectionToTree`.
6. I made `setParent()` private because its not useful outside the class itself. And `remove()` also removes the route from its parents. Added public `getRoot()` method.
7. The `Route` class throwed a PHP warning when trying to set an empty requirement.
8. Fixed issue #3777. See discussion there for more info. I fixed it by removing the over-optimization that was introduced in 91f4097a0905e but didn't work properly. One cannot reorder the route definitions, as is was done, because then the wrong route might me matched before the correct one. If one really wanted to do that, it would require to calculate the intersection of two regular expressions to determine if they can be grouped together (a tool that would also be useful to check whether a route is unreachable, see discussion in #3678) We can only safely optimize routes with a static prefix within a RouteCollection, not across multiple RouteCollections with different parents.  This is especially true when using variables and regular expressions requirements.
   I could however apply an optimization that was missing yet: Collections with a single route were missing the static prefix optimization with `0 === strpos()`.
9. Fixed an issue where the `PhpMatcherDumper` would not apply the optimization if the root collection to be dumped has a prefix itself. For this I had to rewrite `compileRoutes`. It is also much easier to understand now. Addionally I added many comments and PHPdoc because complex recursive methods like this are still hard to grasp. 
   I added a test case for this (`url_matcher3.php`).
10. Fix that `Route::compile` needs to recompile a route once it is modified. Otherwise we have a wrong result. Test case added.
