### PR TITLE
Autoloader refactoring

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -178,6 +178,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 ### ClassLoader
 
+ * added a DebugClassLoader able to wrap any autoloader providing a findFile method
  * added a new ApcClassLoader using composition to wrap other loaders
  * added a new ClassLoader which does not distinguish between namespaced and pear-like classes (as the PEAR
    convention is a subset of PSR-0) and supports using Composer's namespace maps

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -178,6 +178,9 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 ### ClassLoader
 
+ * added a new ApcClassLoader using composition to wrap other loaders
+ * added a new ClassLoader which does not distinguish between namespaced and pear-like classes (as the PEAR
+   convention is a subset of PSR-0) and supports using Composer's namespace maps
  * added a class map generator
  * added support for loading globally-installed PEAR packages
 

--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -1,41 +1,33 @@
 <?php
 
-require_once __DIR__.'/src/Symfony/Component/ClassLoader/UniversalClassLoader.php';
+require_once __DIR__.'/src/Symfony/Component/ClassLoader/ClassLoader.php';
 
-use Symfony\Component\ClassLoader\UniversalClassLoader;
+use Symfony\Component\ClassLoader\ClassLoader;
 use Doctrine\Common\Annotations\AnnotationRegistry;
 
-$loader = new UniversalClassLoader();
-$loader->registerNamespaces(array(
-    'Symfony\\Tests'   => __DIR__.'/tests',
-    'Symfony'          => __DIR__.'/src',
-    'Doctrine\\Common\\DataFixtures' => __DIR__.'/vendor/doctrine-fixtures/lib',
-    'Doctrine\\Common' => __DIR__.'/vendor/doctrine-common/lib',
-    'Doctrine\\DBAL'   => __DIR__.'/vendor/doctrine-dbal/lib',
-    'Doctrine'         => __DIR__.'/vendor/doctrine/lib',
-    'Monolog'          => __DIR__.'/vendor/monolog/src',
-));
-$loader->registerPrefixes(array(
-    'Twig_' => __DIR__.'/vendor/twig/lib',
+$loader = new ClassLoader();
+$loader->addPrefixes(array(
+    'Symfony\\Tests\\'   => __DIR__.'/tests',
+    'Symfony\\'          => __DIR__.'/src',
+    'Doctrine\\Common\\DataFixtures\\' => __DIR__.'/vendor/doctrine-fixtures/lib',
+    'Doctrine\\Common\\' => __DIR__.'/vendor/doctrine-common/lib',
+    'Doctrine\\DBAL\\'   => __DIR__.'/vendor/doctrine-dbal/lib',
+    'Doctrine\\ORM\\'    => __DIR__.'/vendor/doctrine/lib',
+    'Monolog\\'          => __DIR__.'/vendor/monolog/src',
+    'Twig_'              => __DIR__.'/vendor/twig/lib',
 ));
 if (!function_exists('intl_get_error_code')) {
     require_once __DIR__.'/src/Symfony/Component/Locale/Resources/stubs/functions.php';
 
-    $loader->registerPrefixFallback(__DIR__.'/src/Symfony/Component/Locale/Resources/stubs');
+    $loader->addPrefix('', __DIR__.'/src/Symfony/Component/Locale/Resources/stubs');
 }
 if (!interface_exists('SessionHandlerInterface', false)) {
-    $loader->registerPrefix('SessionHandlerInterface', __DIR__.'/src/Symfony/Component/HttpFoundation/Resources/stubs');
+    $loader->addPrefix('SessionHandlerInterface', __DIR__.'/src/Symfony/Component/HttpFoundation/Resources/stubs');
 }
 $loader->register();
 
 if (is_file(__DIR__.'/vendor/doctrine-common/lib/Doctrine/Common/Annotations/AnnotationRegistry.php')) {
-    AnnotationRegistry::registerLoader(function($class) use ($loader) {
-        $loader->loadClass($class);
-        return class_exists($class, false);
-    });
-    if (is_file(__DIR__.'/vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php')) {
-        AnnotationRegistry::registerFile(__DIR__.'/vendor/doctrine/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
-    }
+    AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 }
 
 if (is_file(__DIR__.'/vendor/swiftmailer/lib/classes/Swift.php')) {

--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -58,6 +58,10 @@ class ApcClassLoader
             throw new \RuntimeException('Unable to use ApcUniversalClassLoader as APC is not enabled.');
         }
 
+        if (!method_exists($classFinder, 'findFile')) {
+            throw new \InvalidArgumentException('The class finder must implement a "findFile" method.');
+        }
+
         $this->prefix = $prefix;
         $this->classFinder = $classFinder;
     }

--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader;
+
+/**
+ * ApcClassLoader implements a wrapping autoloader cached in APC for PHP 5.3.
+ *
+ * It expects an object implementing a findFile method to find the file. This
+ * allow using it as a wrapper around the other loaders of the component (the
+ * ClassLoader and the UniversalClassLoader for instance) but also around any
+ * other autoloader following this convention (the Composer one for instance)
+ *
+ *     $loader = new ClassLoader();
+ *
+ *     // register classes with namespaces
+ *     $loader->add('Symfony\Component', __DIR__.'/component');
+ *     $loader->add('Symfony',           __DIR__.'/framework');
+ *
+ *     $cachedLoader = new ApcClassLoader('my_prefix', $loader);
+ *
+ *     // activate the cached autoloader
+ *     $cachedLoader->register();
+ *
+ *     // eventually deactivate the non-cached loader if it was registered previously
+ *     // to be sure to use the cached one.
+ *     $loader->unregister();
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Kris Wallsmith <kris@symfony.com>
+ *
+ * @api
+ */
+class ApcClassLoader
+{
+    private $prefix;
+    private $classFinder;
+
+    /**
+     * Constructor.
+     *
+     * @param string $prefix A prefix to create a namespace in APC
+     * @param object $classFinder
+     *
+     * @api
+     */
+    public function __construct($prefix, $classFinder)
+    {
+        if (!extension_loaded('apc')) {
+            throw new \RuntimeException('Unable to use ApcUniversalClassLoader as APC is not enabled.');
+        }
+
+        $this->prefix = $prefix;
+        $this->classFinder = $classFinder;
+    }
+
+    /**
+     * Registers this instance as an autoloader.
+     *
+     * @param Boolean $prepend Whether to prepend the autoloader or not
+     */
+    public function register($prepend = false)
+    {
+        spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+    }
+
+    /**
+     * Unregisters this instance as an autoloader.
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister(array($this, 'loadClass'));
+    }
+
+    /**
+     * Loads the given class or interface.
+     *
+     * @param string $class The name of the class
+     * @return Boolean|null True, if loaded
+     */
+    public function loadClass($class)
+    {
+        if ($file = $this->findFile($class)) {
+            require $file;
+            return true;
+        }
+    }
+
+    /**
+     * Finds a file by class name while caching lookups to APC.
+     *
+     * @param string $class A class name to resolve to file
+     *
+     * @return string|null
+     */
+    public function findFile($class)
+    {
+        if (false === $file = apc_fetch($this->prefix.$class)) {
+            apc_store($this->prefix.$class, $file = $this->classFinder->findFile($class));
+        }
+
+        return $file;
+    }
+}

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -1,0 +1,185 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader;
+
+/**
+ * ClassLoader implements an PSR-0 class loader
+ *
+ * See https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md
+ *
+ *     $loader = new ClassLoader();
+ *
+ *     // register classes with namespaces
+ *     $loader->add('Symfony\Component', __DIR__.'/component');
+ *     $loader->add('Symfony',           __DIR__.'/framework');
+ *
+ *     // activate the autoloader
+ *     $loader->register();
+ *
+ *     // to enable searching the include path (eg. for PEAR packages)
+ *     $loader->setUseIncludePath(true);
+ *
+ * In this example, if you try to use a class in the Symfony\Component
+ * namespace or one of its children (Symfony\Component\Console for instance),
+ * the autoloader will first look for the class under the component/
+ * directory, and it will then fallback to the framework/ directory if not
+ * found before giving up.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Jordi Boggiano <j.boggiano@seld.be>
+ */
+class ClassLoader
+{
+    private $prefixes = array();
+    private $fallbackDirs = array();
+    private $useIncludePath = false;
+
+    public function getPrefixes()
+    {
+        return $this->prefixes;
+    }
+
+    public function getFallbackDirs()
+    {
+        return $this->fallbackDirs;
+    }
+
+    public function addPrefixes(array $prefixes)
+    {
+        foreach ($prefixes as $prefix => $path) {
+            $this->addPrefix($prefix, $path);
+        }
+    }
+
+    /**
+     * Registers a set of classes
+     *
+     * @param string       $prefix  The classes prefix
+     * @param array|string $paths   The location(s) of the classes
+     */
+    public function addPrefix($prefix, $paths)
+    {
+        if (!$prefix) {
+            foreach ((array) $paths as $path) {
+                $this->fallbackDirs[] = $path;
+            }
+            return;
+        }
+        if (isset($this->prefixes[$prefix])) {
+            $this->prefixes[$prefix] = array_merge(
+                $this->prefixes[$prefix],
+                (array) $paths
+            );
+        } else {
+            $this->prefixes[$prefix] = (array) $paths;
+        }
+    }
+
+    /**
+     * Turns on searching the include for class files.
+     *
+     * @param Boolean $useIncludePath
+     */
+    public function setUseIncludePath($useIncludePath)
+    {
+        $this->useIncludePath = $useIncludePath;
+    }
+
+    /**
+     * Can be used to check if the autoloader uses the include path to check
+     * for classes.
+     *
+     * @return Boolean
+     */
+    public function getUseIncludePath()
+    {
+        return $this->useIncludePath;
+    }
+
+    /**
+     * Registers this instance as an autoloader.
+     *
+     * @param Boolean $prepend Whether to prepend the autoloader or not
+     */
+    public function register($prepend = false)
+    {
+        spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+    }
+
+    /**
+     * Unregisters this instance as an autoloader.
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister(array($this, 'loadClass'));
+    }
+
+    /**
+     * Loads the given class or interface.
+     *
+     * @param string $class The name of the class
+     * @return Boolean|null True, if loaded
+     */
+    public function loadClass($class)
+    {
+        if ($file = $this->findFile($class)) {
+            require $file;
+            return true;
+        }
+    }
+
+    /**
+     * Finds the path to the file where the class is defined.
+     *
+     * @param string $class The name of the class
+     *
+     * @return string|null The path, if found
+     */
+    public function findFile($class)
+    {
+        if ('\\' == $class[0]) {
+            $class = substr($class, 1);
+        }
+
+        if (false !== $pos = strrpos($class, '\\')) {
+            // namespaced class name
+            $classPath = str_replace('\\', DIRECTORY_SEPARATOR, substr($class, 0, $pos)) . DIRECTORY_SEPARATOR;
+            $className = substr($class, $pos + 1);
+        } else {
+            // PEAR-like class name
+            $classPath = null;
+            $className = $class;
+        }
+
+        $classPath .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
+
+        foreach ($this->prefixes as $prefix => $dirs) {
+            if (0 === strpos($class, $prefix)) {
+                foreach ($dirs as $dir) {
+                    if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
+                        return $dir . DIRECTORY_SEPARATOR . $classPath;
+                    }
+                }
+            }
+        }
+
+        foreach ($this->fallbackDirs as $dir) {
+            if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
+                return $dir . DIRECTORY_SEPARATOR . $classPath;
+            }
+        }
+
+        if ($this->useIncludePath && $file = stream_resolve_include_path($classPath)) {
+            return $file;
+        }
+    }
+}

--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader;
+
+/**
+ * Autoloader checking if the class is really defined in the file found.
+ *
+ * The DebugClassLoader will wrap all registered autoloaders providing a
+ * findFile method and will throw an exception if a file is found but does
+ * not declare the class.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ *
+ * @api
+ */
+class DebugClassLoader
+{
+    private $classFinder;
+
+    /**
+     * Constructor.
+     *
+     * @param object $classFinder
+     *
+     * @api
+     */
+    public function __construct($classFinder)
+    {
+        $this->classFinder = $classFinder;
+    }
+
+    /**
+     * Replaces all autoloaders implementing a findFile method by a DebugClassLoader wrapper.
+     */
+    static public function enable()
+    {
+        if (!is_array($functions = spl_autoload_functions())) {
+            return;
+        }
+
+        foreach ($functions as $function) {
+            spl_autoload_unregister($function);
+        }
+
+        foreach ($functions as $function) {
+            if (is_array($function) && method_exists($function[0], 'findFile')) {
+                $function = array(new static($function[0]), 'loadClass');
+            }
+
+            spl_autoload_register($function);
+        }
+    }
+
+    /**
+     * Unregisters this instance as an autoloader.
+     */
+    public function unregister()
+    {
+        spl_autoload_unregister(array($this, 'loadClass'));
+    }
+
+    /**
+     * Loads the given class or interface.
+     *
+     * @param string $class The name of the class
+     * @return Boolean|null True, if loaded
+     */
+    public function loadClass($class)
+    {
+        if ($file = $this->classFinder->findFile($class)) {
+            require $file;
+
+            if (!class_exists($class, false) && !interface_exists($class, false) && (!function_exists('trait_exists') || !trait_exists($class, false))) {
+                throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but the class was not in it, the class name or namespace probably has a typo.', $class, $file));
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/Symfony/Component/ClassLoader/Tests/ClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassLoaderTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader\Tests;
+
+use Symfony\Component\ClassLoader\ClassLoader;
+
+class ClassLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getLoadClassTests
+     */
+    public function testLoadClass($className, $testClassName, $message)
+    {
+        $loader = new ClassLoader();
+        $loader->addPrefix('Namespaced2\\', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->addPrefix('Pearlike2_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->loadClass($testClassName);
+        $this->assertTrue(class_exists($className), $message);
+    }
+
+    public function getLoadClassTests()
+    {
+        return array(
+            array('\\Namespaced2\\Foo', 'Namespaced2\\Foo',   '->loadClass() loads Namespaced2\Foo class'),
+            array('\\Pearlike2_Foo',    'Pearlike2_Foo',      '->loadClass() loads Pearlike2_Foo class'),
+            array('\\Namespaced2\\Bar', '\\Namespaced2\\Bar', '->loadClass() loads Namespaced2\Bar class with a leading slash'),
+            array('\\Pearlike2_Bar',    '\\Pearlike2_Bar',    '->loadClass() loads Pearlike2_Bar class with a leading slash'),
+        );
+    }
+
+    public function testUseIncludePath()
+    {
+        $loader = new ClassLoader();
+        $this->assertFalse($loader->getUseIncludePath());
+
+        $this->assertEquals(null, $loader->findFile('Foo'));
+
+        $includePath = get_include_path();
+
+        $loader->setUseIncludePath(true);
+        $this->assertTrue($loader->getUseIncludePath());
+
+        set_include_path(__DIR__.'/Fixtures/includepath' . PATH_SEPARATOR . $includePath);
+
+        $this->assertEquals(__DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.'includepath'.DIRECTORY_SEPARATOR.'Foo.php', $loader->findFile('Foo'));
+
+        set_include_path($includePath);
+    }
+
+    /**
+     * @dataProvider getLoadClassFromFallbackTests
+     */
+    public function testLoadClassFromFallback($className, $testClassName, $message)
+    {
+        $loader = new ClassLoader();
+        $loader->addPrefix('Namespaced2\\', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->addPrefix('Pearlike2_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader->addPrefix('', array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'));
+        $loader->loadClass($testClassName);
+        $this->assertTrue(class_exists($className), $message);
+    }
+
+    public function getLoadClassFromFallbackTests()
+    {
+        return array(
+            array('\\Namespaced2\\Baz',    'Namespaced2\\Baz',    '->loadClass() loads Namespaced2\Baz class'),
+            array('\\Pearlike2_Baz',       'Pearlike2_Baz',       '->loadClass() loads Pearlike2_Baz class'),
+            array('\\Namespaced2\\FooBar', 'Namespaced2\\FooBar', '->loadClass() loads Namespaced2\Baz class from fallback dir'),
+            array('\\Pearlike2_FooBar',    'Pearlike2_FooBar',    '->loadClass() loads Pearlike2_Baz class from fallback dir'),
+        );
+    }
+
+    /**
+     * @dataProvider getLoadClassNamespaceCollisionTests
+     */
+    public function testLoadClassNamespaceCollision($namespaces, $className, $message)
+    {
+        $loader = new ClassLoader();
+        $loader->addPrefixes($namespaces);
+
+        $loader->loadClass($className);
+        $this->assertTrue(class_exists($className), $message);
+    }
+
+    public function getLoadClassNamespaceCollisionTests()
+    {
+        return array(
+            array(
+                array(
+                    'NamespaceCollision\\C' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'NamespaceCollision\\C\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'NamespaceCollision\C\Foo',
+                '->loadClass() loads NamespaceCollision\C\Foo from alpha.',
+            ),
+            array(
+                array(
+                    'NamespaceCollision\\C\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'NamespaceCollision\\C' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'NamespaceCollision\C\Bar',
+                '->loadClass() loads NamespaceCollision\C\Bar from alpha.',
+            ),
+            array(
+                array(
+                    'NamespaceCollision\\C' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'NamespaceCollision\\C\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'NamespaceCollision\C\B\Foo',
+                '->loadClass() loads NamespaceCollision\C\B\Foo from beta.',
+            ),
+            array(
+                array(
+                    'NamespaceCollision\\C\\B' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'NamespaceCollision\\C' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'NamespaceCollision\C\B\Bar',
+                '->loadClass() loads NamespaceCollision\C\B\Bar from beta.',
+            ),
+            array(
+                array(
+                    'PrefixCollision_C_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'PrefixCollision_C_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'PrefixCollision_C_Foo',
+                '->loadClass() loads PrefixCollision_C_Foo from alpha.',
+            ),
+            array(
+                array(
+                    'PrefixCollision_C_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'PrefixCollision_C_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'PrefixCollision_C_Bar',
+                '->loadClass() loads PrefixCollision_C_Bar from alpha.',
+            ),
+            array(
+                array(
+                    'PrefixCollision_C_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                    'PrefixCollision_C_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                ),
+                'PrefixCollision_C_B_Foo',
+                '->loadClass() loads PrefixCollision_C_B_Foo from beta.',
+            ),
+            array(
+                array(
+                    'PrefixCollision_C_B_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/beta',
+                    'PrefixCollision_C_' => __DIR__.DIRECTORY_SEPARATOR.'Fixtures/alpha',
+                ),
+                'PrefixCollision_C_B_Bar',
+                '->loadClass() loads PrefixCollision_C_B_Bar from beta.',
+            ),
+        );
+    }
+}

--- a/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassMapGeneratorTest.php
@@ -36,6 +36,8 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
             array(__DIR__.'/Fixtures/beta/NamespaceCollision', array(
                 'NamespaceCollision\\A\\B\\Bar' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Bar.php',
                 'NamespaceCollision\\A\\B\\Foo' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Foo.php',
+                'NamespaceCollision\\C\\B\\Bar' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/C/B/Bar.php',
+                'NamespaceCollision\\C\\B\\Foo' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/C/B/Foo.php',
             )),
             array(__DIR__.'/Fixtures/Pearlike', array(
                 'Pearlike_Foo' => realpath(__DIR__).'/Fixtures/Pearlike/Foo.php',
@@ -82,6 +84,8 @@ class ClassMapGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEqualsNormalized(array(
             'NamespaceCollision\\A\\B\\Bar' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Bar.php',
             'NamespaceCollision\\A\\B\\Foo' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/A/B/Foo.php',
+            'NamespaceCollision\\C\\B\\Bar' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/C/B/Bar.php',
+            'NamespaceCollision\\C\\B\\Foo' => realpath(__DIR__).'/Fixtures/beta/NamespaceCollision/C/B/Foo.php',
         ), ClassMapGenerator::createMap($finder));
     }
 

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced2/Bar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced2/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Namespaced2;
+
+class Bar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced2/Baz.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced2/Baz.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Namespaced2;
+
+class Baz
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced2/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced2/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Namespaced2;
+
+class Foo
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Pearlike2/Bar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Pearlike2/Bar.php
@@ -1,0 +1,6 @@
+<?php
+
+class Pearlike2_Bar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Pearlike2/Baz.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Pearlike2/Baz.php
@@ -1,0 +1,6 @@
+<?php
+
+class Pearlike2_Baz
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Pearlike2/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Pearlike2/Foo.php
@@ -1,0 +1,6 @@
+<?php
+
+class Pearlike2_Foo
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/NamespaceCollision/C/Bar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/NamespaceCollision/C/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NamespaceCollision\C;
+
+class Bar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/NamespaceCollision/C/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/NamespaceCollision/C/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NamespaceCollision\C;
+
+class Foo
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/PrefixCollision/C/Bar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/PrefixCollision/C/Bar.php
@@ -1,0 +1,6 @@
+<?php
+
+class PrefixCollision_C_Bar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/PrefixCollision/C/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/alpha/PrefixCollision/C/Foo.php
@@ -1,0 +1,6 @@
+<?php
+
+class PrefixCollision_C_Foo
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/NamespaceCollision/C/B/Bar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/NamespaceCollision/C/B/Bar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NamespaceCollision\C\B;
+
+class Bar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/NamespaceCollision/C/B/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/NamespaceCollision/C/B/Foo.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NamespaceCollision\C\B;
+
+class Foo
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/PrefixCollision/C/B/Bar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/PrefixCollision/C/B/Bar.php
@@ -1,0 +1,6 @@
+<?php
+
+class PrefixCollision_C_B_Bar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/PrefixCollision/C/B/Foo.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/beta/PrefixCollision/C/B/Foo.php
@@ -1,0 +1,6 @@
+<?php
+
+class PrefixCollision_C_B_Foo
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/fallback/Namespaced2/FooBar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/fallback/Namespaced2/FooBar.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Namespaced2;
+
+class FooBar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/fallback/Pearlike2/FooBar.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/fallback/Pearlike2/FooBar.php
@@ -1,0 +1,6 @@
+<?php
+
+class Pearlike2_FooBar
+{
+    public static $loaded = true;
+}

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -34,7 +34,7 @@ use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
-use Symfony\Component\ClassLoader\DebugUniversalClassLoader;
+use Symfony\Component\ClassLoader\DebugClassLoader;
 
 /**
  * The Kernel is the heart of the Symfony system.
@@ -91,7 +91,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             ini_set('display_errors', 1);
             error_reporting(-1);
 
-            DebugUniversalClassLoader::enable();
+            DebugClassLoader::enable();
             ErrorHandler::register($this->errorReportingLevel);
             if ('cli' !== php_sapi_name()) {
                 ExceptionHandler::register();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/stof/symfony.png?branch=autoloader_refactoring)](http://travis-ci.org/stof/symfony)

As discussed in #3623, I added a new ClassLoader instead of modifying the UniversalClassLoader, to be able to use the method names without BC concerns. The new class works the same than the composer autoloader regarding the handling of fallbacks, to be able to reuse namespace maps generated by composer.

``` php
<?php

// autoload.php
require_once __DIR__.'/vendor/symfony/class-loader/Symfony/Component/ClassLoader/ClassLoader.php';

$loader = new Symfony\Component\ClassLoader\ClassLoader();

$map = require __DIR__.'/vendor/.composer/autoload_namespaces.php';
$loader->addPrefixes($map);

$loader->register();
```

Differences with the composer class loader:
- Composer's `add` method is named `addPrefix` in the Symfony ClassLoader
- the methods related to the class map are removed as Symfony has a separate laoder for class maps
- the `addPrefixes` method is added, accepting a namespace map.

I also added a new ApcClassLoader which uses composition instead of inheriting from a class loader, which makes it far more easier to reuse (we could wrap a Composer autoloader with it for instance).

``` php
<?php

$composerLoader = require __DIR__.'/vendor/.composer/autoload.php';

// no need to require the file manually as Composer already registered its autoloader
$cachedLoader = new Symfony\Component\ClassLoader\ApcClassLoader('autoload.my_app', $composerLoader);

$cachedLoader->register();
// unregister the Composer autoloader as we wrapped it in the ApcClassLoader
$composerLoader->unregister();
```

TODO:
- refactor the Debug class loader to use composition too to be able to support different class loaders
