### PR TITLE
moved event dispatcher classes to the EventDispatcher component

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -34,6 +34,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 ### FrameworkBundle
 
+ * moved Symfony\Bundle\FrameworkBundle\ContainerAwareEventDispatcher to Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher
+ * moved Symfony\Bundle\FrameworkBundle\Debug\TraceableEventDispatcher to Symfony\Component\EventDispatcher\ContainerAwareTraceableEventDispatcher
  * added a router:match command
  * added a config:dump-reference command
  * added kernel.event_subscriber tag

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -122,6 +122,7 @@ class FrameworkExtension extends Extension
             'Symfony\\Component\\EventDispatcher\\EventDispatcher',
             'Symfony\\Component\\EventDispatcher\\Event',
             'Symfony\\Component\\EventDispatcher\\EventSubscriberInterface',
+            'Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher',
 
             'Symfony\\Component\\HttpKernel\\HttpKernel',
             'Symfony\\Component\\HttpKernel\\EventListener\\ResponseListener',
@@ -141,7 +142,6 @@ class FrameworkExtension extends Extension
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerResolver',
             // Cannot be included because annotations will parse the big compiled class file
             // 'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
-            'Symfony\\Bundle\\FrameworkBundle\\ContainerAwareEventDispatcher',
             'Symfony\\Bundle\\FrameworkBundle\\HttpKernel',
         ));
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="debug.event_dispatcher.class">Symfony\Bundle\FrameworkBundle\Debug\TraceableEventDispatcher</parameter>
+        <parameter key="debug.event_dispatcher.class">Symfony\Component\EventDispatcher\ContainerAwareTraceableEventDispatcher</parameter>
         <parameter key="debug.stopwatch.class">Symfony\Component\HttpKernel\Debug\Stopwatch</parameter>
         <parameter key="debug.container.dump">%kernel.cache_dir%/%kernel.container_class%.xml</parameter>
         <parameter key="debug.controller_resolver.class">Symfony\Bundle\FrameworkBundle\Controller\TraceableControllerResolver</parameter>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="event_dispatcher.class">Symfony\Bundle\FrameworkBundle\ContainerAwareEventDispatcher</parameter>
+        <parameter key="event_dispatcher.class">Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher</parameter>
         <parameter key="http_kernel.class">Symfony\Bundle\FrameworkBundle\HttpKernel</parameter>
         <parameter key="filesystem.class">Symfony\Component\Filesystem\Filesystem</parameter>
         <parameter key="cache_warmer.class">Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate</parameter>

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -9,11 +9,9 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle;
+namespace Symfony\Component\EventDispatcher;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcher;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Lazily loads listeners and subscribers from the dependency injection

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareTraceableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareTraceableEventDispatcher.php
@@ -9,22 +9,22 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Debug;
+namespace Symfony\Component\EventDispatcher;
 
-use Symfony\Bundle\FrameworkBundle\ContainerAwareEventDispatcher;
 use Symfony\Component\HttpKernel\Debug\Stopwatch;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcherInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\HttpKernel\Profiler\Profiler;
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 
 /**
  * Extends the ContainerAwareEventDispatcher to add some debugging tools.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class TraceableEventDispatcher extends ContainerAwareEventDispatcher implements TraceableEventDispatcherInterface
+class ContainerAwareTraceableEventDispatcher extends ContainerAwareEventDispatcher implements TraceableEventDispatcherInterface
 {
     private $logger;
     private $called;

--- a/src/Symfony/Component/EventDispatcher/README.md
+++ b/src/Symfony/Component/EventDispatcher/README.md
@@ -21,3 +21,10 @@ Resources
 You can run the unit tests with the following command:
 
     phpunit -c src/Symfony/Component/EventDispatcher/
+
+If you also want to run the unit tests that depend on other Symfony
+Components, declare the following environment variables before running
+PHPUnit:
+
+    export SYMFONY_DEPENDENCY_INJECTION=../path/to/DependencyInjection
+    export SYMFONY_HTTP_KERNEL=../path/to/HttpKernel

--- a/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareEventDispatcherTest.php
@@ -9,21 +9,28 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests;
+namespace Symfony\Component\EventDispatcher\Tests;
 
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Bundle\FrameworkBundle\ContainerAwareEventDispatcher;
+use Symfony\Component\DependencyInjection\Scope;
+use Symfony\Component\EventDispatcher\ContainerAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\DependencyInjection\Scope;
 
 class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
+            $this->markTestSkipped('The "DependencyInjection" component is not available');
+        }
+    }
+
     public function testAddAListenerService()
     {
         $event = new Event();
 
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $service
             ->expects($this->once())
@@ -44,7 +51,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\SubscriberService');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\SubscriberService');
 
         $service
             ->expects($this->once())
@@ -56,7 +63,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $container->set('service.subscriber', $service);
 
         $dispatcher = new ContainerAwareEventDispatcher($container);
-        $dispatcher->addSubscriberService('service.subscriber', 'Symfony\Bundle\FrameworkBundle\Tests\SubscriberService');
+        $dispatcher->addSubscriberService('service.subscriber', 'Symfony\Component\EventDispatcher\Tests\SubscriberService');
 
         $dispatcher->dispatch('onEvent', $event);
     }
@@ -65,7 +72,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $service
             ->expects($this->once())
@@ -88,7 +95,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
      */
     public function testTriggerAListenerServiceOutOfScope()
     {
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $scope = new Scope('scope');
         $container = new Container();
@@ -108,7 +115,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $service1 = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service1 = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $service1
             ->expects($this->exactly(2))
@@ -127,7 +134,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher->addListenerService('onEvent', array('service.listener', 'onEvent'));
         $dispatcher->dispatch('onEvent', $event);
 
-        $service2 = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service2 = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $service2
             ->expects($this->once())
@@ -149,7 +156,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $container = new Container();
         $container->set('service.listener', $service);
@@ -177,7 +184,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $container = new Container();
         $container->set('service.listener', $service);
@@ -196,7 +203,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $container = new Container();
         $container->set('service.listener', $service);
@@ -213,7 +220,7 @@ class ContainerAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
     {
         $event = new Event();
 
-        $service = $this->getMock('Symfony\Bundle\FrameworkBundle\Tests\Service');
+        $service = $this->getMock('Symfony\Component\EventDispatcher\Tests\Service');
 
         $container = new Container();
         $container->set('service.listener', $service);

--- a/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareTraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ContainerAwareTraceableEventDispatcherTest.php
@@ -9,14 +9,23 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bundle\FrameworkBundle\Tests\Debug;
+namespace Symfony\Component\EventDispatcher\Tests;
 
-use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
-use Symfony\Bundle\FrameworkBundle\Debug\TraceableEventDispatcher;
+use Symfony\Component\EventDispatcher\ContainerAwareTraceableEventDispatcher;
 use Symfony\Component\HttpKernel\Debug\Stopwatch;
 
-class TraceableEventDispatcherTest extends TestCase
+class ContainerAwareTraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 {
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\DependencyInjection\Container')) {
+            $this->markTestSkipped('The "DependencyInjection" component is not available');
+        }
+
+        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
+            $this->markTestSkipped('The "HttpKernel" component is not available');
+        }
+    }
 
     /**
      * @expectedException \RuntimeException
@@ -24,14 +33,14 @@ class TraceableEventDispatcherTest extends TestCase
     public function testThrowsAnExceptionWhenAListenerMethodIsNotCallable()
     {
         $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $dispatcher = new TraceableEventDispatcher($container, new Stopwatch());
+        $dispatcher = new ContainerAwareTraceableEventDispatcher($container, new Stopwatch());
         $dispatcher->addListener('onFooEvent', new \stdClass());
     }
 
     public function testClosureDoesNotTriggerErrorNotice()
     {
         $container  = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $dispatcher = new TraceableEventDispatcher($container, new StopWatch());
+        $dispatcher = new ContainerAwareTraceableEventDispatcher($container, new StopWatch());
         $triggered  = false;
 
         $dispatcher->addListener('onFooEvent', function() use (&$triggered) {
@@ -46,5 +55,4 @@ class TraceableEventDispatcherTest extends TestCase
 
         $this->assertTrue($triggered, 'Closure should have been executed upon dispatch');
     }
-
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/bootstrap.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/bootstrap.php
@@ -10,6 +10,17 @@
  */
 
 spl_autoload_register(function ($class) {
+    foreach (array(
+        'SYMFONY_DEPENDENCY_INJECTION' => 'DependencyInjection',
+        'SYMFONY_HTTP_KERNEL'          => 'HttpKernel',
+    ) as $env => $name) {
+        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
+            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
+                require_once $file;
+            }
+        }
+    }
+
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\EventDispatcher')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\EventDispatcher')).'.php')) {
             require_once $file;

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -18,6 +18,10 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "suggest": {
+        "symfony/dependency-injection": "self.version",
+        "symfony/http-kernel": "self.version"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\EventDispatcher": "" }
     },


### PR DESCRIPTION
I have moved the two specialized event dispatcher classes from the FrameworkBundle bundle to the EventDispatcher component.

It makes them reusable outside the Symfony full-stack framework as they can be quite useful (people like @drak has a use for them for instance).

It makes the event dispatcher component _optionally_ rely on DependencyInjection and HttpKernel for these classes, like what we have in other components.

What do you think?
