### PR TITLE
[TwigBridge] Added a TwigEngine in the bridge

### DIFF
--- a/src/Symfony/Bridge/Twig/TwigEngine.php
+++ b/src/Symfony/Bridge/Twig/TwigEngine.php
@@ -1,0 +1,127 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\Templating\StreamingEngineInterface;
+use Symfony\Component\Templating\TemplateNameParserInterface;
+
+/**
+ * This engine knows how to render Twig templates.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TwigEngine implements EngineInterface, StreamingEngineInterface
+{
+    protected $environment;
+    protected $parser;
+
+    /**
+     * Constructor.
+     *
+     * @param \Twig_Environment           $environment A \Twig_Environment instance
+     * @param TemplateNameParserInterface $parser      A TemplateNameParserInterface instance
+     */
+    public function __construct(\Twig_Environment $environment, TemplateNameParserInterface $parser)
+    {
+        $this->environment = $environment;
+        $this->parser = $parser;
+    }
+
+    /**
+     * Renders a template.
+     *
+     * @param mixed $name       A template name
+     * @param array $parameters An array of parameters to pass to the template
+     *
+     * @return string The evaluated template as a string
+     *
+     * @throws \InvalidArgumentException if the template does not exist
+     * @throws \RuntimeException         if the template cannot be rendered
+     */
+    public function render($name, array $parameters = array())
+    {
+        return $this->load($name)->render($parameters);
+    }
+
+    /**
+     * Streams a template.
+     *
+     * @param mixed $name       A template name or a TemplateReferenceInterface instance
+     * @param array $parameters An array of parameters to pass to the template
+     *
+     * @throws \RuntimeException if the template cannot be rendered
+     */
+    public function stream($name, array $parameters = array())
+    {
+        $this->load($name)->display($parameters);
+    }
+
+    /**
+     * Returns true if the template exists.
+     *
+     * @param mixed $name A template name
+     *
+     * @return Boolean true if the template exists, false otherwise
+     */
+    public function exists($name)
+    {
+        try {
+            $this->load($name);
+        } catch (\InvalidArgumentException $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if this class is able to render the given template.
+     *
+     * @param string $name A template name
+     *
+     * @return Boolean True if this class supports the given resource, false otherwise
+     */
+    public function supports($name)
+    {
+        if ($name instanceof \Twig_Template) {
+            return true;
+        }
+
+        $template = $this->parser->parse($name);
+
+        return 'twig' === $template->get('engine');
+    }
+
+    /**
+     * Loads the given template.
+     *
+     * @param mixed $name A template name or an instance of Twig_Template
+     *
+     * @return \Twig_TemplateInterface A \Twig_TemplateInterface instance
+     *
+     * @throws \InvalidArgumentException if the template does not exist
+     */
+    protected function load($name)
+    {
+        if ($name instanceof \Twig_Template) {
+            return $name;
+        }
+
+        try {
+            return $this->environment->loadTemplate($name);
+        } catch (\Twig_Error_Loader $e) {
+            throw new \InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+}


### PR DESCRIPTION
This TwigEngine implements the interface available in the component.
the TwigBridge in TwigBundle now extends this class and provides only
the additional methods for the FrameworkBundle interface.

This will allow people to support the PhpEngine and Twig in their code more easily when using the component as they don't need to reimplement the class.
I originally thought about when I helped @dragoonis to integrate the Templating component in the PPI framework 2.0 as he talked about adding the support for Twig later too.
