### PR TITLE
performance improvement in PhpMatcherDumper

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -73,7 +73,7 @@ class RouteCollection implements \IteratorAggregate
     }
 
     /**
-     * Gets the current RouteCollection as an Iterator.
+     * Gets the current RouteCollection as an Iterator that includes all routes and child route collections.
      *
      * @return \ArrayIterator An \ArrayIterator interface
      */

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -131,7 +131,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                     $matches['_route'] = 'bar2';
                     return $matches;
                 }
-
             }
 
             // overriden
@@ -149,7 +148,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
                 $matches['_route'] = 'foo4';
                 return $matches;
             }
-
         }
 
         // foo3

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -137,7 +137,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                     $matches['_route'] = 'bar2';
                     return $matches;
                 }
-
             }
 
             // overriden
@@ -155,7 +154,6 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
                 $matches['_route'] = 'foo4';
                 return $matches;
             }
-
         }
 
         // foo3

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -20,11 +20,11 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
 {
     public function testDump()
     {
-        $dumper = new PhpMatcherDumper($this->getRouteCollection(), new RequestContext());
+        $collection = $this->getRouteCollection();
+
+        $dumper = new PhpMatcherDumper($collection, new RequestContext());
 
         $this->assertStringEqualsFile(__DIR__.'/../../Fixtures/dumper/url_matcher1.php', $dumper->dump(), '->dump() dumps basic routes to the correct PHP file.');
-
-        $collection = $this->getRouteCollection();
 
         // force HTTPS redirection
         $collection->add('secure', new Route(


### PR DESCRIPTION
Tests pass: yes

The code generation uses a string internally instead of an array. The array wasn't used for random access anyway. 
I also removed 4 unneeded iterations this way (when imploding, when merging and twice when applying the extra indention). A `preg_replace` could also be saved under certain circumstances by moving it.
And there was a small code errror in line 139.
