### PR TITLE
Added a clientToApp method for use in the BindClientData event

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1090,6 +1090,22 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * Helper function for use in BIND_CLIENT_DATA event. Only allowed for child
+     * forms
+     * 
+     * @params string $value The value to reverse transform
+     * 
+     * @return mixed
+     */
+    public function clientToApp($value)
+    {
+        if ($this->isRoot()) {
+            throw new \InvalidArgumentException('Cannot use clientToApp on a root form');
+        }
+        return $this->normToApp($this->clientToNorm($value));
+    }
+
+    /**
      * Validates whether the given variable is a valid form name.
      *
      * @param string $name The tested form name.

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1090,26 +1090,28 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
-     * Helper function for use in BIND_CLIENT_DATA event. Only allowed for child
-     * forms
+     * Helper function for use in BIND_CLIENT_DATA event.
      * 
-     * @params string $value The value to reverse transform
+     * @params string $name The name of the child field
+     * @params array $clientData the client data from the event
      * 
      * @return mixed
      */
-    public function clientToApp($value)
+    public function getChildNormData($name, $clientData)
     {
-        if ($this->isRoot()) {
-            throw new \InvalidArgumentException('Cannot use clientToApp on a root form');
+        if (!$this->hasChildren()) {
+            throw new \InvalidArgumentException('This form has no children');
         }
         
-        $event = new DataEvent($this, $value);
+        $form = $this->get($name);
+
+        $event = new DataEvent($form, $clientData[$name]);
         $this->dispatcher->dispatch(FormEvents::PRE_BIND, $event);
         
-        $event = new FilterDataEvent($this, $value);
+        $event = new FilterDataEvent($form, $clientData[$name]);
         $this->dispatcher->dispatch(FormEvents::BIND_CLIENT_DATA, $event);
-        
-        return $this->normToApp($this->clientToNorm($event->getData()));
+
+        return $form->clientToNorm($event->getData());
     }
 
     /**

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -1102,7 +1102,14 @@ class Form implements \IteratorAggregate, FormInterface
         if ($this->isRoot()) {
             throw new \InvalidArgumentException('Cannot use clientToApp on a root form');
         }
-        return $this->normToApp($this->clientToNorm($value));
+        
+        $event = new DataEvent($this, $value);
+        $this->dispatcher->dispatch(FormEvents::PRE_BIND, $event);
+        
+        $event = new FilterDataEvent($this, $value);
+        $this->dispatcher->dispatch(FormEvents::BIND_CLIENT_DATA, $event);
+        
+        return $this->normToApp($this->clientToNorm($event->getData()));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/FormTest.php
+++ b/src/Symfony/Component/Form/Tests/FormTest.php
@@ -889,14 +889,10 @@ class FormTest extends \PHPUnit_Framework_TestCase
                 '' => '',
                 'b' => 'a'
             )))
-            ->appendNormTransformer(new FixedDataTransformer(array(
-                '' => '',
-                'c' => 'b'
-            )))
             ->getForm()
         );
-        
-        $this->assertEquals('c', $form->get('test')->clientToApp('a'));
+
+        $this->assertEquals('b', $form->getChildNormData('test', array('test' => 'a')));
     }
 
     public function testBindMapsBoundChildrenOntoEmptyData()

--- a/src/Symfony/Component/Form/Tests/FormTest.php
+++ b/src/Symfony/Component/Form/Tests/FormTest.php
@@ -880,6 +880,25 @@ class FormTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
+    public function testClientToApp()
+    {
+        $form = $this->getBuilder()->getForm();
+        
+        $form->add($this->getBuilder('test')
+            ->appendClientTransformer(new FixedDataTransformer(array(
+                '' => '',
+                'b' => 'a'
+            )))
+            ->appendNormTransformer(new FixedDataTransformer(array(
+                '' => '',
+                'c' => 'b'
+            )))
+            ->getForm()
+        );
+        
+        $this->assertEquals('c', $form->get('test')->clientToApp('a'));
+    }
+
     public function testBindMapsBoundChildrenOntoEmptyData()
     {
         $test = $this;


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

This is an alternative to PR #3514. For an explanation as of why this method can be useful, please refer to the discussion there. In my opinion, this would be a very useful addition, but perhaps methods should be found to restrict it more, to prevent people from using it to get app data without actually binding the form.
