### PR TITLE
[Locale] use the correct way for Intl error

### DIFF
--- a/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
@@ -155,7 +155,7 @@ class FullTransformer
         }
 
         // behave like the intl extension
-        StubIntl::setErrorCode(StubIntl::U_PARSE_ERROR);
+        StubIntl::setErrorCode(StubIntl::U_PARSE_ERROR, 'Date parsing failed');
 
         return false;
     }
@@ -292,7 +292,7 @@ class FullTransformer
 
         // If month is false, return immediately (intl behavior)
         if (false === $month) {
-            StubIntl::setErrorCode(StubIntl::U_PARSE_ERROR);
+            StubIntl::setErrorCode(StubIntl::U_PARSE_ERROR, 'Date parsing failed');
 
             return false;
         }

--- a/src/Symfony/Component/Locale/Stub/StubIntl.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntl.php
@@ -45,20 +45,9 @@ abstract class StubIntl
      * @var array
      */
     private static $errorCodes = array(
-        self::U_ZERO_ERROR,
-        self::U_ILLEGAL_ARGUMENT_ERROR,
-        self::U_PARSE_ERROR,
-    );
-
-    /**
-     * The error messages of all known error codes
-     *
-     * @var array
-     */
-    private static $errorMessages = array(
         self::U_ZERO_ERROR => 'U_ZERO_ERROR',
-        self::U_ILLEGAL_ARGUMENT_ERROR => 'datefmt_format: takes either an array  or an integer timestamp value : U_ILLEGAL_ARGUMENT_ERROR',
-        self::U_PARSE_ERROR => 'Date parsing failed: U_PARSE_ERROR',
+        self::U_ILLEGAL_ARGUMENT_ERROR => 'U_ILLEGAL_ARGUMENT_ERROR',
+        self::U_PARSE_ERROR => 'U_PARSE_ERROR',
     );
 
     /**
@@ -69,6 +58,13 @@ abstract class StubIntl
     private static $errorCode = self::U_ZERO_ERROR;
 
     /**
+     * The error code of the last operation
+     *
+     * @var integer
+     */
+    private static $errorMessage = 'U_ZERO_ERROR';
+
+    /**
      * Returns whether the error code indicates a failure
      *
      * @param  integer $errorCode The error code returned by StubIntl::getErrorCode()
@@ -77,8 +73,8 @@ abstract class StubIntl
      */
     static public function isFailure($errorCode)
     {
-        return in_array($errorCode, self::$errorCodes, true)
-            && $errorCode !== self::U_ZERO_ERROR;
+        return array_key_exists($errorCode, self::$errorCodes)
+            && $errorCode > self::U_ZERO_ERROR;
     }
 
     /**
@@ -102,22 +98,24 @@ abstract class StubIntl
      */
     static public function getErrorMessage()
     {
-        return self::$errorMessages[self::$errorCode];
+        return self::$errorMessage;
     }
 
     /**
      * Sets the current error code
      *
-     * @param  integer $code  One of the error constants in this class
+     * @param  integer $code     One of the error constants in this class
+     * @param  string  $message  The ICU class error message
      *
      * @throws \InvalidArgumentException If the code is not one of the error constants in this class
      */
-    static public function setErrorCode($code)
+    static public function setErrorCode($code, $message = '')
     {
-        if (!isset(self::$errorMessages[$code])) {
+        if (!isset(self::$errorCodes[$code])) {
             throw new \InvalidArgumentException(sprintf('No such error code: "%s"', $code));
         }
 
+        self::$errorMessage = $message ? sprintf('%s: %s', $message, self::$errorCodes[$code]) : self::$errorCodes[$code];
         self::$errorCode = $code;
     }
 }

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -26,14 +26,18 @@ use Symfony\Component\Locale\Exception\MethodArgumentValueNotImplementedExceptio
 class StubIntlDateFormatter
 {
     /**
-     * Constants defined by the intl extension, not class constants in IntlDateFormatter
-     * TODO: remove if the Form component drop the call to the intl_is_failure() function
+     * The error code from the last operation
      *
-     * @see StubIntlDateFormatter::getErrorCode()
-     * @see StubIntlDateFormatter::getErrorMessage()
+     * @var integer
      */
-    const U_ZERO_ERROR = 0;
-    const U_ZERO_ERROR_MESSAGE = 'U_ZERO_ERROR';
+    protected $errorCode;
+
+    /**
+     * The error message from the last operation
+     *
+     * @var string
+     */
+    protected $errorMessage;
 
     /* date/time format types */
     const NONE = -1;
@@ -133,6 +137,10 @@ class StubIntlDateFormatter
 
         $this->setPattern($pattern);
         $this->setTimeZoneId($timezone);
+
+        StubIntl::setErrorCode(StubIntl::U_ZERO_ERROR);
+        $this->errorCode = StubIntl::getErrorCode();
+        $this->errorMessage = StubIntl::getErrorMessage();
     }
 
     /**
@@ -176,7 +184,7 @@ class StubIntlDateFormatter
 
         if (!is_int($timestamp)) {
             // behave like the intl extension
-            StubIntl::setErrorCode(StubIntl::U_ILLEGAL_ARGUMENT_ERROR);
+            StubIntl::setErrorCode(StubIntl::U_ILLEGAL_ARGUMENT_ERROR, 'datefmt_format: takes either an array  or an integer timestamp value ');
 
             return false;
         }
@@ -220,7 +228,7 @@ class StubIntlDateFormatter
      */
     public function getErrorCode()
     {
-        return self::U_ZERO_ERROR;
+        return $this->errorCode;
     }
 
     /**
@@ -232,7 +240,7 @@ class StubIntlDateFormatter
      */
     public function getErrorMessage()
     {
-        return self::U_ZERO_ERROR_MESSAGE;
+        return $this->errorMessage;
     }
 
     /**

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -30,14 +30,14 @@ class StubIntlDateFormatter
      *
      * @var integer
      */
-    protected $errorCode;
+    protected $errorCode = StubIntl::U_ZERO_ERROR;
 
     /**
      * The error message from the last operation
      *
      * @var string
      */
-    protected $errorMessage;
+    protected $errorMessage = 'U_ZERO_ERROR';
 
     /* date/time format types */
     const NONE = -1;
@@ -137,10 +137,6 @@ class StubIntlDateFormatter
 
         $this->setPattern($pattern);
         $this->setTimeZoneId($timezone);
-
-        StubIntl::setErrorCode(StubIntl::U_ZERO_ERROR);
-        $this->errorCode = StubIntl::getErrorCode();
-        $this->errorMessage = StubIntl::getErrorMessage();
     }
 
     /**
@@ -185,6 +181,8 @@ class StubIntlDateFormatter
         if (!is_int($timestamp)) {
             // behave like the intl extension
             StubIntl::setErrorCode(StubIntl::U_ILLEGAL_ARGUMENT_ERROR, 'datefmt_format: takes either an array  or an integer timestamp value ');
+            $this->errorCode = StubIntl::getErrorCode();
+            $this->errorMessage = StubIntl::getErrorMessage();
 
             return false;
         }
@@ -353,12 +351,17 @@ class StubIntlDateFormatter
             throw new MethodArgumentNotImplementedException(__METHOD__, 'position');
         }
 
-        StubIntl::setErrorCode(StubIntl::U_ZERO_ERROR);
-
         $dateTime = $this->createDateTime(0);
         $transformer = new FullTransformer($this->getPattern(), $this->getTimeZoneId());
 
-        return $transformer->parse($dateTime, $value);
+        $timestamp = $transformer->parse($dateTime, $value);
+
+        if (false === $timestamp) {
+            $this->errorCode = StubIntl::getErrorCode();
+            $this->errorMessage = StubIntl::getErrorMessage();
+        }
+
+        return $timestamp;
     }
 
     /**

--- a/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
@@ -25,31 +25,18 @@ use Symfony\Component\Locale\Exception\MethodArgumentValueNotImplementedExceptio
 class StubNumberFormatter
 {
     /**
-     * Constants defined by the intl extension, not class constants in NumberFormatter
-     * TODO: remove if the Form component drop the call to the intl_is_failure() function
-     *
-     * @see StubNumberFormatter::getErrorCode()
-     * @see StubNumberFormatter::getErrorMessage()
-     */
-    const U_ZERO_ERROR = 0;
-    const U_PARSE_ERROR = 9;
-
-    /**
-     * The error messages for each error code
-     *
-     * @var array
-     */
-    protected $errorMessages = array(
-        self::U_ZERO_ERROR => 'U_ZERO_ERROR',
-        self::U_PARSE_ERROR => 'Number parsing failed: U_PARSE_ERROR',
-    );
-
-    /**
      * The error code from the last operation
      *
      * @var integer
      */
-    protected $errorCode = self::U_ZERO_ERROR;
+    protected $errorCode;
+
+    /**
+     * The error message from the last operation
+     *
+     * @var string
+     */
+    protected $errorMessage;
 
     /** Format style constants */
     const PATTERN_DECIMAL   = 0;
@@ -268,6 +255,10 @@ class StubNumberFormatter
 
         $this->locale = $locale;
         $this->style  = $style;
+
+        StubIntl::setErrorCode(StubIntl::U_ZERO_ERROR);
+        $this->errorCode = StubIntl::getErrorCode();
+        $this->errorMessage = StubIntl::getErrorMessage();
     }
 
     /**
@@ -403,7 +394,7 @@ class StubNumberFormatter
      */
     public function getErrorMessage()
     {
-        return $this->errorMessages[$this->errorCode];
+        return $this->errorMessage;
     }
 
     /**
@@ -514,7 +505,9 @@ class StubNumberFormatter
 
         // Any string before the numeric value causes error in the parsing
         if (isset($matches[1]) && !empty($matches[1])) {
-            $this->errorCode = self::U_PARSE_ERROR;
+            StubIntl::setErrorCode(StubIntl::U_PARSE_ERROR);
+            $this->errorCode = StubIntl::getErrorCode();
+            $this->errorMessage = StubIntl::getErrorMessage();
 
             return false;
         }

--- a/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
@@ -29,14 +29,14 @@ class StubNumberFormatter
      *
      * @var integer
      */
-    protected $errorCode;
+    protected $errorCode = StubIntl::U_ZERO_ERROR;
 
     /**
      * The error message from the last operation
      *
      * @var string
      */
-    protected $errorMessage;
+    protected $errorMessage = 'U_ZERO_ERROR';
 
     /** Format style constants */
     const PATTERN_DECIMAL   = 0;
@@ -255,10 +255,6 @@ class StubNumberFormatter
 
         $this->locale = $locale;
         $this->style  = $style;
-
-        StubIntl::setErrorCode(StubIntl::U_ZERO_ERROR);
-        $this->errorCode = StubIntl::getErrorCode();
-        $this->errorMessage = StubIntl::getErrorMessage();
     }
 
     /**

--- a/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
@@ -61,6 +61,9 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->assertSame($errorMessage, StubIntl::getErrorMessage());
         $this->assertSame($errorCode, StubIntl::getErrorCode());
         $this->assertSame($errorCode != 0, StubIntl::isFailure(StubIntl::getErrorCode()));
+        $this->assertSame($errorMessage, $formatter->getErrorMessage());
+        $this->assertSame($errorCode, $formatter->getErrorCode());
+        $this->assertSame($errorCode != 0, StubIntl::isFailure($formatter->getErrorCode()));
     }
 
     /**
@@ -541,6 +544,9 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->assertSame($errorMessage, StubIntl::getErrorMessage());
         $this->assertSame($errorCode, StubIntl::getErrorCode());
         $this->assertSame($errorCode != 0, StubIntl::isFailure(StubIntl::getErrorCode()));
+        $this->assertSame($errorMessage, $formatter->getErrorMessage());
+        $this->assertSame($errorCode, $formatter->getErrorCode());
+        $this->assertSame($errorCode != 0, StubIntl::isFailure($formatter->getErrorCode()));
     }
 
     public function parseProvider()
@@ -715,6 +721,9 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->assertSame($errorMessage, StubIntl::getErrorMessage());
         $this->assertSame($errorCode, StubIntl::getErrorCode());
         $this->assertSame($errorCode != 0, StubIntl::isFailure(StubIntl::getErrorCode()));
+        $this->assertSame($errorMessage, $formatter->getErrorMessage());
+        $this->assertSame($errorCode, $formatter->getErrorCode());
+        $this->assertSame($errorCode != 0, StubIntl::isFailure($formatter->getErrorCode()));
     }
 
     public function parseErrorProvider()

--- a/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
@@ -467,13 +467,13 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     public function testGetErrorCode()
     {
         $formatter = $this->createStubFormatter();
-        $this->assertEquals(StubIntlDateFormatter::U_ZERO_ERROR, $formatter->getErrorCode());
+        $this->assertEquals(StubIntl::getErrorCode(), $formatter->getErrorCode());
     }
 
     public function testGetErrorMessage()
     {
         $formatter = $this->createStubFormatter();
-        $this->assertEquals(StubIntlDateFormatter::U_ZERO_ERROR_MESSAGE, $formatter->getErrorMessage());
+        $this->assertEquals(StubIntl::getErrorMessage(), $formatter->getErrorMessage());
     }
 
     public function testGetLocale()

--- a/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Locale\Tests\Stub;
 
 use Symfony\Component\Locale\Locale;
+use Symfony\Component\Locale\Stub\StubIntl;
 use Symfony\Component\Locale\Stub\StubNumberFormatter;
 use Symfony\Component\Locale\Tests\TestCase as LocaleTestCase;
 
@@ -611,7 +612,7 @@ class StubNumberFormatterTest extends LocaleTestCase
     public function testGetErrorCode()
     {
         $formatter = $this->getStubFormatterWithDecimalStyle();
-        $this->assertEquals(StubNumberFormatter::U_ZERO_ERROR, $formatter->getErrorCode());
+        $this->assertEquals(StubIntl::U_ZERO_ERROR, $formatter->getErrorCode());
     }
 
     public function testGetLocale()
@@ -666,9 +667,9 @@ class StubNumberFormatterTest extends LocaleTestCase
         $this->assertSame($expected, $parsedValue, $message);
 
         if ($expected === false) {
-            $this->assertSame($formatter::U_PARSE_ERROR, $formatter->getErrorCode());
+            $this->assertSame(StubIntl::U_PARSE_ERROR, $formatter->getErrorCode());
         } else {
-            $this->assertEquals($formatter::U_ZERO_ERROR, $formatter->getErrorCode());
+            $this->assertEquals(StubIntl::U_ZERO_ERROR, $formatter->getErrorCode());
         }
     }
 


### PR DESCRIPTION
```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: Needs feedback
```

All Stub\* should filled the intl_get_*

An ICU error code may have differents messages and it's a failure only when it > 0 (a negative code is just a warning)

I think this PR should be more simple, (cause all sucess method should return a `U_ZERO_ERROR`) so I need your feedback
After this I'll make a PR for the `StubResourceBundle` :v:
