### PR TITLE
[Form] added ChildDataEvent

### DIFF
--- a/src/Symfony/Component/Form/Event/ChildDataEvent.php
+++ b/src/Symfony/Component/Form/Event/ChildDataEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Event;
+
+use Symfony\Component\Form\FormInterface;
+
+class ChildDataEvent extends DataEvent
+{
+    private $name;
+
+    /**
+     * Constructs an event.
+     *
+     * @param FormInterface $form The associated form
+     * @param string        $name The name of the field that was just set
+     * @param mixed         $data The data of the field that was just set
+     */
+    public function __construct(FormInterface $form, $name, $data)
+    {
+        $this->name = $name;
+        parent::__construct($form, $data);
+    }
+
+    /**
+     * Gets the data of the field that was just set
+     */
+    public function getData()
+    {
+        return parent::getData();
+    }
+
+    /**
+     * Gets the name of the field that was updated
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -523,8 +523,6 @@ class Form implements \IteratorAggregate, FormInterface
                 }
             } while(count($extraData) && $lastChildren !== $this->children);
 
-            $clientData = array_diff_key($clientData, $extraData);
-
             // If we have a data mapper, use old client data and merge
             // data from the children into it later
             if ($this->dataMapper) {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Event\DataEvent;
 use Symfony\Component\Form\Event\FilterDataEvent;
+use Symfony\Component\Form\Event\ChildDataEvent;
 use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Form\Exception\AlreadyBoundException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
@@ -506,13 +507,23 @@ class Form implements \IteratorAggregate, FormInterface
                 }
             }
 
-            foreach ($clientData as $name => $value) {
-                if ($this->has($name)) {
-                    $this->children[$name]->bind($value);
-                } else {
-                    $extraData[$name] = $value;
+            $extraData = $clientData;
+            $lastCount = count($this);
+            do {
+                foreach ($extraData as $name => $value) {
+                    if ($this->has($name)) {
+                        $this->children[$name]->bind($value);
+                        unset($extraData[$name]);
+
+                        // every time we bind a child, we dispatch an event to allow
+                        // listeners to add or remove field based on the result value
+                        $event = new ChildDataEvent($this, $name, $this->children[$name]->getData());
+                        $this->dispatcher->dispatch(FormEvents::BIND_CHILD, $event);
+                    }
                 }
-            }
+            } while(count($extraData) && $lastCount != ($lastCount = count($this)));
+
+            $clientData = array_diff_key($clientData, $extraData);
 
             // If we have a data mapper, use old client data and merge
             // data from the children into it later

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -508,8 +508,8 @@ class Form implements \IteratorAggregate, FormInterface
             }
 
             $extraData = $clientData;
-            $lastCount = count($this);
             do {
+                $lastChildren = $this->children;
                 foreach ($extraData as $name => $value) {
                     if ($this->has($name)) {
                         $this->children[$name]->bind($value);
@@ -521,7 +521,7 @@ class Form implements \IteratorAggregate, FormInterface
                         $this->dispatcher->dispatch(FormEvents::BIND_CHILD, $event);
                     }
                 }
-            } while(count($extraData) && $lastCount != ($lastCount = count($this)));
+            } while(count($extraData) && $lastChildren !== $this->children);
 
             $clientData = array_diff_key($clientData, $extraData);
 

--- a/src/Symfony/Component/Form/FormEvents.php
+++ b/src/Symfony/Component/Form/FormEvents.php
@@ -26,6 +26,8 @@ final class FormEvents
 
     const BIND_CLIENT_DATA = 'form.bind_client_data';
 
+    const BIND_CHILD = 'form.bind_child';
+
     const BIND_NORM_DATA = 'form.bind_norm_data';
 
     const SET_DATA = 'form.set_data';


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3767

This new event is fired every time a forms child is bound, allowing listeners to add or remove field accordingly, based on the appData of the child form. See the ticket mentioned above for a use case scenario
