### PR TITLE
[Form] Make sure bind() fills appData with its childrens appData

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -508,7 +508,9 @@ class Form implements \IteratorAggregate, FormInterface
 
             foreach ($clientData as $name => $value) {
                 if ($this->has($name)) {
-                    $this->children[$name]->bind($value);
+                    $child = $this->children[$name];
+                    $child->bind($value);
+                    $clientData[$name] = $child->getData();
                 } else {
                     $extraData[$name] = $value;
                 }

--- a/src/Symfony/Component/Form/Tests/FormTest.php
+++ b/src/Symfony/Component/Form/Tests/FormTest.php
@@ -194,6 +194,9 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $child->expects($this->once())
             ->method('bind')
             ->with($this->equalTo('Bernhard'));
+        $child->expects($this->once())
+            ->method('getData')
+            ->will($this->returnValue('Bernhard'));
 
         $this->form->bind(array('firstName' => 'Bernhard'));
 
@@ -1302,6 +1305,17 @@ class FormTest extends \PHPUnit_Framework_TestCase
             ->getForm();
 
         $this->assertEquals(array($validator), $form->getValidators());
+    }
+
+    public function testDataTransformersOnChildrenDontRequireADataMapper()
+    {
+        $transformer = $this->getDataTransformer();
+        $transformer->expects($this->once())->method('reverseTransform')->will($this->returnValue('11'));
+        $form = $this->getBuilder()->getForm();
+        $form->add( $this->getBuilder('a')->appendClientTransformer($transformer)->getForm() );
+
+        $form->bind(array('a' => '1'));
+        $this->assertEquals(array('a'=>'11'), $form->getData());
     }
 
     protected function getBuilder($name = 'name', EventDispatcherInterface $dispatcher = null)


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Not sure if this was intentional, but I don't think it was:

when the data of a form is an array, then after binding the form, the forms getData method returns an array containing the client data of each child, rather than the app Data.

The test testDataTransformersOnChildrenDontRequireADataMapper would fail with the message:

1) Symfony\Component\Form\Tests\FormTest::testDataTransformersOnChildrenDontRequireADataMapper
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    'a' => '11'
-    'a' => '1'
  )
