### PR TITLE
[FrameworkBundle] Added the translation file for the en locale

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.en.xlf
@@ -1,0 +1,219 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>This value should be false</source>
+                <target>This value should be false</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>This value should be true</source>
+                <target>This value should be true</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>This value should be of type {{ type }}</source>
+                <target>This value should be of type {{ type }}</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>This value should be blank</source>
+                <target>This value should be blank</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>The value you selected is not a valid choice</source>
+                <target>The value you selected is not a valid choice</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>You must select at least {{ limit }} choices</source>
+                <target>You must select at least {{ limit }} choices</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>You must select at most {{ limit }} choices</source>
+                <target>You must select at most {{ limit }} choices</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>One or more of the given values is invalid</source>
+                <target>One or more of the given values is invalid</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>The fields {{ fields }} were not expected</source>
+                <target>The fields {{ fields }} were not expected</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>The fields {{ fields }} are missing</source>
+                <target>The fields {{ fields }} are missing</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>This value is not a valid date</source>
+                <target>This value is not a valid date</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>This value is not a valid datetime</source>
+                <target>This value is not a valid datetime</target>
+            </trans-unit>
+            <trans-unit id="13">
+                <source>This value is not a valid email address</source>
+                <target>This value is not a valid email address</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>The file could not be found</source>
+                <target>The file could not be found</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>The file is not readable</source>
+                <target>The file is not readable</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}</source>
+                <target>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}</target>
+            </trans-unit>
+            <trans-unit id="17">
+                <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}</source>
+                <target>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}</target>
+            </trans-unit>
+            <trans-unit id="18">
+                <source>This value should be {{ limit }} or less</source>
+                <target>This value should be {{ limit }} or less</target>
+            </trans-unit>
+            <trans-unit id="19">
+                <source>This value is too long. It should have {{ limit }} characters or less</source>
+                <target>This value is too long. It should have {{ limit }} characters or less</target>
+            </trans-unit>
+            <trans-unit id="20">
+                <source>This value should be {{ limit }} or more</source>
+                <target>This value should be {{ limit }} or more</target>
+            </trans-unit>
+            <trans-unit id="21">
+                <source>This value is too short. It should have {{ limit }} characters or more</source>
+                <target>This value is too short. It should have {{ limit }} characters or more</target>
+            </trans-unit>
+            <trans-unit id="22">
+                <source>This value should not be blank</source>
+                <target>This value should not be blank</target>
+            </trans-unit>
+            <trans-unit id="23">
+                <source>This value should not be null</source>
+                <target>This value should not be null</target>
+            </trans-unit>
+            <trans-unit id="24">
+                <source>This value should be null</source>
+                <target>This value should be null</target>
+            </trans-unit>
+            <trans-unit id="25">
+                <source>This value is not valid</source>
+                <target>This value is not valid</target>
+            </trans-unit>
+            <trans-unit id="26">
+                <source>This value is not a valid time</source>
+                <target>This value is not a valid time</target>
+            </trans-unit>
+            <trans-unit id="27">
+                <source>This value is not a valid URL</source>
+                <target>This value is not a valid URL</target>
+            </trans-unit>
+            <trans-unit id="28">
+                <source>This form should not contain extra fields</source>
+                <target>This form should not contain extra fields</target>
+            </trans-unit>
+            <trans-unit id="29">
+                <source>The uploaded file was too large. Please try to upload a smaller file</source>
+                <target>The uploaded file was too large. Please try to upload a smaller file</target>
+            </trans-unit>
+            <trans-unit id="30">
+                <source>The CSRF token is invalid. Please try to resubmit the form</source>
+                <target>The CSRF token is invalid. Please try to resubmit the form</target>
+            </trans-unit>
+            <trans-unit id="31">
+                <source>The two values should be equal</source>
+                <target>The two values should be equal</target>
+            </trans-unit>
+            <trans-unit id="32">
+                <source>The file is too large. Allowed maximum size is {{ limit }}</source>
+                <target>The file is too large. Allowed maximum size is {{ limit }}</target>
+            </trans-unit>
+            <trans-unit id="33">
+                <source>The file is too large</source>
+                <target>The file is too large</target>
+            </trans-unit>
+            <trans-unit id="34">
+                <source>The file could not be uploaded</source>
+                <target>The file could not be uploaded</target>
+            </trans-unit>
+            <trans-unit id="35">
+                <source>This value should be a valid number</source>
+                <target>This value should be a valid number</target>
+            </trans-unit>
+            <trans-unit id="36">
+                <source>This file is not a valid image</source>
+                <target>This file is not a valid image</target>
+            </trans-unit>
+            <trans-unit id="37">
+                <source>This is not a valid IP address</source>
+                <target>This is not a valid IP address</target>
+            </trans-unit>
+            <trans-unit id="38">
+                <source>This value is not a valid language</source>
+                <target>This value is not a valid language</target>
+            </trans-unit>
+            <trans-unit id="39">
+                <source>This value is not a valid locale</source>
+                <target>This value is not a valid locale</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>This value is not a valid country</source>
+                <target>This value is not a valid country</target>
+            </trans-unit>
+            <trans-unit id="41">
+                <source>This value is already used</source>
+                <target>This value is already used</target>
+            </trans-unit>
+            <trans-unit id="42">
+                <source>The size of the image could not be detected</source>
+                <target>The size of the image could not be detected</target>
+            </trans-unit>
+            <trans-unit id="43">
+                <source>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px</source>
+                <target>The image width is too big ({{ width }}px). Allowed maximum width is {{ max_width }}px</target>
+            </trans-unit>
+            <trans-unit id="44">
+                <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px</source>
+                <target>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px</target>
+            </trans-unit>
+            <trans-unit id="45">
+                <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px</source>
+                <target>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px</target>
+            </trans-unit>
+            <trans-unit id="46">
+                <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px</source>
+                <target>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px</target>
+            </trans-unit>
+            <trans-unit id="47">
+                <source>This value should be the user current password</source>
+                <target>This value should be the user current password</target>
+            </trans-unit>
+            <trans-unit id="48">
+                <source>This value should have exactly {{ limit }} characters</source>
+                <target>This value should have exactly {{ limit }} characters</target>
+            </trans-unit>
+            <trans-unit id="49">
+                <source>The file was only partially uploaded</source>
+                <target>The file was only partially uploaded</target>
+            </trans-unit>
+            <trans-unit id="50">
+                <source>No file was uploaded</source>
+                <target>No file was uploaded</target>
+            </trans-unit>
+            <trans-unit id="51">
+                <source>No temporary folder was configured in php.ini</source>
+                <target>No temporary folder was configured in php.ini</target>
+            </trans-unit>
+            <trans-unit id="52">
+                <source>Cannot write temporary file to disk</source>
+                <target>Cannot write temporary file to disk</target>
+            </trans-unit>
+            <trans-unit id="53">
+                <source>A PHP extension caused the upload to fail</source>
+                <target>A PHP extension caused the upload to fail</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
This fixes the translation when the fallback is set to another language.
This new file can be used as reference by translators to find missing keys
in their translations as every contributor will be able to update it when
adding new keys.

See the discussion on #3773
