### PR TITLE
[Form] getParent() does not receive correct options array

### DIFF
--- a/src/Symfony/Component/Form/Tests/Fixtures/AuthorType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AuthorType.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilder;
+
+class AuthorType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder->add('firstName', 'text');
+        $builder->add('lastName', 'text');
+    }
+
+    public function getName()
+    {
+        return 'collection_row';
+    }
+
+    public function getDefaultOptions()
+    {
+        return array(
+            'data_class'=>'Symfony\Component\Form\Tests\Fixtures\Author'
+        );
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooChildType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooChildType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FooChildType extends AbstractType
+{
+
+    public function getName()
+    {
+        return 'foo_child';
+    }
+
+    public function getParent(array $options)
+    {
+        return new FooType();
+    }
+
+    public function getDefaultOptions()
+    {
+        return array(
+            'parent' => new FooParentType()
+        );
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooParentType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooParentType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+
+class FooParentType extends AbstractType
+{
+
+    public function getName()
+    {
+        return 'foo_parent';
+    }
+    
+    public function getParent(array $options)
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooType.php
@@ -41,6 +41,7 @@ class FooType extends AbstractType
             'required' => false,
             'max_length' => null,
             'a_or_b' => 'a',
+            'parent' => null,
         );
     }
 
@@ -53,6 +54,6 @@ class FooType extends AbstractType
 
     public function getParent(array $options)
     {
-        return null;
+        return $options['parent'];
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -535,6 +535,36 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $factory->createNamedBuilder($type, "text", "value", array("unknown" => "opt"));
     }
 
+    public function testChildDefaultOptionIsPassedToChildsGetParentMethod()
+    {
+        $type = new Fixtures\FooChildType();
+
+        $builder = $this->factory->createNamedBuilder($type, 'foo_child');
+        $this->assertCount(3, $builder->getTypes());
+
+        $builder = $this->factory->createNamedBuilder($type, 'foo_child', null, array('parent'=>null));
+        $this->assertCount(2, $builder->getTypes());
+    }
+
+    public function testCollectionTypeGetParentAndGetDefaultOptionsReceiveCorrectOptions()
+    {
+        $collectionType = new \Symfony\Component\Form\Extension\Core\Type\CollectionType();
+        $type = new Fixtures\AuthorType();
+        $this->factory->addType(new \Symfony\Component\Form\Extension\Core\Type\FormType());
+        $this->factory->addType(new \Symfony\Component\Form\Extension\Core\Type\FieldType());
+        $this->factory->addType(new \Symfony\Component\Form\Extension\Core\Type\TextType());
+
+        $builder = $this->factory->createNamedBuilder($collectionType, 'collection', null, array('type'=>$type, 'allow_add'=>true));
+
+        $form = $builder->getForm();
+        $form->bind(array(array('firstName'=>'foo', 'lastName'=>'bar')));
+
+        $author = new Fixtures\Author();
+        $author->setLastName('bar');
+        $author->firstName = 'foo';
+        $this->assertEquals($author, current($form->getData()));
+    }
+
     private function createMockFactory(array $methods = array())
     {
         return $this->getMockBuilder('Symfony\Component\Form\FormFactory')


### PR DESCRIPTION
This PR is based on PR #3789. I wrote two tests which show exactly what functionality was broken by PR #3290. Unfortunately one of them (testChildDefaultOptionIsPassedToChildsGetParentMethod) is still broken after PR #3789.

The default options of children or even the type itself are still not passed to the getParent method, forcing users to pass these options to the factory every time they use the type. A more specific use case is when you create a type which has "choice" as it's parent. When in its default options it defines "expanded"=>true and "multiple"=>true, the getParent() of the "choice" type should always return "form", otherwise a dataMapper will never be assigned and the checkbox list shows empty, even if some values are "true".

At this moment the getParent method reads as follows:

``` php
public function getParent(array $options)
{
    return isset($options['expanded']) && $options['expanded'] ? 'form' : 'field';
}
```

If the option was not passed to the factory (e.g. from the controller), it seems to just assume the form is not "expanded", which sounds wrong to me.

Hopefully this test can help fix the problem!
