### PR TITLE
[Validator] Allow empty keys in the validation config

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -64,7 +64,7 @@ class YamlFileLoader extends FileLoader
                 }
             }
 
-            if (isset($yaml['properties']) && is_array($yaml['constraints'])) {
+            if (isset($yaml['properties']) && is_array($yaml['properties'])) {
                 foreach ($yaml['properties'] as $property => $constraints) {
                     if (null !== $constraints) {
                         foreach ($this->parseNodes($constraints) as $constraint) {
@@ -74,7 +74,7 @@ class YamlFileLoader extends FileLoader
                 }
             }
 
-            if (isset($yaml['getters'])) {
+            if (isset($yaml['getters']) && is_array($yaml['getters'])) {
                 foreach ($yaml['getters'] as $getter => $constraints) {
                     if (null !== $constraints) {
                         foreach ($this->parseNodes($constraints) as $constraint) {

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -58,24 +58,28 @@ class YamlFileLoader extends FileLoader
                 $metadata->setGroupSequenceProvider((bool)$yaml['group_sequence_provider']);
             }
 
-            if (isset($yaml['constraints'])) {
+            if (isset($yaml['constraints']) && is_array($yaml['constraints'])) {
                 foreach ($this->parseNodes($yaml['constraints']) as $constraint) {
                     $metadata->addConstraint($constraint);
                 }
             }
 
-            if (isset($yaml['properties'])) {
+            if (isset($yaml['properties']) && is_array($yaml['constraints'])) {
                 foreach ($yaml['properties'] as $property => $constraints) {
-                    foreach ($this->parseNodes($constraints) as $constraint) {
-                        $metadata->addPropertyConstraint($property, $constraint);
+                    if (null !== $constraints) {
+                        foreach ($this->parseNodes($constraints) as $constraint) {
+                            $metadata->addPropertyConstraint($property, $constraint);
+                        }
                     }
                 }
             }
 
             if (isset($yaml['getters'])) {
                 foreach ($yaml['getters'] as $getter => $constraints) {
-                    foreach ($this->parseNodes($constraints) as $constraint) {
-                        $metadata->addGetterConstraint($getter, $constraint);
+                    if (null !== $constraints) {
+                        foreach ($this->parseNodes($constraints) as $constraint) {
+                            $metadata->addGetterConstraint($getter, $constraint);
+                        }
                     }
                 }
             }

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/constraint-mapping.yml
@@ -35,6 +35,7 @@ Symfony\Component\Validator\Tests\Fixtures\Entity:
               - Min: 5
       # Constraint with options
       - Choice: { choices: [A, B], message: Must be one of %choices% }
+    dummy:
 
   getters:
     lastName:


### PR DESCRIPTION
This allows you to just list fields that don't have validation rules (yet), for future reference it's kinda helpful. Right now if they're not commented out a fatal is thrown because null isn't an array.
