### PR TITLE
[Form] Removed FormValidatorInterface and notion of form validators

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -267,6 +267,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
    in their name anymore. Their names terminate with "[]" now.
  * [BC BREAK] FormType::getDefaultOptions() and FormType::getAllowedOptionValues()
    don't receive an options array anymore.
+ * Deprecated FormValidatorInterface and substituted its implementations
+   by event subscribers
 
 ### HttpFoundation
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -417,6 +417,14 @@
     `FormEvents::PRE_BIND`, `FormEvents::BIND_CLIENT_DATA` or
     `FormEvents::BIND_NORM_DATA`.
 
+  * The interface FormValidatorInterface was deprecated and will be removed
+    in Symfony 2.3.
+
+    If you implemented custom validators using this interface, you can
+    substitute them by event listeners listening to the FormEvents::POST_BIND
+    (or any other of the BIND events). In case you used the CallbackValidator
+    class, you should now pass the callback directly to `addEventListener`.
+
 ### Session
 
   * Flash messages now return an array based on their type. The old method is
@@ -543,6 +551,7 @@ To use mock session storage use the following.  `handler_id` is irrelevant in th
          session:
              storage_id: session.storage.mock_file
   ```
+
 ### WebProfilerBundle
 
   * You must clear old profiles after upgrading to 2.1. If you are using a

--- a/src/Symfony/Component/Form/CallbackValidator.php
+++ b/src/Symfony/Component/Form/CallbackValidator.php
@@ -11,17 +11,28 @@
 
 namespace Symfony\Component\Form;
 
+/**
+ * Deprecated. You should use FormEvents::POST_BIND event listeners instead.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated Deprecated since version 2.1, to be removed in 2.3.
+ */
 class CallbackValidator implements FormValidatorInterface
 {
     private $callback;
 
+    /**
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
+     */
     public function __construct($callback)
     {
-        // TODO validate callback
-
         $this->callback = $callback;
     }
 
+    /**
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
+     */
     public function validate(FormInterface $form)
     {
         return call_user_func($this->callback, $form);

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ValidationListener.php
@@ -9,16 +9,30 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Form\Extension\Core\Validator;
+namespace Symfony\Component\Form\Extension\Core\EventListener;
 
-use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\FormValidatorInterface;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class DefaultValidator implements FormValidatorInterface
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class ValidationListener implements EventSubscriberInterface
 {
-    public function validate(FormInterface $form)
+    /**
+     * {@inheritdoc}
+     */
+    static public function getSubscribedEvents()
     {
+        return array(FormEvents::POST_BIND => 'validateForm');
+    }
+
+    public function validateForm(DataEvent $event)
+    {
+        $form = $event->getForm();
+
         if (!$form->isSynchronized()) {
             $form->addError(new FormError(
                 $form->getAttribute('invalid_message'),

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -19,7 +19,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Extension\Core\EventListener\TrimListener;
-use Symfony\Component\Form\Extension\Core\Validator\DefaultValidator;
+use Symfony\Component\Form\Extension\Core\EventListener\ValidationListener;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Exception\FormException;
 
@@ -60,7 +60,7 @@ class FieldType extends AbstractType
             ->setAttribute('invalid_message_parameters', $options['invalid_message_parameters'])
             ->setAttribute('translation_domain', $options['translation_domain'])
             ->setData($options['data'])
-            ->addValidator(new DefaultValidator())
+            ->addEventSubscriber(new ValidationListener())
         ;
 
         if ($options['trim']) {

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FieldTypeValidatorExtension.php
@@ -13,9 +13,12 @@ namespace Symfony\Component\Form\Extension\Validator\Type;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Extension\Validator\Validator\DelegatingValidator;
+use Symfony\Component\Form\Extension\Validator\EventListener\DelegatingValidationListener;
 use Symfony\Component\Validator\ValidatorInterface;
 
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
 class FieldTypeValidatorExtension extends AbstractTypeExtension
 {
     private $validator;
@@ -39,7 +42,8 @@ class FieldTypeValidatorExtension extends AbstractTypeExtension
             ->setAttribute('validation_groups', $options['validation_groups'])
             ->setAttribute('validation_constraint', $options['validation_constraint'])
             ->setAttribute('cascade_validation', $options['cascade_validation'])
-            ->addValidator(new DelegatingValidator($this->validator));
+            ->addEventSubscriber(new DelegatingValidationListener($this->validator))
+        ;
     }
 
     public function getDefaultOptions()

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -573,9 +573,6 @@ class Form implements \IteratorAggregate, FormInterface
             $validator->validate($this);
         }
 
-        $event = new DataEvent($this, $clientData);
-        $this->dispatcher->dispatch(FormEvents::POST_VALIDATE, $event);
-
         return $this;
     }
 
@@ -808,6 +805,8 @@ class Form implements \IteratorAggregate, FormInterface
      * Returns the Validators
      *
      * @return array An array of FormValidatorInterface
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
     public function getValidators()
     {

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -17,6 +17,9 @@ use Symfony\Component\Form\Exception\CircularReferenceException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
 class FormBuilder
 {
     /**
@@ -261,6 +264,8 @@ class FormBuilder
      * @param FormValidatorInterface $validator The validator
      *
      * @return FormBuilder The current builder
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
     public function addValidator(FormValidatorInterface $validator)
     {
@@ -273,6 +278,8 @@ class FormBuilder
      * Returns the validators used by the form.
      *
      * @return array An array of FormValidatorInterface
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
     public function getValidators()
     {

--- a/src/Symfony/Component/Form/FormEvents.php
+++ b/src/Symfony/Component/Form/FormEvents.php
@@ -29,6 +29,4 @@ final class FormEvents
     const BIND_NORM_DATA = 'form.bind_norm_data';
 
     const SET_DATA = 'form.set_data';
-
-    const POST_VALIDATE = 'form.post_validate';
 }

--- a/src/Symfony/Component/Form/FormValidatorInterface.php
+++ b/src/Symfony/Component/Form/FormValidatorInterface.php
@@ -11,7 +11,18 @@
 
 namespace Symfony\Component\Form;
 
+/**
+ * This interface is deprecated. You should use a FormEvents::POST_BIND event
+ * listener instead.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated Deprecated since version 2.1, to be removed in 2.3.
+ */
 interface FormValidatorInterface
 {
+    /**
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
+     */
     function validate(FormInterface $form);
 }

--- a/src/Symfony/Component/Form/Resources/config/validation.xml
+++ b/src/Symfony/Component/Form/Resources/config/validation.xml
@@ -7,11 +7,11 @@
   <class name="Symfony\Component\Form\Form">
     <constraint name="Callback">
       <value>
-        <value>Symfony\Component\Form\Extension\Validator\Validator\DelegatingValidator</value>
+        <value>Symfony\Component\Form\Extension\Validator\EventListener\DelegatingValidationListener</value>
         <value>validateFormData</value>
       </value>
       <value>
-        <value>Symfony\Component\Form\Extension\Validator\Validator\DelegatingValidator</value>
+        <value>Symfony\Component\Form\Extension\Validator\EventListener\DelegatingValidationListener</value>
         <value>validateFormChildren</value>
       </value>
     </constraint>

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/DelegatingValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/DelegatingValidationListenerTest.php
@@ -9,20 +9,20 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Form\Tests\Extension\Validator\Validator;
+namespace Symfony\Component\Form\Tests\Extension\Validator\EventListener;
 
-use Symfony\Component\Validator\GlobalExecutionContext;
-
+use Symfony\Component\Form\Event\DataEvent;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Util\PropertyPath;
-use Symfony\Component\Form\Extension\Validator\Validator\DelegatingValidator;
+use Symfony\Component\Form\Extension\Validator\EventListener\DelegatingValidationListener;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\GlobalExecutionContext;
 use Symfony\Component\Validator\ExecutionContext;
 
-class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
+class DelegatingValidationListenerTest extends \PHPUnit_Framework_TestCase
 {
     private $dispatcher;
 
@@ -40,18 +40,10 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        if (!class_exists('Symfony\Component\Validator\Constraint')) {
-            $this->markTestSkipped('The "Validator" component is not available');
-        }
-
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->delegate = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
-        $this->validator = new DelegatingValidator($this->delegate);
+        $this->listener = new DelegatingValidationListener($this->delegate);
         $this->message = 'Message';
         $this->params = array('foo' => 'bar');
     }
@@ -131,7 +123,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->delegate->expects($this->once())->method('validateValue');
 
-        $this->validator->validate($form);
+        $this->listener->validateForm(new DataEvent($form, null));
     }
 
     public function testFormErrorsOnForm()
@@ -144,7 +136,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('constrainedProp')
             )));
 
-        $this->validator->validate($form);
+        $this->listener->validateForm(new DataEvent($form, null));
 
         $this->assertEquals(array($this->getFormError()), $form->getErrors());
     }
@@ -162,7 +154,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children.data.firstName')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertEquals(array($this->getFormError()), $child->getErrors());
@@ -181,7 +173,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children[address].data.street.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertEquals(array($this->getFormError()), $child->getErrors());
@@ -202,7 +194,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children[address].data.street')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -224,7 +216,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children[address].constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertEquals(array($this->getFormError()), $child->getErrors());
@@ -244,7 +236,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children[lastName].constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertEquals(array($this->getFormError()), $parent->getErrors());
         $this->assertFalse($child->hasErrors());
@@ -267,7 +259,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children[1].data.firstName'),
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
 
@@ -290,7 +282,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.constrainedProp')
             )));
 
-        $this->validator->validate($form);
+        $this->listener->validateForm(new DataEvent($form, null));
 
         $this->assertEquals(array($this->getFormError()), $form->getErrors());
     }
@@ -308,7 +300,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.firstName.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertEquals(array($this->getFormError()), $child->getErrors());
@@ -327,7 +319,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.address.street.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertEquals(array($this->getFormError()), $child->getErrors());
@@ -348,7 +340,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.address.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertEquals(array($this->getFormError()), $child->getErrors());
@@ -370,7 +362,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.address.street.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -392,7 +384,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children[address].data.street.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -414,7 +406,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data[address].street.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -434,7 +426,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.lastName.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertEquals(array($this->getFormError()), $parent->getErrors());
         $this->assertFalse($child->hasErrors());
@@ -463,7 +455,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
         $child->setData(array());
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors(), '->hasErrors() returns false for parent form');
         $this->assertFalse($child->hasErrors(), '->hasErrors() returns false for child form');
@@ -494,7 +486,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.passwordPlain.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertEquals(array($this->getFormError()), $child->getErrors());
@@ -519,7 +511,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.address.streetName.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -545,7 +537,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('children[address].data.streetName.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -571,7 +563,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.address.streetName.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -599,7 +591,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
                 $this->getConstraintViolation('data.streetName.constrainedProp')
             )));
 
-        $this->validator->validate($parent);
+        $this->listener->validateForm(new DataEvent($parent, null));
 
         $this->assertFalse($parent->hasErrors());
         $this->assertFalse($child->hasErrors());
@@ -624,7 +616,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
         $form->setData($object);
 
-        DelegatingValidator::validateFormData($form, $context);
+        DelegatingValidationListener::validateFormData($form, $context);
     }
 
     public function testValidateFormDataCanHandleCallbackValidationGroups()
@@ -645,7 +637,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
         $form->setData($object);
 
-        DelegatingValidator::validateFormData($form, $context);
+        DelegatingValidationListener::validateFormData($form, $context);
     }
 
     public function testValidateFormDataCanHandleClosureValidationGroups()
@@ -668,7 +660,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
         $form->setData($object);
 
-        DelegatingValidator::validateFormData($form, $context);
+        DelegatingValidationListener::validateFormData($form, $context);
     }
 
     public function testValidateFormDataUsesInheritedValidationGroup()
@@ -691,7 +683,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('walkReference')
             ->with($object, 'group', 'foo.bar.data', true);
 
-        DelegatingValidator::validateFormData($child, $context);
+        DelegatingValidationListener::validateFormData($child, $context);
     }
 
     public function testValidateFormDataUsesInheritedCallbackValidationGroup()
@@ -717,7 +709,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('walkReference')
             ->with($object, 'group2', 'foo.bar.data', true);
 
-        DelegatingValidator::validateFormData($child, $context);
+        DelegatingValidationListener::validateFormData($child, $context);
     }
 
     public function testValidateFormDataUsesInheritedClosureValidationGroup()
@@ -745,7 +737,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('walkReference')
             ->with($object, 'group2', 'foo.bar.data', true);
 
-        DelegatingValidator::validateFormData($child, $context);
+        DelegatingValidationListener::validateFormData($child, $context);
     }
 
     public function testValidateFormDataAppendsPropertyPath()
@@ -761,7 +753,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
         $form->setData($object);
 
-        DelegatingValidator::validateFormData($form, $context);
+        DelegatingValidationListener::validateFormData($form, $context);
     }
 
     public function testValidateFormDataDoesNotWalkScalars()
@@ -783,7 +775,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
 
         $form->bind(array('foo' => 'bar')); // reverse transformed to "foobar"
 
-        DelegatingValidator::validateFormData($form, $context);
+        DelegatingValidationListener::validateFormData($form, $context);
     }
 
     public function testValidateFormChildren()
@@ -802,7 +794,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
             // constraint is in the Default group as well
             ->with($form->getChildren(), Constraint::DEFAULT_GROUP, 'children', true);
 
-        DelegatingValidator::validateFormChildren($form, $context);
+        DelegatingValidationListener::validateFormChildren($form, $context);
     }
 
     public function testValidateFormChildrenAppendsPropertyPath()
@@ -818,7 +810,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('walkReference')
             ->with($form->getChildren(), 'Default', 'foo.bar.children', true);
 
-        DelegatingValidator::validateFormChildren($form, $context);
+        DelegatingValidationListener::validateFormChildren($form, $context);
     }
 
     public function testValidateFormChildrenDoesNothingIfDisabled()
@@ -833,7 +825,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
         $graphWalker->expects($this->never())
             ->method('walkReference');
 
-        DelegatingValidator::validateFormChildren($form, $context);
+        DelegatingValidationListener::validateFormChildren($form, $context);
     }
 
     public function testValidateIgnoresNonRoot()
@@ -846,6 +838,6 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
         $this->delegate->expects($this->never())
             ->method('validate');
 
-        $this->validator->validate($form);
+        $this->listener->validateForm(new DataEvent($form, null));
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=remove-form-validator)

This cleanup has been lying on a disk for a while, so here it goes.

The FormValidatorInterface has been removed in order to reduce the complexity of the Form API. The same expressivity can be achieved by using POST_BIND event listeners. The POST_VALIDATE event introduced in e6577debf6892afeb2d10eb8a3a0fae0d55c9545 can be replaced by a POST_BIND listener with low priority.
