### PR TITLE
[Validator] added less-strict email host verification

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Email.php
+++ b/src/Symfony/Component/Validator/Constraints/Email.php
@@ -22,4 +22,5 @@ class Email extends Constraint
 {
     public $message = 'This value is not a valid email address';
     public $checkMX = false;
+    public $checkHost = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -51,9 +51,11 @@ class EmailValidator extends ConstraintValidator
                 $valid = false;
             }
 
-            // Check MX records
+            // Check for host DNS resource records
             if ($valid && $constraint->checkMX) {
                 $valid = $this->checkMX($host);
+            } else if ($valid && $constraint->checkHost) {
+                $valid = $this->checkHost($host);
             }
         }
 
@@ -69,12 +71,24 @@ class EmailValidator extends ConstraintValidator
     /**
      * Check DNS Records for MX type.
      *
-     * @param string $host Host name
+     * @param string $host Hostname
      *
      * @return Boolean
      */
     private function checkMX($host)
     {
         return checkdnsrr($host, 'MX');
+    }
+    
+    /**
+     * Check if one of MX, A or AAAA DNS RR exists.
+     *
+     * @param string $host Hostname
+     * 
+     * @return Boolean
+     */
+    private function checkHost($host)
+    {
+        return $this->checkMX($host) || (checkdnsrr($host, "A") || checkdnsrr($host, "AAAA"));
     }
 }


### PR DESCRIPTION
uhhhhh, my first pull request :>. uhm... tell me if i did something wrong :)
#### Request info

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes... well,not really (i guess master branch is not passing - at least i didnt broke the email test)
Fixes the following tickets: #2827
#### Description

New checkHost attribute in email constraint will make the validator check for only one of MX, A or AAAA DNS resource records to verify it as a valid email address.
