### PR TITLE
[Console] Exception rendering fixes

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -734,7 +734,7 @@ class Application
             $title = sprintf('  [%s]  ', get_class($e));
             $len = $strlen($title);
             $lines = array();
-            foreach (explode("\n", $e->getMessage()) as $line) {
+            foreach (preg_split("{\r?\n}", $e->getMessage()) as $line) {
                 $lines[] = sprintf('  %s  ', $line);
                 $len = max($strlen($line) + 4, $len);
             }

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -255,6 +255,15 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester->run(array('command' => 'foo3:bar'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $this->normalize($tester->getDisplay()), '->renderException() renders a pretty exceptions with previous exceptions');
 
+        $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
+        $application->setAutoExit(false);
+        $application->expects($this->any())
+            ->method('getTerminalWidth')
+            ->will($this->returnValue(32));
+        $tester = new ApplicationTester($application);
+
+        $tester->run(array('command' => 'foo'), array('decorated' => false));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception4.txt', $this->normalize($tester->getDisplay()), '->renderException() wraps messages when they are bigger than the terminal');
     }
 
     public function testRun()

--- a/tests/Symfony/Tests/Component/Console/Fixtures/application_renderexception4.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/application_renderexception4.txt
@@ -1,0 +1,9 @@
+
+
+                               
+  [InvalidArgumentException]   
+  Command "foo" is not define  
+  d.                           
+                               
+
+


### PR DESCRIPTION
This fixes two things:
- `\r`'s in exception messages were output (in case of `\r\n` newlines), creating really weird results on windows.
- long exception messages were wrapping and then the "red" block was completely messed up, with half black/half red lines, now it's wrapped before output if the terminal width can be detected.

If you don't care about merging this for 2.0, you can also merge the `console_ex` branch which applies on master. Due to moving tests and renaming of some normalize stuff in the tests, the two test patches are kind of different.

RFC: I am really not sure where to put those getTerminalWidth/Height methods. I guess this is not the best place.
