### PR TITLE
[Form] Fixed default label generated for the CollectionType prototype

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -26,7 +26,9 @@ class CollectionType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         if ($options['allow_add'] && $options['prototype']) {
-            $prototype = $builder->create($options['prototype_name'], $options['type'], $options['options']);
+            $prototype = $builder->create($options['prototype_name'], $options['type'], array_replace(array(
+                'label' => $options['prototype_name'] . 'label__',
+            ), $options['options']));
             $builder->setAttribute('prototype', $prototype->getForm());
         }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -200,6 +200,6 @@ class FieldType extends AbstractType
 
     private function humanize($text)
     {
-        return ucfirst(strtolower(str_replace('_', ' ', $text)));
+        return ucfirst(trim(strtolower(preg_replace('/[_\s]+/', ' ', $text))));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -185,4 +185,15 @@ class CollectionTypeTest extends TypeTestCase
 
         $this->assertSame('__test__', $form->getAttribute('prototype')->getName());
     }
+
+    public function testPrototypeDefaultLabel()
+    {
+        $form = $this->factory->create('collection', array(), array(
+            'type'      => 'file',
+            'allow_add' => true,
+            'prototype' => true,
+        ));
+
+        $this->assertSame('__name__', $form->createView()->get('prototype')->get('label'));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -192,8 +192,9 @@ class CollectionTypeTest extends TypeTestCase
             'type'      => 'file',
             'allow_add' => true,
             'prototype' => true,
+            'prototype_name' => '__test__',
         ));
 
-        $this->assertSame('__name__', $form->createView()->get('prototype')->get('label'));
+        $this->assertSame('__test__label__', $form->createView()->get('prototype')->get('label'));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FieldTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FieldTypeTest.php
@@ -188,6 +188,22 @@ class FieldTypeTest extends TypeTestCase
         $this->assertSame('test', $view->get('translation_domain'));
     }
 
+    public function testPassDefaultLabelToView()
+    {
+        $form = $this->factory->createNamed('field', '__test___field');
+        $view = $form->createView();
+
+        $this->assertSame('Test field', $view->get('label'));
+    }
+
+    public function testPassLabelToView()
+    {
+        $form = $this->factory->createNamed('field', '__test___field', null, array('label' => 'My label'));
+        $view = $form->createView();
+
+        $this->assertSame('My label', $view->get('label'));
+    }
+
     public function testDefaultTranslationDomain()
     {
         $form = $this->factory->create('field');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3738, #3739
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3738)

(the fact that the build fails seems to origin from the broken master)
