### PR TITLE
[DependencyInjection] Fix Yaml file loader test

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -14,6 +14,7 @@ services:
         class: FooClass
         calls:
             - [ setBar, [] ]
+            - [ setBar ]
     method_call2:
         class: FooClass
         calls:


### PR DESCRIPTION
This broke when 2.0 was recently merged into master with b9daae28476385d16984a729b9e7c8e30911fa23, as the Yaml fixture change from 24a0d0a2dcf334efc7d85f1c816c01d7fa4111f8 was not included.

https://twitter.com/webmozart/status/188325579894947840
