### PR TITLE
[Filesystem] Fixed a bug in remove() being unable to unlink broken symlinks

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -264,6 +264,11 @@ class Filesystem
         return false;
     }
 
+    /**
+     * @param mixed $files
+     *
+     * @return \Traversable
+     */
     private function toIterator($files)
     {
         if (!$files instanceof \Traversable) {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -69,7 +69,7 @@ class Filesystem
     /**
      * Creates empty files.
      *
-     * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to remove
+     * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to create
      */
     public function touch($files)
     {
@@ -105,7 +105,7 @@ class Filesystem
     /**
      * Change mode for an array of files or directories.
      *
-     * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to remove
+     * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to change mode
      * @param integer                   $mode  The new mode
      * @param integer                   $umask The mode mask (octal)
      */
@@ -171,8 +171,8 @@ class Filesystem
     /**
      * Given an existing path, convert it to a path relative to a given starting path
      *
-     * @var string Absolute path of target
-     * @var string Absolute path where traversal begins
+     * @param string $endPath   Absolute path of target
+     * @param string $startPath Absolute path where traversal begins
      *
      * @return string Path of target relative to starting path
      */

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -180,7 +180,7 @@ class Filesystem
     {
         // Find for which character the the common path stops
         $offset = 0;
-        while ($startPath[$offset] === $endPath[$offset]) {
+        while (isset($startPath[$offset]) && isset($endPath[$offset]) && $startPath[$offset] === $endPath[$offset]) {
             $offset++;
         }
 

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -88,7 +88,7 @@ class Filesystem
         $files = iterator_to_array($this->toIterator($files));
         $files = array_reverse($files);
         foreach ($files as $file) {
-            if (!file_exists($file)) {
+            if (!file_exists($file) && !is_link($file)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -441,6 +441,28 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         return $paths;
     }
 
+    public function testMirrorCopiesFilesAndDirectoriesRecursively()
+    {
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+        $directory = $sourcePath.'directory'.DIRECTORY_SEPARATOR;
+        $file1 = $directory.'file1';
+        $file2 = $sourcePath.'file2';
+
+        mkdir($sourcePath);
+        mkdir($directory);
+        file_put_contents($file1, 'FILE1');
+        file_put_contents($file2, 'FILE2');
+
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mirror($sourcePath, $targetPath);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertTrue(is_dir($targetPath.'directory'));
+        $this->assertFileEquals($file1, $targetPath.'directory'.DIRECTORY_SEPARATOR.'file1');
+        $this->assertFileEquals($file2, $targetPath.'file2');
+    }
+
     /**
      * @dataProvider providePathsForIsAbsolutePath
      */

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -411,6 +411,37 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider provideAbsolutePaths
+     */
+    public function testMakePathRelative($endPath, $startPath, $expectedPath)
+    {
+        $path = $this->filesystem->makePathRelative($endPath, $startPath);
+
+        $this->assertEquals($expectedPath, $path);
+    }
+
+    /**
+     * @return array
+     */
+    public function provideAbsolutePaths()
+    {
+        $paths = array(
+            array('/var/lib/symfony/src/Symfony/', '/var/lib/symfony/src/Symfony/Component', '../'),
+            array('var/lib/symfony/', 'var/lib/symfony/src/Symfony/Component', '../../../'),
+            array('/usr/lib/symfony/', '/var/lib/symfony/src/Symfony/Component', '../../../../../../usr/lib/symfony/')
+        );
+
+        // fix directory separator
+        foreach ($paths as $i => $pathItems) {
+            foreach ($pathItems as $k => $path) {
+                $paths[$i][$k] = str_replace('/', DIRECTORY_SEPARATOR, $path);
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
      * Returns file permissions as three digits (i.e. 755)
      *
      * @return integer

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -193,4 +193,59 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         unlink($basePath.'2');
         rmdir($basePath.'3');
     }
+
+    public function testTouchCreatesEmptyFile()
+    {
+        $basePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $file = $basePath.'1';
+
+        $filesystem = new Filesystem();
+        $filesystem->touch($file);
+
+        $this->assertFileExists($basePath.'1');
+
+        unlink($basePath.'1');
+    }
+
+    public function testTouchCreatesEmptyFilesFromArray()
+    {
+        $basePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $files = array(
+            $basePath.'1', $basePath.'2', $basePath.'3'
+        );
+        mkdir($basePath);
+
+        $filesystem = new Filesystem();
+        $filesystem->touch($files);
+
+        $this->assertFileExists($basePath.'1');
+        $this->assertFileExists($basePath.'2');
+        $this->assertFileExists($basePath.'3');
+
+        unlink($basePath.'1');
+        unlink($basePath.'2');
+        unlink($basePath.'3');
+        rmdir($basePath);
+    }
+
+    public function testTouchCreatesEmptyFilesFromTraversableObject()
+    {
+        $basePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $files = new \ArrayObject(array(
+            $basePath.'1', $basePath.'2', $basePath.'3'
+        ));
+        mkdir($basePath);
+
+        $filesystem = new Filesystem();
+        $filesystem->touch($files);
+
+        $this->assertFileExists($basePath.'1');
+        $this->assertFileExists($basePath.'2');
+        $this->assertFileExists($basePath.'3');
+
+        unlink($basePath.'1');
+        unlink($basePath.'2');
+        unlink($basePath.'3');
+        rmdir($basePath);
+    }
 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -342,6 +342,32 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(753, $this->getFilePermisions($directory));
     }
 
+    public function testRename()
+    {
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $newPath = $this->workspace.DIRECTORY_SEPARATOR.'new_file';
+        touch($file);
+
+        $this->filesystem->rename($file, $newPath);
+
+        $this->assertFileNotExists($file);
+        $this->assertFileExists($newPath);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testRenameThrowsExceptionIfTargetAlreadyExists()
+    {
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $newPath = $this->workspace.DIRECTORY_SEPARATOR.'new_file';
+
+        touch($file);
+        touch($newPath);
+
+        $this->filesystem->rename($file, $newPath);
+    }
+
     /**
      * Returns file permissions as three digits (i.e. 755)
      *

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -45,10 +45,6 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
      */
     private function clean($file)
     {
-        if (!file_exists($file)) {
-            return;
-        }
-
         if (is_dir($file) && !is_link($file)) {
             $dir = new \FilesystemIterator($file);
             foreach ($dir as $childFile) {
@@ -304,5 +300,55 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->filesystem->remove($files);
 
         $this->assertTrue(!is_dir($basePath.'dir'));
+    }
+
+    public function testChmodChangesFileMode()
+    {
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        touch($file);
+
+        $this->filesystem->chmod($file, 0753);
+
+        $this->assertEquals(753, $this->getFilePermisions($file));
+    }
+
+    public function testChmodChangesModeOfArrayOfFiles()
+    {
+        $directory = $this->workspace.DIRECTORY_SEPARATOR.'directory';
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $files = array($directory, $file);
+
+        mkdir($directory);
+        touch($file);
+
+        $this->filesystem->chmod($files, 0753);
+
+        $this->assertEquals(753, $this->getFilePermisions($file));
+        $this->assertEquals(753, $this->getFilePermisions($directory));
+    }
+
+    public function testChmodChangesModeOfTraversableFileObject()
+    {
+        $directory = $this->workspace.DIRECTORY_SEPARATOR.'directory';
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $files = new \ArrayObject(array($directory, $file));
+
+        mkdir($directory);
+        touch($file);
+
+        $this->filesystem->chmod($files, 0753);
+
+        $this->assertEquals(753, $this->getFilePermisions($file));
+        $this->assertEquals(753, $this->getFilePermisions($directory));
+    }
+
+    /**
+     * Returns file permissions as three digits (i.e. 755)
+     *
+     * @return integer
+     */
+    private function getFilePermisions($filePath)
+    {
+        return (int) substr(sprintf('%o', fileperms($filePath)), -3);
     }
 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -297,6 +297,22 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(!is_dir($basePath.'dir'));
     }
 
+    public function testRemoveCleansInvalidLinks()
+    {
+        $this->markAsSkippeIfSymlinkIsMissing();
+
+        $basePath = $this->workspace.DIRECTORY_SEPARATOR.'directory'.DIRECTORY_SEPARATOR;
+
+        mkdir($basePath);
+        mkdir($basePath.'dir');
+        // create symlink to unexisting file
+        symlink($basePath.'file', $basePath.'link');
+
+        $this->filesystem->remove($basePath);
+
+        $this->assertTrue(!is_dir($basePath));
+    }
+
     public function testChmodChangesFileMode()
     {
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -238,4 +238,71 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($basePath.'2');
         $this->assertFileExists($basePath.'3');
     }
+
+    public function testRemoveCleansFilesLinksAndDirectoriesIteratively()
+    {
+        $basePath = $this->workspace.DIRECTORY_SEPARATOR.'directory'.DIRECTORY_SEPARATOR;
+
+        mkdir($basePath);
+        mkdir($basePath.'dir');
+        touch($basePath.'file');
+        link($basePath.'file', $basePath.'link');
+
+        $this->filesystem->remove($basePath);
+
+        $this->assertTrue(!is_dir($basePath));
+    }
+
+    public function testRemoveCleansArrayOfFilesLinksAndDirectories()
+    {
+        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
+
+        mkdir($basePath.'dir');
+        touch($basePath.'file');
+        link($basePath.'file', $basePath.'link');
+
+        $files = array(
+            $basePath.'dir', $basePath.'file', $basePath.'link'
+        );
+
+        $this->filesystem->remove($files);
+
+        $this->assertTrue(!is_dir($basePath.'dir'));
+        $this->assertTrue(!is_file($basePath.'file'));
+        $this->assertTrue(!is_link($basePath.'link'));
+    }
+
+    public function testRemoveCleansTraversableObjectOfFilesLinksAndDirectories()
+    {
+        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
+
+        mkdir($basePath.'dir');
+        touch($basePath.'file');
+        link($basePath.'file', $basePath.'link');
+
+        $files = new \ArrayObject(array(
+            $basePath.'dir', $basePath.'file', $basePath.'link'
+        ));
+
+        $this->filesystem->remove($files);
+
+        $this->assertTrue(!is_dir($basePath.'dir'));
+        $this->assertTrue(!is_file($basePath.'file'));
+        $this->assertTrue(!is_link($basePath.'link'));
+    }
+
+    public function testRemoveIgnoresNonExistingFiles()
+    {
+        $basePath = $this->workspace.DIRECTORY_SEPARATOR;
+
+        mkdir($basePath.'dir');
+
+        $files = array(
+            $basePath.'dir', $basePath.'file'
+        );
+
+        $this->filesystem->remove($files);
+
+        $this->assertTrue(!is_dir($basePath.'dir'));
+    }
 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -115,4 +115,82 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         unlink($targetFilePath);
         rmdir($targetFileDirectory);
     }
+
+    public function testMkdirCreatesDirectoriesRecursively()
+    {
+        $directory = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $subDirectory = $directory.DIRECTORY_SEPARATOR.'sub_directory';
+
+        $filesystem = new Filesystem();
+        $result = $filesystem->mkdir($subDirectory);
+
+        $this->assertTrue($result);
+        $this->assertTrue(is_dir($subDirectory));
+
+        rmdir($subDirectory);
+        rmdir($directory);
+    }
+
+    public function testMkdirCreatesDirectoriesFromArray()
+    {
+        $basePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $directories = array(
+            $basePath.'1', $basePath.'2', $basePath.'3'
+        );
+
+        $filesystem = new Filesystem();
+        $result = $filesystem->mkdir($directories);
+
+        $this->assertTrue($result);
+        $this->assertTrue(is_dir($basePath.'1'));
+        $this->assertTrue(is_dir($basePath.'2'));
+        $this->assertTrue(is_dir($basePath.'3'));
+
+        rmdir($basePath.'1');
+        rmdir($basePath.'2');
+        rmdir($basePath.'3');
+    }
+
+    public function testMkdirCreatesDirectoriesFromTraversableObject()
+    {
+        $basePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $directories = new \ArrayObject(array(
+            $basePath.'1', $basePath.'2', $basePath.'3'
+        ));
+
+        $filesystem = new Filesystem();
+        $result = $filesystem->mkdir($directories);
+
+        $this->assertTrue($result);
+        $this->assertTrue(is_dir($basePath.'1'));
+        $this->assertTrue(is_dir($basePath.'2'));
+        $this->assertTrue(is_dir($basePath.'3'));
+
+        rmdir($basePath.'1');
+        rmdir($basePath.'2');
+        rmdir($basePath.'3');
+    }
+
+    public function testMkdirCreatesDirectoriesEvenIfItFailsToCreateOneOfThem()
+    {
+        $basePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $directories = array(
+            $basePath.'1', $basePath.'2', $basePath.'3'
+        );
+
+        // create a file to make that directory cannot be created
+        file_put_contents($basePath.'2', '');
+
+        $filesystem = new Filesystem();
+        $result = $filesystem->mkdir($directories);
+
+        $this->assertFalse($result);
+        $this->assertTrue(is_dir($basePath.'1'));
+        $this->assertFalse(is_dir($basePath.'2'));
+        $this->assertTrue(is_dir($basePath.'3'));
+
+        rmdir($basePath.'1');
+        unlink($basePath.'2');
+        rmdir($basePath.'3');
+    }
 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Tests;
+
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * Test class for Filesystem.
+ */
+class FilesystemTest extends \PHPUnit_Framework_TestCase
+{
+    public function testCopyCreatesNewFile()
+    {
+        $sourceFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_target_file';
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+
+        $filesystem = new Filesystem();
+        $filesystem->copy($sourceFilePath, $targetFilePath);
+
+        $this->assertFileExists($targetFilePath);
+        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+
+        unlink($sourceFilePath);
+        unlink($targetFilePath);
+    }
+
+    public function testCopyOverridesExistingFileIfModified()
+    {
+        $sourceFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_target_file';
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+        file_put_contents($targetFilePath, 'TARGET FILE');
+        touch($targetFilePath, time() - 1000);
+
+        $filesystem = new Filesystem();
+        $filesystem->copy($sourceFilePath, $targetFilePath);
+
+        $this->assertFileExists($targetFilePath);
+        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+
+        unlink($sourceFilePath);
+        unlink($targetFilePath);
+    }
+
+    public function testCopyDoesNotOverrideExistingFileByDefault()
+    {
+        $sourceFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_target_file';
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+        file_put_contents($targetFilePath, 'TARGET FILE');
+        $modificationTime = time() - 1000;
+        touch($sourceFilePath, $modificationTime);
+        touch($targetFilePath, $modificationTime);
+
+        $filesystem = new Filesystem();
+        $filesystem->copy($sourceFilePath, $targetFilePath);
+
+        $this->assertFileExists($targetFilePath);
+        $this->assertEquals('TARGET FILE', file_get_contents($targetFilePath));
+
+        unlink($sourceFilePath);
+        unlink($targetFilePath);
+    }
+
+    public function testCopyOverridesExistingFileIfForced()
+    {
+        $sourceFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_target_file';
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+        file_put_contents($targetFilePath, 'TARGET FILE');
+        $modificationTime = time() - 1000;
+        touch($sourceFilePath, $modificationTime);
+        touch($targetFilePath, $modificationTime);
+
+        $filesystem = new Filesystem();
+        $filesystem->copy($sourceFilePath, $targetFilePath, true);
+
+        $this->assertFileExists($targetFilePath);
+        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+
+        unlink($sourceFilePath);
+        unlink($targetFilePath);
+    }
+
+    public function testCopyCreatesTargetDirectoryIfItDoesNotExist()
+    {
+        $sourceFilePath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'copy_source_file';
+        $targetFileDirectory = sys_get_temp_dir().DIRECTORY_SEPARATOR.time();
+        $targetFilePath = $targetFileDirectory.DIRECTORY_SEPARATOR.'copy_target_file';
+
+        file_put_contents($sourceFilePath, 'SOURCE FILE');
+
+        $filesystem = new Filesystem();
+        $filesystem->copy($sourceFilePath, $targetFilePath);
+
+        $this->assertTrue(is_dir($targetFileDirectory));
+        $this->assertFileExists($targetFilePath);
+        $this->assertEquals('SOURCE FILE', file_get_contents($targetFilePath));
+
+        unlink($sourceFilePath);
+        unlink($targetFilePath);
+        rmdir($targetFileDirectory);
+    }
+}

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -444,7 +444,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $paths = array(
             array('/var/lib/symfony/src/Symfony/', '/var/lib/symfony/src/Symfony/Component', '../'),
             array('var/lib/symfony/', 'var/lib/symfony/src/Symfony/Component', '../../../'),
-            array('/usr/lib/symfony/', '/var/lib/symfony/src/Symfony/Component', '../../../../../../usr/lib/symfony/')
+            array('/usr/lib/symfony/', '/var/lib/symfony/src/Symfony/Component', '../../../../../../usr/lib/symfony/'),
+            array('/var/lib/symfony/src/Symfony/', '/var/lib/symfony/', '../src/Symfony/'),
         );
 
         // fix directory separator

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -411,7 +411,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideAbsolutePaths
+     * @dataProvider providePathsForMakePathRelative
      */
     public function testMakePathRelative($endPath, $startPath, $expectedPath)
     {
@@ -423,7 +423,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
     /**
      * @return array
      */
-    public function provideAbsolutePaths()
+    public function providePathsForMakePathRelative()
     {
         $paths = array(
             array('/var/lib/symfony/src/Symfony/', '/var/lib/symfony/src/Symfony/Component', '../'),
@@ -439,6 +439,30 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         }
 
         return $paths;
+    }
+
+    /**
+     * @dataProvider providePathsForIsAbsolutePath
+     */
+    public function testIsAbsolutePath($path, $expectedResult)
+    {
+        $result = $this->filesystem->isAbsolutePath($path);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function providePathsForIsAbsolutePath()
+    {
+        return array(
+            array('/var/lib', true),
+            array('c:\\\\var\\lib', true),
+            array('\\var\\lib', true),
+            array('var/lib', false),
+            array('../var/lib', false)
+        );
     }
 
     /**


### PR DESCRIPTION
While working on test coverage for Filesystem class I discovered a bug in remove() method. 

Before removing a file a check is made if it exists:

```
if (!file_exists($file)) {
    continue;
}
```

Problem is [file_exists()](http://php.net/file_exists) returns false if link's target file doesn't exist. Therefore remove() will fail to delete a directory containing a broken link. Solution is to handle links a bit different:

```
if (!file_exists($file) && !is_link($file)) {
    continue;
}
```

Additionally, this PR improves test coverage of Filesystem component.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
