### PR TITLE
Fixed ACL handling of Doctrine proxies

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Acl\Domain;
 use Symfony\Component\Security\Acl\Exception\InvalidDomainObjectException;
 use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
  * ObjectIdentity implementation
@@ -42,7 +43,7 @@ final class ObjectIdentity implements ObjectIdentityInterface
         }
 
         $this->identifier = $identifier;
-        $this->type = $type;
+        $this->type = (class_exists('Doctrine\Common\Util\ClassUtils')) ? ClassUtils::getRealClass($type) : $type;
     }
 
     /**

--- a/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/ObjectIdentity.php
@@ -43,7 +43,7 @@ final class ObjectIdentity implements ObjectIdentityInterface
         }
 
         $this->identifier = $identifier;
-        $this->type = (class_exists('Doctrine\Common\Util\ClassUtils')) ? ClassUtils::getRealClass($type) : $type;
+        $this->type = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getRealClass($type) : $type;
     }
 
     /**

--- a/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Acl\Domain;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
+use Doctrine\Common\Util\ClassUtils;
 
 /**
  * A SecurityIdentity implementation used for actual users
@@ -41,7 +42,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
         }
 
         $this->username = (string) $username;
-        $this->class = $class;
+        $this->class = (class_exists('Doctrine\Common\Util\ClassUtils')) ? ClassUtils::getRealClass($class) : $class;
     }
 
     /**

--- a/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/UserSecurityIdentity.php
@@ -42,7 +42,7 @@ final class UserSecurityIdentity implements SecurityIdentityInterface
         }
 
         $this->username = (string) $username;
-        $this->class = (class_exists('Doctrine\Common\Util\ClassUtils')) ? ClassUtils::getRealClass($class) : $class;
+        $this->class = class_exists('Doctrine\Common\Util\ClassUtils') ? ClassUtils::getRealClass($class) : $class;
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/ObjectIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/ObjectIdentityTest.php
@@ -62,15 +62,19 @@ class ObjectIdentityTest extends \PHPUnit_Framework_TestCase
 
     public function getCompareData()
     {
-        $proxyClass = ClassUtils::generateProxyClassName('Foo', 'Acme\\DemoBundle\\Proxy\\');
-
-        return array(
+        $data = array(
             array(new ObjectIdentity('123', 'foo'), new ObjectIdentity('123', 'foo'), true),
             array(new ObjectIdentity('123', 'foo'), new ObjectIdentity(123, 'foo'), true),
             array(new ObjectIdentity('1', 'foo'), new ObjectIdentity('2', 'foo'), false),
             array(new ObjectIdentity('1', 'bla'), new ObjectIdentity('1', 'blub'), false),
-            array(new ObjectIdentity('1', $proxyClass), new ObjectIdentity('1', 'Foo'), true),
         );
+
+        if (class_exists('Doctrine\Common\Util\ClassUtils')) {
+            $proxyClass = ClassUtils::generateProxyClassName('Foo', 'Acme\\DemoBundle\\Proxy\\');
+            $data[] = array(new ObjectIdentity('1', $proxyClass), new ObjectIdentity('1', 'Foo'), true);
+        }
+
+        return $data;
     }
 
     public function setUp()

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/ObjectIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/ObjectIdentityTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Tests\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Doctrine\Common\Util\ClassUtils;
 
 class ObjectIdentityTest extends \PHPUnit_Framework_TestCase
 {
@@ -61,11 +62,14 @@ class ObjectIdentityTest extends \PHPUnit_Framework_TestCase
 
     public function getCompareData()
     {
+        $proxyClass = ClassUtils::generateProxyClassName('Foo', 'Acme\\DemoBundle\\Proxy\\');
+
         return array(
             array(new ObjectIdentity('123', 'foo'), new ObjectIdentity('123', 'foo'), true),
             array(new ObjectIdentity('123', 'foo'), new ObjectIdentity(123, 'foo'), true),
             array(new ObjectIdentity('1', 'foo'), new ObjectIdentity('2', 'foo'), false),
             array(new ObjectIdentity('1', 'bla'), new ObjectIdentity('1', 'blub'), false),
+            array(new ObjectIdentity('1', $proxyClass), new ObjectIdentity('1', 'Foo'), true),
         );
     }
 

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Tests\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
+use Doctrine\Common\Util\ClassUtils;
 
 class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
 {
@@ -50,6 +51,8 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($account))
         ;
 
+        $proxyClass = ClassUtils::generateProxyClassName('Foo', 'Acme\\DemoBundle\\Proxy\\');
+
         return array(
             array(new UserSecurityIdentity('foo', 'Foo'), new UserSecurityIdentity('foo', 'Foo'), true),
             array(new UserSecurityIdentity('foo', 'Bar'), new UserSecurityIdentity('foo', 'Foo'), false),
@@ -59,6 +62,7 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             array(new UserSecurityIdentity('foo', 'Foo'), new RoleSecurityIdentity('foo'), false),
             array(new UserSecurityIdentity('foo', 'Foo'), UserSecurityIdentity::fromToken($token), false),
             array(new UserSecurityIdentity('foo', 'USI_AccountImpl'), UserSecurityIdentity::fromToken($token), true),
+            array(new UserSecurityIdentity('foo', $proxyClass), new UserSecurityIdentity('foo', 'Foo'), true),
         );
     }
 }

--- a/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
+++ b/tests/Symfony/Tests/Component/Security/Acl/Domain/UserSecurityIdentityTest.php
@@ -51,9 +51,7 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($account))
         ;
 
-        $proxyClass = ClassUtils::generateProxyClassName('Foo', 'Acme\\DemoBundle\\Proxy\\');
-
-        return array(
+        $data = array(
             array(new UserSecurityIdentity('foo', 'Foo'), new UserSecurityIdentity('foo', 'Foo'), true),
             array(new UserSecurityIdentity('foo', 'Bar'), new UserSecurityIdentity('foo', 'Foo'), false),
             array(new UserSecurityIdentity('foo', 'Foo'), new UserSecurityIdentity('bar', 'Foo'), false),
@@ -62,7 +60,13 @@ class UserSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             array(new UserSecurityIdentity('foo', 'Foo'), new RoleSecurityIdentity('foo'), false),
             array(new UserSecurityIdentity('foo', 'Foo'), UserSecurityIdentity::fromToken($token), false),
             array(new UserSecurityIdentity('foo', 'USI_AccountImpl'), UserSecurityIdentity::fromToken($token), true),
-            array(new UserSecurityIdentity('foo', $proxyClass), new UserSecurityIdentity('foo', 'Foo'), true),
         );
+
+        if (class_exists('Doctrine\Common\Util\ClassUtils')) {
+            $proxyClass = ClassUtils::generateProxyClassName('Foo', 'Acme\\DemoBundle\\Proxy\\');
+            $data[] = array(new UserSecurityIdentity('foo', $proxyClass), new UserSecurityIdentity('foo', 'Foo'), true);
+        }
+
+        return $data;
     }
 }

--- a/vendors.php
+++ b/vendors.php
@@ -32,12 +32,12 @@ if (isset($argv[1]) && in_array($argv[1], array('--transport=http', '--transport
 }
 
 $deps = array(
-    array('doctrine', 'http://github.com/doctrine/doctrine2.git', '2.2.1'),
-    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', '2.2.1'),
-    array('doctrine-common', 'http://github.com/doctrine/common.git', '2.2.1'),
+    array('doctrine', 'http://github.com/doctrine/doctrine2.git', '2.1.6'),
+    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', '2.1.6'),
+    array('doctrine-common', 'http://github.com/doctrine/common.git', '2.1.4'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', '1.0.2'),
-    array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.6'),
-    array('twig', 'http://github.com/fabpot/Twig.git', 'v1.6.4'),
+    array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.5'),
+    array('twig', 'http://github.com/fabpot/Twig.git', 'v1.6.2'),
 );
 
 foreach ($deps as $dep) {

--- a/vendors.php
+++ b/vendors.php
@@ -32,12 +32,12 @@ if (isset($argv[1]) && in_array($argv[1], array('--transport=http', '--transport
 }
 
 $deps = array(
-    array('doctrine', 'http://github.com/doctrine/doctrine2.git', '2.1.6'),
-    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', '2.1.6'),
-    array('doctrine-common', 'http://github.com/doctrine/common.git', '2.1.4'),
+    array('doctrine', 'http://github.com/doctrine/doctrine2.git', '2.2.1'),
+    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', '2.2.1'),
+    array('doctrine-common', 'http://github.com/doctrine/common.git', '2.2.1'),
     array('monolog', 'http://github.com/Seldaek/monolog.git', '1.0.2'),
-    array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.5'),
-    array('twig', 'http://github.com/fabpot/Twig.git', 'v1.6.2'),
+    array('swiftmailer', 'http://github.com/swiftmailer/swiftmailer.git', 'v4.1.6'),
+    array('twig', 'http://github.com/fabpot/Twig.git', 'v1.6.4'),
 );
 
 foreach ($deps as $dep) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/jalliot/symfony.png?branch=acl_proxies)](http://travis-ci.org/jalliot/symfony)
Fixes the following tickets: #2611, #2056, #2048, #2035 and probably others
Todo: -

Hi,

Here is a new attempt to fix all the issues related to Symfony ACL identities and Doctrine proxies.
It only fixes the issue for Doctrine >=2.2 (older versions of Doctrine will still not work properly with ACL because `Doctrine\Common\Util\ClassUtils` didn't exist before and proxy naming strategy was not consistent between all Doctrine implementations (ORM/ODM/etc.)).

This needs to be merged in `master` as well.

/cc @schmittjoh
