### PR TITLE
[Form] Fixed required value guessed by ValidatorTypeGuesser

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -260,6 +260,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * [BC BREAK] FormType::getParent() does not see default options anymore
  * [BC BREAK] The methods `add`, `remove`, `setParent`, `bind` and `setData`
    in class Form now throw an exception if the form is already bound
+ * fields of constrained classes without a NotBlank or NotNull constraint are
+   set to not required now, as stated in the docs
 
 ### HttpFoundation
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no*
Symfony2 tests pass: yes
Fixes the following tickets: #3661
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3661)

The documentation states that a field is set to required if constrained with NotBlank or NotNull and to not required otherwise. Due to a bug this was not the case and fields were always required. This is now fixed.

The consequence is that some fields that were required before by default are not required anymore. The only difference is that the HTML5 "required" attribute disappears, because server-side validation did not occur before anyway.
