### PR TITLE
[BrowserKit] Fixed CookieJar being unable to parse multiple cookies

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -96,7 +96,19 @@ class CookieJar
      */
     public function updateFromResponse(Response $response, $uri = null)
     {
+        $cookies = array();
+
         foreach ($response->getHeader('Set-Cookie', false) as $cookie) {
+            foreach (explode(',', $cookie) as $i => $part) {
+                if ($i==0 || preg_match('/^(?P<token>\s*[0-9A-Za-z!#\$%\&\'\*\+\-\.^_`\|~]+)=/', $part)) {
+                    $cookies[] = ltrim($part);
+                } else {
+                    $cookies[count($cookies)-1].= ','.$part;
+                }
+            }
+        }
+
+        foreach ($cookies as $cookie) {
             $this->set(Cookie::fromString($cookie, $uri));
         }
     }

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -100,10 +100,10 @@ class CookieJar
 
         foreach ($response->getHeader('Set-Cookie', false) as $cookie) {
             foreach (explode(',', $cookie) as $i => $part) {
-                if ($i==0 || preg_match('/^(?P<token>\s*[0-9A-Za-z!#\$%\&\'\*\+\-\.^_`\|~]+)=/', $part)) {
+                if (0 === $i || preg_match('/^(?P<token>\s*[0-9A-Za-z!#\$%\&\'\*\+\-\.^_`\|~]+)=/', $part)) {
                     $cookies[] = ltrim($part);
                 } else {
-                    $cookies[count($cookies)-1].= ','.$part;
+                    $cookies[count($cookies) - 1] .= ','.$part;
                 }
             }
         }

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -94,7 +94,7 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $barCookie->getValue());
         $this->assertEquals('id', $phpCookie->getValue());
         $this->assertEquals($timestamp, $fooCookie->getExpiresTime());
-        $this->assertEquals(null, $barCookie->getExpiresTime());
+        $this->assertNull($barCookie->getExpiresTime());
         $this->assertEquals($timestamp, $phpCookie->getExpiresTime());
     }
 

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -66,8 +66,36 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $cookieJar->set(new Cookie('bar', 'bar'));
         $cookieJar->updateFromResponse($response);
 
+        $this->assertInstanceOf('Symfony\Component\BrowserKit\Cookie', $cookieJar->get('foo'));
+        $this->assertInstanceOf('Symfony\Component\BrowserKit\Cookie', $cookieJar->get('bar'));
         $this->assertEquals('foo', $cookieJar->get('foo')->getValue(), '->updateFromResponse() updates cookies from a Response objects');
         $this->assertEquals('bar', $cookieJar->get('bar')->getValue(), '->updateFromResponse() keeps existing cookies');
+    }
+
+    public function testUpdateFromResponseWithMultipleCookies()
+    {
+        $timestamp = time() + 3600;
+        $date = gmdate('D, d M Y H:i:s \G\M\T', $timestamp);
+        $response = new Response('', 200, array(
+            'Set-Cookie' => sprintf('foo=foo; expires=%s; domain=.symfony.com; path=/, bar=bar; domain=.blog.symfony.com, PHPSESSID=id; expires=%s', $date, $date)
+        ));
+
+        $cookieJar = new CookieJar();
+        $cookieJar->updateFromResponse($response);
+
+        $fooCookie = $cookieJar->get('foo', '/', '.symfony.com');
+        $barCookie = $cookieJar->get('bar', '/', '.blog.symfony.com');
+        $phpCookie = $cookieJar->get('PHPSESSID');
+
+        $this->assertInstanceOf('Symfony\Component\BrowserKit\Cookie', $fooCookie);
+        $this->assertInstanceOf('Symfony\Component\BrowserKit\Cookie', $barCookie);
+        $this->assertInstanceOf('Symfony\Component\BrowserKit\Cookie', $phpCookie);
+        $this->assertEquals('foo', $fooCookie->getValue());
+        $this->assertEquals('bar', $barCookie->getValue());
+        $this->assertEquals('id', $phpCookie->getValue());
+        $this->assertEquals($timestamp, $fooCookie->getExpiresTime());
+        $this->assertEquals(null, $barCookie->getExpiresTime());
+        $this->assertEquals($timestamp, $phpCookie->getExpiresTime());
     }
 
     /**


### PR DESCRIPTION
Fix proposition for #3109

My fix splits value of _Set-Cookie_ header by comma. Than it checks each extracted part if it starts with a cookie-name (token). If check is positive cookie is added to the list. Otherwise it's appended to the previous value. First element is always added to the list.

[rfc6265](http://tools.ietf.org/html/rfc6265) defines cookie-name with token:

```
cookie-name = token
token = <token, defined in [RFC2616], Section 2.2>
```

token is defined in [rfc2616](http://tools.ietf.org/html/rfc2616#section-2.2) as follows:

```
token = 1*<any CHAR except CTLs or separators>
CHAR = <any US-ASCII character (octets 0 - 127)>
separators = "(" | ")" | "<" | ">" | "@"
              | "," | ";" | ":" | "\" | <">
              | "/" | "[" | "]" | "?" | "="
              | "{" | "}" | SP | HT
```

That means cookie-name can be built out of following set of characters: _! # $ % & ' \* + - . ^ _ ` | ~ 0-9 A-Z a-z_

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
