### PR TITLE
[2.2] [Form] Enhanced DateType with support for different widgets types per date part (year, month, day)

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -36,6 +36,36 @@ class DateTypeTest extends LocalizedTestCase
     /**
      * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
+    public function testInvalidWidgetDatePartOption()
+    {
+        $form = $this->factory->create('date', null, array(
+            'widget' => array('fake_widget_part' => 'input'),
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testInvalidWidgetDatePartWidgetOption()
+    {
+        $form = $this->factory->create('date', null, array(
+            'widget' => array('year' => 'fake_widget'),
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testInvalidWidgetDatePartSingleTextOption()
+    {
+        $form = $this->factory->create('date', null, array(
+            'widget' => array('month' => 'single_text'),
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
     public function testInvalidInputOption()
     {
         $form = $this->factory->create('date', null, array(
@@ -739,5 +769,75 @@ class DateTypeTest extends LocalizedTestCase
 
         $this->assertSame(array(), $form['day']->getErrors());
         $this->assertSame(array($error), $form->getErrors());
+    }
+
+    public function testSubmitFromYearChoiceAndMonthAndDayTextDateTime()
+    {
+        $form = $this->factory->create('date', null, array(
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
+            'widget' => array('year' => 'choice', 'day' => 'text', 'month' => 'text'),
+        ));
+
+        $text = array(
+            'day' => '2',
+            'month' => '6',
+            'year' => '2010',
+        );
+
+        $form->bind($text);
+
+        $dateTime = new \DateTime('2010-06-02 UTC');
+
+        $this->assertDateTimeEquals($dateTime, $form->getData());
+        $this->assertEquals($text, $form->getViewData());
+    }
+
+    public function testDayWidgetOptions()
+    {
+        $form = $this->factory->create('date', null, array(
+            'day_options' => array(
+                'attr' => array(
+                    'data-mask' => 'd'
+                )
+            )
+        ));
+
+        $view = $form->createView();
+        $attr = $view['day']->vars['attr'];
+
+        $this->assertEquals('d', $attr['data-mask']);
+    }
+
+    public function testMonthWidgetOptions()
+    {
+        $form = $this->factory->create('date', null, array(
+            'month_options' => array(
+                'attr' => array(
+                    'data-mask' => 'm'
+                )
+            )
+        ));
+
+        $view = $form->createView();
+        $attr = $view['month']->vars['attr'];
+
+        $this->assertEquals('m', $attr['data-mask']);
+    }
+
+    public function testYearWidgetOptions()
+    {
+        $form = $this->factory->create('date', null, array(
+            'year_options' => array(
+                'attr' => array(
+                    'data-mask' => 'y'
+                )
+            )
+        ));
+
+        $view = $form->createView();
+        $attr = $view['year']->vars['attr'];
+
+        $this->assertEquals('y', $attr['data-mask']);
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: ![Build status](https://secure.travis-ci.org/ruimarinho/symfony.png?branch=date_type)
Fixes the following tickets: #3490
Todo: discuss with @bschussek if it is possible to add support for padded dates per date type (not just globally, as it is now). 

The _DateType_ widget is incredibly powerful it offers developers a wealth of features and customization options. This PR builds on this work and adds some extra flexibility to this widget, without compromising BC:

**Features**:
- The `widget` option now accepts an array for `year`, `month` and `day` date parts, which allows you to have something like a `choice` widget for `month` and `text` widgets for `year` and `day`. It defaults to `choice` if any of those parts is missing when using the array format.
- Developers can now pass options for each of the date parts widgets - `year_options`, `month_options` and `day_options`. A typical use case is passing an attribute like `data-mask` to control user input client side using JavaScript masks. 
- Choose to pad dates or not - currently, dates are always displayed with the padded format (see issue #3490), although this behavior is not really consistent since the `DateTimeToArrayTransformer` defaults to not pad dates. What happens is that when using `choice` widgets, the value is casted to _int_ and it removes the padding, but the representation on the HTML still shows the padded date. This PR changes this by passing the correct padding option to the transform so that the output is either completely padded or not (both the `value` and its representation). This can be passed through the widget `options` option  (`padded`: _boolean_). 

Tests were added for these new features.
