### PR TITLE
Tweaked the exceptions layout CSS in order to display the error message even when wrapped around <pre> tags

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
@@ -76,6 +76,7 @@ build: 56
     padding: 5px 4px;
     list-style-type: decimal;
     margin-left: 20px;
+    white-space: break-word;
 }
 .sf-exceptionreset #logs .traces li.error {
     font-style: normal;
@@ -196,7 +197,7 @@ build: 56
     vertical-align: middle;
 }
 
-.sf-exceptionreset .linked ul, 
+.sf-exceptionreset .linked ul,
 .sf-exceptionreset .linked li {
     display: inline;
 }
@@ -210,16 +211,16 @@ build: 56
     padding: 10px 0;
 }
 .sf-exceptionreset ol li {
-    list-style: decimal; 
-    margin-left: 20px; 
+    list-style: decimal;
+    margin-left: 20px;
     padding: 2px;
     padding-bottom: 20px;
 }
 .sf-exceptionreset ol ol li {
-    list-style-position: inside; 
-    margin-left: 0; 
-    white-space: nowrap; 
-    font-size: 12px; 
+    list-style-position: inside;
+    margin-left: 0;
+    white-space: nowrap;
+    font-size: 12px;
     padding-bottom: 0;
 }
 .sf-exceptionreset li .selected {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception_layout.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception_layout.css
@@ -3,7 +3,7 @@ html {
 }
 
 body {
-    font: 11px Verdana, Arial, sans-serif; 
+    font: 11px Verdana, Arial, sans-serif;
     color: #333;
 }
 
@@ -53,15 +53,15 @@ img {
 }
 
 .search label {
-    line-height: 28px; 
+    line-height: 28px;
     vertical-align: middle;
 }
 
 .search input {
-    width: 188px; 
-    margin-right: 10px; 
-    font-size: 12px; 
-    border: 1px solid #dadada; 
+    width: 188px;
+    margin-right: 10px;
+    font-size: 12px;
+    border: 1px solid #dadada;
     background: #FFFFFF url(../images/input_bg.gif) repeat-x left top;
     padding: 5px 6px;
     color: #565656;
@@ -128,4 +128,9 @@ img {
 #content {
     width: 970px;
     margin: 0 auto;
+}
+
+pre {
+    white-space: normal;
+    font-family: Arial, Helvetica, sans-serif;
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: ![Build status](https://secure.travis-ci.org/ruimarinho/symfony.png?branch=exception_css_tweaks)
Fixes the following tickets: -
Todo: -

Ever been in a situation when you're debugging code wrapped around `<pre>` tags and that code throws an exception? If you're familiar with this screenshot, you have :-) ![Image](http://i.imgur.com/dwxdD.png) 

This PR is just a little tweak to the exceptions layout CSS in order to allow your to view the exception message. It also fixes a word break when messages are too long. ![Image 2](http://i.imgur.com/whxZv.png).

The build is currently failing due to an unmerged patch from the 2.0 branch.
