### PR TITLE
Slightly re-design the debugging toolbar.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -70,6 +70,13 @@ class RedirectController extends ContainerAware
             return new Response(null, 410);
         }
 
+        $statusCode = $permanent ? 301 : 302;
+
+        // redirect if the path is a full URL
+        if (parse_url($path, PHP_URL_SCHEME)) {
+            return new RedirectResponse($path, $statusCode);
+        }
+
         $request = $this->container->get('request');
         if (null === $scheme) {
             $scheme = $request->getScheme();
@@ -89,6 +96,6 @@ class RedirectController extends ContainerAware
 
         $url = $scheme.'://'.$request->getHost().$port.$request->getBaseUrl().$path.$qs;
 
-        return new RedirectResponse($url, $permanent ? 301 : 302);
+        return new RedirectResponse($url, $statusCode);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -92,15 +92,22 @@ class RedirectControllerTest extends TestCase
 
     public function testEmptyPath()
     {
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-
         $controller = new RedirectController();
-        $controller->setContainer($container);
-
         $returnResponse = $controller->urlRedirectAction('');
 
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
 
         $this->assertEquals(410, $returnResponse->getStatusCode());
+    }
+
+    public function testFullURL()
+    {
+        $controller = new RedirectController();
+        $returnResponse = $controller->urlRedirectAction('http://foo.bar/');
+
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
+
+        $this->assertEquals('http://foo.bar/', $returnResponse->headers->get('Location'));
+        $this->assertEquals(302, $returnResponse->getStatusCode());
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -62,7 +62,7 @@ class HttpDigestFactory implements SecurityFactoryInterface
             ->children()
                 ->scalarNode('provider')->end()
                 ->scalarNode('realm')->defaultValue('Secured Area')->end()
-                ->scalarNode('key')->cannotBeEmpty()->end()
+                ->scalarNode('key')->isRequired()->cannotBeEmpty()->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpDigestFactory.php
@@ -62,7 +62,7 @@ class HttpDigestFactory implements SecurityFactoryInterface
             ->children()
                 ->scalarNode('provider')->end()
                 ->scalarNode('realm')->defaultValue('Secured Area')->end()
-                ->scalarNode('key')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('key')->cannotBeEmpty()->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -48,7 +48,7 @@ $container->loadFromExtension('security', array(
         'simple' => array('pattern' => '/login', 'security' => false),
         'secure' => array('stateless' => true,
             'http_basic' => true,
-            'http_digest' => true,
+            'http_digest' => array('key' => 'TheKey'),
             'form_login' => true,
             'anonymous' => true,
             'switch_user' => true,

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -41,7 +41,7 @@
 
         <firewall name="secure" stateless="true">
             <http-basic />
-            <http-digest />
+            <http-digest key="TheKey" />
             <form-login />
             <anonymous />
             <switch-user />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -35,7 +35,8 @@ security:
         secure:
             stateless: true
             http_basic: true
-            http_digest: true
+            http_digest:
+                key: TheKey
             form_login: true
             anonymous: true
             switch_user: true

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/toolbar.css
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/toolbar.css
@@ -7,6 +7,10 @@ build: 56
 */
 .sf-toolbarreset div,.sf-toolbarreset dl,.sf-toolbarreset dt,.sf-toolbarreset dd,.sf-toolbarreset ul,.sf-toolbarreset ol,.sf-toolbarreset li,.sf-toolbarreset h1,.sf-toolbarreset h2,.sf-toolbarreset h3,.sf-toolbarreset h4,.sf-toolbarreset h5,.sf-toolbarreset h6,.sf-toolbarreset pre,.sf-toolbarreset code,.sf-toolbarreset form,.sf-toolbarreset fieldset,.sf-toolbarreset legend,.sf-toolbarreset input,.sf-toolbarreset textarea,.sf-toolbarreset p,.sf-toolbarreset blockquote,.sf-toolbarreset th,.sf-toolbarreset td{margin:0;padding:0;}.sf-toolbarreset table{border-collapse:collapse;border-spacing:0;}.sf-toolbarreset fieldset,.sf-toolbarreset img{border:0;}.sf-toolbarreset address,.sf-toolbarreset caption,.sf-toolbarreset cite,.sf-toolbarreset code,.sf-toolbarreset dfn,.sf-toolbarreset em,.sf-toolbarreset strong,.sf-toolbarreset th,.sf-toolbarreset var{font-style:normal;font-weight:normal;}.sf-toolbarreset li{list-style:none;}.sf-toolbarreset caption,.sf-toolbarreset th{text-align:left;}.sf-toolbarreset h1,.sf-toolbarreset h2,.sf-toolbarreset h3,.sf-toolbarreset h4,.sf-toolbarreset h5,.sf-toolbarreset h6{font-size:100%;font-weight:normal;}.sf-toolbarreset q:before,.sf-toolbarreset q:after{content:'';}.sf-toolbarreset abbr,.sf-toolbarreset acronym{border:0;font-variant:normal;}.sf-toolbarreset sup{vertical-align:text-top;}.sf-toolbarreset sub{vertical-align:text-bottom;}.sf-toolbarreset input,.sf-toolbarreset textarea,.sf-toolbarreset select{font-family:inherit;font-size:inherit;font-weight:inherit;}.sf-toolbarreset input,.sf-toolbarreset textarea,.sf-toolbarreset select{*font-size:100%;}.sf-toolbarreset legend{color:#000;}
 
+/*
+Style for the toolbar in the profiler page.
+*/
+
 .sf-toolbarreset {
     background: #cbcbcb;
     background-image: -moz-linear-gradient(-90deg, #e8e8e8, #cbcbcb);
@@ -20,9 +24,70 @@ build: 56
     margin: 0;
     font: 11px Verdana, Arial, sans-serif;
     color: #000;
+    min-height: 38px;
 }
 
 .sf-toolbarreset abbr {
     border-bottom: 1px dotted #000000;
     cursor: help;
+}
+
+.sf-toolbar-block {
+    float: left;
+    white-space: nowrap;
+    color: #2f2f2f;
+    display: inline-block;
+    min-height: 24px;
+    min-width: 28px;
+    text-align: center;
+    border-right: 1px solid #cdcdcd;
+    padding: 5px 4px;
+}
+        
+.sf-toolbar-block img {
+    border-width: 0;
+    vertical-align: middle;
+    margin: 0;
+    padding: 0;
+}
+        
+.sf-toolbar-block-info {
+    -moz-transition: all ease 200ms;
+    -webkit-transition: all ease 200ms;
+    margin-left: -5px;
+    top: 38px;
+    display: none;
+    padding: 10px;
+    position: absolute;
+    background-color: rgba(255, 255, 255, 0.95);
+    border-left: 1px solid #000;
+    border-bottom: 1px solid #cdcdcd;
+    border-right: 1px solid #cdcdcd;
+}
+        
+.sf-toolbar-block-info a, .sf-toolbar-block-info a:link {
+    color: #215498;
+}
+        
+.sf-toolbar-block-info-delimiter {
+    margin: 0 2px;
+    padding: 0;
+    color: #ccc;
+}
+        
+.sf-toolbar-block-icon {
+    text-decoration: none;
+    margin: 0;
+    padding: 0;
+    display: inline-block;
+}
+        
+.sf-toolbar-block:hover {
+    background-color: #fff;
+    border-left: 1px solid #000;
+    margin-left: -1px;
+}
+        
+.sf-toolbar-block:hover .sf-toolbar-block-info {
+    display: block;
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -23,6 +23,7 @@
                     font-family: 'Georgia', serif;
                     font-style: italic;
                     cursor: default;
+                    overflow:hidden;
                 ">P</div>
                 <span class="sf-toolbar-block-info">
                     <span>PHP {{ collector.phpversion }}</span>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -9,35 +9,54 @@
     {% if verbose %}
         {% set text %}
             {% spaceless %}
-                <span>PHP {{ collector.phpversion }}</span>
-                <span style="margin: 0; padding: 0; color: #979696;">|</span>
-                <span style="color: {{ collector.hasxdebug ? '#759e1a' : '#a33' }}">xdebug</span>
-                <span style="margin: 0; padding: 0; color: #979696">|</span>
-                <span style="color: {{ collector.hasaccelerator ? '#759e1a' : '#a33' }}">accel</span>
+                <div style="
+                    text-align:center;
+                    width:28px; 
+                    height:26px;
+                    padding-top: 2px;
+                    background-color:#2f2f2f;
+                    border-radius:14px;
+                    display:inline-block;
+                    color: #fff;
+                    font-weight:400;
+                    font-size: 18px;
+                    font-family: 'Georgia', serif;
+                    font-style: italic;
+                    cursor: default;
+                ">P</div>
+                <span class="sf-toolbar-block-info">
+                    <span>PHP {{ collector.phpversion }}</span>
+                    <span class="sf-toolbar-block-info-delimiter">|</span>
+                    <span style="color: {{ collector.hasxdebug ? '#759e1a' : '#a33' }}">xdebug</span>
+                    <span class="sf-toolbar-block-info-delimiter">|</span>
+                    <span style="color: {{ collector.hasaccelerator ? '#759e1a' : '#a33' }}">accel</span>
+                </span>
             {% endspaceless %}
         {% endset %}
         {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false, 'icon': '' } %}
     {% endif %}
 
     {% set icon %}
-        <img width="21" height="28" alt="Environment" style="border-width: 0; vertical-align: middle; margin-right: 5px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAcCAYAAACOGPReAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAZNJREFUeNpi/P//PwO1ARMDDcCooWDA4+npeRiEQWw0NTweHh4nQZhYORYoLf39+3cbGBuIbyJplPnx44cZjA3ENwjJwQzljoqKOghjo7lGBAcbBLiA+g7B2DBBRqCXj3/79s0CRSUX14lt27a5AplfgNgBCPaDxA8cOOAIokBe9fLy2o1LHxO6BAhAxWTwxIUMPn0seDTCvPotLi7uJIyNIxhQ9OEzVADoRZSgWbRo0UmoF1vx6GPBl06l8XhRmtzEL0KmHF5DWcmUo1E21dLSeo0uCBX7jUffb3z6GIGFdC2QYXPp0iVw4Ovp6T0FUkeA+BUw0c/AZiIwE2QAKTEc+laBktQqIL6al5e3FqqhDsQHYhU8Ln0CzVnY9D1hghYeD5E0PISKfcDjxQ949H2FJX5eJEkY+820adMm4/DiGzz6GFgIeBFX0DzBF/swQ/8oKCi8h7Gh9FeodzikpKSeQ8XuopW12PQxMEKraE0gDoSKrQfi60gaSZaDGQqqCiShks+h5Si8yiBVjnFkNyYAAgwAQGPBFLF65f4AAAAASUVORK5CYII="/>
+        <img width="21" height="28" alt="Environment" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABUAAAAcCAYAAACOGPReAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAZNJREFUeNpi/P//PwO1ARMDDcCooWDA4+npeRiEQWw0NTweHh4nQZhYORYoLf39+3cbGBuIbyJplPnx44cZjA3ENwjJwQzljoqKOghjo7lGBAcbBLiA+g7B2DBBRqCXj3/79s0CRSUX14lt27a5AplfgNgBCPaDxA8cOOAIokBe9fLy2o1LHxO6BAhAxWTwxIUMPn0seDTCvPotLi7uJIyNIxhQ9OEzVADoRZSgWbRo0UmoF1vx6GPBl06l8XhRmtzEL0KmHF5DWcmUo1E21dLSeo0uCBX7jUffb3z6GIGFdC2QYXPp0iVw4Ovp6T0FUkeA+BUw0c/AZiIwE2QAKTEc+laBktQqIL6al5e3FqqhDsQHYhU8Ln0CzVnY9D1hghYeD5E0PISKfcDjxQ949H2FJX5eJEkY+820adMm4/DiGzz6GFgIeBFX0DzBF/swQ/8oKCi8h7Gh9FeodzikpKSeQ8XuopW12PQxMEKraE0gDoSKrQfi60gaSZaDGQqqCiShks+h5Si8yiBVjnFkNyYAAgwAQGPBFLF65f4AAAAASUVORK5CYII="/>
     {% endset %}
     {% set text %}
         {% spaceless %}
-            {% if verbose %}
-                <span>{{ collector.appname }}</span>
-                <span style="margin: 0; padding: 0; color: #979696;">|</span>
-                <span>{{ collector.env }}</span>
-                <span style="margin: 0; padding: 0; color: #979696;">|</span>
-                <span>{{ collector.debug ? 'debug' : 'no-debug' }}</span>
-                <span style="margin: 0; padding: 0; color: #979696;">|</span>
-            {% endif %}
-            <span>
-                {% if profiler_url %}
-                    <a style="color: #2f2f2f" href="{{ profiler_url }}">{{ collector.token }}</a>
-                {% else %}
-                    {{ collector.token }}
+            <span class="sf-toolbar-block-info">
+                {% if verbose %}
+                    <span>{{ collector.appname }}</span>
+                    <span class="sf-toolbar-block-info-delimiter">|</span>
+                    <span>{{ collector.env }}</span>
+                    <span class="sf-toolbar-block-info-delimiter">|</span>
+                    <span>{{ collector.debug ? 'debug' : 'no-debug' }}</span>
+                    <span class="sf-toolbar-block-info-delimiter">|</span>
                 {% endif %}
+                <span>
+                    {% if profiler_url %}
+                        <a href="{{ profiler_url }}">{{ collector.token }}</a>
+                    {% else %}
+                        {{ collector.token }}
+                    {% endif %}
+                </span>
             </span>
         {% endspaceless %}
     {% endset %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/memory.html.twig
@@ -2,10 +2,10 @@
 
 {% block toolbar %}
     {% set icon %}
-        <img width="13" height="28" alt="Memory Usage" style="vertical-align: middle; margin-right: 5px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAcCAYAAAC6YTVCAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAJBJREFUeNpi/P//PwOpgImBDDAcNbE4ODiAg+/AgQOC586d+4BLoZGRkQBQ7Xt0mxQIWKCAzXkCBDQJDEBAIHOKiooicSkEBtTz0WQ0xFI5Mqevr285HrUOMAajvb09ySULk5+f3w1SNIDUMwKLsAIg256IrAECoEx6EKQJlLkkgJiDCE0/gPgF4+AuLAECDAAolCeEmdURAgAAAABJRU5ErkJggg=="/>
+        <img width="13" height="28" alt="Memory Usage" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAAcCAYAAAC6YTVCAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAJBJREFUeNpi/P//PwOpgImBDDAcNbE4ODiAg+/AgQOC586d+4BLoZGRkQBQ7Xt0mxQIWKCAzXkCBDQJDEBAIHOKiooicSkEBtTz0WQ0xFI5Mqevr285HrUOMAajvb09ySULk5+f3w1SNIDUMwKLsAIg256IrAECoEx6EKQJlLkkgJiDCE0/gPgF4+AuLAECDAAolCeEmdURAgAAAABJRU5ErkJggg=="/>
     {% endset %}
     {% set text %}
-        {{ '%.0f'|format(collector.memory / 1024) }} KB
+        <span class="sf-toolbar-block-info">{{ '%.0f'|format(collector.memory / 1024) }} KB</span>
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false } %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -2,23 +2,25 @@
 
 {% block toolbar %}
     {% set icon %}
-        <img width="28" height="28" alt="Request" style="border-width: 0; vertical-align: middle; margin-right: 5px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABOZJREFUeNrsVmsspFcY9jHMMsxKE9sxM1SUNHRpSNR9bbQqrrNUCG1E1z3ZyIpq+dEfIiToRtomEiFi/zQrWdlZFFstDYK632ZRu2yxFNu4GzOY6fPKN80YVu1m41dP8uac75zz3t/3OR+jVqv1LnLo613wuHCFnJcdTExM8LOzs+9vb28HaPZMTU1bSkpKohwcHDbPI3xwcPBMhUx+fv6V4eHhG0KhsMfd3V2srYwGfQ8MDPiWlZUtYHjZ2dlJYcBfOFK/qof6YHTs7OxsUigU4rW1tQNjY+NHpzGMjo6my2SyQJVKxcH6mzt37gRmZWXJcKQ6j0IGVcpUV1e/W1NT0y6Xyy1fNScwbCkmJuZaQkLCU11PTwspFc0lhPHW6yijQXzET3LOG9JLYWFhywiTan9//1jVisVilbe3946FhYVieXmZ297ezsN87I6hoaEqODj4BatQfh6FKlipCA8Pf1ZbW2urOQgICNjKzMxsNzExofxQVZrHx8c7FRQUXOvp6THW3CM+GCo/dw4lEsnP6+vrx6rRxsZGWVlZWcHhcH7a2tpaKCwsdElOTpbZ2tqKNjc3I5KSkj5fWVk51lLm5ubNUqk0CsudM3O4sbHxke6mj4/PYyirr6urm4+MjPy1u7v7bkpKyi9VVVV/8/l8qa+v71NdHsj5BJPwP0OKKj2BNmhwCuPs2NiYBOGyoL2DgwPzycnJT7G8y+Vyn2B+T5uHlUN3pzV7rq6uJz3EONG0s7OzXEyHKKZ1Ho93cGQZh6MODQ1dof3FxUXDUwSRHOPY2NjoiIiI22R3XFzcFyEhIT9ibfKvh6jCuY6Ojne0mYEmPsgV19nZ+Y/S0tIHQ0NDHo6OjqNOTk4j8JKP3Hyoq5DkUNEyDHMTwBEI427v7u6KDAwMFNgXgGY0jf/1/Py8pKGh4X00P18jwMrKqjE3N/dLKBJTh4CWR0ZGloqKir6Hhz6ae1FRUZsovMcI+RByzjQ1NcXv7e2ZaBuDtpIhNf2BgYFfkULHxsbGzwBROYeHh/o6KLKAy40I6zJwVLi6uhoKYW9r34EHqpycnO9aWlquA+pccK7n6em5nZqa+ufMzAwfcoU7OzsGkLWOar9Opf28q6tLoKuMRRHx3NxcyllVR3y9vb3CtLS0uoyMjKsU1vT09GZra+s2tJcFKjwVxliiX0ddXFz0SYkB+moQL4T8daBNIBDsARAGkC8F4TLtwYBZTA9Bj2DwUdG1tbU5jI+Pc0ihHJaMFRcXP0Tejg5R9nqJiYmnGkD7dE5DJBIdIGTEN15eXv4xQncEBhUVFbdQod9GR0f/MDU1ZUV7CDWvv7/fnmGtegvkBYbI1tZWLzc3t+dAGDXQxV9XIYS1mpmZMX19fSI/P7/fAQT3sT2pVCo94cHN+vr6D+DNZW2evLy8J7hbj+U9DvukrIE6URwv0HtNWO8iVJYeHh5XgZtXNIz4XrG3t7+H5RLu8TDPkzKQ0sjIqA+NzkxPT6dCoUdQUNAagUFzc/NlROQ33Kml1mC0/trIUyOWCIhtQDdAniAei5HdICnoGfu0KVlSsw+BAD0Yir6V+Pv7L5AcGMCBkTXkEDnCnPGbSL0kYuHKiBW8SlVNjC/hoeRas3zbhIisIcRzhFLMG/4vZVgFBqwyFRsJleb5Yv7/EX7T4x8BBgDTTU7fbnA/yAAAAABJRU5ErkJggg=="/>
+        <img width="28" height="28" alt="Request" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAYAAAByDd+UAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAABOZJREFUeNrsVmsspFcY9jHMMsxKE9sxM1SUNHRpSNR9bbQqrrNUCG1E1z3ZyIpq+dEfIiToRtomEiFi/zQrWdlZFFstDYK632ZRu2yxFNu4GzOY6fPKN80YVu1m41dP8uac75zz3t/3OR+jVqv1LnLo613wuHCFnJcdTExM8LOzs+9vb28HaPZMTU1bSkpKohwcHDbPI3xwcPBMhUx+fv6V4eHhG0KhsMfd3V2srYwGfQ8MDPiWlZUtYHjZ2dlJYcBfOFK/qof6YHTs7OxsUigU4rW1tQNjY+NHpzGMjo6my2SyQJVKxcH6mzt37gRmZWXJcKQ6j0IGVcpUV1e/W1NT0y6Xyy1fNScwbCkmJuZaQkLCU11PTwspFc0lhPHW6yijQXzET3LOG9JLYWFhywiTan9//1jVisVilbe3946FhYVieXmZ297ezsN87I6hoaEqODj4BatQfh6FKlipCA8Pf1ZbW2urOQgICNjKzMxsNzExofxQVZrHx8c7FRQUXOvp6THW3CM+GCo/dw4lEsnP6+vrx6rRxsZGWVlZWcHhcH7a2tpaKCwsdElOTpbZ2tqKNjc3I5KSkj5fWVk51lLm5ubNUqk0CsudM3O4sbHxke6mj4/PYyirr6urm4+MjPy1u7v7bkpKyi9VVVV/8/l8qa+v71NdHsj5BJPwP0OKKj2BNmhwCuPs2NiYBOGyoL2DgwPzycnJT7G8y+Vyn2B+T5uHlUN3pzV7rq6uJz3EONG0s7OzXEyHKKZ1Ho93cGQZh6MODQ1dof3FxUXDUwSRHOPY2NjoiIiI22R3XFzcFyEhIT9ibfKvh6jCuY6Ojne0mYEmPsgV19nZ+Y/S0tIHQ0NDHo6OjqNOTk4j8JKP3Hyoq5DkUNEyDHMTwBEI427v7u6KDAwMFNgXgGY0jf/1/Py8pKGh4X00P18jwMrKqjE3N/dLKBJTh4CWR0ZGloqKir6Hhz6ae1FRUZsovMcI+RByzjQ1NcXv7e2ZaBuDtpIhNf2BgYFfkULHxsbGzwBROYeHh/o6KLKAy40I6zJwVLi6uhoKYW9r34EHqpycnO9aWlquA+pccK7n6em5nZqa+ufMzAwfcoU7OzsGkLWOar9Opf28q6tLoKuMRRHx3NxcyllVR3y9vb3CtLS0uoyMjKsU1vT09GZra+s2tJcFKjwVxliiX0ddXFz0SYkB+moQL4T8daBNIBDsARAGkC8F4TLtwYBZTA9Bj2DwUdG1tbU5jI+Pc0ihHJaMFRcXP0Tejg5R9nqJiYmnGkD7dE5DJBIdIGTEN15eXv4xQncEBhUVFbdQod9GR0f/MDU1ZUV7CDWvv7/fnmGtegvkBYbI1tZWLzc3t+dAGDXQxV9XIYS1mpmZMX19fSI/P7/fAQT3sT2pVCo94cHN+vr6D+DNZW2evLy8J7hbj+U9DvukrIE6URwv0HtNWO8iVJYeHh5XgZtXNIz4XrG3t7+H5RLu8TDPkzKQ0sjIqA+NzkxPT6dCoUdQUNAagUFzc/NlROQ33Kml1mC0/trIUyOWCIhtQDdAniAei5HdICnoGfu0KVlSsw+BAD0Yir6V+Pv7L5AcGMCBkTXkEDnCnPGbSL0kYuHKiBW8SlVNjC/hoeRas3zbhIisIcRzhFLMG/4vZVgFBqwyFRsJleb5Yv7/EX7T4x8BBgDTTU7fbnA/yAAAAABJRU5ErkJggg=="/>
     {% endset %}
     {% set text %}
+        <span class="sf-toolbar-block-info">
         {% spaceless %}
             {% if collector.controller.class is defined %}
                 <span>{{ collector.controller.class|abbr_class }}</span>
                 <span>::</span>
                 {% set link = collector.controller.file|file_link(collector.controller.line) %}
-                <span>{% if link %}<a style="color: #2f2f2f" href="{{ link }}">{{ collector.controller.method }}</a>{% else %}{{ collector.controller.method }}{% endif %}</span>
+                <span>{% if link %}<a href="{{ link }}">{{ collector.controller.method }}</a>{% else %}{{ collector.controller.method }}{% endif %}</span>
             {% else %}
                 <span>{{ collector.controller }}</span>
             {% endif %}
-            <span style="margin: 0; padding: 0; color: #979696;">|</span>
+            <span class="sf-toolbar-block-info-delimiter">|</span>
             <span{{ not collector.route ? ' style="color:#a33"' : '' }}>{{ collector.route ? collector.route : 'NONE' }}</span>
-            <span style="margin: 0; padding: 0; color: #979696;">|</span>
-            <span style="color: {{ 200 == collector.statuscode ? '#759e1a' : '#a33' }}">{{ collector.statuscode }}</span>
+            <span class="sf-toolbar-block-info-delimiter">|</span>
+            <span style="font-weight: 700; color: {{ 200 == collector.statuscode ? '#759e1a' : '#a33' }}">{{ collector.statuscode }}</span>
         {% endspaceless %}
+        </span>
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/timer.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/timer.html.twig
@@ -2,10 +2,10 @@
 
 {% block toolbar %}
     {% set icon %}
-        <img width="16" height="28" alt="Timers" style="vertical-align: middle; margin-right: 5px;" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAcCAYAAABoMT8aAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAiNJREFUeNpi/P//PwMlgImBQjDwBrCcO3cOq0RRUdF3ZH5fXx8nTVzAePbsWcq8gMwxMjJiSUlJcXv9+nXm169fbf78+SMAVsTC8paXl3ePmJjYjJkzZx4GevsviheAGhmBguL+/v4779y5s/Xjx48+MM0gAGQLv3//PvzmzZv7AwMD19y+fVsEpAfsBWBCYly8eLHcsmXLjnz//l2GGGcDXXM1IyPD2dvb+xXIBTwbN25chU3zgQMHwBgdfP78WXvp0qVzgUwuprq6utg3b96YkRp4z549854wYYI7071791LJjYFLly7lM7148UKHXAOALtdnAYYwCyGFyOHg4OAAZ3/69ImfopTIzMz8j4WVlfXf79+/sRqEbBs2wMfH94tJXV39DbkuUFFReclkb29/jlwDPD09jzGFhoZu0NTU/EKqZktLyzdOTk7bQX4/U1tbu1pcXPwvsZoVFBR+lZeXLwUyz4MMuCMlJbWmv79/o56e3k9Cms3MzL5PmjRphYCAwCYg9wE4MwEZwkBsDsReO3fudN+zZ4/shQsX2ICxA9bEzs7OYGBg8NPHx+eBra3tdqDQVpDLgfgjuEABZk2QS3hBAQvExkBsAHIpMAsLAOP6PzC63gP590FOBmJQCXQPiL8Ai4D/KCUS0CBWIAUqB8SAWAiIQeUgqOIAlY/vgPgVEH8AavyDtUQCSoDc/BqEoQUGLIH9A9mGtUwc8JoJIMAAS9XemfR7crQAAAAASUVORK5CYII="/>
+        <img width="16" height="28" alt="Timers" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAcCAYAAABoMT8aAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAiNJREFUeNpi/P//PwMlgImBQjDwBrCcO3cOq0RRUdF3ZH5fXx8nTVzAePbsWcq8gMwxMjJiSUlJcXv9+nXm169fbf78+SMAVsTC8paXl3ePmJjYjJkzZx4GevsviheAGhmBguL+/v4779y5s/Xjx48+MM0gAGQLv3//PvzmzZv7AwMD19y+fVsEpAfsBWBCYly8eLHcsmXLjnz//l2GGGcDXXM1IyPD2dvb+xXIBTwbN25chU3zgQMHwBgdfP78WXvp0qVzgUwuprq6utg3b96YkRp4z549854wYYI7071791LJjYFLly7lM7148UKHXAOALtdnAYYwCyGFyOHg4OAAZ3/69ImfopTIzMz8j4WVlfXf79+/sRqEbBs2wMfH94tJXV39DbkuUFFReclkb29/jlwDPD09jzGFhoZu0NTU/EKqZktLyzdOTk7bQX4/U1tbu1pcXPwvsZoVFBR+lZeXLwUyz4MMuCMlJbWmv79/o56e3k9Cms3MzL5PmjRphYCAwCYg9wE4MwEZwkBsDsReO3fudN+zZ4/shQsX2ICxA9bEzs7OYGBg8NPHx+eBra3tdqDQVpDLgfgjuEABZk2QS3hBAQvExkBsAHIpMAsLAOP6PzC63gP590FOBmJQCXQPiL8Ai4D/KCUS0CBWIAUqB8SAWAiIQeUgqOIAlY/vgPgVEH8AavyDtUQCSoDc/BqEoQUGLIH9A9mGtUwc8JoJIMAAS9XemfR7crQAAAAASUVORK5CYII="/>
     {% endset %}
     {% set text %}
-        {{ '%.0f'|format(collector.time * 1000) }} ms
+        <span class="sf-toolbar-block-info">{{ '%.0f'|format(collector.time * 1000) }} ms</span>
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false } %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,16 +1,15 @@
 <!-- START of Symfony2 Web Debug Toolbar -->
 {% if 'normal' != position %}
-    <div style="clear: both; height: 40px;"></div>
-{% endif %}
-
-<div class="sf-toolbarreset"
-    {% if 'normal' != position %}
-    style="position: {{ position }};
-        background-color: #f7f7f7;
+    <style type="text/css">
+        .sf-toolbarreset {
+            -moz-transition: all ease 200ms;
+            -webkit-transition: all ease 200ms;
+            position: {{ position }};
+            background-color: #f7f7f7;
             background-image: -moz-linear-gradient(-90deg, #e4e4e4, #ffffff);
             background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#e4e4e4), to(#ffffff));
-            bottom: 0;
-            left:0;
+            bottom: 0px;
+            left:95%;
             margin:0;
             padding: 0;
             z-index: 6000000;
@@ -18,9 +17,28 @@
             border-top: 1px solid #bbb;
             font: 11px Verdana, Arial, sans-serif;
             text-align: left;
-            color: #2f2f2f;"
-    {% endif %}
->
+            color: #2f2f2f;
+            border-left: 1px solid #bbb;
+        }
+
+        .sf-toolbarreset:hover {
+            left: 0;
+        }
+
+        /*
+        .sf-toolbarreset a[href$="request"] ~ span {
+            display: inline-block;
+            overflow: hidden;
+            max-width: 70px;
+            text-overflow: ellipsis;
+            border-left: 0px;
+        }
+        */
+    </style>
+    <div style="clear: both; height: 40px;"></div>
+{% endif %}
+
+<div class="sf-toolbarreset">
 
     <span style="display: inline-block; min-height: 24px; width: 40px; float: right;">&nbsp;</span>
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,6 +1,10 @@
 <!-- START of Symfony2 Web Debug Toolbar -->
 {% if 'normal' != position %}
     <style type="text/css">
+        /*
+        Style for the embedded toolbar
+        */
+        
         .sf-toolbarreset {
             -moz-transition: all ease 200ms;
             -webkit-transition: all ease 200ms;
@@ -19,21 +23,73 @@
             text-align: left;
             color: #2f2f2f;
             border-left: 1px solid #bbb;
+            opacity: 0.4;
         }
 
         .sf-toolbarreset:hover {
-            left: 0;
+            opacity: 1;
+            box-shadow: rgba(0,0,0,0.2) 0 0 10px;
         }
-
-        /*
-        .sf-toolbarreset a[href$="request"] ~ span {
+        
+        .sf-toolbar-block {
+            float: left;
+            white-space: nowrap;
+            color: #2f2f2f;
             display: inline-block;
-            overflow: hidden;
-            max-width: 70px;
-            text-overflow: ellipsis;
-            border-left: 0px;
+            min-height: 24px;
+            min-width: 28px;
+            text-align: center;
+            border-right: 1px solid #cdcdcd;
+            padding: 5px 4px;
         }
-        */
+        
+        .sf-toolbar-block img {
+            border-width: 0;
+            vertical-align: middle;
+            margin: 0;
+            padding: 0;
+        }
+        
+        .sf-toolbar-block-info {
+            -moz-transition: all ease 200ms;
+            -webkit-transition: all ease 200ms;
+            margin-left: -5px;
+            bottom: 38px;
+            display: none;
+            padding: 10px;
+            position: absolute;
+            background-color: rgba(255, 255, 255, 0.95);
+            border-left: 1px solid #000;
+            border-top: 1px solid #cdcdcd;
+            border-right: 1px solid #cdcdcd;
+        }
+        
+        .sf-toolbar-block-info a, .sf-toolbar-block-info a:link {
+            color: #215498;
+        }
+        
+        .sf-toolbar-block-info-delimiter {
+            margin: 0 2px;
+            padding: 0;
+            color: #ccc;
+        }
+        
+        .sf-toolbar-block-icon {
+            text-decoration: none;
+            margin: 0;
+            padding: 0;
+            display: inline-block;
+        }
+        
+        .sf-toolbar-block:hover {
+            background-color: #fff;
+            border-left: 1px solid #000;
+            margin-left: -1px;
+        }
+        
+        .sf-toolbar-block:hover .sf-toolbar-block-info {
+            display: block;
+        }
     </style>
     <div style="clear: both; height: 40px;"></div>
 {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -9,7 +9,7 @@
             background-image: -moz-linear-gradient(-90deg, #e4e4e4, #ffffff);
             background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#e4e4e4), to(#ffffff));
             bottom: 0px;
-            left:95%;
+            left: 0;
             margin:0;
             padding: 0;
             z-index: 6000000;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_item.html.twig
@@ -1,9 +1,9 @@
 {% if link %}
     {% set icon %}
-        <a style="text-decoration: none; margin: 0; padding: 0;" href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">{{ icon }}</a>
+        <a class="sf-toolbar-block-icon" href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">{{ icon }}</a>
     {% endset %}
 {% endif %}
-<span style="white-space:nowrap; color:#2f2f2f; display:inline-block; min-height:24px; border-right:1px solid #cdcdcd; padding:5px 7px 5px 4px; ">
+<span class="sf-toolbar-block">
      {{ icon|default('') }}
      {{ text|default('') }}
 </span>

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -734,7 +734,7 @@ class Application
             $title = sprintf('  [%s]  ', get_class($e));
             $len = $strlen($title);
             $lines = array();
-            foreach (explode("\n", $e->getMessage()) as $line) {
+            foreach (preg_split("{\r?\n}", $e->getMessage()) as $line) {
                 $lines[] = sprintf('  %s  ', $line);
                 $len = max($strlen($line) + 4, $len);
             }

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -789,6 +789,11 @@ class Application
         }
     }
 
+    /**
+     * Tries to figure out the terminal width in which this application runs
+     *
+     * @return int|null
+     */
     protected function getTerminalWidth()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD') && $ansicon = getenv('ANSICON')) {
@@ -800,6 +805,11 @@ class Application
         }
     }
 
+    /**
+     * Tries to figure out the terminal height in which this application runs
+     *
+     * @return int|null
+     */
     protected function getTerminalHeight()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD') && $ansicon = getenv('ANSICON')) {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -196,7 +196,8 @@ class YamlFileLoader extends FileLoader
 
         if (isset($service['calls'])) {
             foreach ($service['calls'] as $call) {
-                $definition->addMethodCall($call[0], $this->resolveServices($call[1]));
+                $args = isset($call[1]) ? $this->resolveServices($call[1]) : array();
+                $definition->addMethodCall($call[0], $args);
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -28,7 +28,7 @@ class ServerBag extends ParameterBag
             }
             // CONTENT_* are not prefixed with HTTP_
             elseif (in_array($key, array('CONTENT_LENGTH', 'CONTENT_MD5', 'CONTENT_TYPE'))) {
-                $headers[$key] = $this->parameters[$key];
+                $headers[$key] = $value;
             }
         }
 

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -95,7 +95,7 @@ class RouteCollection implements \IteratorAggregate
     public function add($name, Route $route)
     {
         if (!preg_match('/^[a-z0-9A-Z_.]+$/', $name)) {
-            throw new \InvalidArgumentException(sprintf('The provided route name "%s" contains non valid characters. A route name must only contain digits (0-9), letters (A-Z), underscores (_) and dots (.).', $name));
+            throw new \InvalidArgumentException(sprintf('The provided route name "%s" contains non valid characters. A route name must only contain digits (0-9), letters (a-z and A-Z), underscores (_) and dots (.).', $name));
         }
 
         $parent = $this;

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -95,7 +95,7 @@ class RouteCollection implements \IteratorAggregate
     public function add($name, Route $route)
     {
         if (!preg_match('/^[a-z0-9A-Z_.]+$/', $name)) {
-            throw new \InvalidArgumentException(sprintf('Name "%s" contains non valid characters for a route name.', $name));
+            throw new \InvalidArgumentException(sprintf('The provided route name "%s" contains non valid characters. A route name must only contain digits (0-9), letters (A-Z), underscores (_) and dots (.).', $name));
         }
 
         $parent = $this;

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -37,7 +37,7 @@ class ContextListener implements ListenerInterface
     private $logger;
     private $userProviders;
 
-    public function __construct(SecurityContext $context, array $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(SecurityContextInterface $context, array $userProviders, $contextKey, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         if (empty($contextKey)) {
             throw new \InvalidArgumentException('$contextKey must not be empty.');

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -6,7 +6,7 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\SecurityContext;
+use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\RememberMe\RememberMeServicesInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
@@ -37,13 +37,13 @@ class RememberMeListener implements ListenerInterface
     /**
      * Constructor
      *
-     * @param SecurityContext                $securityContext
+     * @param SecurityContextInterface       $securityContext
      * @param RememberMeServicesInterface    $rememberMeServices
      * @param AuthenticationManagerInterface $authenticationManager
      * @param LoggerInterface                $logger
      * @param EventDispatcherInterface       $dispatcher
      */
-    public function __construct(SecurityContext $securityContext, RememberMeServicesInterface $rememberMeServices, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
+    public function __construct(SecurityContextInterface $securityContext, RememberMeServicesInterface $rememberMeServices, AuthenticationManagerInterface $authenticationManager, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->securityContext = $securityContext;
         $this->rememberMeServices = $rememberMeServices;

--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -10,12 +10,12 @@ translated strings from these including support for pluralization.
 
     $translator = new Translator('fr_FR', new MessageSelector());
     $translator->setFallbackLocale('fr');
-    $translator->addLoader('array', return new ArrayLoader());
+    $translator->addLoader('array', new ArrayLoader());
     $translator->addResource('array', array(
         'Hello World!' => 'Bonjour',
     ), 'fr');
 
-    $translator->trans('Hello World!');
+    echo $translator->trans('Hello World!') . "\n";
 
 Resources
 ---------

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -201,8 +201,11 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function testSetCatchExceptions()
     {
-        $application = new Application();
+        $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
         $application->setAutoExit(false);
+        $application->expects($this->any())
+            ->method('getTerminalWidth')
+            ->will($this->returnValue(120));
         $tester = new ApplicationTester($application);
 
         $application->setCatchExceptions(true);
@@ -237,8 +240,11 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     public function testRenderException()
     {
-        $application = new Application();
+        $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
         $application->setAutoExit(false);
+        $application->expects($this->any())
+            ->method('getTerminalWidth')
+            ->will($this->returnValue(120));
         $tester = new ApplicationTester($application);
 
         $tester->run(array('command' => 'foo'), array('decorated' => false));

--- a/tests/Symfony/Tests/Component/Console/ApplicationTest.php
+++ b/tests/Symfony/Tests/Component/Console/ApplicationTest.php
@@ -255,6 +255,15 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $tester->run(array('command' => 'foo3:bar'), array('decorated' => false));
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception3.txt', $this->normalize($tester->getDisplay()), '->renderException() renders a pretty exceptions with previous exceptions');
 
+        $application = $this->getMock('Symfony\Component\Console\Application', array('getTerminalWidth'));
+        $application->setAutoExit(false);
+        $application->expects($this->any())
+            ->method('getTerminalWidth')
+            ->will($this->returnValue(32));
+        $tester = new ApplicationTester($application);
+
+        $tester->run(array('command' => 'foo'), array('decorated' => false));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_renderexception4.txt', $this->normalize($tester->getDisplay()), '->renderException() wraps messages when they are bigger than the terminal');
     }
 
     public function testRun()

--- a/tests/Symfony/Tests/Component/Console/Fixtures/application_renderexception4.txt
+++ b/tests/Symfony/Tests/Component/Console/Fixtures/application_renderexception4.txt
@@ -1,0 +1,9 @@
+
+
+                               
+  [InvalidArgumentException]   
+  Command "foo" is not define  
+  d.                           
+                               
+
+

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services6.yml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/services6.yml
@@ -14,6 +14,7 @@ services:
     class: FooClass
     calls:
       - [ setBar, [] ]
+      - [ setBar ]
   method_call2:
     class: FooClass
     calls:

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
@@ -113,7 +113,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('sc_configure', $services['configurator1']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array(new Reference('baz'), 'configure'), $services['configurator2']->getConfigurator(), '->load() parses the configurator tag');
         $this->assertEquals(array('BazClass', 'configureStatic'), $services['configurator3']->getConfigurator(), '->load() parses the configurator tag');
-        $this->assertEquals(array(array('setBar', array())), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
+        $this->assertEquals(array(array('setBar', array()), array('setBar', array())), $services['method_call1']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
 


### PR DESCRIPTION
The toolbar is very useful and containing lots of information. However, as there are too much information, it is very distracting and the toolbar area somehow ends up taking too much space.

The main purpose of this pull request is to hide any information and show only whenever the user wants to see.

Additionally, the CSS is partially re-organized when we embed the toolbar on each responded page.
