### PR TITLE
[Filesystem] Prevented infinite loop on windows while mirrorring symlinks

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -229,12 +229,12 @@ class Filesystem
         }
 
         foreach ($iterator as $file) {
-            $target = $targetDir.'/'.str_replace($originDir.DIRECTORY_SEPARATOR, '', $file->getPathname());
+            $target = str_replace($originDir, $targetDir, $file->getPathname());
 
-            if (is_link($file)) {
-                $this->symlink($file, $target);
-            } elseif (is_dir($file)) {
+            if (is_dir($file)) {
                 $this->mkdir($target);
+            } elseif (!$copyOnWindows && is_link($file)) {
+                $this->symlink($file, $target);
             } elseif (is_file($file) || ($copyOnWindows && is_link($file))) {
                 $this->copy($file, $target, isset($options['override']) ? $options['override'] : false);
             } else {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -483,6 +483,25 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertFileEquals($file2, $targetPath.'file2');
     }
 
+    public function testMirrorCopiesLinks()
+    {
+        $this->markAsSkippeIfSymlinkIsMissing();
+
+        $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
+
+        mkdir($sourcePath);
+        file_put_contents($sourcePath.'file1', 'FILE1');
+        symlink($sourcePath.'file1', $sourcePath.'link1');
+
+        $targetPath = $this->workspace.DIRECTORY_SEPARATOR.'target'.DIRECTORY_SEPARATOR;
+
+        $this->filesystem->mirror($sourcePath, $targetPath);
+
+        $this->assertTrue(is_dir($targetPath));
+        $this->assertFileEquals($sourcePath.'file1', $targetPath.DIRECTORY_SEPARATOR.'link1');
+        $this->assertTrue(is_link($targetPath.DIRECTORY_SEPARATOR.'link1'));
+    }
+
     /**
      * @dataProvider providePathsForIsAbsolutePath
      */


### PR DESCRIPTION
First check for filetype in _mirror()_ method is:

```
if (is_link($file)) {
    $this->symlink($file, $target);
```

later we see:

```
} elseif (is_file($file) || ($copyOnWindows && is_link($file))) {
    $this->copy($file, $target, isset($options['override']) ? $options['override'] : false);
```

The later check for links on windows (_$copyOnWindows && is_link($file)_) won't ever get called. Calling _symlink()_ in _mirror()_ on windows would lead to calling _mirror()_ again. 

Note that I didn't actually try running it on windows platform. I added a test for mirroring symlinks (non-windows test). I think it'd be good if someone added some windows specific tests to this class.

I also modified the target path:

```
$target = $targetDir.'/'.str_replace($originDir.DIRECTORY_SEPARATOR, '', $file->getPathname());
```

It didn't use DIRECTORY_SEPARATOR and is equivalent to:

```
$target = str_replace($originDir, $targetDir, $file->getPathname());
```

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
