### PR TITLE
[Form] Add option with_minutes to the DateTimeType & TimeType

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -148,7 +148,7 @@
         {{ block('form_widget_simple') }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
-            {{ form_widget(form.hour, { 'attr': { 'size': '1' } }) }}:{{ form_widget(form.minute, { 'attr': { 'size': '1' } }) }}{% if with_seconds %}:{{ form_widget(form.second, { 'attr': { 'size': '1' } }) }}{% endif %}
+            {{ form_widget(form.hour, { 'attr': { 'size': '1' } }) }}{% if with_minutes %}:{{ form_widget(form.minute, { 'attr': { 'size': '1' } }) }}{% endif %}{% if with_seconds %}:{{ form_widget(form.second, { 'attr': { 'size': '1' } }) }}{% endif %}
         </div>
     {% endif %}
 {% endspaceless %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/time_widget.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/time_widget.html.php
@@ -6,8 +6,11 @@
             // There should be no spaces between the colons and the widgets, that's why
             // this block is written in a single PHP tag
             echo $view['form']->widget($form['hour'], array('attr' => array('size' => 1)));
-            echo ':';
-            echo $view['form']->widget($form['minute'], array('attr' => array('size' => 1)));
+
+            if ($with_minutes) {
+                echo ':';
+                echo $view['form']->widget($form['minute'], array('attr' => array('size' => 1)));
+            }
 
             if ($with_seconds) {
                 echo ':';

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -69,9 +69,14 @@ class DateTimeType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $parts = array('year', 'month', 'day', 'hour', 'minute');
+        $parts = array('year', 'month', 'day', 'hour');
         $dateParts = array('year', 'month', 'day');
-        $timeParts = array('hour', 'minute');
+        $timeParts = array('hour');
+
+        if ($options['with_minutes']) {
+            $parts[] = 'minute';
+            $timeParts[] = 'minute';
+        }
 
         if ($options['with_seconds']) {
             $parts[] = 'second';
@@ -118,6 +123,7 @@ class DateTimeType extends AbstractType
                 'hours',
                 'minutes',
                 'seconds',
+                'with_minutes',
                 'with_seconds',
                 'empty_value',
                 'required',
@@ -223,6 +229,7 @@ class DateTimeType extends AbstractType
             'widget'         => null,
             'date_widget'    => $dateWidget,
             'time_widget'    => $timeWidget,
+            'with_minutes'   => true,
             'with_seconds'   => false,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -94,6 +94,35 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals($dateTime->format('U'), $form->getData());
     }
 
+    public function testSubmit_withoutMinutes()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'date_widget' => 'choice',
+            'time_widget' => 'choice',
+            'input' => 'datetime',
+            'with_minutes' => false,
+        ));
+
+        $form->setData(new \DateTime('2010-06-02 03:04:05 UTC'));
+
+        $input = array(
+            'date' => array(
+                'day' => '2',
+                'month' => '6',
+                'year' => '2010',
+            ),
+            'time' => array(
+                'hour' => '3',
+            ),
+        );
+
+        $form->bind($input);
+
+        $this->assertDateTimeEquals(new \DateTime('2010-06-02 03:00:00 UTC'), $form->getData());
+    }
+
     public function testSubmit_withSeconds()
     {
         $form = $this->factory->create('datetime', null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -111,6 +111,22 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
+    public function testSubmit_datetimeSingleTextWithoutMinutes()
+    {
+        $form = $this->factory->create('time', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'input' => 'datetime',
+            'widget' => 'single_text',
+            'with_minutes' => false,
+        ));
+
+        $form->bind('03');
+
+        $this->assertEquals(new \DateTime('1970-01-01 03:00:00 UTC'), $form->getData());
+        $this->assertEquals('03', $form->getViewData());
+    }
+
     public function testSubmit_arraySingleText()
     {
         $form = $this->factory->create('time', null, array(
@@ -129,6 +145,26 @@ class TimeTypeTest extends LocalizedTestCase
 
         $this->assertEquals($data, $form->getData());
         $this->assertEquals('03:04', $form->getViewData());
+    }
+
+    public function testSubmit_arraySingleTextWithoutMinutes()
+    {
+        $form = $this->factory->create('time', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'input' => 'array',
+            'widget' => 'single_text',
+            'with_minutes' => false,
+        ));
+
+        $data = array(
+            'hour' => '3',
+        );
+
+        $form->bind('03');
+
+        $this->assertEquals($data, $form->getData());
+        $this->assertEquals('03', $form->getViewData());
     }
 
     public function testSubmit_arraySingleTextWithSeconds()
@@ -166,6 +202,36 @@ class TimeTypeTest extends LocalizedTestCase
 
         $this->assertEquals('03:04:00', $form->getData());
         $this->assertEquals('03:04', $form->getViewData());
+    }
+
+    public function testSubmit_stringSingleTextWithoutMinutes()
+    {
+        $form = $this->factory->create('time', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'input' => 'string',
+            'widget' => 'single_text',
+            'with_minutes' => false,
+        ));
+
+        $form->bind('03');
+
+        $this->assertEquals('03:00:00', $form->getData());
+        $this->assertEquals('03', $form->getViewData());
+    }
+
+    public function testSetData_withoutMinutes()
+    {
+        $form = $this->factory->create('time', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'input' => 'datetime',
+            'with_minutes' => false,
+        ));
+
+        $form->setData(new \DateTime('03:04:05 UTC'));
+
+        $this->assertEquals(array('hour' => 3), $form->getClientData());
     }
 
     public function testSetData_withSeconds()
@@ -560,5 +626,16 @@ class TimeTypeTest extends LocalizedTestCase
 
         $this->assertSame(array(), $form['second']->getErrors());
         $this->assertSame(array($error), $form->getErrors());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\InvalidConfigurationException
+     */
+    public function testInitializeWithSecondsAndWithoutMinutes()
+    {
+        $this->factory->create('time', null, array(
+            'with_minutes' => false,
+            'with_seconds' => true,
+        ));
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Fixes the following tickets: -
Todo: -

Hey,

One of my project requires the datetime usage only with hours. I have submit a patch allowing to disable minutes like seconds are disabled.
