### PR TITLE
[Filesystem] rename() throws RuntimeException on error.

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -128,6 +128,7 @@ class Filesystem
      * @param string $target  The new filename
      *
      * @throws \RuntimeException When target file already exists
+     * @throws \RuntimeException When origin cannot be renamed
      */
     public function rename($origin, $target)
     {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -136,7 +136,9 @@ class Filesystem
             throw new \RuntimeException(sprintf('Cannot rename because the target "%s" already exist.', $target));
         }
 
-        rename($origin, $target);
+        if (false === rename($origin, $target)) {
+            throw new \RuntimeException(sprintf('Cannot rename "%s" to "%s".', $origin, $target));
+        }
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -137,7 +137,7 @@ class Filesystem
             throw new \RuntimeException(sprintf('Cannot rename because the target "%s" already exist.', $target));
         }
 
-        if (false === rename($origin, $target)) {
+        if (false === @rename($origin, $target)) {
             throw new \RuntimeException(sprintf('Cannot rename "%s" to "%s".', $origin, $target));
         }
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -379,6 +379,17 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->filesystem->rename($file, $newPath);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testRenameThrowsExceptionOnError()
+    {
+        $file = $this->workspace.DIRECTORY_SEPARATOR.uniqid();
+        $newPath = $this->workspace.DIRECTORY_SEPARATOR.'new_file';
+
+        $this->filesystem->rename($file, $newPath);
+    }
+
     public function testSymlink()
     {
         $this->markAsSkippeIfSymlinkIsMissing();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3848
