### PR TITLE
removed `param_converter` from symfony-1.0.xsd

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -42,10 +42,6 @@
         <xsd:attribute name="enabled" type="xsd:boolean" />
     </xsd:complexType>
 
-    <xsd:complexType name="param_converter">
-        <xsd:attribute name="enabled" type="xsd:boolean" />
-    </xsd:complexType>
-
     <xsd:complexType name="profiler">
         <xsd:all>
             <xsd:element name="matcher" type="profiler_matcher" minOccurs="0" maxOccurs="1" />


### PR DESCRIPTION
I think its a relict of the SensioFrameworkExtraBundle?
