### PR TITLE
[2.2][Console] default command

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -56,7 +56,7 @@ class Application
     private $autoExit;
     private $definition;
     private $helperSet;
-
+    private $defaultCommandName = null;
     /**
      * Constructor.
      *
@@ -81,6 +81,30 @@ class Application
     }
 
     /**
+     * Sets the name of the default command, this command will be executed if
+     * no command is provided in the CLI arguments
+     * @param String $command
+     */
+    public function setDefaultCommandName($command)
+    {
+        if (!is_string($command)) {
+            throw new \UnexpectedValueException('Default Command Name must be a String');
+        }
+        $this->defaultCommandName = $command;
+    }
+
+    /**
+     * gets the name of the default command, this command will be executed if
+     * no command is provided in the CLI arguments
+
+     * @return String
+     */
+    public function getDefaultCommandName()
+    {
+        return $this->defaultCommandName ;
+    }
+
+    /**
      * Runs the current application.
      *
      * @param InputInterface  $input  An Input instance
@@ -96,6 +120,15 @@ class Application
     {
         if (null === $input) {
             $input = new ArgvInput();
+            // if we have a default command and we can not decide which command
+            // to execute we execute the default one
+            if (! is_null($this->getDefaultcommandName())) {
+                if (! $this->has($this->getCommandName($input))) {
+                    $argv = $_SERVER['argv'];
+                    array_splice($argv, 1, 0, $this->getDefaultcommandName());
+                    $input = new ArgvInput($argv);
+                }
+            }
         }
 
         if (null === $output) {

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -427,6 +427,27 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Tests the run() with the default command set
+     */
+    public function testRun_defaultCommand()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        $application->add($command = new \Foo1Command());
+        $application->setDefaultCommandName('foo:bar1');
+        $_SERVER['argv'] = array('cli.php');
+
+        ob_start();
+        $application->run();
+        ob_end_clean();
+
+        $this->assertSame('Symfony\Component\Console\Input\ArgvInput', get_class($command->input), '->run() creates an ArgvInput by default if none is given');
+        $this->assertSame('Symfony\Component\Console\Output\ConsoleOutput', get_class($command->output), '->run() creates a ConsoleOutput by default if none is given');
+
+    }
+
+    /**
      * @expectedException \LogicException
      * @dataProvider getAddingAlreadySetDefinitionElementData
      */
@@ -453,5 +474,21 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             array(new InputOption('quiet', '', InputOption::VALUE_NONE)),
             array(new InputOption('query', 'q', InputOption::VALUE_NONE)),
         );
+    }
+
+    public function testSetGetDefaultCommandName()
+    {
+        $application = new Application();
+        $application->setDefaultCommandName('foo');
+        $this->assertEquals('foo', $application->getDefaultCommandName());
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    public function testSetGetDefaultCommandName_InvalidParameter()
+    {
+        $application = new Application();
+        $application->setDefaultCommandName(new \stdClass);
     }
 }


### PR DESCRIPTION
For stand alone applications passing a command is mandatory but most of the times not really necessary

So instead of calling my application like this `/myapp.php mycommand --my_option` I can just write `./myapp.php --my_option`

this PR allows for it while allowing to add (and execute) more than one command

You just need to add `$app->setDefaultCommandName('command:name');` and if the command is not found the default one will be executed

includes unit tests and does not breack BC

it is the same as https://github.com/symfony/Console/pull/2, but I did the pull request on the wrong repository
