### PR TITLE
[Form] Fixed display of [Date]TimeType when displayed as "single_text" and "with_seconds" is false

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -263,6 +263,8 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
    in class Form now throw an exception if the form is already bound
  * fields of constrained classes without a NotBlank or NotNull constraint are
    set to not required now, as stated in the docs
+ * fixed TimeType and DateTimeType to not display seconds when "widget" is
+   "single_text" unless "with_seconds" is set to true
 
 ### HttpFoundation
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -32,7 +32,7 @@ class DateTimeType extends AbstractType
         $parts = array('year', 'month', 'day', 'hour', 'minute');
         $timeParts = array('hour', 'minute');
 
-        $format = 'Y-m-d H:i:00';
+        $format = 'Y-m-d H:i';
         if ($options['with_seconds']) {
             $format = 'Y-m-d H:i:s';
 
@@ -102,7 +102,7 @@ class DateTimeType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], $format)
+                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'])
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -29,7 +29,7 @@ class TimeType extends AbstractType
     public function buildForm(FormBuilder $builder, array $options)
     {
         $parts  = array('hour', 'minute');
-        $format = 'H:i:00';
+        $format = 'H:i';
         if ($options['with_seconds']) {
             $format  = 'H:i:s';
             $parts[] = 'second';
@@ -108,7 +108,7 @@ class TimeType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], $format)
+                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], 'H:i:s')
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->appendNormTransformer(new ReversedTransformer(

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -950,7 +950,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
             [@type="text"]
             [@id="name_time"]
             [@name="name[time]"]
-            [@value="04:05:00"]
+            [@value="04:05"]
     ]
 '
         );
@@ -967,7 +967,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 '/input
     [@type="text"]
     [@name="name"]
-    [@value="2011-02-03 04:05:00"]
+    [@value="2011-02-03 04:05"]
 '
         );
     }
@@ -985,7 +985,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 '/input
     [@type="text"]
     [@name="name"]
-    [@value="2011-02-03 04:05:00"]
+    [@value="2011-02-03 04:05"]
 '
         );
     }
@@ -1583,7 +1583,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 '/input
     [@type="text"]
     [@name="name"]
-    [@value="04:05:00"]
+    [@value="04:05"]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -173,7 +173,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $outputTime->setTimezone(new \DateTimeZone('America/New_York'));
 
         $this->assertDateTimeEquals($outputTime, $form->getData());
-        $this->assertEquals('2010-06-02 03:04:00', $form->getClientData());
+        $this->assertEquals('2010-06-02 03:04', $form->getClientData());
     }
 
     public function testSubmit_stringSingleText()
@@ -188,7 +188,23 @@ class DateTimeTypeTest extends LocalizedTestCase
         $form->bind('2010-06-02 03:04:05');
 
         $this->assertEquals('2010-06-02 03:04:00', $form->getData());
-        $this->assertEquals('2010-06-02 03:04:00', $form->getClientData());
+        $this->assertEquals('2010-06-02 03:04', $form->getClientData());
+    }
+
+    public function testSubmit_stringSingleText_withSeconds()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'input' => 'string',
+            'widget' => 'single_text',
+            'with_seconds' => true,
+        ));
+
+        $form->bind('2010-06-02 03:04:05');
+
+        $this->assertEquals('2010-06-02 03:04:05', $form->getData());
+        $this->assertEquals('2010-06-02 03:04:05', $form->getClientData());
     }
 
     public function testSubmit_differentPattern()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -107,7 +107,7 @@ class TimeTypeTest extends LocalizedTestCase
         $form->bind('03:04:05');
 
         $this->assertEquals(new \DateTime('03:04:00 UTC'), $form->getData());
-        $this->assertEquals('03:04:00', $form->getClientData());
+        $this->assertEquals('03:04', $form->getClientData());
     }
 
     public function testSubmit_arraySingleText()
@@ -127,7 +127,7 @@ class TimeTypeTest extends LocalizedTestCase
         $form->bind('03:04');
 
         $this->assertEquals($data, $form->getData());
-        $this->assertEquals('03:04:00', $form->getClientData());
+        $this->assertEquals('03:04', $form->getClientData());
     }
 
     public function testSubmit_arraySingleTextWithSeconds()
@@ -164,7 +164,7 @@ class TimeTypeTest extends LocalizedTestCase
         $form->bind('03:04:05');
 
         $this->assertEquals('03:04:00', $form->getData());
-        $this->assertEquals('03:04:00', $form->getClientData());
+        $this->assertEquals('03:04', $form->getClientData());
     }
 
     public function testSetData_withSeconds()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3278
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue3278)
