### PR TITLE
[2.0] Router: make $container a protected property

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class Router extends BaseRouter
 {
-    private $container;
+    protected $container;
 
     /**
      * Constructor.


### PR DESCRIPTION
I am extending Symfony\Bundle\FrameworkBundle\Routing\Router and need to access $container (currently private).
