### PR TITLE
[2.2] [Routing] Check for trusted hosts when generating absolute URL

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -54,44 +54,4 @@ class Router extends BaseRouter
 
         return $this->collection;
     }
-
-    /*
-     * Validate "Host" (untrusted user input)
-     *
-     * @param string $host           Contents of Host: header from Request
-     * @param array  $trustedDomains An array of trusted domains
-     *
-     * @return boolean True if valid; false otherwise
-     */
-    public function isValidHost($host, $trustedDomains)
-    {
-        // Only punctuation we allow is '[', ']', ':', '.' and '-'
-        $hostLength = function_exists('mb_orig_strlen') ? mb_orig_strlen($host) : strlen($host);
-        if ($hostLength !== strcspn($host, '`~!@#$%^&*()_+={}\\|;"\'<>,?/ ')) {
-            return false;
-        }
-
-        $untrustedHost = function_exists('mb_strtolower') ? mb_strtolower($host) : strtolower($host);
-        $domainRegex   = str_replace('.', '\.', '/(^|.)' . implode('|', $trustedDomains) . '(:[0-9]+)?$/');
-
-        return 0 !== preg_match($domainRegex, rtrim($untrustedHost, '.'));
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function generate($name, $parameters = array(), $absolute = false)
-    {
-        if (!$absolute) {
-            return $this->getGenerator()->generate($name, $parameters, $absolute);
-        }
-
-        $validRoute = !isset($this->container)
-                   || $this->isValidHost($this->context->getHost(), $this->container->getParameter('trusted_domains'));
-        if ($validRoute) {
-            return $this->getGenerator()->generate($name, $parameters, $absolute);
-        }
-
-        throw new RouteNotFoundException(sprintf('The "%s" route requires a valid host.', $name));
-    }
 }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -204,10 +204,10 @@ class Router implements RouterInterface
      */
     public function generate($name, $parameters = array(), $absolute = false)
     {
-        $validRoute = !$absolute
-                   || !$this->options['trusted_hosts']
-                   || $this->isValidHost($this->context->getHost(), $this->options['trusted_hosts']);
-        if ($validRoute) {
+        if (!$absolute
+            || !$this->options['trusted_hosts']
+            || $this->isValidHost($this->context->getHost(), $this->options['trusted_hosts']
+        ) {
             return $this->getGenerator()->generate($name, $parameters, $absolute);
         }
 

--- a/tests/Symfony/Tests/Component/Routing/RouterTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouterTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Routing;
+
+use Symfony\Component\Routing\Router;
+
+class RouterTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsValidHost()
+    {
+        $testData = array(
+            // $expected, $host, $trustedDomains, $description
+            array(true, 'example.com', array('example.com'), 'Naked domain'),
+            array(true, 'stof.example.com', array('stof.example.com'), 'Fully qualified domain name'),
+            array(true, 'stof.example.com', array('example.com'), 'Valid subdomain'),
+            array(false, 'example.net', array('example.com'), 'Invalid domain'),
+            array(false, '.example.com', array('stof.example.com'), 'Invalid subdomain'),
+            array(false, 'example-com', array('example.com'), 'Regex should match . literally'),
+            array(false, 'www.attacker.com?example.com', array('example.com'), 'Spoofed host'),
+            array(false, 'example.com.attacker.com', array('example.com'), 'Spoofed subdomain'),
+            array(true, 'example.com.', array('example.com'), 'Trailing . on host is actually valid'),
+            array(true, 'www-dev.example.com', array('example.com'), 'host with dashes is valid'),
+            array(true, 'www.example.com:8080', array('example.com'), 'host:port is valid'),
+        );
+ 
+        $router = new Router($this->getMock('Symfony\Component\Config\Loader\LoaderInterface'), null);
+ 
+        foreach ($testData as $test)
+        {
+            list($expected, $host, $trustedDomains, $description) = $test;
+ 
+            $this->assertEquals($expected, $router->isValidHost($host, $trustedDomains), $description);
+        }
+    }
+}

--- a/tests/Symfony/Tests/Component/Routing/RouterTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouterTest.php
@@ -34,8 +34,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
  
         $router = new Router($this->getMock('Symfony\Component\Config\Loader\LoaderInterface'), null);
  
-        foreach ($testData as $test)
-        {
+        foreach ($testData as $test) {
             list($expected, $host, $trustedDomains, $description) = $test;
  
             $this->assertEquals($expected, $router->isValidHost($host, $trustedDomains), $description);


### PR DESCRIPTION
The Host: request header should be considered untrusted given that Apache lets many characters through.
