### PR TITLE
[Form] Added all() method to the FormBuilder class

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -644,6 +644,16 @@ class FormBuilder
     }
 
     /**
+     * Returns the children.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return $this->children;
+    }
+
+    /**
      * Creates the form.
      *
      * @return Form The form

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -110,6 +110,22 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->builder->has('foo'));
     }
 
+    public function testAll()
+    {
+        $this->assertEquals(0, count($this->builder->all()));
+        $this->assertFalse($this->builder->has('foo'));
+
+        $this->builder->add('foo', 'text');
+        $children = $this->builder->all();
+
+        $this->assertTrue($this->builder->has('foo'));
+        $this->assertEquals(1, count($children));
+        $this->assertArrayHasKey('foo', $children);
+
+        $foo = $children['foo'];
+        $this->assertEquals('text', $foo['type']);
+    }
+
     public function testAddFormType()
     {
         $this->assertFalse($this->builder->has('foo'));

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -112,14 +112,14 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testAll()
     {
-        $this->assertEquals(0, count($this->builder->all()));
+        $this->assertCount(0, $this->builder->all());
         $this->assertFalse($this->builder->has('foo'));
 
         $this->builder->add('foo', 'text');
         $children = $this->builder->all();
 
         $this->assertTrue($this->builder->has('foo'));
-        $this->assertEquals(1, count($children));
+        $this->assertCount(1, $children);
         $this->assertArrayHasKey('foo', $children);
 
         $foo = $children['foo'];


### PR DESCRIPTION
In order to perform some introspection on a FormBuilder instance,
we need to be able to get its children. Almost everything is accessible
in this class, but the children are not.

This PR adds a all() method to respect the current API (get(), remove(),
...).
