### PR TITLE
[2.2] [FrameworkBundle][Translation] Added logging capability to translator

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -337,6 +337,7 @@ class Configuration implements ConfigurationInterface
                     ->treatTrueLike(array('enabled' => true))
                     ->children()
                         ->booleanNode('enabled')->defaultTrue()->end()
+                        ->booleanNode('enable_logging')->defaultFalse()->end()
                         ->scalarNode('fallback')->defaultValue('en')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -337,7 +337,7 @@ class Configuration implements ConfigurationInterface
                     ->treatTrueLike(array('enabled' => true))
                     ->children()
                         ->booleanNode('enabled')->defaultTrue()->end()
-                        ->booleanNode('enable_logging')->defaultFalse()->end()
+                        ->booleanNode('logging')->defaultFalse()->end()
                         ->scalarNode('fallback')->defaultValue('en')->end()
                     ->end()
                 ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -549,6 +549,10 @@ class FrameworkExtension extends Extension
                     $translator->addMethodCall('addResource', array($format, (string) $file, $locale, $domain));
                 }
             }
+
+            if ($config['enable_logging']) {
+                $translator->addMethodCall('setLogger', array(new Reference('logger')));
+            }
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -550,7 +550,7 @@ class FrameworkExtension extends Extension
                 }
             }
 
-            if ($config['enable_logging']) {
+            if ($config['logging']) {
                 $translator->addMethodCall('setLogger', array(new Reference('logger')));
             }
         }

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -125,7 +125,9 @@ class Translator implements TranslatorInterface
             $this->loadCatalogue($locale);
         }
 
-        return strtr($this->catalogues[$locale]->get((string) $id, $domain), $parameters);
+        $catalogue = $this->validateCatalogueForId($this->catalogues[$locale], $id, $domain);
+
+        return strtr($catalogue->get((string) $id, $domain), $parameters);
     }
 
     /**
@@ -145,7 +147,7 @@ class Translator implements TranslatorInterface
 
         $id = (string) $id;
 
-        $catalogue = $this->catalogues[$locale];
+        $catalogue = $this->validateCatalogueForId($this->catalogues[$locale], $id, $domain);
         while (!$catalogue->defines($id, $domain)) {
             if ($cat = $catalogue->getFallbackCatalogue()) {
                 $catalogue = $cat;
@@ -156,6 +158,20 @@ class Translator implements TranslatorInterface
         }
 
         return strtr($this->selector->choose($catalogue->get($id, $domain), (int) $number, $locale), $parameters);
+    }
+
+    /**
+     * Extension point for handling catalogue misses or fallbacks.
+     *
+     * @param MessageCatalogueInterface $catalogue
+     * @param string $id
+     * @param string $domain
+     * @return MessageCatalogueInterface
+     */
+    protected function validateCatalogueForId(MessageCatalogueInterface $catalogue, $id, $domain)
+    {
+        // by default, do nothing
+        return $catalogue;
     }
 
     protected function loadCatalogue($locale)


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3015
Todo: -

Adds logging capabilities to `Symfony\Bundle\FrameworkBundle\Translation\Translator`. Logging is switchable through the new `logging` config flag and defaults to `false`.

A minor addition to the Translation Component was necessary to avoid complete duplication of `trans()`and `transChoice()`.
