### PR TITLE
[Validator] Added range constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ *
+ * @api
+ */
+class Range extends Constraint
+{
+    public $minMessage = 'This value should be {{ min }} or more';
+    public $maxMessage = 'This value should be {{ max }} or less';
+    public $invalidMessage = 'This value should be a valid number';
+    public $min;
+    public $max;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRequiredOptions()
+    {
+        return array('min', 'max');
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @api
+ */
+class RangeValidator extends ConstraintValidator
+{
+    /**
+     * Checks if the passed value is valid.
+     *
+     * @param mixed      $value      The value that should be validated
+     * @param Constraint $constraint The constraint for the validation
+     *
+     * @return Boolean Whether or not the value is valid
+     *
+     * @api
+     */
+    public function isValid($value, Constraint $constraint)
+    {
+        if (null === $value) {
+            return true;
+        }
+
+        // checks if the value is numeric
+        if (!is_numeric($value)) {
+            $this->context->addViolation($constraint->invalidMessage, array(
+                '{{ value }}' => $value,
+                '{{ min }}'   => $constraint->min,
+                '{{ max }}'   => $constraint->max,
+            ));
+
+            return false;
+        }
+
+        // checks min limit
+        if ($value < $constraint->min) {
+            $this->context->addViolation($constraint->minMessage, array(
+                '{{ value }}' => $value,
+                '{{ min }}'   => $constraint->min,
+                '{{ max }}'   => $constraint->max,
+            ));
+
+            return false;
+        }
+
+        // checks max limit
+        if ($value > $constraint->max) {
+            $this->context->addViolation($constraint->maxMessage, array(
+                '{{ value }}' => $value,
+                '{{ min }}'   => $constraint->min,
+                '{{ max }}'   => $constraint->max,
+            ));
+
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
When using the Min and Max constraints in combination and a non-numeric value is submitted, both show an "invalid" message at the same time.

Another approach that I can see could be making their type validation optional, ignoring every non-numeric value when asked to, but this would change their current API, and I don't think it's a smart move for something so critical as validation.

This new Constraint works around that by creating a combined min/max constraint without changing their existing API and also simplifying the configuration by reducing the number of annotations needed to perform this validation.
