### PR TITLE
[FrameworkBundle] Make session save path configurable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -181,6 +181,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('gc_divisor')->end()
                         ->scalarNode('gc_probability')->end()
                         ->scalarNode('gc_maxlifetime')->end()
+                        ->scalarNode('save_path')->defaultValue('%kernel.cache_dir%/sessions')->end()
                         ->scalarNode('lifetime')->setInfo('DEPRECATED! Please use: cookie_lifetime')->end()
                         ->scalarNode('path')->setInfo('DEPRECATED! Please use: cookie_path')->end()
                         ->scalarNode('domain')->setInfo('DEPRECATED! Please use: cookie_domain')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -313,6 +313,8 @@ class FrameworkExtension extends Extension
         // session handler (the internal callback registered with PHP session management)
         $container->setAlias('session.handler', $config['handler_id']);
 
+        $container->setParameter('session.save_path', $config['save_path']);
+
         $this->addClassesToCompile(array(
             'Symfony\\Bundle\\FrameworkBundle\\EventListener\\SessionListener',
             'Symfony\\Component\\HttpFoundation\\Session\\Storage\\SessionStorageInterface',

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -89,6 +89,7 @@
         <xsd:attribute name="gc-maxlifetime" type="xsd:string" />
         <xsd:attribute name="gc-divisor" type="xsd:string" />
         <xsd:attribute name="gc-probability" type="xsd:string" />
+        <xsd:attribute name="save-path" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="templating">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -35,7 +35,7 @@
         </service>
 
         <service id="session.handler.native_file" class="%session.handler.native_file.class%" public="false">
-            <argument>%kernel.cache_dir%/sessions</argument>
+            <argument>%session.save_path%</argument>
         </service>
 
         <service id="session_listener" class="%session_listener.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -31,6 +31,7 @@ $container->loadFromExtension('framework', array(
         'gc_maxlifetime' => 90000,
         'gc_divisor'     => 108,
         'gc_probability' => 1,
+        'save_path'      => '/path/to/sessions',
     ),
     'templating' => array(
         'assets_version'   => 'SomeVersionScheme',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -12,7 +12,7 @@
         <framework:esi enabled="true" />
         <framework:profiler only-exceptions="true" />
         <framework:router resource="%kernel.root_dir%/config/routing.xml" type="xml" />
-        <framework:session auto-start="true" gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-id="session.storage.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="true" />
+        <framework:session auto-start="true" gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-id="session.storage.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="true" save-path="/path/to/sessions" />
         <framework:templating assets-version="SomeVersionScheme" cache="/path/to/cache" >
             <framework:loader>loader.foo</framework:loader>
             <framework:loader>loader.bar</framework:loader>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -25,6 +25,7 @@ framework:
         gc_probability: 1
         gc_divisor:     108
         gc_maxlifetime: 90000
+        save_path:      /path/to/sessions
     templating:
         assets_version:   SomeVersionScheme
         assets_base_urls: http://cdn.example.com

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -91,6 +91,8 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertEquals(108, $options['gc_divisor']);
         $this->assertEquals(1, $options['gc_probability']);
         $this->assertEquals(90000, $options['gc_maxlifetime']);
+
+        $this->assertEquals('/path/to/sessions', $container->getParameter('session.save_path'));
     }
 
     public function testSessionDeprecatedMergeFull()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=configurable-session-save-path)](http://travis-ci.org/asm89/symfony)

Makes it possible to configure the session save path. It still defaults to saving sessions in the kernel cache dir. This might not be appropriate if you want to keep your user sessions after deploying your application.

As promised to @fabpot I will also do a PR on the docs explaining why this might be useful.
