### PR TITLE
[SecurityBundle] is_granted crashes in non-firewalled pages

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/Twig/Extension/SecurityExtension.php
@@ -34,6 +34,10 @@ class SecurityExtension extends \Twig_Extension
             return false;
         }
 
+        if (null === $this->context->getToken()) {
+            return false;
+        }
+
         if (null !== $field) {
             $object = new FieldVote($object, $field);
         }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: did not run
Fixes the following tickets: none

Scenario:
I have a navbar, which is printed on every page, and also in the login page. I added an extra item in there that only shows up for Admin users. By my reasoning this means that when the user is not logged in (login page) this of course should return false, if there is no user or no firewall/token then obviously its not granted. However this crashes on my login page as its not firewalled.

```
An exception has been thrown during the rendering of a template ("The security context contains no authentication token. One possible reason may be that there is no firewall configured for this URL.")
```

I fixed this by adding an extra check that verifies that a token is present, if the token is not present it stops the process and return false.
