### PR TITLE
For 2.0: Fix issue 3251: Check attribute type of service tags

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -216,6 +216,12 @@ class YamlFileLoader extends FileLoader
                 $name = $tag['name'];
                 unset($tag['name']);
 
+                foreach ($tag as $attribute => $value) {
+                    if (!is_scalar($value)) {
+                        throw new InvalidArgumentException(sprintf('A "tags" attribute must be of a scalar-type for service "%s", tag "%s" in %s.', $id, $name, $file));
+                    }
+                }
+
                 $definition->addTag($name, $tag);
             }
         }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/badtag3.yml
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Fixtures/yaml/badtag3.yml
@@ -1,0 +1,6 @@
+services:
+    foo_service:
+        class:    FooClass
+        tags:
+          # tag-attribute is not a scalar
+          - { name: foo, foo: { foo: foo, bar: bar } }

--- a/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
+++ b/tests/Symfony/Tests/Component/DependencyInjection/Loader/YamlFileLoaderTest.php
@@ -185,4 +185,16 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertStringStartsWith('A "tags" entry is missing a "name" key for service ', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag is missing the name key');
         }
     }
+
+    public function testTagWithAttributeArrayThrowsException()
+    {
+        $loader = new YamlFileLoader(new ContainerBuilder(), new FileLocator(self::$fixturesPath.'/yaml'));
+        try {
+            $loader->load('badtag3.yml');
+            $this->fail('->load() should throw an exception when a tag-attribute is not a scalar');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
+            $this->assertStringStartsWith('A "tags" attribute must be of a scalar-type for service ', $e->getMessage(), '->load() throws an InvalidArgumentException if a tag-attribute is not a scalar');
+        }
+    }
 }


### PR DESCRIPTION
The attributes of service tags have to be of a scalar type.
It was possible to add arrays here with yaml-configuration.
