### PR TITLE
[Form] Cleaned the FormValidatorInterface deprecation

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -77,7 +77,7 @@ class Form implements \IteratorAggregate, FormInterface
 
     /**
      * The mapper for mapping data to children and back
-     * @var DataMapper\DataMapperInterface
+     * @var DataMapperInterface
      */
     private $dataMapper;
 
@@ -799,18 +799,6 @@ class Form implements \IteratorAggregate, FormInterface
     public function getClientTransformers()
     {
         return $this->clientTransformers;
-    }
-
-    /**
-     * Returns the Validators
-     *
-     * @return array An array of FormValidatorInterface
-     *
-     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
-     */
-    public function getValidators()
-    {
-        return $this->validators;
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/DelegatingValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/DelegatingValidationListenerTest.php
@@ -32,7 +32,7 @@ class DelegatingValidationListenerTest extends \PHPUnit_Framework_TestCase
 
     private $delegate;
 
-    private $validator;
+    private $listener;
 
     private $message;
 
@@ -40,6 +40,10 @@ class DelegatingValidationListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
+        if (!class_exists('Symfony\Component\EventDispatcher\Event')) {
+            $this->markTestSkipped('The "EventDispatcher" component is not available');
+        }
+
         $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
         $this->delegate = $this->getMock('Symfony\Component\Validator\ValidatorInterface');

--- a/src/Symfony/Component/Form/Tests/FormTest.php
+++ b/src/Symfony/Component/Form/Tests/FormTest.php
@@ -1294,16 +1294,6 @@ class FormTest extends \PHPUnit_Framework_TestCase
             ->getForm();
     }
 
-    public function testGetValidatorsReturnsValidators()
-    {
-        $validator = $this->getFormValidator();
-        $form = $this->getBuilder()
-            ->addValidator($validator)
-            ->getForm();
-
-        $this->assertEquals(array($validator), $form->getValidators());
-    }
-
     protected function getBuilder($name = 'name', EventDispatcherInterface $dispatcher = null)
     {
         return new FormBuilder($name, $this->factory, $dispatcher ?: $this->dispatcher);


### PR DESCRIPTION
This fixes my feedback on #3797

[![Build Status](https://secure.travis-ci.org/stof/symfony.png?branch=form_cleanup)](http://travis-ci.org/stof/symfony)
