### PR TITLE
[Validator] Fixed StaticMethodLoader when used with abstract methods.

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
@@ -37,7 +37,7 @@ class StaticMethodLoader implements LoaderInterface
                 throw new MappingException(sprintf('The method %s::%s should be static', $reflClass->getName(), $this->methodName));
             }
 
-            if ($reflMethod->getDeclaringClass()->getName() != $reflClass->getName()) {
+            if ($reflClass->isAbstract() || $reflMethod->getDeclaringClass()->getName() != $reflClass->getName()) {
                 return false;
             }
 

--- a/tests/Symfony/Tests/Component/Validator/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Mapping/Loader/StaticMethodLoaderTest.php
@@ -35,6 +35,14 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->loadClassMetadata($metadata));
     }
 
+    public function testLoadClassMetadataReturnsFalseIfMethodIsAbstract()
+    {
+        $loader = new StaticMethodLoader('loadMetadata');
+        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticLoaderEntity');
+
+        $this->assertFalse($loader->loadClassMetadata($metadata));
+    }
+
     public function testLoadClassMetadata()
     {
         $loader = new StaticMethodLoader('loadMetadata');
@@ -79,4 +87,9 @@ class BaseStaticLoaderDocument
     {
         $metadata->addConstraint(new ConstraintA());
     }
+}
+
+abstract class AbstractStaticLoaderEntity
+{
+    abstract public static function loadMetadata(ClassMetadata $metadata);
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3179
