### PR TITLE
[Form] Allow to inherit translation domain for all elements of a form

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -59,6 +59,7 @@ class FieldType extends AbstractType
             ->setAttribute('invalid_message', $options['invalid_message'])
             ->setAttribute('invalid_message_parameters', $options['invalid_message_parameters'])
             ->setAttribute('translation_domain', $options['translation_domain'])
+            ->setAttribute('form_translation_domain', $options['form_translation_domain'])
             ->setData($options['data'])
             ->addEventSubscriber(new ValidationListener())
         ;
@@ -123,8 +124,21 @@ class FieldType extends AbstractType
             ->set('multipart', false)
             ->set('attr', $form->getAttribute('attr'))
             ->set('types', $types)
-            ->set('translation_domain', $form->getAttribute('translation_domain'))
         ;
+
+        $translationDomain = $form->getAttribute('translation_domain');
+        // handle form_translation_domain top down
+        $formTranslationDomain = $view->hasParent() ?
+            $view->getParent()->get('form_translation_domain') : $form->getAttribute('form_translation_domain');
+
+        $view->set('form_translation_domain', $formTranslationDomain);
+
+        // translation_domain wins over form_translation_domain at field level if set
+        if (!empty($translationDomain)) {
+            $view->set('translation_domain', $translationDomain);
+        } else {
+            $view->set('translation_domain', $formTranslationDomain);
+        }
     }
 
     /**
@@ -176,7 +190,8 @@ class FieldType extends AbstractType
             'attr'              => array(),
             'invalid_message'   => 'This value is not valid',
             'invalid_message_parameters' => array(),
-            'translation_domain' => 'messages',
+            'translation_domain' => '',
+            'form_translation_domain' => 'messages',
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -134,7 +134,7 @@ class FieldType extends AbstractType
         $view->set('form_translation_domain', $formTranslationDomain);
 
         // translation_domain wins over form_translation_domain at field level if set
-        if (!empty($translationDomain)) {
+        if (null !== $translationDomain) {
             $view->set('translation_domain', $translationDomain);
         } else {
             $view->set('translation_domain', $formTranslationDomain);
@@ -190,7 +190,7 @@ class FieldType extends AbstractType
             'attr'              => array(),
             'invalid_message'   => 'This value is not valid',
             'invalid_message_parameters' => array(),
-            'translation_domain' => '',
+            'translation_domain' => null,
             'form_translation_domain' => 'messages',
         );
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FieldTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FieldTypeTest.php
@@ -187,6 +187,48 @@ class FieldTypeTest extends TypeTestCase
         $this->assertSame('test', $view->get('translation_domain'));
     }
 
+    public function testInheritTranslationDomain()
+    {
+        $type = new \Symfony\Component\Form\Tests\Fixtures\TestTranslationType();
+
+        $form = $this->factory->create($type);
+        $view = $form->createView();
+
+        $this->assertSame('test', $view->get('translation_domain'));
+        $this->assertSame('field1', $view->getChild('field1')->get('translation_domain'));
+        $this->assertSame('test', $view->getChild('field2')->get('translation_domain'));
+    }
+
+    public function testInheritTranslationDomainWithAddedForm()
+    {
+        $type = new \Symfony\Component\Form\Tests\Fixtures\TestTranslationType();
+
+        $form1 = $this->factory->create($type);
+        $form2 = $this->factory->create('field', null, array('form_translation_domain' => 'form2'));
+
+        $form2->add($form1);
+        $view = $form2->createView();
+
+        $this->assertSame('form2', $view->get('translation_domain'));
+        $this->assertSame('field1', $view->getChild('test_translation_type')->getChild('field1')->get('translation_domain'));
+        $this->assertSame('form2', $view->getChild('test_translation_type')->getChild('field2')->get('translation_domain'));
+    }
+
+    public function testInheritTranslationDomainWithAddedFormAndDomainSet()
+    {
+        $type = new \Symfony\Component\Form\Tests\Fixtures\TestTranslationType();
+
+        $form1 = $this->factory->create($type);
+        $form2 = $this->factory->create('field', null, array('form_translation_domain' => 'form2', 'translation_domain' => 'simple'));
+
+        $form2->add($form1);
+        $view = $form2->createView();
+
+        $this->assertSame('simple', $view->get('translation_domain'));
+        $this->assertSame('field1', $view->getChild('test_translation_type')->getChild('field1')->get('translation_domain'));
+        $this->assertSame('form2', $view->getChild('test_translation_type')->getChild('field2')->get('translation_domain'));
+    }
+
     public function testPassDefaultLabelToView()
     {
         $form = $this->factory->createNamed('field', '__test___field');

--- a/src/Symfony/Component/Form/Tests/Fixtures/TestTranslationType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/TestTranslationType.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilder;
+
+class TestTranslationType extends AbstractType
+{
+    public function buildForm(FormBuilder $builder, array $options)
+    {
+        $builder->add('field1', 'choice', array(
+            'choices' => array('1' => 'choice.1', '2' => 'choice.2'),
+            'required' => true,
+            'expanded' => true,
+            'translation_domain' => 'field1'
+        ));
+        $builder->add('field2', 'checkbox', array('required' => true));
+        $builder->add('field3', 'text');
+    }
+
+    public function getDefaultOptions()
+    {
+        return array('form_translation_domain' => 'test');
+    }
+
+    public function getName()
+    {
+        return 'test_translation_type';
+    }
+}
+

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -516,7 +516,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Symfony\Component\Form\Exception\InvalidOptionException',
             'The options "invalid", "unknown" do not exist. Known options are: ' .
             '"attr", "by_reference", "data", "data_class", "disabled", ' .
-            '"empty_data", "error_bubbling", "error_mapping", "invalid_message", ' .
+            '"empty_data", "error_bubbling", "error_mapping", "form_translation_domain", "invalid_message", ' .
             '"invalid_message_parameters", "label", "max_length", "pattern", ' .
             '"property_path", "read_only", "required", "translation_domain", ' .
             '"trim"'
@@ -533,7 +533,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Symfony\Component\Form\Exception\InvalidOptionException',
             'The option "unknown" does not exist. Known options are: "attr", ' .
             '"by_reference", "data", "data_class", "disabled", "empty_data", ' .
-            '"error_bubbling", "error_mapping", "invalid_message", ' .
+            '"error_bubbling", "error_mapping", "form_translation_domain", "invalid_message", ' .
             '"invalid_message_parameters", "label", "max_length", "pattern", ' .
             '"property_path", "read_only", "required", "translation_domain", ' .
             '"trim"'


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: https://github.com/symfony/symfony/issues/3872
Todo: document form_translation_domain

translation_domain is currently used only at field level, there is no way to set it once for a form. With an additional option form_translation_domain it is possible to set it during building the view top down. If there is a field with translation_domain set, this wins at field level.
