### PR TITLE
[2.0][Locale] StubIntlDateFormatter should behave like original Intl extension

### DIFF
--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -101,9 +101,9 @@ class StubIntlDateFormatter
     private $unitializedTimeZoneId = false;
 
     /**
-     * @var string
+     * @var null|string
      */
-    private $timeZoneId;
+    private $timeZoneId = null;
 
     /**
      * Constructor
@@ -436,8 +436,10 @@ class StubIntlDateFormatter
      */
     public function setTimeZoneId($timeZoneId)
     {
-        if (null === $timeZoneId) {
-            $timeZoneId = date_default_timezone_get();
+        if (empty($timeZoneId)) {
+            // Default time zone is system default. (@see https://github.com/symfony/symfony/issues/3841)
+            $timeZoneId = getenv('TZ') ?: date_default_timezone_get();
+
             $this->unitializedTimeZoneId = true;
         }
 

--- a/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
@@ -49,8 +49,62 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     public function testConstructorDefaultTimeZoneIntl()
     {
         $this->skipIfIntlExtensionIsNotLoaded();
+
         $formatter = new \IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
         $this->assertNull($formatter->getTimeZoneId());
+    }
+
+    // Issue https://github.com/symfony/symfony/issues/3841
+    public function testDefaultTimeZoneBasesOnSystemEnvStub()
+    {
+        // Hold actual value of env variable
+        $tmp = getenv('TZ');
+
+        // Set proper timezone
+        putenv('TZ=GMT-03:00');
+
+        $formatter = new StubIntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
+		$formatter->setPattern('yyyy-MM-dd HH:mm:ss');
+        $this->assertEquals('1969-12-31 21:00:00', $formatter->format(0));
+
+        // Unset env
+        putenv('TZ');
+
+        $formatter = new StubIntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
+        $this->assertNull($formatter->getTimeZoneId());
+
+        // restore old env variable if was set
+        if ($tmp) {
+            putenv('TZ='.$tmp);
+        }
+    }
+
+    // Issue https://github.com/symfony/symfony/issues/3841
+    public function testDefaultTimeZoneBasesOnSystemEnvIntl()
+    {
+        $this->skipIfIntlExtensionIsNotLoaded();
+
+        // Hold actual value of env variable
+        $tmp = getenv('TZ');
+
+        // Set proper timezone
+        putenv('TZ=GMT-03:00');
+
+        $formatter = new \IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
+		$formatter->setPattern('yyyy-MM-dd HH:mm:ss');
+        $this->assertEquals('1969-12-31 21:00:00', $formatter->format(0));
+
+        // Unset env
+        putenv('TZ');
+
+        $formatter = new \IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
+		$formatter->setPattern('yyyy-MM-dd HH:mm:ss');
+        $this->assertNull($formatter->getTimeZoneId());
+
+        // restore old env variable if was set
+        if ($tmp) {
+            putenv('TZ='.$tmp);
+        }
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Validator/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Mapping/Loader/StaticMethodLoaderTest.php
@@ -91,5 +91,7 @@ class BaseStaticLoaderDocument
 
 abstract class AbstractStaticLoaderEntity
 {
-    abstract public static function loadMetadata(ClassMetadata $metadata);
+    static public function loadMetadata(ClassMetadata $metadata)
+	{
+	}
 }


### PR DESCRIPTION
<table>
  <tr>
    <th>Bug fix</th><th>Feature addition</th><th>BC break</th><th>Tests pass</th><th>Fixes issues</th>
  </tr>
  <tr>
    <td>yes</td><td>no</td><td>no</td><td>yes</td><td>#3841</td>
  </tr>
</table>


For more details please check: #3841
