### PR TITLE
[Form] [DoctrineBridge] Better field type guessing for array doctrine type and array validator type

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -14,6 +14,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
  * added a default implementation of the ManagerRegistry
  * added a session storage for Doctrine DBAL
+ * DoctrineOrmTypeGuesser now guesses "collection" for array Doctrine type
 
 ### TwigBridge
 
@@ -273,6 +274,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
  * deprecated FieldType and merged it into FormType
  * [BC BREAK] renamed "field_*" theme blocks to "form_*" and "field_widget" to
    "input"
+ * ValidatorTypeGuesser now guesses "collection" for array type constraint
 
 ### HttpFoundation
 

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -50,8 +50,8 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
 
         switch ($metadata->getTypeOfField($property))
         {
-            //case 'array':
-            //  return new TypeGuess('Collection', array(), Guess::HIGH_CONFIDENCE);
+            case 'array':
+                return new TypeGuess('collection', array(), Guess::MEDIUM_CONFIDENCE);
             case 'boolean':
                 return new TypeGuess('checkbox', array(), Guess::HIGH_CONFIDENCE);
             case 'datetime':

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -89,6 +89,8 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
         switch (get_class($constraint)) {
             case 'Symfony\Component\Validator\Constraints\Type':
                 switch ($constraint->type) {
+                    case 'array':
+                        return new TypeGuess('collection', array(), Guess::MEDIUM_CONFIDENCE);
                     case 'boolean':
                     case 'bool':
                         return new TypeGuess('checkbox', array(), Guess::MEDIUM_CONFIDENCE);


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #1692
Todo: -
