### PR TITLE
[WebProfilerBundle] Toolbar 'abbr' element normalized.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/toolbar.css
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/toolbar.css
@@ -25,4 +25,5 @@ build: 56
 .sf-toolbarreset abbr {
     border-bottom: 1px dotted #000000;
     cursor: help;
+    text-transform: none;
 }


### PR DESCRIPTION
This avoids that abbreviations are uppercased by CSS frameworks such as Bootstrap.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
