### PR TITLE
[2.0][Tests] Fixed Strict Standard warning

### DIFF
--- a/tests/Symfony/Tests/Component/Validator/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/tests/Symfony/Tests/Component/Validator/Mapping/Loader/StaticMethodLoaderTest.php
@@ -91,5 +91,7 @@ class BaseStaticLoaderDocument
 
 abstract class AbstractStaticLoaderEntity
 {
-    abstract public static function loadMetadata(ClassMetadata $metadata);
+    static public function loadMetadata(ClassMetadata $metadata)
+    {
+    }
 }


### PR DESCRIPTION
> PHP Strict standards:  Static function Symfony\Tests\Component\Validator\Mapping\Loader\AbstractStaticLoaderEntity::loadMetadata() should not be abstract
