### PR TITLE
Return  from Response::prepare() so that the method may be chained.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -198,6 +198,8 @@ class Response
      * the Request that is "associated" with this Response.
      *
      * @param Request $request A Request instance
+     *
+     * @return Response The current response.
      */
     public function prepare(Request $request)
     {
@@ -237,6 +239,8 @@ class Response
                 $headers->set('Content-Length', $length);
             }
         }
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -82,7 +82,7 @@ class StreamedResponse extends Response
 
         $this->headers->set('Cache-Control', 'no-cache');
 
-        parent::prepare($request);
+        return parent::prepare($request);
     }
 
     /**


### PR DESCRIPTION
Currently, Response::prepare() returns nothing, ever.  That's such a waste.  This one-liner returns $this, so that the method may be chained.  That allows for, for instance:

$kernel->handle($request)->prepare($request)->send();
