### PR TITLE
[2.2] [Routing] add support for path-relative URL generation

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * [BC BREAK] restricted the `render` tag to only accept URIs as reference (the signature changed)
  * added a render function to render a request
  * The `app` global variable is now injected even when using the twig service directly.
+ * Added an optional parameter to the `path` and `url` function which allows to generate
+   relative paths (e.g. "../parent-file") and scheme-relative URLs (e.g. "//example.com/dir/file").
 
 2.1.0
 -----

--- a/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
@@ -40,14 +40,14 @@ class RoutingExtension extends \Twig_Extension
         );
     }
 
-    public function getPath($name, $parameters = array())
+    public function getPath($name, $parameters = array(), $relative = false)
     {
-        return $this->generator->generate($name, $parameters, false);
+        return $this->generator->generate($name, $parameters, $relative ? UrlGeneratorInterface::RELATIVE_PATH : UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
-    public function getUrl($name, $parameters = array())
+    public function getUrl($name, $parameters = array(), $schemeRelative = false)
     {
-        return $this->generator->generate($name, $parameters, true);
+        return $this->generator->generate($name, $parameters, $schemeRelative ? UrlGeneratorInterface::NETWORK_PATH : UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -19,8 +20,8 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Doctrine\Bundle\DoctrineBundle\Registry;
-use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Controller is a simple implementation of a Controller.
@@ -34,15 +35,15 @@ class Controller extends ContainerAware
     /**
      * Generates a URL from the given parameters.
      *
-     * @param string  $route      The name of the route
-     * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
+     * @param string $route         The name of the route
+     * @param mixed  $parameters    An array of parameters
+     * @param string $referenceType The type of reference (see UrlGeneratorInterface)
      *
      * @return string The generated URL
      */
-    public function generateUrl($route, $parameters = array(), $absolute = false)
+    public function generateUrl($route, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return $this->container->get('router')->generate($route, $parameters, $absolute);
+        return $this->container->get('router')->generate($route, $parameters, $referenceType);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -35,11 +35,13 @@ class Controller extends ContainerAware
     /**
      * Generates a URL from the given parameters.
      *
-     * @param string $route         The name of the route
-     * @param mixed  $parameters    An array of parameters
-     * @param string $referenceType The type of reference (see UrlGeneratorInterface)
+     * @param string         $route         The name of the route
+     * @param mixed          $parameters    An array of parameters
+     * @param Boolean|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The generated URL
+     *
+     * @see UrlGeneratorInterface
      */
     public function generateUrl($route, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -12,8 +12,9 @@
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
 use Symfony\Component\DependencyInjection\ContainerAware;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Redirects a request to another URL.
@@ -45,7 +46,7 @@ class RedirectController extends ContainerAware
         $attributes = $this->container->get('request')->attributes->get('_route_params');
         unset($attributes['route'], $attributes['permanent']);
 
-        return new RedirectResponse($this->container->get('router')->generate($route, $attributes, true), $permanent ? 301 : 302);
+        return new RedirectResponse($this->container->get('router')->generate($route, $attributes, UrlGeneratorInterface::ABSOLUTE_URL), $permanent ? 301 : 302);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
@@ -36,11 +36,13 @@ class RouterHelper extends Helper
     /**
      * Generates a URL from the given parameters.
      *
-     * @param string $name          The name of the route
-     * @param mixed  $parameters    An array of parameters
-     * @param string $referenceType The type of reference (see UrlGeneratorInterface)
+     * @param string         $name          The name of the route
+     * @param mixed          $parameters    An array of parameters
+     * @param Boolean|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The generated URL
+     *
+     * @see UrlGeneratorInterface
      */
     public function generate($name, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
@@ -36,15 +36,15 @@ class RouterHelper extends Helper
     /**
      * Generates a URL from the given parameters.
      *
-     * @param string  $name       The name of the route
-     * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
+     * @param string $name          The name of the route
+     * @param mixed  $parameters    An array of parameters
+     * @param string $referenceType The type of reference (see UrlGeneratorInterface)
      *
      * @return string The generated URL
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return $this->generator->generate($name, $parameters, $absolute);
+        return $this->generator->generate($name, $parameters, $referenceType);
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -55,36 +55,40 @@ class LogoutUrlHelper extends Helper
     }
 
     /**
-     * Generate the relative logout URL for the firewall.
+     * Generates the absolute logout path for the firewall.
      *
      * @param string $key The firewall key
-     * @return string The relative logout URL
+     *
+     * @return string The logout path
      */
     public function getLogoutPath($key)
     {
-        return $this->generateLogoutUrl($key, false);
+        return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_PATH);
     }
 
     /**
-     * Generate the absolute logout URL for the firewall.
+     * Generates the absolute logout URL for the firewall.
      *
      * @param string $key The firewall key
-     * @return string The absolute logout URL
+     *
+     * @return string The logout URL
      */
     public function getLogoutUrl($key)
     {
-        return $this->generateLogoutUrl($key, true);
+        return $this->generateLogoutUrl($key, UrlGeneratorInterface::ABSOLUTE_URL);
     }
 
     /**
-     * Generate the logout URL for the firewall.
+     * Generates the logout URL for the firewall.
      *
-     * @param string  $key      The firewall key
-     * @param Boolean $absolute Whether to generate an absolute URL
+     * @param string $key           The firewall key
+     * @param string $referenceType The type of reference (see UrlGeneratorInterface)
+     *
      * @return string The logout URL
+     *
      * @throws \InvalidArgumentException if no LogoutListener is registered for the key
      */
-    private function generateLogoutUrl($key, $absolute)
+    private function generateLogoutUrl($key, $referenceType)
     {
         if (!array_key_exists($key, $this->listeners)) {
             throw new \InvalidArgumentException(sprintf('No LogoutListener found for firewall key "%s".', $key));
@@ -97,13 +101,13 @@ class LogoutUrlHelper extends Helper
         if ('/' === $logoutPath[0]) {
             $request = $this->container->get('request');
 
-            $url = ($absolute ? $request->getUriForPath($logoutPath) : $request->getBasePath() . $logoutPath);
+            $url = UrlGeneratorInterface::ABSOLUTE_URL === $referenceType ? $request->getUriForPath($logoutPath) : $request->getBasePath() . $logoutPath;
 
             if (!empty($parameters)) {
                 $url .= '?' . http_build_query($parameters);
             }
         } else {
-            $url = $this->router->generate($logoutPath, $parameters, $absolute);
+            $url = $this->router->generate($logoutPath, $parameters, $referenceType);
         }
 
         return $url;

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -81,8 +81,8 @@ class LogoutUrlHelper extends Helper
     /**
      * Generates the logout URL for the firewall.
      *
-     * @param string $key           The firewall key
-     * @param string $referenceType The type of reference (see UrlGeneratorInterface)
+     * @param string         $key           The firewall key
+     * @param Boolean|string $referenceType The type of reference (one of the constants in UrlGeneratorInterface)
      *
      * @return string The logout URL
      *

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Security/LocalizedFormFailureHandler.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/Bundle/FormLoginBundle/Security/LocalizedFormFailureHandler.php
@@ -12,9 +12,10 @@
 namespace Symfony\Bundle\SecurityBundle\Tests\Functional\Bundle\FormLoginBundle\Security;
 
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 
 class LocalizedFormFailureHandler implements AuthenticationFailureHandlerInterface
@@ -28,6 +29,6 @@ class LocalizedFormFailureHandler implements AuthenticationFailureHandlerInterfa
 
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
-        return new RedirectResponse($this->router->generate('localized_login_path', array(), true));
+        return new RedirectResponse($this->router->generate('localized_login_path', array(), UrlGeneratorInterface::ABSOLUTE_URL));
     }
 }

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -81,6 +81,12 @@ CHANGELOG
    are now also allowed.
  * [BC BREAK] `RouteCompilerInterface::compile(Route $route)` was made static
    (only relevant if you implemented your own RouteCompiler).
+ * Added possibility to generate relative paths and network paths in the UrlGenerator, e.g.
+   "../parent-file" and "//example.com/dir/file". The third parameter in
+   `UrlGeneratorInterface::generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)`
+   now accepts more values and you should use the constants defined in `UrlGeneratorInterface` for
+   claritiy. The old method calls with a Boolean parameter will continue to work because they
+   equal the signature using the constants.
 
 2.1.0
 -----

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -108,7 +108,7 @@ EOF;
     private function generateGenerateMethod()
     {
         return <<<EOF
-    public function generate(\$name, \$parameters = array(), \$absolute = false)
+    public function generate(\$name, \$parameters = array(), \$referenceType = self::ABSOLUTE_PATH)
     {
         if (!isset(self::\$declaredRoutes[\$name])) {
             throw new RouteNotFoundException(sprintf('Route "%s" does not exist.', \$name));
@@ -116,7 +116,7 @@ EOF;
 
         list(\$variables, \$defaults, \$requirements, \$tokens, \$hostnameTokens) = self::\$declaredRoutes[\$name];
 
-        return \$this->doGenerate(\$variables, \$defaults, \$requirements, \$tokens, \$parameters, \$name, \$absolute, \$hostnameTokens);
+        return \$this->doGenerate(\$variables, \$defaults, \$requirements, \$tokens, \$parameters, \$name, \$referenceType, \$hostnameTokens);
     }
 EOF;
     }

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -141,8 +141,9 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     }
 
     /**
-     * @throws MissingMandatoryParametersException When route has some missing mandatory parameters
-     * @throws InvalidParameterException When a parameter value is not correct
+     * @throws MissingMandatoryParametersException When some parameters are missing that mandatory for the route
+     * @throws InvalidParameterException           When a parameter value for a placeholder is not correct because
+     *                                             it does not match the requirement
      */
     protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostnameTokens)
     {
@@ -151,7 +152,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
 
         // all params must be given
         if ($diff = array_diff_key($variables, $mergedParams)) {
-            throw new MissingMandatoryParametersException(sprintf('The "%s" route has some missing mandatory parameters ("%s").', $name, implode('", "', array_keys($diff))));
+            throw new MissingMandatoryParametersException(sprintf('Some mandatory parameters are missing ("%s") to generate a URL for route "%s".', implode('", "', array_keys($diff)), $name));
         }
 
         $url = '';
@@ -161,7 +162,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                 if (!$optional || !array_key_exists($token[3], $defaults) || (string) $mergedParams[$token[3]] !== (string) $defaults[$token[3]]) {
                     // check requirement
                     if (null !== $this->strictRequirements && !preg_match('#^'.$token[2].'$#', $mergedParams[$token[3]])) {
-                        $message = sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given).', $token[3], $name, $token[2], $mergedParams[$token[3]]);
+                        $message = sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given) to generate a corresponding URL.', $token[3], $name, $token[2], $mergedParams[$token[3]]);
                         if ($this->strictRequirements) {
                             throw new InvalidParameterException($message);
                         }
@@ -213,7 +214,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                 foreach ($hostnameTokens as $token) {
                     if ('variable' === $token[0]) {
                         if (null !== $this->strictRequirements && !preg_match('#^'.$token[2].'$#', $mergedParams[$token[3]])) {
-                            $message = sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given).', $token[3], $name, $token[2], $mergedParams[$token[3]]);
+                            $message = sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given) to generate a corresponding URL.', $token[3], $name, $token[2], $mergedParams[$token[3]]);
 
                             if ($this->strictRequirements) {
                                 throw new InvalidParameterException($message);

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -19,7 +19,8 @@ use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 /**
- * UrlGenerator generates a URL based on a set of routes.
+ * UrlGenerator can generate a URL or a path for any route in the RouteCollection
+ * based on the passed parameters.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
@@ -140,36 +141,11 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     }
 
     /**
-     * This method converts the reference type to the new value introduced in Symfony 2.2. It can be used by
-     * other UrlGenerator implementations to be BC with Symfony 2.1. Reference type was a Boolean called
-     * $absolute in Symfony 2.1 and only supported two reference types.
-     *
-     * @param Boolean $absolute Whether to generate an absolute URL
-     *
-     * @return string The new reference type
-     *
-     * @deprecated Deprecated since version 2.2, to be removed in 2.3.
-     */
-    public static function convertReferenceType($absolute)
-    {
-        if (false === $absolute) {
-            return self::ABSOLUTE_PATH;
-        }
-        if (true === $absolute) {
-            return self::ABSOLUTE_URL;
-        }
-
-        return $absolute;
-    }
-
-    /**
      * @throws MissingMandatoryParametersException When route has some missing mandatory parameters
      * @throws InvalidParameterException When a parameter value is not correct
      */
     protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostnameTokens)
     {
-        $referenceType = self::convertReferenceType($referenceType);
-
         $variables = array_flip($variables);
         $mergedParams = array_replace($defaults, $this->context->getParameters(), $parameters);
 

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -11,8 +11,10 @@
 
 namespace Symfony\Component\Routing\Generator;
 
-use Symfony\Component\Routing\RequestContextAwareInterface;
+use Symfony\Component\Routing\Exception\InvalidParameterException;
+use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
+use Symfony\Component\Routing\RequestContextAwareInterface;
 
 /**
  * UrlGeneratorInterface is the interface that all URL generator classes must implement.
@@ -74,7 +76,10 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *
      * @return string The generated URL
      *
-     * @throws RouteNotFoundException if route doesn't exist
+     * @throws RouteNotFoundException              If the named route doesn't exist
+     * @throws MissingMandatoryParametersException When some parameters are missing that are mandatory for the route
+     * @throws InvalidParameterException           When a parameter value for a placeholder is not correct because
+     *                                             it does not match the requirement
      *
      * @api
      */

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -17,6 +17,13 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 /**
  * UrlGeneratorInterface is the interface that all URL generator classes must implement.
  *
+ * The constants in this interface define the different types of resource references that
+ * are declared in RFC 3986: http://tools.ietf.org/html/rfc3986
+ * We are using the term "URL" instead of "URI" as this is more common in web applications
+ * and we do not need to distinguish them as the difference is mostly semantical and
+ * less technical. Generating URIs, i.e. representation-independent resource identifiers,
+ * is also possible.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Tobias Schultze <http://tobion.de>
  *
@@ -25,27 +32,45 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
 interface UrlGeneratorInterface extends RequestContextAwareInterface
 {
     /**
-     * These constants define the different types of resource references that are declared
-     * in RFC 3986: http://tools.ietf.org/html/rfc3986
-     * We are using the term "URL" instead of "URI" as this is more common in web applications
-     * and we do not need to distinguish them as the difference is mostly semantical and
-     * less technical. Generating URIs, i.e. representation-independent resource identifiers,
-     * is still possible.
+     * Generates an absolute URL, e.g. "http://example.com/dir/file".
      */
-    const ABSOLUTE_URL = 'url';
-    const ABSOLUTE_PATH = 'path';
+    const ABSOLUTE_URL = true;
+
+    /**
+     * Generates an absolute path, e.g. "/dir/file".
+     */
+    const ABSOLUTE_PATH = false;
+
+    /**
+     * Generates a relative path based on the current request path, e.g. "../parent-file".
+     * @see UrlGenerator::getRelativePath()
+     */
     const RELATIVE_PATH = 'relative';
+
+    /**
+     * Generates a network path, e.g. "//example.com/dir/file".
+     * Such reference reuses the current scheme but specifies the hostname.
+     */
     const NETWORK_PATH = 'network';
 
     /**
-     * Generates a URL from the given parameters.
+     * Generates a URL or path for a specific route based on the given parameters.
      *
-     * If the generator is not able to generate the url, it must throw the RouteNotFoundException
-     * as documented below.
+     * Parameters that reference placeholders in the route pattern will substitute them in the
+     * path or hostname. Extra params are added as query string to the URL.
      *
-     * @param string $name          The name of the route
-     * @param mixed  $parameters    An array of parameters
-     * @param string $referenceType The type of reference to be generated (see defined constants)
+     * When the passed reference type cannot be generated for the route because it requires a different
+     * hostname or scheme than the current one, the method will return a more comprehensive reference
+     * that includes the required params. For example, when you call this method with $referenceType = ABSOLUTE_PATH
+     * but the route requires the https scheme whereas the current scheme is http, it will instead return an
+     * ABSOLUTE_URL with the https scheme and the current hostname. This makes sure the generated URL matches
+     * the route in any case.
+     *
+     * If there is no route with the given name, the generator must throw the RouteNotFoundException.
+     *
+     * @param string         $name          The name of the route
+     * @param mixed          $parameters    An array of parameters
+     * @param Boolean|string $referenceType The type of reference to be generated (one of the constants)
      *
      * @return string The generated URL
      *

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -18,20 +18,34 @@ use Symfony\Component\Routing\Exception\RouteNotFoundException;
  * UrlGeneratorInterface is the interface that all URL generator classes must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Tobias Schultze <http://tobion.de>
  *
  * @api
  */
 interface UrlGeneratorInterface extends RequestContextAwareInterface
 {
     /**
+     * These constants define the different types of resource references that are declared
+     * in RFC 3986: http://tools.ietf.org/html/rfc3986
+     * We are using the term "URL" instead of "URI" as this is more common in web applications
+     * and we do not need to distinguish them as the difference is mostly semantical and
+     * less technical. Generating URIs, i.e. representation-independent resource identifiers,
+     * is still possible.
+     */
+    const ABSOLUTE_URL = 'url';
+    const ABSOLUTE_PATH = 'path';
+    const RELATIVE_PATH = 'relative';
+    const NETWORK_PATH = 'network';
+
+    /**
      * Generates a URL from the given parameters.
      *
      * If the generator is not able to generate the url, it must throw the RouteNotFoundException
      * as documented below.
      *
-     * @param string  $name       The name of the route
-     * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
+     * @param string $name          The name of the route
+     * @param mixed  $parameters    An array of parameters
+     * @param string $referenceType The type of reference to be generated (see defined constants)
      *
      * @return string The generated URL
      *
@@ -39,5 +53,5 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *
      * @api
      */
-    public function generate($name, $parameters = array(), $absolute = false);
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH);
 }

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
 class RequestContext
 {
     private $baseUrl;
+    private $pathInfo;
     private $method;
     private $host;
     private $scheme;
@@ -43,10 +44,11 @@ class RequestContext
      * @param string  $scheme    The HTTP scheme
      * @param integer $httpPort  The HTTP port
      * @param integer $httpsPort The HTTPS port
+     * @param string  $pathInfo  The path info
      *
      * @api
      */
-    public function __construct($baseUrl = '', $method = 'GET', $host = 'localhost', $scheme = 'http', $httpPort = 80, $httpsPort = 443)
+    public function __construct($baseUrl = '', $method = 'GET', $host = 'localhost', $scheme = 'http', $httpPort = 80, $httpsPort = 443, $pathInfo = '/')
     {
         $this->baseUrl = $baseUrl;
         $this->method = strtoupper($method);
@@ -54,11 +56,13 @@ class RequestContext
         $this->scheme = strtolower($scheme);
         $this->httpPort = $httpPort;
         $this->httpsPort = $httpsPort;
+        $this->pathInfo = $pathInfo;
     }
 
     public function fromRequest(Request $request)
     {
         $this->setBaseUrl($request->getBaseUrl());
+        $this->setPathInfo($request->getPathInfo());
         $this->setMethod($request->getMethod());
         $this->setHost($request->getHost());
         $this->setScheme($request->getScheme());
@@ -86,6 +90,26 @@ class RequestContext
     public function setBaseUrl($baseUrl)
     {
         $this->baseUrl = $baseUrl;
+    }
+
+    /**
+     * Gets the path info.
+     *
+     * @return string The path info
+     */
+    public function getPathInfo()
+    {
+        return $this->pathInfo;
+    }
+
+    /**
+     * Sets the path info.
+     *
+     * @param string $pathInfo The path info
+     */
+    public function setPathInfo($pathInfo)
+    {
+        $this->pathInfo = $pathInfo;
     }
 
     /**

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -202,9 +202,9 @@ class Router implements RouterInterface
     /**
      * {@inheritdoc}
      */
-    public function generate($name, $parameters = array(), $absolute = false)
+    public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
-        return $this->getGenerator()->generate($name, $parameters, $absolute);
+        return $this->getGenerator()->generate($name, $parameters, $referenceType);
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -379,7 +379,6 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
      */
     public function testDefaultRequirementOfVariableDisallowsNextSeparator()
     {
-
         $routes = $this->getRoutes('test', new Route('/{page}.{_format}'));
         $this->getGenerator($routes)->generate('test', array('page' => 'do.t', '_format' => 'html'));
     }
@@ -388,7 +387,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $routes = $this->getRoutes('test', new Route('/{name}', array(), array(), array(), '{locale}.example.com'));
 
-        $this->assertEquals('http://fr.example.com/app.php/Fabien', $this->getGenerator($routes)->generate('test', array('name' =>'Fabien', 'locale' => 'fr')));
+        $this->assertEquals('//fr.example.com/app.php/Fabien', $this->getGenerator($routes)->generate('test', array('name' =>'Fabien', 'locale' => 'fr')));
     }
 
     public function testWithHostnameSameAsContext()
@@ -438,6 +437,120 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->getGenerator($routes);
         $generator->setStrictRequirements(false);
         $this->assertNull($generator->generate('test', array('foo' => 'baz'), false));
+    }
+
+    /**
+     * @dataProvider provideRelativePaths
+     */
+    public function testGetRelativePath($sourcePath, $targetPath, $expectedPath)
+    {
+        $this->assertSame($expectedPath, UrlGenerator::getRelativePath($sourcePath, $targetPath));
+    }
+
+    public function provideRelativePaths()
+    {
+        return array(
+            array(
+                '/same/dir/',
+                '/same/dir/',
+                ''
+            ),
+            array(
+                '/same/file',
+                '/same/file',
+                ''
+            ),
+            array(
+                '/',
+                '/file',
+                'file'
+            ),
+            array(
+                '/',
+                '/dir/file',
+                'dir/file'
+            ),
+            array(
+                '/dir/file.html',
+                '/dir/different-file.html',
+                'different-file.html'
+            ),
+            array(
+                '/same/dir/extra-file',
+                '/same/dir/',
+                './'
+            ),
+            array(
+                '/parent/dir/',
+                '/parent/',
+                '../'
+            ),
+            array(
+                '/parent/dir/extra-file',
+                '/parent/',
+                '../'
+            ),
+            array(
+                '/a/b/',
+                '/x/y/z/',
+                '../../x/y/z/'
+            ),
+            array(
+                '/a/b/c/d/e',
+                '/a/c/d',
+                '../../../c/d'
+            ),
+            array(
+                '/a/b/c//',
+                '/a/b/c/',
+                '../'
+            ),
+            array(
+                '/a/b/c/',
+                '/a/b/c//',
+                './/'
+            ),
+            array(
+                '/root/a/b/c/',
+                '/root/x/b/c/',
+                '../../../x/b/c/'
+            ),
+            array(
+                '/a/b/c/d/',
+                '/a',
+                '../../../../a'
+            ),
+            array(
+                '/special-chars/sp%20ce/1€/mäh/e=mc²',
+                '/special-chars/sp%20ce/1€/<µ>/e=mc²',
+                '../<µ>/e=mc²'
+            ),
+            array(
+                'not-rooted',
+                'dir/file',
+                'dir/file'
+            ),
+            array(
+                '//dir/',
+                '',
+                '../../'
+            ),
+            array(
+                '/dir/',
+                '/dir/file:with-colon',
+                './file:with-colon'
+            ),
+            array(
+                '/dir/',
+                '/dir/subdir/file:with-colon',
+                'subdir/file:with-colon'
+            ),
+            array(
+                '/dir/',
+                '/dir/:subdir/',
+                './:subdir/'
+            ),
+        );
     }
 
     protected function getGenerator(RouteCollection $routes, array $parameters = array(), $logger = null)

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Routing\Tests\Generator;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\RequestContext;
 
 class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
@@ -437,6 +438,58 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator = $this->getGenerator($routes);
         $generator->setStrictRequirements(false);
         $this->assertNull($generator->generate('test', array('foo' => 'baz'), false));
+    }
+
+    public function testGenerateNetworkPath()
+    {
+        $routes = $this->getRoutes('test', new Route('/{name}', array(), array('_scheme' => 'http'), array(), '{locale}.example.com'));
+
+        $this->assertSame('//fr.example.com/app.php/Fabien', $this->getGenerator($routes)->generate('test',
+            array('name' =>'Fabien', 'locale' => 'fr'), UrlGeneratorInterface::NETWORK_PATH), 'network path with different host'
+        );
+        $this->assertSame('//fr.example.com/app.php/Fabien?query=string', $this->getGenerator($routes, array('host' => 'fr.example.com'))->generate('test',
+            array('name' =>'Fabien', 'locale' => 'fr', 'query' => 'string'), UrlGeneratorInterface::NETWORK_PATH), 'network path although host same as context'
+        );
+        $this->assertSame('http://fr.example.com/app.php/Fabien', $this->getGenerator($routes, array('scheme' => 'https'))->generate('test',
+            array('name' =>'Fabien', 'locale' => 'fr'), UrlGeneratorInterface::NETWORK_PATH), 'absolute URL because scheme requirement does not match context'
+        );
+        $this->assertSame('http://fr.example.com/app.php/Fabien', $this->getGenerator($routes)->generate('test',
+            array('name' =>'Fabien', 'locale' => 'fr'), UrlGeneratorInterface::ABSOLUTE_URL), 'absolute URL with same scheme because it is requested'
+        );
+    }
+
+    public function testGenerateRelativePath()
+    {
+        $routes = new RouteCollection();
+        $routes->add('article', new Route('/{author}/{article}/'));
+        $routes->add('comments', new Route('/{author}/{article}/comments'));
+        $routes->add('hostname', new Route('/{article}', array(), array(), array(), '{author}.example.com'));
+        $routes->add('scheme', new Route('/{author}', array(), array('_scheme' => 'https')));
+        $routes->add('unrelated', new Route('/about'));
+
+        $generator = $this->getGenerator($routes, array('host' => 'example.com', 'pathInfo' => '/fabien/symfony-is-great/'));
+
+        $this->assertSame('comments', $generator->generate('comments',
+            array('author' =>'fabien', 'article' => 'symfony-is-great'), UrlGeneratorInterface::RELATIVE_PATH)
+        );
+        $this->assertSame('comments?page=2', $generator->generate('comments',
+            array('author' =>'fabien', 'article' => 'symfony-is-great', 'page' => 2), UrlGeneratorInterface::RELATIVE_PATH)
+        );
+        $this->assertSame('../twig-is-great/', $generator->generate('article',
+            array('author' =>'fabien', 'article' => 'twig-is-great'), UrlGeneratorInterface::RELATIVE_PATH)
+        );
+        $this->assertSame('../../bernhard/forms-are-great/', $generator->generate('article',
+            array('author' =>'bernhard', 'article' => 'forms-are-great'), UrlGeneratorInterface::RELATIVE_PATH)
+        );
+        $this->assertSame('//bernhard.example.com/app.php/forms-are-great', $generator->generate('hostname',
+            array('author' =>'bernhard', 'article' => 'forms-are-great'), UrlGeneratorInterface::RELATIVE_PATH)
+        );
+        $this->assertSame('https://example.com/app.php/bernhard', $generator->generate('scheme',
+            array('author' =>'bernhard'), UrlGeneratorInterface::RELATIVE_PATH)
+        );
+        $this->assertSame('../../about', $generator->generate('unrelated',
+            array(), UrlGeneratorInterface::RELATIVE_PATH)
+        );
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -71,8 +71,8 @@ class HttpUtils
     public function createRequest(Request $request, $path)
     {
         $newRequest = Request::create($this->generateUri($request, $path), 'get', array(), $request->cookies->all(), array(), $request->server->all());
-        if ($session = $request->getSession()) {
-            $newRequest->setSession($session);
+        if ($request->hasSession()) {
+            $newRequest->setSession($request->getSession());
         }
 
         if ($request->attributes->has(SecurityContextInterface::AUTHENTICATION_ERROR)) {
@@ -136,15 +136,10 @@ class HttpUtils
             return $request->getUriForPath($path);
         }
 
-        return $this->generateUrl($path, true);
-    }
-
-    private function generateUrl($route, $absolute = false)
-    {
         if (null === $this->urlGenerator) {
             throw new \LogicException('You must provide a UrlGeneratorInterface instance to be able to use routes.');
         }
 
-        return $this->urlGenerator->generate($route, array(), $absolute);
+        return $this->urlGenerator->generate($path, array(), UrlGeneratorInterface::ABSOLUTE_URL);
     }
 }


### PR DESCRIPTION
Tests pass: yes
Feature addition: yes
BC break: <del>tiny (see below)</del> NO
deprecations: NO

At the moment the Routing component only supports absolute and domain-relative URLs, e.g.
`http://example.org/user-slug/article-slug/comments` and
`/user-slug/article-slug/comments`.

But there are two link types missing: schema-relative URLs and path-relative URLs.
schema-relative: e.g. `//example.org/user-slug/article-slug/comments`
path-relative: e.g. `comments`.

Both of them would now be possible with this PR. I think it closes a huge gap in the Routing component.
Use cases are pretty common. Schema-relative URLs are for example used when you want to include assets (scripts, images etc) in a secured website with HTTPS. Path-relative URLs are the only option when you want to generate static files (e.g. documentation) that can be downloaded as an HTML archive. Such use-cases are currently not possible with symfony.

The calculation of the relative path based on the request path and target path is hightly unit tested. So it is really equivalent. I found several implemenations on the internet but none of them worked in all cases. Mine is pretty short and works.

I also added an optional parameter to the twig `path` function, so this feature can also be used in twig templates.

Ref: This implements path-relative URLs as suggested in #3908.

<del>[BC BREAK] The signature of UrlGeneratorInterface::generate changed to support scheme-relative and path-relative URLs. The core UrlGenerator is BC and does not break anything, but users who implemented their own UrlGenerator need to be aware of this change. See UrlGenerator::convertReferenceType.</del>
