### PR TITLE
[Locale] Complete StubIntl with the missing intl_error_name

### DIFF
--- a/src/Symfony/Component/Locale/Resources/stubs/functions.php
+++ b/src/Symfony/Component/Locale/Resources/stubs/functions.php
@@ -45,3 +45,14 @@ function intl_get_error_code() {
 function intl_get_error_message() {
     return StubIntl::getErrorMessage();
 }
+
+/**
+ * Stub implementation for the intl_error_name function of the intl extension
+ *
+ * @return String will be the same as the name of the error code constant
+ *
+ * @see    Symfony\Component\Locale\Stub\StubIntl::getErrorName
+ */
+function intl_error_name($errorCode) {
+    return StubIntl::getErrorName($errorCode);
+}

--- a/src/Symfony/Component/Locale/Stub/StubIntl.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntl.php
@@ -102,6 +102,20 @@ abstract class StubIntl
     }
 
     /**
+     * Returns the symbolic name for a given error code
+     *
+     * @return string
+     */
+    static public function getErrorName($code)
+    {
+        if (isset(self::$errorCodes[$code])) {
+            return self::$errorCodes[$code];
+        }
+
+        return '[BOGUS UErrorCode]';
+    }
+
+    /**
      * Sets the current error
      *
      * @param  integer $code     One of the error constants in this class

--- a/tests/Symfony/Tests/Component/Locale/Stub/StubIntlTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubIntlTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Tests\Component\Locale\Stub;
+
+require_once __DIR__.'/../TestCase.php';
+
+use Symfony\Component\Locale\Locale;
+use Symfony\Component\Locale\Stub\StubIntl;
+use Symfony\Tests\Component\Locale\TestCase as LocaleTestCase;
+
+class StubIntlTest extends LocaleTestCase
+{
+    public function codeProvider()
+    {
+        return array (
+            array(0, 'U_ZERO_ERROR'),
+            array(1, 'U_ILLEGAL_ARGUMENT_ERROR'),
+            array(9, 'U_PARSE_ERROR'),
+        );
+    }
+
+    /**
+     * @dataProvider codeProvider
+     */
+    public function testGetErrorName($code, $name)
+    {
+        $this->assertSame($name, StubIntl::getErrorName($code));
+    }
+
+    /**
+     * @dataProvider codeProvider
+     */
+    public function testGetErrorNameWithIntl($code, $name)
+    {
+        $this->skipIfIntlExtensionIsNotLoaded();
+        $this->assertSame(intl_error_name($code), StubIntl::getErrorName($code));
+    }
+}

--- a/tests/Symfony/Tests/Component/Locale/Stub/StubIntlTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubIntlTest.php
@@ -22,9 +22,11 @@ class StubIntlTest extends LocaleTestCase
     public function codeProvider()
     {
         return array (
+            array(-129, '[BOGUS UErrorCode]'),
             array(0, 'U_ZERO_ERROR'),
             array(1, 'U_ILLEGAL_ARGUMENT_ERROR'),
             array(9, 'U_PARSE_ERROR'),
+            array(129, '[BOGUS UErrorCode]'),
         );
     }
 


### PR DESCRIPTION
```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
```
