### PR TITLE
[Twig] added subpath function

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
@@ -31,12 +32,14 @@ class RoutingExtensionTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('_route', 'page');
         $request->attributes->set('_route_params', array('dir' => 'dir', 'page' => 'page', '_format' => 'html'));
 
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
         $context = new RequestContext();
         $context->fromRequest($request);
         $generator = new UrlGenerator($routes, $context);
 
-        $extension = new RoutingExtension($generator);
-        $extension->setRequest($request);
+        $extension = new RoutingExtension($generator, $requestStack);
 
         $this->assertSame('http://example.com/dir/page/comments', $extension->getUrl('comments', array('dir' => 'dir', 'page' => 'page')));
         $this->assertSame('//example.com/dir/page/comments', $extension->getUrl('comments', array('dir' => 'dir', 'page' => 'page'), true));
@@ -68,12 +71,14 @@ class RoutingExtensionTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('_route', 'page');
         $request->attributes->set('_route_params', array('page' => 'mypage'));
 
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
         $context = new RequestContext();
         $context->fromRequest($request);
         $generator = new UrlGenerator($routes, $context);
 
-        $extension = new RoutingExtension($generator);
-        $extension->setRequest($request);
+        $extension = new RoutingExtension($generator, $requestStack);
 
         $this->assertStringStartsNotWith('querypage', $extension->getSubPath('', array(), true),
             'when the request query string has a parameter with the same name as a placeholder, the query param is ignored when includeQuery=true'
@@ -110,6 +115,8 @@ class RoutingExtensionTest extends \PHPUnit_Framework_TestCase
             array('{{ path(name = "foo", parameters = { foo: ["foo", "bar"] }) }}', true),
             array('{{ path(name = "foo", parameters = { foo: foo }) }}', true),
             array('{{ path(name = "foo", parameters = { foo: "foo", bar: "bar" }) }}', true),
+
+            array('{{ subpath("foo") }}', true),
         );
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/RoutingExtensionTest.php
@@ -12,9 +12,74 @@
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
 
 class RoutingExtensionTest extends \PHPUnit_Framework_TestCase
 {
+    public function testUrlGeneration()
+    {
+        $routes = new RouteCollection();
+        $routes->add('dir', new Route('/{dir}/'));
+        $routes->add('page', new Route('/{dir}/{page}.{_format}', array('_format' => 'html')));
+        $routes->add('comments', new Route('/{dir}/{page}/comments'));
+
+        $request = Request::create('http://example.com/dir/page?foo=bar&test=test');
+        $request->attributes->set('_route', 'page');
+        $request->attributes->set('_route_params', array('dir' => 'dir', 'page' => 'page', '_format' => 'html'));
+
+        $context = new RequestContext();
+        $context->fromRequest($request);
+        $generator = new UrlGenerator($routes, $context);
+
+        $extension = new RoutingExtension($generator);
+        $extension->setRequest($request);
+
+        $this->assertSame('http://example.com/dir/page/comments', $extension->getUrl('comments', array('dir' => 'dir', 'page' => 'page')));
+        $this->assertSame('//example.com/dir/page/comments', $extension->getUrl('comments', array('dir' => 'dir', 'page' => 'page'), true));
+
+        $this->assertSame('/dir/page/comments', $extension->getPath('comments', array('dir' => 'dir', 'page' => 'page')));
+        $this->assertSame('page/comments', $extension->getPath('comments', array('dir' => 'dir', 'page' => 'page'), true));
+
+        $this->assertSame('page.pdf', $extension->getSubPath('', array('_format' => 'pdf')));
+        $this->assertSame('?test=test', $extension->getSubPath('', array('test' => 'test'), false));
+        $this->assertSame('?foo=bar&test=test&extra=extra', $extension->getSubPath('', array('extra' => 'extra'), true));
+        $this->assertSame('?foo=bar&extra=extra', $extension->getSubPath('', array('extra' => 'extra', 'test' => null), true));
+        $this->assertSame('otherpage.json?foo=bar&test=test&extra=extra', $extension->getSubPath('', array('extra' => 'extra', 'page' => 'otherpage', '_format' => 'json'), true));
+        $this->assertSame('page/comments', $extension->getSubPath('comments', array('_format' => null)));
+        $this->assertSame('./', $extension->getSubPath('dir', array('page' => null, '_format' => null)));
+        $this->assertSame('./?foo=bar', $extension->getSubPath('dir', array('page' => null, '_format' => null, 'test' => null), true));
+        $this->assertSame('../otherdir/page.xml', $extension->getSubPath('page', array('dir' => 'otherdir', '_format' => 'xml')));
+
+        // we remove the request query string, so the resulting empty relative reference is actually correct for the current url and includeQuery=false
+        $context->setQueryString('');
+        $this->assertSame('', $extension->getSubPath());
+    }
+
+    public function testPlaceholdersHaveHigherPriorityThanQueryInSubPath()
+    {
+        $routes = new RouteCollection();
+        $routes->add('page', new Route('/{page}'));
+
+        $request = Request::create('http://example.com/mypage?page=querypage&bar=test');
+        $request->attributes->set('_route', 'page');
+        $request->attributes->set('_route_params', array('page' => 'mypage'));
+
+        $context = new RequestContext();
+        $context->fromRequest($request);
+        $generator = new UrlGenerator($routes, $context);
+
+        $extension = new RoutingExtension($generator);
+        $extension->setRequest($request);
+
+        $this->assertStringStartsNotWith('querypage', $extension->getSubPath('', array(), true),
+            'when the request query string has a parameter with the same name as a placeholder, the query param is ignored when includeQuery=true'
+        );
+    }
+
     /**
      * @dataProvider getEscapingTemplates
      */

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "symfony/form": "~2.2",
+        "symfony/http-foundation": "~2.4",
         "symfony/http-kernel": "~2.2",
         "symfony/routing": "~2.2",
         "symfony/templating": "~2.1",
@@ -31,6 +32,7 @@
     },
     "suggest": {
         "symfony/form": "",
+        "symfony/http-foundation": "",
         "symfony/http-kernel": "",
         "symfony/routing": "",
         "symfony/templating": "",

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -81,7 +81,7 @@
 
         <service id="twig.extension.routing" class="%twig.extension.routing.class%" public="false">
             <argument type="service" id="router" />
-            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false" /></call>
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="twig.extension.yaml" class="%twig.extension.yaml.class%" public="false">

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -81,6 +81,7 @@
 
         <service id="twig.extension.routing" class="%twig.extension.routing.class%" public="false">
             <argument type="service" id="router" />
+            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false" /></call>
         </service>
 
         <service id="twig.extension.yaml" class="%twig.extension.yaml.class%" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #4849, partly #6857 |
| License | MIT |

The new function `subpath` merges the variables of the current route request with the ones you optionally passed to the function. On top of that you can also add the query params (disabled by default).

It will generate a path-relative URL once #3958 gets merged but this PR is not necessarily depending on it. Since the target URL, that inherits some params from the current request, is probably a sub-page in the URL hierarchy (which is why it's called `subpath`), it makes sense to default it to a relative path, which makes the links shorter.

Use cases:
1. Generating the **same route** but changing a few parameters while keeping others of the current request (e.g. typical locale switcher).
2. Generating a **different route** while removing/overriding/adding some parameters on top of the current params. This is very useful when you have hierarchically structured pages, which is very common.
   Example: We are at `/user-slug/article-slug/` (article_show) and want to generate the link to comments of the article (article_comments). At the moment we would have to always repeat the current variables like
   `{{ path('article_comments', {'user': 'user-slug', 'article': 'article-slug'}) }}` and would for example get `/user-slug/article-slug/comments`.
   With `subpath` the advantage is you don't need to specify the variables of the current request again.
   So simply `{{ subpath('article_comments') }}` is enough for the relative URL `comments` in this case. But you can optionally overwrite some request variables with `{{ subpath('article_comments', {'article': 'different-article-slug'} ) }}` which would generate `../different-article-slug/comments` (i.e. same user, but different article).
3. Merging the **query params** can be used for filtering links, e.g. a facetted navigation page that filters items and you want to generate a link to add/overwrite filters based on the current filters. This is also one reason why removing params is needed which can be achieved by passing `null` as value for the unwanted param.
4. Generating a route with the same host params. See #6857.
5. <del>Generating the **same URL**.</del> I really thought much about this use-case. And I came to the conclusion it's not necessary for it to have a specific twig function. Of course you can also generate the same URL with path, url and subpath functions. But with path and url, you need to pass all variables again. And with subpath it will just generate an empty string `''` because that's the relative path for the current URL. So you don't need to call subpath at all. And if you need an absolute path or url, then you can just access the request information directly (`Request::getRequestUri`, i.e. in twig `{{ app.request.requestUri }}`. It's also faster because it doesn't go through the routing url generation at all. So all in all, it's already easy to get the same url. It would also not have much to do with `subpath` but instead it would be more appropriate to expose a new function like `{{ self() }}`. But as I said, it's not really needed and not part of this PR.
