### PR TITLE
reverse transform into PropelObjectCollection

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/DataTransformer/CollectionToArrayTransformer.php
+++ b/src/Symfony/Bridge/Propel1/Form/DataTransformer/CollectionToArrayTransformer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Propel1\Form\DataTransformer;
 
 use \PropelCollection;
+use \PropelObjectCollection;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
@@ -38,7 +39,7 @@ class CollectionToArrayTransformer implements DataTransformerInterface
 
     public function reverseTransform($array)
     {
-        $collection = new PropelCollection();
+        $collection = new PropelObjectCollection();
 
         if ('' === $array || null === $array) {
             return $collection;

--- a/src/Symfony/Bridge/Propel1/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/DataTransformer/CollectionToArrayTransformerTest.php
@@ -71,7 +71,7 @@ class CollectionToArrayTransformerTest extends Propel1TestCase
     {
         $result = $this->transformer->reverseTransform(null);
 
-        $this->assertInstanceOf('\PropelCollection', $result);
+        $this->assertInstanceOf('\PropelObjectCollection', $result);
         $this->assertEquals(0, count($result->getData()));
     }
 
@@ -79,7 +79,7 @@ class CollectionToArrayTransformerTest extends Propel1TestCase
     {
         $result = $this->transformer->reverseTransform('');
 
-        $this->assertInstanceOf('\PropelCollection', $result);
+        $this->assertInstanceOf('\PropelObjectCollection', $result);
         $this->assertEquals(0, count($result->getData()));
     }
 
@@ -98,7 +98,7 @@ class CollectionToArrayTransformerTest extends Propel1TestCase
         $result     = $this->transformer->reverseTransform($inputData);
         $data       = $result->getData();
 
-        $this->assertInstanceOf('\PropelCollection', $result);
+        $this->assertInstanceOf('\PropelObjectCollection', $result);
 
         $this->assertTrue(is_array($data));
         $this->assertEquals(2, count($data));


### PR DESCRIPTION
Allow usage of shortcut methods of `PropelObjectCollection` on submitted data from e.g. multiple choice form type.

Ping @willdurand
