### PR TITLE
[Filesystem] fixed mirror method to ensure targetDir is created

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -229,6 +229,15 @@ class Filesystem
 
         if ('/' === substr($originDir, -1) || '\\' === substr($originDir, -1)) {
             $originDir = substr($originDir, 0, -1);
+	}
+
+        if (!is_dir($targetDir)) {
+            if (file_exists($targetDir)) {
+                throw new \RuntimeException(sprintf('Target directory "%s" is not a directory.', $targetDir));
+            }
+            if (!mkdir($targetDir)) {
+                throw new \RuntimeException(sprintf('Target directory "%s" could not be created.', $targetDir));
+            }
         }
 
         foreach ($iterator as $file) {

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -229,7 +229,7 @@ class Filesystem
 
         if ('/' === substr($originDir, -1) || '\\' === substr($originDir, -1)) {
             $originDir = substr($originDir, 0, -1);
-	}
+        }
 
         if (!is_dir($targetDir)) {
             if (file_exists($targetDir)) {


### PR DESCRIPTION
When running the test suite, I found that the testMirrorCopiesLinks test failed because the targetDir did not exist. Added code to create directory inside FileSystem->mirror(...) to ensure it gets created.
