### PR TITLE
Added Monolog to composer.json as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "doctrine/dbal": "2.2.*",
         "doctrine/orm": "2.2.*",
         "doctrine/data-fixtures": "1.0.*",
-        "propel/propel1": "dev-master"
+        "propel/propel1": "dev-master",
+        "monolog/monolog": "dev-master"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/michal-pipa/symfony.png?branch=composer-fix)](http://travis-ci.org/michal-pipa/symfony)
Fixes the following tickets: -
Todo: -

Monolog was missing in dev composer dependences. It was present in `vendors.php`: https://github.com/symfony/symfony/blob/35e6c8ed0fb1ee329c26868c87e0fb5c54eef06a/vendors.php

Without this code coverage report generation fails with error message: `Fatal error: Class 'Monolog\Handler\ChromePHPHandler' not found`.
