### PR TITLE
[Form] Fix/csrf token added to prototypes, fixes #3987.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -27,7 +27,8 @@ class CollectionType extends AbstractType
     {
         if ($options['allow_add'] && $options['prototype']) {
             $prototype = $builder->create($options['prototype_name'], $options['type'], array_replace(array(
-                'label' => $options['prototype_name'] . 'label__',
+                'label'           => $options['prototype_name'] . 'label__',
+                'csrf_protection' => false
             ), $options['options']));
             $builder->setAttribute('prototype', $prototype->getForm());
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -27,8 +27,7 @@ class CollectionType extends AbstractType
     {
         if ($options['allow_add'] && $options['prototype']) {
             $prototype = $builder->create($options['prototype_name'], $options['type'], array_replace(array(
-                'label'           => $options['prototype_name'] . 'label__',
-                'csrf_protection' => false
+                'label' => $options['prototype_name'] . 'label__',
             ), $options['options']));
             $builder->setAttribute('prototype', $prototype->getForm());
         }

--- a/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/Type/FormTypeCsrfExtension.php
@@ -80,6 +80,23 @@ class FormTypeCsrfExtension extends AbstractTypeExtension
     }
 
     /**
+     * Removes CSRF field from the form view if it's not root
+     *
+     * @param FormView      $view The form view
+     * @param FormInterface $form The form
+     */
+    public function buildViewBottomUp(FormView $view, FormInterface $form)
+    {
+        if ($view->hasParent() && $form->hasAttribute('csrf_field_name')) {
+            $name = $form->getAttribute('csrf_field_name');
+
+            if (isset($view[$name])) {
+                unset($view[$name]);
+            }
+        }
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getDefaultOptions()


### PR DESCRIPTION
**Bug fix**: yes.
**Feature addition**: no.
**Backwards compatibility break**: no.
**Symfony2 tests pass**: no, but it's not related in any way to forms.
**Fixes the following tickets**: #3987.

After recent refactoring of csrf protection, the token was added to all prototypes.
