### PR TITLE
[Validator] validators.nl.xlf Fixed grammar error

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xliff
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xliff
@@ -24,7 +24,7 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choices</source>
-                <target>Selecteer tenminste {{ limit }} opties</target>
+                <target>Selecteer ten minste {{ limit }} opties</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choices</source>


### PR DESCRIPTION
There is a small grammar error in validators.nl.xlf

tenminste is wrong is this context.
http://www.onzetaal.nl/taaladvies/advies/tenminste

"tenminste" (instead of) -> "ten minste" (at minimum).
