### PR TITLE
[Templating] Return base URL when an empty path is given to asset()

### DIFF
--- a/src/Symfony/Component/Templating/Asset/PathPackage.php
+++ b/src/Symfony/Component/Templating/Asset/PathPackage.php
@@ -51,7 +51,7 @@ class PathPackage extends Package
         $url = $this->applyVersion($path);
 
         // apply the base path
-        if ($url && '/' != $url[0]) {
+        if ('/' !== substr($url, 0, 1)) {
             $url = $this->basePath.$url;
         }
 

--- a/src/Symfony/Component/Templating/Tests/Helper/AssetsHelperTest.php
+++ b/src/Symfony/Component/Templating/Tests/Helper/AssetsHelperTest.php
@@ -52,6 +52,9 @@ class AssetsHelperTest extends \PHPUnit_Framework_TestCase
 
         $helper = new AssetsHelper('/bar', 'http://www.example.com/foo', 'abcd');
         $this->assertEquals('http://www.example.com/foo/foo.js?abcd', $helper->getUrl('foo.js'), '->getUrl() appends the version if defined');
+
+        $helper = new AssetsHelper();
+        $this->assertEquals('/', $helper->getUrl(''), '->getUrl() with empty arg returns the prefix alone');
     }
 
     public function testGetUrlLeavesProtocolRelativePathsUntouched()


### PR DESCRIPTION
I think it's straightforward enough in the patch. Tests pass. It's quite useful to generate the base path to send to a JS frontend.
