### PR TITLE
Add Support for boolean as to string into yaml extension

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
@@ -52,7 +52,7 @@ class YamlExtension extends \Twig_Extension
             return '%'.gettype($value).'% '.$this->encode($value);
         }
 
-        return $value;
+        return $this->encode($value);
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 3992
Todo:
- Maybe use only boolean checker instead of YamlDumper->dump
