### PR TITLE
[Filesystem][Others] Fix chmod method and all calls to chmod throughout the framework

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -181,7 +181,7 @@ class ClassCollectionLoader
     {
         $tmpFile = tempnam(dirname($file), basename($file));
         if (false !== @file_put_contents($tmpFile, $content) && @rename($tmpFile, $file)) {
-            chmod($file, 0777);
+            chmod($file, 0666 ^ umask());
 
             return;
         }

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -101,7 +101,7 @@ class ConfigCache
 
         $tmpFile = tempnam(dirname($this->file), basename($this->file));
         if (false !== @file_put_contents($tmpFile, $content) && @rename($tmpFile, $this->file)) {
-            chmod($this->file, 0666);
+            chmod($this->file, 0666 ^ umask());
         } else {
             throw new \RuntimeException(sprintf('Failed to write cache file "%s".', $this->file));
         }
@@ -110,7 +110,7 @@ class ConfigCache
             $file = $this->file.'.meta';
             $tmpFile = tempnam(dirname($file), basename($file));
             if (false !== @file_put_contents($tmpFile, serialize($metadata)) && @rename($tmpFile, $file)) {
-                chmod($file, 0666);
+                chmod($file, 0666 ^ umask());
             }
         }
     }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -181,6 +181,12 @@ class Filesystem
      */
     public function makePathRelative($endPath, $startPath)
     {
+        // Normalize separators on windows
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $endPath = strtr($endPath, '\\', '/');
+            $startPath = strtr($startPath, '\\', '/');
+        }
+
         // Find for which character the the common path stops
         $offset = 0;
         while (isset($startPath[$offset]) && isset($endPath[$offset]) && $startPath[$offset] === $endPath[$offset]) {
@@ -188,8 +194,8 @@ class Filesystem
         }
 
         // Determine how deep the start path is relative to the common path (ie, "web/bundles" = 2 levels)
-        $diffPath = trim(substr($startPath, $offset), DIRECTORY_SEPARATOR);
-        $depth = strlen($diffPath) > 0 ? substr_count($diffPath, DIRECTORY_SEPARATOR) + 1 : 0;
+        $diffPath = trim(substr($startPath, $offset), '/');
+        $depth = strlen($diffPath) > 0 ? substr_count($diffPath, '/') + 1 : 0;
 
         // Repeated "../" for each level need to reach the common path
         $traverser = str_repeat('../', $depth);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -106,19 +106,14 @@ class Filesystem
      * Change mode for an array of files or directories.
      *
      * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to change mode
-     * @param integer                   $mode  The new mode
+     * @param integer                   $mode  The new mode (octal)
      * @param integer                   $umask The mode mask (octal)
      */
     public function chmod($files, $mode, $umask = 0000)
     {
-        $currentUmask = umask();
-        umask($umask);
-
         foreach ($this->toIterator($files) as $file) {
-            chmod($file, $mode);
+            chmod($file, $mode ^ $umask);
         }
-
-        umask($currentUmask);
     }
 
     /**

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -315,6 +315,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testChmodChangesFileMode()
     {
+        $this->markAsSkippedIfChmodIsMissing();
+
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
         touch($file);
 
@@ -323,8 +325,21 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(753, $this->getFilePermisions($file));
     }
 
+    public function testChmodAppliesUmask()
+    {
+        $this->markAsSkippedIfChmodIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        touch($file);
+
+        $this->filesystem->chmod($file, 0777, 0022);
+        $this->assertEquals(755, $this->getFilePermisions($file));
+    }
+
     public function testChmodChangesModeOfArrayOfFiles()
     {
+        $this->markAsSkippedIfChmodIsMissing();
+
         $directory = $this->workspace.DIRECTORY_SEPARATOR.'directory';
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
         $files = array($directory, $file);
@@ -340,6 +355,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testChmodChangesModeOfTraversableFileObject()
     {
+        $this->markAsSkippedIfChmodIsMissing();
+
         $directory = $this->workspace.DIRECTORY_SEPARATOR.'directory';
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
         $files = new \ArrayObject(array($directory, $file));
@@ -545,6 +562,13 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
     {
         if (!function_exists('symlink')) {
             $this->markTestSkipped('symlink is not supported');
+        }
+    }
+
+    private function markAsSkippedIfChmodIsMissing()
+    {
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $this->markTestSkipped('chmod is not supported on windows');
         }
     }
 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -477,8 +477,11 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
             array('var/lib/symfony/', 'var/lib/symfony/src/Symfony/Component', '../../../'),
             array('/usr/lib/symfony/', '/var/lib/symfony/src/Symfony/Component', '../../../../../../usr/lib/symfony/'),
             array('/var/lib/symfony/src/Symfony/', '/var/lib/symfony/', 'src/Symfony/'),
-            array('c:\var\lib/symfony/src/Symfony/', 'c:/var/lib/symfony/', 'src/Symfony/'),
         );
+
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $paths[] = array('c:\var\lib/symfony/src/Symfony/', 'c:/var/lib/symfony/', 'src/Symfony/');
+        }
 
         return $paths;
     }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -299,7 +299,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testRemoveCleansInvalidLinks()
     {
-        $this->markAsSkippeIfSymlinkIsMissing();
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         $basePath = $this->workspace.DIRECTORY_SEPARATOR.'directory'.DIRECTORY_SEPARATOR;
 
@@ -392,7 +392,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testSymlink()
     {
-        $this->markAsSkippeIfSymlinkIsMissing();
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
         $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
@@ -407,7 +407,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testSymlinkIsOverwrittenIfPointsToDifferentTarget()
     {
-        $this->markAsSkippeIfSymlinkIsMissing();
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
         $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
@@ -423,7 +423,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testSymlinkIsNotOverwrittenIfAlreadyCreated()
     {
-        $this->markAsSkippeIfSymlinkIsMissing();
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
         $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
@@ -490,7 +490,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
 
     public function testMirrorCopiesLinks()
     {
-        $this->markAsSkippeIfSymlinkIsMissing();
+        $this->markAsSkippedIfSymlinkIsMissing();
 
         $sourcePath = $this->workspace.DIRECTORY_SEPARATOR.'source'.DIRECTORY_SEPARATOR;
 
@@ -541,7 +541,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         return (int) substr(sprintf('%o', fileperms($filePath)), -3);
     }
 
-    private function markAsSkippeIfSymlinkIsMissing()
+    private function markAsSkippedIfSymlinkIsMissing()
     {
         if (!function_exists('symlink')) {
             $this->markTestSkipped('symlink is not supported');

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -460,14 +460,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
             array('var/lib/symfony/', 'var/lib/symfony/src/Symfony/Component', '../../../'),
             array('/usr/lib/symfony/', '/var/lib/symfony/src/Symfony/Component', '../../../../../../usr/lib/symfony/'),
             array('/var/lib/symfony/src/Symfony/', '/var/lib/symfony/', 'src/Symfony/'),
+            array('c:\var\lib/symfony/src/Symfony/', 'c:/var/lib/symfony/', 'src/Symfony/'),
         );
-
-        // fix directory separator
-        foreach ($paths as $i => $pathItems) {
-            foreach ($pathItems as $k => $path) {
-                $paths[$i][$k] = str_replace('/', DIRECTORY_SEPARATOR, $path);
-            }
-        }
 
         return $paths;
     }

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -122,7 +122,7 @@ class File extends \SplFileInfo
             throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
         }
 
-        chmod($target, 0666);
+        chmod($target, 0666 ^ umask());
 
         return new File($target);
     }

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmer.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmer.php
@@ -22,7 +22,7 @@ abstract class CacheWarmer implements CacheWarmerInterface
     {
         $tmpFile = tempnam(dirname($file), basename($file));
         if (false !== @file_put_contents($tmpFile, $content) && @rename($tmpFile, $file)) {
-            chmod($file, 0644);
+            chmod($file, 0666 ^ umask());
 
             return;
         }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -332,7 +332,7 @@ class Store implements StoreInterface
             return false;
         }
 
-        chmod($path, 0644);
+        chmod($path, 0666 ^ umask());
     }
 
     public function getPath($key)


### PR DESCRIPTION
Fixes the issue I mentioned in #4004 - basically php's chmod() does not apply the umask by default (unlike mkdir's mode arg which is masked by umask, from which I guess the confusion comes from).

So I expanded all cache writes and such to 0666 when they were 0644, and then mask it against umask, so that we respect the user settings a bit better.

Also fixed Filesystem::chmod which completely ignored the umask argument before.

Fixed a few tests on windows too.
