### PR TITLE
[Finder] search by contents

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -44,6 +44,8 @@ class Finder implements \IteratorAggregate
     private $dirs        = array();
     private $dates       = array();
     private $iterators   = array();
+    private $contents    = array();
+    private $notContents = array();
 
     static private $vcsPatterns = array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.hg');
 
@@ -184,6 +186,53 @@ class Finder implements \IteratorAggregate
     public function notName($pattern)
     {
         $this->notNames[] = $pattern;
+
+        return $this;
+    }
+
+    /**
+     * Adds tests that file contents must match.
+     *
+     * Strings or PCRE patterns can be used:
+     *
+     * $finder->content('Lorem ipsum')
+     * $finder->content('/Lorem ipsum/i')
+     *
+     * @param  string $pattern A pattern (string or regexp)
+     *
+     * @return Finder The current Finder instance
+     *
+     * @see Symfony\Component\Finder\Iterator\FilecontentFilterIterator
+     *
+     * @api
+     */
+    public function content($pattern)
+    {
+        $this->contents[] = $pattern;
+
+        return $this;
+    }
+
+    /**
+     * Adds tests that file contents must not match.
+     *
+     * Strings or PCRE patterns can be used:
+     *
+     * $finder->notContent('Lorem ipsum')
+     * $finder->notContent('/Lorem ipsum/i')
+
+     *
+     * @param  string $pattern A pattern (string or regexp)
+     *
+     * @return Finder The current Finder instance
+     *
+     * @see Symfony\Component\Finder\Iterator\FilecontentFilterIterator
+     *
+     * @api
+     */
+    public function notContent($pattern)
+    {
+        $this->notContents[] = $pattern;
 
         return $this;
     }
@@ -549,6 +598,10 @@ class Finder implements \IteratorAggregate
 
         if ($this->names || $this->notNames) {
             $iterator = new Iterator\FilenameFilterIterator($iterator, $this->names, $this->notNames);
+        }
+
+        if ($this->contents || $this->notContents) {
+            $iterator = new Iterator\FilecontentFilterIterator($iterator, $this->contents, $this->notContents);
         }
 
         if ($this->sizes) {

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -44,8 +44,8 @@ class Finder implements \IteratorAggregate
     private $dirs        = array();
     private $dates       = array();
     private $iterators   = array();
-    private $contents    = array();
-    private $notContents = array();
+    private $contains    = array();
+    private $notContains = array();
 
     static private $vcsPatterns = array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.hg');
 
@@ -195,20 +195,18 @@ class Finder implements \IteratorAggregate
      *
      * Strings or PCRE patterns can be used:
      *
-     * $finder->content('Lorem ipsum')
-     * $finder->content('/Lorem ipsum/i')
+     * $finder->contains('Lorem ipsum')
+     * $finder->contains('/Lorem ipsum/i')
      *
      * @param  string $pattern A pattern (string or regexp)
      *
      * @return Finder The current Finder instance
      *
      * @see Symfony\Component\Finder\Iterator\FilecontentFilterIterator
-     *
-     * @api
      */
-    public function content($pattern)
+    public function contains($pattern)
     {
-        $this->contents[] = $pattern;
+        $this->contains[] = $pattern;
 
         return $this;
     }
@@ -218,8 +216,8 @@ class Finder implements \IteratorAggregate
      *
      * Strings or PCRE patterns can be used:
      *
-     * $finder->notContent('Lorem ipsum')
-     * $finder->notContent('/Lorem ipsum/i')
+     * $finder->notContains('Lorem ipsum')
+     * $finder->notContains('/Lorem ipsum/i')
 
      *
      * @param  string $pattern A pattern (string or regexp)
@@ -227,12 +225,10 @@ class Finder implements \IteratorAggregate
      * @return Finder The current Finder instance
      *
      * @see Symfony\Component\Finder\Iterator\FilecontentFilterIterator
-     *
-     * @api
      */
-    public function notContent($pattern)
+    public function notContains($pattern)
     {
-        $this->notContents[] = $pattern;
+        $this->notContains[] = $pattern;
 
         return $this;
     }
@@ -600,8 +596,8 @@ class Finder implements \IteratorAggregate
             $iterator = new Iterator\FilenameFilterIterator($iterator, $this->names, $this->notNames);
         }
 
-        if ($this->contents || $this->notContents) {
-            $iterator = new Iterator\FilecontentFilterIterator($iterator, $this->contents, $this->notContents);
+        if ($this->contains || $this->notContains) {
+            $iterator = new Iterator\FilecontentFilterIterator($iterator, $this->contains, $this->notContains);
         }
 
         if ($this->sizes) {

--- a/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Iterator;
+
+use Symfony\Component\Finder\Glob;
+
+/**
+ * MultiplePcreFilterIterator filters files using patterns (regexps, globs or strings).
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+abstract class MultiplePcreFilterIterator extends \FilterIterator
+{
+    protected $matchRegexps;
+    protected $noMatchRegexps;
+
+    /**
+     * Constructor.
+     *
+     * @param \Iterator $iterator        The Iterator to filter
+     * @param array     $matchPatterns   An array of patterns that need to match
+     * @param array     $noMatchPatterns An array of patterns that need to not match
+     */
+    public function __construct(\Iterator $iterator, array $matchPatterns, array $noMatchPatterns)
+    {
+        $this->matchRegexps = array();
+        foreach ($matchPatterns as $pattern) {
+            $this->matchRegexps[] = $this->toRegex($pattern);
+        }
+
+        $this->noMatchRegexps = array();
+        foreach ($noMatchPatterns as $pattern) {
+            $this->noMatchRegexps[] = $this->toRegex($pattern);
+        }
+
+        parent::__construct($iterator);
+    }
+
+    /**
+     * Converts string into regexp.
+     *
+     * @param string $str Pattern
+     *
+     * @return string regexp corresponding to a given string
+     */
+    abstract protected function toRegex($str);
+
+}

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -330,4 +330,46 @@ class FinderTest extends Iterator\RealIteratorTestCase
 
         return $f;
     }
+
+    protected function toAbsoluteFixtures($files)
+    {
+        $f = array();
+        foreach ($files as $file) {
+            $f[] = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$file;
+        }
+
+        return $f;
+    }
+
+    /**
+     * @dataProvider getContentTestData
+     */
+    public function testContent($matchPatterns, $noMatchPatterns, $expected)
+    {
+        $finder = new Finder();
+        $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures')
+            ->name('*.txt')->sortByName()
+            ->content($matchPatterns)
+            ->notContent($noMatchPatterns);
+
+        $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
+    }
+
+    public function getContentTestData()
+    {
+        return array(
+            array('', '', array()),
+            array('foo', 'bar', array()),
+            array('', 'foobar', array('dolor.txt', 'ipsum.txt', 'lorem.txt')),
+            array('lorem ipsum dolor sit amet', 'foobar', array('lorem.txt')),
+            array('sit', 'bar', array('dolor.txt', 'ipsum.txt', 'lorem.txt')),
+            array('dolor sit amet', '@^L@m', array('dolor.txt', 'ipsum.txt')),
+            array('/^lorem ipsum dolor sit amet$/m', 'foobar', array('lorem.txt')),
+            array('lorem', 'foobar', array('lorem.txt')),
+
+            array('', 'lorem', array('dolor.txt', 'ipsum.txt')),
+            array('ipsum dolor sit amet', '/^IPSUM/m', array('lorem.txt')),
+        );
+    }
+
 }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -342,20 +342,20 @@ class FinderTest extends Iterator\RealIteratorTestCase
     }
 
     /**
-     * @dataProvider getContentTestData
+     * @dataProvider getContainsTestData
      */
-    public function testContent($matchPatterns, $noMatchPatterns, $expected)
+    public function testContains($matchPatterns, $noMatchPatterns, $expected)
     {
         $finder = new Finder();
         $finder->in(__DIR__.DIRECTORY_SEPARATOR.'Fixtures')
             ->name('*.txt')->sortByName()
-            ->content($matchPatterns)
-            ->notContent($noMatchPatterns);
+            ->contains($matchPatterns)
+            ->notContains($noMatchPatterns);
 
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 
-    public function getContentTestData()
+    public function getContainsTestData()
     {
         return array(
             array('', '', array()),

--- a/src/Symfony/Component/Finder/Tests/Fixtures/dolor.txt
+++ b/src/Symfony/Component/Finder/Tests/Fixtures/dolor.txt
@@ -1,0 +1,2 @@
+dolor sit amet
+DOLOR SIT AMET

--- a/src/Symfony/Component/Finder/Tests/Fixtures/ipsum.txt
+++ b/src/Symfony/Component/Finder/Tests/Fixtures/ipsum.txt
@@ -1,0 +1,2 @@
+ipsum dolor sit amet
+IPSUM DOLOR SIT AMET

--- a/src/Symfony/Component/Finder/Tests/Fixtures/lorem.txt
+++ b/src/Symfony/Component/Finder/Tests/Fixtures/lorem.txt
@@ -1,0 +1,2 @@
+lorem ipsum dolor sit amet
+LOREM IPSUM DOLOR SIT AMET

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilecontentFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilecontentFilterIteratorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests\Iterator;
+
+use Symfony\Component\Finder\Iterator\FilecontentFilterIterator;
+
+class FilecontentFilterIteratorTest extends IteratorTestCase
+{
+
+    public function testAccept()
+    {
+        $inner = new ContentInnerNameIterator(array('test.txt'));
+
+        $iterator = new FilecontentFilterIterator($inner, array(), array());
+
+        $this->assertIterator(array('test.txt'), $iterator);
+    }
+
+}
+
+class ContentInnerNameIterator extends \ArrayIterator
+{
+    public function current()
+    {
+        return new \SplFileInfo(parent::current());
+    }
+
+    public function getFilename()
+    {
+        return parent::current();
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Sometimes I need to search for files containing some text:

```
$finder
    ->content('lorem')->notContent('ipsum')
    ->content('/^Begining/m')->notContent('/the end$/m');
```

I don't know how to tests exceptions thrown by `file_get_contents()` calls.
