### PR TITLE
[Filesystem] symlink() creates target directories

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -152,6 +152,8 @@ class Filesystem
             return;
         }
 
+        $this->mkdir(dirname($targetDir));
+
         $ok = false;
         if (is_link($targetDir)) {
             if (readlink($targetDir) != $originDir) {

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -454,6 +454,23 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($file, readlink($link));
     }
 
+    public function testSymlinkCreatesTargetDirectoryIfItDoesNotExist()
+    {
+        $this->markAsSkippedIfSymlinkIsMissing();
+
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $link1 = $this->workspace.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'link';
+        $link2 = $this->workspace.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'subdir'.DIRECTORY_SEPARATOR.'link';
+
+        $this->filesystem->symlink($file, $link1);
+        $this->filesystem->symlink($file, $link2);
+
+        $this->assertTrue(is_link($link1));
+        $this->assertEquals($file, readlink($link1));
+        $this->assertTrue(is_link($link2));
+        $this->assertEquals($file, readlink($link2));
+    }
+
     /**
      * @dataProvider providePathsForMakePathRelative
      */


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/michal-pipa/symfony.png?branch=symlink-fix)](http://travis-ci.org/michal-pipa/symfony)
Fixes the following tickets: #3967
Todo: -

Changed symlink() method behavior to recursively create target directory if it does not exist. It makes Filesystem component methods more consistent since copy() does the same. It is also more convenient.

Also mirror() fails to create symlink in non-existent directory (if we don't want to change symlink(), than we need to fix mirror()).

Fixes: #3967
