### PR TITLE
[HttpKernel] Enhance FlattenException to include more methods from Exception.  

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
@@ -27,6 +27,8 @@ class FlattenException
     private $class;
     private $statusCode;
     private $headers;
+    private $file;
+    private $line;
 
     static public function create(\Exception $exception, $statusCode = null, array $headers = array())
     {
@@ -42,6 +44,8 @@ class FlattenException
         $e->setHeaders($headers);
         $e->setTrace($exception->getTrace(), $exception->getFile(), $exception->getLine());
         $e->setClass(get_class($exception));
+        $e->setFile($exception->getFile());
+        $e->setLine($exception->getLine());
         if ($exception->getPrevious()) {
             $e->setPrevious(static::create($exception->getPrevious()));
         }
@@ -91,6 +95,26 @@ class FlattenException
     public function setClass($class)
     {
         $this->class = $class;
+    }
+
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    public function setFile($file)
+    {
+        $this->file = $file;
+    }
+
+    public function getLine()
+    {
+        return $this->line;
+    }
+
+    public function setLine($line)
+    {
+        $this->line = $line;
     }
 
     public function getMessage()

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
@@ -62,6 +62,24 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider flattenDataProvider
      */
+    public function testLine(\Exception $exception)
+    {
+        $flattened = FlattenException::create($exception);
+        $this->assertSame($exception->getLine(), $flattened->getLine());
+    }
+
+    /**
+     * @dataProvider flattenDataProvider
+     */
+    public function testFile(\Exception $exception)
+    {
+        $flattened = FlattenException::create($exception);
+        $this->assertSame($exception->getFile(), $flattened->getFile());
+    }
+
+    /**
+     * @dataProvider flattenDataProvider
+     */
     public function testToArray(\Exception $exception, $statusCode)
     {
         $flattened = FlattenException::create($exception);


### PR DESCRIPTION
I'm trying to retrofit FlattenException into Drupal, in places where Drupal expects an Exception.  That doesn't quite work though, as FlattenException only has some of the methods from Exception.  I'm not entirely clear why it only has some, but this PR adds getFile() and getLine() so that it's a more ready drop-in.  I did not add them to the toArray() method for fear of breaking BC somewhere, but that could be done as well no doubt if folks felt it was appropriate.

Note: While the parts of Drupal in question will get rewritten later anyway, I think having this information exposed is a good thing in general for logging purposes if nothing else.  It's already possible to dig it out of the trace, so this is just an improved "Developer eXperience" (DX).
