### PR TITLE
[Propel1] Removed useless require in autoload.php.dist

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -20,7 +20,3 @@ if (is_file(__DIR__.'/vendor/swiftmailer/swiftmailer/lib/classes/Swift.php')) {
     require_once __DIR__.'/vendor/swiftmailer/swiftmailer/lib/classes/Swift.php';
     Swift::registerAutoload(__DIR__.'/vendor/swiftmailer/swiftmailer/lib/swift_init.php');
 }
-
-if (is_file($file = __DIR__.'/vendor/propel/propel1/runtime/lib/Propel.php')) {
-    require_once $file;
-}


### PR DESCRIPTION
Since we have Composer, and a classmap, no need to trigger the Propel's autoloader
