### PR TITLE
[Global] ignore composer.phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 phpunit.xml
 composer.lock
+composer.phar
 autoload.php
 /vendor/


### PR DESCRIPTION
for running unit tests the external dependencies are managed using composer (since aa055dfd983ccfca6e09a375dd7111c874452dab), so it's necessary to download composer.phar to install them. We don't want composer.phar to be comitted to the codebase so it's necessary to ignore it.

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
