### PR TITLE
[2.2] [DomCrawler] Allow selecting by Select value

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -272,6 +272,7 @@ class ChoiceFormField extends FormField
         $defaultValue = (isset($node->nodeValue) && !empty($node->nodeValue)) ? $node->nodeValue : '1';
         $option['value'] = $node->hasAttribute('value') ? $node->getAttribute('value') : $defaultValue;
         $option['disabled'] = ($node->hasAttribute('disabled') && $node->getAttribute('disabled') == 'disabled');
+        $option['label'] = $defaultValue;
 
         return $option;
     }

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -277,7 +277,7 @@ class ChoiceFormField extends FormField
     }
 
     /**
-     * Checks whether given vale is in the existing options
+     * Checks whether given value is in the existing options
      *
      * @param string $optionValue
      * @param array  $options

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -133,11 +133,17 @@ class ChoiceFormField extends FormField
 
                 foreach ($value as $v) {
                     if (!$this->containsOption($v, $this->options)) {
-                        throw new \InvalidArgumentException(sprintf('Input "%s" cannot take "%s" as a value (possible values: %s).', $this->name, $v, implode(', ', $this->availableOptionValues())));
+                        if (!($labelValue = $this->convertLabelToValue($value))) {
+                            throw new \InvalidArgumentException(sprintf('Input "%s" cannot take "%s" as a value (possible values: %s).', $this->name, $v, implode(', ', $this->availableOptionValues())));
+                        }
+                        $value = $labelValue;
                     }
                 }
             } elseif (!$this->containsOption($value, $this->options)) {
-                throw new \InvalidArgumentException(sprintf('Input "%s" cannot take "%s" as a value (possible values: %s).', $this->name, $value, implode(', ', $this->availableOptionValues())));
+                if (!($labelValue = $this->convertLabelToValue($value))) {
+                    throw new \InvalidArgumentException(sprintf('Input "%s" cannot take "%s" as a value (possible values: %s).', $this->name, $value, implode(', ', $this->availableOptionValues())));
+                }
+                $value = $labelValue;
             }
 
             if ($this->multiple) {
@@ -303,5 +309,23 @@ class ChoiceFormField extends FormField
         }
 
         return $values;
+    }
+
+    /**
+     * Find a select field's value based on it's label
+     *
+     * @param string$label
+     *
+     * @return string
+     */
+    public function convertLabelToValue($label)
+    {
+        foreach ($this->options as $option) {
+            if ($option['label'] == $label) {
+                return $option['value'];
+            }
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
This allows setting the value of a select node by passing in the name of the option instead of the value (`<select value="VALUE">NAME</select>`).

I needed this when trying to select a value from a select field where the value is the database id (that will change) and the name is the value that stays the same.

Bug fix: no
Feature addition: yes
Backwards compatibility break: I think not
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/colinfrei/symfony.png?branch=selectValue)](http://travis-ci.org/colinfrei/symfony)
Fixes the following tickets: -
Todo: -
