### PR TITLE
[Propel1] Added security layer

### DIFF
--- a/src/Symfony/Bridge/Propel1/DependencyInjection/Security/UserProvider/PropelFactory.php
+++ b/src/Symfony/Bridge/Propel1/DependencyInjection/Security/UserProvider/PropelFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Propel1\DependencyInjection\Security\UserProvider;
+
+use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\UserProvider\UserProviderFactoryInterface;
+use Symfony\Component\Config\Definition\Builder\NodeDefinition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * PropelFactory creates services for Doctrine user provider.
+ *
+ * @author William Durand <william.durand1@gmail.com>
+ */
+class PropelFactory implements UserProviderFactoryInterface
+{
+    private $key;
+    private $providerId;
+
+    public function __construct($key, $providerId)
+    {
+        $this->key = $key;
+        $this->providerId = $providerId;
+    }
+
+    public function create(ContainerBuilder $container, $id, $config)
+    {
+        $container
+            ->setDefinition($id, new DefinitionDecorator($this->providerId))
+            ->addArgument($config['class'])
+            ->addArgument($config['property'])
+            ;
+    }
+
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function addConfiguration(NodeDefinition $node)
+    {
+        $node
+            ->children()
+            ->scalarNode('class')->isRequired()->cannotBeEmpty()->end()
+            ->scalarNode('property')->defaultNull()->end()
+            ->end()
+            ;
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Security/User/PropelUserProvider.php
+++ b/src/Symfony/Bridge/Propel1/Security/User/PropelUserProvider.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Propel1\Security\User;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
+use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+
+/**
+ * Provides easy to use provisioning for Propel model users.
+ *
+ * @author William DURAND <william.durand1@gmail.com>
+ */
+class PropelUserProvider implements UserProviderInterface
+{
+    /**
+     * A Model class name.
+     * @var string
+     */
+    protected $class;
+
+    /**
+     * A Query class name.
+     * @var string
+     */
+    protected $queryClass;
+
+    /**
+     * A property to use to retrieve the user.
+     * @var string
+     */
+    protected $property;
+
+    /**
+     * Default constructor
+     *
+     * @param $class        The User model class.
+     * @param $property     The property to use to retrieve a user.
+     */
+    public function __construct($class, $property = null)
+    {
+        $this->class = $class;
+        $this->queryClass = $class . 'Query';
+        $this->property = $property;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadUserByUsername($username)
+    {
+        $queryClass = $this->queryClass;
+        $query      = $queryClass::create();
+
+        if (null !== $this->property) {
+            $filter = 'filterBy' . ucfirst($this->property);
+            $query->$filter($username);
+        } else {
+            $query->filterByUsername($username);
+        }
+
+        if (null === $user = $query->findOne()) {
+            throw new UsernameNotFoundException(sprintf('User "%s" not found.', $username));
+        }
+
+        return $user;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refreshUser(UserInterface $user)
+    {
+        if (!$user instanceof $this->class) {
+            throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', get_class($user)));
+        }
+
+        $queryClass = $this->queryClass;
+
+        return $queryClass::create()->findPk($user->getPrimaryKey());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsClass($class)
+    {
+        return $class === $this->class;
+    }
+}


### PR DESCRIPTION
Fixed the security layer for Propel 1.6, and Symfony2 2.1.

The PropelBundle is ready to go: https://github.com/propelorm/PropelBundle/pull/139
Unit tests are part of the PropelBundle at the moment, as it requires to setup a quick builder.
