### PR TITLE
Removes DoctrineMapping registry and SwiftMailer in autoload.php.dist

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -14,9 +14,3 @@ if (!function_exists('intl_get_error_code')) {
 }
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
-AnnotationRegistry::registerFile(__DIR__.'/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
-
-if (is_file(__DIR__.'/vendor/swiftmailer/swiftmailer/lib/classes/Swift.php')) {
-    require_once __DIR__.'/vendor/swiftmailer/swiftmailer/lib/classes/Swift.php';
-    Swift::registerAutoload(__DIR__.'/vendor/swiftmailer/swiftmailer/lib/swift_init.php');
-}


### PR DESCRIPTION
This allows running phpunit without errors.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
