### PR TITLE
[Form] Extra Form Event

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -541,6 +541,9 @@ class Form implements \IteratorAggregate, FormInterface
         // Merge form data from children into existing client data
         if (count($this->children) > 0 && $this->dataMapper && null !== $clientData) {
             $this->dataMapper->mapFormsToData($this->children, $clientData);
+            
+            $event = new FilterDataEvent($this, $this->getClientData());
+            $this->dispatcher->dispatch(FormEvents::MAP_CLIENT_DATA, $event);
         }
 
         try {


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: -
Todo: Decide if this is possible or makes sense.

[![Build Status](https://secure.travis-ci.org/rdohms/symfony.png?branch=patch-5)](http://travis-ci.org/rdohms/symfony)

I'm trying to implement filtering of form data based on the mapped entity. Much like validation runs with regular filed validations and then runs for the entities annotation based validation. Using the DMS\Filter library.

I can easily bind this to the FormEvents::POST_BIND event now, but then the filter will be acting on top of normalized data, which is not ideal.

I looked into the FormEvents::BIND_CLIENT_DATA but at this point the data is not yet mapped to the entity (dataMapper) which is only done shortly afterwards. So i would either have to extract the filters and apply them individually to the fields, or build the entity, filter, then break it down into data again.

Would it be possible to create a new event to be thrown between the mapping and the normalization?

I made the changes in this PR, but it needs to be refined, in this case since the filtering is based on the entity, there is no need to work with the return of the event, since the entity itself is already changed, so maybe we should not pass any data into the event object as the subscriber will act on the entity directly through the form instance. But if this will be used by other people then it might make sense to re-bind the data.

This is just a suggestion that would make filtering happen at the best moment, it may also be implemented in another way based on the results of #3973.
