### PR TITLE
[Component][Finder] tests and condition: contains() used on dir

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
@@ -30,7 +30,11 @@ class FilecontentFilterIterator extends MultiplePcreFilterIterator
             return true;
         }
 
-        $content = file_get_contents($this->getRealpath());
+        if ($this->isDir() || !$this->isReadable()) {
+            return false;
+        }
+
+        $content = @file_get_contents($filename = $this->getRealpath());
         if (false === $content) {
             throw new \RuntimeException(sprintf('Error reading file "%s".', $this->getRealpath()));
         }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -372,4 +372,24 @@ class FinderTest extends Iterator\RealIteratorTestCase
         );
     }
 
+    public function testContainsOnDirectory()
+    {
+        $finder = new Finder();
+        $finder->in(__DIR__)
+            ->directories()
+            ->name('Fixtures')
+            ->contains('abc');
+        $this->assertIterator(array(), $finder);
+    }
+
+    public function testNotContainsOnDirectory()
+    {
+        $finder = new Finder();
+        $finder->in(__DIR__)
+            ->directories()
+            ->name('Fixtures')
+            ->notContains('abc');
+        $this->assertIterator(array(), $finder);
+    }
+
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilecontentFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilecontentFilterIteratorTest.php
@@ -19,10 +19,32 @@ class FilecontentFilterIteratorTest extends IteratorTestCase
     public function testAccept()
     {
         $inner = new ContentInnerNameIterator(array('test.txt'));
-
         $iterator = new FilecontentFilterIterator($inner, array(), array());
-
         $this->assertIterator(array('test.txt'), $iterator);
+    }
+
+    public function testDirectory()
+    {
+        $inner = new ContentInnerNameIterator(array('directory'));
+        $iterator = new FilecontentFilterIterator($inner, array('directory'), array());
+        $this->assertIterator(array(), $iterator);
+    }
+
+    public function testUnreadableFile()
+    {
+        $inner = new ContentInnerNameIterator(array('file r-'));
+        $iterator = new FilecontentFilterIterator($inner, array('file r-'), array());
+        $this->assertIterator(array(), $iterator);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testFileGetContents()
+    {
+        $inner = new ContentInnerNameIterator(array('file r+'));
+        $iterator = new FilecontentFilterIterator($inner, array('file r+'), array());
+        $array = iterator_to_array($iterator);
     }
 
 }
@@ -38,4 +60,28 @@ class ContentInnerNameIterator extends \ArrayIterator
     {
         return parent::current();
     }
+
+    public function isFile()
+    {
+        $name = parent::current();
+        return preg_match('/file/', $name);
+    }
+
+    public function isDir()
+    {
+        $name = parent::current();
+        return preg_match('/directory/', $name);
+    }
+
+    public function getRealpath()
+    {
+        return parent::current();
+    }
+
+    public function isReadable()
+    {
+        $name = parent::current();
+        return preg_match('/r\+/', $name);
+    }
+
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

`Finder::contains()` and `Finder::notContains()` can't be used on directories.
