### PR TITLE
[Bridge][Monolog] Fixed WebProcessorTest

### DIFF
--- a/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
+++ b/src/Symfony/Bridge/Monolog/Tests/Processor/WebProcessorTest.php
@@ -30,6 +30,8 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
             'REQUEST_URI'    => 'A',
             'REMOTE_ADDR'    => 'B',
             'REQUEST_METHOD' => 'C',
+            'SERVER_NAME'    => 'D',
+            'HTTP_REFERER'   => 'E'
         );
 
         $request = new Request();
@@ -41,6 +43,8 @@ class WebProcessorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($server['REQUEST_URI'], $record['extra']['url']);
         $this->assertEquals($server['REMOTE_ADDR'], $record['extra']['ip']);
         $this->assertEquals($server['REQUEST_METHOD'], $record['extra']['http_method']);
+        $this->assertEquals($server['SERVER_NAME'], $record['extra']['server']);
+        $this->assertEquals($server['HTTP_REFERER'], $record['extra']['referrer']);
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/michal-pipa/symfony.png?branch=WebProcessorTest-fix)](http://travis-ci.org/michal-pipa/symfony)
Fixes the following tickets: -
Todo: -

Fixed WebProcessorTest in compliance with latest monolog changes: Seldaek/monolog@3c4bc178cc389bc35660f29f72fd84be5b653f52.

Test was failing with message: `Symfony\Bridge\Monolog\Tests\Processor\WebProcessorTest::testUsesRequestServerData
Undefined index: SERVER_NAME`
