### PR TITLE
[DomCrawler] http_build_query extra parameters

### DIFF
--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -142,7 +142,7 @@ class Form extends Link implements \ArrayAccess
      */
     public function getPhpValues()
     {
-        $qs = http_build_query($this->getValues());
+        $qs = http_build_query($this->getValues(), '' ,'&');
         parse_str($qs, $values);
 
         return $values;
@@ -160,7 +160,7 @@ class Form extends Link implements \ArrayAccess
      */
     public function getPhpFiles()
     {
-        $qs = http_build_query($this->getFiles());
+        $qs = http_build_query($this->getFiles(), '' ,'&');
         parse_str($qs, $values);
 
         return $values;


### PR DESCRIPTION
Bug fix: yes

arg_separator.output is not always "&", so it is better ini_set it or put an extra parameters to http_build_query
