### PR TITLE
[Component][Finder][DateComparator] tenary ifs and tests coverage

### DIFF
--- a/src/Symfony/Component/Finder/Comparator/DateComparator.php
+++ b/src/Symfony/Component/Finder/Comparator/DateComparator.php
@@ -39,7 +39,12 @@ class DateComparator extends Comparator
             throw new \InvalidArgumentException(sprintf('"%s" is not a valid date.', $matches[2]));
         }
 
-        $operator = isset($matches[1]) ? $matches[1] : '==';
+        if (isset($matches[1])) {
+            $operator = $matches[1];
+        } else {
+            $operator = '==';
+        }
+
         if ('since' === $operator || 'after' === $operator) {
             $operator = '>';
         }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

I think that inline tenary ifs `?:` result in misleading tests coverage information:

[terary-if-tests.png](http://udostepnione.gajdaw.pl/terary-if-tests.png)
