### PR TITLE
[Form] Restored and deprecated method `guessMinLength` in FormTypeGuesser

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -280,6 +280,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
    "input"
  * ValidatorTypeGuesser now guesses "collection" for array type constraint
  * added method `guessPattern` to FormTypeGuesserInterface to guess which pattern to use in the HTML5 attribute "pattern"
+ * deprecated method `guessMinLength` in favor of `guessPattern`
 
 ### HttpFoundation
 

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -372,6 +372,29 @@
 
   * [BC BREAK] renamed "field_*" theme blocks to "form_*" and "field_widget" to
     "input"
+    
+  * The method `guessMinLength()` of FormTypeGuesserInterface was deprecated
+    and will be removed in Symfony 2.3. You should use the new method
+    `guessPattern()` instead which may return any regular expression that
+    is inserted in the HTML5 attribute "pattern".
+    
+    Before:
+    
+    public function guessMinLength($class, $property)
+    {
+        if (/* condition */) {
+            return new ValueGuess($minLength, Guess::LOW_CONFIDENCE);
+        }
+    }
+    
+    After:
+    
+    public function guessPattern($class, $property)
+    {
+        if (/* condition */) {
+            return new ValueGuess('.{' . $minLength . ',}', Guess::LOW_CONFIDENCE);
+        }
+    }
 
 ### Validator
 

--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -115,6 +115,13 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
+    public function guessMinLength($class, $property)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function guessPattern($class, $property)
     {
         $ret = $this->getMetadata($class);

--- a/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
@@ -124,6 +124,13 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
+    public function guessMinLength($class, $property)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function guessPattern($class, $property)
     {
         if ($column = $this->getColumn($class, $property)) {

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -68,6 +68,13 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
+    public function guessMinLength($class, $property)
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function guessPattern($class, $property)
     {
         $guesser = $this;
@@ -206,7 +213,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
     /**
      * Guesses a field's pattern based on the given constraint
-     * 
+     *
      * @param  Constraint $constraint  The constraint to guess for
      *
      * @return Guess The guess for the pattern
@@ -228,7 +235,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
 
             case 'Symfony\Component\Validator\Constraints\Size':
                 return new ValueGuess(sprintf('.{%s,%s}', strlen((string) $constraint->min), strlen((string) $constraint->max)), Guess::LOW_CONFIDENCE);
-            
+
             case 'Symfony\Component\Validator\Constraints\Type':
                 if (in_array($constraint->type, array('double', 'float', 'numeric', 'real'))) {
                     return new ValueGuess(null, Guess::MEDIUM_CONFIDENCE);

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -327,24 +327,32 @@ class FormFactory implements FormFactoryInterface
 
         $typeGuess = $this->guesser->guessType($class, $property);
         $maxLengthGuess = $this->guesser->guessMaxLength($class, $property);
+        // Keep $minLengthGuess for BC until Symfony 2.3
+        $minLengthGuess = $this->guesser->guessMinLength($class, $property);
         $requiredGuess = $this->guesser->guessRequired($class, $property);
         $patternGuess = $this->guesser->guessPattern($class, $property);
 
         $type = $typeGuess ? $typeGuess->getType() : 'text';
 
         $maxLength = $maxLengthGuess ? $maxLengthGuess->getValue() : null;
+        $minLength = $minLengthGuess ? $minLengthGuess->getValue() : null;
         $pattern   = $patternGuess ? $patternGuess->getValue() : null;
+
+        // overrides $minLength, if set
+        if (null !== $pattern) {
+            $options = array_merge(array('pattern' => $pattern), $options);
+        }
 
         if (null !== $maxLength) {
             $options = array_merge(array('max_length' => $maxLength), $options);
         }
 
-        if ($requiredGuess) {
-            $options = array_merge(array('required' => $requiredGuess->getValue()), $options);
+        if (null !== $minLength && $minLength > 0) {
+            $options = array_merge(array('pattern' => '.{'.$minLength.','.$maxLength.'}'), $options);
         }
 
-        if (null !== $pattern) {
-            $options = array_merge(array('pattern' => $pattern), $options);
+        if ($requiredGuess) {
+            $options = array_merge(array('required' => $requiredGuess->getValue()), $options);
         }
 
         // user options may override guessed options

--- a/src/Symfony/Component/Form/FormTypeGuesserChain.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserChain.php
@@ -73,6 +73,16 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
+    public function guessMinLength($class, $property)
+    {
+        return $this->guess(function ($guesser) use ($class, $property) {
+            return $guesser->guessMinLength($class, $property);
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function guessPattern($class, $property)
     {
         return $this->guess(function ($guesser) use ($class, $property) {

--- a/src/Symfony/Component/Form/FormTypeGuesserInterface.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserInterface.php
@@ -44,8 +44,20 @@ interface FormTypeGuesserInterface
     function guessMaxLength($class, $property);
 
     /**
+     * Returns a guess about the field's minimum length
+     *
+     * @param  string $class      The fully qualified class name
+     * @param  string $property   The name of the property to guess for
+     *
+     * @return Guess  A guess for the field's minimum length
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3.
+     */
+    function guessMinLength($class, $property);
+
+    /**
      * Returns a guess about the field's pattern
-     * 
+     *
      * - When you have a min value, you guess a min length of this min (LOW_CONFIDENCE) , lines below
      * - If this value is a float type, this is wrong so you guess null with MEDIUM_CONFIDENCE to override the previous guess.
      * Example:


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

![Travis Build Status](https://secure.travis-ci.org/bschussek/symfony.png?branch=issue4077)

This is a follow-up PR to #4077 (see comments in #3927 for reference).
