### PR TITLE
[Doctrine Bridge] Fixed UniqueEntityValidator when using inheritance

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -83,13 +83,22 @@ class UniqueEntityValidator extends ConstraintValidator
             }
         }
 
-        $repository = $em->getRepository($className);
-        $result = $repository->findBy($criteria);
+        /*
+         * When using this constraint in an inherited entity we need to ensure
+         * that the actual repository used by the constraint is actually the
+         * one in which the field was defined
+         */
+        if (isset($class->fieldMappings[$fields[0]]['inherited'])) {
+            $repository = $em->getRepository($class->fieldMappings[$fields[0]]['inherited']);
+        } else {
+            $repository = $em->getRepository($className);
+        }
 
         /* If no entity matched the query criteria or a single entity matched,
          * which is the same as the entity being validated, the criteria is
          * unique.
          */
+        $result = $repository->findBy($criteria);
         if (0 === count($result) || (1 === count($result) && $entity === $result[0])) {
             return true;
         }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/datiecher/symfony.png?branch=ticket_4087)](http://travis-ci.org/datiecher/symfony)
Fixes the following tickets: #4087
Todo: -

I've described the issue in high detail on #4087 so you'll need to read it before reviewing this PR.

As you can see, I'm currently determining the right repository to use based on where it was defined according to the mapping info.

I've also thought about adding a new option in the current validator where the developer could define which repository class should be used, but failed to see a real use case for it.

Thoughts?
