### PR TITLE
[Console] Use proc_open instead of exec to suppress errors.

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -838,7 +838,7 @@ class Application
             return preg_replace('{^(\d+)x.*$}', '$1', $ansicon);
         }
 
-        if (preg_match("{rows.(\d+);.columns.(\d+);}i", exec('stty -a | grep columns'), $match)) {
+        if (preg_match("{rows.(\d+);.columns.(\d+);}i", $this->getSttyColumns(), $match)) {
             return $match[1];
         }
     }
@@ -854,7 +854,7 @@ class Application
             return preg_replace('{^\d+x\d+ \(\d+x(\d+)\)$}', '$1', trim($ansicon));
         }
 
-        if (preg_match("{rows.(\d+);.columns.(\d+);}i", exec('stty -a | grep columns'), $match)) {
+        if (preg_match("{rows.(\d+);.columns.(\d+);}i", $this->getSttyColumns(), $match)) {
             return $match[2];
         }
     }
@@ -912,6 +912,25 @@ class Application
             new FormatterHelper(),
             new DialogHelper(),
         ));
+    }
+
+    /**
+     * Runs and parses stty -a if it's available, suppressing any error output
+     *
+     * @return string
+     */
+    private function getSttyColumns()
+    {
+        $descriptorspec = array(1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
+        $process = proc_open('stty -a | grep columns', $descriptorspec, $pipes, null, null, array('suppress_errors' => true));
+        if (is_resource($process)) {
+            $info = stream_get_contents($pipes[1]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            proc_close($process);
+
+            return $info;
+        }
     }
 
     /**


### PR DESCRIPTION
stty is _sometimes_ there on windows, but not always, so with proc_open we can quietly return null instead of outputting errors.

/cc @gnutix: that's the error you told me about this morning in https://gist.github.com/2478037
