### PR TITLE
[2.2][Console] command's name required when added to an application

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -45,8 +45,6 @@ class Command
      *
      * @param string $name The name of the command
      *
-     * @throws \LogicException When the command name is empty
-     *
      * @api
      */
     public function __construct($name = null)
@@ -61,10 +59,6 @@ class Command
         }
 
         $this->configure();
-
-        if (!$this->name) {
-            throw new \LogicException('The command name cannot be empty.');
-        }
     }
 
     /**
@@ -82,10 +76,16 @@ class Command
      *
      * @param Application $application An Application instance
      *
+     * @throws \LogicException When the command name is empty
+     *
      * @api
      */
     public function setApplication(Application $application = null)
     {
+        if (!$this->name) {
+            throw new \LogicException('The command name cannot be empty.');
+        }
+
         $this->application = $application;
         if ($application) {
             $this->setHelperSet($application->getHelperSet());

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -35,13 +35,6 @@ class CommandTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructor()
     {
-        try {
-            $command = new Command();
-            $this->fail('__construct() throws a \LogicException if the name is null');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('\LogicException', $e, '__construct() throws a \LogicException if the name is null');
-            $this->assertEquals('The command name cannot be empty.', $e->getMessage(), '__construct() throws a \LogicException if the name is null');
-        }
         $command = new Command('foo:bar');
         $this->assertEquals('foo:bar', $command->getName(), '__construct() takes the command name as its first argument');
     }
@@ -52,6 +45,17 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $command = new \TestCommand();
         $command->setApplication($application);
         $this->assertEquals($application, $command->getApplication(), '->setApplication() sets the current application');
+
+        $application = new Application();
+        $command = new Command();
+
+        try {
+            $command->setApplication($application);
+            $this->fail('__construct() throws a \LogicException if the command name is null or empty');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\LogicException', $e, '->setApplication() throws a \LogicException if the command name is null or empty');
+            $this->assertEquals('The command name cannot be empty.', $e->getMessage(), '->setApplication() throws a \LogicException if the command name is null or empty');
+        }
     }
 
     public function testSetGetDefinition()


### PR DESCRIPTION
- Bug fix: no
- Feature addition: yes
- Backwards compatibility break: no
- Symfony2 tests pass: yes
- Fixes the following tickets: #3857
- Todo: -

[![Build Status](https://secure.travis-ci.org/brikou/symfony.png?branch=console_simple)](http://travis-ci.org/brikou/symfony)

---

Here is an application with a single purpose/command : listing a directory [as seen here](http://fabien.potencier.org/article/49/what-is-symfony2)

``` php
<?php
// console.php
// usage: php console.php ls <dir>

require_once __DIR__.'/../../../../../vendor/autoload.php';

use Symfony\Component\Console\Application;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputOption;
use Symfony\Component\Console\Output\OutputInterface;

$console = new Application();
$console
    ->register('ls')
    ->setDefinition(array(
        new InputArgument('dir', InputArgument::REQUIRED, 'Directory name'),
    ))
    ->setDescription('Displays the files in the given directory')
    ->setCode(function (InputInterface $input, OutputInterface $output) {
        $dir = $input->getArgument('dir');

        $output->writeln(sprintf('Dir listing for <info>%s</info>', $dir));
    })
;
$console->run();

```

This simple command can be refactored into this...

``` php
<?php
// ls.php
// usage: php ls.php <dir>

require_once __DIR__.'/../../../../../vendor/autoload.php';

use Symfony\Component\Console\Command\Command;
use Symfony\Component\Console\Input\ArgvInput;
use Symfony\Component\Console\Input\InputArgument;
use Symfony\Component\Console\Input\InputInterface;
use Symfony\Component\Console\Output\OutputInterface;
use Symfony\Component\Console\Output\ConsoleOutput;

$command = new Command("ANameAsItIsMandatory");
$command
    ->setDefinition(array(
        new InputArgument('dir', InputArgument::REQUIRED, 'Directory name'),
    ))
    ->setDescription('Displays the files in the given directory')
    ->setCode(function (InputInterface $input, OutputInterface $output) {
        $dir = $input->getArgument('dir');

        $output->writeln(sprintf('Dir listing for <info>%s</info>', $dir));
    })
;

$command->run(new ArgvInput(), new ConsoleOutput());
```

The conceptual problem is that command's name is required even if not needed/used.
This PR makes the **name required only when this command is attached to an application**.
