### PR TITLE
[2.2] [Form] Trim listener, unicode whitespace characters.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
@@ -30,11 +30,7 @@ class TrimListener implements EventSubscriberInterface
             return;
         }
 
-        if (function_exists('mb_check_encoding')
-            && mb_check_encoding($data, 'UTF-8')
-            && null !== $result = @preg_replace('~^[\pZ\p{Cc}}]+|[\pZ\p{Cc}]+$~u', '', $data)
-        ) {
-
+        if (null !== $result = @preg_replace('/^[\pZ\p{Cc}]+|[\pZ\p{Cc}]+$/u', '', $data)) {
             $event->setData($result);
         } else {
             $event->setData(trim($data));

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
@@ -26,7 +26,17 @@ class TrimListener implements EventSubscriberInterface
     {
         $data = $event->getData();
 
-        if (is_string($data)) {
+        if (!is_string($data)) {
+            return;
+        }
+
+        if (function_exists('mb_check_encoding')
+            && mb_check_encoding($data, 'UTF-8')
+            && null !== $result = @preg_replace('~^[\pZ\p{Cc}}]+|[\pZ\p{Cc}]+$~u', '', $data)
+        ) {
+
+            $event->setData($result);
+        } else {
             $event->setData(trim($data));
         }
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
@@ -60,10 +60,10 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
         $data = $data."ab\ncd".$data;
 
         $form  = $this->getMock('Symfony\Component\Form\Tests\FormInterface');
-        $event = new FilterDataEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $filter = new TrimListener();
-        $filter->onBindClientData($event);
+        $filter->preBind($event);
 
         $this->assertSame("ab\ncd", $event->getData(), 'TrimListener should trim character(s): '.$description.': '.implode(', ', $chars));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
@@ -46,4 +46,36 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(1234, $event->getData());
     }
+
+    /**
+     * @dataProvider codePointProvider
+     */
+    public function testTrimUtf8($description, $chars)
+    {
+        if (!function_exists('mb_check_encoding')) {
+            $this->markTestSkipped('The "mb_check_encoding" function is not available');
+        }
+
+        $data = mb_convert_encoding(pack('H*', implode('', (array)$chars)), 'UTF-8', 'UCS-2BE');
+        $data = $data."ab\ncd".$data;
+
+        $form  = $this->getMock('Symfony\Component\Form\Tests\FormInterface');
+        $event = new FilterDataEvent($form, $data);
+
+        $filter = new TrimListener();
+        $filter->onBindClientData($event);
+
+        $this->assertSame("ab\ncd", $event->getData(), 'TrimListener should trim character(s): '.$description.': '.implode(', ', $chars));
+    }
+
+    public function codePointProvider()
+    {
+        return array(
+            array('General category: Separator',
+                array('0020', '00A0', '1680', '180E', '2000', '2001', '2002', '2003', '2004', '2005',
+                    '2006', '2007', '2008', '2009', '200A', '2028', '2029', '202F', '205F', '3000')),
+            array('General category: Other, control', array('0009', '000A', '000B', '000C', '000D', '0085')),
+//            array('General category: Other, format. ZERO WIDTH SPACE', '200B')
+        );
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: 

I have some questions. ZERO WIDTH SPACE (200B) doesn't belong to White_Space but it's invisible and treated as white space by the html4.1 spec - http://www.w3.org/TR/html4/struct/text.html#h-9.1
Same question for 
- U+202F    NARROW NO-BREAK SPACE
- U+FEFF    ZERO WIDTH NO-BREAK SPACE
