### PR TITLE
[WDT] added documentation link

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -9,7 +9,12 @@
         </a>
     {% endset %}
     {% set text %}
-        Symfony <b>{{ collector.symfonyversion }}</b>
+        <div class="sf-toolbar-info-piece">
+            Symfony <b>{{ collector.symfonyversion }}</b>
+        </div>
+        <div class="sf-toolbar-info-piece">
+            <a href="http://symfony.com/doc/{{ collector.symfonyversion }}/index.html" rel="help">Documentation</a>
+        </div>
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': false } %}
 


### PR DESCRIPTION
This adds a documentation link in the WDT for the appropriate branch according to the current symfony version.
@weaverryan there is no documentation branch yet for the currently created 2.1 branch.
Also it might be a nice feature to redirect the dev branch to master automatically on the website. I.e. `http://symfony.com/doc/2.1/index.html` -> `http://symfony.com/doc/master/index.html`
@fabpot It might be a good idea to introduce a `Kernel::BRANCH` constant. So there would be no need to extract the branch from the symfony version in `ConfigDataCollector`. And bumping new versions/branches would be in one place.
