### PR TITLE
[HttpKernel] Memcache and Redis profiler storage update

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,6 @@
     <groups>
         <exclude>
             <group>benchmark</group>
-            <group>memcached</group>
         </exclude>
     </groups>
 

--- a/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
@@ -95,7 +95,28 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
      */
     public function purge()
     {
-        $this->flush();
+        // delete only items from index
+        $indexName = $this->getIndexName();
+
+        $indexContent = $this->getValue($indexName);
+
+        if (!$indexContent) {
+            return false;
+        }
+
+        $profileList = explode("\n", $indexContent);
+
+        foreach ($profileList as $item) {
+            if ($item == '') {
+                continue;
+            }
+
+            if (false !== $pos = strpos($item, "\t")) {
+                $this->delete($this->getItemName(substr($item, 0, $pos)));
+            }
+        }
+
+        return $this->delete($indexName);
     }
 
     /**
@@ -172,11 +193,13 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
     abstract protected function setValue($key, $value, $expiration = 0);
 
     /**
-     * Flush all existing items at the memcache server
+     * Delete item from the memcache server
+     *
+     * @param string $key
      *
      * @return boolean
      */
-    abstract protected function flush();
+    abstract protected function delete($key);
 
     /**
      * Append data to an existing item on the memcache server

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -51,6 +51,16 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
     }
 
     /**
+     * Set instance of the Memcache
+     *
+     * @param Memcache $memcache
+     */
+    public function setMemcache($memcache)
+    {
+        $this->memcache = $memcache;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getValue($key)

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcacheProfilerStorage.php
@@ -69,9 +69,9 @@ class MemcacheProfilerStorage extends BaseMemcacheProfilerStorage
     /**
      * {@inheritdoc}
      */
-    protected function flush()
+    protected function delete($key)
     {
-        return $this->getMemcache()->flush();
+        return $this->getMemcache()->delete($key);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -73,9 +73,9 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
     /**
      * {@inheritdoc}
      */
-    protected function flush()
+    protected function delete($key)
     {
-        return $this->getMemcached()->flush();
+        return $this->getMemcached()->delete($key);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MemcachedProfilerStorage.php
@@ -55,6 +55,16 @@ class MemcachedProfilerStorage extends BaseMemcacheProfilerStorage
     }
 
     /**
+     * Set instance of the Memcached
+     *
+     * @param Memcached $memcached
+     */
+    public function setMemcached($memcached)
+    {
+        $this->memcached = $memcached;
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getValue($key)

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -211,6 +211,16 @@ class RedisProfilerStorage implements ProfilerStorageInterface
         return $this->redis;
     }
 
+    /**
+     * Set instance of the Redis
+     *
+     * @param Redis $redis
+     */
+    public function setRedis($redis)
+    {
+        $this->redis = $redis;
+    }
+
     private function createProfileFromData($token, $data, $parent = null)
     {
         $profile = new Profile($token);

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/MemcachedProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/MemcachedProfilerStorageTest.php
@@ -12,44 +12,30 @@
 namespace Symfony\Component\HttpKernel\Tests\Profiler;
 
 use Symfony\Component\HttpKernel\Profiler\MemcachedProfilerStorage;
+use Symfony\Component\HttpKernel\Tests\Profiler\Mock\MemcachedMock;
 
-class DummyMemcachedProfilerStorage extends MemcachedProfilerStorage
-{
-    public function getMemcached()
-    {
-        return parent::getMemcached();
-    }
-}
-
-/**
- * @group memcached
- */
 class MemcachedProfilerStorageTest extends AbstractProfilerStorageTest
 {
     protected static $storage;
 
-    public static function tearDownAfterClass()
+    protected function setUp()
     {
+        $memcachedMock = new MemcachedMock();
+        $memcachedMock->addServer('127.0.0.1', 11211);
+
+        self::$storage = new MemcachedProfilerStorage('memcached://127.0.0.1:11211', '', '', 86400);
+        self::$storage->setMemcached($memcachedMock);
+
         if (self::$storage) {
             self::$storage->purge();
         }
     }
 
-    protected function setUp()
+    protected function tearDown()
     {
-        if (!extension_loaded('memcached')) {
-            $this->markTestSkipped('MemcachedProfilerStorageTest requires that the extension memcached is loaded');
-        }
-
-        self::$storage = new DummyMemcachedProfilerStorage('memcached://127.0.0.1:11211', '', '', 86400);
-        try {
-            self::$storage->getMemcached();
-        } catch (\Exception $e) {
-            $this->markTestSkipped('MemcachedProfilerStorageTest requires that there is a Memcache server present on localhost');
-        }
-
         if (self::$storage) {
             self::$storage->purge();
+            self::$storage = false;
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcacheMock.php
@@ -1,0 +1,242 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Profiler\Mock;
+
+/**
+ * MemcacheMock for simulating Memcache extension in tests.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class MemcacheMock
+{
+    private $connected;
+    private $storage;
+
+    public function __construct()
+    {
+        $this->connected = false;
+        $this->storage = array();
+    }
+
+    /**
+     * Open memcached server connection
+     *
+     * @param string $host
+     * @param integer $port
+     * @param integer $timeout
+     *
+     * @return boolean
+     */
+    public function connect($host, $port = null, $timeout = null)
+    {
+        if ('127.0.0.1' == $host && 11211 == $port) {
+            $this->connected = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Open memcached server persistent connection
+     *
+     * @param string $host
+     * @param integer $port
+     * @param integer $timeout
+     *
+     * @return boolean
+     */
+    public function pconnect($host, $port = null, $timeout = null)
+    {
+        if ('127.0.0.1' == $host && 11211 == $port) {
+            $this->connected = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Add a memcached server to connection pool
+     *
+     * @param string $host
+     * @param integer $port
+     * @param boolean $persistent
+     * @param integer $weight
+     * @param integer $timeout
+     * @param integer $retry_interval
+     * @param boolean $status
+     * @param callable $failure_callback
+     * @param integer $timeoutms
+     *
+     * @return boolean
+     */
+    public function addServer($host, $port = 11211, $persistent = null, $weight = null, $timeout = null, $retry_interval = null, $status = null, $failure_callback = null, $timeoutms = null)
+    {
+        if ('127.0.0.1' == $host && 11211 == $port) {
+            $this->connected = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Add an item to the server only if such key doesn't exist at the server yet.
+     *
+     * @param string $key
+     * @param mixed $var
+     * @param integer $flag
+     * @param integer $expire
+     *
+     * @return boolean
+     */
+    public function add($key, $var, $flag = null, $expire = null)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (!isset($this->storage[$key])) {
+            $this->storeData($key, $var);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Store data at the server.
+     *
+     * @param string $key
+     * @param string $var
+     * @param integer $flag
+     * @param integer $expire
+     *
+     * @return boolean
+     */
+    public function set($key, $var, $flag = null, $expire = null)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        $this->storeData($key, $var);
+        return true;
+    }
+
+    /**
+     * Replace value of the existing item.
+     *
+     * @param string $key
+     * @param mixed $var
+     * @param integer $flag
+     * @param integer $expire
+     *
+     * @return boolean
+     */
+    public function replace($key, $var, $flag = null, $expire = null)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (isset($this->storage[$key])) {
+            $this->storeData($key, $var);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Retrieve item from the server.
+     *
+     * @param string|array $key
+     * @param integer|array $flags
+     *
+     * @return mixed
+     */
+    public function get($key, &$flags = null)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (is_array($key)) {
+            $result = array();
+            foreach ($key as $k) {
+                if (isset($this->storage[$k])) {
+                    $result[] = $this->getData($k);
+                }
+            }
+            return $result;
+        }
+
+        return $this->getData($key);
+    }
+
+    /**
+     * Delete item from the server
+     *
+     * @param string $key
+     *
+     * @return boolean
+     */
+    public function delete($key)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (isset($this->storage[$key])) {
+            unset($this->storage[$key]);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Flush all existing items at the server
+     *
+     * @return boolean
+     */
+    public function flush()
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        $this->storage = array();
+        return true;
+    }
+
+    /**
+     * Close memcached server connection
+     *
+     * @return boolean
+     */
+    public function close()
+    {
+        $this->connected = false;
+        return true;
+    }
+
+    private function getData($key)
+    {
+        if (isset($this->storage[$key])) {
+            return unserialize($this->storage[$key]);
+        }
+        return false;
+    }
+
+    private function storeData($key, $value)
+    {
+        $this->storage[$key] = serialize($value);
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/MemcachedMock.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Profiler\Mock;
+
+/**
+ * MemcachedMock for simulating Memcached extension in tests.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class MemcachedMock
+{
+    private $connected;
+    private $storage;
+
+    public function __construct()
+    {
+        $this->connected = false;
+        $this->storage = array();
+    }
+
+    /**
+     * Set a Memcached option
+     *
+     * @param integer $option
+     * @param mixed $value
+     *
+     * @return boolean
+     */
+    public function setOption($option, $value)
+    {
+        return true;
+    }
+
+    /**
+     * Add a memcached server to connection pool
+     *
+     * @param string $host
+     * @param integer $port
+     * @param integer $weight
+     *
+     * @return boolean
+     */
+    public function addServer($host, $port = 11211, $weight = 0)
+    {
+        if ('127.0.0.1' == $host && 11211 == $port) {
+            $this->connected = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Add an item to the server only if such key doesn't exist at the server yet.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param integer $expiration
+     *
+     * @return boolean
+     */
+    public function add($key, $value, $expiration = 0)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (!isset($this->storage[$key])) {
+            $this->storeData($key, $value);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Store data at the server.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param integer $expiration
+     *
+     * @return boolean
+     */
+    public function set($key, $value, $expiration = null)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        $this->storeData($key, $value);
+        return true;
+    }
+
+    /**
+     * Replace value of the existing item.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @param integer $expiration
+     *
+     * @return boolean
+     */
+    public function replace($key, $value, $expiration = null)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (isset($this->storage[$key])) {
+            $this->storeData($key, $value);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Retrieve item from the server.
+     *
+     * @param string $key
+     * @param callable $cache_cb
+     * @param float $cas_token
+     *
+     * @return boolean
+     */
+    public function get($key, $cache_cb = null, &$cas_token = null)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        return $this->getData($key);
+    }
+
+    /**
+     * Append data to an existing item
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @return boolean
+     */
+    public function append($key, $value)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (isset($this->storage[$key])) {
+            $this->storeData($key, $this->getData($key).$value);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Delete item from the server
+     *
+     * @param string $key
+     *
+     * @return boolean
+     */
+    public function delete($key)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (isset($this->storage[$key])) {
+            unset($this->storage[$key]);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Flush all existing items at the server
+     *
+     * @return boolean
+     */
+    public function flush()
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        $this->storage = array();
+        return true;
+    }
+
+    private function getData($key)
+    {
+        if (isset($this->storage[$key])) {
+            return unserialize($this->storage[$key]);
+        }
+        return false;
+    }
+
+    private function storeData($key, $value)
+    {
+        $this->storage[$key] = serialize($value);
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -1,0 +1,228 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Profiler\Mock;
+
+/**
+ * RedisMock for simulating Redis extension in tests.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+class RedisMock
+{
+
+    private $connected;
+    private $storage;
+
+    public function __construct()
+    {
+        $this->connected = false;
+        $this->storage = array();
+    }
+
+    /**
+     * Add a memcached server to connection pool
+     *
+     * @param string $host
+     * @param integer $port
+     * @param float $timeout
+     *
+     * @return boolean
+     */
+    public function connect($host, $port = 6379, $timeout = 0)
+    {
+        if ('127.0.0.1' == $host && 6379 == $port) {
+            $this->connected = true;
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Set client option.
+     *
+     * @param integer $name
+     * @param integer $value
+     *
+     * @return boolean
+     */
+    public function setOption($name, $value)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Verify if the specified key exists.
+     *
+     * @param string $key
+     *
+     * @return boolean
+     */
+    public function exists($key)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        return isset($this->storage[$key]);
+    }
+
+    /**
+     * Store data at the server with expiration time.
+     *
+     * @param string $key
+     * @param integer $ttl
+     * @param mixed $value
+     *
+     * @return boolean
+     */
+    public function setex($key, $ttl, $value)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        $this->storeData($key, $value);
+        return true;
+    }
+
+    /**
+     * Sets an expiration time on an item.
+     *
+     * @param string $key
+     * @param integer $ttl
+     *
+     * @return boolean
+     */
+    public function setTimeout($key, $ttl)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (isset($this->storage[$key])) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Retrieve item from the server.
+     *
+     * @param string $key
+     *
+     * @return boolean
+     */
+    public function get($key)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        return $this->getData($key);
+    }
+
+    /**
+     * Append data to an existing item
+     *
+     * @param string $key
+     * @param string $value
+     *
+     * @return integer Size of the value after the append.
+     */
+    public function append($key, $value)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (isset($this->storage[$key])) {
+            $this->storeData($key, $this->getData($key).$value);
+            return strlen($this->storage[$key]);
+        }
+        return false;
+    }
+
+    /**
+     * Remove specified keys.
+     *
+     * @param string|array $key
+     *
+     * @return integer
+     */
+    public function delete($key)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        if (is_array($key)) {
+            $result = 0;
+            foreach ($key as $k) {
+                if (isset($this->storage[$k])) {
+                    unset($this->storage[$k]);
+                    ++$result;
+                }
+            }
+            return $result;
+        }
+
+        if (isset($this->storage[$key])) {
+            unset($this->storage[$key]);
+            return 1;
+        }
+        return 0;
+    }
+
+    /**
+     * Flush all existing items from all databases at the server.
+     *
+     * @return boolean
+     */
+    public function flushAll()
+    {
+        if (!$this->connected) {
+            return false;
+        }
+
+        $this->storage = array();
+        return true;
+    }
+
+    /**
+     * Close Redis server connection
+     *
+     * @return boolean
+     */
+    public function close()
+    {
+        $this->connected = false;
+        return true;
+    }
+
+    private function getData($key)
+    {
+        if (isset($this->storage[$key])) {
+            return unserialize($this->storage[$key]);
+        }
+        return false;
+    }
+
+    private function storeData($key, $value)
+    {
+        $this->storage[$key] = serialize($value);
+        return true;
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Changes of this PR:
- change `purge()` method of memcache(d) profiler storage to delete only required items and be less destructive,
- mock objects for Redis and Memcache(d) storages were added to make unit tests independent from memcache(d)/redis extensions and memcache(d)/redis servers running on localhost.
