### PR TITLE
[MonologBridge] Fixed the WebProcessor

### DIFF
--- a/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
+++ b/src/Symfony/Bridge/Monolog/Processor/WebProcessor.php
@@ -13,6 +13,8 @@ namespace Symfony\Bridge\Monolog\Processor;
 
 use Monolog\Processor\WebProcessor as BaseWebProcessor;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 /**
  * WebProcessor override to read from the HttpFoundation's Request
@@ -21,8 +23,16 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class WebProcessor extends BaseWebProcessor
 {
-    public function __construct(Request $request)
+    public function __construct()
     {
-        parent::__construct($request->server->all());
+        // Pass an empty array as the default null value would access $_SERVER
+        parent::__construct(array());
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
+            $this->serverData = $event->getRequest()->server->all();
+        }
     }
 }


### PR DESCRIPTION
The WebProcessor can now be registered as a kernel.request listener to
get the request instead of passing it as a constructor argument, which
was broken as the request is not yet available when the logger is
instantiated.

I'm sending it to 2.0 even if the way to use the processor is not BC as this is really a bugfix. The processor was simply unusable with the previous way. Tell me if you think it should only be fixed for 2.1

Fixes #3311
