### PR TITLE
[Console] Selectively output to STDOUT or OUTPUT stream

### DIFF
--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -42,6 +42,26 @@ class ConsoleOutput extends StreamOutput
      */
     public function __construct($verbosity = self::VERBOSITY_NORMAL, $decorated = null, OutputFormatterInterface $formatter = null)
     {
-        parent::__construct(fopen('php://stdout', 'w'), $verbosity, $decorated, $formatter);
+        $outputStream = 'php://stdout';
+        if (!$this->hasStdoutSupport()) {
+            $outputStream = 'php://output';
+        }
+
+        parent::__construct(fopen($outputStream, 'w'), $verbosity, $decorated, $formatter);
+    }
+
+    /**
+     * Returns true if current environment supports writing console output to
+     * STDOUT.
+     *
+     * IBM iSeries (OS400) exhibits character-encoding issues when writing to
+     * STDOUT and doesn't properly convert ASCII to EBCDIC, resulting in garbage
+     * output.
+     *
+     * @return boolean
+     */
+    protected function hasStdoutSupport()
+    {
+        return ('OS400' != php_uname('s'));
     }
 }


### PR DESCRIPTION
Originally opened in this PR targeting master, but asked to target 2.0 instead: https://github.com/symfony/symfony/pull/4148

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #1434
Todo: -

As noted in the ticket discussion and linked discussion threads, IBM i5 Series has issues with writing output to STDOUT when viewed via their QP2TERM console. The output is likely not being converted to the correct character-encoding on the system level.

This PR changes the default output stream from `php://stdout` to `php://output` for OS400 environments, which does not exhibit this issue.

I'm using `php_uname('s')` to check for the presence of "OS400", which is at least one of the IBM OS's exhibiting this issue. This check is only done once when executing a Console task and shouldn't see any adverse affects in speed on the 99% other platforms using Symfony.

I'm not a native to the OS400 platform so I can't really anticipate any other possible regressions that might occur from switching output streams for that platform. On my Mac, this change would strip all color output, but the PR code only changes output for OS400 environment. To my knowledge the QP2TERM console doesn't even support color, so no loss there.

I think this change is best to make the Console component at least usable out of the box for anyone else trying to build CLI applications for use on OS400.
