### PR TITLE
Fix components

### DIFF
--- a/src/Symfony/Component/BrowserKit/.gitignore
+++ b/src/Symfony/Component/BrowserKit/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/BrowserKit/README.md
+++ b/src/Symfony/Component/BrowserKit/README.md
@@ -18,11 +18,9 @@ provided by the HttpKernel component.
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/BrowserKit/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_PROCESS=../path/to/Process
-    export SYMFONY_DOM_CRAWLER=../path/to/DomCrawler
+    php composer.phar install --dev

--- a/src/Symfony/Component/BrowserKit/Tests/bootstrap.php
+++ b/src/Symfony/Component/BrowserKit/Tests/bootstrap.php
@@ -10,21 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_PROCESS'      => 'Process',
-        'SYMFONY_DOM_CRAWLER'  => 'DomCrawler',
-        'SYMFONY_CSS_SELECTOR' => 'CssSelector',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\BrowserKit')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\BrowserKit')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -17,7 +17,11 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/dom-crawler": "self.version"
+        "symfony/dom-crawler": "2.1.*"
+    },
+    "require-dev": {
+        "symfony/process": "2.1.*",
+        "symfony/css-selector": "2.1.*"
     },
     "suggest": {
         "symfony/process": "self.version"

--- a/src/Symfony/Component/BrowserKit/phpunit.xml.dist
+++ b/src/Symfony/Component/BrowserKit/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/ClassLoader/.gitignore
+++ b/src/Symfony/Component/ClassLoader/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/ClassLoader/README.md
+++ b/src/Symfony/Component/ClassLoader/README.md
@@ -64,10 +64,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/ClassLoader/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_FINDER=../path/to/Finder
+    php composer.phar install --dev

--- a/src/Symfony/Component/ClassLoader/Tests/bootstrap.php
+++ b/src/Symfony/Component/ClassLoader/Tests/bootstrap.php
@@ -10,19 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_FINDER' => 'Finder',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\ClassLoader')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\ClassLoader')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "symfony/finder": "2.1.*"
+    },
     "autoload": {
         "psr-0": { "Symfony\\Component\\ClassLoader": "" }
     },

--- a/src/Symfony/Component/ClassLoader/phpunit.xml.dist
+++ b/src/Symfony/Component/ClassLoader/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/Config/README.md
+++ b/src/Symfony/Component/Config/README.md
@@ -11,4 +11,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Config/
+    phpunit

--- a/src/Symfony/Component/Config/phpunit.xml.dist
+++ b/src/Symfony/Component/Config/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/Console/README.md
+++ b/src/Symfony/Component/Console/README.md
@@ -45,10 +45,10 @@ Tests
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Console
+    phpunit
 
 Resources
----------    
+---------
 
 [The Console Component](http://symfony.com/doc/current/components/console.html)
 

--- a/src/Symfony/Component/Console/phpunit.xml.dist
+++ b/src/Symfony/Component/Console/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/CssSelector/README.md
+++ b/src/Symfony/Component/CssSelector/README.md
@@ -20,4 +20,4 @@ Current code is a port of http://codespeak.net/svn/lxml/trunk/src/lxml/cssselect
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/CssSelector/
+    phpunit

--- a/src/Symfony/Component/CssSelector/phpunit.xml.dist
+++ b/src/Symfony/Component/CssSelector/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/DependencyInjection/.gitignore
+++ b/src/Symfony/Component/DependencyInjection/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/DependencyInjection/README.md
+++ b/src/Symfony/Component/DependencyInjection/README.md
@@ -48,8 +48,8 @@ If your service is retrieved by calling a static method:
 
 File Include:
 
-For some services, especially those that are difficult or impossible to 
-autoload, you may need the container to include a file before 
+For some services, especially those that are difficult or impossible to
+autoload, you may need the container to include a file before
 instantiating your class.
 
     $sc = new ContainerBuilder();
@@ -68,11 +68,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/DependencyInjection/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_CONFIG=../path/to/Config
-    export SYMFONY_YAML=../path/to/Yaml
+    php composer.phar install --dev

--- a/src/Symfony/Component/DependencyInjection/Tests/bootstrap.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/bootstrap.php
@@ -10,20 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_CONFIG' => 'Config',
-        'SYMFONY_YAML'   => 'Yaml',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\DependencyInjection')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\DependencyInjection')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -18,6 +18,10 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "symfony/yaml": "2.1.*",
+        "symfony/config": "2.1.*"
+    },
     "suggest": {
         "symfony/yaml": "self.version",
         "symfony/config": "self.version"

--- a/src/Symfony/Component/DependencyInjection/phpunit.xml.dist
+++ b/src/Symfony/Component/DependencyInjection/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/DomCrawler/.gitignore
+++ b/src/Symfony/Component/DomCrawler/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/DomCrawler/README.md
+++ b/src/Symfony/Component/DomCrawler/README.md
@@ -27,10 +27,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/DomCrawler/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_CSS_SELECTOR=../path/to/CssSelector
+    php composer.phar install --dev

--- a/src/Symfony/Component/DomCrawler/Tests/bootstrap.php
+++ b/src/Symfony/Component/DomCrawler/Tests/bootstrap.php
@@ -10,19 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_CSS_SELECTOR' => 'CssSelector',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\DomCrawler')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\DomCrawler')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "symfony/css-selector": "2.1.*"
+    },
     "suggest": {
         "symfony/css-selector": "self.version"
     },

--- a/src/Symfony/Component/DomCrawler/phpunit.xml.dist
+++ b/src/Symfony/Component/DomCrawler/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/EventDispatcher/.gitignore
+++ b/src/Symfony/Component/EventDispatcher/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/EventDispatcher/README.md
+++ b/src/Symfony/Component/EventDispatcher/README.md
@@ -20,11 +20,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/EventDispatcher/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_DEPENDENCY_INJECTION=../path/to/DependencyInjection
-    export SYMFONY_HTTP_KERNEL=../path/to/HttpKernel
+    php composer.phar install --dev

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -18,6 +18,9 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "symfony/dependency-injection": "2.1.*"
+    },
     "suggest": {
         "symfony/dependency-injection": "self.version",
         "symfony/http-kernel": "self.version"

--- a/src/Symfony/Component/EventDispatcher/phpunit.xml.dist
+++ b/src/Symfony/Component/EventDispatcher/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/Filesystem/README.md
+++ b/src/Symfony/Component/Filesystem/README.md
@@ -27,3 +27,9 @@ Filesystem provides basic utility to manipulate the file system:
 
     $filesystem->isAbsolutePath($file);
 
+Resources
+---------
+
+You can run the unit tests with the following command:
+
+    phpunit

--- a/src/Symfony/Component/Filesystem/Tests/bootstrap.php
+++ b/src/Symfony/Component/Filesystem/Tests/bootstrap.php
@@ -10,13 +10,9 @@
  */
 
 spl_autoload_register(function ($class) {
-    if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\EventDispatcher')) {
-        if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\EventDispatcher')).'.php')) {
+    if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\Filesystem')) {
+        if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\Filesystem')).'.php')) {
             require_once $file;
         }
     }
 });
-
-if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
-    require_once $loader;
-}

--- a/src/Symfony/Component/Filesystem/phpunit.xml.dist
+++ b/src/Symfony/Component/Filesystem/phpunit.xml.dist
@@ -12,7 +12,7 @@
          bootstrap="Tests/bootstrap.php"
 >
     <testsuites>
-        <testsuite name="Symfony Security Component Test Suite">
+        <testsuite name="Symfony Filesystem Component Test Suite">
             <directory>./Tests/</directory>
         </testsuite>
     </testsuites>
@@ -21,7 +21,6 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./vendor</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>

--- a/src/Symfony/Component/Finder/README.md
+++ b/src/Symfony/Component/Finder/README.md
@@ -35,4 +35,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Finder/
+    phpunit

--- a/src/Symfony/Component/Finder/phpunit.xml.dist
+++ b/src/Symfony/Component/Finder/phpunit.xml.dist
@@ -21,8 +21,8 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/Form/.gitignore
+++ b/src/Symfony/Component/Form/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/Form/README.md
+++ b/src/Symfony/Component/Form/README.md
@@ -21,13 +21,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Form/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_EVENT_DISPATCHER=../path/to/EventDispatcher
-    export SYMFONY_LOCALE=../path/to/Locale
-    export SYMFONY_VALIDATOR=../path/to/Validator
-    export SYMFONY_HTTP_FOUNDATION=../path/to/HttpFoundation
+    php composer.phar install --dev

--- a/src/Symfony/Component/Form/Tests/bootstrap.php
+++ b/src/Symfony/Component/Form/Tests/bootstrap.php
@@ -10,22 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_EVENT_DISPATCHER' => 'EventDispatcher',
-        'SYMFONY_LOCALE'           => 'Locale',
-        'SYMFONY_VALIDATOR'        => 'Validator',
-        'SYMFONY_HTTP_FOUNDATION'  => 'HttpFoundation',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\Form')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\Form')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -17,8 +17,12 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/event-dispatcher": "self.version",
-        "symfony/locale": "self.version"
+        "symfony/event-dispatcher": "2.1.*",
+        "symfony/locale": "2.1.*"
+    },
+    "require-dev": {
+        "symfony/validator": "2.1.*",
+        "symfony/http-foundation": "2.1.*"
     },
     "suggest": {
         "symfony/validator": "self.version",

--- a/src/Symfony/Component/Form/phpunit.xml.dist
+++ b/src/Symfony/Component/Form/phpunit.xml.dist
@@ -21,8 +21,8 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/HttpFoundation/README.md
+++ b/src/Symfony/Component/HttpFoundation/README.md
@@ -43,4 +43,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/HttpFoundation/
+    phpunit

--- a/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpFoundation/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/HttpKernel/.gitignore
+++ b/src/Symfony/Component/HttpKernel/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/HttpKernel/README.md
+++ b/src/Symfony/Component/HttpKernel/README.md
@@ -84,18 +84,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/HttpKernel/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_EVENT_DISPATCHER=../path/to/EventDispatcher
-    export SYMFONY_HTTP_FOUNDATION=../path/to/HttpFoundation
-    export SYMFONY_DEPENDENCY_INJECTION=../path/to/DependencyInjection
-    export SYMFONY_CONSOLE=../path/to/Console
-    export SYMFONY_BROWSER_KIT=../path/to/BrowserKit
-    export SYMFONY_FINDER=../path/to/Finder
-    export SYMFONY_PROCESS=../path/to/Process
-    export SYMFONY_ROUTING=../path/to/Routing
-    export SYMFONY_CONFIG=../path/to/Config
+    php composer.phar install --dev

--- a/src/Symfony/Component/HttpKernel/Tests/bootstrap.php
+++ b/src/Symfony/Component/HttpKernel/Tests/bootstrap.php
@@ -10,28 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_EVENT_DISPATCHER'     => 'EventDispatcher',
-        'SYMFONY_HTTP_FOUNDATION'      => 'HttpFoundation',
-        'SYMFONY_DEPENDENCY_INJECTION' => 'DependencyInjection',
-        'SYMFONY_CONSOLE'              => 'Console',
-        'SYMFONY_BROWSER_KIT'          => 'BrowserKit',
-        'SYMFONY_FINDER'               => 'Finder',
-        'SYMFONY_CLASS_LOADER'         => 'ClassLoader',
-        'SYMFONY_PROCESS'              => 'Process',
-        'SYMFONY_ROUTING'              => 'Routing',
-        'SYMFONY_CONFIG'               => 'Config',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\HttpKernel')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\HttpKernel')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,8 +17,18 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/event-dispatcher": "self.version",
-        "symfony/http-foundation": "self.version"
+        "symfony/event-dispatcher": "2.1.*",
+        "symfony/http-foundation": "2.1.*"
+    },
+    "require-dev": {
+        "symfony/browser-kit": "2.1.*",
+        "symfony/class-loader": "2.1.*",
+        "symfony/config": "2.1.*",
+        "symfony/console": "2.1.*",
+        "symfony/dependency-injection": "2.1.*",
+        "symfony/finder": "2.1.*",
+        "symfony/process": "2.1.*",
+        "symfony/routing": "2.1.*"
     },
     "suggest": {
         "symfony/browser-kit": "self.version",

--- a/src/Symfony/Component/HttpKernel/phpunit.xml.dist
+++ b/src/Symfony/Component/HttpKernel/phpunit.xml.dist
@@ -21,8 +21,8 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/Locale/README.md
+++ b/src/Symfony/Component/Locale/README.md
@@ -19,4 +19,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Locale/
+    phpunit

--- a/src/Symfony/Component/Locale/phpunit.xml.dist
+++ b/src/Symfony/Component/Locale/phpunit.xml.dist
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/Process/README.md
+++ b/src/Symfony/Component/Process/README.md
@@ -42,4 +42,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Process/
+    phpunit

--- a/src/Symfony/Component/Process/phpunit.xml.dist
+++ b/src/Symfony/Component/Process/phpunit.xml.dist
@@ -21,7 +21,6 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>

--- a/src/Symfony/Component/Routing/.gitignore
+++ b/src/Symfony/Component/Routing/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/Routing/README.md
+++ b/src/Symfony/Component/Routing/README.md
@@ -29,12 +29,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Routing/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_CONFIG=../path/to/Config
-    export SYMFONY_YAML=../path/to/Yaml
-    export DOCTRINE_COMMON=../path/to/doctrine-common
+    php composer.phar install --dev

--- a/src/Symfony/Component/Routing/Tests/bootstrap.php
+++ b/src/Symfony/Component/Routing/Tests/bootstrap.php
@@ -10,26 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_CONFIG' => 'Config',
-        'SYMFONY_YAML'   => 'Yaml',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
-    if (isset($_SERVER['DOCTRINE_COMMON']) && 0 === strpos(ltrim($class, '/'), 'Doctrine\Common')) {
-        if (file_exists($file = $_SERVER['DOCTRINE_COMMON'].'/lib/'.str_replace('\\', '/', $class).'.php')) {
-            require_once $file;
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\Routing')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\Routing')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -18,9 +18,15 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "symfony/config": "2.1.*",
+        "symfony/yaml": "2.1.*",
+        "doctrine/common": ">=2.1,<2.3-dev"
+    },
     "suggest": {
         "symfony/config": "self.version",
-        "symfony/yaml": "self.version"
+        "symfony/yaml": "self.version",
+        "doctrine/common": ">=2.1,<2.3-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Routing": "" }

--- a/src/Symfony/Component/Routing/phpunit.xml.dist
+++ b/src/Symfony/Component/Routing/phpunit.xml.dist
@@ -21,7 +21,7 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
+                <directory>./vendor</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>

--- a/src/Symfony/Component/Security/.gitignore
+++ b/src/Symfony/Component/Security/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/Security/README.md
+++ b/src/Symfony/Component/Security/README.md
@@ -18,16 +18,9 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Security/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_HTTP_FOUNDATION=../path/to/HttpFoundation
-    export SYMFONY_HTTP_KERNEL=../path/to/HttpKernel
-    export SYMFONY_EVENT_DISPATCHER=../path/to/EventDispatcher
-    export SYMFONY_FORM=../path/to/Form
-    export SYMFONY_ROUTING=../path/to/Routing
-    export DOCTRINE_DBAL=../path/to/doctrine-dbal
-    export DOCTRINE_COMMON=../path/to/doctrine-common
+    php composer.phar install --dev

--- a/src/Symfony/Component/Security/Tests/bootstrap.php
+++ b/src/Symfony/Component/Security/Tests/bootstrap.php
@@ -10,35 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_HTTP_FOUNDATION' => 'HttpFoundation',
-        'SYMFONY_HTTP_KERNEL' => 'HttpKernel',
-        'SYMFONY_EVENT_DISPATCHER' => 'EventDispatcher',
-        'SYMFONY_FORM' => 'Form',
-        'SYMFONY_ROUTING' => 'Routing',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
-    if (isset($_SERVER['DOCTRINE_DBAL']) && 0 === strpos(ltrim($class, '/'), 'Doctrine\DBAL')) {
-        if (file_exists($file = $_SERVER['DOCTRINE_DBAL'].'/lib/'.str_replace('\\', '/', $class).'.php')) {
-            require_once $file;
-        }
-    }
-
-    if (isset($_SERVER['DOCTRINE_COMMON']) && 0 === strpos(ltrim($class, '/'), 'Doctrine\Common')) {
-        if (file_exists($file = $_SERVER['DOCTRINE_COMMON'].'/lib/'.str_replace('\\', '/', $class).'.php')) {
-            require_once $file;
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\Security')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\Security')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -17,9 +17,15 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/event-dispatcher": "self.version",
-        "symfony/http-foundation": "self.version",
-        "symfony/http-kernel": "self.version"
+        "symfony/event-dispatcher": "2.1.*",
+        "symfony/http-foundation": "2.1.*",
+        "symfony/http-kernel": "2.1.*"
+    },
+    "require-dev": {
+        "symfony/form": "2.1.*",
+        "symfony/routing": "2.1.*",
+        "doctrine/common": ">=2.1,<2.3-dev",
+        "doctrine/dbal": ">=2.1,<2.3-dev"
     },
     "suggest": {
         "symfony/class-loader": "self.version",

--- a/src/Symfony/Component/Serializer/README.md
+++ b/src/Symfony/Component/Serializer/README.md
@@ -10,4 +10,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Serializer/
+    phpunit

--- a/src/Symfony/Component/Serializer/phpunit.xml.dist
+++ b/src/Symfony/Component/Serializer/phpunit.xml.dist
@@ -21,7 +21,7 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
+                <directory>./vendor</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>

--- a/src/Symfony/Component/Templating/README.md
+++ b/src/Symfony/Component/Templating/README.md
@@ -13,4 +13,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Templating/
+    phpunit

--- a/src/Symfony/Component/Templating/phpunit.xml.dist
+++ b/src/Symfony/Component/Templating/phpunit.xml.dist
@@ -21,7 +21,7 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
+                <directory>./vendor</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>

--- a/src/Symfony/Component/Translation/.gitignore
+++ b/src/Symfony/Component/Translation/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/Translation/README.md
+++ b/src/Symfony/Component/Translation/README.md
@@ -30,11 +30,9 @@ http://symfony.com/doc/2.0/book/translation.html
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Translation/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_CONFIG=../path/to/Config
-    export SYMFONY_YAML=../path/to/Yaml
+    php composer.phar install --dev

--- a/src/Symfony/Component/Translation/Tests/bootstrap.php
+++ b/src/Symfony/Component/Translation/Tests/bootstrap.php
@@ -10,20 +10,13 @@
  */
 
 spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_CONFIG' => 'Config',
-        'SYMFONY_YAML'   => 'Yaml',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\Translation')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\Translation')).'.php')) {
             require_once $file;
         }
     }
 });
+
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -18,6 +18,10 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "symfony/config": "2.1.*",
+        "symfony/yaml": "2.1.*"
+    },
     "suggest": {
         "symfony/config": "self.version",
         "symfony/yaml": "self.version"

--- a/src/Symfony/Component/Translation/phpunit.xml.dist
+++ b/src/Symfony/Component/Translation/phpunit.xml.dist
@@ -21,7 +21,7 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
+                <directory>./vendor</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>

--- a/src/Symfony/Component/Validator/.gitignore
+++ b/src/Symfony/Component/Validator/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Component/Validator/README.md
+++ b/src/Symfony/Component/Validator/README.md
@@ -46,13 +46,9 @@ http://jcp.org/en/jsr/detail?id=303
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Validator/
+    phpunit
 
 If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
+Components, install dev dependencies before running PHPUnit:
 
-    export SYMFONY_YAML=../path/to/Yaml
-    export SYMFONY_LOCALE=../path/to/Locale
-    export SYMFONY_HTTP_FOUNDATION=../path/to/HttpFoundation
-    export DOCTRINE_COMMON=../path/to/doctrine-common
+    php composer.phar install --dev

--- a/src/Symfony/Component/Validator/Tests/bootstrap.php
+++ b/src/Symfony/Component/Validator/Tests/bootstrap.php
@@ -9,25 +9,7 @@
  * file that was distributed with this source code.
  */
 
-spl_autoload_register($loader = function ($class) {
-    foreach (array(
-        'SYMFONY_YAML'            => 'Yaml',
-        'SYMFONY_LOCALE'          => 'Locale',
-        'SYMFONY_HTTP_FOUNDATION' => 'HttpFoundation',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
-    if (isset($_SERVER['DOCTRINE_COMMON']) && 0 === strpos(ltrim($class, '/'), 'Doctrine\Common')) {
-        if (file_exists($file = $_SERVER['DOCTRINE_COMMON'].'/lib/'.str_replace('\\', '/', $class).'.php')) {
-            require_once $file;
-        }
-    }
-
+spl_autoload_register(function ($class) {
     if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\Validator')) {
         if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\Validator')).'.php')) {
             require_once $file;
@@ -35,9 +17,17 @@ spl_autoload_register($loader = function ($class) {
     }
 });
 
-if (isset($_SERVER['DOCTRINE_COMMON'])) {
-    Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(function($class) use ($loader) {
-        $loader($class);
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}
+
+if (class_exists($annotationRegistry = 'Doctrine\Common\Annotations\AnnotationRegistry')) {
+    $annotationRegistry::registerLoader(function($class) {
+        if (0 === strpos(ltrim($class, '/'), 'Symfony\Component\Validator')) {
+            if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\Validator')).'.php')) {
+                require_once $file;
+            }
+        }
 
         return class_exists($class, false);
     });

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -19,6 +19,11 @@
         "php": ">=5.3.2",
         "doctrine/common": ">=2.1,<2.3"
     },
+    "require-dev": {
+        "symfony/http-foundation": "2.1.*",
+        "symfony/locale": "2.1.*",
+        "symfony/yaml": "2.1.*"
+    },
     "suggest": {
         "symfony/http-foundation": "self.version",
         "symfony/yaml": "self.version"

--- a/src/Symfony/Component/Validator/phpunit.xml.dist
+++ b/src/Symfony/Component/Validator/phpunit.xml.dist
@@ -21,7 +21,7 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
+                <directory>./vendor</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>

--- a/src/Symfony/Component/Yaml/README.md
+++ b/src/Symfony/Component/Yaml/README.md
@@ -14,4 +14,4 @@ Resources
 
 You can run the unit tests with the following command:
 
-    phpunit -c src/Symfony/Component/Yaml/
+    phpunit

--- a/src/Symfony/Component/Yaml/phpunit.xml.dist
+++ b/src/Symfony/Component/Yaml/phpunit.xml.dist
@@ -21,7 +21,7 @@
         <whitelist>
             <directory>./</directory>
             <exclude>
-                <directory>./Resources</directory>
+                <directory>./vendor</directory>
                 <directory>./Tests</directory>
             </exclude>
         </whitelist>


### PR DESCRIPTION
See #4141

---

This PR:
- configures each component to use composer to manage "dev" dependencies instead of env variables;
- adds phpunit configuration file on Filesystem component;
- fixes READMEs.

It's mergeable without any problems, but I would recommend to wait a fix in Composer in order to use `self.version` in `require`/`require-dev` sections.

Note: I kept `suggest` sections because it makes sense but this PR doesn't aim to provide useful explanations for each entry. It could be another PR, not that one.
