### PR TITLE
[Security] Configure ports in RetryAuthenticationEntryPoint according to...

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -51,7 +51,10 @@
             <argument /> <!-- Key -->
         </service>
 
-        <service id="security.authentication.retry_entry_point" class="%security.authentication.retry_entry_point.class%" public="false" />
+        <service id="security.authentication.retry_entry_point" class="%security.authentication.retry_entry_point.class%" public="false">
+            <argument>%request_listener.http_port%</argument>
+            <argument>%request_listener.https_port%</argument>
+        </service>
 
         <service id="security.authentication.basic_entry_point" class="%security.authentication.basic_entry_point.class%" public="false" />
 


### PR DESCRIPTION
... router settings

As requested against 2.0 branch ... 

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Currently the ports in RetryAuthenticationEntryPoint are fixed in the constructor call, there is no way to set them when you run your application on different ports.

With this fix the ports are taken from the router configuration.
