### PR TITLE
[DoctrineBundle] Proxy autoloader should not throw exception

### DIFF
--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -81,7 +81,9 @@ class DoctrineBundle extends Bundle
                         clearstatcache($file);
                     }
 
-                    @include $file;
+                    if (file_exists($file)) {
+                        require $file;
+                    }
                 }
             };
             spl_autoload_register($this->autoloader);

--- a/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
+++ b/src/Symfony/Bundle/DoctrineBundle/DoctrineBundle.php
@@ -79,13 +79,9 @@ class DoctrineBundle extends Bundle
                         }
 
                         clearstatcache($file);
-
-                        if (!file_exists($file)) {
-                            throw new \RuntimeException(sprintf('The proxy file "%s" does not exist. If you still have objects serialized in the session, you need to clear the session manually.', $file));
-                        }
                     }
 
-                    require $file;
+                    @include $file;
                 }
             };
             spl_autoload_register($this->autoloader);


### PR DESCRIPTION
Also change 'require' to non-fatal '@include' in the event no file is generated.
