### PR TITLE
[HttpFoundation] Added native Redis session handler to CHANGELOG

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -25,7 +25,7 @@ CHANGELOG
    `Symfony\Component\HttpFoundation\Storage\Handler\NativeSessionHandler` base class.
  * Added internal storage driver proxy mechanism for forward compatibility with
    PHP 5.4 `\SessionHandler` class.
- * Added session handlers for PHP native MongoDb, Memcache, Memcached and SQLite session
+ * Added session handlers for PHP native MongoDb, Memcache, Memcached, Redis and SQLite session
    save handlers.
  * Added session handlers for custom Memcache, Memcached and Null session save handlers.
  * [BC BREAK] Removed `NativeSessionStorage` and replaced with `NativeFileSessionHandler`.


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
