### PR TITLE
[BrowserKit] Remove dependency of CookieJar to Response

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -89,16 +89,16 @@ class CookieJar
     }
 
     /**
-     * Updates the cookie jar from a Response object.
+     * Updates the cookie jar from a response Set-Cookie headers.
      *
-     * @param Response $response A Response object
-     * @param string   $uri      The base URL
+     * @param array    $setCookies  Set-Cookie headers from an HTTP response
+     * @param string   $uri         The base URL
      */
-    public function updateFromResponse(Response $response, $uri = null)
+    public function updateFromSetCookie(array $setCookies, $uri = null)
     {
         $cookies = array();
 
-        foreach ($response->getHeader('Set-Cookie', false) as $cookie) {
+        foreach ($setCookies as $cookie) {
             foreach (explode(',', $cookie) as $i => $part) {
                 if (0 === $i || preg_match('/^(?P<token>\s*[0-9A-Za-z!#\$%\&\'\*\+\-\.^_`\|~]+)=/', $part)) {
                     $cookies[] = ltrim($part);
@@ -111,6 +111,17 @@ class CookieJar
         foreach ($cookies as $cookie) {
             $this->set(Cookie::fromString($cookie, $uri));
         }
+    }
+
+    /**
+     * Updates the cookie jar from a Response object.
+     *
+     * @param Response $response A Response object
+     * @param string $uri The base URL
+     */
+    public function updateFromResponse(Response $response, $uri = null)
+    {
+        $this->updateFromSetCookie($response->getHeader('Set-Cookie', false), $uri);
     }
 
     /**

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -63,25 +63,33 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $response = new Response('', 200, array('Set-Cookie' => 'foo=foo'));
 
         $cookieJar = new CookieJar();
-        $cookieJar->set(new Cookie('bar', 'bar'));
         $cookieJar->updateFromResponse($response);
+
+        $this->assertEquals('foo', $cookieJar->get('foo')->getValue(), '->updateFromResponse() updates cookies from a Response objects');
+    }
+
+    public function testUpdateFromSetCookie()
+    {
+        $setCookies = array('foo=foo');
+
+        $cookieJar = new CookieJar();
+        $cookieJar->set(new Cookie('bar', 'bar'));
+        $cookieJar->updateFromSetCookie($setCookies);
 
         $this->assertInstanceOf('Symfony\Component\BrowserKit\Cookie', $cookieJar->get('foo'));
         $this->assertInstanceOf('Symfony\Component\BrowserKit\Cookie', $cookieJar->get('bar'));
-        $this->assertEquals('foo', $cookieJar->get('foo')->getValue(), '->updateFromResponse() updates cookies from a Response objects');
-        $this->assertEquals('bar', $cookieJar->get('bar')->getValue(), '->updateFromResponse() keeps existing cookies');
+        $this->assertEquals('foo', $cookieJar->get('foo')->getValue(), '->updateFromSetCookie() updates cookies from a Set-Cookie header');
+        $this->assertEquals('bar', $cookieJar->get('bar')->getValue(), '->updateFromSetCookie() keeps existing cookies');
     }
 
-    public function testUpdateFromResponseWithMultipleCookies()
+    public function testUpdateFromSetCookieWithMultipleCookies()
     {
         $timestamp = time() + 3600;
         $date = gmdate('D, d M Y H:i:s \G\M\T', $timestamp);
-        $response = new Response('', 200, array(
-            'Set-Cookie' => sprintf('foo=foo; expires=%s; domain=.symfony.com; path=/, bar=bar; domain=.blog.symfony.com, PHPSESSID=id; expires=%s', $date, $date)
-        ));
+        $setCookies = array(sprintf('foo=foo; expires=%s; domain=.symfony.com; path=/, bar=bar; domain=.blog.symfony.com, PHPSESSID=id; expires=%s', $date, $date));
 
         $cookieJar = new CookieJar();
-        $cookieJar->updateFromResponse($response);
+        $cookieJar->updateFromSetCookie($setCookies);
 
         $fooCookie = $cookieJar->get('foo', '/', '.symfony.com');
         $barCookie = $cookieJar->get('bar', '/', '.blog.symfony.com');


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

The CookieJar has currently a hard dependency to `BrowserKit\Response`, but this dependency could be avoided.
