### PR TITLE
[Translation] Improved error message

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -74,7 +74,7 @@ class MessageSelector
 
         $position = PluralizationRules::get($number, $locale);
         if (!isset($standardRules[$position])) {
-            throw new \InvalidArgumentException('Unable to choose a translation.');
+            throw new \InvalidArgumentException(sprintf('Unable to choose a translation for "%s" with locale "%s".', $message, $locale));
         }
 
         return $standardRules[$position];


### PR DESCRIPTION
Bug fix: [no]
Feature addition: [no]
Backwards compatibility break: [no]
Symfony2 tests pass: [no] -  (no more or less than they were passing before this addition)

Updates an error message in the translator so the developers can know what is the message causing the error.
