### PR TITLE
[Form] made ValueToStringTransformer convert Boolean false to empty string

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValueToStringTransformer.php
@@ -32,7 +32,7 @@ class ValueToStringTransformer implements DataTransformerInterface
      */
     public function transform($value)
     {
-        if (null === $value) {
+        if (null === $value || false === $value) {
             return '';
         }
 


### PR DESCRIPTION
It's common in PHP for Boolean `false` to represent the lack of a value (e.g. core functions like `strpos()`) - therefore the code here should intuit this intention to represent the lack of something with `false` and convert it to an empty string the same way it does for `null`, rather than throwing a rather opaque exception.
