### PR TITLE
Update allowed exit code max value to 254

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -120,8 +120,8 @@ class Application
         }
 
         if ($this->autoExit) {
-            if ($statusCode > 255) {
-                $statusCode = 255;
+            if ($statusCode > 254) {
+                $statusCode = 254;
             }
             // @codeCoverageIgnoreStart
             exit($statusCode);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Exit code 255 is apparently reserved, and not to be used as per http://us.php.net/exit
