### PR TITLE
[Validator] Min/Max validators should ignore empty string 

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/MaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxValidator.php
@@ -31,7 +31,7 @@ class MaxValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Constraints/MinValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinValidator.php
@@ -31,7 +31,7 @@ class MinValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (null === $value) {
+        if (null === $value || '' === $value) {
             return;
         }
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/MaxValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MaxValidatorTest.php
@@ -40,6 +40,14 @@ class MaxValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate(null, new Max(array('limit' => 10)));
     }
 
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate('', new Max(array('limit' => 10)));
+    }
+
     /**
      * @dataProvider getValidValues
      */

--- a/src/Symfony/Component/Validator/Tests/Constraints/MinValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MinValidatorTest.php
@@ -34,6 +34,14 @@ class MinValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate(null, new Min(array('limit' => 10)));
     }
 
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate('', new Min(array('limit' => 10)));
+    }
+
     /**
      * @dataProvider getValidValues
      */


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes ![Build status](https://secure.travis-ci.org/mythmakr/symfony.png?branch=3686-min-max-validators-to-ignore-empty-string)
Fixes the following tickets: #3686
Closed related PR #3687
Todo: 
