### PR TITLE
[BrowserKit] Check class existence only when required.

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -84,7 +84,7 @@ abstract class Client
      */
     public function insulate($insulated = true)
     {
-        if (!class_exists('Symfony\\Component\\Process\\Process')) {
+        if ($insulated && !class_exists('Symfony\\Component\\Process\\Process')) {
             // @codeCoverageIgnoreStart
             throw new \RuntimeException('Unable to isolate requests as the Symfony Process Component is not installed.');
             // @codeCoverageIgnoreEnd


### PR DESCRIPTION
See PR #4177

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Remove incorrect exception when doing $client->insulate(false)
