### PR TITLE
[Routing] fixed route generation when pattern already has question mark

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -147,7 +147,12 @@ class UrlGenerator implements UrlGeneratorInterface
         // add a query string if needed
         $extra = array_diff_key($originParameters, $variables, $defaults);
         if ($extra && $query = http_build_query($extra, '', '&')) {
-            $url .= '?'.$query;
+            if (false === strpos($url, '?')) {
+                $url .= '?';
+            } else {
+                $url .= '&';
+            }
+            $url .= $query;
         }
 
         $url = $this->context->getBaseUrl().$url;

--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -125,6 +125,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('/app.php/testing?foo=bar', $url);
     }
+    
+    public function testUrlWithExtraParametersAndQuestionMarkAlready()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing?foo=bar'));
+        $url = $this->getGenerator($routes)->generate('test', array('extra' => '123'));
+
+        $this->assertSame('/app.php/testing?foo=bar&extra=123', $url);
+    }
 
     public function testUrlWithGlobalParameter()
     {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: If someone relied no this bug, yes
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

I sometimes have routes like the following used purely for generating a url, whether that be to the symfony app or an external app:

``` yaml
blog_news:
    pattern:  /blog/?category=news
```

When generating this route with extra parameters, the url it generates is invalid.

``` php
$router->generate('blog_news', array('page' => 2));
// results in /blog/?category=news?page=2
```

I've changed the generator to use & if the url already has a ?
