### PR TITLE
[Form] Circular references fix

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -541,7 +541,7 @@ class FormBuilder
             throw new UnexpectedTypeException($type, 'string or Symfony\Component\Form\FormTypeInterface');
         }
 
-        if ($this->currentLoadingType && ($type instanceof FormTypeInterface ? $type->getName() : $type) == $this->currentLoadingType) {
+        if ($this->currentLoadingType && $this->name == $child && ($type instanceof FormTypeInterface ? $type->getName() : $type) == $this->currentLoadingType) {
             throw new CircularReferenceException(is_string($type) ? $this->getFormFactory()->getType($type) : $type);
         }
 


### PR DESCRIPTION
This PR should loose a little the circular reference check, allowing form fields of a given type to be children of a filed of the same type, given that they don't have the same name. This should still keep the circular reference check there but allow a few more use case(I found one while using Sonata Bundle, for instance).
