### PR TITLE
[Form] Added right HTML types to Datetime/Date/Time types if single_text is true

### DIFF
--- a/src/Symfony/Bridge/Twig/.gitignore
+++ b/src/Symfony/Bridge/Twig/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+composer.lock

--- a/src/Symfony/Bridge/Twig/README.md
+++ b/src/Symfony/Bridge/Twig/README.md
@@ -7,17 +7,9 @@ Symfony2 components.
 Resources
 ---------
 
-You can run the unit tests with the following command:
+If you want to run the unit tests, install dev dependencies before
+running PHPUnit:
 
-    phpunit -c src/Symfony/Bridge/Twig/
+    php composer.phar install --dev
 
-If you also want to run the unit tests that depend on other Symfony
-Components, declare the following environment variables before running
-PHPUnit:
-
-    export TWIG=../path/to/Twig
-    export SYMFONY_EVENT_DISPATCHER=../path/to/EventDispatcher
-    export SYMFONY_FORM=../path/to/Form
-    export SYMFONY_LOCALE=../path/to/Locale
-    export SYMFONY_TEMPLATING=../path/to/Templating
-    export SYMFONY_TRANSLATION=../path/to/Translation
+    phpunit

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Bridge\Twig\Tests\Extension;
 
-use Symfony\Component\Form\FormView;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
-use Symfony\Component\Form\Tests\AbstractDivLayoutTest;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubTranslator;
 use Symfony\Bridge\Twig\Tests\Extension\Fixtures\StubFilesystemLoader;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\Form\Tests\AbstractDivLayoutTest;
 
 class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
 {

--- a/src/Symfony/Bridge/Twig/Tests/bootstrap.php
+++ b/src/Symfony/Bridge/Twig/Tests/bootstrap.php
@@ -9,30 +9,6 @@
  * file that was distributed with this source code.
  */
 
-spl_autoload_register(function ($class) {
-    foreach (array(
-        'SYMFONY_EVENT_DISPATCHER' => 'EventDispatcher',
-        'SYMFONY_FORM'             => 'Form',
-        'SYMFONY_LOCALE'           => 'Locale',
-        'SYMFONY_TEMPLATING'       => 'Templating',
-        'SYMFONY_TRANSLATION'      => 'Translation',
-    ) as $env => $name) {
-        if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
-            if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {
-                require_once $file;
-            }
-        }
-    }
-
-    if (isset($_SERVER['TWIG']) && 0 === strpos(ltrim($class, '/'), 'Twig_')) {
-        if (file_exists($file = $_SERVER['TWIG'].'/lib/'.str_replace('_', '/', $class).'.php')) {
-            require_once $file;
-        }
-    }
-
-    if (0 === strpos(ltrim($class, '/'), 'Symfony\Bridge\Twig')) {
-        if (file_exists($file = __DIR__.'/../'.substr(str_replace('\\', '/', $class), strlen('Symfony\Bridge\Twig')).'.php')) {
-            require_once $file;
-        }
-    }
-});
+if (file_exists($loader = __DIR__.'/../vendor/autoload.php')) {
+    require_once $loader;
+}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -19,6 +19,13 @@
         "php": ">=5.3.3",
         "twig/twig": ">=1.8,<2.0-dev"
     },
+    "require-dev": {
+        "symfony/form": "2.1.*",
+        "symfony/routing": "2.1.*",
+        "symfony/templating": "2.1.*",
+        "symfony/translation": "2.1.*",
+        "symfony/yaml": "2.1.*"
+    },
     "suggest": {
         "symfony/form": "self.version",
         "symfony/routing": "self.version",

--- a/src/Symfony/Bridge/Twig/phpunit.xml.dist
+++ b/src/Symfony/Bridge/Twig/phpunit.xml.dist
@@ -9,7 +9,7 @@
          processIsolation="false"
          stopOnFailure="false"
          syntaxCheck="false"
-         bootstrap="tests/bootstrap.php"
+         bootstrap="Tests/bootstrap.php"
 >
     <testsuites>
         <testsuite name="Symfony Twig Bridge Test Suite">
@@ -23,6 +23,7 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -124,6 +124,10 @@ class DateTimeType extends AbstractType
     public function buildView(FormView $view, FormInterface $form)
     {
         $view->set('widget', $form->getAttribute('widget'));
+
+        if ('single_text' === $form->getAttribute('widget')) {
+            $view->set('type', 'datetime');
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -142,6 +142,10 @@ class DateType extends AbstractType
     {
         $view->set('widget', $form->getAttribute('widget'));
 
+        if ('single_text' === $form->getAttribute('widget')) {
+            $view->set('type', 'date');
+        }
+
         if ($view->hasChildren()) {
             $pattern = $form->getAttribute('formatter')->getPattern();
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -130,6 +130,10 @@ class TimeType extends AbstractType
             ->set('widget', $form->getAttribute('widget'))
             ->set('with_seconds', $form->getAttribute('with_seconds'))
         ;
+
+        if ('single_text' === $form->getAttribute('widget')) {
+            $view->set('type', 'time');
+        }
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -947,12 +947,12 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 '/div
     [
         ./input
-            [@type="text"]
+            [@type="date"]
             [@id="name_date"]
             [@name="name[date]"]
             [@value="Feb 3, 2011"]
         /following-sibling::input
-            [@type="text"]
+            [@type="time"]
             [@id="name_time"]
             [@name="name[time]"]
             [@value="04:05"]
@@ -970,7 +970,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
-    [@type="text"]
+    [@type="datetime"]
     [@name="name"]
     [@value="2011-02-03 04:05"]
 '
@@ -988,7 +988,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
-    [@type="text"]
+    [@type="datetime"]
     [@name="name"]
     [@value="2011-02-03 04:05"]
 '
@@ -1111,7 +1111,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
-    [@type="text"]
+    [@type="date"]
     [@name="name"]
     [@value="Feb 3, 2011"]
 '
@@ -1586,7 +1586,7 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
-    [@type="text"]
+    [@type="time"]
     [@name="name"]
     [@value="04:05"]
 '

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -259,4 +259,14 @@ class DateTimeTypeTest extends LocalizedTestCase
         // to null in the type
         $this->factory->create('datetime', new \DateTime());
     }
+
+    public function testSingleTextWidgetShouldUseTheRightInputType()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'widget' => 'single_text',
+        ));
+
+        $view = $form->createView();
+        $this->assertEquals('datetime', $view->get('type'));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -536,4 +536,14 @@ class DateTypeTest extends LocalizedTestCase
         // to null in the type
         $this->factory->create('date', new \DateTime());
     }
+
+    public function testSingleTextWidgetShouldUseTheRightInputType()
+    {
+        $form = $this->factory->create('date', null, array(
+            'widget' => 'single_text',
+        ));
+
+        $view = $form->createView();
+        $this->assertEquals('date', $view->get('type'));
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -406,4 +406,14 @@ class TimeTypeTest extends LocalizedTestCase
         // to null in the type
         $this->factory->create('time', new \DateTime());
     }
+
+    public function testSingleTextWidgetShouldUseTheRightInputType()
+    {
+        $form = $this->factory->create('time', null, array(
+            'widget' => 'single_text',
+        ));
+
+        $view = $form->createView();
+        $this->assertEquals('time', $view->get('type'));
+    }
 }


### PR DESCRIPTION
When you set the `widget` option to `single_text`, you get a HTML input tag which is fine, but you the type is `text`, and it's wrong. You don't have any other way to get the right `type` as this attribute is defined to the FormView instance itself (see FileType for instance).

This PR adds right HTML types like the FileType does.

Cheers,
William
