### PR TITLE
[Routing] fix encoding of static static

### DIFF
--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -162,12 +162,23 @@ class UrlGenerator implements UrlGeneratorInterface
             }
         }
 
-        if (!$url) {
+        if ('' === $url) {
             $url = '/';
         }
 
         // do not encode the contexts base url as it is already encoded (see Symfony\Component\HttpFoundation\Request)
         $url = $this->context->getBaseUrl().strtr(rawurlencode($url), $this->decodedChars);
+
+        // the path segments "." and ".." are interpreted as relative reference when resolving a URI; see http://tools.ietf.org/html/rfc3986#section-3.3
+        // so we need to encode them as they are not used for this purpose here
+        // otherwise we would generate a URI that, when followed by a user agent (e.g. browser), does not match this route
+        // a probably slower one line solution: preg_replace(array('#/\.\.(/|$)#', '#/\.(/|$)#'), array('/%2E%2E$1', '/%2E$1'), $url);
+        $url = strtr($url, array('/../' => '/%2E%2E/', '/./' => '/%2E/'));
+        if ('/..' === substr($url, -3)) {
+            $url = substr($url, 0, -2) . '%2E%2E';
+        } elseif ('/.' === substr($url, -2)) {
+            $url = substr($url, 0, -1) . '%2E';
+        }
 
         // add a query string if needed
         $extra = array_diff_key($originParameters, $variables, $defaults);

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -172,7 +172,7 @@ class UrlGenerator implements UrlGeneratorInterface
         // the path segments "." and ".." are interpreted as relative reference when resolving a URI; see http://tools.ietf.org/html/rfc3986#section-3.3
         // so we need to encode them as they are not used for this purpose here
         // otherwise we would generate a URI that, when followed by a user agent (e.g. browser), does not match this route
-        // a probably slower one line solution: preg_replace(array('#/\.\.(/|$)#', '#/\.(/|$)#'), array('/%2E%2E$1', '/%2E$1'), $url);
+        // a 1.4 times slower one line solution: preg_replace(array('#/\.\.(/|$)#', '#/\.(/|$)#'), array('/%2E%2E$1', '/%2E$1'), $url);
         $url = strtr($url, array('/../' => '/%2E%2E/', '/./' => '/%2E/'));
         if ('/..' === substr($url, -3)) {
             $url = substr($url, 0, -2) . '%2E%2E';

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -76,9 +76,7 @@ class UrlGenerator implements UrlGeneratorInterface
     }
 
     /**
-     * Sets the request context.
-     *
-     * @param RequestContext $context The context
+     * {@inheritDoc}
      *
      * @api
      */
@@ -88,9 +86,9 @@ class UrlGenerator implements UrlGeneratorInterface
     }
 
     /**
-     * Gets the request context.
+     * {@inheritDoc}
      *
-     * @return RequestContext The context
+     * @api
      */
     public function getContext()
     {

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -28,9 +28,33 @@ use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
 class UrlGenerator implements UrlGeneratorInterface
 {
     protected $context;
+
+    /**
+     * This array defines the characters (besides alphanumeric ones) that will not be percent-encoded in the path segment of the generated URL.
+     *
+     * PHP's rawurlencode() encodes all chars except "a-zA-Z0-9-._~" according to RFC 3986. But we want to allow some chars
+     * to be used in their literal form (reasons below). Other chars inside the path must of course be encoded, e.g.
+     * "?" and "#" (would be interpreted wrongly as query and fragment identifier),
+     * "'" and """ (are used as delimiters in HTML).
+     */
     protected $decodedChars = array(
-        // %2F is not valid in a URL, so we don't encode it (which is fine as the requirements explicitely allowed it)
+        // the slash can be used to designate a hierarchical structure and we want allow using it with this meaning
+        // some webservers don't allow the slash in encoded form in the path for security reasons anyway
+        // see http://stackoverflow.com/questions/4069002/http-400-if-2f-part-of-get-url-in-jboss
         '%2F' => '/',
+        // the following chars are general delimiters in the URI specification but have only special meaning in the authority component
+        // so they can safely be used in the path in unencoded form
+        '%40' => '@',
+        '%3A' => ':',
+        // these chars are only sub-delimiters that have no predefined meaning and can therefore be used literally
+        // so URI producing applications can use these chars to delimit subcomponents in a path segment without being encoded for better readability
+        '%3B' => ';',
+        '%2C' => ',',
+        '%3D' => '=',
+        '%2B' => '+',
+        '%21' => '!',
+        '%2A' => '*',
+        '%7C' => '|',
     );
 
     protected $routes;
@@ -129,7 +153,7 @@ class UrlGenerator implements UrlGeneratorInterface
                     }
 
                     if (!$isEmpty || !$optional) {
-                        $url = $token[1].strtr(rawurlencode($tparams[$token[3]]), $this->decodedChars).$url;
+                        $url = $token[1].$tparams[$token[3]].$url;
                     }
 
                     $optional = false;
@@ -144,13 +168,14 @@ class UrlGenerator implements UrlGeneratorInterface
             $url = '/';
         }
 
+        // do not encode the contexts base url as it is already encoded (see Symfony\Component\HttpFoundation\Request)
+        $url = $this->context->getBaseUrl().strtr(rawurlencode($url), $this->decodedChars);
+
         // add a query string if needed
         $extra = array_diff_key($originParameters, $variables, $defaults);
         if ($extra && $query = http_build_query($extra, '', '&')) {
             $url .= '?'.$query;
         }
-
-        $url = $this->context->getBaseUrl().$url;
 
         if ($this->context->getHost()) {
             $scheme = $this->context->getScheme();

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -45,9 +45,7 @@ class UrlMatcher implements UrlMatcherInterface
     }
 
     /**
-     * Sets the request context.
-     *
-     * @param RequestContext $context The context
+     * {@inheritDoc}
      *
      * @api
      */
@@ -57,9 +55,9 @@ class UrlMatcher implements UrlMatcherInterface
     }
 
     /**
-     * Gets the request context.
+     * {@inheritDoc}
      *
-     * @return RequestContext The context
+     * @api
      */
     public function getContext()
     {

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -145,9 +145,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * Sets the request context.
-     *
-     * @param RequestContext $context The context
+     * {@inheritdoc}
      */
     public function setContext(RequestContext $context)
     {
@@ -158,9 +156,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * Gets the request context.
-     *
-     * @return RequestContext The context
+     * {@inheritdoc}
      */
     public function getContext()
     {

--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -206,6 +206,13 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/app.php/foo', $this->getGenerator($routes)->generate('test', array('default' => 'foo')));
     }
 
+    public function testUrlEncoding()
+    {
+        $routes = $this->getRoutes('test', new Route('/"/{var}'));
+
+        $this->assertSame('/app.php/%22/%22', $this->getGenerator($routes)->generate('test', array('var' => '"')));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array())
     {
         $context = new RequestContext('/app.php');

--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -208,9 +208,18 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testUrlEncoding()
     {
-        $routes = $this->getRoutes('test', new Route('/"/{var}'));
-
-        $this->assertSame('/app.php/%22/%22', $this->getGenerator($routes)->generate('test', array('var' => '"')));
+        // This tests the encoding of reserved characters that are used for delimiting of URI components (defined in RFC 3986)
+        // and other special ASCII chars. These chars are tested as static text path, variable path and query param.
+        $chars = '@:[]/()*\'" +,;-._~&$<>|{}%\\^`!?foo=bar#id';
+        $routes = $this->getRoutes('test', new Route("/$chars/{varpath}", array(), array('varpath' => '.+')));
+        $this->assertSame('/app.php/@:%5B%5D/%28%29*%27%22%20+,;-._~%26%24%3C%3E|%7B%7D%25%5C%5E%60!%3Ffoo=bar%23id'
+            . '/@:%5B%5D/%28%29*%27%22%20+,;-._~%26%24%3C%3E|%7B%7D%25%5C%5E%60!%3Ffoo=bar%23id'
+            . '?query=%40%3A%5B%5D%2F%28%29%2A%27%22+%2B%2C%3B-._%7E%26%24%3C%3E%7C%7B%7D%25%5C%5E%60%21%3Ffoo%3Dbar%23id',
+            $this->getGenerator($routes)->generate('test', array(
+                'varpath' => $chars,
+                'query' => $chars
+            ))
+        );
     }
 
     protected function getGenerator(RouteCollection $routes, array $parameters = array())

--- a/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/UrlGeneratorTest.php
@@ -222,6 +222,16 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testEncodingOfRelativePathSegments()
+    {
+        $routes = $this->getRoutes('test', new Route('/dir/../dir/..'));
+        $this->assertSame('/app.php/dir/%2E%2E/dir/%2E%2E', $this->getGenerator($routes)->generate('test'));
+        $routes = $this->getRoutes('test', new Route('/dir/./dir/.'));
+        $this->assertSame('/app.php/dir/%2E/dir/%2E', $this->getGenerator($routes)->generate('test'));
+        $routes = $this->getRoutes('test', new Route('/a./.a/a../..a/...'));
+        $this->assertSame('/app.php/a./.a/a../..a/...', $this->getGenerator($routes)->generate('test'));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array())
     {
         $context = new RequestContext('/app.php');


### PR DESCRIPTION
BC break: no
Fixes #4166

The first commit shows simply what the problem is: The chars, in this case `"`, get encoded when part of a placeholder but not as static text. This makes it inconsistent and can produce invalid URLs.

The second commit fixes the issue and further enhances the test with more chars. It also adds chars that do not need to be encoded for better usuability (explained in code). Some people might want to use chars like `+` in the path and it looks better when its not encoded and it doesn't change anything semantically (it generates the same url, but is easier to read).

The third commit fixed a phpDoc issue (not using inheritDoc and the setter was marked with @api but not the getter).

The forth commit fixes another problem I found out: The path segments "." and ".." are interpreted as relative reference when resolving a URI. So we need to encode them as they are not (and can not be) used for this purpose by a user. Otherwise we would generate a URI that, when followed by a user agent (e.g. browser), does not match this route. See test cases for examples. This issue can potentially be exploited by users.
Example exploit: The developer has defined a route like `/blog/{slug}` and let the user define the slug title himself. When the user choses ".." as slug and the developer generates a URL for this route with this slug, the resulting URL will be: `/blog/..`.
But a link to this URI basically means `/` (the parent) and thus points to a complete different URI than intended. So the user could change the target URL which is a security issue.
