### PR TITLE
[RFC][Session] Native storage handlers should not update the global config

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcacheSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcacheSessionHandler.php
@@ -26,7 +26,9 @@ class NativeMemcacheSessionHandler extends NativeSessionHandler
      * Constructor.
      *
      * @param string $savePath Path of memcache server.
-     * @param array  $options  Session configuration options.
+     * @param array  $options  Memcache ini values
+     *
+     * @throws \RuntimeException If memcache is not available
      */
     public function __construct($savePath = 'tcp://127.0.0.1:11211?persistent=0', array $options = array())
     {
@@ -45,24 +47,16 @@ class NativeMemcacheSessionHandler extends NativeSessionHandler
     }
 
     /**
-     * Set any memcached ini values.
+     * Set any memcache ini values.
+     *
+     * @param array  $options  Memcache ini values
      *
      * @see http://php.net/memcache.ini
      */
     protected function setOptions(array $options)
     {
-        $validOptions = array_flip(array(
-            'memcache.allow_failover', 'memcache.max_failover_attempts',
-            'memcache.chunk_size', 'memcache.default_port', 'memcache.hash_strategy',
-            'memcache.hash_function', 'memcache.protocol', 'memcache.redundancy',
-            'memcache.session_redundancy', 'memcache.compress_threshold',
-            'memcache.lock_timeout',
-        ));
-
-        foreach ($options as $key => $value) {
-            if (isset($validOptions[$key])) {
-                ini_set($key, $value);
-            }
+        if (isset($options['memcache.session_redundancy'])) {
+            ini_set('memcache.session_redundancy', $options['memcache.session_redundancy']);
         }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcachedSessionHandler.php
@@ -26,7 +26,9 @@ class NativeMemcachedSessionHandler extends NativeSessionHandler
      * Constructor.
      *
      * @param string $savePath Comma separated list of servers: e.g. memcache1.example.com:11211,memcache2.example.com:11211
-     * @param array  $options  Session configuration options.
+     * @param array  $options  Memcached ini values
+     *
+     * @throws \RuntimeException When the memcached extension is not available
      */
     public function __construct($savePath = '127.0.0.1:11211', array $options = array())
     {
@@ -47,15 +49,16 @@ class NativeMemcachedSessionHandler extends NativeSessionHandler
     /**
      * Set any memcached ini values.
      *
+     * @param array  $options  Memcached ini values
+     *
      * @see https://github.com/php-memcached-dev/php-memcached/blob/master/memcached.ini
      */
     protected function setOptions(array $options)
     {
         $validOptions = array_flip(array(
-            'memcached.sess_locking', 'memcached.sess_lock_wait',
-            'memcached.sess_prefix', 'memcached.compression_type',
-            'memcached.compression_factor', 'memcached.compression_threshold',
-            'memcached.serializer',
+            'memcached.sess_locking',
+            'memcached.sess_lock_wait',
+            'memcached.sess_prefix'
         ));
 
         foreach ($options as $key => $value) {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSqliteSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeSqliteSessionHandler.php
@@ -24,9 +24,10 @@ class NativeSqliteSessionHandler extends NativeSessionHandler
      * Constructor.
      *
      * @param string $savePath Path to SQLite database file itself.
-     * @param array  $options  Session configuration options.
+     *
+     * @throws \RuntimeException When the sqlite extension is not available
      */
-    public function __construct($savePath, array $options = array())
+    public function __construct($savePath)
     {
         if (!extension_loaded('sqlite')) {
             throw new \RuntimeException('PHP does not have "sqlite" session module registered');
@@ -38,21 +39,5 @@ class NativeSqliteSessionHandler extends NativeSessionHandler
 
         ini_set('session.save_handler', 'sqlite');
         ini_set('session.save_path', $savePath);
-
-        $this->setOptions($options);
-    }
-
-    /**
-     * Set any sqlite ini values.
-     *
-     * @see http://php.net/sqlite.configuration
-     */
-    protected function setOptions(array $options)
-    {
-        foreach ($options as $key => $value) {
-            if (in_array($key, array('sqlite.assoc_case'))) {
-                ini_set($key, $value);
-            }
-        }
     }
 }


### PR DESCRIPTION
I submit this as a RFC because we can not get to an agreement on things should be done with @drak and I would like to hear the voice of the community on this point.

Memcache will be used as an example for the discussion.

**Context**

When you want to use memcache to store your sesssion data, you will need to create an instance of "NativeMemcacheSessionHandler" and pass the `save_path` as argument. The `save_path` specify the host, port and a few options (i.e. the ones passed to [addServer](http://www.php.net/manual/fr/memcache.addserver.php)).

All the other options (i.e. the compression factor, the serializer, ...) are retrieved from the ini values.

**What we do today**

In order to configure the native memcache storage the `NativeMemcacheSessionHandler` class [update](https://github.com/symfony/symfony/blob/7dfd41048120cd884db63ee8074452dc7c17134c/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeMemcacheSessionHandler.php#L64) the ini values.

**What I propose**

I propose **not** to update any ini value that is gobal to **all the** memcache instances. To me ini values are global configs that should not be updated for a local need.
_(I am ok with updating session specific settings ('memcache.session_redundancy') because those are not shared by all the memcache instances)_

In order to configure the memcache native storage:
- update your php.ini with the desired value,
- or if you don't have access to the php.ini (i.e. on a shared server) set the value at some "global" place (i.e. your kernel).

**The question**

Do you think:

A- It is ok to change any ini settings from inside the Session ? (The current state)
B- We should not modify any ini settings that is not strictly related to the session from inside the session. (The state after this PR)
