### PR TITLE
[DomCrawler] fixed encoding when using addHtmlContent() (fixes #3881)

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -129,6 +129,10 @@ class Crawler extends \SplObjectStorage
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
 
+        if (function_exists('mb_convert_encoding')) {
+            $content = mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
+        }
+
         $current = libxml_use_internal_errors(true);
         @$dom->loadHTML($content);
         libxml_use_internal_errors($current);

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -72,6 +72,17 @@ class CrawlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
      */
+    public function testAddHtmlContentCharset()
+    {
+        $crawler = new Crawler();
+        $crawler->addHtmlContent('<html><div class="foo">Tiếng Việt</html>', 'UTF-8');
+
+        $this->assertEquals('Tiếng Việt', $crawler->filterXPath('//div')->text());
+    }
+
+    /**
+     * @covers Symfony\Component\DomCrawler\Crawler::addHtmlContent
+     */
     public function testAddHtmlContentWithErrors()
     {
         libxml_use_internal_errors(true);
@@ -106,6 +117,17 @@ EOF
         $crawler->addXmlContent('<html><div class="foo"></div></html>', 'UTF-8');
 
         $this->assertEquals('foo', $crawler->filterXPath('//div')->attr('class'), '->addXmlContent() adds nodes from an XML string');
+    }
+
+    /**
+     * @covers Symfony\Component\DomCrawler\Crawler::addXmlContent
+     */
+    public function testAddXmlContentCharset()
+    {
+        $crawler = new Crawler();
+        $crawler->addXmlContent('<html><div class="foo">Tiếng Việt</div></html>', 'UTF-8');
+
+        $this->assertEquals('Tiếng Việt', $crawler->filterXPath('//div')->text());
     }
 
     /**


### PR DESCRIPTION
After looking around, this is clear that loadHtml() resets the encoding set on the DomDocument instance. So, the only workaround that actually works (and which is not an ugly hack) is to use `mb_convert_encoding` when it exists.
