### PR TITLE
[Form] [PropertyPath] Avoid to throw exceptions if add/remove methods are not found, in order to use fallbacks (setter for example)

### DIFF
--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -461,24 +461,6 @@ class PropertyPath implements \IteratorAggregate
                             $removeMethod = $removeMethodName;
                         }
 
-                        if ($addMethod && !$removeMethod) {
-                            throw new InvalidPropertyException(sprintf(
-                                'Found the public method "%s", but did not find a public "%s" on class %s',
-                                $addMethodName,
-                                $removeMethodName,
-                                $reflClass->getName()
-                            ));
-                        }
-
-                        if ($removeMethod && !$addMethod) {
-                            throw new InvalidPropertyException(sprintf(
-                                'Found the public method "%s", but did not find a public "%s" on class %s',
-                                $removeMethodName,
-                                $addMethodName,
-                                $reflClass->getName()
-                            ));
-                        }
-
                         if ($addMethod && $removeMethod) {
                             break;
                         }


### PR DESCRIPTION
Everything is in the title.

It should be possible to use a setter if there is a adder, and no remover for example. The code after these exceptions is ready to deal with that.
