### PR TITLE
[Form] Added "valid" to view parameters

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -110,6 +110,7 @@ class FormType extends AbstractType
             ->set('full_name', $fullName)
             ->set('read_only', $readOnly)
             ->set('errors', $form->getErrors())
+            ->set('valid', $form->isBound() ? $form->isValid() : true)
             ->set('value', $form->getClientData())
             ->set('disabled', $form->isDisabled())
             ->set('required', $form->isRequired())

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -16,6 +16,7 @@ use Symfony\Component\Form\Form;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;
+use Symfony\Component\Form\FormError;
 
 class FormTest_AuthorWithoutRefSetter
 {
@@ -603,5 +604,21 @@ class FormTypeTest extends TypeTestCase
 
         $this->assertEquals(new PropertyPath('foo'), $form->getPropertyPath());
         $this->assertFalse($form->getConfig()->getMapped());
+    }
+
+    public function testViewValidUnbound()
+    {
+        $form = $this->factory->create('form');
+        $view = $form->createView();
+        $this->assertTrue($view->get('valid'));
+    }
+
+    public function testViewNotValidBound()
+    {
+        $form = $this->factory->create('form');
+        $form->bind(array());
+        $form->addError(new FormError('An error'));
+        $view = $form->createView();
+        $this->assertFalse($view->get('valid'));
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: 
License of the code: MIT
Documentation PR: 

This PR adds a parameter of contains_errors to a FormView when buildView is called.

The use case for this addition is when you want to show that a form or sub forms has errors (e.g. when rendering a long form a header message of "This form contains errors" or adding a class to a whole sub form to show an erroneous state) is currently very difficult/near impossible and may need the original form object being accessible in the view layer. 

Whats a bit grey here is the best phrasing to use for this. Options I weighed up were is_valid (seemed a bit semantically incorrect in a template, since it would return true pre bind) and has_errors_deep (which i wasn't sure if it fitted naming conventions).
