### PR TITLE
[Component][Yaml] unindented collection - failing test

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/Fixtures/unindentedCollections.yml
+++ b/src/Symfony/Component/Yaml/Tests/Fixtures/unindentedCollections.yml
@@ -60,3 +60,20 @@ yaml: |
         foo: bar
 php: |
     array('collection' => array('key' => array('a', 'b', 'c'), 'foo' => 'bar'))
+---
+
+#
+# http://yaml-online-parser.appspot.com/?yaml=collection%3A%0A-+a%0A++++-+b%0A++++++++-+c&type=python
+#
+
+test: Unindented collection with faux elements
+brief: >
+    Unindented collection with faux elements
+yaml: |
+    collection:
+    - a
+        - b
+            - c
+php: |
+    array('collection' => array("a - b - c"))
+


### PR DESCRIPTION
According to http://yaml-online-parser.appspot.com/?yaml=collection%3A%0A-+a%0A++++-+b%0A++++++++-+c&type=python we have another bug in Yaml component.

The commit contains test for this case. The test is currently failing.

I will work on it, but I need some confirmation about Yaml syntax.

Should the output of parsing following Yaml:

```
collection:
- a
    - b
        - c
```

be:

```
array('collection' => array("a - b - c"))
```
