### PR TITLE
[Form] Removed index_generation mention from the UPGRADE instructions 

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -223,8 +223,7 @@
     has changed.
 
     The `choices` variable now contains ChoiceView objects with two getters,
-    `getValue()` and `getLabel()`, to access the choice data. The indices of the
-    array are controlled by the choice field's `index_generation` option.
+    `getValue()` and `getLabel()`, to access the choice data.
 
     Before:
 


### PR DESCRIPTION
The index_generation option no longer exists. 

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/jakzal/symfony.png?branch=UpgradeFix)](http://travis-ci.org/jakzal/symfony)
Fixes the following tickets: #4108
