### PR TITLE
[Validator] separate numeric values from suffixes in File validation error messages

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ca.xlf
@@ -127,8 +127,8 @@
                 <target>Els dos valors haurien de ser iguals.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>L'arxiu és massa gran. El tamany màxim permés és {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>L'arxiu és massa gran. El tamany màxim permés és {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ca.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ca.xlf
@@ -63,8 +63,8 @@
                 <target>No es pot llegir l'arxiu.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>L'arxiu és massa gran ({{ size }}). La grandària màxima permesa és {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>L'arxiu és massa gran ({{ size }} {{ suffix }}). La grandària màxima permesa és {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xlf
@@ -63,8 +63,8 @@
                 <target>Soubor je nečitelný.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Soubor je příliš velký ({{ size }}). Maximální povolená velikost souboru je {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Soubor je příliš velký ({{ size }} {{ suffix }}). Maximální povolená velikost souboru je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.cs.xlf
@@ -127,8 +127,8 @@
                 <target>Tyto dvě hodnoty musí být stejné.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Soubor je příliš velký. Maximální povolená velikost souboru je {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Soubor je příliš velký. Maximální povolená velikost souboru je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.da.xlf
@@ -63,8 +63,8 @@
                 <target>Filen kan ikke læses.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Filen er for stor ({{ size }}). Tilladte maksimale størrelse {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Filen er for stor ({{ size }} {{ suffix }}). Tilladte maksimale størrelse {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.da.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.da.xlf
@@ -127,8 +127,8 @@
                 <target>De to værdier skal være ens.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Filen er for stor. Den maksimale størrelse er {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Filen er for stor. Den maksimale størrelse er {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.de.xlf
@@ -127,8 +127,8 @@
                 <target>Die beiden Werte sollten identisch sein.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Die Datei ist zu groß. Die maximal zulässige Größe beträgt {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Die Datei ist zu groß. Die maximal zulässige Größe beträgt {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.de.xlf
@@ -63,8 +63,8 @@
                 <target>Die Datei ist nicht lesbar.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Die Datei ist zu groß ({{ size }}). Die maximal zulässige Größe beträgt {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Die Datei ist zu groß ({{ size }} {{ suffix }}). Die maximal zulässige Größe beträgt {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.en.xlf
@@ -127,8 +127,8 @@
                 <target>The two values should be equal.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>The file is too large. Allowed maximum size is {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.en.xlf
@@ -63,8 +63,8 @@
                 <target>The file is not readable.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.es.xlf
@@ -127,8 +127,8 @@
                 <target>Los dos valores deberían ser iguales.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>El archivo es demasiado grande. El tamaño máximo permitido es {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>El archivo es demasiado grande. El tamaño máximo permitido es {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.es.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.es.xlf
@@ -63,8 +63,8 @@
                 <target>No se puede leer el archivo.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>El archivo es demasiado grande ({{ size }}). El tamaño máximo permitido es {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>El archivo es demasiado grande ({{ size }} {{ suffix }}). El tamaño máximo permitido es {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.et.xlf
@@ -63,8 +63,8 @@
                 <target>Fail ei ole loetav.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Fail on liiga suur ({{ size }}). Suurim lubatud suurus on {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Fail on liiga suur ({{ size }} {{ suffix }}). Suurim lubatud suurus on {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.et.xlf
@@ -127,8 +127,8 @@
                 <target>Väärtused peaksid olema võrdsed.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Fail on liiga suur. Maksimaalne lubatud suurus on {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Fail on liiga suur. Maksimaalne lubatud suurus on {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.eu.xlf
@@ -127,8 +127,8 @@
                 <target>Bi balioak berdinak izan beharko lirateke.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Fitxategia handiegia da. Baimendutako tamainu handiena {{ limit }} da.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Fitxategia handiegia da. Baimendutako tamainu handiena {{ limit }} {{ suffix }} da.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.eu.xlf
@@ -63,8 +63,8 @@
                 <target>Fitxategia ez dago irakurgai.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Fitxategia handiegia da ({{ size }}). Baimendutako tamainu handiena {{ limit }} da.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Fitxategia handiegia da ({{ size }} {{ suffix }}). Baimendutako tamainu handiena {{ limit }} {{ suffix }} da.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fa.xlf
@@ -127,8 +127,8 @@
                 <target>دو مقدار باید برابر باشند.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>فایل بیش از اندازه بزرگ است. حداکثر اندازه مجاز برابر {{ limit }} است.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>فایل بیش از اندازه بزرگ است. حداکثر اندازه مجاز برابر {{ limit }} {{ suffix }} است.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fa.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fa.xlf
@@ -63,8 +63,8 @@
                 <target>فایل قابلیت خواندن ندارد.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>فایل بیش از اندازه بزرگ است({{ size }}). حداکثر اندازه مجاز برابر {{ limit }} است.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>فایل بیش از اندازه بزرگ است({{ size }} {{ suffix }}). حداکثر اندازه مجاز برابر {{ limit }} {{ suffix }} است.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fi.xlf
@@ -63,8 +63,8 @@
                 <target>Tiedostoa ei voida lukea.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Tiedostonkoko ({{ size }}) on liian iso. Suurin sallittu tiedostonkoko on {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Tiedostonkoko ({{ size }} {{ suffix }}) on liian iso. Suurin sallittu tiedostonkoko on {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fi.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fi.xlf
@@ -127,8 +127,8 @@
                 <target>Kahden annetun arvon tulee olla samat.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Annettu tiedosto on liian iso. Suurin sallittu tiedostokoko on {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Annettu tiedosto on liian iso. Suurin sallittu tiedostokoko on {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xlf
@@ -63,8 +63,8 @@
                 <target>Le fichier n'est pas lisible.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Le fichier est trop volumineux ({{ size }}). Sa taille ne doit pas dépasser {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Le fichier est trop volumineux ({{ size }} {{ suffix }}). Sa taille ne doit pas dépasser {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.fr.xlf
@@ -127,8 +127,8 @@
                 <target>Les deux valeurs doivent être identiques.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Le fichier est trop volumineux. Sa taille ne doit pas dépasser {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Le fichier est trop volumineux. Sa taille ne doit pas dépasser {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.he.xlf
@@ -127,8 +127,8 @@
                 <target>שני הערכים צריכים להיות שווים.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>הקובץ גדול מדי. הגודל המרבי המותר הוא {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>הקובץ גדול מדי. הגודל המרבי המותר הוא {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.he.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.he.xlf
@@ -63,8 +63,8 @@
                 <target>לא ניתן לקרוא את הקובץ.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>הקובץ גדול מדי ({{ size }}). הגודל המרבי המותר הוא {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>הקובץ גדול מדי ({{ size }} {{ suffix }}). הגודל המרבי המותר הוא {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hr.xlf
@@ -127,8 +127,8 @@
                 <target>Obje vrijednosti trebaju biti jednake.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Ova datoteka je prevelika. Najveća dozvoljena veličina je {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Ova datoteka je prevelika. Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hr.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hr.xlf
@@ -63,8 +63,8 @@
                 <target>Datoteka nije čitljiva.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Datoteka je prevelika ({{ size }}). Najveća dozvoljena veličina je {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Datoteka je prevelika ({{ size }} {{ suffix }}). Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hu.xlf
@@ -63,8 +63,8 @@
                 <target>A fájl nem olvasható.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>A fájl túl nagy ({{ size }}). A legnagyobb megengedett méret {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>A fájl túl nagy ({{ size }} {{ suffix }}). A legnagyobb megengedett méret {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hu.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hu.xlf
@@ -127,8 +127,8 @@
                 <target>A két értéknek azonosnak kell lennie.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>A fájl túl nagy. A megengedett maximális méret: {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>A fájl túl nagy. A megengedett maximális méret: {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hy.xlf
@@ -127,8 +127,8 @@
                 <target>Երկու արժեքները պետք է նույնը լինեն.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Ֆայլը չափազանց մեծ է: Մաքսիմալ թույլատրելի չափսը {{ limit }} է.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Ֆայլը չափազանց մեծ է: Մաքսիմալ թույլատրելի չափսը {{ limit }} {{ suffix }} է.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hy.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.hy.xlf
@@ -63,8 +63,8 @@
                 <target>Ֆայլը անընթեռնելի է.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Ֆայլը չափազանց մեծ է ({{ size }}): Մաքսիմալ թույլատրելի չափսը՝ {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Ֆայլը չափազանց մեծ է ({{ size }} {{ suffix }}): Մաքսիմալ թույլատրելի չափսը՝ {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.id.xlf
@@ -63,8 +63,8 @@
                 <target>Berkas tidak bisa dibaca.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Ukuran berkas terlalu besar ({{ size }}). Ukuran maksimum yang diijinkan adalah {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Ukuran berkas terlalu besar ({{ size }} {{ suffix }}). Ukuran maksimum yang diijinkan adalah {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.id.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.id.xlf
@@ -127,8 +127,8 @@
                 <target>Isi keduanya harus sama.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Ukuran berkas terlalu besar. Ukuran maksimum yang diijinkan adalah {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Ukuran berkas terlalu besar. Ukuran maksimum yang diijinkan adalah {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.it.xlf
@@ -127,8 +127,8 @@
                 <target>I due valori dovrebbero essere uguali.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Il file è troppo grande. La dimensione massima è {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Il file è troppo grande. La dimensione massima è {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.it.xlf
@@ -63,8 +63,8 @@
                 <target>Il file non è leggibile.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Il file è troppo grande ({{ size }}). La dimensione massima consentita è {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Il file è troppo grande ({{ size }} {{ suffix }}). La dimensione massima consentita è {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ja.xlf
@@ -63,8 +63,8 @@
                 <target>ファイルを読み込めません.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>ファイルのサイズが大きすぎます({{ size }})。有効な最大サイズは{{ limit }}です.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>ファイルのサイズが大きすぎます({{ size }} {{ suffix }})。有効な最大サイズは{{ limit }} {{ suffix }}です.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ja.xlf
@@ -131,8 +131,8 @@
                 <target>値は有効な国名ではありません.</target>
             </trans-unit>
             <trans-unit id="33">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>ファイルのサイズが大きすぎます。有効な最大サイズは{{ limit }}です.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>ファイルのサイズが大きすぎます。有効な最大サイズは{{ limit }} {{ suffix }}です.</target>
             </trans-unit>
             <trans-unit id="34">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lb.xlf
@@ -63,8 +63,8 @@
                 <target>De Fichier ass net liesbar.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>De Fichier ass ze grouss ({{ size }}). Déi zougeloosse Maximalgréisst bedréit {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>De Fichier ass ze grouss ({{ size }} {{ suffix }}). Déi zougeloosse Maximalgréisst bedréit {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lb.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lb.xlf
@@ -127,8 +127,8 @@
                 <target>Béid Wäerter sollten identesch sinn.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>De fichier ass ze grouss. Déi maximal Gréisst dierf {{ limit }} net depasséieren.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>De fichier ass ze grouss. Déi maximal Gréisst dierf {{ limit }} {{ suffix }} net depasséieren.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lt.xlf
@@ -127,8 +127,8 @@
                 <target>Abi reikšmės turi būti identiškos.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Byla yra per didelė. Maksimalus dydis yra {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Byla yra per didelė. Maksimalus dydis yra {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lt.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.lt.xlf
@@ -63,8 +63,8 @@
                 <target>Negalima nuskaityti bylos.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Byla yra per didelė ({{ size }}). Maksimalus dydis {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Byla yra per didelė ({{ size }} {{ suffix }}). Maksimalus dydis {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.mn.xlf
@@ -127,8 +127,8 @@
                 <target>Хоёр утгууд ижил байх ёстой.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Файл хэтэрхий том байна. Зөвшөөрөгдөх дээд хэмжээ нь {{ limit }} байна.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Файл хэтэрхий том байна. Зөвшөөрөгдөх дээд хэмжээ нь {{ limit }} {{ suffix }} байна.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.mn.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.mn.xlf
@@ -63,8 +63,8 @@
                 <target>Файл уншигдахуйц биш байна.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Файл хэтэрхий том байна ({{ size }}). Зөвшөөрөгдөх дээд хэмжээ  {{ limit }} байна.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Файл хэтэрхий том байна ({{ size }} {{ suffix }}). Зөвшөөрөгдөх дээд хэмжээ  {{ limit }} {{ suffix }} байна.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nb.xlf
@@ -127,8 +127,8 @@
                 <target>De to verdier skal være ens.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Filen er for stor. Den maksimale størrelse er {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Filen er for stor. Den maksimale størrelse er {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nb.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nb.xlf
@@ -63,8 +63,8 @@
                 <target>Filen kan ikke leses.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Filen er for stor ({{ size }}). Tilatte maksimale størrelse {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Filen er for stor ({{ size }} {{ suffix }}). Tilatte maksimale størrelse {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xlf
@@ -127,8 +127,8 @@
                 <target>De twee waarden moeten gelijk zijn.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Het bestand is te groot. Toegestane maximum grootte is {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Het bestand is te groot. Toegestane maximum grootte is {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.nl.xlf
@@ -63,8 +63,8 @@
                 <target>Het bestand is niet leesbaar.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Het bestand is te groot ({{ size }}). Toegestane maximum grootte is {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Het bestand is te groot ({{ size }} {{ suffix }}). Toegestane maximum grootte is {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pl.xlf
@@ -63,8 +63,8 @@
                 <target>Nie można odczytać pliku.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Plik jest za duży ({{ size }}). Maksymalny dozwolony rozmiar to {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Plik jest za duży ({{ size }} {{ suffix }}). Maksymalny dozwolony rozmiar to {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pl.xlf
@@ -127,8 +127,8 @@
                 <target>Obie wartości powinny być równe.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Plik jest za duży. Maksymalny dozwolony rozmiar to {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Plik jest za duży. Maksymalny dozwolony rozmiar to {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt.xlf
@@ -63,8 +63,8 @@
                 <target>O arquivo não pôde ser lido.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>O arquivo é muito grande ({{ size }}). O tamanho máximo permitido é de {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>O arquivo é muito grande ({{ size }} {{ suffix }}). O tamanho máximo permitido é de {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt.xlf
@@ -127,8 +127,8 @@
                 <target>Os dois valores deveriam ser iguais.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>O arquivo é muito grande ({{ size }}). O tamanho máximo permitido é de {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>O arquivo é muito grande. O tamanho máximo permitido é de {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_BR.xlf
@@ -127,8 +127,8 @@
                 <target>Os dois valores devem ser iguais.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>O arquivo é muito grande. O tamanho máximo permitido é de {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>O arquivo é muito grande. O tamanho máximo permitido é de {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_BR.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.pt_BR.xlf
@@ -63,8 +63,8 @@
                 <target>O arquivo não pode ser lido.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>O arquivo é muito grande ({{ size }}). O tamanho máximo permitido é {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>O arquivo é muito grande ({{ size }} {{ suffix }}). O tamanho máximo permitido é {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ro.xlf
@@ -127,8 +127,8 @@
                 <target>Cele două valori ar trebui să fie egale.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Fișierul este prea mare. Mărimea maximă permisă este {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Fișierul este prea mare. Mărimea maximă permisă este {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ro.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ro.xlf
@@ -63,8 +63,8 @@
                 <target>Fișierul nu poate fi citit.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Fișierul este prea mare ({{ size }}). Dimensiunea maximă permisă este {{ limit}}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Fișierul este prea mare ({{ size }} {{ suffix }}). Dimensiunea maximă permisă este {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ru.xlf
@@ -127,8 +127,8 @@
                 <target>Оба значения должны быть одинаковыми.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Файл слишком большой. Максимальный допустимый размер {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Файл слишком большой. Максимальный допустимый размер {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ru.xlf
@@ -63,8 +63,8 @@
                 <target>Файл не может быть прочитан.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Файл слишком большой ({{ size }}). Максимальный допустимый размер {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Файл слишком большой ({{ size }} {{ suffix }}). Максимальный допустимый размер {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sk.xlf
@@ -63,8 +63,8 @@
                 <target>Súbor nie je čitateľný.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Súbor je príliš veľký ({{ size }}). Maximálna povolená veľkosť je {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Súbor je príliš veľký ({{ size }} {{ suffix }}). Maximálna povolená veľkosť je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sk.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sk.xlf
@@ -127,8 +127,8 @@
                 <target>Tieto dve hodnoty by mali byť rovnaké.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Súbor je príliš veľký. Maximálna povolená veľkosť je {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Súbor je príliš veľký. Maximálna povolená veľkosť je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sl.xlf
@@ -63,8 +63,8 @@
                 <target>Datoteke ni mogoče prebrati.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Datoteka je prevelika ({{ size }}). Največja dovoljena velikost je {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Datoteka je prevelika ({{ size }} {{ suffix }}). Največja dovoljena velikost je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sl.xlf
@@ -127,8 +127,8 @@
                 <target>Vrednosti morata biti enaki.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Datoteka je prevelika. Največja dovoljena velikost je {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Datoteka je prevelika. Največja dovoljena velikost je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Cyrl.xlf
@@ -127,8 +127,8 @@
                 <target>Обе вредности треба да буду једнаке.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Датотека је превелика. Највећа дозвољена величина је {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Датотека је превелика. Највећа дозвољена величина је {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Cyrl.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Cyrl.xlf
@@ -63,8 +63,8 @@
                 <target>Датотека није читљива.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Датотека је превелика ({{ size }}). Највећа дозвољена величина је {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Датотека је превелика ({{ size }} {{ suffix }}). Највећа дозвољена величина је {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Latn.xlf
@@ -127,8 +127,8 @@
                 <target>Obe vrednosti treba da budu jednake.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Datoteka je prevelika. Najveća dozvoljena veličina je {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Datoteka je prevelika. Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Latn.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sr_Latn.xlf
@@ -63,8 +63,8 @@
                 <target>Datoteka nije čitljiva.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Datoteka je prevelika ({{ size }}). Najveća dozvoljena veličina je {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Datoteka je prevelika ({{ size }} {{ suffix }}). Najveća dozvoljena veličina je {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sv.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.sv.xlf
@@ -63,8 +63,8 @@
                 <target>Filen är inte läsbar.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Filen är för stor ({{ size }}). Största tillåtna storlek är {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Filen är för stor ({{ size }} {{ suffix }}). Största tillåtna storlek är {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ua.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ua.xlf
@@ -63,8 +63,8 @@
                 <target>Файл не читається.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>Файл занадто великий ({{ size }}). Дозволений максимальний розмір {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Файл занадто великий ({{ size }} {{ suffix }}). Дозволений максимальний розмір {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ua.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.ua.xlf
@@ -127,8 +127,8 @@
                 <target>Обидва занчення повинні бути одинаковими.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>Файл занадто великий. Максимальний допустимий розмір {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>Файл занадто великий. Максимальний допустимий розмір {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.zh_CN.xlf
@@ -63,8 +63,8 @@
                 <target>文件不可读.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.</source>
-                <target>文件太大 ({{ size }}). 文件大小不可以超过 {{ limit }}.</target>
+                <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>文件太大 ({{ size }} {{ suffix }}). 文件大小不可以超过 {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.zh_CN.xlf
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/translations/validators.zh_CN.xlf
@@ -127,8 +127,8 @@
                 <target>该两个变量的值应该相同.</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>The file is too large. Allowed maximum size is {{ limit }}.</source>
-                <target>文件太大， 文件大小不可以超过 {{ limit }}.</target>
+                <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
+                <target>文件太大， 文件大小不可以超过 {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -24,7 +24,7 @@ class File extends Constraint
     public $mimeTypes = array();
     public $notFoundMessage = 'The file could not be found.';
     public $notReadableMessage = 'The file is not readable.';
-    public $maxSizeMessage = 'The file is too large ({{ size }}). Allowed maximum size is {{ limit }}.';
+    public $maxSizeMessage = 'The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.';
     public $mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.';
 
     public $uploadIniSizeErrorMessage   = 'The file is too large. Allowed maximum size is {{ limit }}.';

--- a/src/Symfony/Component/Validator/Constraints/File.php
+++ b/src/Symfony/Component/Validator/Constraints/File.php
@@ -27,7 +27,7 @@ class File extends Constraint
     public $maxSizeMessage = 'The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.';
     public $mimeTypesMessage = 'The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.';
 
-    public $uploadIniSizeErrorMessage   = 'The file is too large. Allowed maximum size is {{ limit }}.';
+    public $uploadIniSizeErrorMessage   = 'The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.';
     public $uploadFormSizeErrorMessage  = 'The file is too large.';
     public $uploadPartialErrorMessage   = 'The file was only partially uploaded.';
     public $uploadNoFileErrorMessage    = 'No file was uploaded.';

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -100,23 +100,24 @@ class FileValidator extends ConstraintValidator
             if (ctype_digit((string) $constraint->maxSize)) {
                 $size = filesize($path);
                 $limit = $constraint->maxSize;
-                $suffix = ' bytes';
+                $suffix = 'bytes';
             } elseif (preg_match('/^(\d+)k$/', $constraint->maxSize, $matches)) {
                 $size = round(filesize($path) / 1000, 2);
                 $limit = $matches[1];
-                $suffix = ' kB';
+                $suffix = 'kB';
             } elseif (preg_match('/^(\d+)M$/', $constraint->maxSize, $matches)) {
                 $size = round(filesize($path) / 1000000, 2);
                 $limit = $matches[1];
-                $suffix = ' MB';
+                $suffix = 'MB';
             } else {
                 throw new ConstraintDefinitionException(sprintf('"%s" is not a valid maximum size', $constraint->maxSize));
             }
 
             if ($size > $limit) {
                 $this->context->addViolation($constraint->maxSizeMessage, array(
-                    '{{ size }}'    => $size.$suffix,
-                    '{{ limit }}'   => $limit.$suffix,
+                    '{{ size }}'    => $size,
+                    '{{ limit }}'   => $limit,
+                    '{{ suffix }}'  => $suffix,
                     '{{ file }}'    => $path,
                 ));
 

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -44,7 +44,10 @@ class FileValidator extends ConstraintValidator
                 case UPLOAD_ERR_INI_SIZE:
                     $maxSize = UploadedFile::getMaxFilesize();
                     $maxSize = $constraint->maxSize ? min($maxSize, $constraint->maxSize) : $maxSize;
-                    $this->context->addViolation($constraint->uploadIniSizeErrorMessage, array('{{ limit }}' => $maxSize.' bytes'));
+                    $this->context->addViolation($constraint->uploadIniSizeErrorMessage, array(
+                        '{{ limit }}' => $maxSize,
+                        '{{ suffix }}' => 'bytes',
+                    ));
 
                     return;
                 case UPLOAD_ERR_FORM_SIZE:

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -99,8 +99,9 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->once())
             ->method('addViolation')
             ->with('myMessage', array(
-                '{{ limit }}'   => '10 bytes',
-                '{{ size }}'    => '11 bytes',
+                '{{ limit }}'   => '10',
+                '{{ size }}'    => '11',
+                '{{ suffix }}'  => 'bytes',
                 '{{ file }}'    => $this->path,
             ));
 
@@ -119,8 +120,9 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->once())
             ->method('addViolation')
             ->with('myMessage', array(
-                '{{ limit }}'   => '1 kB',
-                '{{ size }}'    => '1.4 kB',
+                '{{ limit }}'   => '1',
+                '{{ size }}'    => '1.4',
+                '{{ suffix }}'  => 'kB',
                 '{{ file }}'    => $this->path,
             ));
 
@@ -139,8 +141,9 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->once())
             ->method('addViolation')
             ->with('myMessage', array(
-                '{{ limit }}'   => '1 MB',
-                '{{ size }}'    => '1.4 MB',
+                '{{ limit }}'   => '1',
+                '{{ size }}'    => '1.4',
+                '{{ suffix }}'  => 'MB',
                 '{{ file }}'    => $this->path,
             ));
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/FileValidatorTest.php
@@ -317,7 +317,10 @@ abstract class FileValidatorTest extends \PHPUnit_Framework_TestCase
         );
 
         if (class_exists('Symfony\Component\HttpFoundation\File\UploadedFile')) {
-            $tests[] = array(UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', array('{{ limit }}' => UploadedFile::getMaxFilesize() . ' bytes'));
+            $tests[] = array(UPLOAD_ERR_INI_SIZE, 'uploadIniSizeErrorMessage', array(
+                '{{ limit }}' => UploadedFile::getMaxFilesize(),
+                '{{ suffix }}' => 'bytes',
+            ));
         }
 
         return $tests;


### PR DESCRIPTION
This change allows me to locale-aware format the numbers in a form theme, i.e., to use a comma instead of a dot. If there's a better way without re-implementing the entire validator, let me know.

Such changes also allow for using a different separator than the usual space in translations.
