### PR TITLE
Fix DelegatingValidator class path

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorExtension.php
@@ -26,7 +26,7 @@ class ValidatorExtension extends AbstractExtension
         $this->validator = $validator;
 
         $metadata = $this->validator->getMetadataFactory()->getClassMetadata('Symfony\Component\Form\Form');
-        $metadata->addConstraint(new Callback(array(array('Symfony\Component\Form\Extension\Validator\Validator\DelegatingValidator', 'validateFormData'))));
+        $metadata->addConstraint(new Callback(array(array('Symfony\Component\Form\Extension\Validator\EventListener\DelegatingValidator', 'validateFormData'))));
         $metadata->addPropertyConstraint('children', new Valid());
     }
 


### PR DESCRIPTION
fix `DelegatingValidator` registration path when the Form component is used outside the symfony framework.

see commit https://github.com/symfony/symfony/commit/2b1bb2c35754e051106a531fa787b2a49e806944 and discussion https://github.com/fabpot/Silex/issues/111
