### PR TITLE
[Form] fixed invalid 'type' option in ValidatorTypeGuesser for Date/TimeFields

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -134,13 +134,13 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\Date':
                 return new TypeGuess(
                     'date',
-                    array('type' => 'string'),
+                    array(),
                     Guess::HIGH_CONFIDENCE
                 );
             case 'Symfony\Component\Validator\Constraints\DateTime':
                 return new TypeGuess(
                     'datetime',
-                    array('type' => 'string'),
+                    array(),
                     Guess::HIGH_CONFIDENCE
                 );
             case 'Symfony\Component\Validator\Constraints\Email':
@@ -212,7 +212,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\Time':
                 return new TypeGuess(
                     'time',
-                    array('type' => 'string'),
+                    array(),
                     Guess::HIGH_CONFIDENCE
                 );
             case 'Symfony\Component\Validator\Constraints\Url':

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -134,13 +134,13 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\Date':
                 return new TypeGuess(
                     'date',
-                    array(),
+                    array('input'=>'string'),
                     Guess::HIGH_CONFIDENCE
                 );
             case 'Symfony\Component\Validator\Constraints\DateTime':
                 return new TypeGuess(
                     'datetime',
-                    array(),
+                    array('input'=>'string'),
                     Guess::HIGH_CONFIDENCE
                 );
             case 'Symfony\Component\Validator\Constraints\Email':
@@ -212,7 +212,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
             case 'Symfony\Component\Validator\Constraints\Time':
                 return new TypeGuess(
                     'time',
-                    array(),
+                    array('input'=>'string'),
                     Guess::HIGH_CONFIDENCE
                 );
             case 'Symfony\Component\Validator\Constraints\Url':


### PR DESCRIPTION
Automatic field type guessing breaks, if you use any of the Date/Time
constraints (i.e. Symfony\Component\Validator\Constraints\DateTime), since these field types have no 'type' option defined.
(See getDefaultOptions() in DateTimeType.php)
