### PR TITLE
[HttpFoundation] [ParameterBag] Added only() and except() methods to the HttpFoundation ParameterBag.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -74,3 +74,4 @@ CHANGELOG
    a `Request` now all return a raw value (vs a urldecoded value before). Any call
    to one of these methods must be checked and wrapped in a `rawurldecode()` if
    needed.
+ * Added only() and except() to ParameterBag object. 

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -185,6 +185,30 @@ class ParameterBag implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Returns a subset of parameters.
+     *
+     * @param array $keys The parameters to be returned
+     *
+     * @api
+     */
+    public function only(array $keys)
+    {
+        return array_intersect_key($this->parameters, array_flip($keys));
+    }
+
+    /**
+     * Returns all of the parameters except those specified.
+     *
+     * @param array $keys The parameters to be excluded
+     *
+     * @api
+     */
+    public function except(array $keys)
+    {
+        return array_diff_key($this->parameters, array_flip($keys));
+    }
+
+    /**
      * Returns the alphabetic characters of the parameter value.
      *
      * @param string  $key     The parameter key

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -120,6 +120,26 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\HttpFoundation\ParameterBag::only
+     */
+    public function testOnly()
+    {
+        $bag = new ParameterBag(array('foo' => 'bar', 'baz' => 'bam'));
+
+        $this->assertEquals($bag->only(array('foo')), array('foo' => 'bar'));
+    }
+
+    /**
+     * @covers Symfony\Component\HttpFoundation\ParameterBag::except
+     */
+    public function testExcept()
+    {
+        $bag = new ParameterBag(array('foo' => 'bar', 'baz' => 'bam'));
+
+        $this->assertEquals($bag->except(array('foo')), array('baz' => 'bam'));
+    }
+
+    /**
      * @covers Symfony\Component\HttpFoundation\ParameterBag::getAlpha
      */
     public function testGetAlpha()

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -126,7 +126,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
     {
         $bag = new ParameterBag(array('foo' => 'bar', 'baz' => 'bam'));
 
-        $this->assertEquals($bag->only(array('foo')), array('foo' => 'bar'));
+        $this->assertEquals(array('foo' => 'bar'), $bag->only(array('foo')));
     }
 
     /**
@@ -136,7 +136,7 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
     {
         $bag = new ParameterBag(array('foo' => 'bar', 'baz' => 'bam'));
 
-        $this->assertEquals($bag->except(array('foo')), array('baz' => 'bam'));
+        $this->assertEquals(array('baz' => 'bam'), $bag->except(array('foo')));
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This pull adds two new methods to the HttpFoundation ParameterBag: `only` and `except`. These are useful for fetch a subset of the parameter bag as follows:

```
$bag = new ParameterBag(array('foo' => 'bar', 'baz' => 'bam'));

$array = $bag->only(array('foo'));

// $array is array('foo' => 'bar')

$array = $bag->except(array('foo'));

// $array is array('baz' => 'bam')
```

ParameterBag tests pass. No breaking changes.
