### PR TITLE
[WDT] Fix the color of Documentation link to keep concistence.

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -67,7 +67,7 @@
                 <b>Token</b>
                 <span>
                     {% if profiler_url %}
-                        <a style="color: #2f2f2f" href="{{ profiler_url }}">{{ collector.token }}</a>
+                        <a href="{{ profiler_url }}">{{ collector.token }}</a>
                     {% else %}
                         {{ collector.token }}
                     {% endif %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
@@ -51,6 +51,10 @@
     .sf-toolbar-block .sf-toolbar-info-piece:last-child {
         padding-bottom: 0;
     }
+    
+    .sf-toolbar-block .sf-toolbar-info-piece a {
+        color: #2f2f2f;
+    }
 
     .sf-toolbar-block .sf-toolbar-info-piece b {
         display: inline-block;

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
@@ -52,7 +52,8 @@
         padding-bottom: 0;
     }
     
-    .sf-toolbar-block .sf-toolbar-info-piece a {
+    .sf-toolbar-block .sf-toolbar-info-piece a,
+    .sf-toolbar-block .sf-toolbar-info-piece abbr {
         color: #2f2f2f;
     }
 


### PR DESCRIPTION
This pull request is to make the Documentation link black as the other links of the WDT
