### PR TITLE
[Config] Numerical keys for prot. arrays if useAttributeAsKey is set

### DIFF
--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -242,10 +242,11 @@ class PrototypedArrayNode extends ArrayNode
 
         $value = $this->remapXml($value);
 
+        $isAssoc = array_keys($value) === range(0, count($value) -1);
         $normalized = array();
         foreach ($value as $k => $v) {
             if (null !== $this->keyAttribute && is_array($v)) {
-                if (!isset($v[$this->keyAttribute]) && is_int($k)) {
+                if (!isset($v[$this->keyAttribute]) && is_int($k) && $isAssoc) {
                     $msg = sprintf('The attribute "%s" must be set for path "%s".', $this->keyAttribute, $this->getPath());
                     $ex = new InvalidConfigurationException($msg);
                     $ex->setPath($this->getPath());


### PR DESCRIPTION
Bug fix: not sure
Feature addition: not sure
Backwards compatibility break: not sure
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=numeric-keys-config)](http://travis-ci.org/asm89/symfony)
License of the code: MIT

When using an array node with children of prototype array and `useAttributeAsKey`, using numerical values for the keys throws an exception. For example (`useAttributeAsKey('id')`):

``` php
<?php
// works
array (
    'thing' => array(
        array('foo', 'bar', 'id' => 'a')
    )
);

// works and is the same as above
array (
    'thing' => array(
        'a' => array('foo', 'bar')
    )
);

// works
array(
    'thing' => array(
        array('foo', 'bar', 'id' => 42), array('baz', 'qux', 'id' => 1337),
    ),  
);

// works with this patch and is the same as above
array(
    'thing' => array(
        42 => array('foo', 'bar'), 1337 => array('baz', 'qux'),
    ),  
);
```
