### PR TITLE
[Form] [DataMapper] Read only form datamapper fix

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -77,7 +77,7 @@ class PropertyPathMapper implements DataMapperInterface
 
     public function mapFormToData(FormInterface $form, &$data)
     {
-        if ($form->getAttribute('property_path') !== null && $form->isSynchronized()) {
+        if ($form->getAttribute('property_path') !== null && $form->isSynchronized() && !$form->isReadOnly()) {
             $propertyPath = $form->getAttribute('property_path');
 
             // If the data is identical to the value in $data, we are

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -34,7 +34,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $this->propertyPath = null;
     }
 
-    private function getForm(PropertyPath $propertyPath = null)
+    private function getForm(PropertyPath $propertyPath = null, $synchronized = true, $readOnly = false)
     {
         $form = $this->getMock('Symfony\Tests\Component\Form\FormInterface');
 
@@ -42,6 +42,14 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('getAttribute')
             ->with('property_path')
             ->will($this->returnValue($propertyPath));
+
+        $form->expects($this->any())
+            ->method('isSynchronized')
+            ->will($this->returnValue($synchronized));
+
+        $form->expects($this->any())
+            ->method('isReadOnly')
+            ->will($this->returnValue($readOnly));
 
         return $form;
     }
@@ -86,5 +94,17 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $form->getAttribute('property_path'); // <- weird PHPUnit bug if I don't do this
 
         $this->mapper->mapDataToForm(null, $form);
+    }
+
+    public function testMapFormToDataIgnoresReadOnlyForm()
+    {
+        $data = new \stdClass();
+
+        $form = $this->getForm($this->propertyPath, true, true);
+
+        $this->propertyPath->expects($this->never())
+            ->method('setValue');
+
+        $this->mapper->mapFormToData($form, $data);
     }
 }


### PR DESCRIPTION
The current 2.0.13 `Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper` enables to overwrite data from form values, no matter the form fields are read only or not.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
