### PR TITLE
[Serializer][JsonEncoder] Exposed json_encode and json_decode params

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonDecode.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Encoder;
+
+/**
+ * Decodes JSON data
+ * 
+ * @author Sander Coolen <sander@jibber.nl> 
+ */
+class JsonDecode implements DecoderInterface
+{
+    /**
+     * @var bool 
+     */
+    private $associative = false;
+    /**
+     * @var int 
+     */
+    private $recursionDepth = 512;
+    /**
+     * @var int
+     */
+    private $lastError = JSON_ERROR_NONE;
+    
+    public function __construct($assoc = false, $depth = 512)
+    {
+        $this->associative = $assoc;
+        $this->recursionDepth = $depth;
+    }
+    
+    /**
+     * Returns the last decoding error (if any)
+     * 
+     * @return int
+     * @see http://php.net/manual/en/function.json-last-error.php json_last_error
+     */
+    public function getLastError()
+    {
+        return $this->lastError;
+    }
+    
+    /**
+     * Decodes a JSON string into PHP data
+     * 
+     * @param string $data JSON
+     * @return mixed 
+     */
+    public function decode($data, $format)
+    {
+        $decodedData = json_decode($data, $this->associative, $this->recursionDepth);
+        $this->lastError = json_last_error();
+        
+        return $decodedData;
+    }
+    
+   /**
+     * {@inheritdoc}
+     */
+    public function supportsDecoding($format)
+    {
+        return JsonEncoder::FORMAT === $format;
+    }
+}

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncode.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Encoder;
+
+/**
+ * Encodes JSON data
+ *
+ * @author Sander Coolen <sander@jibber.nl>
+ */
+class JsonEncode implements EncoderInterface
+{
+    /**
+     * @var int 
+     */
+    private $options = 0;
+    /**
+     * @var int
+     */
+    private $lastError = JSON_ERROR_NONE;
+    
+    public function __construct($bitmask = 0)
+    {
+        $this->options = $bitmask;
+    }
+    
+    /**
+     * Returns the last encoding error (if any)
+     * 
+     * @return int
+     * @see http://php.net/manual/en/function.json-last-error.php json_last_error 
+     */
+    public function getLastError()
+    {
+        return $this->lastError;
+    }
+    
+    /**
+     * Encodes PHP data to a JSON string
+     * 
+     * @param mixed $data
+     * @return string 
+     */
+    public function encode($data, $format)
+    {
+        $encodedJson = json_encode($data, $this->options);
+        $this->lastError = json_last_error();
+        
+        return $encodedJson;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsEncoding($format)
+    {
+        return JsonEncoder::FORMAT === $format;
+    }
+}

--- a/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/JsonEncoder.php
@@ -18,12 +18,55 @@ namespace Symfony\Component\Serializer\Encoder;
  */
 class JsonEncoder implements EncoderInterface, DecoderInterface
 {
+    const FORMAT = 'json';
+    
+    /**
+     * @var JsonEncode
+     */
+    protected $encodingImpl;
+    /**
+     * @var JsonDecode
+     */
+    protected $decodingImpl;
+
+    public function __construct(JsonEncode $encodingImpl = null, JsonDecode $decodingImpl = null)
+    {
+        if (null === $encodingImpl) {
+            $encodingImpl = new JsonEncode;
+        }
+        $this->encodingImpl = $encodingImpl;
+        if (null === $decodingImpl) {
+            $decodingImpl = new JsonDecode(true);
+        }
+        $this->decodingImpl = $decodingImpl;
+    }
+    
+    /**
+     * Returns the last encoding error (if any)
+     * 
+     * @return int 
+     */
+    public function getLastEncodingError()
+    {
+        return $this->encodingImpl->getLastError();
+    }
+    
+    /**
+     * Returns the last decoding error (if any)
+     * 
+     * @return int 
+     */
+    public function getLastDecodingError()
+    {
+        return $this->decodingImpl->getLastError();
+    }
+    
     /**
      * {@inheritdoc}
      */
     public function encode($data, $format)
     {
-        return json_encode($data);
+        return $this->encodingImpl->encode($data, self::FORMAT);
     }
 
     /**
@@ -31,28 +74,22 @@ class JsonEncoder implements EncoderInterface, DecoderInterface
      */
     public function decode($data, $format)
     {
-        return json_decode($data, true);
+        return $this->decodingImpl->decode($data, self::FORMAT);
     }
 
     /**
-     * Checks whether the serializer can encode to given format
-     *
-     * @param string $format format name
-     * @return Boolean
+     * {@inheritdoc}
      */
     public function supportsEncoding($format)
     {
-        return 'json' === $format;
+        return self::FORMAT === $format;
     }
 
     /**
-     * Checks whether the serializer can decode from given format
-     *
-     * @param string $format format name
-     * @return Boolean
+     * {@inheritdoc}
      */
     public function supportsDecoding($format)
     {
-        return 'json' === $format;
+        return self::FORMAT === $format;
     }
 }


### PR DESCRIPTION
In `JsonEncoder::decode()` you are unable to change the `$assoc` parameter from `json_decode`. I created two sub-classes that handle JSON encoding and decoding while exposing all the available parameters from `json_encode` and `json_decode`. You can now do this:

``` php
$jsonEncoder = new JsonEncoder(new JsonEncode(JSON_HEX_TAG), new JsonDecode(true, 1024));
$serializer = new Serializer(array(), array($jsonEncoder));
```

Additionally I made `json_last_error()` available from `JsonEncoder`:

``` php
$jsonEncoder->getLastEncodingError();
$jsonEncoder->getLastDecodingError();
```

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: N/A
Todo: -
License of the code: MIT
Documentation PR: -
