### PR TITLE
[HttpCache] Relying on Doctrine Common

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -14,7 +14,9 @@ namespace Symfony\Bundle\FrameworkBundle\HttpCache;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache as BaseHttpCache;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
+use Symfony\Component\HttpKernel\HttpCache\DriverStore;
 use Symfony\Component\HttpKernel\HttpCache\Store;
+use Symfony\Component\HttpKernel\HttpCache\FilesystemCache;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -27,6 +29,7 @@ abstract class HttpCache extends BaseHttpCache
 {
     protected $cacheDir;
     protected $kernel;
+    protected $storeDriver;
 
     /**
      * Constructor.
@@ -38,6 +41,7 @@ abstract class HttpCache extends BaseHttpCache
     {
         $this->kernel = $kernel;
         $this->cacheDir = $cacheDir;
+        $this->storeDriver = $this->createStoreDriver();
 
         parent::__construct($kernel, $this->createStore(), $this->createEsi(), array_merge(array('debug' => $kernel->isDebug()), $this->getOptions()));
     }
@@ -77,6 +81,14 @@ abstract class HttpCache extends BaseHttpCache
 
     protected function createStore()
     {
-        return new Store($this->cacheDir ?: $this->kernel->getCacheDir().'/http_cache');
+        return new Store($this->storeDriver);
+    }
+
+    protected function createStoreDriver()
+    {
+        $driver = new FileSystemCache;
+        $driver->setPath($this->cacheDir ?: $this->kernel->getCacheDir().'/http_cache');
+
+        return $driver;
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpCache/FilesystemCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/FilesystemCache.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\HttpCache;
+
+use Doctrine\Common\Cache\CacheProvider;
+
+/**
+ * Filesystem cache driver.
+ */
+class FilesystemCache extends CacheProvider
+{
+    private $path;
+
+    /**
+     * Sets the path.
+     *
+     * @param string $path
+     */
+    public function setPath($path)
+    {
+        if (!is_dir($path) && !mkdir($path, 0777, true)) {
+            throw new \RuntimeException('Unable to create the "'.$path.'" directory.');
+        }
+
+        $this->path = $path;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doContains($id)
+    {
+        return file_exists($this->getFullPath($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFetch($id)
+    {
+        if (false === $content = @file_get_contents($this->getFullPath($id))) {
+            return false;
+        }
+
+        return unserialize($content);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doSave($id, $data, $lifeTime = false)
+    {
+        return (bool) @file_put_contents($this->getFullPath($id), serialize($data));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doDelete($id)
+    {
+        return @unlink($this->getFullPath($id));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doFlush()
+    {
+        $files = new \DirectoryIterator($this->path);
+        foreach ($files as $file) {
+            if ($file->isFile()) {
+                @unlink($file->getRealPath());
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function doGetStats()
+    {
+        return null;
+    }
+
+    private function getFullPath($id)
+    {
+        return $this->path . '/' . md5($id);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -515,7 +515,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
             // wait for the lock to be released
             $wait = 0;
-            while (is_file($lock) && $wait < 5000000) {
+            while ($this->storeDriver->contains($lock) && $wait < 5000000) {
                 usleep(50000);
                 $wait += 50000;
             }
@@ -592,7 +592,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             ob_start();
 
             if ($response->headers->has('X-Body-File')) {
-                include $response->headers->get('X-Body-File');
+                eval('; ?>'.$this->storeDriver->fetch($response->headers->get('X-Body-File')).'<?php ;');
             } else {
                 eval('; ?>'.$response->getContent().'<?php ;');
             }
@@ -603,7 +603,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
                 $response->headers->set('Content-Length', strlen($response->getContent()));
             }
         } elseif ($response->headers->has('X-Body-File')) {
-            $response->setContent(file_get_contents($response->headers->get('X-Body-File')));
+            $response->setContent($this->storeDriver->fetch($response->headers->get('X-Body-File')));
         } else {
             return;
         }


### PR DESCRIPTION
I'd like to get some feedback before going further on this.

Would it make sense to rely on doctrine common cache for the HttpCache until the Cache Component is ready? I think it wouldn't need so much refactoring and the framework bundle has already the dependency with doctrine common.

If we also have a file cache storage class that acts like the current way, it could also keep the same behavior  by default.

What do you think?
