### PR TITLE
[Validator] Move doctrine/common dependency from require to suggest

### DIFF
--- a/src/Symfony/Component/Validator/Tests/ValidatorFactoryTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorFactoryTest.php
@@ -80,21 +80,6 @@ class ValidatorFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(new Validator($metadataFactory, $validatorFactory), $validator);
     }
 
-    public function testBuildDefaultFromAnnotations()
-    {
-        if (!class_exists('Doctrine\Common\Annotations\AnnotationReader')) {
-            $this->markTestSkipped('Annotations is required for this test');
-        }
-        $factory = ValidatorFactory::buildDefault();
-
-        $context = new ValidatorContext();
-        $context
-            ->setClassMetadataFactory(new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader())))
-            ->setConstraintValidatorFactory(new ConstraintValidatorFactory());
-
-        $this->assertEquals(new ValidatorFactory($context), $factory);
-    }
-
     public function testBuildDefaultFromAnnotationsWithCustomNamespaces()
     {
         if (!class_exists('Doctrine\Common\Annotations\AnnotationReader')) {
@@ -178,7 +163,7 @@ class ValidatorFactoryTest extends \PHPUnit_Framework_TestCase
      */
     public function testBuildDefaultThrowsExceptionIfNoLoaderIsFound()
     {
-        ValidatorFactory::buildDefault(array(), false);
+        ValidatorFactory::buildDefault();
     }
 
     /**

--- a/src/Symfony/Component/Validator/ValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ValidatorFactory.php
@@ -98,7 +98,7 @@ class ValidatorFactory implements ValidatorContextInterface
      *                                      has neither the extension ".xml" nor
      *                                      ".yml" nor ".yaml"
      */
-    static public function buildDefault(array $mappingFiles = array(), $annotations = true, $staticMethod = null)
+    static public function buildDefault(array $mappingFiles = array(), $annotations = false, $staticMethod = null)
     {
         $xmlMappingFiles = array();
         $yamlMappingFiles = array();
@@ -126,6 +126,10 @@ class ValidatorFactory implements ValidatorContextInterface
         }
 
         if ($annotations) {
+            if (!class_exists('Doctrine\Common\Annotations\AnnotationReader')) {
+                throw new \RuntimeException('Requested a ValidatorFactory with an AnnotationLoader, but the AnnotationReader was not found. You should add Doctrine Common to your project.');
+            }
+
             $loaders[] = new AnnotationLoader(new AnnotationReader());
         }
 

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,7 +17,6 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": ">=2.1,<2.3"
     },
     "require-dev": {
         "symfony/http-foundation": "2.1.*",
@@ -25,6 +24,7 @@
         "symfony/yaml": "2.1.*"
     },
     "suggest": {
+        "doctrine/common": ">=2.1,<2.3",
         "symfony/http-foundation": "self.version",
         "symfony/yaml": "self.version"
     },


### PR DESCRIPTION
`doctrine/common` is only used for the annotations, so it should be made optional.
