### PR TITLE
Change must-proxy-revalidate by proxy-revalidate

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -533,7 +533,7 @@ class Response
      */
     public function mustRevalidate()
     {
-        return $this->headers->hasCacheControlDirective('must-revalidate') || $this->headers->has('must-proxy-revalidate');
+        return $this->headers->hasCacheControlDirective('must-revalidate') || $this->headers->has('proxy-revalidate');
     }
 
     /**


### PR DESCRIPTION
According to specification of Cache-Control i changed must-proxy-revalidate by proxy-revalidate

Docs: http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9.4
