### PR TITLE
[HttpKernel][HttpCache] move ESI parsing to Esi component

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -589,19 +589,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         }
 
         if ($response->headers->has('X-Body-Eval')) {
-            ob_start();
-
-            if ($response->headers->has('X-Body-File')) {
-                include $response->headers->get('X-Body-File');
-            } else {
-                eval('; ?>'.$response->getContent().'<?php ;');
-            }
-
-            $response->setContent(ob_get_clean());
-            $response->headers->remove('X-Body-Eval');
-            if (!$response->headers->has('Transfer-Encoding')) {
-                $response->headers->set('Content-Length', strlen($response->getContent()));
-            }
+            $this->esi->parse($response, $this);
         } elseif ($response->headers->has('X-Body-File')) {
             $response->setContent(file_get_contents($response->headers->get('X-Body-File')));
         } else {
@@ -647,7 +635,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Records that an event took place.
      *
      * @param Request $request A Request instance
-     * @param string  $event   The event name
+     * @param string  $event The event name
      */
     private function record(Request $request, $event)
     {

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -107,18 +107,18 @@ class EsiTest extends \PHPUnit_Framework_TestCase
         $response = new Response('foo <esi:comment text="some comment" /><esi:include src="..." alt="alt" onerror="continue" />');
         $esi->process($request, $response);
 
-        $this->assertEquals('foo <?php echo $this->esi->handle($this, \'...\', \'alt\', true) ?>'."\n", $response->getContent());
+        $this->assertEquals('foo <?php echo $this->handle($cache, \'...\', \'alt\', true) ?>'."\n", $response->getContent());
         $this->assertEquals('ESI', $response->headers->get('x-body-eval'));
 
         $response = new Response('foo <esi:include src="..." />');
         $esi->process($request, $response);
 
-        $this->assertEquals('foo <?php echo $this->esi->handle($this, \'...\', \'\', false) ?>'."\n", $response->getContent());
+        $this->assertEquals('foo <?php echo $this->handle($cache, \'...\', \'\', false) ?>'."\n", $response->getContent());
 
         $response = new Response('foo <esi:include src="..."></esi:include>');
         $esi->process($request, $response);
 
-        $this->assertEquals('foo <?php echo $this->esi->handle($this, \'...\', \'\', false) ?>'."\n", $response->getContent());
+        $this->assertEquals('foo <?php echo $this->handle($cache, \'...\', \'\', false) ?>'."\n", $response->getContent());
     }
 
     public function testProcessEscapesPhpTags()


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

ESI content parsing is moved to the Esi component to provide further de-coupling. With this change, ESI processing and parsing may be overridden by simply extending the Esi class. This change is backwards compatible, however, the cache must be cleaned before upgrading, if it contains previously processed ESI sections. These blocks would contain $this->esi->handle..., which has been changed to $this->handle... The Esi unit tests have been modified to reflect this change.
