### PR TITLE
Modify TwigEngine.php's signature (#3216)

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -17,7 +17,7 @@ use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * This engine knows how to render Twig templates.
+ * This engine renders Twig templates.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
This fixes the "line-ending issues" in TwigEngine.php responsible for connection reset errors on windows (which do still occur on 2.0.13, when `core.autocrlf` is set to GitHub's recommendation rather than Symfony's), caused by factors out of Symfony's control.

I acknowledge the comments on the above issue, but it seems this is trivial to do and it will save a bunch of time for people who find themselves in this situation.

Bug fix: [no]
Feature addition: [no]
Backwards compatibility break: [no]
Symfony2 tests pass: phpdoc changes
Fixes the following tickets: [#3216]
License of the code: MIT
