### PR TITLE
[HttpKernel] Fixed the BundleInterface

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -11,7 +11,9 @@
 
 namespace Symfony\Component\HttpKernel\Bundle;
 
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 /**
  * BundleInterface.
@@ -20,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @api
  */
-interface BundleInterface
+interface BundleInterface extends ContainerAwareInterface
 {
     /**
      * Boots the Bundle.


### PR DESCRIPTION
The kernel expects bundles to implement ContainerAwareInterface (a fatal
error occurs if the method is not implemented). This is done in the base
class but not enforced in the interface.

I spotted it when trying to mock the BundleInterface and pass the mock to the kernel. I created the branch based on master because it is changing the interface but I'm wondering if it should go in 2.0 instead as a bugfix. Someone implementing strictly the interface currently would not be able to use the kernel.
