### PR TITLE
Issue related to custom group (role) and ACL/ACE

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -30,7 +30,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function __construct($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
 


### PR DESCRIPTION
According to the documentation on Symfony.com(1), the class named Group should implements RoleInterface.

However, when implementing ACEs, the code I modified would look for the Role class and therefore saves the Group as an object rather than saving the role name of the group.

(1)http://symfony.com/doc/current/cookbook/security/entity_provider.html#managing-roles-in-the-database
