### PR TITLE
Common deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": "2.1.*",
+        "doctrine/common": ">=2.1,<2.3-dev",
         "monolog/monolog": ">=1.0,<1.2-dev",
         "swiftmailer/swiftmailer": ">=4.1.2,<4.2-dev",
         "twig/twig": ">=1.1,<2.0-dev"

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.1,<2.3"
+        "doctrine/common": ">=2.1,<2.3-dev"
     },
     "recommend": {
         "doctrine/dbal": ">=2.1,<2.3",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "doctrine/common": ">=2.1,<2.3"
+        "doctrine/common": ">=2.1,<2.3-dev"
     },
     "suggest": {
         "symfony/http-foundation": "self.version",


### PR DESCRIPTION
This allows using Doctrine 2.2 when using the full repo as it is compatible. The workaround previously was to use the individual components as the deps was less strict in them.

Closes #4289
