### PR TITLE
[Yaml] Fixed double quotes escaping in Dumper

### DIFF
--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -25,13 +25,13 @@ class Escaper
     // first to ensure proper escaping because str_replace operates iteratively
     // on the input arrays. This ordering of the characters avoids the use of strtr,
     // which performs more slowly.
-    static private $escapees = array('\\\\', '\\"',
+    static private $escapees = array('\\\\', '\\"', '"',
                                      "\x00",  "\x01",  "\x02",  "\x03",  "\x04",  "\x05",  "\x06",  "\x07",
                                      "\x08",  "\x09",  "\x0a",  "\x0b",  "\x0c",  "\x0d",  "\x0e",  "\x0f",
                                      "\x10",  "\x11",  "\x12",  "\x13",  "\x14",  "\x15",  "\x16",  "\x17",
                                      "\x18",  "\x19",  "\x1a",  "\x1b",  "\x1c",  "\x1d",  "\x1e",  "\x1f",
                                      "\xc2\x85", "\xc2\xa0", "\xe2\x80\xa8", "\xe2\x80\xa9");
-    static private $escaped  = array('\\"', '\\\\',
+    static private $escaped  = array('\\"', '\\\\', '\\"',
                                      "\\0",   "\\x01", "\\x02", "\\x03", "\\x04", "\\x05", "\\x06", "\\a",
                                      "\\b",   "\\t",   "\\n",   "\\v",   "\\f",   "\\r",   "\\x0e", "\\x0f",
                                      "\\x10", "\\x11", "\\x12", "\\x13", "\\x14", "\\x15", "\\x16", "\\x17",

--- a/tests/Symfony/Tests/Component/Yaml/Fixtures/escapedCharacters.yml
+++ b/tests/Symfony/Tests/Component/Yaml/Fixtures/escapedCharacters.yml
@@ -137,3 +137,11 @@ yaml: |
     \x41 \u0041 \U00000041"
 php: |
     "Fun with \x5C\n\x22 \x07 \x08 \x1B \x0C\n\x0A \x0D \x09 \x0B \x00\n\x20 \xA0 \x85 \xe2\x80\xa8 \xe2\x80\xa9\nA A A"
+---
+test: Double quotes with a line feed
+yaml: |
+   { double: "some value\n \"some quoted string\" and 'some single quotes one'" }
+php: |
+    array(
+        'double' => "some value\n \"some quoted string\" and 'some single quotes one'"
+    )


### PR DESCRIPTION
Issue #4308 is caused by Dumper::escapeWithDoubleQuotes() which uses [str_replace()](http://php.net/str_replace).

From the php docs:

> Because str_replace() replaces left to right, it might replace a previously inserted value when doing multiple replacements.

We should be very careful in deciding about the order of elements in $escapees array. I'd really appreciate if someone reviewed my fix. Tests say I didn't break anything but I'm not sure what percentage of Yaml specification is covered by tests.

Bug fix: yes
Feature addition: no
Backwards compatibility break: not that I know
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/jakzal/symfony.png?branch=yamlDoubleQuotesDumperFix)](http://travis-ci.org/jakzal/symfony)
Fixes the following tickets: #4308
