### PR TITLE
[HttpFoundation] Add a StreamedFileResponse.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/StreamedFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedFileResponse.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * StreamedFileResponse is an HTTP response that streams a file.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @api
+ */
+class StreamedFileResponse extends StreamedResponse
+{
+    protected $filename;
+    protected $method;
+
+    /**
+     * Constructor.
+     *
+     * @param string  $filename The file to stream
+     * @param integer $status   The response status code
+     * @param array   $headers  An array of response headers
+     * @param string  $method   The method to use to stream the file, like 'readfile' or 'x-sendfile'
+     *
+     * @api
+     */
+    public function __construct($filename, $status = 200, $headers = array(), $method = 'readfile')
+    {
+        parent::__construct(null, $status, $headers);
+
+        $this->filename = $filename;
+        $this->method = $method;
+
+        switch ($this->method) {
+            case 'readfile':
+                $this->setCallback(function () use ($filename) {
+                    if (FALSE === @readfile($filename)) {
+                        throw new NotFoundHttpException();
+                    }
+                });
+                break;
+
+            case 'x-sendfile':
+                $this->setCallback(function() { });
+                break;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function create($filename, $status = 200, $headers = array())
+    {
+        return new static($filename, $status, $headers);
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    public function prepare(Request $request)
+    {
+        switch ($this->method) {
+            case 'x-sendfile':
+                $this->headers->set('X-Sendfile', $this->filename);
+                break;
+        }
+
+        return $parent::prepare($request);
+    }
+}


### PR DESCRIPTION
In the Drupal 8 branch where we are trying to leverage Symfonys HTTP Kernel we
currently have something like this:

```
function file_download(...) {
  // [...]
  return new StreamedResponse(function() use ($uri)) {
    if (... && fopen($uri, 'rb')) {
      while (!feof($fd)) {
        print fread($fd, 1024);
      }
      fclose($fd);
    }
  }, 200, $headers);
}
```

This is bad because:
- There might be better methods of streaming out a file, like X-Sendfile if
  available.
- Code like this is duplicated in different places.

Obvious solution to the latter point: Factor that out to something like a
StreamedFileResponse. Basically, then, the question is why such a class
shouldn't be in Symfony itself.

Heres a sketch of what such a class would have to do. For discussion and as
context for the following questions, without testcoverage or a changelog entry
(yet).
- Generally: Have something like that in Symfony?
- Detail: How to do error handling? Can I throw exceptions from the HttpKernel
  component?
- How to best enable the different transfer methods? The switch-case stuff
  doesn't look good. How to leverage the dependency injection container or
  keep it compatible with that?
