### PR TITLE
[BrowserKit] Removed unnecessary use statements

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -15,9 +15,6 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Link;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\Process\PhpProcess;
-use Symfony\Component\BrowserKit\Request;
-use Symfony\Component\BrowserKit\Response;
-use Symfony\Component\BrowserKit\Client;
 
 /**
  * Client simulates a browser.


### PR DESCRIPTION
Merely a cosmetical fix. My IDE (PhpStorm) marks the `use Symfony\Component\BrowserKit\Client;` statement in  `Symfony/Component/BrowserKit/Client.php` itself as an error.
I also removed the two other `use`s of classes from the same namespace.
