### PR TITLE
constraint_validation option can now be an array

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Validator\ValidatorInterface;
 use Symfony\Component\Validator\ExecutionContext;
 use Symfony\Component\Form\Util\PropertyPath;
+use Symfony\Component\Validator\ConstraintViolationList;
 
 class DelegatingValidator implements FormValidatorInterface
 {
@@ -49,11 +50,25 @@ class DelegatingValidator implements FormValidatorInterface
             // Validation of the data in the custom group is done by validateData(),
             // which is constrained by the Execute constraint
             if ($form->hasAttribute('validation_constraint')) {
-                $violations = $this->validator->validateValue(
-                    $form->getData(),
-                    $form->getAttribute('validation_constraint'),
-                    self::getFormValidationGroups($form)
-                );
+                if (is_array($form->getAttribute('validation_constraint'))) {
+                    $violations = new ConstraintViolationList();
+                    foreach ($form->getAttribute('validation_constraint') as $constraint) {
+                        $newViolations = $this->validator->validateValue(
+                            $form->getData(),
+                            $constraint,
+                            self::getFormValidationGroups($form)
+                        );
+                        if (null !== $newViolations) {
+                            $violations->addAll($newViolations);
+                        }
+                    }
+                } else {
+                    $violations = $this->validator->validateValue(
+                        $form->getData(),
+                        $form->getAttribute('validation_constraint'),
+                        self::getFormValidationGroups($form)
+                    );
+                }
 
                 if ($violations) {
                     foreach ($violations as $violation) {

--- a/tests/Symfony/Tests/Component/Form/Extension/Validator/Validator/DelegatingValidatorTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Validator/Validator/DelegatingValidatorTest.php
@@ -90,7 +90,7 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Tests\Component\Form\FormInterface');
     }
 
-    public function testUseValidateValueWhenValidationConstraintExist()
+    public function testUseValidateValueWhenValidationConstraintIsAValidConstraint()
     {
         $constraint = $this->getMockForAbstractClass('Symfony\Component\Validator\Constraint');
         $form = $this
@@ -101,6 +101,20 @@ class DelegatingValidatorTest extends \PHPUnit_Framework_TestCase
         $this->delegate->expects($this->once())->method('validateValue');
 
         $this->validator->validate($form);
+    }
+
+    public function testUseValidateValueWhenValidationConstraintIsAnArray()
+    {
+        $constraint1 = $this->getMockForAbstractClass('Symfony\Component\Validator\Constraint');
+        $constraint2 = $this->getMockForAbstractClass('Symfony\Component\Validator\Constraint');
+        $form = $this
+            ->getBuilder('name')
+            ->setAttribute('validation_constraint', array($constraint1, $constraint2))
+            ->getForm();
+
+        $this->delegate->expects($this->exactly(2))->method('validateValue');
+
+        $this->validator->validate($form, null);
     }
 
     public function testFormErrorsOnForm()


### PR DESCRIPTION
It's now possible to pass an array of Constraint.

Here is a simple concret example:

``` php
class NewPasswordType extends AbstractType
{
    public function getDefaultOptions()
    {
        return array(
            'type'               => 'password',
            'options'            => array(
                'required' => true,
            ),
            'validation_constraint' => array(
                new NotBlank(),
                new MinLength(5)
            ),
        );
    }

    public function getParent(array $options)
    {
        return 'repeated';
    }
}
```
