### PR TITLE
FormType translation_domain inheritance

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -58,6 +58,7 @@ class FormType extends AbstractType
     {
         $name = $form->getName();
         $readOnly = $options['read_only'];
+        $translationDomain = $options['translation_domain'];
 
         if ($view->hasParent()) {
             if ('' === $name) {
@@ -74,6 +75,10 @@ class FormType extends AbstractType
 
             // Complex fields are read-only if themselves or their parent is.
             $readOnly = $readOnly || $view->getParent()->getVar('read_only');
+
+            if (!$translationDomain) {
+                $translationDomain = $view->getParent()->getVar('translation_domain');
+            }
         } else {
             $id = $name;
             $fullName = $name;
@@ -87,6 +92,10 @@ class FormType extends AbstractType
         $types = array();
         foreach ($form->getConfig()->getTypes() as $type) {
             $types[] = $type->getName();
+        }
+
+        if (!$translationDomain) {
+            $translationDomain = 'messages';
         }
 
         $view->addVars(array(
@@ -109,7 +118,7 @@ class FormType extends AbstractType
             'label_attr'         => $options['label_attr'],
             'compound'           => $options['compound'],
             'types'              => $types,
-            'translation_domain' => $options['translation_domain'],
+            'translation_domain' => $translationDomain,
         ));
     }
 
@@ -185,7 +194,7 @@ class FormType extends AbstractType
             'label_attr'         => array(),
             'virtual'            => false,
             'compound'           => true,
-            'translation_domain' => 'messages',
+            'translation_domain' => null,
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -186,6 +186,33 @@ class FormTypeTest extends TypeTestCase
         $this->assertSame('test', $view->getVar('translation_domain'));
     }
 
+    public function testNonTranslationDomainFormWithTranslationDomainParentBeingTranslationDomain()
+    {
+        $parent = $this->factory->createNamed('parent', 'form', null, array('translation_domain' => 'test'));
+        $child  = $this->factory->createNamed('child', 'form');
+        $view   = $parent->add($child)->createView();
+
+        $this->assertEquals('test', $view['child']->getVar('translation_domain'));
+    }
+
+    public function testTranslationDomainFormWithNonTranslationDomainParentBeingTranslationDomain()
+    {
+        $parent = $this->factory->createNamed('parent', 'form');
+        $child  = $this->factory->createNamed('child', 'form', null, array('translation_domain' => 'test'));
+        $view   = $parent->add($child)->createView();
+
+        $this->assertEquals('test', $view['child']->getVar('translation_domain'));
+    }
+
+    public function testNonTranlsationDomainFormWithNonTranslationDomainParentBeingTranslationDomainDefault()
+    {
+        $parent = $this->factory->createNamed('parent', 'form');
+        $child  = $this->factory->createNamed('child', 'form');
+        $view   = $parent->add($child)->createView();
+
+        $this->assertEquals('messages', $view['child']->getVar('translation_domain'));
+    }
+
     public function testPassDefaultLabelToView()
     {
         $form = $this->factory->createNamed('__test___field', 'form');


### PR DESCRIPTION
Fixes: #3286, #3872, #3938

I found bug in form type parameters inheritance. It's better to inherit some child form element options from parent: translation_domain, required.
