### PR TITLE
constraint_validation option can now be an array

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/DelegatingValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/DelegatingValidationListenerTest.php
@@ -118,7 +118,7 @@ class DelegatingValidationListenerTest extends \PHPUnit_Framework_TestCase
         return array('group1', 'group2');
     }
 
-    public function testUseValidateValueWhenValidationConstraintExist()
+    public function testUseValidateValueWhenValidationConstraintIsAValidConstraint()
     {
         $constraint = $this->getMockForAbstractClass('Symfony\Component\Validator\Constraint');
         $form = $this
@@ -127,6 +127,20 @@ class DelegatingValidationListenerTest extends \PHPUnit_Framework_TestCase
             ->getForm();
 
         $this->delegate->expects($this->once())->method('validateValue');
+
+        $this->listener->validateForm(new DataEvent($form, null));
+    }
+
+    public function testUseValidateValueWhenValidationConstraintIsAnArray()
+    {
+        $constraint1 = $this->getMockForAbstractClass('Symfony\Component\Validator\Constraint');
+        $constraint2 = $this->getMockForAbstractClass('Symfony\Component\Validator\Constraint');
+        $form = $this
+            ->getBuilder('name')
+            ->setAttribute('validation_constraint', array($constraint1, $constraint2))
+            ->getForm();
+
+        $this->delegate->expects($this->exactly(2))->method('validateValue');
 
         $this->listener->validateForm(new DataEvent($form, null));
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

It's now possible to pass an array of Constraint.

Here is a simple concret example:

``` php
class NewPasswordType extends AbstractType
{
    public function getDefaultOptions()
    {
        return array(
            'type'               => 'password',
            'options'            => array(
                'required' => true,
            ),
            'validation_constraint' => array(
                new NotBlank(),
                new MinLength(5)
            ),
        );
    }

    public function getParent(array $options)
    {
        return 'repeated';
    }
}
```
