### PR TITLE
[WebProfilerBundle] Fixed the displaying of the toolbar in the profiler

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,9 +1,9 @@
 <!-- START of Symfony2 Web Debug Toolbar -->
 {% if 'normal' != position %}
     {% include 'WebProfilerBundle:Profiler:toolbar_style.html.twig' with { 'position': position, 'floatable': true } %}
+    <div style="clear: both; height: 50px;"></div>
 {% endif %}
 
-<div style="clear: both; height: 50px;"></div>
 <div class="sf-toolbarreset">
     {% for name, template in templates %}
         {{ template.renderblock('toolbar', {


### PR DESCRIPTION
When re-adding the clearing div a few days ago, you forgot to put it in the `if`, thus breaking the design of the profiler (adding 50px above the toolbar)
