### PR TITLE
[BUG] PoFileLoader pluralhandling uses interval instead of index.

### DIFF
--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -74,7 +74,7 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
                     if (isset($item['ids']['plural'])) {
                         $plurals = array();
                         foreach ($item['translated'] as $plural => $translated) {
-                            $plurals[] = sprintf('{%d} %s', $plural, $translated);
+                            $plurals[] = $translated;
                         }
                         $messages[$item['ids']['plural']] = stripcslashes(implode('|', $plurals));
                     }

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -39,7 +39,7 @@ class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
         $resource = __DIR__.'/../fixtures/plurals.po';
         $catalogue = $loader->load($resource, 'en', 'domain1');
 
-        $this->assertEquals(array('foo' => 'bar', 'foos' => '{0} bar|{1} bars'), $catalogue->all('domain1'));
+        $this->assertEquals(array('foo' => 'bar', 'foos' => 'bar|bars'), $catalogue->all('domain1'));
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
     }

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -62,6 +62,11 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
 
             array('', '{0}|{1} There is one apple|]1,Inf] There is %count% apples', 0),
             array('', '{0} There is no apples|{1}|]1,Inf] There is %count% apples', 1),
+
+            // Indexed only tests which are Gettext PoFile* compatible strings.
+            array('There are %count% apples', 'There is one apple|There are %count% apples', 0),
+            array('There is one apple', 'There is one apple|There are %count% apples', 1),
+            array('There are %count% apples', 'There is one apple|There are %count% apples', 2),
         );
     }
 }


### PR DESCRIPTION
PoFileLoaders parsed Gettext messages as interval but should have used indexed.

I added index only message strings to MessageSelectorTest to reflect this.

(this is part of https://github.com/symfony/symfony/pull/4249)
