### PR TITLE
Fixed for allowing empty translation.

### DIFF
--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -105,6 +105,6 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
         }
         fclose($stream);
 
-        return array_filter($messages);
+        return $messages;
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -54,4 +54,15 @@ class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
     }
+
+    public function testLoadEmptyTranslation()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/empty-translation.po';
+        $catalogue = $loader->load($resource, 'en', 'domain1');
+
+        $this->assertEquals(array('foo' => ''), $catalogue->all('domain1'));
+        $this->assertEquals('en', $catalogue->getLocale());
+        $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/fixtures/empty-translation.po
+++ b/src/Symfony/Component/Translation/Tests/fixtures/empty-translation.po
@@ -1,0 +1,3 @@
+msgid "foo"
+msgstr ""
+


### PR DESCRIPTION
PoFileLoader should accept empty translations.

PoFileLoader calls array_filter just before returning the $messages thus filtering empty translations.

For Drupal we need to be able to load and then translate incomplete PO and POT files.

(this is part of [[WIP]: Allow Drupal to use Translate component](https://github.com/symfony/symfony/pull/4249))
