### PR TITLE
Single dash option check

### DIFF
--- a/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputOptionTest.php
@@ -35,6 +35,10 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('f', $option->getShortcut(), '__construct() can take a shortcut as its second argument');
         $option = new InputOption('foo', '-f');
         $this->assertEquals('f', $option->getShortcut(), '__construct() removes the leading - of the shortcut');
+        $option = new InputOption('foo');
+        $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null by default');
+        $option = new InputOption('foo', '-');
+        $this->assertNull($option->getShortcut(), '__construct() makes the shortcut null if a single dash is specified as its name');
 
         // mode argument
         $option = new InputOption('foo', 'f');


### PR DESCRIPTION
See https://github.com/symfony/symfony/pull/4062
Check that a single dash is equivalent to a null shortcut
