### PR TITLE
Changed composer constraint to allow Doctrine 2.3 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
+        "doctrine/common": ">2.2,<2.4-dev",
         "twig/twig": ">=1.8,<2.0-dev"
     },
     "replace": {
@@ -53,8 +54,8 @@
         "symfony/yaml": "self.version"
     },
     "require-dev": {
-        "doctrine/dbal": "2.2.*",
-        "doctrine/orm": "2.2.*",
+        "doctrine/dbal": ">=2.2,<2.4-dev",
+        "doctrine/orm": ">=2.2,<2.4-dev",
         "doctrine/data-fixtures": "1.0.*",
         "propel/propel1": "dev-master",
         "monolog/monolog": "dev-master"

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "doctrine/common": "2.2.*"
+        "doctrine/common": ">=2.2,<2.4-dev"
     },
     "suggest": {
         "symfony/form": "self.version",
         "symfony/validator": "self.version",
         "doctrine/data-fixtures": "1.0.*",
-        "doctrine/dbal": ">=2.1,<2.3",
-        "doctrine/orm": ">=2.1,<2.3"
+        "doctrine/dbal": ">=2.2,<2.4-dev",
+        "doctrine/orm": ">=2.2,<2.4-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Doctrine": "" }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -25,7 +25,7 @@
         "symfony/routing": "self.version",
         "symfony/templating": "self.version",
         "symfony/translation": "self.version",
-        "doctrine/common": ">=2.1,<2.3-dev"
+        "doctrine/common": ">=2.2,<2.4-dev"
     },
     "suggest": {
         "symfony/console": "self.version",

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -21,12 +21,12 @@
     "require-dev": {
         "symfony/config": "2.1.*",
         "symfony/yaml": "2.1.*",
-        "doctrine/common": ">=2.1,<2.3-dev"
+        "doctrine/common": ">=2.2,<2.4-dev"
     },
     "suggest": {
         "symfony/config": "self.version",
         "symfony/yaml": "self.version",
-        "doctrine/common": ">=2.1,<2.3-dev"
+        "doctrine/common": ">=2.2,<2.4-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Routing": "" }

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -24,14 +24,15 @@
     "require-dev": {
         "symfony/form": "2.1.*",
         "symfony/routing": "2.1.*",
-        "doctrine/common": ">=2.1,<2.3-dev",
-        "doctrine/dbal": ">=2.1,<2.3-dev"
+        "doctrine/common": ">=2.2,<2.4-dev",
+        "doctrine/dbal": ">=2.2,<2.4-dev"
     },
     "suggest": {
         "symfony/class-loader": "self.version",
         "symfony/finder": "self.version",
         "symfony/form": "self.version",
-        "symfony/routing": "self.version"
+        "symfony/routing": "self.version",
+        "doctrine/dbal": "to use the built-in ACL implementation"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Security": "" }

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -24,7 +24,7 @@
         "symfony/yaml": "2.1.*"
     },
     "suggest": {
-        "doctrine/common": ">=2.1,<2.3",
+        "doctrine/common": ">=2.1,<2.4-dev",
         "symfony/http-foundation": "self.version",
         "symfony/yaml": "self.version"
     },


### PR DESCRIPTION
This allows both the 2.2.x and 2.3.x series for the Doctrine constraints instead of restricting to 2.2.x (thus allowing me to allow Doctrine 2.3 in DoctrineBundle too).

It also fixes some constraint that were missed when bumping the requirement to Doctrine 2.2 and added the missing deps in the global file (FrameworkBundle declares its dependency to `doctrine/common` for the `annotation_reader` service but it was not declared in the global file)
