### PR TITLE
[HttpKernel] Make RouterListener members protected.

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -29,8 +29,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class RouterListener implements EventSubscriberInterface
 {
-    private $urlMatcher;
-    private $logger;
+    protected $urlMatcher;
+    protected $logger;
 
     public function __construct(UrlMatcherInterface $urlMatcher, LoggerInterface $logger = null)
     {


### PR DESCRIPTION
Drupal 8 is going to have subclasses of HttpKernel and RouterListener (and more). fgm noted - when reviewing the patch to add that - that we were duplicating the $dispatcher and $resolver members of HttpKernel:

```
class DrupalKernel extends HttpKernel {

  // These are already declared on the parent class.
  protected $dispatcher;
  protected $resolver;

  // [...]
      parent::__construct($dispatcher, $resolver); // <-- This already sets the protected members.
      $this->dispatcher = $dispatcher;
      $this->resolver = $resolver;
  // [...]
```

The visibility has been set to protected as of 56a4ab7903de83d078c9cbb1281f44fa9499f587 by @fabpot.

I wonder if doing the same thing for classes like RouterListener makes sense.
