### PR TITLE
[Console] Check for existence of proc_open to fix #4338

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -921,6 +921,10 @@ class Application
      */
     private function getSttyColumns()
     {
+        if (!function_exists('proc_open')) {
+            return;
+        }
+
         $descriptorspec = array(1 => array('pipe', 'w'), 2 => array('pipe', 'w'));
         $process = proc_open('stty -a | grep columns', $descriptorspec, $pipes, null, null, array('suppress_errors' => true));
         if (is_resource($process)) {


### PR DESCRIPTION
It is quite common to disable proc_open for security purposes.

This PR checks for the existence of the proc_open function and fixes Issue #4338
