### PR TITLE
[HttpFoundation] Fix the UploadedFilename name sanitization (fix #2577)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -94,7 +94,9 @@ class UploadedFile extends File
             throw new FileException(sprintf('Unable to create UploadedFile because "file_uploads" is disabled in your php.ini file (%s)', get_cfg_var('cfg_file_path')));
         }
 
-        $this->originalName = basename($originalName);
+        $originalName = str_replace('\\', '/', $originalName);
+        $pos = strrpos($originalName, '/');
+        $this->originalName = false === $pos ? $originalName : substr($originalName, $pos + 1);
         $this->mimeType = $mimeType ?: 'application/octet-stream';
         $this->size = $size;
         $this->error = $error ?: UPLOAD_ERR_OK;

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
@@ -76,19 +76,6 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(UPLOAD_ERR_OK, $file->getError());
     }
 
-    public function testGetClientOriginalName()
-    {
-        $file = new UploadedFile(
-            __DIR__.'/Fixtures/test.gif',
-            'original.gif',
-            'image/gif',
-            filesize(__DIR__.'/Fixtures/test.gif'),
-            null
-        );
-
-        $this->assertEquals('original.gif', $file->getClientOriginalName());
-    }
-
     /**
      * @expectedException Symfony\Component\HttpFoundation\File\Exception\FileException
      */
@@ -132,18 +119,32 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
         @unlink($targetPath);
     }
 
-
-    public function testGetClientOriginalNameSanitizeFilename()
+    /**
+     * @dataProvider getClientFilenameFixtures
+     */
+    public function testGetClientOriginalNameSanitizeFilename($filename, $sanitizedFilename)
     {
         $file = new UploadedFile(
             __DIR__.'/Fixtures/test.gif',
-            '../../original.gif',
+            $filename,
             'image/gif',
             filesize(__DIR__.'/Fixtures/test.gif'),
             null
         );
 
-        $this->assertEquals('original.gif', $file->getClientOriginalName());
+        $this->assertEquals($sanitizedFilename, $file->getClientOriginalName());
+    }
+
+    public function getClientFilenameFixtures()
+    {
+        return array(
+            array('original.gif', 'original.gif'),
+            array('..\\..\\original.gif', 'original.gif'),
+            array('../../original.gif', 'original.gif'),
+            array('файлfile.gif', 'файлfile.gif'),
+            array('..\\..\\файлfile.gif', 'файлfile.gif'),
+            array('../../файлfile.gif', 'файлfile.gif'),
+        );
     }
 
     public function testGetSize()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/vicb/symfony.png?branch=uploadedfile2.0)](http://travis-ci.org/vicb/symfony)
Fixes the following tickets: #2577
