### PR TITLE
[Routing] removed unused property of Router

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -31,15 +31,13 @@ class Router extends BaseRouter
      * @param mixed              $resource  The main resource to load
      * @param array              $options   An array of options
      * @param RequestContext     $context   The context
-     * @param array              $defaults  The default values
      */
-    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null, array $defaults = array())
+    public function __construct(ContainerInterface $container, $resource, array $options = array(), RequestContext $context = null)
     {
         $this->container = $container;
 
         $this->resource = $resource;
         $this->context = null === $context ? new RequestContext() : $context;
-        $this->defaults = $defaults;
         $this->setOptions($options);
     }
 

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -24,7 +24,6 @@ class Router implements RouterInterface
 {
     protected $matcher;
     protected $generator;
-    protected $defaults;
     protected $context;
     protected $loader;
     protected $collection;
@@ -38,14 +37,12 @@ class Router implements RouterInterface
      * @param mixed           $resource The main resource to load
      * @param array           $options  An array of options
      * @param RequestContext  $context  The context
-     * @param array           $defaults The default values
      */
-    public function __construct(LoaderInterface $loader, $resource, array $options = array(), RequestContext $context = null, array $defaults = array())
+    public function __construct(LoaderInterface $loader, $resource, array $options = array(), RequestContext $context = null)
     {
         $this->loader = $loader;
         $this->resource = $resource;
         $this->context = null === $context ? new RequestContext() : $context;
-        $this->defaults = $defaults;
         $this->setOptions($options);
     }
 
@@ -207,7 +204,7 @@ class Router implements RouterInterface
         }
 
         if (null === $this->options['cache_dir'] || null === $this->options['matcher_cache_class']) {
-            return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context, $this->defaults);
+            return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context);
         }
 
         $class = $this->options['matcher_cache_class'];
@@ -225,7 +222,7 @@ class Router implements RouterInterface
 
         require_once $cache;
 
-        return $this->matcher = new $class($this->context, $this->defaults);
+        return $this->matcher = new $class($this->context);
     }
 
     /**
@@ -240,7 +237,7 @@ class Router implements RouterInterface
         }
 
         if (null === $this->options['cache_dir'] || null === $this->options['generator_cache_class']) {
-            return $this->generator = new $this->options['generator_class']($this->getRouteCollection(), $this->context, $this->defaults);
+            return $this->generator = new $this->options['generator_class']($this->getRouteCollection(), $this->context);
         }
 
         $class = $this->options['generator_cache_class'];
@@ -258,6 +255,6 @@ class Router implements RouterInterface
 
         require_once $cache;
 
-        return $this->generator = new $class($this->context, $this->defaults);
+        return $this->generator = new $class($this->context);
     }
 }

--- a/tests/Symfony/Tests/Component/Routing/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -38,7 +38,7 @@ class PhpGeneratorDumperTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
 
         $this->routeCollection = new RouteCollection();
-        $this->generatorDumper = new PhpGeneratorDumper($this->routeCollection, new RequestContext());
+        $this->generatorDumper = new PhpGeneratorDumper($this->routeCollection);
         $this->testTmpFilepath = sys_get_temp_dir().DIRECTORY_SEPARATOR.'php_generator.php';
         @unlink($this->testTmpFilepath);
     }

--- a/tests/Symfony/Tests/Component/Routing/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Tests\Component\Routing\Generator\Dumper\PhpGeneratorDumper;
+namespace Symfony\Tests\Component\Routing\Generator\Dumper;
 
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Route;

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/ApacheMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/ApacheMatcherDumperTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Tests\Component\Routing;
+namespace Symfony\Tests\Component\Routing\Matcher\Dumper;
 
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Tests\Component\Routing;
+namespace Symfony\Tests\Component\Routing\Matcher\Dumper;
 
 use Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper;
 use Symfony\Component\Routing\Route;

--- a/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -20,7 +20,7 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
 {
     public function testDump()
     {
-        $dumper = new PhpMatcherDumper($this->getRouteCollection(), new RequestContext());
+        $dumper = new PhpMatcherDumper($this->getRouteCollection());
 
         $this->assertStringEqualsFile(__DIR__.'/../../Fixtures/dumper/url_matcher1.php', $dumper->dump(), '->dump() dumps basic routes to the correct PHP file.');
 
@@ -40,7 +40,7 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array('_scheme' => 'http')
         ));
 
-        $dumper = new PhpMatcherDumper($collection, new RequestContext());
+        $dumper = new PhpMatcherDumper($collection);
 
         $this->assertStringEqualsFile(__DIR__.'/../../Fixtures/dumper/url_matcher2.php', $dumper->dump(array('base_class' => 'Symfony\Tests\Component\Routing\Fixtures\RedirectableUrlMatcher')), '->dump() dumps basic routes to the correct PHP file.');
     }
@@ -56,7 +56,7 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
             array(),
             array('_scheme' => 'https')
         ));
-        $dumper = new PhpMatcherDumper($collection, new RequestContext());
+        $dumper = new PhpMatcherDumper($collection);
         $dumper->dump();
     }
 

--- a/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
@@ -74,7 +74,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         // test the patterns are matched are parameters are returned
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo/{bar}'));
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         try {
             $matcher->match('/no-match');
             $this->fail();
@@ -84,38 +84,38 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         // test that defaults are merged
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo/{bar}', array('def' => 'test')));
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertEquals(array('_route' => 'foo', 'bar' => 'baz', 'def' => 'test'), $matcher->match('/foo/baz'));
 
         // test that route "method" is ignored if no method is given in the context
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/foo', array(), array('_method' => 'GET|head')));
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertInternalType('array', $matcher->match('/foo'));
 
         // route does not match with POST method context
-        $matcher = new UrlMatcher($collection, new RequestContext('', 'post'), array());
+        $matcher = new UrlMatcher($collection, new RequestContext('', 'post'));
         try {
             $matcher->match('/foo');
             $this->fail();
         } catch (MethodNotAllowedException $e) {}
 
         // route does match with GET or HEAD method context
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertInternalType('array', $matcher->match('/foo'));
-        $matcher = new UrlMatcher($collection, new RequestContext('', 'head'), array());
+        $matcher = new UrlMatcher($collection, new RequestContext('', 'head'));
         $this->assertInternalType('array', $matcher->match('/foo'));
 
         // route with an optional variable as the first segment
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{bar}/foo', array('bar' => 'bar'), array('bar' => 'foo|bar')));
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'bar'), $matcher->match('/bar/foo'));
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'foo'), $matcher->match('/foo/foo'));
 
         $collection = new RouteCollection();
         $collection->add('bar', new Route('/{bar}', array('bar' => 'bar'), array('bar' => 'foo|bar')));
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'foo'), $matcher->match('/foo'));
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'bar'), $matcher->match('/'));
     }
@@ -131,7 +131,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection = new RouteCollection();
         $collection->addCollection($collection2, '/a');
 
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertEquals(array('_route' => 'foo', 'foo' => 'foo'), $matcher->match('/a/b/foo'));
     }
 
@@ -146,7 +146,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection = new RouteCollection();
         $collection->addCollection($collection2, '/{_locale}');
 
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertEquals(array('_locale' => 'fr', '_route' => 'foo', 'foo' => 'foo'), $matcher->match('/fr/b/foo'));
     }
 
@@ -156,7 +156,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $chars = '!"$%éà &\'()*+,./:;<=>@ABCDEFGHIJKLMNOPQRSTUVWXYZ\\[]^_`abcdefghijklmnopqrstuvwxyz{|}~-';
         $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '['.preg_quote($chars).']+')));
 
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.urlencode($chars).'/bar'));
         $this->assertEquals(array('_route' => 'foo', 'foo' => $chars), $matcher->match('/'.strtr($chars, array('%' => '%25', '+' => '%2B')).'/bar'));
     }
@@ -166,7 +166,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/{foo}/bar', array(), array('foo' => '.+')));
 
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         $this->assertEquals(array('_route' => 'foo', 'foo' => "\n"), $matcher->match('/'.urlencode("\n").'/bar'), 'linefeed character is matched');
     }
 
@@ -180,7 +180,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $collection->addCollection($collection1);
 
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
 
         $this->assertEquals(array('_route' => 'foo'), $matcher->match('/foo1'));
         $this->setExpectedException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
@@ -198,7 +198,7 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $collection = new RouteCollection();
         $collection->add('foo', new Route('/{bar}'));
-        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $matcher = new UrlMatcher($collection, new RequestContext());
         try {
             $matcher->match('/');
             $this->fail();


### PR DESCRIPTION
Test pass: yes
BC break: no

This PR removes an unused property ($defaults) of Router. The property was passed to the constructor of UrlMatcher and UrlGenerator although these classes don't accept this parameter at all. And the dumped equivalents of them (produced by PhpMatcherDumper/PhpGeneratorDumper) don't need this property either.
So passing the $defaults was wrong and the property is not used in any way.
The DI config does not define anything for this property either: [routing.xml](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml#L52)

The second commit fixes the namespaces of test classes that were wrong.

The third commit removes false arguments in the test classes.
