### PR TITLE
Correct example mod_rewrite to not add Authorization header that does not exists

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -44,11 +44,13 @@ class ServerBag extends ParameterBag
         } else {
             /*
              * php-cgi under Apache does not pass HTTP Basic user/pass to PHP by default
-             * For this workaround to work, add this line to your .htaccess file:
+             * For this workaround to work, add these lines to your .htaccess file:
+             * RewriteCond %{HTTP:Authorization} ^(.+)$
              * RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
              *
              * A sample .htaccess file:
              * RewriteEngine On
+             * RewriteCond %{HTTP:Authorization} ^(.+)$
              * RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
              * RewriteCond %{REQUEST_FILENAME} !-f
              * RewriteRule ^(.*)$ app.php [QSA,L]


### PR DESCRIPTION
The in-line PHP code comment suggest to do some changes in .htaccess with mod_rewrite to pass HTTP-Authorization header to PHP. This leads to the Authorization header being introduced even when it's not originally in the request (albit empty, the result of ParameterBag->has('Authorization') will return true when you expect it not to.
Some external libraries might check for this header and perform logic based on wether it was set or not (The php-oauth2 library in my case).

I suggest this fix which I think is a more proper way of handling the case anyway, since when the header is not set you don't expect it to exist in the ServerBag either.

(I tried to search the documentation for this but did not find it, but I guess this probably should go into the documentation somewhere?)
