### PR TITLE
Add tests for output capturing

### DIFF
--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -68,6 +68,25 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(0, $p->getExitCode());
     }
 
+    public function testProcessOutput()
+    {
+        $p = new Process(sprintf('php -r %s', escapeshellarg('echo \'foo\';')));
+        ob_start();
+        $p->run();
+        $output = ob_get_clean();
+
+        $this->assertEquals('foo', $output);
+    }
+
+    public function testProcessWriting()
+    {
+        $stdin = str_repeat('*', 4096);
+        $p = new Process(sprintf('php -r %s', escapeshellarg('echo file_get_contents(\'php://stdin\');')), null, null, $stdin);
+        $p->run();
+
+        $this->assertEquals($stdin, $p->getOutput());
+    }
+
     public function testExitCodeText()
     {
         $process = new Process('');


### PR DESCRIPTION
The first test fails on windows, this problem appeared with the merge of #4069 /cc @pulzarraider

Basically it doesn't seem to be capturing output properly anymore. I have tried to debug it but I just seem to be missing a point in where it captures this.
