### PR TITLE
Composer missing dep

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
+        "symfony/dependency-injection": "self.version",
         "symfony/event-dispatcher": "self.version",
         "symfony/http-kernel": "self.version",
         "symfony/routing": "self.version",


### PR DESCRIPTION
The bundle class extends ContainerAware so the DI component is a required
dependency of the bundle.
