### PR TITLE
[TwigBundle] Composer install

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -55,7 +55,9 @@ class TwigExtension extends Extension
         $container->setParameter('twig.exception_listener.controller', $config['exception_controller']);
 
         $container->setParameter('twig.form.resources', $config['form']['resources']);
-        $container->getDefinition('twig.loader')->addMethodCall('addPath', array(__DIR__.'/../../../Bridge/Twig/Resources/views/Form'));
+
+        $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
+        $container->getDefinition('twig.loader')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName()))));
 
         if (!empty($config['globals'])) {
             $def = $container->getDefinition('twig');


### PR DESCRIPTION
When installing the bundle and the bridge from the standalone repositories
the relative path between them is different. This simply backports the
change done in symfony 2.1 to allow using subtree repositories with 2.0.x
too.
