### PR TITLE
[Form] Fixed: PropertyPathMapper did not always ignore virtual forms

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -71,13 +71,13 @@ CHANGELOG
  * labels don't display field attributes anymore. Label attributes can be
    passed in the "label_attr" option/variable
  * added option "mapped" which should be used instead of setting "property_path" to false
- * "data_class" now *must* be set if a form maps to an object and should be left empty otherwise
+ * [BC BREAK] "data_class" now *must* be set if a form maps to an object and should be left empty otherwise
  * improved error mapping on forms
    * dot (".") rules are now allowed to map errors assigned to a form to
      one of its children
  * errors are not mapped to unsynchronized forms anymore
- * changed Form constructor to accept a single `FormConfigInterface` object
- * changed argument order in the FormBuilder constructor
+ * [BC BREAK] changed Form constructor to accept a single `FormConfigInterface` object
+ * [BC BREAK] changed argument order in the FormBuilder constructor
  * deprecated Form methods
    * `getTypes`
    * `getErrorBubbling`

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -85,3 +85,6 @@ CHANGELOG
    * `getClientTransformers`
  * deprecated the option "validation_constraint" in favor of the new
    option "constraints"
+ * removed superfluous methods from DataMapperInterface
+   * `mapFormToData`
+   * `mapDataToForm`

--- a/src/Symfony/Component/Form/DataMapperInterface.php
+++ b/src/Symfony/Component/Form/DataMapperInterface.php
@@ -21,9 +21,5 @@ interface DataMapperInterface
      */
     function mapDataToForms($data, array $forms);
 
-    function mapDataToForm($data, FormInterface $form);
-
     function mapFormsToData(array $forms, &$data);
-
-    function mapFormToData(FormInterface $form, &$data);
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -32,28 +32,19 @@ class PropertyPathMapper implements DataMapperInterface
             $iterator = new \RecursiveIteratorIterator($iterator);
 
             foreach ($iterator as $form) {
-                $this->mapDataToForm($data, $form);
-            }
-        }
-    }
+                /* @var FormInterface $form */
+                $propertyPath = $form->getPropertyPath();
+                $config = $form->getConfig();
 
-    /**
-     * {@inheritdoc}
-     */
-    public function mapDataToForm($data, FormInterface $form)
-    {
-        if (!empty($data)) {
-            $propertyPath = $form->getPropertyPath();
-            $config = $form->getConfig();
+                if (null !== $propertyPath && $config->getMapped()) {
+                    $propertyData = $propertyPath->getValue($data);
 
-            if (null !== $propertyPath && $config->getMapped()) {
-                $propertyData = $propertyPath->getValue($data);
+                    if (is_object($propertyData) && !$form->getAttribute('by_reference')) {
+                        $propertyData = clone $propertyData;
+                    }
 
-                if (is_object($propertyData) && !$form->getAttribute('by_reference')) {
-                    $propertyData = clone $propertyData;
+                    $form->setData($propertyData);
                 }
-
-                $form->setData($propertyData);
             }
         }
     }
@@ -67,28 +58,21 @@ class PropertyPathMapper implements DataMapperInterface
         $iterator = new \RecursiveIteratorIterator($iterator);
 
         foreach ($iterator as $form) {
-            $this->mapFormToData($form, $data);
-        }
-    }
+            /* @var FormInterface $form */
+            $propertyPath = $form->getPropertyPath();
+            $config = $form->getConfig();
 
-    /**
-     * {@inheritdoc}
-     */
-    public function mapFormToData(FormInterface $form, &$data)
-    {
-        $propertyPath = $form->getPropertyPath();
-        $config = $form->getConfig();
+            // Write-back is disabled if the form is not synchronized (transformation failed)
+            // and if the form is disabled (modification not allowed)
+            if (null !== $propertyPath && $config->getMapped() && $form->isSynchronized() && !$form->isDisabled()) {
+                // If the data is identical to the value in $data, we are
+                // dealing with a reference
+                $isReference = $form->getData() === $propertyPath->getValue($data);
+                $byReference = $form->getAttribute('by_reference');
 
-        // Write-back is disabled if the form is not synchronized (transformation failed)
-        // and if the form is disabled (modification not allowed)
-        if (null !== $propertyPath && $config->getMapped() && $form->isSynchronized() && !$form->isDisabled()) {
-            // If the data is identical to the value in $data, we are
-            // dealing with a reference
-            $isReference = $form->getData() === $propertyPath->getValue($data);
-            $byReference = $form->getAttribute('by_reference');
-
-            if (!(is_object($data) && $isReference && $byReference)) {
-                $propertyPath->setValue($data, $form->getData());
+                if (!(is_object($data) && $isReference && $byReference)) {
+                    $propertyPath->setValue($data, $form->getData());
+                }
             }
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -37,13 +37,7 @@ class PropertyPathMapper implements DataMapperInterface
                 $config = $form->getConfig();
 
                 if (null !== $propertyPath && $config->getMapped()) {
-                    $propertyData = $propertyPath->getValue($data);
-
-                    if (is_object($propertyData) && !$form->getAttribute('by_reference')) {
-                        $propertyData = clone $propertyData;
-                    }
-
-                    $form->setData($propertyData);
+                    $form->setData($propertyPath->getValue($data));
                 }
             }
         }
@@ -68,9 +62,8 @@ class PropertyPathMapper implements DataMapperInterface
                 // If the data is identical to the value in $data, we are
                 // dealing with a reference
                 $isReference = $form->getData() === $propertyPath->getValue($data);
-                $byReference = $form->getAttribute('by_reference');
 
-                if (!(is_object($data) && $isReference && $byReference)) {
+                if (!is_object($data) || !$isReference || !$config->getByReference()) {
                     $propertyPath->setValue($data, $form->getData());
                 }
             }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -46,9 +46,9 @@ class FormType extends AbstractType
             // BC compatibility, when "property_path" could be false
             ->setPropertyPath(is_string($options['property_path']) ? $options['property_path'] : null)
             ->setMapped($options['mapped'])
+            ->setByReference($options['by_reference'])
             ->setVirtual($options['virtual'])
             ->setAttribute('read_only', $options['read_only'])
-            ->setAttribute('by_reference', $options['by_reference'])
             ->setAttribute('max_length', $options['max_length'])
             ->setAttribute('pattern', $options['pattern'])
             ->setAttribute('label', $options['label'] ?: $this->humanize($builder->getName()))

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -805,7 +805,7 @@ class Form implements \IteratorAggregate, FormInterface
         $child->setParent($this);
 
         if ($this->config->getDataMapper()) {
-            $this->config->getDataMapper()->mapDataToForm($this->getClientData(), $child);
+            $this->config->getDataMapper()->mapDataToForms($this->getClientData(), array($child));
         }
 
         return $this;

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -319,6 +319,10 @@ class Form implements \IteratorAggregate, FormInterface
             throw new AlreadyBoundException('You cannot change the data of a bound form');
         }
 
+        if (is_object($appData) && !$this->config->getByReference()) {
+            $appData = clone $appData;
+        }
+
         $event = new DataEvent($this, $appData);
         $this->config->getEventDispatcher()->dispatch(FormEvents::PRE_SET_DATA, $event);
 

--- a/src/Symfony/Component/Form/FormConfig.php
+++ b/src/Symfony/Component/Form/FormConfig.php
@@ -41,12 +41,12 @@ class FormConfig implements FormConfigInterface
     /**
      * @var Boolean
      */
-    private $mapped;
+    private $mapped = true;
 
     /**
      * @var Boolean
      */
-    private $virtual;
+    private $virtual = false;
 
     /**
      * @var array
@@ -76,17 +76,17 @@ class FormConfig implements FormConfigInterface
     /**
      * @var Boolean
      */
-    private $required;
+    private $required = true;
 
     /**
      * @var Boolean
      */
-    private $disabled;
+    private $disabled = false;
 
     /**
      * @var Boolean
      */
-    private $errorBubbling;
+    private $errorBubbling = false;
 
     /**
      * @var mixed

--- a/src/Symfony/Component/Form/FormConfig.php
+++ b/src/Symfony/Component/Form/FormConfig.php
@@ -46,6 +46,11 @@ class FormConfig implements FormConfigInterface
     /**
      * @var Boolean
      */
+    private $byReference = true;
+
+    /**
+     * @var Boolean
+     */
     private $virtual = false;
 
     /**
@@ -292,6 +297,14 @@ class FormConfig implements FormConfigInterface
     public function getMapped()
     {
         return $this->mapped;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getByReference()
+    {
+        return $this->byReference;
     }
 
     /**
@@ -546,6 +559,21 @@ class FormConfig implements FormConfigInterface
     public function setMapped($mapped)
     {
         $this->mapped = $mapped;
+
+        return $this;
+    }
+
+    /**
+     * Sets whether the form's data should be modified by reference.
+     *
+     * @param  Boolean $byReference Whether the data should be
+                                    modified by reference.
+     *
+     * @return self The configuration object.
+     */
+    public function setByReference($byReference)
+    {
+        $this->byReference = $byReference;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -48,6 +48,13 @@ interface FormConfigInterface
     function getMapped();
 
     /**
+     * Returns whether the form's data should be modified by reference.
+     *
+     * @return Boolean Whether to modify the form's data by reference.
+     */
+    function getByReference();
+
+    /**
      * Returns whether the form should be virtual.
      *
      * When mapping data to the children of a form, the data mapper

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -110,7 +110,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($engine));
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $form = $this->getForm($config);
 
@@ -133,7 +133,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($engine));
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', false);
+        $config->setByReference(false);
         $config->setPropertyPath($propertyPath);
         $form = $this->getForm($config);
 
@@ -148,7 +148,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $car = new \stdClass();
 
         $config = new FormConfig(null, '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $form = $this->getForm($config);
 
         $this->assertNull($form->getPropertyPath());
@@ -167,7 +167,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('getValue');
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setMapped(false);
         $config->setPropertyPath($propertyPath);
         $form = $this->getForm($config);
@@ -185,7 +185,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('getValue');
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $form = $this->getForm($config);
 
@@ -206,12 +206,12 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($engine));
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setVirtual(true);
         $form = $this->getForm($config);
 
         $config = new FormConfig('engine', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $child = $this->getForm($config);
 
@@ -234,7 +234,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->with($car, $engine);
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', false);
+        $config->setByReference(false);
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $form = $this->getForm($config);
@@ -253,7 +253,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->with($car, $engine);
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $form = $this->getForm($config);
@@ -277,7 +277,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('setValue');
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $form = $this->getForm($config);
@@ -295,7 +295,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('setValue');
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $config->setMapped(false);
@@ -313,7 +313,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('setValue');
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $config->setData(null);
         $form = $this->getForm($config);
@@ -331,7 +331,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('setValue');
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $form = $this->getForm($config, false);
@@ -349,7 +349,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
             ->method('setValue');
 
         $config = new FormConfig('name', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($propertyPath);
         $config->setData($engine);
         $config->setDisabled(true);
@@ -380,7 +380,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $form = $this->getForm($config);
 
         $config = new FormConfig('engine', '\stdClass', $this->dispatcher);
-        $config->setAttribute('by_reference', true);
+        $config->setByReference(true);
         $config->setPropertyPath($childPath);
         $config->setData($engine);
         $child = $this->getForm($config);

--- a/src/Symfony/Component/Form/Tests/FormTest.php
+++ b/src/Symfony/Component/Form/Tests/FormTest.php
@@ -464,6 +464,25 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $this->form->setData(null);
     }
 
+    public function testSetDataClonesObjectIfNotByReference()
+    {
+        $data = new \stdClass();
+        $form = $this->getBuilder('name', null, '\stdClass')->setByReference(false)->getForm();
+        $form->setData($data);
+
+        $this->assertNotSame($data, $form->getData());
+        $this->assertEquals($data, $form->getData());
+    }
+
+    public function testSetDataDoesNotCloneObjectIfByReference()
+    {
+        $data = new \stdClass();
+        $form = $this->getBuilder('name', null, '\stdClass')->setByReference(true)->getForm();
+        $form->setData($data);
+
+        $this->assertSame($data, $form->getData());
+    }
+
     public function testSetDataExecutesTransformationChain()
     {
         // use real event dispatcher now

--- a/src/Symfony/Component/Form/Tests/FormTest.php
+++ b/src/Symfony/Component/Form/Tests/FormTest.php
@@ -736,8 +736,8 @@ class FormTest extends \PHPUnit_Framework_TestCase
 
         $child = $this->getBuilder()->getForm();
         $mapper->expects($this->once())
-            ->method('mapDataToForm')
-            ->with('bar', $child);
+            ->method('mapDataToForms')
+            ->with('bar', array($child));
 
         $form->add($child);
     }

--- a/src/Symfony/Component/Form/UnmodifiableFormConfig.php
+++ b/src/Symfony/Component/Form/UnmodifiableFormConfig.php
@@ -45,6 +45,11 @@ class UnmodifiableFormConfig implements FormConfigInterface
     /**
      * @var Boolean
      */
+    private $byReference;
+
+    /**
+     * @var Boolean
+     */
     private $virtual;
 
     /**
@@ -123,6 +128,7 @@ class UnmodifiableFormConfig implements FormConfigInterface
         $this->name = $config->getName();
         $this->propertyPath = $config->getPropertyPath();
         $this->mapped = $config->getMapped();
+        $this->byReference = $config->getByReference();
         $this->virtual = $config->getVirtual();
         $this->types = $config->getTypes();
         $this->clientTransformers = $config->getClientTransformers();
@@ -168,6 +174,14 @@ class UnmodifiableFormConfig implements FormConfigInterface
     public function getMapped()
     {
         return $this->mapped;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getByReference()
+    {
+        return $this->byReference;
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4385
Todo: -
