### PR TITLE
fix cache:clear issue on windows, #3453

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -112,7 +112,7 @@ EOF
             $content = preg_replace($regex, '', $content);
 
             // fix absolute paths to the cache directory
-            $content = preg_replace('/'.preg_quote($warmupDir, '/').'/', preg_replace('/_new$/', '', $warmupDir), $content);
+            $content = preg_replace('/'.preg_quote(str_replace('\\', '\\\\', $warmupDir), '/').'/', preg_replace('/_new$/', '', $warmupDir), $content);
 
             file_put_contents(preg_replace($regex, '', $file), $content);
             unlink($file);


### PR DESCRIPTION
Hi,

This fix an issue #3453 with the cache:clear command on windows. It fail to rename kernel.dir path in the container file.
