### PR TITLE
[WebProfilerBundle] avoid showing the web profiler toolbar loading error if status is 0

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -9,7 +9,9 @@
                 el.style.display = -1 !== xhr.responseText.indexOf('sf-toolbarreset') ? 'block' : 'none';
             },
             function(xhr) {
-                confirm('An error occurred while loading the web debug toolbar (' + xhr.status + ': ' + xhr.statusText + ').\n\nDo you want to open the profiler?') && (window.location = '{{ path("_profiler", { "token": token }) }}')
+                if (xhr.status !== 0) {
+                    confirm('An error occurred while loading the web debug toolbar (' + xhr.status + ': ' + xhr.statusText + ').\n\nDo you want to open the profiler?') && (window.location = '{{ path("_profiler", { "token": token }) }}');
+                }
             }
         );
     })();


### PR DESCRIPTION
Currently, such error is also shown if loading the page is manually aborted, e.g. by clicking on a link before the toolbar has been loaded, which is quite annoying.
