### PR TITLE
[WIP][RFC][MessageCatalogue*] Add Metadata to MessageCatalogue.

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -23,6 +23,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
 class MessageCatalogue implements MessageCatalogueInterface
 {
     private $messages = array();
+    private $metaData = array();
     private $locale;
     private $resources;
     private $fallbackCatalogue;
@@ -175,6 +176,9 @@ class MessageCatalogue implements MessageCatalogueInterface
         foreach ($catalogue->getResources() as $resource) {
             $this->addResource($resource);
         }
+
+        $meta = $catalogue->getMetaData();
+        $this->addMetaData($meta);
     }
 
     /**
@@ -231,4 +235,87 @@ class MessageCatalogue implements MessageCatalogueInterface
     {
         $this->resources[] = $resource;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function getMetaData($domain = '', $key = '')
+    {
+        if (empty($domain)) {
+            return $this->metaData;
+        }
+
+        if (!is_string($domain)) {
+            throw new \InvalidArgumentException("Domain should be an string.");
+        }
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException("Key should be an string.");
+        }
+        if (isset($this->metaData[$domain])) {
+            if (!empty($key)) {
+                if (isset($this->metaData[$domain][$key])) {
+                    return $this->metaData[$domain][$key];
+                }
+            } else {
+                return $this->metaData[$domain];
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function setMetaData($key, $value, $domain = 'messages')
+    {
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException("Key should be an string.");
+        }
+        if (!isset($this->metaData[$domain])) {
+            $this->metaData[$domain] = array();
+        }
+        $this->metaData[$domain][$key] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function deleteMetaData($domain = '', $key = '')
+    {
+        if (empty($domain)) {
+            $this->metaData = array();
+        }
+        if (!is_string($domain)) {
+            throw new \InvalidArgumentException("Domain should be an string.");
+        }
+        if (empty($key)) {
+            unset($this->metaData[$domain]);
+        }
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException("Key should be an string.");
+        }
+        unset($this->metaData[$domain][$key]);
+    }
+
+    /**
+     * Adds or overwrite current values with the new values.
+     *
+     * TODO: do we want to overwrite values?!?
+     *
+     * @param array $values Values to add
+     */
+    private function addMetaData(array $values)
+    {
+        foreach ($values as $domain => $keys) {
+            foreach ($keys as $key => $value) {
+                $this->setMetaData($key, $value, $domain);
+            }
+        }
+    }
+
 }

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -29,7 +29,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function getLocale();
+    public function getLocale();
 
     /**
      * Gets the domains.
@@ -38,7 +38,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function getDomains();
+    public function getDomains();
 
     /**
      * Gets the messages within a given domain.
@@ -51,7 +51,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function all($domain = null);
+    public function all($domain = null);
 
     /**
      * Sets a message translation.
@@ -62,7 +62,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function set($id, $translation, $domain = 'messages');
+    public function set($id, $translation, $domain = 'messages');
 
     /**
      * Checks if a message has a translation.
@@ -74,7 +74,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function has($id, $domain = 'messages');
+    public function has($id, $domain = 'messages');
 
     /**
      * Checks if a message has a translation (it does not take into account the fallback mechanism).
@@ -86,7 +86,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function defines($id, $domain = 'messages');
+    public function defines($id, $domain = 'messages');
 
     /**
      * Gets a message translation.
@@ -98,7 +98,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function get($id, $domain = 'messages');
+    public function get($id, $domain = 'messages');
 
     /**
      * Sets translations for a given domain.
@@ -108,7 +108,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function replace($messages, $domain = 'messages');
+    public function replace($messages, $domain = 'messages');
 
     /**
      * Adds translations for a given domain.
@@ -118,7 +118,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function add($messages, $domain = 'messages');
+    public function add($messages, $domain = 'messages');
 
     /**
      * Merges translations from the given Catalogue into the current one.
@@ -129,7 +129,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function addCatalogue(MessageCatalogueInterface $catalogue);
+    public function addCatalogue(MessageCatalogueInterface $catalogue);
 
     /**
      * Merges translations from the given Catalogue into the current one
@@ -141,7 +141,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function addFallbackCatalogue(MessageCatalogueInterface $catalogue);
+    public function addFallbackCatalogue(MessageCatalogueInterface $catalogue);
 
     /**
      * Gets the fallback catalogue.
@@ -150,7 +150,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function getFallbackCatalogue();
+    public function getFallbackCatalogue();
 
     /**
      * Returns an array of resources loaded to build this collection.
@@ -159,7 +159,7 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function getResources();
+    public function getResources();
 
     /**
      * Adds a resource for this collection.
@@ -168,5 +168,31 @@ interface MessageCatalogueInterface
      *
      * @api
      */
-    function addResource(ResourceInterface $resource);
+    public function addResource(ResourceInterface $resource);
+
+    /**
+     * Gets meta data for given domain and key.
+     *
+     * @param string $key    Key to set
+     * @param string $domain The domain name
+     */
+    public function getMetaData($domain = '', $key = '');
+
+    /**
+     * Adds meta data to a message domain.
+     *
+     * @param string       $key    Key to set
+     * @param string|array $value  Value to store
+     * @param string       $domain The domain name
+     */
+    public function setMetaData($key, $value, $domain = 'messages');
+
+    /**
+     * Deletes meta data for given key and domain
+     *
+     * @param string $key    Key to set
+     * @param string $domain The domain name
+     */
+    public function deleteMetaData($domain = '', $key = '');
+
 }

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -170,4 +170,79 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array($r, $r1), $catalogue->getResources());
     }
+
+    public function testMetaDataDelete()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $expected = array();
+        $actual = $catalogue->getMetaData();
+        $this->assertEquals($expected, $actual, 'Metadata is empty');
+        $catalogue->deleteMetaData('messages', 'key');
+        $catalogue->deleteMetaData('messages');
+        $catalogue->deleteMetaData();
+    }
+
+    public function testMetaDataSetGetDelete()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->setMetaData('key', 'value');
+        $expected = 'value';
+        $actual = $catalogue->getMetaData('messages', 'key');
+        $this->assertEquals($expected, $actual, "Metadata 'key' = 'value'");
+
+        $catalogue->setMetaData('key2', array());
+        $expected = array();
+        $actual = $catalogue->getMetaData('messages', 'key2');
+        $this->assertEquals($expected, $actual, 'Metadata key2 is array');
+
+        $catalogue->deleteMetaData('messages', 'key2');
+        $expected = null;
+        $actual = $catalogue->getMetaData('messages', 'key2');
+        $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
+
+        $catalogue->deleteMetaData('domain', 'key2');
+        $expected = null;
+        $actual = $catalogue->getMetaData('domain', 'key2');
+        $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
+
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMetaDataExceptionsKey()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->deleteMetaData('messages', array());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMetaDataExceptionsDomain()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->deleteMetaData(array());
+    }
+
+    public function testMetaDataMerge()
+    {
+        $cat1 = new MessageCatalogue('en');
+        $cat1->setMetaData('a','b');
+        $expected = array('messages'=>array('a'=>'b'));
+        $actual = $cat1->getMetaData();
+        $this->assertEquals($expected, $actual, 'Cat1 contains messages metadata.');
+
+        $cat2 = new MessageCatalogue('en');
+        $cat2->setMetaData('b', 'c', 'domain');
+        $expected = array('domain'=>array('b'=>'c'));
+        $actual = $cat2->getMetaData();
+        $this->assertEquals($expected, $actual, 'Cat2 contains domain metadata.');
+
+        $cat1->addCatalogue($cat2);
+        $expected = array('messages'=>array('a'=>'b'),'domain'=>array('b'=>'c'));
+        $actual = $cat1->getMetaData();
+        $this->assertEquals($expected, $actual, 'Cat1 contains merged metadata.');
+
+    }
 }


### PR DESCRIPTION
For improving the Gettext tools (PO, MO File Loader/Dumper) we need at least storage for their meta data.

This patch allows for issues below to store and process ie Po Header, Po Header Pluralisation rule.

Open
- [[WIP]: Allow Drupal to use Translate component](https://github.com/symfony/symfony/pull/4249)
- [[2.1][Translator] Symfony translation process & gettext](https://github.com/symfony/symfony/issues/4245)

Closed:
- [[Translation] Po/MoFileLoader parse plurization rules](https://github.com/symfony/symfony/pull/3023)

It has 1 TODO regarding addCatalogue: it now just override old values with new.
