### PR TITLE
Force root package version in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ php:
 
 before_script:
     - curl -s http://getcomposer.org/installer | php
-    - php composer.phar --dev install
+    - COMPOSER_ROOT_VERSION=dev-master php composer.phar --dev install


### PR DESCRIPTION
This hopefully fixes the composer builds. Let's see what travisbot thinks.
