### PR TITLE
Fix cache:clear on windows #3453

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -392,7 +392,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     {
         if (null === $this->rootDir) {
             $r = new \ReflectionObject($this);
-            $this->rootDir = dirname($r->getFileName());
+            $this->rootDir = str_replace('\\', '/', dirname($r->getFileName()));
         }
 
         return $this->rootDir;


### PR DESCRIPTION
Hi,

This fix the issue #3453, in a better way than #4390

It force the kernel path to have linux separator only, before it had mixed linux/windows on a windows platforme.
