### PR TITLE
[FrameworkBundle] Fix for notice in AddCacheWarmerPass

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheWarmerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/AddCacheWarmerPass.php
@@ -37,6 +37,10 @@ class AddCacheWarmerPass implements CompilerPassInterface
             $warmers[$priority][] = new Reference($id);
         }
 
+        if (empty($warmers)) {
+            return;
+        }
+
         // sort by priority and flatten
         krsort($warmers);
         $warmers = call_user_func_array('array_merge', $warmers);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
@@ -69,4 +69,24 @@ class AddCacheWarmerPassTest extends \PHPUnit_Framework_TestCase
         $addCacheWarmerPass = new AddCacheWarmerPass();
         $addCacheWarmerPass->process($container);
     }
+
+    public function testThatCacheWarmersMightBeNotDefined()
+    {
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $container->expects($this->atLeastOnce())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnValue(array()));
+        $container->expects($this->never())->method('getDefinition');
+        $container->expects($this->atLeastOnce())
+            ->method('hasDefinition')
+            ->with('cache_warmer')
+            ->will($this->returnValue(true));
+
+        $definition->expects($this->never())->method('replaceArgument');
+
+        $addCacheWarmerPass = new AddCacheWarmerPass();
+        $addCacheWarmerPass->process($container);
+    }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/AddCacheWarmerPassTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddCacheWarmerPass;
+
+class AddCacheWarmerPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatCacheWarmersAreProcessedInPriorityOrder()
+    {
+        $services = array(
+            'my_cache_warmer_service1' => array(0 => array('priority' => 100)),
+            'my_cache_warmer_service2' => array(0 => array('priority' => 200)),
+            'my_cache_warmer_service3' => array()
+        );
+
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $container->expects($this->atLeastOnce())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnValue($services));
+        $container->expects($this->atLeastOnce())
+            ->method('getDefinition')
+            ->with('cache_warmer')
+            ->will($this->returnValue($definition));
+        $container->expects($this->atLeastOnce())
+            ->method('hasDefinition')
+            ->with('cache_warmer')
+            ->will($this->returnValue(true));
+
+        $definition->expects($this->once())
+            ->method('replaceArgument')
+            ->with(0, array(
+                new Reference('my_cache_warmer_service2'),
+                new Reference('my_cache_warmer_service1'),
+                new Reference('my_cache_warmer_service3')
+            ));
+
+        $addCacheWarmerPass = new AddCacheWarmerPass();
+        $addCacheWarmerPass->process($container);
+    }
+
+    public function testThatCompilerPassIsIgnoredIfThereIsNoCacheWarmerDefinition()
+    {
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $container->expects($this->never())->method('findTaggedServiceIds');
+        $container->expects($this->never())->method('getDefinition');
+        $container->expects($this->atLeastOnce())
+            ->method('hasDefinition')
+            ->with('cache_warmer')
+            ->will($this->returnValue(false));
+        $definition->expects($this->never())->method('replaceArgument');
+
+        $addCacheWarmerPass = new AddCacheWarmerPass();
+        $addCacheWarmerPass->process($container);
+    }
+}


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4391
