### PR TITLE
[WebProfilerBundle] Added Session Metadata info to the Request section of the WDT

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -34,6 +34,10 @@
                 <b>Route name</b>
                 <span>{{ request_route }}</span>
             </div>
+            <div class="sf-toolbar-info-piece">
+                <b>Has session</b>
+                <span>{% if collector.sessionmetadata|length %}yes{% else %}no{% endif %}</span>
+            </div>
         {% endspaceless %}
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
@@ -108,6 +112,16 @@
     <h2>Response Headers</h2>
 
     {% include 'WebProfilerBundle:Profiler:bag.html.twig' with { 'bag': collector.responseheaders } only %}
+
+    <h2>Session Metadata</h2>
+
+    {% if collector.sessionmetadata|length %}
+    {% include 'WebProfilerBundle:Profiler:table.html.twig' with { 'data': collector.sessionmetadata } only %}
+    {% else %}
+    <p>
+        <em>No session metadata</em>
+    </p>
+    {% endif %}
 
     <h2>Session Attributes</h2>
 

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -59,6 +59,14 @@ class RequestDataCollector extends DataCollector
             $content = false;
         }
 
+        $sessionMetadata = array();
+
+        if ($request->hasSession()) {
+            $sessionMetadata['Created'] = date(DATE_RFC822, $request->getSession()->getMetadataBag()->getCreated());
+            $sessionMetadata['Last used'] = date(DATE_RFC822, $request->getSession()->getMetadataBag()->getLastUsed());
+            $sessionMetadata['Lifetime'] = $request->getSession()->getMetadataBag()->getLifetime();
+        }
+
         $this->data = array(
             'format'             => $request->getRequestFormat(),
             'content'            => $content,
@@ -71,6 +79,7 @@ class RequestDataCollector extends DataCollector
             'request_cookies'    => $request->cookies->all(),
             'request_attributes' => $attributes,
             'response_headers'   => $responseHeaders,
+            'session_metadata'   => $sessionMetadata,
             'session_attributes' => $request->hasSession() ? $request->getSession()->all() : array(),
             'flashes'            => $request->hasSession() ? $request->getSession()->getFlashBag()->peekAll() : array(),
             'path_info'          => $request->getPathInfo(),
@@ -115,6 +124,11 @@ class RequestDataCollector extends DataCollector
     public function getResponseHeaders()
     {
         return new ResponseHeaderBag($this->data['response_headers']);
+    }
+
+    public function getSessionMetadata()
+    {
+        return $this->data['session_metadata'];
     }
 
     public function getSessionAttributes()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/dlsniper/symfony.png?branch=wdt-session-metadata)](http://travis-ci.org/dlsniper/symfony)
Fixes the following tickets: #4181
Todo: ~
License of the code: MIT
Documentation PR: ~

This PR adds some session metadata available into the WDT (Created, Last used, Lifetime specifically).
If you'd like to see more info then let me know.
