### PR TITLE
[Form] fixed a bug that caused input date validation not to be strict when using the single_text widget with a date/datetime field

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -157,6 +157,8 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
         $calendar = $this->calendar;
         $pattern = $this->pattern;
 
-        return new \IntlDateFormatter(\Locale::getDefault(), $dateFormat, $timeFormat, $timezone, $calendar, $pattern);
+        $intlDateFormatter = new \IntlDateFormatter(\Locale::getDefault(), $dateFormat, $timeFormat, $timezone, $calendar, $pattern);
+        $intlDateFormatter->setLenient(false);
+        return $intlDateFormatter;
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -96,6 +96,10 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
 
         try {
             $dateTime = new \DateTime($value, new \DateTimeZone($this->outputTimezone));
+            $lastErrors = \DateTime::getLastErrors();
+            if (0 < $lastErrors['warning_count'] || 0 < $lastErrors['error_count']) {
+                throw new \UnexpectedValueException(implode(', ', array_merge(array_values($lastErrors['warnings']), array_values($lastErrors['errors']))));
+            }
 
             // Force value to be in same format as given to transform
             if ($value !== $dateTime->format($this->format)) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -61,6 +61,7 @@ class DateType extends AbstractType
             \IntlDateFormatter::GREGORIAN,
             $pattern
         );
+        $formatter->setLenient(false);
 
         if ($options['widget'] === 'single_text') {
             $builder->appendClientTransformer(new DateTimeToLocalizedStringTransformer($options['data_timezone'], $options['user_timezone'], $format, \IntlDateFormatter::NONE, \IntlDateFormatter::GREGORIAN, $pattern));

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -286,4 +286,14 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
     {
         new DateTimeToLocalizedStringTransformer(null, null, null, 'foobar');
     }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformWithNonExistingDate()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::SHORT);
+
+        $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('31.04.10 04:05'));
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -140,4 +140,13 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
 
         $reverseTransformer->reverseTransform('2010-2010-2010');
     }
+
+    public function testReverseTransformWithNonExistingDate()
+    {
+        $reverseTransformer = new DateTimeToStringTransformer();
+
+        $this->setExpectedException('Symfony\Component\Form\Exception\TransformationFailedException');
+
+        $reverseTransformer->reverseTransform('2010-04-31');
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
@@ -234,4 +234,22 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['date']->getErrors());
         $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['time']->getErrors());
     }
+
+    public function testSubmit_invalidDateTimeSingleText()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'input' => 'datetime',
+            'widget' => 'single_text',
+            'invalid_message' => 'Customized invalid message',
+        ));
+
+        $form->bind('2012-04-31 03:04:05');
+
+        $this->assertFalse($form->isValid());
+        $this->assertNull($form->getData());
+        $this->assertEquals('2012-04-31 03:04:05', $form->getClientData());
+        $this->assertEquals(array(new FormError('Customized invalid message', array())), $form->getErrors());
+    }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTypeTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Tests\Component\Form\Extension\Core\Type;
 
 require_once __DIR__ . '/LocalizedTestCase.php';
 
+use Symfony\Component\Form\FormError;
 
 class DateTypeTest extends LocalizedTestCase
 {
@@ -459,5 +460,23 @@ class DateTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertSame('single_text', $view->get('widget'));
+    }
+
+    public function testInvalidDateWithSingleTextDateTime()
+    {
+        $form = $this->factory->create('date', null, array(
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
+            'widget' => 'single_text',
+            'input' => 'datetime',
+            'invalid_message' => 'Customized invalid message',
+        ));
+
+        $form->bind('31.4.2012');
+
+        $this->assertFalse($form->isValid());
+        $this->assertNull($form->getData());
+        $this->assertEquals('31.4.2012', $form->getClientData());
+        $this->assertEquals(array(new FormError('Customized invalid message', array())), $form->getErrors());
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Currently, input date validation is not strict when using the single_text widget with a date or datetime field. This will cause unexpected transformation of input date value as follows:
- 2012-04-31 => 2012-05-01
- 2012-04-31 03:04:00 => 2012-05-01 03:04:00

Additionally this is not same as other transformation logic for date/datetime fields because they use the checkdate() function to validate input date values. The checkdate() function validates a date strictly.

``` php
<?php
var_dump(checkdate(4, 31, 2012)); // bool(false)
```

BTW, the documentation of [IntlDateFormatter::setLenient()](http://php.net/manual/en/intldateformatter.setlenient.php) and [IntlDateFormatter::isLenient()](http://php.net/manual/en/intldateformatter.islenient.php) have been fixed recently. Please see https://bugs.php.net/bug.php?id=61896 **The default parser is lenient, not strict**.
