### PR TITLE
[WIP][Form] added support for different invalid messages for date, time.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -44,6 +44,14 @@ class DateTimeType extends AbstractType
             $builder->appendClientTransformer(new DateTimeToStringTransformer($options['data_timezone'], $options['user_timezone'], $format));
         } else {
             // Only pass a subset of the options to children
+            
+            // Check if an invalid date message is defined
+            if(isset($options['date_invalid_message'])) {
+                $options['invalid_message'] = $options['date_invalid_message'];
+            }
+            if(isset($options['date_invalid_message_parameters'])) {
+                $options['invalid_message_parameters'] = $options['date_invalid_message_parameters'];
+            }
             $dateOptions = array_intersect_key($options, array_flip(array(
                 'years',
                 'months',
@@ -53,6 +61,14 @@ class DateTimeType extends AbstractType
                 'invalid_message',
                 'invalid_message_parameters'
             )));
+            
+            // Check if an invalid time message is defined
+            if(isset($options['time_invalid_message'])) {
+                $options['invalid_message'] = $options['time_invalid_message'];
+            }
+            if(isset($options['time_invalid_message_parameters'])) {
+                $options['invalid_message_parameters'] = $options['time_invalid_message_parameters'];
+            }
             $timeOptions = array_intersect_key($options, array_flip(array(
                 'hours',
                 'minutes',
@@ -151,6 +167,10 @@ class DateTimeType extends AbstractType
             'widget'        => null,
             // This will overwrite "empty_value" child options
             'empty_value'   => null,
+            'date_invalid_message'   => 'This date is not valid',
+            'time_invalid_message'   => 'This time is not valid',
+            'date_invalid_message_parameters'   => array(),
+            'time_invalid_message_parameters'   => array(),
         );
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -167,8 +167,8 @@ class DateTimeType extends AbstractType
             'widget'        => null,
             // This will overwrite "empty_value" child options
             'empty_value'   => null,
-            'date_invalid_message'   => 'This date is not valid',
-            'time_invalid_message'   => 'This time is not valid',
+            'date_invalid_message'   => null,
+            'time_invalid_message'   => null,
             'date_invalid_message_parameters'   => array(),
             'time_invalid_message_parameters'   => array(),
         );

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/DateTimeTypeTest.php
@@ -234,4 +234,28 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['date']->getErrors());
         $this->assertEquals(array(new FormError('Customized invalid message', array())), $form['time']->getErrors());
     }
+    
+    public function testSubmit_invalidDateTime_differentMessages()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'date_invalid_message' => 'Customized invalid date message',
+            'time_invalid_message' => 'Customized invalid time message',
+        ));
+
+        $form->bind(array(
+            'date' => array(
+                'day' => '31',
+                'month' => '9',
+                'year' => '2010',
+            ),
+            'time' => array(
+                'hour' => '25',
+                'minute' => '4',
+            ),
+        ));
+
+        $this->assertFalse($form->isValid());
+        $this->assertEquals(array(new FormError('Customized invalid date message', array())), $form['date']->getErrors());
+        $this->assertEquals(array(new FormError('Customized invalid time message', array())), $form['time']->getErrors());
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4359
Todo: DateTimeType, when used with the widget "text", currently
duplicates the invalid error when an invalid value is entered.
License of the code: MIT
Documentation PR: none
