### PR TITLE
[Bridge][Doctrine] Fix missing dot in unique entity error message

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -127,7 +127,7 @@ class UniqueValidatorTest extends DoctrineOrmTestCase
         $this->assertEquals(1, $violationsList->count(), "No violations found on entity after it was saved to the database.");
 
         $violation = $violationsList[0];
-        $this->assertEquals('This value is already used', $violation->getMessage());
+        $this->assertEquals('This value is already used.', $violation->getMessage());
         $this->assertEquals('name', $violation->getPropertyPath());
         $this->assertEquals('Foo', $violation->getInvalidValue());
     }

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -21,7 +21,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class UniqueEntity extends Constraint
 {
-    public $message = 'This value is already used';
+    public $message = 'This value is already used.';
     public $service = 'doctrine.orm.validator.unique';
     public $em = null;
     public $fields = array();


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: none
Todo: none
License of the code: MIT
Documentation PR: none

The translation message defined in the FrameworkExtraBundle defines the unique entity error message like that: `This value is already used.` but is defined without the dot in the Doctrine UniqueEntity validator. This PR fixes this issue.
