### PR TITLE
Fix broken web test cases with session already started

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
@@ -49,10 +49,9 @@ class TestSessionListener implements EventSubscriberInterface
 
         $session = $this->container->get('session');
         $cookies = $event->getRequest()->cookies;
+        
         if ($cookies->has($session->getName())) {
             $session->setId($cookies->get($session->getName()));
-        } else {
-            $session->setId('');
         }
     }
 


### PR DESCRIPTION
This PR fixes the issues highlighted in PR #4445 and #3741 by not overriding the session id if the session is already started.
