### PR TITLE
[2.2] [WIP][Validator][Constraints][Collection] walk constraints by groups

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -41,16 +41,17 @@ class CollectionValidator extends ConstraintValidator
         $map = new ValueMetadata();
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
+            $map->setConstraints($fieldConstraint->constraints);
+
             if (
                 // bug fix issue #2779
                 (is_array($value) && array_key_exists($field, $value)) ||
                 ($value instanceof \ArrayAccess && $value->offsetExists($field))
             ) {
-                foreach ($fieldConstraint->constraints as $constr) {
+                foreach ($map->findConstraints($group) as $constr) {
                     $this->context->validateValue($value[$field], $constr, '['.$field.']', $group);
-                foreach ($map->setConstraints($constraints)->findConstraints($group) as $constr) {
                 }
-            } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
+            } elseif ($map->hasConstraints($group) && !$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
                 $this->context->addViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(
                     '{{ field }}' => $field
                 ), null);

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -15,6 +15,7 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 use Symfony\Component\Validator\Constraints\Optional;
+use Symfony\Component\Validator\Mapping\ValueMetadata;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -37,6 +38,7 @@ class CollectionValidator extends ConstraintValidator
         }
 
         $group = $this->context->getGroup();
+        $map = new ValueMetadata;
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
             if (
@@ -46,6 +48,7 @@ class CollectionValidator extends ConstraintValidator
             ) {
                 foreach ($fieldConstraint->constraints as $constr) {
                     $this->context->validateValue($value[$field], $constr, '['.$field.']', $group);
+                foreach ($map->setConstraints($constraints)->findConstraints($group) as $constr) {
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
                 $this->context->addViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -38,7 +38,7 @@ class CollectionValidator extends ConstraintValidator
         }
 
         $group = $this->context->getGroup();
-        $map = new ValueMetadata;
+        $map = new ValueMetadata();
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
             if (

--- a/src/Symfony/Component/Validator/Mapping/ValueMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ValueMetadata.php
@@ -13,11 +13,11 @@ namespace Symfony\Component\Validator\Mapping;
 
 class ValueMetadata extends ElementMetadata
 {
-/**
- * Sets the constraint(s) for this value.
- *
- * @param array $constraints
- */
+    /**
+    * Sets the constraint(s) for this value.
+    *
+    * @param array $constraints
+    */
 	public function setConstraints(array $constraints)
     {
         $this->constraints = $constraints;
@@ -30,6 +30,15 @@ class ValueMetadata extends ElementMetadata
         });
 
         $this->constraintsByGroup = $constraintsByGroup;
-        return $this;
+    }
+
+    /**
+     * Returns whether this element has any constraints, optionally by group.
+     *
+     * @return Boolean
+     */
+    public function hasConstraints($group = null)
+    {
+        return isset($group) ? !empty($this->constraintsByGroup[$group]) : count($this->constraints) > 0;
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/ValueMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ValueMetadata.php
@@ -20,14 +20,16 @@ class ValueMetadata extends ElementMetadata
  */
 	public function setConstraints(array $constraints)
     {
-		$this->constraints = $constraints;
-		$this->constraintsByGroup = array();
-		array_walk($constraints,function($constraint,$k,$self){
-            foreach($constraint->groups as $group){
-                $self->constraintsByGroup[$group][] = $constraint;
-            }
-        },$this);
+        $this->constraints = $constraints;
+        $constraintsByGroup = array();
 
+        array_walk($constraints, function($constraint) use (&$constraintsByGroup) {
+            foreach($constraint->groups as $group){
+                $constraintsByGroup[$group][] = $constraint;
+            }
+        });
+
+        $this->constraintsByGroup = $constraintsByGroup;
         return $this;
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/ValueMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ValueMetadata.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Mapping;
+
+class ValueMetadata extends ElementMetadata
+{
+/**
+ * Sets the constraint(s) for this value.
+ *
+ * @param array $constraints
+ */
+	public function setConstraints(array $constraints)
+    {
+		$this->constraints = $constraints;
+		$this->constraintsByGroup = array();
+		array_walk($constraints,function($constraint,$k,$self){
+            foreach($constraint->groups as $group){
+                $self->constraintsByGroup[$group][] = $constraint;
+            }
+        },$this);
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -107,7 +107,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $constraints = array(
             new Range(array('min' => 4)),
-            new NotNull(),
+            new NotNull(array('groups' => 'MyGroup')),
         );
 
         $array = array(
@@ -289,7 +289,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $constraints = array(
-            new NotNull(),
+            new NotNull(array('groups' => 'MyGroup')),
             new Range(array('min' => 4)),
         );
         $i = 1;
@@ -371,7 +371,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         );
 
         $constraints = array(
-            new NotNull(),
+            new NotNull(array('groups' => 'MyGroup')),
             new Range(array('min' => 4)),
         );
         $i = 1;
@@ -407,5 +407,32 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'foo' => 3
         ), (array) $value);
+    }
+
+    public function testWalkbyGroup()
+    {
+        $array = array(
+            'foo' => 2,
+        );
+
+        $constraints = array(
+            new Min(array('limit' => 5, 'groups' => 'MyGroup')),
+            new Min(array('limit' => 3, 'groups' => 'YourGroup')),
+        );
+
+        $this->walker->expects($this->once())
+            ->method('walkConstraint')
+            ->with($constraints[0], $array['foo'], 'MyGroup', 'foo.bar[foo]');
+
+        $this->context->expects($this->never())
+            ->method('addViolationAtSubPath');
+
+        $data = $this->prepareTestData($array);
+
+        $this->validator->validate($data, new Collection(array(
+            'fields' => array(
+                'foo' => $constraints,
+            )
+        )));
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: not sure
Symfony2 tests pass: no
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

This change to the Validator Collection Constraint allows for walking by group. Consider the following use case example for validating postal code lengths:

```
$array = array(
    'postal' => '123abc',
    //and a bunch of other properties
);

$collection = new Collection(array(
    'postal' => 
    array (new Size(array('min' => 6, 'max' => 6, 'groups' => array('can'))),
    new Size(array('min' => 5, 'max' => 5, 'groups' => array('fin','usa'))),
    ))); //and a bunch of other constraints

$validator->validateValue($array, $collection, array('Default','can'));
```

In the above code, the Collection constraint would walk all of the constraints for the field 'postal'. This has been changed so only the group(s) specified would be applied, which I beleive is how groups work when validating an object's properties. My concern is that some of the current Collection Constraint tests fail, since they use 'MyGroup' for the validation. The constraint within the test collection belongs to the 'Default' group and is not walked as the test intends. I'm not sure if this is the desired behavior, or if the tests can merely be changed to pass the desired group, as illustrated in the test case diff.
