### PR TITLE
Update src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
+++ b/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php
@@ -52,6 +52,8 @@ class TestSessionListener implements EventSubscriberInterface
         
         if ($cookies->has($session->getName())) {
             $session->setId($cookies->get($session->getName()));
+        } else {
+            $session->migrate(false);
         }
     }
 


### PR DESCRIPTION
Better patch for initialization/regeneration of id of already started session
