### PR TITLE
Avoid IntlDateFormatter::setLenient(false) to throw an exception

### DIFF
--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -416,12 +416,12 @@ class StubIntlDateFormatter
      *
      * @see    http://www.php.net/manual/en/intldateformatter.setlenient.php
      *
-     * @throws MethodNotImplementedException When $lenient is true
+     * @throws MethodArgumentValueNotImplementedException When $lenient is true
      */
     public function setLenient($lenient)
     {
         if ($lenient) {
-            throw new MethodNotImplementedException(__METHOD__);
+            throw new MethodArgumentValueNotImplementedException(__METHOD__, 'lenient', $lenient, 'Only the strict parser is supported');
         }
     }
 

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -416,11 +416,13 @@ class StubIntlDateFormatter
      *
      * @see    http://www.php.net/manual/en/intldateformatter.setlenient.php
      *
-     * @throws MethodNotImplementedException
+     * @throws MethodNotImplementedException When $lenient is true
      */
     public function setLenient($lenient)
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        if ($lenient) {
+            throw new MethodNotImplementedException(__METHOD__);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
@@ -906,7 +906,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Locale\Exception\MethodNotImplementedException
+     * @expectedException Symfony\Component\Locale\Exception\MethodArgumentValueNotImplementedException
      */
     public function testSetLenient()
     {


### PR DESCRIPTION
Right now it is breaking because the changes introduced here:

https://github.com/symfony/symfony/commit/f541844c781309b63d899f82525c93731c4c2fef
