### PR TITLE
getClientIp() will now only return valid IP addresses, rather than assuming the X_FORWARDED_FOR is the first comma seperated value.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -546,9 +546,16 @@ class Request
             if ($this->server->has('HTTP_CLIENT_IP')) {
                 return $this->server->get('HTTP_CLIENT_IP');
             } elseif ($this->server->has('HTTP_X_FORWARDED_FOR')) {
-                $clientIp = explode(',', $this->server->get('HTTP_X_FORWARDED_FOR'), 2);
+                $clientIp = explode(',', $this->server->get('HTTP_X_FORWARDED_FOR'));
 
-                return isset($clientIp[0]) ? trim($clientIp[0]) : '';
+                foreach ($clientIp as $ipAddress) {
+                    $cleanIpAddress = trim($ipAddress);
+
+                    if (false !== filter_var($cleanIpAddress, FILTER_VALIDATE_IP)) {
+                        return $cleanIpAddress;
+                    }
+                }
+                return '';
             }
         }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -552,7 +552,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
         $this->assertEquals('', $request->getClientIp());
-        $this->assertEquals('', $request->getClientIp(true));
 
         $server = array('REMOTE_ADDR' => $remoteAddr);
         if (null !== $httpClientIp) {
@@ -584,6 +583,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('2620:0:1cfe:face:b00c::3', true, '::1', '2620:0:1cfe:face:b00c::3', null),
             array('2620:0:1cfe:face:b00c::3', true, '::1', null, '2620:0:1cfe:face:b00c::3, ::1'),
             array('88.88.88.88', true, '123.45.67.89', null, '88.88.88.88, 87.65.43.21, 127.0.0.1'),
+            array('88.88.88.88', true, '123.45.67.89', null, 'unknown, 88.88.88.88'),
         );
     }
 


### PR DESCRIPTION
Fixes #4471

I'm not sure why an empty string was being returned in the first place, rather than null.  Any ideas?
