### PR TITLE
[Bridge][Form] Rename some deprecated methods

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -39,7 +39,7 @@ abstract class DoctrineType extends AbstractType
         if ($options['multiple']) {
             $builder
                 ->addEventSubscriber(new MergeDoctrineCollectionListener())
-                ->prependClientTransformer(new CollectionToArrayTransformer())
+                ->addViewTransformer(new CollectionToArrayTransformer())
             ;
         }
     }

--- a/src/Symfony/Bridge/Propel1/Form/Type/ModelType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/ModelType.php
@@ -28,7 +28,7 @@ class ModelType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if ($options['multiple']) {
-            $builder->prependClientTransformer(new CollectionToArrayTransformer());
+            $builder->addViewTransformer(new CollectionToArrayTransformer());
         }
     }
 


### PR DESCRIPTION
This pull request is for renaming some deprecated Form's methods from the Bridge namespace.
