### PR TITLE
[FrameworkBundle] Fix built-in server command for PHP > 5.4.1

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
@@ -18,12 +18,13 @@
  * and pass it as a value to 'router' option of server:run command.
  *
  * @author: Michał Pipa <michal.pipa.xsolve@gmail.com>
+ * @author: Albert Jessurum <ajessu@gmail.com>
  */
 
-if (isset($_SERVER['SCRIPT_FILENAME'])) {
+if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['REQUEST_URI'])) {
     return false;
 }
 
-$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'].DIRECTORY_SEPARATOR.'app_dev.php';
+$_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'app_dev.php';
 
 require 'app_dev.php';


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes

License of the code: MIT

The router isn't routing with PHP > 5.4.1, unless you explicitly include the name of the controller.

For the default command: `app/console server:run`

localhost:8000/app_dev.php `Works`
localhost:8000/ `Doesn't work (it used to work on PHP 5.4.0`)

There was a change after PHP 5.4.1 which makes the router from the built-in server command not work, when no resource is specified, as the variable `$_SERVER['SCRIPT_FILENAME']` passes the `isset` check.

Changelog: http://php.net/ChangeLog-5.php#5.4.1
- Implemented #60850 (Built in web server does not set $_SERVER['SCRIPT_FILENAME'] when using router)

The `router` used to rely on the `$_SERVER['SCRIPT_FILENAME']` being set, to return any asset/file if it existed.

This behavior was changed, so that when using PHP's built-in server, the `$_SERVER['SCRIPT_FILENAME']` is now populated with a combination of the document root and the router filename
Patch: https://bugs.php.net/patch-display.php?bug_id=60850&patch=add_router_script_file_name_svr_var&revision=latest)
