### PR TITLE
GH-4491 - Move patch from master to 2.0

### DIFF
--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -416,12 +416,12 @@ class StubIntlDateFormatter
      *
      * @see    http://www.php.net/manual/en/intldateformatter.setlenient.php
      *
-     * @throws MethodNotImplementedException When $lenient is true
+     * @throws MethodArgumentValueNotImplementedException When $lenient is true
      */
     public function setLenient($lenient)
     {
         if ($lenient) {
-            throw new MethodNotImplementedException(__METHOD__);
+            throw new MethodArgumentValueNotImplementedException(__METHOD__, 'lenient', $lenient, 'Only the strict parser is supported');
         }
     }
 

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -416,11 +416,13 @@ class StubIntlDateFormatter
      *
      * @see    http://www.php.net/manual/en/intldateformatter.setlenient.php
      *
-     * @throws MethodNotImplementedException
+     * @throws MethodNotImplementedException When $lenient is true
      */
     public function setLenient($lenient)
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        if ($lenient) {
+            throw new MethodNotImplementedException(__METHOD__);
+        }
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
@@ -908,7 +908,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Locale\Exception\MethodNotImplementedException
+     * @expectedException Symfony\Component\Locale\Exception\MethodArgumentValueNotImplementedException
      */
     public function testSetLenient()
     {


### PR DESCRIPTION
A patch in PR-4469 fixed an issue with setLenient() and not having intl. This was only merged into master, although the original issue was created in the 2.0 branch. This PR cherry-picked the patches against 2.0 again.
