### PR TITLE
[console] Removed hardcoded style formatter from style stack.

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -139,6 +139,14 @@ class OutputFormatter implements OutputFormatterInterface
     }
 
     /**
+     * @return OutputFormatterStyleStack
+     */
+    public function getStyleStack()
+    {
+        return $this->styleStack;
+    }
+
+    /**
      * Replaces style of the output.
      *
      * @param array $match

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -17,15 +17,23 @@ namespace Symfony\Component\Console\Formatter;
 class OutputFormatterStyleStack
 {
     /**
-     * @var OutputFormatterStyle[]
+     * @var OutputFormatterStyleInterface[]
      */
     private $styles;
 
     /**
-     * Constructor.
+     * @var OutputFormatterStyleInterface
      */
-    public function __construct()
+    private $emptyStyle;
+
+    /**
+     * Constructor.
+     *
+     * @param \Symfony\Component\Console\Formatter\OutputFormatterStyleInterface $emptyStyle
+     */
+    public function __construct(OutputFormatterStyleInterface $emptyStyle = null)
     {
+        $this->emptyStyle = $emptyStyle ?: new OutputFormatterStyle();
         $this->reset();
     }
 
@@ -59,7 +67,7 @@ class OutputFormatterStyleStack
     public function pop(OutputFormatterStyleInterface $style = null)
     {
         if (empty($this->styles)) {
-            return new OutputFormatterStyle();
+            return $this->emptyStyle;
         }
 
         if (null === $style) {
@@ -85,9 +93,29 @@ class OutputFormatterStyleStack
     public function getCurrent()
     {
         if (empty($this->styles)) {
-            return new OutputFormatterStyle();
+            return $this->emptyStyle;
         }
 
         return $this->styles[count($this->styles)-1];
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Formatter\OutputFormatterStyleInterface $emptyStyle
+     *
+     * @return \Symfony\Component\Console\Formatter\OutputFormatterStyleStack
+     */
+    public function setEmptyStyle(OutputFormatterStyleInterface $emptyStyle)
+    {
+        $this->emptyStyle = $emptyStyle;
+
+        return $this;
+    }
+
+    /**
+     * @return \Symfony\Component\Console\Formatter\OutputFormatterStyleInterface
+     */
+    public function getEmptyStyle()
+    {
+        return $this->emptyStyle;
     }
 }

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterStyleStack.php
@@ -29,7 +29,7 @@ class OutputFormatterStyleStack
     /**
      * Constructor.
      *
-     * @param \Symfony\Component\Console\Formatter\OutputFormatterStyleInterface $emptyStyle
+     * @param OutputFormatterStyleInterface $emptyStyle
      */
     public function __construct(OutputFormatterStyleInterface $emptyStyle = null)
     {
@@ -100,9 +100,9 @@ class OutputFormatterStyleStack
     }
 
     /**
-     * @param \Symfony\Component\Console\Formatter\OutputFormatterStyleInterface $emptyStyle
+     * @param OutputFormatterStyleInterface $emptyStyle
      *
-     * @return \Symfony\Component\Console\Formatter\OutputFormatterStyleStack
+     * @return OutputFormatterStyleStack
      */
     public function setEmptyStyle(OutputFormatterStyleInterface $emptyStyle)
     {
@@ -112,7 +112,7 @@ class OutputFormatterStyleStack
     }
 
     /**
-     * @return \Symfony\Component\Console\Formatter\OutputFormatterStyleInterface
+     * @return OutputFormatterStyleInterface
      */
     public function getEmptyStyle()
     {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

This PR make it possible to replace OutputFormatter again.
Fixes issue #4495.
