### PR TITLE
[browser kit] Client now stores filtered response after request.

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1028,6 +1028,14 @@
     decoded twice before. Note that the `urldecode()` calls have been changed for a
     single `rawurldecode()` in order to support `+` for input paths.
 
+### BrowserKit
+
+#### BC Breaks
+
+  * The Symfony\Component\HttpKernel\Client::request() method
+    now returns a Symfony\Component\BrowserKit\Response instance
+    (instead of a Symfony\Component\HttpFoundation\Response instance)
+
 ### FrameworkBundle
 
   * session options: lifetime, path, domain, secure, httponly were deprecated.

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -4,5 +4,9 @@ CHANGELOG
 2.1.0
 -----
 
+ * [BR BREAK] The Symfony\Component\HttpKernel\Client::request() method
+   now returns a Symfony\Component\BrowserKit\Response instance
+   (instead of a Symfony\Component\HttpFoundation\Response instance)
+
  * [BC BREAK] The CookieJar internals have changed to allow cookies with the
    same name on different sub-domains/sub-paths

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -264,17 +264,17 @@ abstract class Client
             $this->response = $this->doRequest($this->request);
         }
 
-        $response = $this->filterResponse($this->response);
+        $this->response = $this->filterResponse($this->response);
 
-        $this->cookieJar->updateFromResponse($response);
+        $this->cookieJar->updateFromResponse($this->response);
 
-        $this->redirect = $response->getHeader('Location');
+        $this->redirect = $this->response->getHeader('Location');
 
         if ($this->followRedirects && $this->redirect) {
             return $this->crawler = $this->followRedirect();
         }
 
-        return $this->crawler = $this->createCrawlerFromContent($request->getUri(), $response->getContent(), $response->getHeader('Content-Type'));
+        return $this->crawler = $this->createCrawlerFromContent($request->getUri(), $this->response->getContent(), $this->response->getHeader('Content-Type'));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/ClientTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests;
 
+use Symfony\Component\BrowserKit\Response as DomResponse;
 use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,6 +35,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client->request('GET', '/');
         $this->assertEquals('Request: /', $client->getResponse()->getContent(), '->doRequest() uses the request handler to make the request');
+        $this->assertTrue($client->getResponse() instanceof DomResponse, '->getResponse() returns a Symfony\Component\BrowserKit\Response instance');
 
         $client->request('GET', 'http://www.example.com/');
         $this->assertEquals('Request: /', $client->getResponse()->getContent(), '->doRequest() uses the request handler to make the request');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes/no, choice is your
Symfony2 tests pass: yes

`Symfony\Component\HttpKernel\Client::request()` method now returns a `Symfony\Component\BrowserKit\Response` instance.

Fixes issue #4475.
