### PR TITLE
[WIP] failing test for HEAD StreamedResponse requests

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -50,6 +50,14 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('no-cache, private', $response->headers->get('Cache-Control'));
     }
 
+    public function testPrepareWithHeadRequest()
+    {
+        $response = new StreamedResponse(function () { echo 'foo'; });
+        $request = Request::create('/', 'HEAD');
+
+        $response->prepare($request);
+    }
+
     public function testSendContent()
     {
         $called = 0;


### PR DESCRIPTION
An exception is thrown if you prepare a StreamedResponse with a HEAD request. I'm not sure what the right fix is…
