### PR TITLE
[HttpFoundation] Make JsonResponse HTML safe.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -82,7 +82,8 @@ class JsonResponse extends Response
             $data = new \ArrayObject();
         }
 
-        $this->data = json_encode($data);
+        // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
+        $this->data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
 
         return $this->update();
     }


### PR DESCRIPTION
After porting Drupal 8 to the HTTP Kernel, we noticed regressions on our JSON responses.

The original issue was http://drupal.org/node/479368. To summarize that:
- Doing the changes in this pull requests is backwarts compatible, because >>As RFC4627-2.5 clearly states that "Any character _may_ be escaped", we can avoid special treatment of characters ', ", <, > and & by an HTML parser through simple substitution with a Unicode escape sequence (\uXXXX).<<
- A number of characters MUST be escaped for the JSON parser. These are: ", \, U+0000 - U+001F

Since PHP 5.3 we can simply get RFC compliant safe JSON by passing a few flags to json_encode().

Current issue: http://drupal.org/node/1619446.
