### PR TITLE
[Form][Validator] Fixed generation of HTML5 pattern attribute based on Assert\Regex to remove delimiters.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -261,7 +261,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 return new ValueGuess(sprintf('.{%s,%s}', (string) $constraint->min, (string) $constraint->max), Guess::LOW_CONFIDENCE);
 
             case 'Symfony\Component\Validator\Constraints\Regex':
-                return new ValueGuess($constraint->pattern, Guess::HIGH_CONFIDENCE );
+                return new ValueGuess($constraint->getNonDelimitedPattern(), Guess::HIGH_CONFIDENCE );
 
             case 'Symfony\Component\Validator\Constraints\Min':
                 return new ValueGuess(sprintf('.{%s,}', strlen((string) $constraint->limit)), Guess::LOW_CONFIDENCE);

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -528,7 +528,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 ->method('guessPattern')
                 ->with('Application\Author', 'firstName')
                 ->will($this->returnValue(new ValueGuess(
-                    '/[a-z]/',
+                    '[a-z]',
                     Guess::MEDIUM_CONFIDENCE
                 )));
 
@@ -536,7 +536,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 ->method('guessPattern')
                 ->with('Application\Author', 'firstName')
                 ->will($this->returnValue(new ValueGuess(
-                    '/[a-zA-Z]/',
+                    '[a-zA-Z]',
                     Guess::HIGH_CONFIDENCE
                 )));
 
@@ -544,7 +544,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('pattern' => '/[a-zA-Z]/'))
+            ->with('firstName', 'text', null, array('pattern' => '[a-zA-Z]'))
             ->will($this->returnValue('builderInstance'));
 
         $builder = $factory->createBuilderForProperty(

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -43,7 +43,7 @@ class Regex extends Constraint
 
     /**
      * Sometimes, like when converting to HTML5 pattern attribute, the regex is needed without the delimiters
-     * Example: /[a-z]+/i would be converted to [a-z]+
+     * Example: /[a-z]+/ would be converted to [a-z]+
      * However, if options are specified, it cannot be converted and this will throw an Exception
      * @return string regex
      * @throws Symfony\Component\Validator\Exception\ConstraintDefinitionException

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @Annotation
@@ -38,5 +39,20 @@ class Regex extends Constraint
     public function getRequiredOptions()
     {
         return array('pattern');
+    }
+
+    /**
+     * Sometimes, like when converting to HTML5 pattern attribute, the regex is needed without the delimiters
+     * Example: /[a-z]+/i would be converted to [a-z]+
+     * However, if options are specified, it cannot be converted and this will throw an Exception
+     * @return string regex
+     * @throws Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function getNonDelimitedPattern() {
+        if (preg_match('/^(.)(.*)\1$/', $this->pattern, $matches)) {
+            return $matches[2];
+        } else {
+            throw new ConstraintDefinitionException("Cannot remove delimiters from pattern '{$this->pattern}'.");
+        }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -113,4 +113,21 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('pattern', $constraint->getDefaultOption());
     }
+
+    public function testNonDelimitedPattern() {
+        $constraint = new Regex(array(
+            'pattern' => '/^[0-9]+$/',
+        ));
+
+        $this->assertEquals('^[0-9]+$', $constraint->getNonDelimitedPattern());
+    }
+
+    public function testNonDelimitedPatternError() {
+        $constraint = new Regex(array(
+            'pattern' => '/^[0-9]+$/i',
+        ));
+
+        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $constraint->getNonDelimitedPattern();
+    }
 }


### PR DESCRIPTION
In Issue #3766, it was asked that Assert\Regex generates HTML5 pattern attribute. 
It was done in PR #4077, but the generated Regex is in delimited format which is not supported by HTML5.

Hence, `/[a-z]+/` would be converted to `[a-z]+`.
However, if options are specified like in `/[a-z]+/i`, it cannot be converted and this will throw an Exception. Developer will have to convert his Regex to `/[a-zA-Z]+/`

**Note**
<del>I haven’t been able to run PHPUnit, anyone is invited to test the code and the tests themselves. 
Sorry about that.</del> Tests were ran using [Travis](http://travis-ci.org/#!/lavoiesl/symfony/builds/1564242)
