### PR TITLE
Reset image styling for the web-profiler toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
@@ -17,6 +17,10 @@
         bottom: 0;
         border-top: 1px solid #bbb;
     }
+    .sf-toolbarreset img {
+        width: auto;
+        display: inline;
+    }
 
     .sf-toolbarreset .hide-button {
         display: block;


### PR DESCRIPTION
This fixes the issue #4516 by resetting image styling to browser defaults, which is what the toolbar expects.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: n/a
Fixes the following tickets: #4516
