### PR TITLE
[Form][Validator] Fixed generation of HTML5 pattern attribute based on Assert\Regex by removing delimiters or using a new option: html_pattern.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -261,7 +261,7 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 return new ValueGuess(sprintf('.{%s,%s}', (string) $constraint->min, (string) $constraint->max), Guess::LOW_CONFIDENCE);
 
             case 'Symfony\Component\Validator\Constraints\Regex':
-                return new ValueGuess($constraint->pattern, Guess::HIGH_CONFIDENCE );
+                return new ValueGuess($constraint->getNonDelimitedPattern(), Guess::HIGH_CONFIDENCE );
 
             case 'Symfony\Component\Validator\Constraints\Min':
                 return new ValueGuess(sprintf('.{%s,}', strlen((string) $constraint->limit)), Guess::LOW_CONFIDENCE);

--- a/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ValidatorTypeGuesser.php
@@ -261,7 +261,10 @@ class ValidatorTypeGuesser implements FormTypeGuesserInterface
                 return new ValueGuess(sprintf('.{%s,%s}', (string) $constraint->min, (string) $constraint->max), Guess::LOW_CONFIDENCE);
 
             case 'Symfony\Component\Validator\Constraints\Regex':
-                return new ValueGuess($constraint->getNonDelimitedPattern(), Guess::HIGH_CONFIDENCE );
+                $html_pattern = $constraint->getHtmlPattern();
+                return $html_pattern
+                    ? new ValueGuess($html_pattern, Guess::HIGH_CONFIDENCE)
+                    : null;
 
             case 'Symfony\Component\Validator\Constraints\Min':
                 return new ValueGuess(sprintf('.{%s,}', strlen((string) $constraint->limit)), Guess::LOW_CONFIDENCE);

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -528,7 +528,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 ->method('guessPattern')
                 ->with('Application\Author', 'firstName')
                 ->will($this->returnValue(new ValueGuess(
-                    '/[a-z]/',
+                    '[a-z]',
                     Guess::MEDIUM_CONFIDENCE
                 )));
 
@@ -536,7 +536,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
                 ->method('guessPattern')
                 ->with('Application\Author', 'firstName')
                 ->will($this->returnValue(new ValueGuess(
-                    '/[a-zA-Z]/',
+                    '[a-zA-Z]',
                     Guess::HIGH_CONFIDENCE
                 )));
 
@@ -544,7 +544,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory->expects($this->once())
             ->method('createNamedBuilder')
-            ->with('firstName', 'text', null, array('pattern' => '/[a-zA-Z]/'))
+            ->with('firstName', 'text', null, array('pattern' => '[a-zA-Z]'))
             ->will($this->returnValue('builderInstance'));
 
         $builder = $factory->createBuilderForProperty(

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -50,7 +50,10 @@ class Regex extends Constraint
      */
     public function getNonDelimitedPattern() {
         if (preg_match('/^(.)(.*)\1$/', $this->pattern, $matches)) {
-            return $matches[2];
+            $delimiter = $matches[1];
+            // Unescape the delimiter in pattern
+            $pattern = str_replace('\\' . $delimiter, $delimiter, $matches[2]);
+            return $pattern;
         } else {
             throw new ConstraintDefinitionException("Cannot remove delimiters from pattern '{$this->pattern}'.");
         }

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -23,7 +23,7 @@ class Regex extends Constraint
 {
     public $message = 'This value is not valid.';
     public $pattern;
-    public $html_pattern = null;
+    public $htmlPattern = null;
     public $match = true;
 
     /**
@@ -49,30 +49,36 @@ class Regex extends Constraint
      * @return string regex
      * @throws Symfony\Component\Validator\Exception\ConstraintDefinitionException
      */
-    public function getNonDelimitedPattern() {
+    public function getNonDelimitedPattern()
+    {
         if (preg_match('/^(.)(.*)\1$/', $this->pattern, $matches)) {
-            $delimiter = $matches[1];
+            list($delimiter, $pattern) = $matches;
+
             // Unescape the delimiter in pattern
-            $pattern = str_replace('\\' . $delimiter, $delimiter, $matches[2]);
-            return $pattern;
-        } else {
-            throw new ConstraintDefinitionException("Cannot remove delimiters from pattern '{$this->pattern}'.");
+            return str_replace('\\' . $delimiter, $delimiter, $pattern);
         }
+
+        throw new ConstraintDefinitionException("Cannot remove delimiters from pattern '{$this->pattern}'.");
     }
 
-    public function getHtmlPattern() {
-        // If html_pattern is specified, use it
-        if (!is_null($this->html_pattern)) {
-            return empty($this->html_pattern)
+    /**
+     * Returns htmlPattern if exists or pattern is convertible
+     * @return string regex
+     */
+    public function getHtmlPattern()
+    {
+        // If htmlPattern is specified, use it
+        if (null !== $this->htmlPattern) {
+            return empty($this->htmlPattern)
                 ? false
-                : $this->html_pattern;
-        } else {
-            try {
-                return $this->getNonDelimitedPattern();
-            } catch (ConstraintDefinitionException $e) {
-                // Pattern cannot be converted
-                return false;
-            }
+                : $this->htmlPattern;
+        }
+
+        try {
+            return $this->getNonDelimitedPattern();
+        } catch (ConstraintDefinitionException $e) {
+            // Pattern cannot be converted
+            return false;
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -43,7 +43,7 @@ class Regex extends Constraint
 
     /**
      * Sometimes, like when converting to HTML5 pattern attribute, the regex is needed without the delimiters
-     * Example: /[a-z]+/i would be converted to [a-z]+
+     * Example: /[a-z]+/ would be converted to [a-z]+
      * However, if options are specified, it cannot be converted and this will throw an Exception
      * @return string regex
      * @throws Symfony\Component\Validator\Exception\ConstraintDefinitionException

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 
 /**
  * @Annotation
@@ -38,5 +39,20 @@ class Regex extends Constraint
     public function getRequiredOptions()
     {
         return array('pattern');
+    }
+
+    /**
+     * Sometimes, like when converting to HTML5 pattern attribute, the regex is needed without the delimiters
+     * Example: /[a-z]+/i would be converted to [a-z]+
+     * However, if options are specified, it cannot be converted and this will throw an Exception
+     * @return string regex
+     * @throws Symfony\Component\Validator\Exception\ConstraintDefinitionException
+     */
+    public function getNonDelimitedPattern() {
+        if (preg_match('/^(.)(.*)\1$/', $this->pattern, $matches)) {
+            return $matches[2];
+        } else {
+            throw new ConstraintDefinitionException("Cannot remove delimiters from pattern '{$this->pattern}'.");
+        }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -23,6 +23,7 @@ class Regex extends Constraint
 {
     public $message = 'This value is not valid.';
     public $pattern;
+    public $html_pattern = null;
     public $match = true;
 
     /**
@@ -56,6 +57,22 @@ class Regex extends Constraint
             return $pattern;
         } else {
             throw new ConstraintDefinitionException("Cannot remove delimiters from pattern '{$this->pattern}'.");
+        }
+    }
+
+    public function getHtmlPattern() {
+        // If html_pattern is specified, use it
+        if (!is_null($this->html_pattern)) {
+            return empty($this->html_pattern)
+                ? false
+                : $this->html_pattern;
+        } else {
+            try {
+                return $this->getNonDelimitedPattern();
+            } catch (ConstraintDefinitionException $e) {
+                // Pattern cannot be converted
+                return false;
+            }
         }
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -144,4 +144,33 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
         $constraint->getNonDelimitedPattern();
     }
+
+    public function testHtmlPattern() {
+        // Specified html_pattern
+        $constraint = new Regex(array(
+            'pattern' => '/^[a-z]+$/i',
+            'html_pattern' => '^[a-zA-Z]+$',
+        ));
+        $this->assertEquals('^[a-zA-Z]+$', $constraint->getHtmlPattern());
+
+        // Disabled html_pattern
+        $constraint = new Regex(array(
+            'pattern' => '/^[a-z]+$/i',
+            'html_pattern' => false,
+        ));
+        $this->assertFalse($constraint->getHtmlPattern());
+
+        // Cannot be converted
+        $constraint = new Regex(array(
+            'pattern' => '/^[a-z]+$/i',
+        ));
+        $this->assertFalse($constraint->getHtmlPattern());
+
+        // Automaticaly converted
+        $constraint = new Regex(array(
+            'pattern' => '/^[a-z]+$/',
+        ));
+        $this->assertEquals('^[a-z]+$', $constraint->getHtmlPattern());
+    }
+
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -122,6 +122,20 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('^[0-9]+$', $constraint->getNonDelimitedPattern());
     }
 
+    public function testNonDelimitedPatternEscaping() {
+        $constraint = new Regex(array(
+            'pattern' => '/^[0-9]+\/$/',
+        ));
+
+        $this->assertEquals('^[0-9]+/$', $constraint->getNonDelimitedPattern());
+
+        $constraint = new Regex(array(
+            'pattern' => '#^[0-9]+\#$#',
+        ));
+
+        $this->assertEquals('^[0-9]+#$', $constraint->getNonDelimitedPattern());
+    }
+
     public function testNonDelimitedPatternError() {
         $constraint = new Regex(array(
             'pattern' => '/^[0-9]+$/i',

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -113,4 +113,21 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('pattern', $constraint->getDefaultOption());
     }
+
+    public function testNonDelimitedPattern() {
+        $constraint = new Regex(array(
+            'pattern' => '/^[0-9]+$/',
+        ));
+
+        $this->assertEquals('^[0-9]+$', $constraint->getNonDelimitedPattern());
+    }
+
+    public function testNonDelimitedPatternError() {
+        $constraint = new Regex(array(
+            'pattern' => '/^[0-9]+$/i',
+        ));
+
+        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+        $constraint->getNonDelimitedPattern();
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -114,7 +114,8 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('pattern', $constraint->getDefaultOption());
     }
 
-    public function testNonDelimitedPattern() {
+    public function testNonDelimitedPattern()
+    {
         $constraint = new Regex(array(
             'pattern' => '/^[0-9]+$/',
         ));
@@ -122,7 +123,8 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('^[0-9]+$', $constraint->getNonDelimitedPattern());
     }
 
-    public function testNonDelimitedPatternEscaping() {
+    public function testNonDelimitedPatternEscaping()
+    {
         $constraint = new Regex(array(
             'pattern' => '/^[0-9]+\/$/',
         ));
@@ -136,7 +138,8 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('^[0-9]+#$', $constraint->getNonDelimitedPattern());
     }
 
-    public function testNonDelimitedPatternError() {
+    public function testNonDelimitedPatternError()
+    {
         $constraint = new Regex(array(
             'pattern' => '/^[0-9]+$/i',
         ));
@@ -145,7 +148,8 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
         $constraint->getNonDelimitedPattern();
     }
 
-    public function testHtmlPattern() {
+    public function testHtmlPattern()
+    {
         // Specified html_pattern
         $constraint = new Regex(array(
             'pattern' => '/^[a-z]+$/i',


### PR DESCRIPTION
- Fixes: [#3766, #4077, #4513, #4520]
- Bug fix: yes
- Feature addition: yes
- BC break: no
- Symfony2 tests pass: yes

In Issue #3766, it was asked that Assert\Regex generates HTML5 pattern attribute. 
It was done in PR #4077, but the generated Regex is in delimited format which is not supported by HTML5.

Hence, `/[a-z]+/` would be converted to `[a-z]+`.
If flags are specified like in `/[a-z]+/i`, it cannot be converted and pattern validation will be disabled client-side. If is however now possible, using a new option, `html_pattern`, to specify the pattern you want to be used.

Example:

``` php
<?php
/**
 * @Assert\Regex(pattern="/^[0-9]+[a-z]*$/i", html_pattern="^[0-9]+[a-zA-Z]*$")
 */
private $civic_number;
```

**Note**: [Documentation](http://symfony.com/doc/current/reference/constraints/Regex.html) should be updated accordingly.
