### PR TITLE
[Security] Take `post_only` into consideration in requiresAuthentication

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -51,6 +51,18 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     }
 
     /**
+     * @{inheritdoc}
+     */
+    protected function requiresAuthentication(Request $request)
+    {
+        if ($this->options['post_only'] && !$request->isMethod('post')) {
+            return false;
+        }
+
+        return parent::requiresAuthentication($request);
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function attemptAuthentication(Request $request)


### PR DESCRIPTION
Change requiresAuthentication to look at the `post_only` option. Fixes #4524
