### PR TITLE
[2.2] [HttpFoundation] Add redis session storage

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/RedisSessionHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+/**
+ * RedisSessionHandler
+ *
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class RedisSessionHandler implements \SessionHandlerInterface
+{
+    /**
+     * @var \Redis
+     */
+    private $redis;
+
+    /**
+     * @var integer
+     */
+    private $lifetime;
+
+    /**
+     * Constructor
+     *
+     * @param \Redis $redis     The redis instance
+     * @param integer $lifetime Max lifetime in seconds to keep sessions stored.
+     */
+    public function __construct(\Redis $redis, $lifetime)
+    {
+        $this->redis = $redis;
+        $this->lifetime = $lifetime;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function open($savePath, $sessionName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function read($sessionId)
+    {
+        return (string) $this->redis->get($sessionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function write($sessionId, $data)
+    {
+        return $this->redis->setex($sessionId, $this->lifetime, $data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function destroy($sessionId)
+    {
+        return 1 === $this->redis->delete($sessionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function gc($lifetime)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -93,7 +93,7 @@ class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $this->handler->read('not-exist'));
     }
 
-    public function testDestory()
+    public function testDestroy()
     {
         $data = array(
             'foo' => 'bar'

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/RedisSessionHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler;
+
+/**
+ * RedisSessionHandlerTest
+ *
+ * @author Markus Bachmann <markus.bachmann@bachi.biz>
+ */
+class RedisSessionHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RedisSessionHandler
+     */
+    private $handler;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $redis;
+
+    public static function setUpBeforeClass()
+    {
+        if (!extension_loaded('redis')) {
+            self::markTestSkipped('The "redis" extension must be loaded');
+        }
+    }
+
+
+    protected function setup()
+    {
+        $this->redis = $this->getMockBuilder('Redis')->disableOriginalConstructor()->getMock();
+        $this->handler = new RedisSessionHandler($this->redis, 86400);
+    }
+
+    public function testOpen()
+    {
+        $this->assertTrue($this->handler->open('test', 'test'));
+    }
+
+    public function testClose()
+    {
+        $this->assertTrue($this->handler->close());
+    }
+
+    public function testGc()
+    {
+        $this->assertTrue($this->handler->gc(200));
+    }
+
+    public function testWrite()
+    {
+        $data = array();
+
+        $this->redis->expects($this->once())
+             ->method('setex')
+             ->will($this->returnCallback(function($key, $lifetime, $value) use (&$data) {
+                 $data[$key] = $value;
+                 return true;
+             }));
+
+        $this->handler->write('sessionid', 'foobar');
+
+        $this->assertArrayHasKey('sessionid', $data);
+        $this->assertEquals($data['sessionid'], 'foobar');
+    }
+
+    public function testRead()
+    {
+        $data = array(
+            'foo' => 'bar',
+        );
+
+        $this->redis->expects($this->any())
+             ->method('get')
+             ->will($this->returnCallback(function($key) use (&$data) {
+                 return isset($data[$key]) ? $data[$key] : false;
+             }));
+
+        $this->assertEquals('bar', $this->handler->read('foo'));
+        $this->assertEquals('', $this->handler->read('not-exist'));
+    }
+
+    public function testDestory()
+    {
+        $data = array(
+            'foo' => 'bar'
+        );
+
+        $this->redis->expects($this->any())
+             ->method('delete')
+             ->will($this->returnCallback(function($key) use (&$data) {
+                 if (!isset($data[$key])) {
+                     return false;
+                 }
+                 unset($data[$key]);
+                 return 1;
+             }));
+
+        $this->assertTrue($this->handler->destroy('foo'));
+        $this->assertArrayNotHasKey('foo', $data);
+
+        $this->assertFalse($this->handler->destroy('not-exist'));
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

This session storage use the [redis](https://github.com/nicolasff/phpredis) PHP extension.
