### PR TITLE
[HttpKernel] Automatically give the kernel to bundles

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -65,6 +65,11 @@
 
     After: `$request->getLocale()`
 
+### HttpKernel
+
+  * The methods `getKernel()` and `setKernel()` have been added to
+    `Symfony\Component\HttpKernel\Bundle\BundleInterface`.
+
 ### Security
 
   * `Symfony\Component\Security\Core\User\UserInterface::equals()` has moved to

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -16,6 +16,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Finder\Finder;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * An implementation of BundleInterface that adds a few conventions
@@ -30,6 +31,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
     protected $name;
     protected $reflected;
     protected $extension;
+    protected $kernel;
 
     /**
      * Boots the Bundle.
@@ -95,6 +97,16 @@ abstract class Bundle extends ContainerAware implements BundleInterface
         if ($this->extension) {
             return $this->extension;
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function getKernel()
+    {
+        return $this->kernel;
     }
 
     /**
@@ -190,5 +202,15 @@ abstract class Bundle extends ContainerAware implements BundleInterface
                 $application->add($r->newInstance());
             }
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function setKernel(KernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\Bundle;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
  * BundleInterface.
@@ -59,6 +60,15 @@ interface BundleInterface extends ContainerAwareInterface
     function getContainerExtension();
 
     /**
+     * Returns the kernel
+     *
+     * @return KernelInterface The current kernel
+     *
+     * @api
+     */
+    function getKernel();
+
+    /**
      * Returns the bundle parent name.
      *
      * @return string The Bundle parent name it overrides or null if no parent
@@ -95,4 +105,13 @@ interface BundleInterface extends ContainerAwareInterface
      * @api
      */
     function getPath();
+
+    /**
+     * Sets the kernel
+     *
+     * @param KernelInterface The kernel
+     *
+     * @api
+     */
+    function setKernel(KernelInterface $kernel);
 }

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -17,3 +17,5 @@ CHANGELOG
  * improved extensibility between bundles
  * added profiler storages for Memcache(d), File-based, MongoDB, Redis
  * moved Filesystem class to its own component
+ * [BC BREAK] The methods getKernel() and setKernel() have been added to BundleInterface
+ * automatically set the kernel on bundles before booting

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -491,6 +491,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 throw new \LogicException(sprintf('Trying to register two bundles with the same name "%s"', $name));
             }
             $this->bundles[$name] = $bundle;
+            $bundle->setKernel($this);
 
             if ($parentName = $bundle->getParent()) {
                 if (isset($directChildren[$parentName])) {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -93,6 +93,25 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $kernel->boot();
     }
 
+    public function testBootSetsTheKernelToTheBundles()
+    {
+        $bundle = $this->getMockBuilder('Symfony\Component\HttpKernel\Bundle\Bundle')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $bundle->expects($this->once())
+            ->method('setKernel');
+
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->disableOriginalConstructor()
+            ->setMethods(array('initializeContainer', 'registerBundles'))
+            ->getMock();
+        $kernel->expects($this->once())
+            ->method('registerBundles')
+            ->will($this->returnValue(array($bundle)));
+
+        $kernel->boot();
+    }
+
     public function testBootSetsTheBootedFlagToTrue()
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes (only for people reimplementing `BundleInterface` themselves)
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/jalliot/symfony.png?branch=bundles-kernel)](http://travis-ci.org/jalliot/symfony)
Fixes the following tickets: -
Todo: -

This PR makes the bundles Kernel-aware. That should allow to simplify some bundles' constructors (I'm thinking [JMSDiExtraBundle](https://github.com/schmittjoh/JMSDiExtraBundle/blob/master/JMSDiExtraBundle.php#L35) and [JMSSerializerBundle](https://github.com/schmittjoh/JMSSerializerBundle/blob/master/JMSSerializerBundle.php#L37) for instance).
This might also allow to create a composer installer for Symfony bundles (which would have it difficult with the 2 mentioned bundles...).

I think the BC break is not a big one (does someone reimplement `BundleInterface` instead of using the `Bundle` class as a parent?) but we can always create a new interface in order to keep BC if you want so.

/cc @schmittjoh @Seldaek
