### PR TITLE
[WIP][HttpFoundation][Session] Fixed detection of an active session

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -518,7 +518,7 @@ class Request
      */
     public function hasSession()
     {
-        return null !== $this->session;
+        return null !== $this->session && $this->session->isStarted();
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -131,6 +131,14 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function isStarted()
+    {
+        return $this->storage->isStarted();
+    }
+
+    /**
      * Returns an iterator for attributes.
      *
      * @return \ArrayIterator An \ArrayIterator instance

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -175,6 +175,15 @@ interface SessionInterface
     function clear();
 
     /**
+     * Check if a session was started
+     *
+     * @api
+     *
+     * @return boolean
+     */
+    public function isStarted();
+
+    /**
      * Registers a SessionBagInterface with the session.
      *
      * @param SessionBagInterface $bag

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockArraySessionStorage.php
@@ -200,6 +200,16 @@ class MockArraySessionStorage implements SessionStorageInterface
     }
 
     /**
+     * Check if the session was started or not
+     *
+     * @return boolean
+     */
+    public function isStarted()
+    {
+        return $this->started;
+    }
+
+    /**
      * Sets the MetadataBag.
      *
      * @param MetadataBag $bag

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -290,6 +290,16 @@ class NativeSessionStorage implements SessionStorageInterface
     }
 
     /**
+     * Check if the session was started or not
+     *
+     * @return boolean
+     */
+    public function isStarted()
+    {
+        return $this->started;
+    }
+
+    /**
      * Sets session.* ini variables.
      *
      * For convenience we omit 'session.' from the beginning of the keys.

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -884,6 +884,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($request->hasSession());
         $request->setSession(new Session(new MockArraySessionStorage()));
+        $request->getSession()->start();
         $this->assertTrue($request->hasSession());
     }
 
@@ -895,6 +896,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->cookies->set('MOCKSESSID', 'foo');
         $this->assertFalse($request->hasPreviousSession());
         $request->setSession(new Session(new MockArraySessionStorage()));
+        $request->getSession()->start();
         $this->assertTrue($request->hasPreviousSession());
     }
 

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/ContextListenerTest.php
@@ -85,6 +85,7 @@ class ContextListenerTest extends \PHPUnit_Framework_TestCase
     protected function runSessionOnKernelResponse($newToken, $original = null)
     {
         $session = new Session(new MockArraySessionStorage());
+        $session->start();
 
         if ($original !== null) {
             $session->set('_security_session', $original);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: not sure
Symfony2 tests pass: no
Fixes the following tickets: #4529
Todo: Fix failing tests
License of the code: MIT
Documentation PR: ~

This fixes the problem when the session variable inside $request now has always data in it as it's now more powerful but this introduces the problem that the old way of detecting if a session is started or not doesn't work anymore.
