### PR TITLE
[FrameworkBundle] Generate the class cache when warming up the cache

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -31,3 +31,5 @@ CHANGELOG
   `gc_probability`/`gc_divisor` chance of being run. The `gc_maxlifetime` defines
    how long a session can idle for. It is different from cookie lifetime which
    declares how long a cookie can be stored on the remote client.
+ * Commands cache:warmup and cache:clear (unless --no-warmup is specified) now
+   create the class cache.

--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheWarmupCommand.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
+use Symfony\Component\ClassLoader\ClassCollectionLoader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -56,6 +57,12 @@ EOF
             $warmer->enableOptionalWarmers();
         }
 
-        $warmer->warmUp($this->getContainer()->getParameter('kernel.cache_dir'));
+        $cacheDir = $this->getContainer()->getParameter('kernel.cache_dir');
+        $warmer->warmUp($cacheDir);
+
+        $classmap = $cacheDir.'/classes.map';
+        if (is_file($classmap)) {
+            ClassCollectionLoader::load(include($classmap), $cacheDir, 'classes', $kernel->isDebug(), false, '.php');
+        }
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/jalliot/symfony.png?branch=load-class-cache)](http://travis-ci.org/jalliot/symfony)
Fixes the following tickets: -
Todo: -

With this PR, the commands `cache:clear` (if `--no-warmup` hasn't been specified) and `cache:warmup` generate the class cache. Now the first page load after clearing the cache does not take over one second anymore :)
Of course, if someone does not want to use the class cache for whatever reason, he can always remove the `$kernel->loadClassCache()` in his front controller and the cache will just be ignored...

On a side note, can someone explain why [SensioDistributionBundle does not warmup the cache in the Composer post-install script](https://github.com/sensio/SensioDistributionBundle/blob/master/Composer/ScriptHandler.php#L48)?
