### PR TITLE
[Form] Add escape_label option

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -225,7 +225,13 @@
     {% if required %}
         {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
     {% endif %}
-    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
+    <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+        {%- if escape_label -%}
+            {{ label|trans({}, translation_domain) }}
+        {%- else -%}
+            {{ label|trans({}, translation_domain)|raw }}
+        {%- endif -%}
+    </label>
 {% endspaceless %}
 {% endblock form_label %}
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -1,3 +1,3 @@
 <?php if ($required) { $label_attr['class'] = trim((isset($label_attr['class']) ? $label_attr['class'] : '').' required'); } ?>
 <?php if (!$compound) { $label_attr['for'] = $id; } ?>
-<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>
+<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php if ($escape_label) ?><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?><?php else ?><?php echo $view['translator']->trans($label, array(), $translation_domain) ?><?php endif ?></label>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -1,3 +1,3 @@
 <?php if ($required) { $label_attr['class'] = trim((isset($label_attr['class']) ? $label_attr['class'] : '').' required'); } ?>
 <?php if (!$compound) { $label_attr['for'] = $id; } ?>
-<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php if ($escape_label) ?><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?><?php else ?><?php echo $view['translator']->trans($label, array(), $translation_domain) ?><?php endif ?></label>
+<label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo ($escape_label) ? $view->escape($view['translator']->trans($label, array(), $translation_domain)) : $view['translator']->trans($label, array(), $translation_domain) ?></label>

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -119,6 +119,7 @@ class FormType extends AbstractType
             'compound'           => $options['compound'],
             'types'              => $types,
             'translation_domain' => $translationDomain,
+            'escape_label'       => $options['escape_label'],
         ));
     }
 
@@ -195,11 +196,13 @@ class FormType extends AbstractType
             'virtual'            => false,
             'compound'           => true,
             'translation_domain' => null,
+            'escape_label'       => true,
         ));
 
         $resolver->setAllowedTypes(array(
-            'attr'       => 'array',
-            'label_attr' => 'array',
+            'attr'         => 'array',
+            'label_attr'   => 'array',
+            'escape_label' => 'bool',
         ));
     }
 

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -557,4 +557,31 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
 '
         );
     }
+
+    public function testEscapeLabel()
+    {
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('first', 'text', array(
+                'label'        => '<strong>Test</strong>',
+                'escape_label' => false,
+            ))
+            ->getForm();
+        $html = $this->renderRow($form->createView());
+
+        $this->assertMatchesXpath($html,
+'/div
+    [
+        ./label
+        /following-sibling::div
+            [
+                ./div[
+                    ./label[./strong[.="Test"]]
+                    /following-sibling::input
+                ]
+                /following-sibling::input
+            ]
+    ]
+'
+        );
+    }
 }

--- a/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractTableLayoutTest.php
@@ -341,4 +341,35 @@ abstract class AbstractTableLayoutTest extends AbstractLayoutTest
 '
         );
     }
+
+    public function testEscapeLabel()
+    {
+        $form = $this->factory->createNamedBuilder('name', 'form')
+            ->add('first', 'text', array(
+                'label'        => '<strong>Test</strong>',
+                'escape_label' => false,
+            ))
+            ->getForm();
+        $html = $this->renderRow($form->createView());
+
+        $this->assertMatchesXpath($html,
+'/tr
+    [
+        ./td[./label]
+        /following-sibling::td
+            [
+                ./table
+                    [
+                        ./tr
+                            [
+                                ./td[./label[./strong[.="Test"]]]
+                                /following-sibling::td[./input]
+                            ]
+                         /following-sibling::tr[./td[./input]]
+                    ]
+            ]
+    ]
+'
+        );
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: https://github.com/symfony/symfony-docs/pull/1442

---

This option simply tells Twig not to escape a form's label and is useful when wanting to use a HTML tag inside a label.

``` php
->add('acceptRules', 'checkbox', array(
    'property_path' => false,
    'label'         => '<strong>I accept <br />the rules</strong>',
    'escape_label'  => false,
));
```

It is set to false by default, and thus doesn't break BC.

_I'm aware that this option may lead to writing dirty code sometimes, but I believe the choice is up to the developer ; it can't hurt if one knows what he's doing. Besides, it'd save time when writing simple forms._
