### PR TITLE
[Form] addEventListener now accepts a string or an array

### DIFF
--- a/src/Symfony/Component/Form/FormConfig.php
+++ b/src/Symfony/Component/Form/FormConfig.php
@@ -149,9 +149,11 @@ class FormConfig implements FormConfigEditorInterface
     /**
      * {@inheritdoc}
      */
-    public function addEventListener($eventName, $listener, $priority = 0)
+    public function addEventListener($events, $listener, $priority = 0)
     {
-        $this->dispatcher->addListener($eventName, $listener, $priority);
+        foreach ((array) $events as $event) {
+            $this->dispatcher->addListener($event, $listener, $priority);
+        }
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigEditorInterface.php
+++ b/src/Symfony/Component/Form/FormConfigEditorInterface.php
@@ -21,15 +21,15 @@ interface FormConfigEditorInterface extends FormConfigInterface
     /**
      * Adds an event listener to an event on this form.
      *
-     * @param string   $eventName The name of the event to listen to.
-     * @param callable $listener  The listener to execute.
-     * @param integer  $priority  The priority of the listener. Listeners
-     *                            with a higher priority are called before
-     *                            listeners with a lower priority.
+     * @param string|array $events    The event(s) to listen to.
+     * @param callable     $listener  The listener to execute.
+     * @param integer      $priority  The priority of the listener. Listeners
+     *                                with a higher priority are called before
+     *                                listeners with a lower priority.
      *
      * @return self The configuration object.
      */
-    function addEventListener($eventName, $listener, $priority = 0);
+    function addEventListener($events, $listener, $priority = 0);
 
     /**
      * Adds an event subscriber for events on this form.


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/fixe/symfony.png?branch=form-event-listener)](http://travis-ci.org/fixe/symfony)
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
