### PR TITLE
[Form] Make bind() method bind while fields are being added

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -493,13 +493,17 @@ class Form implements \IteratorAggregate, FormInterface
                 }
             }
 
-            foreach ($viewData as $name => $value) {
-                if ($this->has($name)) {
-                    $this->children[$name]->bind($value);
-                } else {
-                    $extraData[$name] = $value;
+            $extraData = $viewData;
+            do {
+                $countBound = 0;
+                foreach ($extraData as $name => $value) {
+                    if ($this->has($name)) {
+                        $this->children[$name]->bind($value);
+                        unset($extraData[$name]);
+                        $countBound++;
+                    }
                 }
-            }
+            } while ($countBound > 0);
 
             // If we have a data mapper, use old view data and merge
             // data from the children into it later

--- a/src/Symfony/Component/Form/Tests/Fixtures/AuthorWithListenersType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AuthorWithListenersType.php
@@ -23,9 +23,6 @@ class AuthorWithListenersType extends AbstractType
         
         $basicListener = function(FormEvent $e) use ($factory) {
             $data = $e->getData();
-            if (null === $data) {
-                return;
-            }
             if ($data == 'Smith') {
                 $e->getForm()->getParent()->add($factory->createNamed('australian', 'checkbox'));
             }

--- a/src/Symfony/Component/Form/Tests/Fixtures/AuthorWithListenersType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AuthorWithListenersType.php
@@ -10,11 +10,9 @@ use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class AuthorWithListenersType extends AbstractType
 {
-    const 
-        POST_SET_DATA = 1,
-        POST_BIND = 2
-    ;
-    
+    const POST_SET_DATA = 1;
+    const POST_BIND = 2;
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $factory = $builder->getFormFactory();

--- a/src/Symfony/Component/Form/Tests/Fixtures/AuthorWithListenersType.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/AuthorWithListenersType.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class AuthorWithListenersType extends AbstractType
+{
+    const 
+        POST_SET_DATA = 1,
+        POST_BIND = 2
+    ;
+    
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $factory = $builder->getFormFactory();
+        
+        $builder->add('lastName');
+        
+        $basicListener = function(FormEvent $e) use ($factory) {
+            $data = $e->getData();
+            if (null === $data) {
+                return;
+            }
+            if ($data == 'Smith') {
+                $e->getForm()->getParent()->add($factory->createNamed('australian', 'checkbox'));
+            }
+        };
+        
+        switch($options['listener_set']) {
+            case self::POST_SET_DATA:
+                $builder->get('lastName')->addEventListener(FormEvents::POST_SET_DATA, $basicListener);
+                break;
+            case self::POST_BIND:
+                $builder->get('lastName')->addEventListener(FormEvents::POST_BIND, $basicListener);
+                break;
+        }
+    }
+
+    public function getName()
+    {
+        return 'author_with_listeners';
+    }
+
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
+            'listener_set' => self::POST_SET_DATA
+        ));
+        
+        $resolver->setAllowedValues(array(
+            'listener_set' => array(self::POST_SET_DATA, self::POST_BIND)
+        ));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/FormTest.php
+++ b/src/Symfony/Component/Form/Tests/FormTest.php
@@ -1298,6 +1298,27 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $form->setData('foo');
     }
 
+    public function testChildListenerCanAddFieldBasedOnOtherField()
+    {
+        $factory = new \Symfony\Component\Form\FormFactory(array(new \Symfony\Component\Form\Extension\Core\CoreExtension()));
+
+        $baseAuthor = new Fixtures\Author;
+        $baseAuthor->setLastName('Smith');
+
+        $form = $factory->createNamedBuilder('author', new Fixtures\AuthorWithListenersType(), clone $baseAuthor)->getForm();
+        $this->assertTrue($form->has('australian'));
+
+        $form = $factory->createNamedBuilder('author', new Fixtures\AuthorWithListenersType(), clone $baseAuthor, array('listener_set' => Fixtures\AuthorWithListenersType::POST_BIND))->getForm();
+        $form->bind(array('lastName' => 'Smith', 'australian' => 1));
+        $this->assertTrue($form->has('australian'));
+        $this->assertTrue($form->getData()->isAustralian());
+
+        $form = $factory->createNamedBuilder('author', new Fixtures\AuthorWithListenersType(), clone $baseAuthor, array('listener_set' => Fixtures\AuthorWithListenersType::POST_BIND))->getForm();
+        $form->bind(array('australian' => 1, 'lastName' => 'Smith'));
+        $this->assertTrue($form->has('australian'));
+        $this->assertTrue($form->getData()->isAustralian());
+    }
+
     protected function getBuilder($name = 'name', EventDispatcherInterface $dispatcher = null, $dataClass = null)
     {
         return new FormBuilder($name, $dataClass, $dispatcher ?: $this->dispatcher, $this->factory);


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3767
Todo: See Cons

This PR fixes #3767 and could probably replace #3768

The method used in this PR has it's pros and it's cons compared to #3768:

Pro:
- The listeners for both POST_SET_DATA and POST_BIND can now be identical, allowing for if's to be removed and possibly prevent code duplication
- No new event is necessary (as opposed to #3768) and other code updates are only minor

Con:
- It is no longer possible to update the view data in the event. Imagine the field 'australian' being removed by the POST_BIND listener, you'd want to remove 'australian' from the view data in order to prevent a "should not contain extra fields" error. This is the point that'd need work
- It's still possible to trigger an endless loop if one listener adds a field based on a value, and another adds it again. Perhaps a maximum of times the loop is run should be configured for these cases
