### PR TITLE
[Regression fix] Authorization header should only be rebuild when Basic Auth scheme is used

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -63,8 +63,8 @@ class ServerBag extends ParameterBag
                 $authorizationHeader = $this->parameters['REDIRECT_HTTP_AUTHORIZATION'];
             }
 
-            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW
-            if (null !== $authorizationHeader) {
+            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
+            if ((null !== $authorizationHeader) && ('basic' == strtolower(substr($authorizationHeader, 0, 5)))) {
                 $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
                 if (count($exploded) == 2) {
                     list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;

--- a/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ServerBagTest.php
@@ -88,4 +88,14 @@ class ServerBagTest extends \PHPUnit_Framework_TestCase
             'PHP_AUTH_PW' => ''
         ), $bag->getHeaders());
     }
+
+    public function testOAuthBearerAuth()
+    {
+        $headerContent = 'Bearer L-yLEOr9zhmUYRkzN1jwwxwQ-PBNiKDc8dgfB4hTfvo';
+        $bag = new ServerBag(array('HTTP_AUTHORIZATION' => $headerContent));
+
+        $this->assertEquals(array(
+            'AUTHORIZATION' => $headerContent,
+        ), $bag->getHeaders());
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: fixes regression introduced by #1813
Todo: N/A
License of the code: MIT
