### PR TITLE
[Form] form contains no children in PRE_SET_DATA and POST_SET_DATA events 

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -207,6 +207,8 @@ class FormBuilder extends FormConfig implements \IteratorAggregate, FormBuilderI
             $form->add($child->getForm());
         }
 
+        $form->setData($this->getData());
+
         return $form;
     }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: N/A
Todo: N/A
License of the code: MIT

When the Form constructor was refactored here 29963400e8d01a42ecd1e88339cd28c33d9ddb8d it changed when setData events are fired. They fire before the children are added in the builder here:
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/FormBuilder.php#L206.

This fix calls setData after the children are added so the setData events have access to the form children.
