### PR TITLE
Added failing YAML inline string to tests

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -115,6 +115,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             "'foo#bar'" => 'foo#bar',
             "'foo # bar'" => 'foo # bar',
             "'#cfcfcf'" => '#cfcfcf',
+            '::form_base.html.twig' => '::form_base.html.twig',
 
             '2007-10-30' => mktime(0, 0, 0, 10, 30, 2007),
             '2007-10-30T02:59:43Z' => gmmktime(2, 59, 43, 10, 30, 2007),


### PR DESCRIPTION
#4042 introduced a regression for yaml string parsing starting with a double colon (::). The below configuration syntax no longer works.

The addition to the tests generates a failure:

1) Symfony\Component\Yaml\Tests\InlineTest::testDump
Symfony\Component\Yaml\Exception\ParseException: Malformed inline YAML string ('::form_base.html.twig').

``` yaml
# Twig Configuration
twig:
    debug:            %kernel.debug%
    strict_variables: %kernel.debug%
    form:
        resources:
            - '::form_theme.html.twig'
            - 'InfiniteFormBundle::form_theme.html.twig'
```
