### PR TITLE
[2.2] [Routing] add escaping syntax for placeholders

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -312,6 +312,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->getGenerator($routes)->generate('test', array('page' => 'do.t', '_format' => 'html'));
     }
 
+    public function testEscapedVariable()
+    {
+        $routes = $this->getRoutes('test', new Route('/{foo}\{static}{bar}'));
+        $generator = $this->getGenerator($routes);
+
+        $this->assertSame('/app.php/foo%7Bstatic%7Dbar', $generator->generate('test', array('foo' => 'foo', 'bar' => 'bar')));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array(), $logger = null)
     {
         $context = new RequestContext('/app.php');

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -309,6 +309,15 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher->match('/do.t.html');
     }
 
+    public function testEscapedVariable()
+    {
+        $coll = new RouteCollection();
+        $coll->add('test', new Route('/{foo}\{static}{bar}'));
+        $matcher = new UrlMatcher($coll, new RequestContext());
+
+        $this->assertEquals(array('foo' => 'foo', 'bar' => 'bar', '_route' => 'test'), $matcher->match('/foo{static}bar'));
+    }
+
     /**
      * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
      */

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -130,6 +130,20 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             )),
 
             array(
+                'Route with escaped variable as static text',
+                array('/\{static}'),
+                '/{static}', '#^/\{static\}$#s', array(), array(
+                array('text', '/{static}'),
+            )),
+
+            array(
+                'Route with escaped variable and a "\" preceding it',
+                array('/\\\\{static}'), // i.e. two backslashes
+                '/\{static}', '#^/\\\\\\{static\}$#s', array(), array(
+                array('text', '/\{static}'),
+            )),
+
+            array(
                 'Route without separator between variables',
                 array('/{w}{x}{y}{z}.{_format}', array('z' => 'default-z', '_format' => 'html'), array('y' => '(y|Y)')),
                 '', '#^/(?<w>[^/\.]+)(?<x>[^/\.]+)(?<y>(y|Y))(?:(?<z>[^/\.]++)(?:\.(?<_format>[^/]++))?)?$#s', array('w', 'x', 'y', 'z', '_format'), array(
@@ -138,6 +152,17 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                 array('variable', '', '(y|Y)', 'y'),
                 array('variable', '', '[^/\.]+', 'x'),
                 array('variable', '/', '[^/\.]+', 'w'),
+            )),
+
+            array(
+                'Route without separator between variables + escaped variables',
+                array('/\{w}{x}\{z}{y}\\\\{z}.'),
+                '/{w}', '#^/\{w\}(?<x>[^/]+)\{z\}(?<y>[^/]+)\\\\\\{z\}\.$#s', array('x', 'y'), array(
+                array('text', '\{z}.'),
+                array('variable', '', '[^/]+', 'y'),
+                array('text', '{z}'),
+                array('variable', '', '[^/]+', 'x'),
+                array('text', '/{w}'),
             )),
 
             array(


### PR DESCRIPTION
Test pass: yes
Feature addition: yes
BC break: only if somebody used a route like `/\{var}` that is now used as escaping syntax

You can now have `{foo}` inside a route as static text instead of beeing considered as variable. This can be achieved by escaping it with "\" as suggested by @Seldaek, e.g. `\{foo}`. This is consistent as other languages use "\" as escaping char too, e.g. PHP itself and PCRE regular expressions.
