### PR TITLE
Add upgrade for UserPassword moving from Bundle to Component

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -143,6 +143,22 @@
   * `MutableAclInterface::setParentAcl` now accepts `null`, review any
     implementations of this interface to reflect this change.
 
+  * The `UserPassword` constraint has moved from the Security Bundle to the Security Component:
+    
+     Before:
+
+     ```
+     use Symfony\Bundle\SecurityBundle\Validator\Constraint\UserPassword;
+     use Symfony\Bundle\SecurityBundle\Validator\Constraint as SecurityAssert;
+     ```
+     
+     After:
+     
+     ```
+     use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
+     use Symfony\Component\Security\Core\Validator\Constraint as SecurityAssert;
+     ```
+
 ### Form
 
 #### BC Breaks in Form Types and Options


### PR DESCRIPTION
Just add some documentation in the Upgrade file about the `UserPassword` moving from Bundle to Component in commit 0995b1f28b80f91cfef7b3201840aa3dbcc66ae1.
