### PR TITLE
[FileSystem] remove symlinks under windows

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -94,12 +94,15 @@ class Filesystem
 
             if (is_dir($file) && !is_link($file)) {
                 $this->remove(new \FilesystemIterator($file));
-                rmdir($file);
-            } elseif(is_dir($file) && is_link($file)) {
-                // https://bugs.php.net/bug.php?id=52176 windows thinks symlinks are directories
+
                 rmdir($file);
             } else {
-                unlink($file);
+                // https://bugs.php.net/bug.php?id=52176
+                if (defined('PHP_WINDOWS_VERSION_MAJOR') && is_dir($file)) {
+                    rmdir($file);
+                } else {
+                    unlink($file);
+                }
             }
         }
     }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -94,7 +94,9 @@ class Filesystem
 
             if (is_dir($file) && !is_link($file)) {
                 $this->remove(new \FilesystemIterator($file));
-
+                rmdir($file);
+            } elseif(is_dir($file) && is_link($file)) {
+                // https://bugs.php.net/bug.php?id=52176 windows thinks symlinks are directories
                 rmdir($file);
             } else {
                 unlink($file);

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -421,6 +421,20 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_link($link));
         $this->assertEquals($file, readlink($link));
     }
+    
+    /**
+     * @depends testSymlink 
+     */
+    public function testRemoveSymlink()
+    {
+        $this->markAsSkippedIfSymlinkIsMissing();
+        
+        $link = $this->workspace.DIRECTORY_SEPARATOR.'link';
+        
+        $this->filesystem->remove($link);
+        
+        $this->assertTrue(!is_link($link));
+    }
 
     public function testSymlinkIsOverwrittenIfPointsToDifferentTarget()
     {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

When installing assets on Windows with symlink, the following error occurs when symlink-folders already exist. This PR makes sure symlink-folders are removed under Windows.

```
$ app/console assets:install web --symlink
Installing assets using the symlink option
Installing assets for Symfony\Bundle\FrameworkBundle into web/bundles/framework

  [ErrorException]
  Warning: symlink(): Cannot create symlink, error code(1314) in C:\path\vendor\symfony\symfony\src\Symfony\Component\Filesystem\Filesystem.php line 167

assets:install [--symlink] [--relative] target
```
