### PR TITLE
Changed the typehint in the LocaleListener

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\RequestContextAwareInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -26,7 +26,7 @@ class LocaleListener implements EventSubscriberInterface
     private $router;
     private $defaultLocale;
 
-    public function __construct($defaultLocale = 'en', RouterInterface $router = null)
+    public function __construct($defaultLocale = 'en', RequestContextAwareInterface $router = null)
     {
         $this->defaultLocale = $defaultLocale;
         $this->router = $router;


### PR DESCRIPTION
The listener does not depend on the RouterInterface but only on the
RequestContextAwareInterface which is also implemented by the matcher
and the generator. Changing the typehint allow reusing the listener
in Silex.
