### PR TITLE
[Form] added FormBuilderInterface in Tests namespace, so as to enable ea...

### DIFF
--- a/src/Symfony/Component/Form/Tests/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests;
+
+interface FormBuilderInterface extends \Iterator, \Symfony\Component\Form\FormBuilderInterface
+{
+}


### PR DESCRIPTION
...sy mocking

Adding a `FormBuilderInterface` in the `Tests` namespace, along same lines as `FormInterface` already there, for the purposes of being able to mock it straightforwardly (as `FormBuilderInterface` extends `\Traversable`, and therefore creating a mock in PHPUnit causes a fatal error that the mock `must implement interface Traversable as part of either Iterator or IteratorAggregate`).  Currently in the tests a `FormBuilder` object is used with a mock event dispatcher and form factory passed into the constructor, but this is long-winded to have to do in tests for code outside the framework.
