### PR TITLE
[WIP][Validator][Tests][Constraints] invalid value passed

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/ChoiceValidatorTest.php
@@ -163,7 +163,10 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ value }}' => 'baz',
             ), null, null);
 
-        $this->validator->validate('baz', $constraint);
+        $this->validator->validate($value = 'baz', $constraint);
+
+        Fixtures\TestViolationInteroperability::newInstance()
+            ->testViolation($constraint, new ChoiceValidator(), $value);
     }
 
     public function testInvalidChoiceMultiple()
@@ -198,7 +201,10 @@ class ChoiceValidatorTest extends \PHPUnit_Framework_TestCase
                 '{{ limit }}' => 2,
             ), null, 2);
 
-        $this->validator->validate(array('foo'), $constraint);
+        $this->validator->validate($value = array('foo'), $constraint);
+
+        Fixtures\TestViolationInteroperability::newInstance()
+            ->testViolation($constraint, new ChoiceValidator(), $value);
     }
 
     public function testTooManyChoices()

--- a/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/TestViolationInteroperability.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/Fixtures/TestViolationInteroperability.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints\Fixtures;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\GlobalExecutionContext;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ExecutionContext;
+
+class TestViolationInteroperability extends \PHPUnit_Framework_TestCase
+{
+
+    public static function newInstance(){
+        return new self();
+    }
+
+    public function testViolation(Constraint $constraint, ConstraintValidator $validator, $value){
+        $walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
+        $metadataFactory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
+        $globalContext = new GlobalExecutionContext('Root', $walker, $metadataFactory);
+        $context = new ExecutionContext($globalContext, $value, 'foo.bar', 'Group', 'ClassName', 'propertyName');
+        $validator->initialize($context);
+        $validator->validate($value, $constraint);
+        $foo = $context->getViolations();
+        $this->assertNotEmpty($foo->count(), 'The violation count should not be empty.');
+        $this->assertEquals($value, $foo[0]->getInvalidValue());
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
@@ -14,13 +14,6 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\MaxLength;
 use Symfony\Component\Validator\Constraints\MaxLengthValidator;
 
-//for "real" validation context
-
-use Symfony\Component\Validator\GlobalExecutionContext;
-use Symfony\Component\Validator\ConstraintViolation;
-use Symfony\Component\Validator\ConstraintViolationList;
-use Symfony\Component\Validator\ExecutionContext;
-
 class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $context;
@@ -31,13 +24,6 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new MaxLengthValidator();
         $this->validator->initialize($this->context);
-        //added for "real" test
-        $this->walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
-        $this->metadataFactory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
-        $this->globalContext = new GlobalExecutionContext('Root', $this->walker, $this->metadataFactory);
-        $this->real_context = new ExecutionContext($this->globalContext, 'currentValue', 'foo.bar', 'Group', 'ClassName', 'propertyName');
-        $this->real_validator = new MaxLengthValidator();
-        $this->real_validator->initialize($this->real_context);
     }
 
     protected function tearDown()
@@ -86,15 +72,6 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($value, $constraint);
     }
 
-    public function testInvalidValuePassedtoViolationList()
-    {
-        $constraint = new MaxLength(array('limit' => 3));
-        $this->real_validator->validate($value = '1234', $constraint);
-        $foo = $this->real_context->getViolations();
-        $this->assertNotEmpty($foo->count(), 'The violation count should not be empty.');
-        $this->assertEquals($value, $foo[0]->getInvalidValue()); 
-    }
-
     public function getValidValues()
     {
         return array(
@@ -127,6 +104,9 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
             ), null, 5);
 
         $this->validator->validate($value, $constraint);
+
+        Fixtures\TestViolationInteroperability::newInstance()
+            ->testViolation($constraint, new MaxLengthValidator(), $value);
     }
 
     public function getInvalidValues()

--- a/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/MaxLengthValidatorTest.php
@@ -14,6 +14,13 @@ namespace Symfony\Component\Validator\Tests\Constraints;
 use Symfony\Component\Validator\Constraints\MaxLength;
 use Symfony\Component\Validator\Constraints\MaxLengthValidator;
 
+//for "real" validation context
+
+use Symfony\Component\Validator\GlobalExecutionContext;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ExecutionContext;
+
 class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $context;
@@ -24,6 +31,13 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
         $this->validator = new MaxLengthValidator();
         $this->validator->initialize($this->context);
+        //added for "real" test
+        $this->walker = $this->getMock('Symfony\Component\Validator\GraphWalker', array(), array(), '', false);
+        $this->metadataFactory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
+        $this->globalContext = new GlobalExecutionContext('Root', $this->walker, $this->metadataFactory);
+        $this->real_context = new ExecutionContext($this->globalContext, 'currentValue', 'foo.bar', 'Group', 'ClassName', 'propertyName');
+        $this->real_validator = new MaxLengthValidator();
+        $this->real_validator->initialize($this->real_context);
     }
 
     protected function tearDown()
@@ -70,6 +84,15 @@ class MaxLengthValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new MaxLength(array('limit' => 5));
         $this->validator->validate($value, $constraint);
+    }
+
+    public function testInvalidValuePassedtoViolationList()
+    {
+        $constraint = new MaxLength(array('limit' => 3));
+        $this->real_validator->validate($value = '1234', $constraint);
+        $foo = $this->real_context->getViolations();
+        $this->assertNotEmpty($foo->count(), 'The violation count should not be empty.');
+        $this->assertEquals($value, $foo[0]->getInvalidValue()); 
     }
 
     public function getValidValues()


### PR DESCRIPTION
Bug fix: not sure
Feature addition: no
Backwards compatibility break: not sure
Symfony2 tests pass: no
Fixes the following tickets: 4398
Todo: -
License of the code: MIT
Documentation PR: -

This is regarding the proposed bug for an invalid value of a given constraint (Max Length) not being passed to the constraint violation object (similar code can be found in other constraints as well). At first glance, it did seem that the original value would not being passed to the violation object as documented. We set up a quick test, to verify this - and it does fail. The constraint violation object does contain null, instead of the passed property value. If this is not desired behavior, fixing the constraint would be rather trivial. However, I'd propose making a TestExecutionContext object of the "real execution context" illustrated in the constraint test diff, so that future and existing constraints could be more finely tested.
