### PR TITLE
Dynamic field

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
@@ -24,7 +24,8 @@ class DynamicFormField extends FormField
     /**
      * Constructor.
      *
-     * @param \DOMNode $node The node associated with this field
+     * @param string  $node     The node associated with this field
+     * @param boolean $disabled The flag to indicate whether or not the field is disabled
      */
     public function __construct($name, $disabled = false)
     {

--- a/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
@@ -26,7 +26,7 @@ class DynamicFormField extends FormField
     /**
      * Constructor.
      *
-     * @param string  $node     The node associated with this field
+     * @param string  $name     The name of this field
      * @param boolean $disabled The flag to indicate whether or not the field is disabled
      */
     public function __construct($name, $disabled = false)

--- a/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DomCrawler\Field;
+
+/**
+ * DynamicFormField is ta form field only used when the element may be created
+ * dynamically or the existence of the element may not be visible on the initial
+ * rendering but possibly valid as defined by the form type, form model or a
+ * database entity.
+ *
+ * @author Juti Noppornpitak <jnopporn@shiroyuki.com>
+ */
+class DynamicFormField extends FormField
+{
+    /**
+     * Constructor.
+     *
+     * @param \DOMNode $node The node associated with this field
+     */
+    public function __construct($name, $disabled = false)
+    {
+        $this->name     = $name;
+        $this->disabled = $disabled;
+    }
+
+    /**
+     * Returns true if the field should be included in the submitted values.
+     *
+     * @return Boolean true if the field should be included in the submitted values, false otherwise
+     */
+    public function hasValue()
+    {
+        return empty($this->value);
+    }
+
+    /**
+     * Check if the current field is disabled
+     *
+     * @return Boolean
+     */
+    public function isDisabled()
+    {
+        return $this->disabled;
+    }
+
+    /**
+     * Initializes the form field.
+     */
+    protected function initialize()
+    {
+        // Do nothing.
+    }
+}

--- a/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/DynamicFormField.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\DomCrawler\Field;
 
 /**
- * DynamicFormField is ta form field only used when the element may be created
+ * DynamicFormField represents a generic form field used to store the data from a dynamic form.
+ *
+ * This type of forms is only used in the situation that the element may be created
  * dynamically or the existence of the element may not be visible on the initial
  * rendering but possibly valid as defined by the form type, form model or a
  * database entity.

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DomCrawler;
 
 use Symfony\Component\DomCrawler\Field\FormField;
+use Symfony\Component\DomCrawler\Field\DynamicFormField;
 
 /**
  * Form represents an HTML form.
@@ -397,14 +398,10 @@ class Form extends Link implements \ArrayAccess
     }
 }
 
-/**
- * @author Juti Noppornpitak <jnopporn@shiroyuki.com>
- */
 class FormFieldRegistry
 {
     /**
      * @var boolean the flag to allow the registry to dynamically generate form fields even if any of them do not exists
-     *
      */
     private $enableDynamicField = false;
 
@@ -472,17 +469,17 @@ class FormFieldRegistry
     public function &get($name)
     {
         $segments = $this->getSegments($name);
-        $target   =& $this->fields;
+        $target =& $this->fields;
 
         while ($segments) {
             $path = array_shift($segments);
 
             if (!array_key_exists($path, $target)) {
-                if ( ! $this->enableDynamicField) {
+                if (!$this->enableDynamicField) {
                     throw new \InvalidArgumentException(sprintf('Unreachable field "%s"', $path));
                 }
 
-                $target[$path] = sizeof($segments) ? array() : new Field\DynamicFormField($path);
+                $target[$path] = count($segments) ? array() : new DynamicFormField($path);
             }
 
             $target =& $target[$path];

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -482,7 +482,7 @@ class FormFieldRegistry
                     throw new \InvalidArgumentException(sprintf('Unreachable field "%s"', $path));
                 }
 
-                $target[$path] = sizeof($segments) ?: array();
+                $target[$path] = sizeof($segments) ? array() : new Field\DynamicFormField($path);
             }
 
             $target =& $target[$path];

--- a/src/Symfony/Component/DomCrawler/Tests/FormTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/FormTest.php
@@ -535,9 +535,16 @@ class FormTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testFormFieldRegistryGetThrowAnExceptionWhenTheFieldDoesNotExist()
+    public function testFormFieldRegistryGetThrowAnExceptionWhenTheFieldDoesNotExistWithoutDynamicField()
     {
         $registry = new FormFieldRegistry();
+        $registry->get('foo');
+    }
+
+    public function testFormFieldRegistryGetDoesNotThrowAnExceptionWhenTheFieldDoesNotExistWithDynamicField()
+    {
+        $registry = new FormFieldRegistry();
+        $registry->enableDynamicField(true);
         $registry->get('foo');
     }
 


### PR DESCRIPTION
This PR is to address when in the following scenario.

Supposed the following `Post` class is a part of a blog software which can freely add or remove tags.

``` php
// A sample code with all annotations omitted and coding standard ignored
// Suppose that we have Tag.
class Post {
  // Omit unrelated to the illustration.

  /* @var ArrayCollection a collection of Tag */
  protected $tags;
}
```

Then, suppose we have a form type for it.

Now as there is a case that a post might not have tags when the form is first rendered, there are no input fields for tags. In this case, when we write the functional test for the controller using this form type, if we want to simulate the case that JavaScript dynamically generates form fields to handle new tags, then the `DomCrawler\Form` will always throw an exception as it cannot find the form fields for the new tags or any tags that aren't rendered by PHP.

Hence, in order to allow developers to test, the PR will allow the form to dynamically generate form fields if any of them is submitted if needed by calling `$form->enableDynamicField(true)` to enable this feature or `$form->enableDynamicField(false)` to disable it (where `$form` is an instance of type `Symfony\Component\DomCrawler\Form`). 
