### PR TITLE
Use statements

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -15,9 +15,6 @@ use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\DomCrawler\Link;
 use Symfony\Component\DomCrawler\Form;
 use Symfony\Component\Process\PhpProcess;
-use Symfony\Component\BrowserKit\Request;
-use Symfony\Component\BrowserKit\Response;
-use Symfony\Component\BrowserKit\Client;
 
 /**
  * Client simulates a browser.

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 abstract class BaseDateTimeTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -76,7 +76,7 @@ class Form implements \IteratorAggregate, FormInterface
 
     /**
      * The mapper for mapping data to children and back
-     * @var DataMapper\DataMapperInterface
+     * @var DataMapperInterface
      */
     private $dataMapper;
 

--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -56,8 +56,8 @@ class ServerBag extends ParameterBag
                 $authorizationHeader = $this->parameters['REDIRECT_HTTP_AUTHORIZATION'];
             }
 
-            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW
-            if (null !== $authorizationHeader) {
+            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
+            if ((null !== $authorizationHeader) && (0 === stripos($authorizationHeader, 'basic'))) {
                 $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
                 if (count($exploded) == 2) {
                     list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;

--- a/tests/Symfony/Tests/Component/HttpFoundation/ServerBagTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ServerBagTest.php
@@ -88,4 +88,14 @@ class ServerBagTest extends \PHPUnit_Framework_TestCase
             'PHP_AUTH_PW' => ''
         ), $bag->getHeaders());
     }
+
+    public function testOAuthBearerAuth()
+    {
+        $headerContent = 'Bearer L-yLEOr9zhmUYRkzN1jwwxwQ-PBNiKDc8dgfB4hTfvo';
+        $bag = new ServerBag(array('HTTP_AUTHORIZATION' => $headerContent));
+
+        $this->assertEquals(array(
+            'AUTHORIZATION' => $headerContent,
+        ), $bag->getHeaders());
+    }
 }


### PR DESCRIPTION
This adds a missing use statements in the Form component (which would cause a fatal error if the exception was thrown) and removes useless use statements in the BrowserKit component (the use statement for the current class confuses the IDEs)
