### PR TITLE
[Routing] RequestMatcherInterface doesn't need context

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -89,6 +89,7 @@
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="router" />
+            <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
         </service>
     </services>

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -36,12 +36,19 @@ class RouterListener implements EventSubscriberInterface
     private $context;
     private $logger;
 
+    /**
+     * Constructor.
+     *
+     * @param UrlMatcherInterface|RequestMatcherInterface $matcher The Url or Request matcher
+     * @param RequestContext|null                         $context The RequestContext (can be null when $matcher implements RequestContextAwareInterface)
+     * @param LoggerInterface|null                        $logger  The logger
+     */
     public function __construct($matcher, RequestContext $context = null, LoggerInterface $logger = null)
     {
         if (!$matcher instanceof UrlMatcherInterface && !$matcher instanceof RequestMatcherInterface) {
             throw new \InvalidArgumentException('Matcher must either implement UrlMatcherInterface or RequestMatcherInterface.');
         }
-        
+
         if (null === $context && !$matcher instanceof RequestContextAwareInterface) {
             throw new \InvalidArgumentException('You must either pass a RequestContext or the matcher must implement RequestContextAwareInterface.');
         }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -92,18 +92,13 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('http://localhost/');
         $event = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
 
-        $context = new RequestContext();
-
         $requestMatcher = $this->getMock('Symfony\Component\Routing\Matcher\RequestMatcherInterface');
-        $requestMatcher->expects($this->any())
-                       ->method('getContext')
-                       ->will($this->returnValue($context));
         $requestMatcher->expects($this->once())
                        ->method('matchRequest')
                        ->with($this->isInstanceOf('Symfony\Component\HttpFoundation\Request'))
                        ->will($this->returnValue(array()));
 
-        $listener = new RouterListener($requestMatcher);
+        $listener = new RouterListener($requestMatcher, new RequestContext());
         $listener->onKernelRequest($event);
     }
 }

--- a/src/Symfony/Component/Routing/Matcher/RequestMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/RequestMatcherInterface.php
@@ -17,7 +17,7 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 /**
- * UrlMatcherInterface is the interface that all URL matcher classes must implement.
+ * RequestMatcherInterface is the interface that all request matcher classes must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Component/Routing/Matcher/RequestMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/RequestMatcherInterface.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Routing\Matcher;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RequestContextAwareInterface;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
@@ -21,7 +20,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface RequestMatcherInterface extends RequestContextAwareInterface
+interface RequestMatcherInterface
 {
     /**
      * Tries to match a request with a set of routes.

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 interface UrlMatcherInterface extends RequestContextAwareInterface
 {
     /**
-     * Tries to match a URL with a set of routes.
+     * Tries to match a URL path with a set of routes.
      *
      * If the matcher can not find information, it must throw one of the exceptions documented
      * below.


### PR DESCRIPTION
Matchers that implement RequestMatcherInterface should match a Request, thus they don't need the request context.
