### PR TITLE
LogoutSuccessHandler can now return null

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -95,13 +95,12 @@ class LogoutListener implements ListenerInterface
             }
         }
 
+        $response = null;
         if (null !== $this->successHandler) {
             $response = $this->successHandler->onLogoutSuccess($request);
+        }
 
-            if (!$response instanceof Response) {
-                throw new \RuntimeException('Logout Success Handler did not return a Response.');
-            }
-        } else {
+        if (null === $response) {
             $response = $this->httpUtils->createRedirectResponse($request, $this->options['target_url']);
         }
 

--- a/src/Symfony/Component/Security/Http/Logout/LogoutSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Logout/LogoutSuccessHandlerInterface.php
@@ -31,7 +31,7 @@ interface LogoutSuccessHandlerInterface
      *
      * @param Request $request
      *
-     * @return Response never null
+     * @return Response|null
      */
     function onLogoutSuccess(Request $request);
 }

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/LogoutListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/LogoutListenerTest.php
@@ -139,9 +139,6 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
         $listener->handle($event);
     }
 
-    /**
-     * @expectedException RuntimeException
-     */
     public function testSuccessHandlerReturnsNonResponse()
     {
         $successHandler = $this->getSuccessHandler();
@@ -154,6 +151,11 @@ class LogoutListenerTest extends \PHPUnit_Framework_TestCase
             ->method('checkRequestPath')
             ->with($request, $options['logout_path'])
             ->will($this->returnValue(true));
+
+        $httpUtils->expects($this->once())
+            ->method('createRedirectResponse')
+            ->with($request, $options['target_url'])
+            ->will($this->returnValue($response = new Response()));
 
         $successHandler->expects($this->once())
             ->method('onLogoutSuccess')


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

It's not required to return a Response from LogoutSuccessHandler anymore.
If null returned, continue with the default behavior.
