### PR TITLE
Add regexp support in HttpFoundation\Response::isRedirect()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1100,7 +1100,19 @@ class Response
      */
     public function isRedirect($location = null)
     {
-        return in_array($this->statusCode, array(201, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
+        if (!in_array($this->statusCode, array(201, 301, 302, 303, 307, 308))) {
+            return false;
+        }
+
+        if (null === $location) {
+            return true;
+        }
+
+        if (!is_string($location) && is_callable($location)) {
+            return (Boolean) call_user_func($location, $this->headers->get('Location'));
+        }
+
+        return $location == $this->headers->get('Location');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -399,6 +399,18 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = new Response('', 301, array('Location' => '/good-uri'));
         $this->assertFalse($response->isRedirect('/bad-uri'));
         $this->assertTrue($response->isRedirect('/good-uri'));
+
+        $response = new Response('', 301, array('Location' => '/a-uri/another-uri'));
+        $this->assertTrue($response->isRedirect(array($this, 'isRedirectCallback')));
+        $this->assertTrue($response->isRedirect(function($location) { return preg_match('/^\/a-uri\//', $location); }));
+    }
+
+    /**
+     * Callback used to test HttpFoundation\Response::isRedirect() few lines above
+     */
+    public function isRedirectCallback($location)
+    {
+        return preg_match('/^\/a-uri\//', $location);
     }
 
     public function testIsNotFound()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: Move `isRegex()` to a more suitable place
License of the code: MIT
Documentation PR: https://github.com/symfony/symfony-docs/pull/1465

---

We can now pass a regular expression to `isRedirect()` instead of a simple string. Example: 

```
if ($response->isRedirect('/\/login$/'))
```

There's one more thing to do though: move the `isRegex()` method, which I did copy from the finder's [MultiplePcreFilterIterator](https://github.com/symfony/Finder/blob/master/Iterator/MultiplePcreFilterIterator.php#L47), to a better (more _global_?) place. 
I think neither where I put it nor where it is right now are suitable places, because that method isn't related to the Finder or the HttpFoundation components only. 

Where do you suggest to move it?
