### PR TITLE
Make sure kernel class exists before using it

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -131,7 +131,7 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
         require_once $file;
 
         if (!class_exists ($class)) {
-            throw new \RuntimeException (sprintf('Your kernel class %s does not exist in %s.  Name sure you did not specify a namespace', $class, $file));
+            throw new \RuntimeException (sprintf('Your kernel class %s does not exist in %s.  Make sure you did not specify a namespace', $class, $file));
         }
 
         return $class;

--- a/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Test/WebTestCase.php
@@ -130,6 +130,10 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
 
         require_once $file;
 
+        if (!class_exists ($class)) {
+            throw new \RuntimeException (sprintf('Your kernel class %s does not exist in %s.  Name sure you did not specify a namespace', $class, $file));
+        }
+
         return $class;
     }
 


### PR DESCRIPTION
Currently, there are checks to make sure the kernel file exists, but it assumes that the class exists within the file.  If someone accidentally specifies a namespace, or incorrectly names the class then some errors occur which look like autoloading issues.

This fix makes sure that the class exists before allowing the system to continue.
