### PR TITLE
[Routing] move strict_parameters implementation from UrlGenerator to Router

### DIFF
--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -49,7 +49,6 @@ class PhpGeneratorDumper extends GeneratorDumper
 
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 /**
  * {$options['class']}
@@ -64,10 +63,9 @@ class {$options['class']} extends {$options['base_class']}
     /**
      * Constructor.
      */
-    public function __construct(RequestContext \$context, LoggerInterface \$logger = null)
+    public function __construct(RequestContext \$context)
     {
         \$this->context = \$context;
-        \$this->logger = \$logger;
     }
 
 {$this->generateGenerateMethod()}

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -165,25 +165,6 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->getGenerator($routes)->generate('test', array('foo' => 'bar'), true);
     }
 
-    public function testGenerateForRouteWithInvalidOptionalParameterNonStrict()
-    {
-        $routes = $this->getRoutes('test', new Route('/testing/{foo}', array('foo' => '1'), array('foo' => 'd+')));
-        $generator = $this->getGenerator($routes);
-        $generator->setStrictParameters(false);
-        $this->assertNull($generator->generate('test', array('foo' => 'bar'), true));
-    }
-
-    public function testGenerateForRouteWithInvalidOptionalParameterNonStrictWithLogger()
-    {
-        $routes = $this->getRoutes('test', new Route('/testing/{foo}', array('foo' => '1'), array('foo' => 'd+')));
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
-        $logger->expects($this->once())
-            ->method('err');
-        $generator = $this->getGenerator($routes, array(), $logger);
-        $generator->setStrictParameters(false);
-        $this->assertNull($generator->generate('test', array('foo' => 'bar'), true));
-    }
-
     /**
      * @expectedException Symfony\Component\Routing\Exception\InvalidParameterException
      */


### PR DESCRIPTION
I think the UrlGenerator shouldn't be responsible to deal with this option.
The router as an integration example of the routing pieces (caching, options etc.) should handle this option directly as it also defined there. It also removes the need of a logger in the UrlGenerator (strange as the UrlMatcher didn't use one).

This also fixes an issue mentioned in #4534. `setStrictParameters` is not part of the UrlGeneratorInterface but was called in `getGenerator`.
