### PR TITLE
Add EditorConfig File

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
http://editorconfig.org is a way to configure the different editor
configurations.

This could help some who develop with ruby and php where ruby uses 2
spaces and we use 4. Or where some develop for Drupal where they also
use 2 spaces but 4 for contributing to Symfony.
