### PR TITLE
[Security] Refactor authentication success handling

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -168,9 +168,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
 
     protected function createAuthenticationSuccessHandler($container, $id, $config)
     {
-        // success handler
         if (isset($config['success_handler'])) {
-
             return $config['success_handler'];
         }
 
@@ -185,7 +183,6 @@ abstract class AbstractFactory implements SecurityFactoryInterface
     protected function createAuthenticationFailureHandler($container, $id, $config)
     {
         if (isset($config['failure_handler'])) {
-
             return $config['failure_handler'];
         }
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -172,12 +172,13 @@ abstract class AbstractFactory implements SecurityFactoryInterface
             return $config['success_handler'];
         }
 
-        $id = 'security.authentication.success_handler.'.$id;
+        $successHandlerId = 'security.authentication.success_handler.'.$id;
 
-        $successHandler = $container->setDefinition($id, new DefinitionDecorator('security.authentication.success_handler'));
-        $successHandler->replaceArgument(1, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
+        $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator('security.authentication.success_handler'));
+        $successHandler->replaceArgument(1, $id);
+        $successHandler->replaceArgument(2, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
 
-        return $id;
+        return $successHandlerId;
     }
 
     protected function createAuthenticationFailureHandler($container, $id, $config)

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -111,6 +111,7 @@
         <service id="security.authentication.success_handler" class="%security.authentication.success_handler.class%" abstract="true" public="false">
             <argument type="service" id="security.http_utils" />
             <argument />
+            <argument />
         </service>
 
         <service id="security.authentication.failure_handler" class="%security.authentication.failure_handler.class%" abstract="true" public="false">

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -39,6 +39,7 @@
         <parameter key="security.authentication.provider.anonymous.class">Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider</parameter>
 
         <parameter key="security.authentication.success_handler.class">Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler</parameter>
+        <parameter key="security.authentication.failure_handler.class">Symfony\Component\Security\Http\Authentication\DefaultAuthenticationFailureHandler</parameter>
     </parameters>
 
     <services>
@@ -101,8 +102,8 @@
             <argument type="service" id="security.http_utils" />
             <argument />
             <argument type="service" id="security.authentication.success_handler" />
+            <argument type="service" id="security.authentication.failure_handler" />
             <argument type="collection"></argument>
-            <argument type="service" id="security.authentication.failure_handler" on-invalid="null" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="event_dispatcher" on-invalid="null" />
         </service>
@@ -110,6 +111,13 @@
         <service id="security.authentication.success_handler" class="%security.authentication.success_handler.class%" abstract="true" public="false">
             <argument type="service" id="security.http_utils" />
             <argument />
+        </service>
+
+        <service id="security.authentication.failure_handler" class="%security.authentication.failure_handler.class%" abstract="true" public="false">
+            <argument type="service" id="http_kernel" />
+            <argument type="service" id="security.http_utils" />
+            <argument />
+            <argument type="service" id="logger" on-invalid="null" />
         </service>
 
         <service id="security.authentication.listener.form"

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -37,6 +37,8 @@
         <parameter key="security.authentication.provider.pre_authenticated.class">Symfony\Component\Security\Core\Authentication\Provider\PreAuthenticatedAuthenticationProvider</parameter>
 
         <parameter key="security.authentication.provider.anonymous.class">Symfony\Component\Security\Core\Authentication\Provider\AnonymousAuthenticationProvider</parameter>
+
+        <parameter key="security.authentication.success_handler.class">Symfony\Component\Security\Http\Authentication\DefaultAuthenticationSuccessHandler</parameter>
     </parameters>
 
     <services>
@@ -98,11 +100,16 @@
             <argument type="service" id="security.authentication.session_strategy" />
             <argument type="service" id="security.http_utils" />
             <argument />
+            <argument type="service" id="security.authentication.success_handler" />
             <argument type="collection"></argument>
-            <argument type="service" id="security.authentication.success_handler" on-invalid="null" />
             <argument type="service" id="security.authentication.failure_handler" on-invalid="null" />
             <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="event_dispatcher" on-invalid="null" />
+        </service>
+
+        <service id="security.authentication.success_handler" class="%security.authentication.success_handler.class%" abstract="true" public="false">
+            <argument type="service" id="security.http_utils" />
+            <argument />
         </service>
 
         <service id="security.authentication.listener.form"

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -21,7 +21,8 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         list($container,
              $authProviderId,
              $listenerId,
-             $entryPointId) = $this->callFactory('foo', array('use_forward' => true, 'failure_path' => '/foo', 'success_handler' => 'qux', 'failure_handler' => 'bar', 'remember_me' => true), 'user_provider', 'entry_point');
+             $entryPointId
+         ) = $this->callFactory('foo', array('use_forward' => true, 'failure_path' => '/foo', 'success_handler' => 'qux', 'failure_handler' => 'bar', 'remember_me' => true), 'user_provider', 'entry_point');
 
         // auth provider
         $this->assertEquals('auth_provider', $authProviderId);
@@ -48,7 +49,8 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         list($container,
              $authProviderId,
              $listenerId,
-             $entryPointId) = $this->callFactory('foo', array('remember_me' => true), 'user_provider', 'entry_point');
+             $entryPointId
+         ) = $this->callFactory('foo', array('remember_me' => true), 'user_provider', 'entry_point');
 
         $definition = $container->getDefinition('abstract_listener.foo');
         $arguments = $definition->getArguments();
@@ -60,7 +62,8 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         list($container,
              $authProviderId,
              $listenerId,
-             $entryPointId) = $this->callFactory('foo', array('remember_me' => true), 'user_provider', 'entry_point');
+             $entryPointId
+         ) = $this->callFactory('foo', array('remember_me' => true), 'user_provider', 'entry_point');
 
         $definition = $container->getDefinition('abstract_listener.foo');
         $arguments = $definition->getArguments();

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -18,7 +18,46 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testCreate()
     {
-        $factory = $this->getFactory();
+        list($container,
+             $authProviderId,
+             $listenerId,
+             $entryPointId) = $this->callFactory('foo', array('use_forward' => true, 'failure_path' => '/foo', 'success_handler' => 'foo', 'remember_me' => true), 'user_provider', 'entry_point');
+
+        // auth provider
+        $this->assertEquals('auth_provider', $authProviderId);
+
+        // listener
+        $this->assertEquals('abstract_listener.foo', $listenerId);
+        $this->assertTrue($container->hasDefinition('abstract_listener.foo'));
+        $definition = $container->getDefinition('abstract_listener.foo');
+        $this->assertEquals(array(
+            'index_4' => 'foo',
+            'index_5' => new Reference('foo'),
+            'index_6' => array(
+                'use_forward'                    => true,
+                'failure_path'                   => '/foo',
+            ),
+        ), $definition->getArguments());
+
+        // entry point
+        $this->assertEquals('entry_point', $entryPointId, '->create() does not change the default entry point.');
+    }
+
+    public function testDefaultSuccessHandler()
+    {
+        list($container,
+             $authProviderId,
+             $listenerId,
+             $entryPointId) = $this->callFactory('foo', array('remember_me' => true), 'user_provider', 'entry_point');
+
+        $definition = $container->getDefinition('abstract_listener.foo');
+        $arguments = $definition->getArguments();
+        $this->assertEquals(new Reference('security.authentication.success_handler.foo'), $arguments['index_5']);
+    }
+
+    protected function callFactory($id, $config, $userProviderId, $defaultEntryPointId)
+    {
+        $factory = $this->getMockForAbstractClass('Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory', array());
 
         $factory
             ->expects($this->once())
@@ -37,30 +76,8 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         list($authProviderId,
              $listenerId,
              $entryPointId
-        ) = $factory->create($container, 'foo', array('use_forward' => true, 'failure_path' => '/foo', 'success_handler' => 'foo', 'remember_me' => true), 'user_provider', 'entry_point');
+         ) = $factory->create($container, $id, $config, $userProviderId, $defaultEntryPointId);
 
-        // auth provider
-        $this->assertEquals('auth_provider', $authProviderId);
-
-        // listener
-        $this->assertEquals('abstract_listener.foo', $listenerId);
-        $this->assertTrue($container->hasDefinition('abstract_listener.foo'));
-        $definition = $container->getDefinition('abstract_listener.foo');
-        $this->assertEquals(array(
-            'index_4' => 'foo',
-            'index_5' => array(
-                'use_forward'                    => true,
-                'failure_path'                   => '/foo',
-            ),
-            'index_6' => new Reference('foo'),
-        ), $definition->getArguments());
-
-        // entry point
-        $this->assertEquals('entry_point', $entryPointId, '->create() does not change the default entry point.');
-    }
-
-    protected function getFactory()
-    {
-        return $this->getMockForAbstractClass('Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory', array());
+        return array($container, $authProviderId, $listenerId, $entryPointId);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -21,7 +21,7 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         list($container,
              $authProviderId,
              $listenerId,
-             $entryPointId) = $this->callFactory('foo', array('use_forward' => true, 'failure_path' => '/foo', 'success_handler' => 'foo', 'remember_me' => true), 'user_provider', 'entry_point');
+             $entryPointId) = $this->callFactory('foo', array('use_forward' => true, 'failure_path' => '/foo', 'success_handler' => 'qux', 'failure_handler' => 'bar', 'remember_me' => true), 'user_provider', 'entry_point');
 
         // auth provider
         $this->assertEquals('auth_provider', $authProviderId);
@@ -32,15 +32,27 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
         $definition = $container->getDefinition('abstract_listener.foo');
         $this->assertEquals(array(
             'index_4' => 'foo',
-            'index_5' => new Reference('foo'),
-            'index_6' => array(
+            'index_5' => new Reference('qux'),
+            'index_6' => new Reference('bar'),
+            'index_7' => array(
                 'use_forward'                    => true,
-                'failure_path'                   => '/foo',
             ),
         ), $definition->getArguments());
 
         // entry point
         $this->assertEquals('entry_point', $entryPointId, '->create() does not change the default entry point.');
+    }
+
+    public function testDefaultFailureHandler()
+    {
+        list($container,
+             $authProviderId,
+             $listenerId,
+             $entryPointId) = $this->callFactory('foo', array('remember_me' => true), 'user_provider', 'entry_point');
+
+        $definition = $container->getDefinition('abstract_listener.foo');
+        $arguments = $definition->getArguments();
+        $this->assertEquals(new Reference('security.authentication.failure_handler.foo'), $arguments['index_6']);
     }
 
     public function testDefaultSuccessHandler()

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -20,3 +20,6 @@ CHANGELOG
  * `ObjectIdentity::fromDomainObject`, `UserSecurityIdentity::fromAccount` and
    `UserSecurityIdentity::fromToken` now return correct identities for proxies
    objects (e.g. Doctrine proxies)
+ * [BC BREAK] moved the default authentication success and failure handling to
+   seperate classes. The order of arguments in the constructor of the
+   `AbstractAuthenticationListener` has changed.

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationFailureHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationFailureHandlerInterface.php
@@ -33,7 +33,7 @@ interface AuthenticationFailureHandlerInterface
      * @param Request                 $request
      * @param AuthenticationException $exception
      *
-     * @return Response|null the response to return
+     * @return Response The response to return, never null
      */
     function onAuthenticationFailure(Request $request, AuthenticationException $exception);
 }

--- a/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
+++ b/src/Symfony/Component/Security/Http/Authentication/AuthenticationSuccessHandlerInterface.php
@@ -33,7 +33,7 @@ interface AuthenticationSuccessHandlerInterface
      * @param Request        $request
      * @param TokenInterface $token
      *
-     * @return Response|null the response to return
+     * @return Response never null
      */
     function onAuthenticationSuccess(Request $request, TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -24,36 +24,23 @@ use Symfony\Component\Security\Http\HttpUtils;
  * Can be optionally be extended from by the developer to alter the behaviour
  * while keeping the default behaviour.
  *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Alexander <iam.asm89@gmail.com>
  */
 class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
 {
-    /**
-     * @var HttpKernel
-     */
-    private $httpKernel;
-
-    /**
-     * @var HttpUtils
-     */
+    protected $httpKernel;
     protected $httpUtils;
-
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
-     * @var array
-     */
+    protected $logger;
     protected $options;
 
     /**
      * Constructor.
      *
-     * @param HttpKernelInterface $httpKernel Kernel
-     * @param HttpUtils           $httpUtils  HttpUtils
-     * @param array               $options    Options for processing a successful authentication attempt.
+     * @param HttpKernelInterface $httpKernel
+     * @param HttpUtils           $httpUtils
+     * @param array               $options    Options for processing a failed authentication attempt.
      * @param LoggerInterface     $logger     Optional logger
      */
     public function __construct(HttpKernelInterface $httpKernel, HttpUtils $httpUtils, array $options, LoggerInterface $logger = null)
@@ -63,9 +50,9 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
         $this->logger     = $logger;
 
         $this->options = array_merge(array(
-            'failure_path'                   => null,
-            'failure_forward'                => false,
-            'login_path'                     => '/login',
+            'failure_path'    => null,
+            'failure_forward' => false,
+            'login_path'      => '/login',
         ), $options);
     }
 

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Http\Authentication;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Http\HttpUtils;
+
+/**
+ * Class with the default authentication failure handling logic.
+ *
+ * Can be optionally be extended from by the developer to alter the behaviour
+ * while keeping the default behaviour.
+ *
+ * @author Alexander <iam.asm89@gmail.com>
+ */
+class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandlerInterface
+{
+    /**
+     * @var HttpKernel
+     */
+    private $httpKernel;
+
+    /**
+     * @var HttpUtils
+     */
+    protected $httpUtils;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
+     * Constructor.
+     *
+     * @param HttpKernelInterface $httpKernel Kernel
+     * @param HttpUtils           $httpUtils  HttpUtils
+     * @param array               $options    Options for processing a successful authentication attempt.
+     * @param LoggerInterface     $logger     Optional logger
+     */
+    public function __construct(HttpKernelInterface $httpKernel, HttpUtils $httpUtils, array $options, LoggerInterface $logger = null)
+    {
+        $this->httpKernel = $httpKernel;
+        $this->httpUtils  = $httpUtils;
+        $this->logger     = $logger;
+
+        $this->options = array_merge(array(
+            'failure_path'                   => null,
+            'failure_forward'                => false,
+            'login_path'                     => '/login',
+        ), $options);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        if (null === $this->options['failure_path']) {
+            $this->options['failure_path'] = $this->options['login_path'];
+        }
+
+        if ($this->options['failure_forward']) {
+            if (null !== $this->logger) {
+                $this->logger->debug(sprintf('Forwarding to %s', $this->options['failure_path']));
+            }
+
+            $subRequest = $this->httpUtils->createRequest($request, $this->options['failure_path']);
+            $subRequest->attributes->set(SecurityContextInterface::AUTHENTICATION_ERROR, $exception);
+
+            return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+        }
+
+        if (null !== $this->logger) {
+            $this->logger->debug(sprintf('Redirecting to %s', $this->options['failure_path']));
+        }
+
+        $request->getSession()->set(SecurityContextInterface::AUTHENTICATION_ERROR, $exception);
+
+        return $this->httpUtils->createRedirectResponse($request, $this->options['failure_path']);
+    }
+}

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -21,24 +21,19 @@ use Symfony\Component\Security\Http\HttpUtils;
  * Can be optionally be extended from by the developer to alter the behaviour
  * while keeping the default behaviour.
  *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Alexander <iam.asm89@gmail.com>
  */
 class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
 {
-    /**
-     * @var HttpUtils
-     */
     protected $httpUtils;
-
-    /**
-     * @var array
-     */
     protected $options;
 
     /**
      * Constructor.
      *
-     * @param HttpUtils $httpUtils HttpUtils
+     * @param HttpUtils $httpUtils
      * @param array     $options   Options for processing a successful authentication attempt.
      */
     public function __construct(HttpUtils $httpUtils, array $options)

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -29,16 +29,19 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
 {
     protected $httpUtils;
     protected $options;
+    protected $providerKey;
 
     /**
      * Constructor.
      *
      * @param HttpUtils $httpUtils
+     * @param string    $providerKey
      * @param array     $options   Options for processing a successful authentication attempt.
      */
-    public function __construct(HttpUtils $httpUtils, array $options)
+    public function __construct(HttpUtils $httpUtils, $providerKey, array $options)
     {
-        $this->httpUtils = $httpUtils;
+        $this->httpUtils   = $httpUtils;
+        $this->providerKey = $providerKey;
 
         $this->options = array_merge(array(
             'always_use_default_target_path' => false,
@@ -75,8 +78,8 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
         }
 
         $session = $request->getSession();
-        if ($targetUrl = $session->get('_security.target_path')) {
-            $session->remove('_security.target_path');
+        if ($targetUrl = $session->get('_security.'.$this->providerKey.'.target_path')) {
+            $session->remove('_security.'.$this->providerKey.'.target_path');
 
             return $targetUrl;
         }

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -26,6 +26,16 @@ use Symfony\Component\Security\Http\HttpUtils;
 class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandlerInterface
 {
     /**
+     * @var HttpUtils
+     */
+    protected $httpUtils;
+
+    /**
+     * @var array
+     */
+    protected $options;
+
+    /**
      * Constructor.
      *
      * @param HttpUtils $httpUtils HttpUtils
@@ -38,6 +48,7 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
         $this->options = array_merge(array(
             'always_use_default_target_path' => false,
             'default_target_path'            => '/',
+            'login_path'                     => '/login',
             'target_path_parameter'          => '_target_path',
             'use_referer'                    => false,
         ), $options);

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -37,7 +37,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     /**
      * {@inheritdoc}
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, CsrfProviderInterface $csrfProvider = null)
+    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, CsrfProviderInterface $csrfProvider = null)
     {
         parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, array_merge(array(
             'username_parameter' => '_username',

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -37,15 +37,15 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     /**
      * {@inheritdoc}
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler = null, array $options = array(), AuthenticationFailureHandlerInterface $failureHandler = null, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, CsrfProviderInterface $csrfProvider = null)
+    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler, array $options = array(), LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, CsrfProviderInterface $csrfProvider = null)
     {
-        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, array_merge(array(
+        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, $failureHandler, array_merge(array(
             'username_parameter' => '_username',
             'password_parameter' => '_password',
             'csrf_parameter'     => '_csrf_token',
             'intention'          => 'authenticate',
             'post_only'          => true,
-        ), $options), $failureHandler, $logger, $dispatcher);
+        ), $options), $logger, $dispatcher);
 
         $this->csrfProvider = $csrfProvider;
     }

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -37,15 +37,15 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     /**
      * {@inheritdoc}
      */
-    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, array $options = array(), AuthenticationSuccessHandlerInterface $successHandler = null, AuthenticationFailureHandlerInterface $failureHandler = null, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, CsrfProviderInterface $csrfProvider = null)
+    public function __construct(SecurityContextInterface $securityContext, AuthenticationManagerInterface $authenticationManager, SessionAuthenticationStrategyInterface $sessionStrategy, HttpUtils $httpUtils, $providerKey, AuthenticationSuccessHandlerInterface $successHandler = null, array $options = array(), AuthenticationFailureHandlerInterface $failureHandler = null, LoggerInterface $logger = null, EventDispatcherInterface $dispatcher = null, CsrfProviderInterface $csrfProvider = null)
     {
-        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, array_merge(array(
+        parent::__construct($securityContext, $authenticationManager, $sessionStrategy, $httpUtils, $providerKey, $successHandler, array_merge(array(
             'username_parameter' => '_username',
             'password_parameter' => '_password',
             'csrf_parameter'     => '_csrf_token',
             'intention'          => 'authenticate',
             'post_only'          => true,
-        ), $options), $successHandler, $failureHandler, $logger, $dispatcher);
+        ), $options), $failureHandler, $logger, $dispatcher);
 
         $this->csrfProvider = $csrfProvider;
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=refactor-authentication-success-handling)](http://travis-ci.org/asm89/symfony)
License of the code: MIT

This PR extracts the default authentication success handling to its own class as discussed in #4553. In the end the PR will basically revert #3183 (as suggested by @schmittjoh) and fix point one of #838.

There are a few noticeable changes in this PR:
- This implementation changes the constructor signature of the `AbstractAuthentictionListener` and `UsernamePasswordFormAuthenticationListener` by making the `AuthenticationSuccessHandler` mandatory (BC break). If this WIP is approved I will refactor the failure handling logic too and then this will also move one place in the constructor
- This PR reverts the change of making the returning of a `Response` optional in the `AuthenticationSuccessHandlerInterface`. Developers can now extend the default behavior themselves

@schmittjoh Any suggestions? Or a +1 to do the failure logic too?
