### PR TITLE
[WebProfilerBundle] removed the extra space before the toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.html.twig
@@ -1,7 +1,7 @@
 <!-- START of Symfony2 Web Debug Toolbar -->
 {% if 'normal' != position %}
     {% include 'WebProfilerBundle:Profiler:toolbar_style.html.twig' with { 'position': position, 'floatable': true } %}
-    <div style="clear: both; height: 50px;"></div>
+    <div style="clear: both; height: 38px;"></div>
 {% endif %}
 
 <div class="sf-toolbarreset">


### PR DESCRIPTION
The profiler toolbar has a height of 38px. This PR removes the (useless) extra space before it.
