### PR TITLE
Fix security encoder factory

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -33,7 +33,7 @@ class EncoderFactory implements EncoderFactoryInterface
     public function getEncoder($user)
     {
         foreach ($this->encoders as $class => $encoder) {
-            if ((is_object($user) && !$user instanceof $class) || (!is_subclass_of($user, $class) && $user != $class)) {
+            if ((is_object($user) && !$user instanceof $class) || (!is_object($user) && !is_subclass_of($user, $class) && $user != $class)) {
                 continue;
             }
 

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/EncoderFactoryTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/EncoderFactoryTest.php
@@ -59,4 +59,27 @@ class EncoderFactoryTest extends \PHPUnit_Framework_TestCase
         $expectedEncoder = new MessageDigestPasswordEncoder('sha1');
         $this->assertEquals($expectedEncoder->encodePassword('foo', ''), $encoder->encodePassword('foo', ''));
     }
+
+    public function testGetEncoderConfiguredForConcreteClassWithService()
+    {
+        $factory = new EncoderFactory(array(
+            'Symfony\Component\Security\Core\User\User' => new MessageDigestPasswordEncoder('sha1'),
+        ));
+
+        $encoder = $factory->getEncoder(new User('user', 'pass'));
+        $expectedEncoder = new MessageDigestPasswordEncoder('sha1');
+        $this->assertEquals($expectedEncoder->encodePassword('foo', ''), $encoder->encodePassword('foo', ''));
+    }
+
+    public function testGetEncoderConfiguredForConcreteClassWithClassName()
+    {
+        $factory = new EncoderFactory(array(
+            'Symfony\Component\Security\Core\User\User' => new MessageDigestPasswordEncoder('sha1'),
+        ));
+
+
+        $encoder = $factory->getEncoder('Symfony\Component\Security\Core\User\User');
+        $expectedEncoder = new MessageDigestPasswordEncoder('sha1');
+        $this->assertEquals($expectedEncoder->encodePassword('foo', ''), $encoder->encodePassword('foo', ''));
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=fix-security-encoder-factory)](http://travis-ci.org/asm89/symfony)
License of the code: MIT

This PR adds two testcases + a fix for the retrieval of an encoder from the `EncoderFactory`.
