### PR TITLE
[Form] PropertyPath readValue fails for custom array objects

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests\Util;
 
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Form\Tests\Fixtures\Author;
+use Symfony\Component\Form\Tests\Fixtures\CustomArrayObject;
 use Symfony\Component\Form\Tests\Fixtures\Magician;
 
 class PropertyPathTest extends \PHPUnit_Framework_TestCase
@@ -579,5 +580,22 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $propertyPath->isIndex(-1);
+    }
+
+    public function testGetValueReadsFromCustomArrayCollection()
+    {
+        $collection = new CustomArrayObject(array('foo', 'bar'));
+
+        $path = new PropertyPath('[1]');
+        $this->assertEquals('bar', $path->getValue($collection));
+    }
+
+    public function testSetValueUpdatesCustomArrayCollection()
+    {
+        $collection = new CustomArrayObject(array('foo', 'bar'));
+
+        $path = new PropertyPath('[1]');
+        $path->setValue($collection, 'meh');
+        $this->assertEquals('meh', $collection[1]);
     }
 }

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -373,7 +373,11 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
             }
 
             if (isset($objectOrArray[$property])) {
-                $result =& $objectOrArray[$property];
+                if (is_array($objectOrArray)) {
+                    $result =& $objectOrArray[$property];
+                } else {
+                    $result = $objectOrArray[$property];
+                }
             }
         } elseif (is_object($objectOrArray)) {
             $camelProp = $this->camelize($property);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=issue-4535)](http://travis-ci.org/asm89/symfony)
License of the code: MIT

This PR addresses issue #4535. I added previously failing tests and a possible fix for the issue. It re-introduced a 'special-case' for real `arrays`. I'd like to have feedback from @bschussek.

Travis will possible say this PR fails after merge because current symfony-master is failing.
