### PR TITLE
[Form] PropertyPath readValue fails for custom array objects

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
@@ -75,6 +75,7 @@ class PropertyPathCollectionTest_CarOnlyRemover
 class PropertyPathCollectionTest_CompositeCar
 {
     public function getStructure() {}
+    public function setStructure($structure) {}
 }
 
 class PropertyPathCollectionTest_CarStructure

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -580,4 +580,21 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
 
         $propertyPath->isIndex(-1);
     }
+
+    public function testGetCustomArrayCollection()
+    {
+        $collection = new \Symfony\Component\Form\Tests\Fixtures\CustomArrayObject(array('foo', array('bar')));
+        $path = new PropertyPath('[1][0]');
+        $bar = $path->getValue($collection);
+        $this->assertEquals('bar', $bar);
+    }
+
+    public function testSetCustomArrayCollection()
+    {
+        $collection = new \Symfony\Component\Form\Tests\Fixtures\CustomArrayObject(array('foo', array('bar')));
+        $path = new PropertyPath('[1][0]');
+        $path->setValue($collection, 'baz');
+        $this->assertEquals('baz', $collection[1][0]);
+    }
+
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This is an alternative solution for #4535
