### PR TITLE
[DependencyInjection] added IntrospectableContainerInterface::initializable()

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -277,7 +277,20 @@ class Container implements IntrospectableContainerInterface
     {
         return isset($this->services[strtolower($id)]);
     }
+    
+    /**
+     * Check whether or not the container is capabable of initializing a service
+     *
+     * @param string $id 
+     * @return Boolean true if service can be initialized, false otherwise
+     */
+    public function initializable($id)
+    {
+        $id = strtolower($id);
 
+        return method_exists($this, $method = 'get'.strtr($id, array('_' => '', '.' => '_')).'Service');
+    }
+    
     /**
      * Gets all service ids.
      *

--- a/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
@@ -29,5 +29,12 @@ interface IntrospectableContainerInterface extends ContainerInterface
      *
      */
     function initialized($id);
-
+    
+    /**
+     * Check whether or not the container is capabable of initializing a service
+     *
+     * @param string $id 
+     * @return Boolean true if service can be initialized, false otherwise
+     */
+    function initializable($id);
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -205,6 +205,19 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($sc->initialized('bar'), '->initialized() returns false if a service is defined, but not currently loaded');
     }
 
+    /**
+     * @covers Symfony\Component\DependencyInjection\Container::initialized
+     */
+    public function testInitializable()
+    {
+        $sc = new ProjectServiceContainer();
+        $sc->set('foo', new \stdClass());
+        $this->assertFalse($sc->initializable('foo'), '->initializable() returns false if service is loaded, but has no get*Method() defined');
+        $this->assertTrue($sc->initializable('bar'), '->initializable() returns true if a service is defined, but not currently loaded');
+        $this->assertTrue($sc->initializable('foo_bar'), '->initializable() returns true if a get*Method() is defined');
+        $this->assertTrue($sc->initializable('foo.baz'), '->initializable() returns true if a get*Method() is defined');
+    }
+
     public function testEnterLeaveCurrentScope()
     {
         $container = new ProjectServiceContainer();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

Fleshed out the `IntrospectableContainerInterface` to provide the other half of `initialized()`, which is `initializable()`, meaning whether or not the container can build a given service in the first place.

Are there any thoughts on the usefulness of having a method called `reinitialize()`?  Meaning, if a service has been initialized, it could be rebuilt, effectively resetting its state to the default.  If so, this would be the place to add that functionality as well.
