### PR TITLE
Composer provide

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "replace": {
         "symfony/doctrine-bridge": "self.version",
         "symfony/monolog-bridge": "self.version",
+        "symfony/swiftmailer-bridge": "self.version",
         "symfony/twig-bridge": "self.version",
         "symfony/doctrine-abstract-bundle": "self.version",
         "symfony/doctrine-bundle": "self.version",


### PR DESCRIPTION
Currently, the standalone bridge will be installed when a library requires it, even if you have the full framework, thus leading to weird issues if the versions missmatch (which is possible as the bridge does not have any hard requirement to a component in the composer.json which would enforce `self.version`)
