### PR TITLE
[Security] Change return value in DocBlock

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -101,7 +101,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
      * @param string                $username The username to retrieve
      * @param UsernamePasswordToken $token    The Token
      *
-     * @return array The user
+     * @return UserInterface The user
      *
      * @throws AuthenticationException if the credentials could not be validated
      */


### PR DESCRIPTION
Change the return value for avoid confusions.

``` php
if (!$user instanceof UserInterface) {
    throw new AuthenticationServiceException('retrieveUser() must return a UserInterface.');
}
```

[UserAuthenticationProvider.php#L67](https://github.com/symfony/symfony/tree/2.0/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php#L67)
