### PR TITLE
[Security] fixed exception message in EncoderFactory

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -44,7 +44,7 @@ class EncoderFactory implements EncoderFactoryInterface
             return $this->encoders[$class];
         }
 
-        throw new \RuntimeException(sprintf('No encoder has been configured for account "%s".', is_object($class) ? get_class($user) : $class));
+        throw new \RuntimeException(sprintf('No encoder has been configured for account "%s".', is_object($user) ? get_class($user) : $user));
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: n/a
Todo: n/a
License of the code: MIT
Documentation PR: n/a

In `EncoderFactory`, fixed the exception message so it uses the class of the provided user (string or object), rather than the class key for whatever happens to be the last loaded encoder.
