### PR TITLE
[Form] Fixed the validation of form validation constraints

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -70,9 +70,7 @@ class FormValidator extends ConstraintValidator
             // in the form
             $constraints = $config->getOption('constraints');
             foreach ($constraints as $constraint) {
-                foreach ($groups as $group) {
-                    $graphWalker->walkConstraint($constraint, $form->getData(), $group, $path . 'data');
-                }
+                $graphWalker->walkConstraint($constraint, $form->getData(), Constraint::DEFAULT_GROUP, $path . 'data');
             }
         } else {
             $clientDataAsString = is_scalar($form->getViewData())

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -110,16 +110,10 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         // Then custom constraints
         $graphWalker->expects($this->at(2))
             ->method('walkConstraint')
-            ->with($constraint1, $object, 'group1', 'data');
+            ->with($constraint1, $object, 'Default', 'data');
         $graphWalker->expects($this->at(3))
             ->method('walkConstraint')
-            ->with($constraint1, $object, 'group2', 'data');
-        $graphWalker->expects($this->at(4))
-            ->method('walkConstraint')
-            ->with($constraint2, $object, 'group1', 'data');
-        $graphWalker->expects($this->at(5))
-            ->method('walkConstraint')
-            ->with($constraint2, $object, 'group2', 'data');
+            ->with($constraint2, $object, 'Default', 'data');
 
         $this->validator->initialize($context);
         $this->validator->validate($form, new Form());
@@ -165,16 +159,10 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
 
         $graphWalker->expects($this->at(0))
             ->method('walkConstraint')
-            ->with($constraint1, $object, 'group1', 'data');
+            ->with($constraint1, $object, 'Default', 'data');
         $graphWalker->expects($this->at(1))
             ->method('walkConstraint')
-            ->with($constraint1, $object, 'group2', 'data');
-        $graphWalker->expects($this->at(2))
-            ->method('walkConstraint')
-            ->with($constraint2, $object, 'group1', 'data');
-        $graphWalker->expects($this->at(3))
-            ->method('walkConstraint')
-            ->with($constraint2, $object, 'group2', 'data');
+            ->with($constraint2, $object, 'Default', 'data');
 
         $this->validator->initialize($context);
         $this->validator->validate($form, new Form());


### PR DESCRIPTION
Validating the form constraints for each validation group results in
duplicated errors when several validation groups are used.

This is an attempt to fix #4427.

@bschussek can you look at it ? I'm not sure if it is the right way to fix it.

Looking at the code of the GraphWalker to debug this, I think we have an issue in the validator component itself (and the Form constraints being only the easiest way to trigger the issue): if a constraint is attached on an object in 2 validation groups and you use both groups when calling the validator, the ConstraintValidator is called twice. This is not something you will generally do in your constraint mapping, but the FormValidator was working in such a way: form constraints were validated for all validation groups of the form. However, I don't see how the GraphWalker could remember the constraint has already been validated for this instance as walkConstraint does not have access to the object.
