### PR TITLE
[FrameworkBundle][Command] ContainerDebugCommand

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "symfony/doctrine-bridge": "self.version",
         "symfony/monolog-bridge": "self.version",
         "symfony/propel1-bridge": "self.version",
+        "symfony/swiftmailer-bridge": "self.version",
         "symfony/twig-bridge": "self.version",
         "symfony/framework-bundle": "self.version",
         "symfony/security-bundle": "self.version",

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -32,7 +32,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
     /**
      * @var ContainerBuilder
      */
-    private $containerBuilder;
+    protected $containerBuilder;
 
     /**
      * @see Command
@@ -209,7 +209,7 @@ EOF
      *
      * @return \Symfony\Component\DependencyInjection\Definition|\Symfony\Component\DependencyInjection\Alias
      */
-    private function resolveServiceDefinition($serviceId)
+    protected function resolveServiceDefinition($serviceId)
     {
         if ($this->containerBuilder->hasDefinition($serviceId)) {
             return $this->containerBuilder->getDefinition($serviceId);

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -19,8 +19,8 @@ namespace Symfony\Component\ClassLoader;
  *     $loader = new ClassLoader();
  *
  *     // register classes with namespaces
- *     $loader->add('Symfony\Component', __DIR__.'/component');
- *     $loader->add('Symfony',           __DIR__.'/framework');
+ *     $loader->addPrefix('Symfony\Component', __DIR__.'/component');
+ *     $loader->addPrefix('Symfony',           __DIR__.'/framework');
  *
  *     // activate the autoloader
  *     $loader->register();

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -40,8 +40,17 @@ class DirectoryResource implements ResourceInterface
      */
     public function getFilteredChilds()
     {
+        if (!$this->exists()) {
+            return array();
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->resource, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
         $childs = array();
-        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->resource), \RecursiveIteratorIterator::SELF_FIRST) as $file) {
+        foreach ($iterator as $file) {
             // if regex filtering is enabled only return matching files
             if ($file->isFile() && !$this->hasFile($file)) {
                 continue;

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class DirectoryResource implements ResourceInterface, \Serializable
+class DirectoryResource implements ResourceInterface
 {
     private $resource;
     private $pattern;

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -59,14 +59,14 @@ class DirectoryResource implements ResourceInterface, \Serializable
     }
 
     /**
-     * Returns true if the resource has not been updated since the given timestamp.
+     * Returns resource mtime.
      *
-     * @param integer $timestamp The last time the resource was loaded
-     *
-     * @return Boolean true if the resource has not been updated, false otherwise
+     * @return integer
      */
-    public function isFresh($timestamp)
+    public function getModificationTime()
     {
+        clearstatcache(true, $this->resource);
+
         if (!is_dir($this->resource)) {
             return false;
         }
@@ -84,10 +84,37 @@ class DirectoryResource implements ResourceInterface, \Serializable
                 continue;
             }
 
+            clearstatcache(true, (string) $file);
             $newestMTime = max($file->getMTime(), $newestMTime);
         }
 
-        return $newestMTime < $timestamp;
+        return $newestMTime;
+    }
+
+    /**
+     * Returns true if the resource has not been updated since the given timestamp.
+     *
+     * @param integer $timestamp The last time the resource was loaded
+     *
+     * @return Boolean true if the resource has not been updated, false otherwise
+     */
+    public function isFresh($timestamp)
+    {
+        if (!$this->exists()) {
+            return false;
+        }
+
+        return $this->getModificationTime() <= $timestamp;
+    }
+
+    /**
+     * Returns true if the resource exists in the filesystem.
+     *
+     * @return Boolean
+     */
+    public function exists()
+    {
+        return file_exists($this->resource);
     }
 
     public function serialize()

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -210,7 +210,7 @@ class DirectoryResource implements ResourceInterface
      */
     public function getId()
     {
-        return md5($this->resource.$this->pattern);
+        return md5('d'.$this->resource.$this->pattern);
     }
 
     public function serialize()

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -75,6 +75,10 @@ class DirectoryResource implements ResourceInterface
      */
     public function getFilteredResources()
     {
+        if (!$this->exists()) {
+            return array();
+        }
+
         $iterator = new \DirectoryIterator($this->resource);
 
         $resources = array();
@@ -166,6 +170,10 @@ class DirectoryResource implements ResourceInterface
      */
     public function getModificationTime()
     {
+        if (!$this->exists()) {
+            return -1;
+        }
+
         clearstatcache(true, $this->resource);
         $newestMTime = filemtime($this->resource);
 

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -53,6 +53,18 @@ class FileResource implements ResourceInterface, \Serializable
     }
 
     /**
+     * Returns resource mtime.
+     *
+     * @return integer
+     */
+    public function getModificationTime()
+    {
+        clearstatcache(true, $this->resource);
+
+        return filemtime($this->resource);
+    }
+
+    /**
      * Returns true if the resource has not been updated since the given timestamp.
      *
      * @param integer $timestamp The last time the resource was loaded
@@ -61,11 +73,21 @@ class FileResource implements ResourceInterface, \Serializable
      */
     public function isFresh($timestamp)
     {
-        if (!file_exists($this->resource)) {
+        if (!$this->exists()) {
             return false;
         }
 
-        return filemtime($this->resource) < $timestamp;
+        return $this->getModificationTime() <= $timestamp;
+    }
+
+    /**
+     * Returns true if the resource exists in the filesystem.
+     *
+     * @return Boolean
+     */
+    public function exists()
+    {
+        return file_exists($this->resource);
     }
 
     public function serialize()

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -90,6 +90,16 @@ class FileResource implements ResourceInterface, \Serializable
         return file_exists($this->resource);
     }
 
+    /**
+     * Returns unique resource ID.
+     *
+     * @return string
+     */
+    public function getId()
+    {
+        return md5($this->resource);
+    }
+
     public function serialize()
     {
         return serialize($this->resource);

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class FileResource implements ResourceInterface, \Serializable
+class FileResource implements ResourceInterface
 {
     private $resource;
 

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -29,7 +29,7 @@ class FileResource implements ResourceInterface
      */
     public function __construct($resource)
     {
-        $this->resource = realpath($resource);
+        $this->resource = file_exists($resource) ? realpath($resource) : $resource;
     }
 
     /**
@@ -59,6 +59,10 @@ class FileResource implements ResourceInterface
      */
     public function getModificationTime()
     {
+        if (!$this->exists()) {
+            return -1;
+        }
+
         clearstatcache(true, $this->resource);
 
         return filemtime($this->resource);

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -87,7 +87,7 @@ class FileResource implements ResourceInterface
      */
     public function exists()
     {
-        return file_exists($this->resource);
+        return is_file($this->resource);
     }
 
     /**

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -97,7 +97,7 @@ class FileResource implements ResourceInterface
      */
     public function getId()
     {
-        return md5($this->resource);
+        return md5('f'.$this->resource);
     }
 
     public function serialize()

--- a/src/Symfony/Component/Config/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/ResourceInterface.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Config\Resource;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface ResourceInterface
+interface ResourceInterface extends \Serializable
 {
     /**
      * Returns a string representation of the Resource.

--- a/src/Symfony/Component/Config/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/ResourceInterface.php
@@ -54,4 +54,11 @@ interface ResourceInterface
      * @return mixed The resource
      */
     function getResource();
+
+    /**
+     * Returns unique resource ID.
+     *
+     * @return string
+     */
+    function getId();
 }

--- a/src/Symfony/Component/Config/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/ResourceInterface.php
@@ -35,6 +35,20 @@ interface ResourceInterface
     function isFresh($timestamp);
 
     /**
+     * Returns resource mtime.
+     *
+     * @return integer
+     */
+    function getModificationTime();
+
+    /**
+     * Returns true if the resource exists in the filesystem.
+     *
+     * @return Boolean
+     */
+    function exists();
+
+    /**
      * Returns the resource tied to this Resource.
      *
      * @return mixed The resource

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -51,6 +51,20 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::getId
+     */
+    public function testGetId()
+    {
+        $resource1 = new DirectoryResource($this->directory);
+        $resource2 = new DirectoryResource($this->directory);
+        $resource3 = new DirectoryResource($this->directory, '/\.(foo|xml)$/');
+
+        $this->assertNotNull($resource1->getId());
+        $this->assertEquals($resource1->getId(), $resource2->getId());
+        $this->assertNotEquals($resource1->getId(), $resource3->getId());
+    }
+
+    /**
      * @covers Symfony\Component\Config\Resource\DirectoryResource::getResource
      */
     public function testGetResource()
@@ -167,6 +181,72 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
 
         touch($this->directory.'/new.xml', time() + 20);
         $this->assertFalse($resource->isFresh(time() + 10), '->isFresh() returns false if an new file matching the filter regex is created ');
+    }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::hasFile
+     */
+    public function testHasFile()
+    {
+        $resource = new DirectoryResource($this->directory, '/\.foo$/');
+
+        touch($this->directory.'/new.foo', time() + 20);
+
+        $this->assertFalse($resource->hasFile($this->directory.'/tmp.xml'));
+        $this->assertTrue($resource->hasFile($this->directory.'/new.foo'));
+    }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::getFilteredChilds
+     */
+    public function testGetFilteredChilds()
+    {
+        $resource = new DirectoryResource($this->directory, '/\.(foo|xml)$/');
+
+        touch($file1 = $this->directory.'/new.xml', time() + 20);
+        touch($file2 = $this->directory.'/old.foo', time() + 20);
+        touch($this->directory.'/old', time() + 20);
+        mkdir($dir = $this->directory.'/sub');
+        touch($file3 = $this->directory.'/sub/file.foo', time() + 20);
+
+        $childs = $resource->getFilteredChilds();
+        $this->assertSame(5, count($childs));
+
+        $childs = array_map(function($item) {
+            return (string) $item;
+        }, $childs);
+
+        $this->assertContains($file1, $childs);
+        $this->assertContains($file2, $childs);
+        $this->assertContains($dir, $childs);
+        $this->assertContains($this->directory.'/tmp.xml', $childs);
+        $this->assertContains($file3, $childs);
+    }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::getFilteredResources
+     */
+    public function testGetFilteredResources()
+    {
+        $resource = new DirectoryResource($this->directory, '/\.(foo|xml)$/');
+
+        touch($file1 = $this->directory.'/new.xml', time() + 20);
+        touch($file2 = $this->directory.'/old.foo', time() + 20);
+        touch($this->directory.'/old', time() + 20);
+        mkdir($dir = $this->directory.'/sub');
+        touch($file3 = $this->directory.'/sub/file.foo', time() + 20);
+
+        $resources = $resource->getFilteredResources();
+        $this->assertSame(4, count($resources));
+
+        $childs = array_map(function($item) {
+            return realpath($item->getResource());
+        }, $resources);
+
+        $this->assertContains(realpath($file1), $childs);
+        $this->assertContains(realpath($file2), $childs);
+        $this->assertContains(realpath($dir), $childs);
+        $this->assertContains(realpath($this->directory.'/tmp.xml'), $childs);
     }
 
     /**

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -161,6 +161,7 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Symfony\Component\Config\Resource\DirectoryResource::isFresh
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::getFilteredChilds
      */
     public function testFilterRegexListNoMatch()
     {

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -119,19 +119,7 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\Config\Resource\DirectoryResource::exists
-     */
-    public function testExists()
-    {
-        $this->assertTrue($this->resource->exists(), '->exists() returns true if the directory still exist');
-
-        $this->removeDirectory($this->directory);
-        $this->assertFalse($this->resource->exists(), '->exists() returns false if the directory does not exist');
-    }
-
-    /**
      * @covers Symfony\Component\Config\Resource\DirectoryResource::isFresh
-     * @covers Symfony\Component\Config\Resource\DirectoryResource::getModificationTime
      */
     public function testIsFreshCreateFileInSubdirectory()
     {
@@ -161,7 +149,6 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers Symfony\Component\Config\Resource\DirectoryResource::isFresh
-     * @covers Symfony\Component\Config\Resource\DirectoryResource::getFilteredChilds
      */
     public function testFilterRegexListNoMatch()
     {
@@ -180,5 +167,37 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
 
         touch($this->directory.'/new.xml', time() + 20);
         $this->assertFalse($resource->isFresh(time() + 10), '->isFresh() returns false if an new file matching the filter regex is created ');
+    }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::exists
+     */
+    public function testDirectoryExists()
+    {
+        $resource = new DirectoryResource($this->directory);
+
+        $this->assertTrue($resource->exists(), '->exists() returns true if directory exists ');
+
+        unlink($this->directory.'/tmp.xml');
+        rmdir($this->directory);
+
+        $this->assertFalse($resource->exists(), '->exists() returns false if directory does not exists');
+    }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::getModificationTime
+     */
+    public function testGetModificationTime()
+    {
+        $resource = new DirectoryResource($this->directory, '/\.(foo|xml)$/');
+
+        touch($this->directory.'/new.xml', $time = time() + 20);
+        $this->assertSame($time, $resource->getModificationTime(), '->getModificationTime() returns time of the last modificated resource');
+
+        touch($this->directory.'/some', time() + 60);
+        $this->assertSame($time, $resource->getModificationTime(), '->getModificationTime() returns time of last modificated resource, that only matches pattern');
+
+        touch($this->directory, $time2 = time() + 90);
+        $this->assertSame($time2, $resource->getModificationTime(), '->getModificationTime() returns modification time of the directory itself');
     }
 }

--- a/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/DirectoryResourceTest.php
@@ -119,7 +119,19 @@ class DirectoryResourceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::exists
+     */
+    public function testExists()
+    {
+        $this->assertTrue($this->resource->exists(), '->exists() returns true if the directory still exist');
+
+        $this->removeDirectory($this->directory);
+        $this->assertFalse($this->resource->exists(), '->exists() returns false if the directory does not exist');
+    }
+
+    /**
      * @covers Symfony\Component\Config\Resource\DirectoryResource::isFresh
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::getModificationTime
      */
     public function testIsFreshCreateFileInSubdirectory()
     {

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -33,6 +33,18 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\Config\Resource\DirectoryResource::getId
+     */
+    public function testGetId()
+    {
+        $resource1 = new FileResource($this->file);
+        $resource2 = new FileResource($this->file);
+
+        $this->assertNotNull($resource1->getId());
+        $this->assertEquals($resource1->getId(), $resource2->getId());
+    }
+
+    /**
      * @covers Symfony\Component\Config\Resource\FileResource::getResource
      */
     public function testGetResource()

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -27,7 +27,9 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        unlink($this->file);
+        if ($this->file) {
+            unlink($this->file);
+        }
     }
 
     /**
@@ -51,21 +53,24 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Symfony\Component\Config\Resource\FileResource::exists
-     */
-    public function testExists()
-    {
-        $this->assertTrue($this->resource->exists(), '->exists() returns true if the resource does exist');
-
-        $resource = new FileResource('/____foo/foobar'.rand(1, 999999));
-        $this->assertFalse($resource->exists(), '->exists() returns false if the resource does not exist');
-    }
-
-    /**
      * @covers Symfony\Component\Config\Resource\FileResource::getModificationTime
      */
     public function testGetModificationTime()
     {
-        $this->assertSame(filemtime($this->resource->getResource()), $this->resource->getModificationTime());
+        touch($this->file, $time = time() + 100);
+        $this->assertSame($time, $this->resource->getModificationTime());
+    }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\FileResource::exists
+     */
+    public function testExists()
+    {
+        $this->assertTrue($this->resource->exists(), '->exists() returns true if the resource exists');
+
+        unlink($this->file);
+        $this->file = null;
+
+        $this->assertFalse($this->resource->exists(), '->exists() returns false if the resource does not exists');
     }
 }

--- a/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
+++ b/src/Symfony/Component/Config/Tests/Resource/FileResourceTest.php
@@ -49,4 +49,23 @@ class FileResourceTest extends \PHPUnit_Framework_TestCase
         $resource = new FileResource('/____foo/foobar'.rand(1, 999999));
         $this->assertFalse($resource->isFresh(time()), '->isFresh() returns false if the resource does not exist');
     }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\FileResource::exists
+     */
+    public function testExists()
+    {
+        $this->assertTrue($this->resource->exists(), '->exists() returns true if the resource does exist');
+
+        $resource = new FileResource('/____foo/foobar'.rand(1, 999999));
+        $this->assertFalse($resource->exists(), '->exists() returns false if the resource does not exist');
+    }
+
+    /**
+     * @covers Symfony\Component\Config\Resource\FileResource::getModificationTime
+     */
+    public function testGetModificationTime()
+    {
+        $this->assertSame(filemtime($this->resource->getResource()), $this->resource->getModificationTime());
+    }
 }

--- a/src/Symfony/Component/Filesystem/CHANGELOG.md
+++ b/src/Symfony/Component/Filesystem/CHANGELOG.md
@@ -4,4 +4,5 @@ CHANGELOG
 2.1.0
 -----
 
+ * 24eb396 : BC Break : mkdir() function now throws exception in case of failure instead of returning Boolean value
  * created the component

--- a/src/Symfony/Component/Filesystem/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Filesystem/Exception/ExceptionInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Exception;
+
+/**
+ * Exception interface for all exceptions thrown by the component.
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ *
+ * @api
+ */
+interface ExceptionInterface
+{
+
+}

--- a/src/Symfony/Component/Filesystem/Exception/IOException.php
+++ b/src/Symfony/Component/Filesystem/Exception/IOException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Exception;
+
+/**
+ * Exception class thrown when a filesystem operation failure happens
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ *
+ * @api
+ */
+class IOException extends \RuntimeException implements ExceptionInterface
+{
+
+}

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -275,6 +275,12 @@ class Filesystem
 
         if (!$ok) {
             if (true !== @symlink($originDir, $targetDir)) {
+                $report = error_get_last();
+                if (is_array($report)) {
+                    if (defined('PHP_WINDOWS_VERSION_MAJOR') && false !== strpos($report['message'], 'error code(1314)')) {
+                        throw new IOException('Unable to create symlink due to error code 1314: \'A required privilege is not held by the client\'. Do you have the required Administrator-rights?');
+                    }
+                }
                 throw new IOException(sprintf('Failed to create symbolic link from %s to %s', $originDir, $targetDir));
             }
         }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Filesystem;
 
+use Symfony\Component\Filesystem\Exception\IOException;
+
 /**
  * Provides basic utility to manipulate the file system.
  *
@@ -29,7 +31,7 @@ class Filesystem
      * @param string $targetFile The target filename
      * @param array  $override   Whether to override an existing file or not
      *
-     * @throws Exception\IOException When copy fails
+     * @throws IOException When copy fails
      */
     public function copy($originFile, $targetFile, $override = false)
     {
@@ -43,7 +45,7 @@ class Filesystem
 
         if ($doCopy) {
             if (true !== @copy($originFile, $targetFile)) {
-                throw new Exception\IOException(sprintf('Failed to copy %s to %s', $originFile, $targetFile));
+                throw new IOException(sprintf('Failed to copy %s to %s', $originFile, $targetFile));
             }
         }
     }
@@ -54,7 +56,7 @@ class Filesystem
      * @param string|array|\Traversable $dirs The directory path
      * @param integer                   $mode The directory mode
      *
-     * @throws Exception\IOException On any directory creation failure
+     * @throws IOException On any directory creation failure
      */
     public function mkdir($dirs, $mode = 0777)
     {
@@ -64,7 +66,7 @@ class Filesystem
             }
 
             if (true !== @mkdir($dir, $mode, true)) {
-                throw new Exception\IOException(sprintf('Failed to create %s', $dir));
+                throw new IOException(sprintf('Failed to create %s', $dir));
             }
         }
     }
@@ -94,7 +96,7 @@ class Filesystem
      * @param integer                   $time  The touch time as a unix timestamp
      * @param integer                   $atime The access time as a unix timestamp
      *
-     * @throws Exception\IOException When touch fails
+     * @throws IOException When touch fails
      */
     public function touch($files, $time = null, $atime = null)
     {
@@ -104,7 +106,7 @@ class Filesystem
 
         foreach ($this->toIterator($files) as $file) {
             if (true !== @touch($file, $time, $atime)) {
-                throw new Exception\IOException(sprintf('Failed to touch %s', $file));
+                throw new IOException(sprintf('Failed to touch %s', $file));
             }
         }
     }
@@ -114,7 +116,7 @@ class Filesystem
      *
      * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to remove
      *
-     * @throws Exception\IOException When removal fails
+     * @throws IOException When removal fails
      */
     public function remove($files)
     {
@@ -129,17 +131,17 @@ class Filesystem
                 $this->remove(new \FilesystemIterator($file));
 
                 if (true !== @rmdir($file)) {
-                    throw new Exception\IOException(sprintf('Failed to remove directory %s', $file));
+                    throw new IOException(sprintf('Failed to remove directory %s', $file));
                 }
             } else {
                 // https://bugs.php.net/bug.php?id=52176
                 if (defined('PHP_WINDOWS_VERSION_MAJOR') && is_dir($file)) {
                     if (true !== @rmdir($file)) {
-                        throw new Exception\IOException(sprintf('Failed to remove file %s', $file));
+                        throw new IOException(sprintf('Failed to remove file %s', $file));
                     }
                 } else {
                     if (true !== @unlink($file)) {
-                        throw new Exception\IOException(sprintf('Failed to remove file %s', $file));
+                        throw new IOException(sprintf('Failed to remove file %s', $file));
                     }
                 }
             }
@@ -154,7 +156,7 @@ class Filesystem
      * @param integer                   $umask     The mode mask (octal)
      * @param Boolean                   $recursive Whether change the mod recursively or not
      *
-     * @throws Exception\IOException When the change fail
+     * @throws IOException When the change fail
      */
     public function chmod($files, $mode, $umask = 0000, $recursive = false)
     {
@@ -163,7 +165,7 @@ class Filesystem
                 $this->chmod(new \FilesystemIterator($file), $mode, $umask, true);
             }
             if (true !== @chmod($file, $mode & ~$umask)) {
-                throw new Exception\IOException(sprintf('Failed to chmod file %s', $file));
+                throw new IOException(sprintf('Failed to chmod file %s', $file));
             }
         }
     }
@@ -175,7 +177,7 @@ class Filesystem
      * @param string                    $user      The new owner user name
      * @param Boolean                   $recursive Whether change the owner recursively or not
      *
-     * @throws Exception\IOException When the change fail
+     * @throws IOException When the change fail
      */
     public function chown($files, $user, $recursive = false)
     {
@@ -185,11 +187,11 @@ class Filesystem
             }
             if (is_link($file) && function_exists('lchown')) {
                 if (true !== @lchown($file, $user)) {
-                    throw new Exception\IOException(sprintf('Failed to chown file %s', $file));
+                    throw new IOException(sprintf('Failed to chown file %s', $file));
                 }
             } else {
                 if (true !== @chown($file, $user)) {
-                    throw new Exception\IOException(sprintf('Failed to chown file %s', $file));
+                    throw new IOException(sprintf('Failed to chown file %s', $file));
                 }
             }
         }
@@ -202,7 +204,7 @@ class Filesystem
      * @param string                    $group     The group name
      * @param Boolean                   $recursive Whether change the group recursively or not
      *
-     * @throws Exception\IOException When the change fail
+     * @throws IOException When the change fail
      */
     public function chgrp($files, $group, $recursive = false)
     {
@@ -212,11 +214,11 @@ class Filesystem
             }
             if (is_link($file) && function_exists('lchgrp')) {
                 if (true !== @lchgrp($file, $group)) {
-                    throw new Exception\IOException(sprintf('Failed to chgrp file %s', $file));
+                    throw new IOException(sprintf('Failed to chgrp file %s', $file));
                 }
             } else {
                 if (true !== @chgrp($file, $group)) {
-                    throw new Exception\IOException(sprintf('Failed to chgrp file %s', $file));
+                    throw new IOException(sprintf('Failed to chgrp file %s', $file));
                 }
             }
         }
@@ -228,18 +230,18 @@ class Filesystem
      * @param string $origin The origin filename
      * @param string $target The new filename
      *
-     * @throws Exception\IOException When target file already exists
-     * @throws Exception\IOException When origin cannot be renamed
+     * @throws IOException When target file already exists
+     * @throws IOException When origin cannot be renamed
      */
     public function rename($origin, $target)
     {
         // we check that target does not exist
         if (is_readable($target)) {
-            throw new Exception\IOException(sprintf('Cannot rename because the target "%s" already exist.', $target));
+            throw new IOException(sprintf('Cannot rename because the target "%s" already exist.', $target));
         }
 
         if (true !== @rename($origin, $target)) {
-            throw new Exception\IOException(sprintf('Cannot rename "%s" to "%s".', $origin, $target));
+            throw new IOException(sprintf('Cannot rename "%s" to "%s".', $origin, $target));
         }
     }
 
@@ -250,7 +252,7 @@ class Filesystem
      * @param string  $targetDir     The symbolic link name
      * @param Boolean $copyOnWindows Whether to copy files if on Windows
      *
-     * @throws Exception\IOException When symlink fails
+     * @throws IOException When symlink fails
      */
     public function symlink($originDir, $targetDir, $copyOnWindows = false)
     {
@@ -273,7 +275,7 @@ class Filesystem
 
         if (!$ok) {
             if (true !== @symlink($originDir, $targetDir)) {
-                throw new Exception\IOException(sprintf('Failed to create symbolic link from %s to %s', $originDir, $targetDir));
+                throw new IOException(sprintf('Failed to create symbolic link from %s to %s', $originDir, $targetDir));
             }
         }
     }
@@ -322,7 +324,7 @@ class Filesystem
      *                                 - $options['override'] Whether to override an existing file on copy or not (see copy())
      *                                 - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink())
      *
-     * @throws Exception\IOException When file type is unknown
+     * @throws IOException When file type is unknown
      */
     public function mirror($originDir, $targetDir, \Traversable $iterator = null, $options = array())
     {
@@ -349,7 +351,7 @@ class Filesystem
             } elseif (is_file($file) || ($copyOnWindows && is_link($file))) {
                 $this->copy($file, $target, isset($options['override']) ? $options['override'] : false);
             } else {
-                throw new Exception\IOException(sprintf('Unable to guess "%s" file type.', $file));
+                throw new IOException(sprintf('Unable to guess "%s" file type.', $file));
             }
         }
     }

--- a/src/Symfony/Component/Filesystem/README.md
+++ b/src/Symfony/Component/Filesystem/README.md
@@ -3,29 +3,37 @@ Filesystem Component
 
 Filesystem provides basic utility to manipulate the file system:
 
-    use Symfony\Component\Filesystem\Filesystem;
+```php
+<?php
 
-    $filesystem = new Filesystem();
+use Symfony\Component\Filesystem\Filesystem;
 
-    $filesystem->copy($originFile, $targetFile, $override = false);
+$filesystem = new Filesystem();
 
-    $filesystem->mkdir($dirs, $mode = 0777);
+$filesystem->copy($originFile, $targetFile, $override = false);
 
-    $filesystem->touch($files);
+$filesystem->mkdir($dirs, $mode = 0777);
 
-    $filesystem->remove($files);
+$filesystem->touch($files, $time = null, $atime = null);
 
-    $filesystem->chmod($files, $mode, $umask = 0000);
+$filesystem->remove($files);
 
-    $filesystem->rename($origin, $target);
+$filesystem->chmod($files, $mode, $umask = 0000, $recursive = false);
 
-    $filesystem->symlink($originDir, $targetDir, $copyOnWindows = false);
+$filesystem->chown($files, $user, $recursive = false);
 
-    $filesystem->makePathRelative($endPath, $startPath);
+$filesystem->chgrp($files, $group, $recursive = false);
 
-    $filesystem->mirror($originDir, $targetDir, \Traversable $iterator = null, $options = array());
+$filesystem->rename($origin, $target);
 
-    $filesystem->isAbsolutePath($file);
+$filesystem->symlink($originDir, $targetDir, $copyOnWindows = false);
+
+$filesystem->makePathRelative($endPath, $startPath);
+
+$filesystem->mirror($originDir, $targetDir, \Traversable $iterator = null, $options = array());
+
+$filesystem->isAbsolutePath($file);
+```
 
 Resources
 ---------

--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -43,7 +43,7 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator
      */
     public function accept()
     {
-        $path = $this->isDir() ? $this->getSubPathname() : $this->getSubPath();
+        $path = $this->isDir() ? $this->current()->getRelativePathname() : $this->current()->getRelativePath();
         $path = strtr($path, '\\', '/');
         foreach ($this->patterns as $pattern) {
             if (preg_match($pattern, $path)) {

--- a/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
@@ -43,9 +43,10 @@ class FileTypeFilterIterator extends \FilterIterator
      */
     public function accept()
     {
-        if (self::ONLY_DIRECTORIES === (self::ONLY_DIRECTORIES & $this->mode) && $this->isFile()) {
+        $fileinfo = $this->current();
+        if (self::ONLY_DIRECTORIES === (self::ONLY_DIRECTORIES & $this->mode) && $fileinfo->isFile()) {
             return false;
-        } elseif (self::ONLY_FILES === (self::ONLY_FILES & $this->mode) && $this->isDir()) {
+        } elseif (self::ONLY_FILES === (self::ONLY_FILES & $this->mode) && $fileinfo->isDir()) {
             return false;
         }
 

--- a/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
@@ -30,13 +30,15 @@ class FilecontentFilterIterator extends MultiplePcreFilterIterator
             return true;
         }
 
-        if ($this->isDir() || !$this->isReadable()) {
+        $fileinfo = $this->current();
+
+        if ($fileinfo->isDir() || !$fileinfo->isReadable()) {
             return false;
         }
 
-        $content = @file_get_contents($filename = $this->getRealpath());
-        if (false === $content) {
-            throw new \RuntimeException(sprintf('Error reading file "%s".', $this->getRealpath()));
+        $content = $fileinfo->getContents();
+        if (!$content) {
+            return false;
         }
 
         // should at least not match one rule to exclude

--- a/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
@@ -28,7 +28,7 @@ class FilenameFilterIterator extends MultiplePcreFilterIterator
      */
     public function accept()
     {
-        $filename = $this->getFilename();
+        $filename = $this->current()->getFilename();
 
         // should at least not match one rule to exclude
         foreach ($this->noMatchRegexps as $regex) {

--- a/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
@@ -40,11 +40,12 @@ class SizeRangeFilterIterator extends \FilterIterator
      */
     public function accept()
     {
-        if (!$this->isFile()) {
+        $fileinfo = $this->current();
+        if (!$fileinfo->isFile()) {
             return true;
         }
 
-        $filesize = $this->getSize();
+        $filesize = $fileinfo->getSize();
         foreach ($this->comparators as $compare) {
             if (!$compare->test($filesize)) {
                 return false;

--- a/src/Symfony/Component/Finder/SplFileInfo.php
+++ b/src/Symfony/Component/Finder/SplFileInfo.php
@@ -54,4 +54,22 @@ class SplFileInfo extends \SplFileInfo
     {
         return $this->relativePathname;
     }
+
+    /**
+     * Returns the contents of the file
+     *
+     * @return string the contents of the file
+     */
+    public function getContents()
+    {
+        $level = error_reporting(0);
+        $content = file_get_contents($this->getRealpath());
+        error_reporting($level);
+        if (false === $content) {
+            $error = error_get_last();
+            throw new \RuntimeException($error['message']);
+        }
+
+        return $content;
+    }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFileIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFileIteratorTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Finder\Tests\Iterator;
 
 use Symfony\Component\Finder\Iterator\ExcludeDirectoryFilterIterator;
+use Symfony\Component\Finder\Iterator\RecursiveDirectoryIterator;
 
 class ExcludeDirectoryFilterIteratorTest extends RealIteratorTestCase
 {
@@ -20,7 +21,7 @@ class ExcludeDirectoryFilterIteratorTest extends RealIteratorTestCase
      */
     public function testAccept($directories, $expected)
     {
-        $inner = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(sys_get_temp_dir().'/symfony2_finder', \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
+        $inner = new \RecursiveIteratorIterator(new RecursiveDirectoryIterator(sys_get_temp_dir().'/symfony2_finder', \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
 
         $iterator = new ExcludeDirectoryFilterIterator($inner, $directories);
 

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilecontentFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilecontentFilterIteratorTest.php
@@ -18,73 +18,176 @@ class FilecontentFilterIteratorTest extends IteratorTestCase
 
     public function testAccept()
     {
-        $inner = new ContentInnerNameIterator(array('test.txt'));
+        $inner = new MockFileListIterator(array('test.txt'));
         $iterator = new FilecontentFilterIterator($inner, array(), array());
         $this->assertIterator(array('test.txt'), $iterator);
     }
 
     public function testDirectory()
     {
-        $inner = new ContentInnerNameIterator(array('directory'));
+        $inner = new MockFileListIterator(array('directory'));
         $iterator = new FilecontentFilterIterator($inner, array('directory'), array());
         $this->assertIterator(array(), $iterator);
     }
 
     public function testUnreadableFile()
     {
-        $inner = new ContentInnerNameIterator(array('file r-'));
+        $inner = new MockFileListIterator(array('file r-'));
         $iterator = new FilecontentFilterIterator($inner, array('file r-'), array());
         $this->assertIterator(array(), $iterator);
     }
 
     /**
-     * @expectedException RuntimeException
+     * @dataProvider getTestFilterData
      */
-    public function testFileGetContents()
+    public function testFilter(\Iterator $inner, array $matchPatterns, array $noMatchPatterns, array $resultArray)
     {
-        $inner = new ContentInnerNameIterator(array('file r+'));
-        $iterator = new FilecontentFilterIterator($inner, array('file r+'), array());
-        $array = iterator_to_array($iterator);
+        $iterator = new FilecontentFilterIterator($inner, $matchPatterns, $noMatchPatterns);
+        $this->assertIterator($resultArray, $iterator);
     }
 
+    public function getTestFilterData()
+    {
+        $inner = new MockFileListIterator();
+
+        $inner[] = new MockSplFileInfo(array(
+            'name'     => 'a.txt',
+            'contents' => 'Lorem ipsum...',
+            'type'     => 'file',
+            'mode'     => 'r+')
+        );
+
+        $inner[] = new MockSplFileInfo(array(
+            'name'     => 'b.yml',
+            'contents' => 'dolor sit...',
+            'type'     => 'file',
+            'mode'     => 'r+')
+        );
+
+        $inner[] = new MockSplFileInfo(array(
+            'name'     => 'some/other/dir/third.php',
+            'contents' => 'amet...',
+            'type'     => 'file',
+            'mode'     => 'r+')
+        );
+
+        $inner[] = new MockSplFileInfo(array(
+            'name'     => 'unreadable-file.txt',
+            'contents' => false,
+            'type'     => 'file',
+            'mode'     => 'r+')
+        );
+
+        return array(
+            array($inner, array('.'), array(), array('a.txt', 'b.yml', 'some/other/dir/third.php')),
+            array($inner, array('ipsum'), array(), array('a.txt')),
+            array($inner, array('i', 'amet'), array('Lorem', 'amet'), array('b.yml')),
+        );
+    }
 }
 
-class ContentInnerNameIterator extends \ArrayIterator
+class MockSplFileInfo extends \SplFileInfo
 {
-    public function current()
-    {
-        return new \SplFileInfo(parent::current());
-    }
+    const   TYPE_DIRECTORY = 1;
+    const   TYPE_FILE      = 2;
+    const   TYPE_UNKNOWN   = 3;
 
-    public function getFilename()
+    private $contents = null;
+    private $mode     = null;
+    private $type     = null;
+
+    public function __construct($param)
     {
-        return parent::current();
+        if (is_string($param)) {
+            parent::__construct($param);
+        } elseif (is_array($param)) {
+
+            $defaults = array(
+              'name'     => 'file.txt',
+              'contents' => null,
+              'mode'     => null,
+              'type'     => null
+            );
+            $defaults = array_merge($defaults, $param);
+            parent::__construct($defaults['name']);
+            $this->setContents($defaults['contents']);
+            $this->setMode($defaults['mode']);
+            $this->setType($defaults['type']);
+        } else {
+            throw new \RuntimeException(sprintf('Incorrect parameter "%s"', $param));
+        }
     }
 
     public function isFile()
     {
-        $name = parent::current();
+        if ($this->type === null) {
+            return preg_match('/file/', $this->getFilename());
+        };
 
-        return preg_match('/file/', $name);
+        return self::TYPE_FILE === $this->type;
     }
 
     public function isDir()
     {
-        $name = parent::current();
+        if ($this->type === null) {
+            return preg_match('/directory/', $this->getFilename());
+        }
 
-        return preg_match('/directory/', $name);
-    }
-
-    public function getRealpath()
-    {
-        return parent::current();
+        return self::TYPE_DIRECTORY === $this->type;
     }
 
     public function isReadable()
     {
-        $name = parent::current();
+        if ($this->mode === null) {
+            return preg_match('/r\+/', $this->getFilename());
+        }
 
-        return preg_match('/r\+/', $name);
+        return preg_match('/r\+/', $this->mode);
     }
 
+    public function getContents()
+    {
+        return $this->contents;
+    }
+
+    public function setContents($contents)
+    {
+        $this->contents = $contents;
+    }
+
+    public function setMode($mode)
+    {
+        $this->mode = $mode;
+    }
+
+    public function setType($type)
+    {
+        if (is_string($type)) {
+            switch ($type) {
+                case 'directory':
+                    $this->type = self::TYPE_DIRECTORY;
+                case 'd':
+                    $this->type = self::TYPE_DIRECTORY;
+                    break;
+                case 'file':
+                    $this->type = self::TYPE_FILE;
+                case 'f':
+                    $this->type = self::TYPE_FILE;
+                    break;
+                default:
+                    $this->type = self::TYPE_UNKNOWN;
+            }
+        } else {
+            $this->type = $type;
+        }
+    }
+}
+
+class MockFileListIterator extends \ArrayIterator
+{
+    public function __construct(array $filesArray = array())
+    {
+        $files = array_map(function($file){ return new MockSplFileInfo($file); }, $filesArray);
+        parent::__construct($files);
+    }
 }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BaseDateTimeTransformer.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\DataTransformer;
 
 use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 abstract class BaseDateTimeTransformer implements DataTransformerInterface
 {

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -76,6 +76,12 @@ class Form implements \IteratorAggregate, FormInterface
     private $children = array();
 
     /**
+     * The mapper for mapping data to children and back
+     * @var DataMapperInterface
+     */
+    private $dataMapper;
+
+    /**
      * The errors of this form
      * @var array An array of FormError instances
      */

--- a/src/Symfony/Component/HttpFoundation/ServerBag.php
+++ b/src/Symfony/Component/HttpFoundation/ServerBag.php
@@ -63,8 +63,8 @@ class ServerBag extends ParameterBag
                 $authorizationHeader = $this->parameters['REDIRECT_HTTP_AUTHORIZATION'];
             }
 
-            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW
-            if (null !== $authorizationHeader) {
+            // Decode AUTHORIZATION header into PHP_AUTH_USER and PHP_AUTH_PW when authorization header is basic
+            if ((null !== $authorizationHeader) && (0 === stripos($authorizationHeader, 'basic'))) {
                 $exploded = explode(':', base64_decode(substr($authorizationHeader, 6)));
                 if (count($exploded) == 2) {
                     list($headers['PHP_AUTH_USER'], $headers['PHP_AUTH_PW']) = $exploded;

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -59,7 +59,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
                 throw new BadCredentialsException('The credentials were changed from another session.');
             }
         } else {
-            if (!$presentedPassword = $token->getCredentials()) {
+            if ("" === ($presentedPassword = $token->getCredentials())) {
                 throw new BadCredentialsException('The presented password cannot be empty.');
             }
 

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -109,7 +109,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
      * @param string                $username The username to retrieve
      * @param UsernamePasswordToken $token    The Token
      *
-     * @return array The user
+     * @return UserInterface The user
      *
      * @throws AuthenticationException if the credentials could not be validated
      */

--- a/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
+++ b/src/Symfony/Component/Security/Core/Encoder/EncoderFactory.php
@@ -44,7 +44,7 @@ class EncoderFactory implements EncoderFactoryInterface
             return $this->encoders[$class];
         }
 
-        throw new \RuntimeException(sprintf('No encoder has been configured for account "%s".', is_object($class) ? get_class($user) : $class));
+        throw new \RuntimeException(sprintf('No encoder has been configured for account "%s".', is_object($user) ? get_class($user) : $user));
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -179,7 +179,7 @@ class ExceptionListener
     protected function setTargetPath(Request $request)
     {
         // session isn't required when using http basic authentication mechanism for example
-        if ($request->hasSession() && 'GET' == $request->getMethod()) {
+        if ($request->hasSession() && $request->isMethodSafe()) {
             $request->getSession()->set('_security.target_path', $request->getUri());
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -179,7 +179,7 @@ class ExceptionListener
     protected function setTargetPath(Request $request)
     {
         // session isn't required when using http basic authentication mechanism for example
-        if ($request->hasSession()) {
+        if ($request->hasSession() && 'GET' == $request->getMethod()) {
             $request->getSession()->set('_security.target_path', $request->getUri());
         }
     }

--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choices.</source>
-                <target>Selecteer ten minste {{ limit }} opties.</target>
+                <target>Selecteer ten minste {{ limit }} optie.|Selecteer ten minste {{ limit }} opties.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choices.</source>
-                <target>Selecteer maximaal {{ limit }} opties.</target>
+                <target>Selecteer maximaal {{ limit }} optie.|Selecteer maximaal {{ limit }} opties.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Deze waarde is te lang. Hij mag maximaal {{ limit }} tekens bevatten.</target>
+                <target>Deze waarde is te lang. Hij mag maximaal {{ limit }} teken bevatten.|Deze waarde is te lang. Hij mag maximaal {{ limit }} tekens bevatten.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,7 +84,7 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Deze waarde is te kort. Hij moet tenminste {{ limit }} tekens bevatten.</target>
+                <target>Deze waarde is te kort. Hij moet tenminste {{ limit }} teken bevatten.|Deze waarde is te kort. Hij moet tenminste {{ limit }} tekens bevatten.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
@@ -181,6 +181,38 @@
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} characters.</source>
                 <target>Deze waarde moet exact {{ limit }} tekens lang zijn.</target>
+            </trans-unit>
+            <trans-unit id="49">
+                <source>The file was only partially uploaded.</source>
+                <target>Het bestand is niet geheel geüpload.</target>
+            </trans-unit>
+            <trans-unit id="50">
+                <source>No file was uploaded.</source>
+                <target>Er is geen bestand geüpload.</target>
+            </trans-unit>
+            <trans-unit id="51">
+                <source>No temporary folder was configured in php.ini.</source>
+                <target>Er is geen tijdelijke map geconfigureerd in php.ini.</target>
+            </trans-unit>
+            <trans-unit id="52">
+                <source>Cannot write temporary file to disk.</source>
+                <target>Kan het tijdelijke bestand niet wegschrijven op disk.</target>
+            </trans-unit>
+            <trans-unit id="53">
+                <source>A PHP extension caused the upload to fail.</source>
+                <target>De upload is mislukt vanwege een PHP-extensie.</target>
+            </trans-unit>
+            <trans-unit id="54">
+                <source>This collection should contain {{ limit }} elements or more.</source>
+                <target>Deze collectie moet {{ limit }} element of meer bevatten.|Deze collectie moet {{ limit }} elementen of meer bevatten.</target>
+            </trans-unit>
+            <trans-unit id="55">
+                <source>This collection should contain {{ limit }} elements or less.</source>
+                <target>Deze collectie moet {{ limit }} element of minder bevatten.|Deze collectie moet {{ limit }} elementen of minder bevatten.</target>
+            </trans-unit>
+            <trans-unit id="56">
+                <source>This collection should contain exactly {{ limit }} elements.</source>
+                <target>Deze collectie moet exact {{ limit }} element bevatten.|Deze collectie moet exact {{ limit }} elementen bevatten.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

I'm currently working on a command to debug (service) listeners. I wanted to extend the ContainerDebugCommand from the FrameworkBundle but I found that the method resolveServiceDefinition($serviceId) was private so it avoids its usage from children.

This PR changes the visibility so it allows the re-use of this method when extending.
