### PR TITLE
[FrameworkBundle] Fix built-in server when using query params in paths 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/router.php
@@ -21,7 +21,7 @@
  * @author: Albert Jessurum <ajessu@gmail.com>
  */
 
-if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['REQUEST_URI'])) {
+if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_NAME'])) {
     return false;
 }
 


### PR DESCRIPTION
$_SERVER['REQUEST_URI'] will contain the query params so is_file will fail.
I propose to use $_SERVER['SCRIPT_FILENAME'] instead which contains the full path and no query params.
