### PR TITLE
Adding the database to the DSN we are sending to the MongoDB server

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -114,7 +114,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     {
         if ($this->mongo === null) {
             if (preg_match('#^(mongodb://.*)/(.*)/(.*)$#', $this->dsn, $matches)) {
-                $mongo = new \Mongo($matches[1]);
+                $mongo = new \Mongo($matches[1] . (!empty($matches[2]) ? '/' . $matches[2] : ''));
                 $database = $matches[2];
                 $collection = $matches[3];
                 $this->mongo = $mongo->selectCollection($database, $collection);


### PR DESCRIPTION
Adding the database to the DSN we are sending to the MongoDB server.

According to the [documentation from PHP](http://be2.php.net/manual/en/mongo.construct.php) the database will default to admin if it isn't specified in this DSN. Unfortunately the username we're trying to login with shouldn't have access to this database.
