### PR TITLE
Add the Countable interface to RouteCollection.

### DIFF
--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -24,7 +24,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  *
  * @api
  */
-class RouteCollection implements \IteratorAggregate
+class RouteCollection implements \IteratorAggregate, \Countable
 {
     private $routes;
     private $resources;
@@ -86,6 +86,16 @@ class RouteCollection implements \IteratorAggregate
     public function getIterator()
     {
         return new \ArrayIterator($this->routes);
+    }
+
+    /**
+     * Gets the number of Routes in this collection.
+     *
+     * @return int The number of routes in this collection, including nested collections
+     */
+    public function count()
+    {
+        return count($this->routes->all());
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -76,6 +76,18 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/foo1', $this->getFirstNamedRoute($collection, 'foo')->getPattern());
     }
 
+    public function testCount()
+    {
+        $collection = new RouteCollection();
+        $collection->add('foo', new Route('/foo'));
+
+        $collection1 = new RouteCollection();
+        $collection->addCollection($collection1);
+        $collection1->add('foo', new Route('/foo1'));
+
+        $this->assertCount(2, $collection);
+    }
+
     protected function getFirstNamedRoute(RouteCollection $routeCollection, $name)
     {
         foreach ($routeCollection as $key => $route) {


### PR DESCRIPTION
Since RouteCollection is a fancy-pants array of Routes, and it already is iterable, it would be nice if it were also countable.

There may be optimizations to be had here, but I figure this is a decent start.  There should be no BC breaks here, just some DX convenience.
