### PR TITLE
move create of default form label to view layer

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -460,6 +460,22 @@
     {% endfor %}
     ```
 
+  * Creation of default labels has been moved to the view layer. You will need
+    to incorporate this logic into any custom `form_label` templates to
+    accommodate those cases when the `label` option has not been explicitly
+    set.
+
+    ```
+    {% block form_label %}
+        {% if label is empty %}
+            {% set label = name|humanize %}
+        {% endif %}
+
+        {# ... #}
+
+    {% endblock %}
+    ````
+
 #### Other BC Breaks
 
   * The order of the first two arguments of the methods `createNamed` and

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -91,6 +91,13 @@ class FormExtension extends \Twig_Extension
         );
     }
 
+    public function getFilters()
+    {
+        return array(
+            'humanize' => new \Twig_Filter_Function(__NAMESPACE__.'\humanize'),
+        );
+    }
+
     public function isChoiceGroup($label)
     {
         return FormUtil::isChoiceGroup($label);
@@ -363,4 +370,9 @@ class FormExtension extends \Twig_Extension
 
         return $blocks;
     }
+}
+
+function humanize($text)
+{
+    return ucfirst(trim(strtolower(preg_replace('/[_\s]+/', ' ', $text))));
 }

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -225,6 +225,9 @@
     {% if required %}
         {% set label_attr = label_attr|merge({'class': (label_attr.class|default('') ~ ' required')|trim}) %}
     {% endif %}
+    {% if label is empty %}
+        {% set label = name|humanize %}
+    {% endif %}
     <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>{{ label|trans({}, translation_domain) }}</label>
 {% endspaceless %}
 {% endblock form_label %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_label.html.php
@@ -1,3 +1,4 @@
 <?php if ($required) { $label_attr['class'] = trim((isset($label_attr['class']) ? $label_attr['class'] : '').' required'); } ?>
 <?php if (!$compound) { $label_attr['for'] = $id; } ?>
+<?php if (!$label) { $label = $view['form']->humanize($name); } ?>
 <label <?php foreach ($label_attr as $k => $v) { printf('%s="%s" ', $view->escape($k), $view->escape($v)); } ?>><?php echo $view->escape($view['translator']->trans($label, array(), $translation_domain)) ?></label>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -314,6 +314,11 @@ class FormHelper extends Helper
         return trim($this->engine->render($template, $variables));
     }
 
+    public function humanize($text)
+    {
+        return ucfirst(trim(strtolower(preg_replace('/[_\s]+/', ' ', $text))));
+    }
+
     public function getName()
     {
         return 'form';

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -112,7 +112,7 @@ class FormType extends AbstractType
             'max_length'         => $options['max_length'],
             'pattern'            => $options['pattern'],
             'size'               => null,
-            'label'              => $options['label'] ?: $this->humanize($form->getName()),
+            'label'              => $options['label'],
             'multipart'          => false,
             'attr'               => $options['attr'],
             'label_attr'         => $options['label_attr'],
@@ -225,10 +225,5 @@ class FormType extends AbstractType
     public function getName()
     {
         return 'form';
-    }
-
-    private function humanize($text)
-    {
-        return ucfirst(trim(strtolower(preg_replace('/[_\s]+/', ' ', $text))));
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -213,14 +213,6 @@ class FormTypeTest extends TypeTestCase
         $this->assertEquals('messages', $view['child']->getVar('translation_domain'));
     }
 
-    public function testPassDefaultLabelToView()
-    {
-        $form = $this->factory->createNamed('__test___field', 'form');
-        $view = $form->createView();
-
-        $this->assertSame('Test field', $view->getVar('label'));
-    }
-
     public function testPassLabelToView()
     {
         $form = $this->factory->createNamed('__test___field', 'form', null, array('label' => 'My label'));


### PR DESCRIPTION
A small optimization if you provide custom labels in the view layer (i.e. `{{ form_label(form.name, 'Your name') }}`

```
Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~
```
