### PR TITLE
[TwigBundle] added support for custom loader paths

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -124,6 +124,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('strict_variables')->end()
                 ->scalarNode('auto_reload')->end()
                 ->scalarNode('optimizations')->end()
+                ->arrayNode('loader_paths')
+                    ->prototype('variable')->end()
+                ->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -60,6 +60,12 @@ class TwigExtension extends Extension
         $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
         $container->getDefinition('twig.loader')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
 
+        if (!empty($config['loader_paths'])) {
+            foreach ($config['loader_paths'] as $path) {
+                $container->getDefinition('twig.loader')->addMethodCall('addPath', array($path));
+            }
+        }
+
         if (!empty($config['globals'])) {
             $def = $container->getDefinition('twig');
             foreach ($config['globals'] as $key => $global) {


### PR DESCRIPTION
Before this commit, there was no ability to specify custom
search paths for Twig loader. Lets say we have twig templates
outside bundles directories (parts of the domain logic, not
application) - we want to be able to load them.

This commit adds `loader_paths` parameter to twig config,
which is used to set custom paths to the loader.
