### PR TITLE
Fix severity, file and line in ErrorExceptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
@@ -64,7 +64,7 @@ class ErrorHandler
         }
 
         if (error_reporting() & $level && $this->level & $level) {
-            throw new \ErrorException(sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line));
+            throw new \ErrorException(sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line), 0, $level, $file, $line);
         }
 
         return false;

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerTest.php
@@ -51,6 +51,9 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
             $handler->handle(1, 'foo', 'foo.php', 12, 'foo');
         } catch (\ErrorException $e) {
             $this->assertSame('1: foo in foo.php line 12', $e->getMessage());
+            $this->assertSame(1, $e->getSeverity());
+            $this->assertSame('foo.php', $e->getFile());
+            $this->assertSame(12, $e->getLine());
         }
 
         restore_error_handler();


### PR DESCRIPTION
Fix `ErrorHandler` only handing an error message to the constructor of
`ErrorException`, but not the severity, file name or line number.
