### PR TITLE
Replace Boolean by boolean

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -58,21 +58,21 @@ class EntityChoiceList extends ObjectChoiceList
     /**
      * Whether to use the identifier for index generation
      *
-     * @var Boolean
+     * @var boolean
      */
     private $idAsIndex = false;
 
     /**
      * Whether to use the identifier for value generation
      *
-     * @var Boolean
+     * @var boolean
      */
     private $idAsValue = false;
 
     /**
      * Whether the entities have already been loaded.
      *
-     * @var Boolean
+     * @var boolean
      */
     private $loaded = false;
 

--- a/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
+++ b/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
@@ -41,7 +41,7 @@ class ModelChoiceList extends ObjectChoiceList
     /**
      * Whether the model objects have already been loaded.
      *
-     * @var Boolean
+     * @var boolean
      */
     private $loaded = false;
 

--- a/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
+++ b/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
@@ -34,7 +34,7 @@ class MessageDataCollector extends DataCollector
      * to avoid the creation of these objects when no emails are sent.
      *
      * @param ContainerInterface $container A ContainerInterface instance
-     * @param Boolean            $isSpool
+     * @param boolean            $isSpool
      */
     public function __construct(ContainerInterface $container, $isSpool)
     {

--- a/src/Symfony/Bridge/Twig/TwigEngine.php
+++ b/src/Symfony/Bridge/Twig/TwigEngine.php
@@ -71,7 +71,7 @@ class TwigEngine implements EngineInterface, StreamingEngineInterface
      *
      * @param mixed $name A template name
      *
-     * @return Boolean true if the template exists, false otherwise
+     * @return boolean true if the template exists, false otherwise
      */
     public function exists($name)
     {
@@ -89,7 +89,7 @@ class TwigEngine implements EngineInterface, StreamingEngineInterface
      *
      * @param string $name A template name
      *
-     * @return Boolean True if this class supports the given resource, false otherwise
+     * @return boolean True if this class supports the given resource, false otherwise
      */
     public function supports($name)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/RouterCacheWarmer.php
@@ -49,7 +49,7 @@ class RouterCacheWarmer implements CacheWarmerInterface
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return Boolean always true
+     * @return boolean always true
      */
     public function isOptional()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
+++ b/src/Symfony/Bundle/FrameworkBundle/CacheWarmer/TemplatePathsCacheWarmer.php
@@ -55,7 +55,7 @@ class TemplatePathsCacheWarmer extends CacheWarmer
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return Boolean always true
+     * @return boolean always true
      */
     public function isOptional()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -36,7 +36,7 @@ class Controller extends ContainerAware
      *
      * @param string  $route      The name of the route
      * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
+     * @param boolean $absolute   Whether to generate an absolute URL
      *
      * @return string The generated URL
      */
@@ -226,7 +226,7 @@ class Controller extends ContainerAware
      *
      * @param string $id The service id
      *
-     * @return Boolean true if the service id is defined, false otherwise
+     * @return boolean true if the service id is defined, false otherwise
      */
     public function has($id)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -32,7 +32,7 @@ class RedirectController extends ContainerAware
      * If the permanent path parameter is set, the status code will be 302.
      *
      * @param string  $route     The route pattern to redirect to
-     * @param Boolean $permanent Whether the redirect is permanent or not
+     * @param boolean $permanent Whether the redirect is permanent or not
      *
      * @return Response A Response instance
      */
@@ -57,8 +57,8 @@ class RedirectController extends ContainerAware
      * If the permanent flag is set, the status code will be 302.
      *
      * @param string  $path      The path to redirect to
-     * @param Boolean $permanent Whether the redirect is permanent or not
-     * @param Boolean $scheme    The URL scheme (null to keep the current one)
+     * @param boolean $permanent Whether the redirect is permanent or not
+     * @param boolean $scheme    The URL scheme (null to keep the current one)
      * @param integer $httpPort  The HTTP port
      * @param integer $httpsPort The HTTPS port
      *

--- a/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DataCollector/RouterDataCollector.php
@@ -71,7 +71,7 @@ class RouterDataCollector extends DataCollector
     }
 
     /**
-     * @return Boolean Whether this request will result in a redirect
+     * @return boolean Whether this request will result in a redirect
      */
     public function getRedirect()
     {

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -27,11 +27,11 @@ class Configuration implements ConfigurationInterface
     /**
      * Constructor
      *
-     * @param Boolean $debug Whether to use the debug mode
+     * @param boolean $debug Whether to use the debug mode
      */
     public function  __construct($debug)
     {
-        $this->debug = (Boolean) $debug;
+        $this->debug = (boolean) $debug;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpCache/HttpCache.php
@@ -46,7 +46,7 @@ abstract class HttpCache extends BaseHttpCache
      * Forwards the Request to the backend and returns the Response.
      *
      * @param Request  $request A Request instance
-     * @param Boolean  $raw     Whether to catch exceptions or not
+     * @param boolean  $raw     Whether to catch exceptions or not
      * @param Response $entry   A Response instance (the stale entry if present, null otherwise)
      *
      * @return Response A Response instance

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/GlobalVariables.php
@@ -101,10 +101,10 @@ class GlobalVariables
     /**
      * Returns the current app debug mode.
      *
-     * @return Boolean The current debug mode
+     * @return boolean The current debug mode
      */
     public function getDebug()
     {
-        return (Boolean) $this->container->getParameter('kernel.debug');
+        return (boolean) $this->container->getParameter('kernel.debug');
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -325,7 +325,7 @@ class FormHelper extends Helper
      * @param FormView $view  The form view
      * @param string   $block The name of the block
      *
-     * @return string|Boolean The template logical name or false when no template is found
+     * @return string|boolean The template logical name or false when no template is found
      */
     protected function lookupTemplate(FormView $view, $block)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/RouterHelper.php
@@ -38,7 +38,7 @@ class RouterHelper extends Helper
      *
      * @param string  $name       The name of the route
      * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
+     * @param boolean $absolute   Whether to generate an absolute URL
      *
      * @return string The generated URL
      */

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/FilesystemLoader.php
@@ -40,7 +40,7 @@ class FilesystemLoader implements LoaderInterface
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|Boolean false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|boolean false if the template cannot be loaded, a Storage instance otherwise
      */
     public function load(TemplateReferenceInterface $template)
     {

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Loader/TemplateLocator.php
@@ -56,7 +56,7 @@ class TemplateLocator implements FileLocatorInterface
      *
      * @param TemplateReferenceInterface $template    A template
      * @param string                     $currentPath Unused
-     * @param Boolean                    $first       Unused
+     * @param boolean                    $first       Unused
      *
      * @return string The full path for the file
      *

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -62,7 +62,7 @@ class SecurityDataCollector extends DataCollector
     /**
      * Checks if security is enabled.
      *
-     * @return Boolean true if security is enabled, false otherwise
+     * @return boolean true if security is enabled, false otherwise
      */
     public function isEnabled()
     {
@@ -92,7 +92,7 @@ class SecurityDataCollector extends DataCollector
     /**
      * Checks if the user is authenticated or not.
      *
-     * @return Boolean true if the user is authenticated, false otherwise
+     * @return boolean true if the user is authenticated, false otherwise
      */
     public function isAuthenticated()
     {

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -137,7 +137,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
      *
      * @param array $config
      *
-     * @return Boolean Whether a possibly configured RememberMeServices should be set for this listener
+     * @return boolean Whether a possibly configured RememberMeServices should be set for this listener
      */
     protected function isRememberMeAware($config)
     {

--- a/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
+++ b/src/Symfony/Bundle/SecurityBundle/Templating/Helper/LogoutUrlHelper.php
@@ -80,7 +80,7 @@ class LogoutUrlHelper extends Helper
      * Generate the logout URL for the firewall.
      *
      * @param string  $key      The firewall key
-     * @param Boolean $absolute Whether to generate an absolute URL
+     * @param boolean $absolute Whether to generate an absolute URL
      * @return string The logout URL
      * @throws InvalidArgumentException if no LogoutListener is registered for the key
      */

--- a/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
+++ b/src/Symfony/Bundle/TwigBundle/CacheWarmer/TemplateCacheCacheWarmer.php
@@ -69,7 +69,7 @@ class TemplateCacheCacheWarmer implements CacheWarmerInterface
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return Boolean always true
+     * @return boolean always true
      */
     public function isOptional()
     {

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -86,7 +86,7 @@ class ExceptionController extends ContainerAware
      * @param EngineInterface $templating
      * @param string          $format
      * @param integer         $code       An HTTP response status code
-     * @param Boolean         $debug
+     * @param boolean         $debug
      *
      * @return TemplateReference
      */

--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -40,7 +40,7 @@ class WebDebugToolbarListener
     public function __construct(TwigEngine $templating, $interceptRedirects = false, $mode = self::ENABLED, $position = 'bottom')
     {
         $this->templating = $templating;
-        $this->interceptRedirects = (Boolean) $interceptRedirects;
+        $this->interceptRedirects = (boolean) $interceptRedirects;
         $this->mode = (integer) $mode;
         $this->position = $position;
     }

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -61,19 +61,19 @@ abstract class Client
     /**
      * Sets whether to automatically follow redirects or not.
      *
-     * @param Boolean $followRedirect Whether to follow redirects
+     * @param boolean $followRedirect Whether to follow redirects
      *
      * @api
      */
     public function followRedirects($followRedirect = true)
     {
-        $this->followRedirects = (Boolean) $followRedirect;
+        $this->followRedirects = (boolean) $followRedirect;
     }
 
     /**
      * Sets the insulated flag.
      *
-     * @param Boolean $insulated Whether to insulate the requests or not
+     * @param boolean $insulated Whether to insulate the requests or not
      *
      * @throws \RuntimeException When Symfony Process Component is not installed
      *
@@ -87,7 +87,7 @@ abstract class Client
             // @codeCoverageIgnoreEnd
         }
 
-        $this->insulated = (Boolean) $insulated;
+        $this->insulated = (boolean) $insulated;
     }
 
     /**
@@ -233,7 +233,7 @@ abstract class Client
      * @param array   $files         The files
      * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
      * @param string  $content       The raw body data
-     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     * @param boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
      *
      * @return Crawler
      *
@@ -481,7 +481,7 @@ abstract class Client
      * Makes a request from a Request object directly.
      *
      * @param Request $request       A Request instance
-     * @param Boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
+     * @param boolean $changeHistory Whether to update the history or not (only used internally for back(), forward(), and reload())
      *
      * @return Crawler
      */

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -50,9 +50,9 @@ class Cookie
      * @param string  $expires      The time the cookie expires
      * @param string  $path         The path on the server in which the cookie will be available on
      * @param string  $domain       The domain that the cookie is available
-     * @param Boolean $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param Boolean $httponly     The cookie httponly flag
-     * @param Boolean $encodedValue Whether the value is encoded or not
+     * @param boolean $secure       Indicates that the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param boolean $httponly     The cookie httponly flag
+     * @param boolean $encodedValue Whether the value is encoded or not
      *
      * @api
      */
@@ -69,8 +69,8 @@ class Cookie
         $this->expires  = null === $expires ? null : (integer) $expires;
         $this->path     = empty($path) ? '/' : $path;
         $this->domain   = $domain;
-        $this->secure   = (Boolean) $secure;
-        $this->httponly = (Boolean) $httponly;
+        $this->secure   = (boolean) $secure;
+        $this->httponly = (boolean) $httponly;
     }
 
     /**
@@ -280,7 +280,7 @@ class Cookie
     /**
      * Returns the secure flag of the cookie.
      *
-     * @return Boolean The cookie secure flag
+     * @return boolean The cookie secure flag
      *
      * @api
      */
@@ -292,7 +292,7 @@ class Cookie
     /**
      * Returns the httponly flag of the cookie.
      *
-     * @return Boolean The cookie httponly flag
+     * @return boolean The cookie httponly flag
      *
      * @api
      */
@@ -304,7 +304,7 @@ class Cookie
     /**
      * Returns true if the cookie has expired.
      *
-     * @return Boolean true if the cookie has expired, false otherwise
+     * @return boolean true if the cookie has expired, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -149,7 +149,7 @@ class CookieJar
      * Returns not yet expired cookie values for the given URI.
      *
      * @param string  $uri             A URI
-     * @param Boolean $returnsRawValue Returns raw value or urldecoded value
+     * @param boolean $returnsRawValue Returns raw value or urldecoded value
      *
      * @return array An array of cookie values
      */

--- a/src/Symfony/Component/BrowserKit/History.php
+++ b/src/Symfony/Component/BrowserKit/History.php
@@ -53,7 +53,7 @@ class History
     /**
      * Returns true if the history is empty.
      *
-     * @return Boolean true if the history is empty, false otherwise
+     * @return boolean true if the history is empty, false otherwise
      */
     public function isEmpty()
     {

--- a/src/Symfony/Component/BrowserKit/Response.php
+++ b/src/Symfony/Component/BrowserKit/Response.php
@@ -117,7 +117,7 @@ class Response
      * Gets a response header.
      *
      * @param string  $header The header name
-     * @param Boolean $first  Whether to return the first value or all header values
+     * @param boolean $first  Whether to return the first value or all header values
      *
      * @return string|array The first header value if $first is true, an array of values otherwise
      */

--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -69,7 +69,7 @@ class ApcClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param boolean $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {
@@ -89,7 +89,7 @@ class ApcClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return Boolean|null True, if loaded
+     * @return boolean|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -26,8 +26,8 @@ class ClassCollectionLoader
      * @param array   $classes    An array of classes to load
      * @param string  $cacheDir   A cache directory
      * @param string  $name       The cache name prefix
-     * @param Boolean $autoReload Whether to flush the cache when the cache is stale or not
-     * @param Boolean $adaptive   Whether to remove already declared classes or not
+     * @param boolean $autoReload Whether to flush the cache when the cache is stale or not
+     * @param boolean $adaptive   Whether to remove already declared classes or not
      * @param string  $extension  File extension of the resulting file
      *
      * @throws \InvalidArgumentException When class can't be loaded

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -103,7 +103,7 @@ class ClassLoader
     /**
      * Turns on searching the include for class files.
      *
-     * @param Boolean $useIncludePath
+     * @param boolean $useIncludePath
      */
     public function setUseIncludePath($useIncludePath)
     {
@@ -114,7 +114,7 @@ class ClassLoader
      * Can be used to check if the autoloader uses the include path to check
      * for classes.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function getUseIncludePath()
     {
@@ -124,7 +124,7 @@ class ClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param boolean $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {
@@ -144,7 +144,7 @@ class ClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return Boolean|null True, if loaded
+     * @return boolean|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -74,7 +74,7 @@ class DebugClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return Boolean|null True, if loaded
+     * @return boolean|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/ClassLoader/MapClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/MapClassLoader.php
@@ -33,7 +33,7 @@ class MapClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param boolean $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {

--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -70,7 +70,7 @@ class UniversalClassLoader
      * Turns on searching the include for class files. Allows easy loading
      * of installed PEAR packages
      *
-     * @param Boolean $useIncludePath
+     * @param boolean $useIncludePath
      */
     public function useIncludePath($useIncludePath)
     {
@@ -81,7 +81,7 @@ class UniversalClassLoader
      * Can be used to check if the autoloader uses the include path to check
      * for classes.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function getUseIncludePath()
     {
@@ -229,7 +229,7 @@ class UniversalClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param boolean $prepend Whether to prepend the autoloader or not
      *
      * @api
      */

--- a/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
@@ -70,7 +70,7 @@ class XcacheClassLoader
     /**
      * Registers this instance as an autoloader.
      *
-     * @param Boolean $prepend Whether to prepend the autoloader or not
+     * @param boolean $prepend Whether to prepend the autoloader or not
      */
     public function register($prepend = false)
     {
@@ -90,7 +90,7 @@ class XcacheClassLoader
      *
      * @param string $class The name of the class
      *
-     * @return Boolean|null True, if loaded
+     * @return boolean|null True, if loaded
      */
     public function loadClass($class)
     {

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -28,12 +28,12 @@ class ConfigCache
      * Constructor.
      *
      * @param string  $file  The absolute cache path
-     * @param Boolean $debug Whether debugging is enabled or not
+     * @param boolean $debug Whether debugging is enabled or not
      */
     public function __construct($file, $debug)
     {
         $this->file = $file;
-        $this->debug = (Boolean) $debug;
+        $this->debug = (boolean) $debug;
     }
 
     /**
@@ -52,7 +52,7 @@ class ConfigCache
      * This method always returns true when debug is off and the
      * cache file exists.
      *
-     * @return Boolean true if the cache is fresh, false otherwise
+     * @return boolean true if the cache is fresh, false otherwise
      */
     public function isFresh()
     {

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -74,51 +74,51 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
      * Sets whether to add default values for this array if it has not been
      * defined in any of the configuration files.
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      */
     public function setAddIfNotSet($boolean)
     {
-        $this->addIfNotSet = (Boolean) $boolean;
+        $this->addIfNotSet = (boolean) $boolean;
     }
 
     /**
      * Sets whether false is allowed as value indicating that the array should be unset.
      *
-     * @param Boolean $allow
+     * @param boolean $allow
      */
     public function setAllowFalse($allow)
     {
-        $this->allowFalse = (Boolean) $allow;
+        $this->allowFalse = (boolean) $allow;
     }
 
     /**
      * Sets whether new keys can be defined in subsequent configurations.
      *
-     * @param Boolean $allow
+     * @param boolean $allow
      */
     public function setAllowNewKeys($allow)
     {
-        $this->allowNewKeys = (Boolean) $allow;
+        $this->allowNewKeys = (boolean) $allow;
     }
 
     /**
      * Sets if deep merging should occur.
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      */
     public function setPerformDeepMerging($boolean)
     {
-        $this->performDeepMerging = (Boolean) $boolean;
+        $this->performDeepMerging = (boolean) $boolean;
     }
 
     /**
      * Whether extra keys should just be ignore without an exception.
      *
-     * @param Boolean $boolean To allow extra keys
+     * @param boolean $boolean To allow extra keys
      */
     public function setIgnoreExtraKeys($boolean)
     {
-        $this->ignoreExtraKeys = (Boolean) $boolean;
+        $this->ignoreExtraKeys = (boolean) $boolean;
     }
 
     /**
@@ -134,7 +134,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Checks if the node has a default value.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasDefaultValue()
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -138,21 +138,21 @@ abstract class BaseNode implements NodeInterface
     /**
      * Set this node as required.
      *
-     * @param Boolean $boolean Required node
+     * @param boolean $boolean Required node
      */
     public function setRequired($boolean)
     {
-        $this->required = (Boolean) $boolean;
+        $this->required = (boolean) $boolean;
     }
 
     /**
      * Sets if this node can be overridden.
      *
-     * @param Boolean $allow
+     * @param boolean $allow
      */
     public function setAllowOverwrite($allow)
     {
-        $this->allowOverwrite = (Boolean) $allow;
+        $this->allowOverwrite = (boolean) $allow;
     }
 
     /**
@@ -178,7 +178,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Checks if this node is required.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isRequired()
     {

--- a/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ArrayNodeDefinition.php
@@ -183,7 +183,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
      * This method is applicable to prototype nodes only.
      *
      * @param string  $name          The name of the key
-     * @param Boolean $removeKeyItem Whether or not the key item should be removed.
+     * @param boolean $removeKeyItem Whether or not the key item should be removed.
      *
      * @return ArrayNodeDefinition
      */
@@ -198,7 +198,7 @@ class ArrayNodeDefinition extends NodeDefinition implements ParentNodeDefinition
     /**
      * Sets whether the node can be unset.
      *
-     * @param Boolean $allow
+     * @param boolean $allow
      *
      * @return ArrayNodeDefinition
      */

--- a/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/MergeBuilder.php
@@ -37,7 +37,7 @@ class MergeBuilder
     /**
      * Sets whether the node can be unset.
      *
-     * @param Boolean $allow
+     * @param boolean $allow
      *
      * @return MergeBuilder
      */
@@ -51,7 +51,7 @@ class MergeBuilder
     /**
      * Sets whether the node can be overwritten.
      *
-     * @param Boolean $deny Whether the overwriting is forbidden or not
+     * @param boolean $deny Whether the overwriting is forbidden or not
      *
      * @return MergeBuilder
      */

--- a/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/NodeDefinition.php
@@ -116,7 +116,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Creates the node.
      *
-     * @param Boolean $forceRootNode Whether to force this node as the root node
+     * @param boolean $forceRootNode Whether to force this node as the root node
      *
      * @return NodeInterface
      */
@@ -278,7 +278,7 @@ abstract class NodeDefinition implements NodeParentInterface
     /**
      * Sets whether the node can be overwritten.
      *
-     * @param Boolean $deny Whether the overwriting is forbidden or not
+     * @param boolean $deny Whether the overwriting is forbidden or not
      *
      * @return NodeDefinition
      */

--- a/src/Symfony/Component/Config/Definition/NodeInterface.php
+++ b/src/Symfony/Component/Config/Definition/NodeInterface.php
@@ -38,14 +38,14 @@ interface NodeInterface
     /**
      * Returns true when the node is required.
      *
-     * @return Boolean If the node is required
+     * @return boolean If the node is required
      */
     function isRequired();
 
     /**
      * Returns true when the node has a default value.
      *
-     * @return Boolean If the node has a default value
+     * @return boolean If the node has a default value
      */
     function hasDefaultValue();
 

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -77,7 +77,7 @@ class PrototypedArrayNode extends ArrayNode
      * array, then you can set the second argument of this method to false.
      *
      * @param string  $attribute The name of the attribute which value is to be used as a key
-     * @param Boolean $remove    Whether or not to remove the key
+     * @param boolean $remove    Whether or not to remove the key
      */
     public function setKeyAttribute($attribute, $remove = true)
     {
@@ -114,7 +114,7 @@ class PrototypedArrayNode extends ArrayNode
     /**
      * Checks if the node has a default value.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasDefaultValue()
     {

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -55,11 +55,11 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     /**
      * Sets if this node is allowed to have an empty value.
      *
-     * @param Boolean $boolean True if this entity will accept empty values.
+     * @param boolean $boolean True if this entity will accept empty values.
      */
     public function setAllowEmptyValue($boolean)
     {
-        $this->allowEmptyValue = (Boolean) $boolean;
+        $this->allowEmptyValue = (boolean) $boolean;
     }
 
     /**

--- a/src/Symfony/Component/Config/FileLocator.php
+++ b/src/Symfony/Component/Config/FileLocator.php
@@ -35,7 +35,7 @@ class FileLocator implements FileLocatorInterface
      *
      * @param mixed   $name        The file name to locate
      * @param string  $currentPath The current path
-     * @param Boolean $first       Whether to return the first occurrence or an array of filenames
+     * @param boolean $first       Whether to return the first occurrence or an array of filenames
      *
      * @return string|array The full path to the file|An array of file paths
      *
@@ -80,7 +80,7 @@ class FileLocator implements FileLocatorInterface
      *
      * @param string $file A file path
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isAbsolutePath($file)
     {

--- a/src/Symfony/Component/Config/FileLocatorInterface.php
+++ b/src/Symfony/Component/Config/FileLocatorInterface.php
@@ -21,7 +21,7 @@ interface FileLocatorInterface
      *
      * @param mixed   $name        The file name to locate
      * @param string  $currentPath The current path
-     * @param Boolean $first       Whether to return the first occurrence or an array of filenames
+     * @param boolean $first       Whether to return the first occurrence or an array of filenames
      *
      * @return string|array The full path to the file|An array of file paths
      *

--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -53,7 +53,7 @@ abstract class FileLoader extends Loader
      *
      * @param mixed   $resource       A Resource
      * @param string  $type           The resource type
-     * @param Boolean $ignoreErrors   Whether to ignore import errors or not
+     * @param boolean $ignoreErrors   Whether to ignore import errors or not
      * @param string  $sourceResource The original resource importing the new resource
      *
      * @return mixed

--- a/src/Symfony/Component/Config/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Config/Loader/LoaderInterface.php
@@ -32,7 +32,7 @@ interface LoaderInterface
      * @param mixed  $resource A resource
      * @param string $type     The resource type
      *
-     * @return Boolean true if this class supports the given resource, false otherwise
+     * @return boolean true if this class supports the given resource, false otherwise
      */
     function supports($resource, $type = null);
 

--- a/src/Symfony/Component/Config/Resource/DirectoryResource.php
+++ b/src/Symfony/Component/Config/Resource/DirectoryResource.php
@@ -63,7 +63,7 @@ class DirectoryResource implements ResourceInterface, \Serializable
      *
      * @param integer $timestamp The last time the resource was loaded
      *
-     * @return Boolean true if the resource has not been updated, false otherwise
+     * @return boolean true if the resource has not been updated, false otherwise
      */
     public function isFresh($timestamp)
     {

--- a/src/Symfony/Component/Config/Resource/FileResource.php
+++ b/src/Symfony/Component/Config/Resource/FileResource.php
@@ -57,7 +57,7 @@ class FileResource implements ResourceInterface, \Serializable
      *
      * @param integer $timestamp The last time the resource was loaded
      *
-     * @return Boolean true if the resource has not been updated, false otherwise
+     * @return boolean true if the resource has not been updated, false otherwise
      */
     public function isFresh($timestamp)
     {

--- a/src/Symfony/Component/Config/Resource/ResourceInterface.php
+++ b/src/Symfony/Component/Config/Resource/ResourceInterface.php
@@ -30,7 +30,7 @@ interface ResourceInterface
      *
      * @param integer $timestamp The last time the resource was loaded
      *
-     * @return Boolean true if the resource has not been updated, false otherwise
+     * @return boolean true if the resource has not been updated, false otherwise
      */
     function isFresh($timestamp);
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -259,25 +259,25 @@ class Application
     /**
      * Sets whether to catch exceptions or not during commands execution.
      *
-     * @param Boolean $boolean Whether to catch exceptions or not during commands execution
+     * @param boolean $boolean Whether to catch exceptions or not during commands execution
      *
      * @api
      */
     public function setCatchExceptions($boolean)
     {
-        $this->catchExceptions = (Boolean) $boolean;
+        $this->catchExceptions = (boolean) $boolean;
     }
 
     /**
      * Sets whether to automatically exit after a command execution or not.
      *
-     * @param Boolean $boolean Whether to automatically exit after a command execution or not
+     * @param boolean $boolean Whether to automatically exit after a command execution or not
      *
      * @api
      */
     public function setAutoExit($boolean)
     {
-        $this->autoExit = (Boolean) $boolean;
+        $this->autoExit = (boolean) $boolean;
     }
 
     /**
@@ -438,7 +438,7 @@ class Application
      *
      * @param string $name The command name or alias
      *
-     * @return Boolean true if the command exists, false otherwise
+     * @return boolean true if the command exists, false otherwise
      *
      * @api
      */
@@ -695,7 +695,7 @@ class Application
      * Returns an XML representation of the Application.
      *
      * @param string  $namespace An optional namespace name
-     * @param Boolean $asDom     Whether to return a DOM or an XML string
+     * @param boolean $asDom     Whether to return a DOM or an XML string
      *
      * @return string|DOMDocument An XML string representing the Application
      */

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -132,7 +132,7 @@ class Command
      * Override this to check for x or y and return false if the command can not
      * run properly under the current conditions.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isEnabled()
     {
@@ -571,7 +571,7 @@ class Command
     /**
      * Returns an XML representation of the command.
      *
-     * @param Boolean $asDom Whether to return a DOM or an XML string
+     * @param boolean $asDom Whether to return a DOM or an XML string
      *
      * @return string|DOMDocument An XML string representing the command
      */

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -32,14 +32,14 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Initializes console output formatter.
      *
-     * @param Boolean $decorated Whether this formatter should actually decorate strings
+     * @param boolean $decorated Whether this formatter should actually decorate strings
      * @param array   $styles    Array of "name => FormatterStyle" instances
      *
      * @api
      */
     public function __construct($decorated = null, array $styles = array())
     {
-        $this->decorated = (Boolean) $decorated;
+        $this->decorated = (boolean) $decorated;
 
         $this->setStyle('error', new OutputFormatterStyle('white', 'red'));
         $this->setStyle('info', new OutputFormatterStyle('green'));
@@ -56,19 +56,19 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Sets the decorated flag.
      *
-     * @param Boolean $decorated Whether to decorate the messages or not
+     * @param boolean $decorated Whether to decorate the messages or not
      *
      * @api
      */
     public function setDecorated($decorated)
     {
-        $this->decorated = (Boolean) $decorated;
+        $this->decorated = (boolean) $decorated;
     }
 
     /**
      * Gets the decorated flag.
      *
-     * @return Boolean true if the output will decorate messages, false otherwise
+     * @return boolean true if the output will decorate messages, false otherwise
      *
      * @api
      */
@@ -95,7 +95,7 @@ class OutputFormatter implements OutputFormatterInterface
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -191,7 +191,7 @@ class OutputFormatter implements OutputFormatterInterface
      *
      * @param string $string
      *
-     * @return OutputFormatterStyle|Boolean false if string is not format string
+     * @return OutputFormatterStyle|boolean false if string is not format string
      */
     private function createStyleFromString($string)
     {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatterInterface.php
@@ -23,7 +23,7 @@ interface OutputFormatterInterface
     /**
      * Sets the decorated flag.
      *
-     * @param Boolean $decorated Whether to decorate the messages or not
+     * @param boolean $decorated Whether to decorate the messages or not
      *
      * @api
      */
@@ -32,7 +32,7 @@ interface OutputFormatterInterface
     /**
      * Gets the decorated flag.
      *
-     * @return Boolean true if the output will decorate messages, false otherwise
+     * @return boolean true if the output will decorate messages, false otherwise
      *
      * @api
      */
@@ -53,7 +53,7 @@ interface OutputFormatterInterface
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -53,9 +53,9 @@ class DialogHelper extends Helper
      *
      * @param OutputInterface $output   An Output instance
      * @param string|array    $question The question to ask
-     * @param Boolean         $default  The default answer if the user enters nothing
+     * @param boolean         $default  The default answer if the user enters nothing
      *
-     * @return Boolean true if the user has confirmed, false otherwise
+     * @return boolean true if the user has confirmed, false otherwise
      */
     public function askConfirmation(OutputInterface $output, $question, $default = true)
     {

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -37,7 +37,7 @@ class FormatterHelper extends Helper
      *
      * @param string|array $messages The message to write in the block
      * @param string       $style    The style to apply to the whole block
-     * @param Boolean      $large    Whether to return a large block
+     * @param boolean      $large    Whether to return a large block
      *
      * @return string The formatter message
      */

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -57,7 +57,7 @@ class HelperSet
      *
      * @param string $name The helper name
      *
-     * @return Boolean true if the helper is defined, false otherwise
+     * @return boolean true if the helper is defined, false otherwise
      */
     public function has($name)
     {

--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -265,7 +265,7 @@ class ArgvInput extends Input
      *
      * @param string|array $values The value(s) to look for in the raw parameters (can be an array)
      *
-     * @return Boolean true if the value is contained in the raw parameters
+     * @return boolean true if the value is contained in the raw parameters
      */
     public function hasParameterOption($values)
     {

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -65,7 +65,7 @@ class ArrayInput extends Input
      *
      * @param string|array $values The values to look for in the raw parameters (can be an array)
      *
-     * @return Boolean true if the value is contained in the raw parameters
+     * @return boolean true if the value is contained in the raw parameters
      */
     public function hasParameterOption($values)
     {

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -78,7 +78,7 @@ abstract class Input implements InputInterface
     /**
      * Checks if the input is interactive.
      *
-     * @return Boolean Returns true if the input is interactive
+     * @return boolean Returns true if the input is interactive
      */
     public function isInteractive()
     {
@@ -88,11 +88,11 @@ abstract class Input implements InputInterface
     /**
      * Sets the input interactivity.
      *
-     * @param Boolean $interactive If the input should be interactive
+     * @param boolean $interactive If the input should be interactive
      */
     public function setInteractive($interactive)
     {
-        $this->interactive = (Boolean) $interactive;
+        $this->interactive = (boolean) $interactive;
     }
 
     /**
@@ -145,7 +145,7 @@ abstract class Input implements InputInterface
      *
      * @param string|integer $name The InputArgument name or position
      *
-     * @return Boolean true if the InputArgument object exists, false otherwise
+     * @return boolean true if the InputArgument object exists, false otherwise
      */
     public function hasArgument($name)
     {
@@ -202,7 +202,7 @@ abstract class Input implements InputInterface
      *
      * @param string $name The InputOption name
      *
-     * @return Boolean true if the InputOption object exists, false otherwise
+     * @return boolean true if the InputOption object exists, false otherwise
      */
     public function hasOption($name)
     {

--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -69,7 +69,7 @@ class InputArgument
     /**
      * Returns true if the argument is required.
      *
-     * @return Boolean true if parameter mode is self::REQUIRED, false otherwise
+     * @return boolean true if parameter mode is self::REQUIRED, false otherwise
      */
     public function isRequired()
     {
@@ -79,7 +79,7 @@ class InputArgument
     /**
      * Returns true if the argument can take multiple values.
      *
-     * @return Boolean true if mode is self::IS_ARRAY, false otherwise
+     * @return boolean true if mode is self::IS_ARRAY, false otherwise
      */
     public function isArray()
     {

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -164,7 +164,7 @@ class InputDefinition
      *
      * @param string|integer $name The InputArgument name or position
      *
-     * @return Boolean true if the InputArgument object exists, false otherwise
+     * @return boolean true if the InputArgument object exists, false otherwise
      *
      * @api
      */
@@ -298,7 +298,7 @@ class InputDefinition
      *
      * @param string $name The InputOption name
      *
-     * @return Boolean true if the InputOption object exists, false otherwise
+     * @return boolean true if the InputOption object exists, false otherwise
      *
      * @api
      */
@@ -324,7 +324,7 @@ class InputDefinition
      *
      * @param string $name The InputOption shortcut
      *
-     * @return Boolean true if the InputOption object exists, false otherwise
+     * @return boolean true if the InputOption object exists, false otherwise
      */
     public function hasShortcut($name)
     {
@@ -473,7 +473,7 @@ class InputDefinition
     /**
      * Returns an XML representation of the InputDefinition.
      *
-     * @param Boolean $asDom Whether to return a DOM or an XML string
+     * @param boolean $asDom Whether to return a DOM or an XML string
      *
      * @return string|DOMDocument An XML string representing the InputDefinition
      */

--- a/src/Symfony/Component/Console/Input/InputInterface.php
+++ b/src/Symfony/Component/Console/Input/InputInterface.php
@@ -33,7 +33,7 @@ interface InputInterface
      *
      * @param string|array $values The values to look for in the raw parameters (can be an array)
      *
-     * @return Boolean true if the value is contained in the raw parameters
+     * @return boolean true if the value is contained in the raw parameters
      */
     function hasParameterOption($values);
 
@@ -97,7 +97,7 @@ interface InputInterface
      *
      * @param string|integer $name The InputArgument name or position
      *
-     * @return Boolean true if the InputArgument object exists, false otherwise
+     * @return boolean true if the InputArgument object exists, false otherwise
      */
     function hasArgument($name);
 
@@ -132,21 +132,21 @@ interface InputInterface
      *
      * @param string $name The InputOption name
      *
-     * @return Boolean true if the InputOption object exists, false otherwise
+     * @return boolean true if the InputOption object exists, false otherwise
      */
     function hasOption($name);
 
     /**
      * Is this input means interactive?
      *
-     * @return Boolean
+     * @return boolean
      */
     function isInteractive();
 
     /**
      * Sets the input interactivity.
      *
-     * @param Boolean $interactive If the input should be interactive
+     * @param boolean $interactive If the input should be interactive
      */
     function setInteractive($interactive);
 }

--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -109,7 +109,7 @@ class InputOption
     /**
      * Returns true if the option accepts a value.
      *
-     * @return Boolean true if value mode is not self::VALUE_NONE, false otherwise
+     * @return boolean true if value mode is not self::VALUE_NONE, false otherwise
      */
     public function acceptValue()
     {
@@ -119,7 +119,7 @@ class InputOption
     /**
      * Returns true if the option requires a value.
      *
-     * @return Boolean true if value mode is self::VALUE_REQUIRED, false otherwise
+     * @return boolean true if value mode is self::VALUE_REQUIRED, false otherwise
      */
     public function isValueRequired()
     {
@@ -129,7 +129,7 @@ class InputOption
     /**
      * Returns true if the option takes an optional value.
      *
-     * @return Boolean true if value mode is self::VALUE_OPTIONAL, false otherwise
+     * @return boolean true if value mode is self::VALUE_OPTIONAL, false otherwise
      */
     public function isValueOptional()
     {
@@ -139,7 +139,7 @@ class InputOption
     /**
      * Returns true if the option can take multiple values.
      *
-     * @return Boolean true if mode is self::VALUE_IS_ARRAY, false otherwise
+     * @return boolean true if mode is self::VALUE_IS_ARRAY, false otherwise
      */
     public function isArray()
     {
@@ -194,7 +194,7 @@ class InputOption
      * Checks whether the given option equals this one
      *
      * @param InputOption $option option to compare
-     * @return Boolean
+     * @return boolean
      */
     public function equals(InputOption $option)
     {

--- a/src/Symfony/Component/Console/Output/ConsoleOutput.php
+++ b/src/Symfony/Component/Console/Output/ConsoleOutput.php
@@ -39,7 +39,7 @@ class ConsoleOutput extends StreamOutput implements ConsoleOutputInterface
      *
      * @param integer $verbosity The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL,
      *                                   self::VERBOSITY_VERBOSE)
-     * @param Boolean         $decorated Whether to decorate messages or not (null for auto-guessing)
+     * @param boolean         $decorated Whether to decorate messages or not (null for auto-guessing)
      * @param OutputFormatter $formatter Output formatter instance
      *
      * @api

--- a/src/Symfony/Component/Console/Output/NullOutput.php
+++ b/src/Symfony/Component/Console/Output/NullOutput.php
@@ -26,7 +26,7 @@ class NullOutput extends Output
      * Writes a message to the output.
      *
      * @param string  $message A message to write to the output
-     * @param Boolean $newline Whether to add a newline or not
+     * @param boolean $newline Whether to add a newline or not
      */
     protected function doWrite($message, $newline)
     {

--- a/src/Symfony/Component/Console/Output/Output.php
+++ b/src/Symfony/Component/Console/Output/Output.php
@@ -36,7 +36,7 @@ abstract class Output implements OutputInterface
      * Constructor.
      *
      * @param integer                  $verbosity The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL, self::VERBOSITY_VERBOSE)
-     * @param Boolean                  $decorated Whether to decorate messages or not (null for auto-guessing)
+     * @param boolean                  $decorated Whether to decorate messages or not (null for auto-guessing)
      * @param OutputFormatterInterface $formatter Output formatter instance
      *
      * @api
@@ -45,7 +45,7 @@ abstract class Output implements OutputInterface
     {
         $this->verbosity = null === $verbosity ? self::VERBOSITY_NORMAL : $verbosity;
         $this->formatter = null === $formatter ? new OutputFormatter() : $formatter;
-        $this->formatter->setDecorated((Boolean) $decorated);
+        $this->formatter->setDecorated((boolean) $decorated);
     }
 
     /**
@@ -75,19 +75,19 @@ abstract class Output implements OutputInterface
     /**
      * Sets the decorated flag.
      *
-     * @param Boolean $decorated Whether to decorate the messages or not
+     * @param boolean $decorated Whether to decorate the messages or not
      *
      * @api
      */
     public function setDecorated($decorated)
     {
-        $this->formatter->setDecorated((Boolean) $decorated);
+        $this->formatter->setDecorated((boolean) $decorated);
     }
 
     /**
      * Gets the decorated flag.
      *
-     * @return Boolean true if the output will decorate messages, false otherwise
+     * @return boolean true if the output will decorate messages, false otherwise
      *
      * @api
      */
@@ -137,7 +137,7 @@ abstract class Output implements OutputInterface
      * Writes a message to the output.
      *
      * @param string|array $messages The message as an array of lines of a single string
-     * @param Boolean      $newline  Whether to add a newline or not
+     * @param boolean      $newline  Whether to add a newline or not
      * @param integer      $type     The type of output
      *
      * @throws \InvalidArgumentException When unknown output type is given
@@ -174,7 +174,7 @@ abstract class Output implements OutputInterface
      * Writes a message to the output.
      *
      * @param string  $message A message to write to the output
-     * @param Boolean $newline Whether to add a newline or not
+     * @param boolean $newline Whether to add a newline or not
      */
     abstract protected function doWrite($message, $newline);
 }

--- a/src/Symfony/Component/Console/Output/OutputInterface.php
+++ b/src/Symfony/Component/Console/Output/OutputInterface.php
@@ -34,7 +34,7 @@ interface OutputInterface
      * Writes a message to the output.
      *
      * @param string|array $messages The message as an array of lines of a single string
-     * @param Boolean      $newline  Whether to add a newline or not
+     * @param boolean      $newline  Whether to add a newline or not
      * @param integer      $type     The type of output
      *
      * @throws \InvalidArgumentException When unknown output type is given
@@ -74,7 +74,7 @@ interface OutputInterface
     /**
      * Sets the decorated flag.
      *
-     * @param Boolean $decorated Whether to decorate the messages or not
+     * @param boolean $decorated Whether to decorate the messages or not
      *
      * @api
      */
@@ -83,7 +83,7 @@ interface OutputInterface
     /**
      * Gets the decorated flag.
      *
-     * @return Boolean true if the output will decorate messages, false otherwise
+     * @return boolean true if the output will decorate messages, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Output/StreamOutput.php
+++ b/src/Symfony/Component/Console/Output/StreamOutput.php
@@ -38,7 +38,7 @@ class StreamOutput extends Output
      * @param mixed   $stream    A stream resource
      * @param integer $verbosity The verbosity level (self::VERBOSITY_QUIET, self::VERBOSITY_NORMAL,
      *                                   self::VERBOSITY_VERBOSE)
-     * @param Boolean         $decorated Whether to decorate messages or not (null for auto-guessing)
+     * @param boolean         $decorated Whether to decorate messages or not (null for auto-guessing)
      * @param OutputFormatter $formatter Output formatter instance
      *
      * @throws \InvalidArgumentException When first argument is not a real stream
@@ -74,7 +74,7 @@ class StreamOutput extends Output
      * Writes a message to the output.
      *
      * @param string  $message A message to write to the output
-     * @param Boolean $newline Whether to add a newline or not
+     * @param boolean $newline Whether to add a newline or not
      *
      * @throws \RuntimeException When unable to write output (should never happen)
      */
@@ -98,7 +98,7 @@ class StreamOutput extends Output
      *  -  windows without ansicon
      *  -  non tty consoles
      *
-     * @return Boolean true if the stream supports colorization, false otherwise
+     * @return boolean true if the stream supports colorization, false otherwise
      */
     protected function hasColorSupport()
     {

--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -146,7 +146,7 @@ EOF;
      *
      * @param string $text The last segment of the entered text
      *
-     * @return Boolean|array A list of guessed strings or true
+     * @return boolean|array A list of guessed strings or true
      */
     private function autocompleter($text)
     {
@@ -202,6 +202,6 @@ EOF;
 
     public function setProcessIsolation($processIsolation)
     {
-        $this->processIsolation = (Boolean) $processIsolation;
+        $this->processIsolation = (boolean) $processIsolation;
     }
 }

--- a/src/Symfony/Component/CssSelector/Node/FunctionNode.php
+++ b/src/Symfony/Component/CssSelector/Node/FunctionNode.php
@@ -78,8 +78,8 @@ class FunctionNode implements NodeInterface
      *
      * @param XPathExpr $xpath
      * @param mixed     $expr
-     * @param Boolean   $last
-     * @param Boolean   $addNameTest
+     * @param boolean   $last
+     * @param boolean   $addNameTest
      *
      * @return XPathExpr
      */

--- a/src/Symfony/Component/CssSelector/Token.php
+++ b/src/Symfony/Component/CssSelector/Token.php
@@ -54,7 +54,7 @@ class Token
      *
      * @param string $type The type to test against this token's one.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isType($type)
     {

--- a/src/Symfony/Component/CssSelector/XPathExpr.php
+++ b/src/Symfony/Component/CssSelector/XPathExpr.php
@@ -34,7 +34,7 @@ class XPathExpr
      * @param string  $path       Actual path of the expression.
      * @param string  $element    The element in the expression.
      * @param string  $condition  A condition for the expression.
-     * @param Boolean $starPrefix Indicates whether to use a star prefix.
+     * @param boolean $starPrefix Indicates whether to use a star prefix.
      */
     public function __construct($prefix = null, $path = null, $element = '*', $condition = null, $starPrefix = false)
     {
@@ -68,7 +68,7 @@ class XPathExpr
     /**
      * Answers whether this XPath expression has a star prefix.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasStarPrefix()
     {

--- a/src/Symfony/Component/DependencyInjection/Alias.php
+++ b/src/Symfony/Component/DependencyInjection/Alias.php
@@ -23,7 +23,7 @@ class Alias
      * Constructor.
      *
      * @param string  $id     Alias identifier
-     * @param Boolean $public If this alias is public
+     * @param boolean $public If this alias is public
      *
      * @api
      */
@@ -36,7 +36,7 @@ class Alias
     /**
      * Checks if this DI Alias should be public or not.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -48,13 +48,13 @@ class Alias
     /**
      * Sets if this Alias is public.
      *
-     * @param Boolean $boolean If this Alias should be public
+     * @param boolean $boolean If this Alias should be public
      *
      * @api
      */
     public function setPublic($boolean)
     {
-        $this->public = (Boolean) $boolean;
+        $this->public = (boolean) $boolean;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -36,11 +36,11 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
     /**
      * Constructor.
      *
-     * @param Boolean $onlyConstructorArguments Sets this Service Reference pass to ignore method calls
+     * @param boolean $onlyConstructorArguments Sets this Service Reference pass to ignore method calls
      */
     public function __construct($onlyConstructorArguments = false)
     {
-        $this->onlyConstructorArguments = (Boolean) $onlyConstructorArguments;
+        $this->onlyConstructorArguments = (boolean) $onlyConstructorArguments;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -107,7 +107,7 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
      * @param string           $id
      * @param Definition       $definition
      *
-     * @return Boolean If the definition is inlineable
+     * @return boolean If the definition is inlineable
      */
     private function isInlinableDefinition(ContainerBuilder $container, $id, Definition $definition)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -70,7 +70,7 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
      * Processes arguments to determine invalid references.
      *
      * @param array   $arguments    An array of Reference objects
-     * @param Boolean $inMethodCall
+     * @param boolean $inMethodCall
      */
     private function processArguments(array $arguments, $inMethodCall = false)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraphNode.php
@@ -65,7 +65,7 @@ class ServiceReferenceGraphNode
     /**
      * Checks if the value of this node is an Alias.
      *
-     * @return Boolean True if the value is an Alias instance
+     * @return boolean True if the value is an Alias instance
      */
     public function isAlias()
     {
@@ -75,7 +75,7 @@ class ServiceReferenceGraphNode
     /**
      * Checks if the value of this node is a Definition.
      *
-     * @return Boolean True if the value is a Definition instance
+     * @return boolean True if the value is a Definition instance
      */
     public function isDefinition()
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -109,7 +109,7 @@ class Container implements IntrospectableContainerInterface
     /**
      * Returns true if the container parameter bag are frozen.
      *
-     * @return Boolean true if the container parameter bag are frozen, false otherwise
+     * @return boolean true if the container parameter bag are frozen, false otherwise
      *
      * @api
      */
@@ -151,7 +151,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return Boolean The presence of parameter in container
+     * @return boolean The presence of parameter in container
      *
      * @api
      */
@@ -206,7 +206,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return Boolean true if the service is defined, false otherwise
+     * @return boolean true if the service is defined, false otherwise
      *
      * @api
      */
@@ -271,7 +271,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return Boolean true if service has already been initialized, false otherwise
+     * @return boolean true if service has already been initialized, false otherwise
      */
     public function initialized($id)
     {
@@ -416,7 +416,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $name The name of the scope
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -432,7 +432,7 @@ class Container implements IntrospectableContainerInterface
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -94,7 +94,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $name The name of the extension
      *
-     * @return Boolean If the extension exists
+     * @return boolean If the extension exists
      *
      * @api
      */
@@ -293,7 +293,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return Boolean true if the service is defined, false otherwise
+     * @return boolean true if the service is defined, false otherwise
      *
      * @api
      */
@@ -534,7 +534,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return Boolean true if the alias exists, false otherwise
+     * @return boolean true if the alias exists, false otherwise
      *
      * @api
      */
@@ -662,7 +662,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return Boolean true if the service definition exists, false otherwise
+     * @return boolean true if the service definition exists, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -61,7 +61,7 @@ interface ContainerInterface
      *
      * @param string $id The service identifier
      *
-     * @return Boolean true if the service is defined, false otherwise
+     * @return boolean true if the service is defined, false otherwise
      *
      * @api
      */
@@ -85,7 +85,7 @@ interface ContainerInterface
      *
      * @param string $name The parameter name
      *
-     * @return Boolean The presence of parameter in container
+     * @return boolean The presence of parameter in container
      *
      * @api
      */
@@ -133,7 +133,7 @@ interface ContainerInterface
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -146,7 +146,7 @@ interface ContainerInterface
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -351,7 +351,7 @@ class Definition
      *
      * @param string $method The method name to search for
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -442,7 +442,7 @@ class Definition
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -540,7 +540,7 @@ class Definition
     /**
      * Sets the visibility of this service.
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      *
      * @return Definition The current instance
      *
@@ -548,7 +548,7 @@ class Definition
      */
     public function setPublic($boolean)
     {
-        $this->public = (Boolean) $boolean;
+        $this->public = (boolean) $boolean;
 
         return $this;
     }
@@ -556,7 +556,7 @@ class Definition
     /**
      * Whether this service is public facing
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -569,7 +569,7 @@ class Definition
      * Sets whether this definition is synthetic, that is not constructed by the
      * container, but dynamically injected.
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      *
      * @return Definition the current instance
      *
@@ -577,7 +577,7 @@ class Definition
      */
     public function setSynthetic($boolean)
     {
-        $this->synthetic = (Boolean) $boolean;
+        $this->synthetic = (boolean) $boolean;
 
         return $this;
     }
@@ -586,7 +586,7 @@ class Definition
      * Whether this definition is synthetic, that is not constructed by the
      * container, but dynamically injected.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -599,7 +599,7 @@ class Definition
      * Whether this definition is abstract, that means it merely serves as a
      * template for other definitions.
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      *
      * @return Definition the current instance
      *
@@ -607,7 +607,7 @@ class Definition
      */
     public function setAbstract($boolean)
     {
-        $this->abstract = (Boolean) $boolean;
+        $this->abstract = (boolean) $boolean;
 
         return $this;
     }
@@ -616,7 +616,7 @@ class Definition
      * Whether this definition is abstract, that means it merely serves as a
      * template for other definitions.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/GraphvizDumper.php
@@ -121,7 +121,7 @@ class GraphvizDumper extends Dumper
      *
      * @param string  $id        The service id used to find edges
      * @param array   $arguments An array of arguments
-     * @param Boolean $required
+     * @param boolean $required
      * @param string  $name
      *
      * @return array An array of edges

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -344,7 +344,7 @@ class PhpDumper extends Dumper
      * @param string     $id
      * @param Definition $definition
      *
-     * @return Boolean
+     * @return boolean
      */
     private function isSimpleInstance($id, $definition)
     {
@@ -952,7 +952,7 @@ EOF;
      * @param string $id
      * @param array  $arguments
      *
-     * @return Boolean
+     * @return boolean
      */
     private function hasReference($id, array $arguments)
     {
@@ -975,7 +975,7 @@ EOF;
      * Dumps values.
      *
      * @param array   $value
-     * @param Boolean $interpolate
+     * @param boolean $interpolate
      *
      * @return string
      */
@@ -1032,7 +1032,7 @@ EOF;
             return $this->dumpParameter($value);
         } elseif (true === $interpolate && is_string($value)) {
             if (preg_match('/^%([^%]+)%$/', $value, $match)) {
-                // we do this to deal with non string values (Boolean, integer, ...)
+                // we do this to deal with non string values (boolean, integer, ...)
                 // the preg_replace_callback converts them to strings
                 return $this->dumpParameter(strtolower($match[1]));
             } else {

--- a/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/IntrospectableContainerInterface.php
@@ -25,7 +25,7 @@ interface IntrospectableContainerInterface extends ContainerInterface
      *
      * @param string $id
      *
-     * @return Boolean true if the service has been initialized, false otherwise
+     * @return boolean true if the service has been initialized, false otherwise
      *
      */
     function initialized($id);

--- a/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/ClosureLoader.php
@@ -52,7 +52,7 @@ class ClosureLoader extends Loader
      * @param mixed  $resource A resource
      * @param string $type     The resource type
      *
-     * @return Boolean true if this class supports the given resource, false otherwise
+     * @return boolean true if this class supports the given resource, false otherwise
      */
     public function supports($resource, $type = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/IniFileLoader.php
@@ -53,7 +53,7 @@ class IniFileLoader extends FileLoader
      * @param mixed  $resource A resource
      * @param string $type     The resource type
      *
-     * @return Boolean true if this class supports the given resource, false otherwise
+     * @return boolean true if this class supports the given resource, false otherwise
      */
     public function supports($resource, $type = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/PhpFileLoader.php
@@ -48,7 +48,7 @@ class PhpFileLoader extends FileLoader
      * @param mixed  $resource A resource
      * @param string $type     The resource type
      *
-     * @return Boolean true if this class supports the given resource, false otherwise
+     * @return boolean true if this class supports the given resource, false otherwise
      */
     public function supports($resource, $type = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -65,7 +65,7 @@ class XmlFileLoader extends FileLoader
      * @param mixed  $resource A resource
      * @param string $type     The resource type
      *
-     * @return Boolean true if this class supports the given resource, false otherwise
+     * @return boolean true if this class supports the given resource, false otherwise
      */
     public function supports($resource, $type = null)
     {
@@ -101,7 +101,7 @@ class XmlFileLoader extends FileLoader
 
         foreach ($imports as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import((string) $import['resource'], null, (Boolean) $import->getAttributeAsPhp('ignore-errors'), $file);
+            $this->import((string) $import['resource'], null, (boolean) $import->getAttributeAsPhp('ignore-errors'), $file);
         }
     }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -71,7 +71,7 @@ class YamlFileLoader extends FileLoader
      * @param mixed  $resource A resource
      * @param string $type     The resource type
      *
-     * @return Boolean true if this class supports the given resource, false otherwise
+     * @return boolean true if this class supports the given resource, false otherwise
      */
     public function supports($resource, $type = null)
     {
@@ -92,7 +92,7 @@ class YamlFileLoader extends FileLoader
 
         foreach ($content['imports'] as $import) {
             $this->setCurrentDir(dirname($file));
-            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (Boolean) $import['ignore_errors'] : false, $file);
+            $this->import($import['resource'], null, isset($import['ignore_errors']) ? (boolean) $import['ignore_errors'] : false, $file);
         }
     }
 
@@ -127,7 +127,7 @@ class YamlFileLoader extends FileLoader
 
             return;
         } elseif (isset($service['alias'])) {
-            $public = !array_key_exists('public', $service) || (Boolean) $service['public'];
+            $public = !array_key_exists('public', $service) || (boolean) $service['public'];
             $this->container->setAlias($id, new Alias($service['alias'], $public));
 
             return;

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -117,7 +117,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @param string $name The parameter name
      *
-     * @return Boolean true if the parameter name is defined, false otherwise
+     * @return boolean true if the parameter name is defined, false otherwise
      *
      * @api
      */
@@ -207,7 +207,7 @@ class ParameterBag implements ParameterBagInterface
      */
     public function resolveString($value, array $resolving = array())
     {
-        // we do this to deal with non string values (Boolean, integer, ...)
+        // we do this to deal with non string values (boolean, integer, ...)
         // as the preg_replace_callback throw an exception when trying
         // a non-string in a parameter value
         if (preg_match('/^%([^%\s]+)%$/', $value, $match)) {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -75,7 +75,7 @@ interface ParameterBagInterface
      *
      * @param string $name The parameter name
      *
-     * @return Boolean true if the parameter name is defined, false otherwise
+     * @return boolean true if the parameter name is defined, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Reference.php
+++ b/src/Symfony/Component/DependencyInjection/Reference.php
@@ -29,7 +29,7 @@ class Reference
      *
      * @param string  $id              The service identifier
      * @param int     $invalidBehavior The behavior when the service does not exist
-     * @param Boolean $strict          Sets how this reference is validated
+     * @param boolean $strict          Sets how this reference is validated
      *
      * @see Container
      */
@@ -63,7 +63,7 @@ class Reference
     /**
      * Returns true when this Reference is strict
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isStrict()
     {

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -34,7 +34,7 @@ class SimpleXMLElement extends \SimpleXMLElement
      * Returns arguments as valid php types.
      *
      * @param string  $name
-     * @param Boolean $lowercase
+     * @param boolean $lowercase
      *
      * @return mixed
      */

--- a/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/ChoiceFormField.php
@@ -27,7 +27,7 @@ class ChoiceFormField extends FormField
      */
     private $type;
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $multiple;
     /**
@@ -38,7 +38,7 @@ class ChoiceFormField extends FormField
     /**
      * Returns true if the field should be included in the submitted values.
      *
-     * @return Boolean true if the field should be included in the submitted values, false otherwise
+     * @return boolean true if the field should be included in the submitted values, false otherwise
      */
     public function hasValue()
     {
@@ -53,7 +53,7 @@ class ChoiceFormField extends FormField
     /**
      * Check if the current selected option is disabled
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isDisabled()
     {
@@ -188,7 +188,7 @@ class ChoiceFormField extends FormField
     /**
      * Returns true if the field accepts multiple values.
      *
-     * @return Boolean true if the field accepts multiple values, false otherwise
+     * @return boolean true if the field accepts multiple values, false otherwise
      */
     public function isMultiple()
     {

--- a/src/Symfony/Component/DomCrawler/Field/FormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FormField.php
@@ -39,7 +39,7 @@ abstract class FormField
      */
     protected $xpath;
     /**
-     * @var Boolean
+     * @var boolean
      */
     protected $disabled;
 
@@ -98,7 +98,7 @@ abstract class FormField
     /**
      * Returns true if the field should be included in the submitted values.
      *
-     * @return Boolean true if the field should be included in the submitted values, false otherwise
+     * @return boolean true if the field should be included in the submitted values, false otherwise
      */
     public function hasValue()
     {
@@ -108,7 +108,7 @@ abstract class FormField
     /**
      * Check if the current field is disabled
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isDisabled()
     {

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -217,7 +217,7 @@ class Form extends Link implements \ArrayAccess
      *
      * @param string $name The field name
      *
-     * @return Boolean true if the field exists, false otherwise
+     * @return boolean true if the field exists, false otherwise
      *
      * @api
      */
@@ -285,7 +285,7 @@ class Form extends Link implements \ArrayAccess
      *
      * @param string $name The field name
      *
-     * @return Boolean true if the field exists, false otherwise
+     * @return boolean true if the field exists, false otherwise
      */
     public function offsetExists($name)
     {
@@ -469,7 +469,7 @@ class FormFieldRegistry
      *
      * @param string $name The fully qualified name of the field
      *
-     * @return Boolean Whether the form has the given field
+     * @return boolean Whether the form has the given field
      */
     public function has($name)
     {

--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -103,7 +103,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
     public function hasListeners($eventName = null)
     {
         if (null === $eventName) {
-            return (Boolean) count($this->listenerIds) || (Boolean) count($this->listeners);
+            return (boolean) count($this->listenerIds) || (boolean) count($this->listeners);
         }
 
         if (isset($this->listenerIds[$eventName])) {

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -30,7 +30,7 @@ namespace Symfony\Component\EventDispatcher;
 class Event
 {
     /**
-     * @var Boolean Whether no further event listeners should be triggered
+     * @var boolean Whether no further event listeners should be triggered
      */
     private $propagationStopped = false;
 
@@ -48,7 +48,7 @@ class Event
      * Returns whether further event listeners should be triggered.
      *
      * @see Event::stopPropagation
-     * @return Boolean Whether propagation was already stopped for this event.
+     * @return boolean Whether propagation was already stopped for this event.
      *
      * @api
      */

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -82,7 +82,7 @@ class EventDispatcher implements EventDispatcherInterface
      */
     public function hasListeners($eventName = null)
     {
-        return (Boolean) count($this->getListeners($eventName));
+        return (boolean) count($this->getListeners($eventName));
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -90,7 +90,7 @@ interface EventDispatcherInterface
      *
      * @param string $eventName The name of the event
      *
-     * @return Boolean true if the specified event has any listeners, false otherwise
+     * @return boolean true if the specified event has any listeners, false otherwise
      */
     function hasListeners($eventName = null);
 }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -76,7 +76,7 @@ class Filesystem
      *
      * @param string|array|\Traversable $files A filename, an array of files, or a \Traversable instance to check
      *
-     * @return Boolean true if the file exists, false otherwise
+     * @return boolean true if the file exists, false otherwise
      */
     public function exists($files)
     {
@@ -154,7 +154,7 @@ class Filesystem
      * @param string|array|\Traversable $files     A filename, an array of files, or a \Traversable instance to change mode
      * @param integer                   $mode      The new mode (octal)
      * @param integer                   $umask     The mode mask (octal)
-     * @param Boolean                   $recursive Whether change the mod recursively or not
+     * @param boolean                   $recursive Whether change the mod recursively or not
      *
      * @throws IOException When the change fail
      */
@@ -175,7 +175,7 @@ class Filesystem
      *
      * @param string|array|\Traversable $files     A filename, an array of files, or a \Traversable instance to change owner
      * @param string                    $user      The new owner user name
-     * @param Boolean                   $recursive Whether change the owner recursively or not
+     * @param boolean                   $recursive Whether change the owner recursively or not
      *
      * @throws IOException When the change fail
      */
@@ -202,7 +202,7 @@ class Filesystem
      *
      * @param string|array|\Traversable $files     A filename, an array of files, or a \Traversable instance to change group
      * @param string                    $group     The group name
-     * @param Boolean                   $recursive Whether change the group recursively or not
+     * @param boolean                   $recursive Whether change the group recursively or not
      *
      * @throws IOException When the change fail
      */
@@ -250,7 +250,7 @@ class Filesystem
      *
      * @param string  $originDir     The origin directory path
      * @param string  $targetDir     The symbolic link name
-     * @param Boolean $copyOnWindows Whether to copy files if on Windows
+     * @param boolean $copyOnWindows Whether to copy files if on Windows
      *
      * @throws IOException When symlink fails
      */
@@ -367,7 +367,7 @@ class Filesystem
      *
      * @param string $file A file path
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isAbsolutePath($file)
     {

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -277,7 +277,7 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Excludes "hidden" directories and files (starting with a dot).
      *
-     * @param Boolean $ignoreDotFiles Whether to exclude "hidden" files or not
+     * @param boolean $ignoreDotFiles Whether to exclude "hidden" files or not
      *
      * @return Finder The current Finder instance
      *
@@ -299,7 +299,7 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Forces the finder to ignore version control directories.
      *
-     * @param Boolean $ignoreVCS Whether to exclude VCS files or not
+     * @param boolean $ignoreVCS Whether to exclude VCS files or not
      *
      * @return Finder The current Finder instance
      *

--- a/src/Symfony/Component/Finder/Glob.php
+++ b/src/Symfony/Component/Finder/Glob.php
@@ -39,8 +39,8 @@ class Glob
      * Returns a regexp which is the equivalent of the glob pattern.
      *
      * @param string  $glob                The glob pattern
-     * @param Boolean $strictLeadingDot
-     * @param Boolean $strictWildcardSlash
+     * @param boolean $strictLeadingDot
+     * @param boolean $strictWildcardSlash
      *
      * @return string regex The regexp
      */

--- a/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/CustomFilterIterator.php
@@ -44,7 +44,7 @@ class CustomFilterIterator extends \FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -36,7 +36,7 @@ class DateRangeFilterIterator extends \FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/DepthRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DepthRangeFilterIterator.php
@@ -58,7 +58,7 @@ class DepthRangeFilterIterator extends \FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/ExcludeDirectoryFilterIterator.php
@@ -39,7 +39,7 @@ class ExcludeDirectoryFilterIterator extends \FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FileTypeFilterIterator.php
@@ -39,7 +39,7 @@ class FileTypeFilterIterator extends \FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilecontentFilterIterator.php
@@ -22,7 +22,7 @@ class FilecontentFilterIterator extends MultiplePcreFilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilenameFilterIterator.php
@@ -24,7 +24,7 @@ class FilenameFilterIterator extends MultiplePcreFilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
@@ -49,7 +49,7 @@ abstract class MultiplePcreFilterIterator extends \FilterIterator
      *
      * @param string $str
      *
-     * @return Boolean Whether the given string is a regex
+     * @return boolean Whether the given string is a regex
      */
     protected function isRegex($str)
     {

--- a/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
@@ -36,7 +36,7 @@ class SizeRangeFilterIterator extends \FilterIterator
     /**
      * Filters the iterator values.
      *
-     * @return Boolean true if the value should be kept, false otherwise
+     * @return boolean true if the value should be kept, false otherwise
      */
     public function accept()
     {

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -39,7 +39,7 @@ abstract class AbstractExtension implements FormExtensionInterface
 
     /**
      * Whether the type guesser has been loaded
-     * @var Boolean
+     * @var boolean
      */
     private $typeGuesserLoaded = false;
 

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/BooleanToStringTransformer.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
- * Transforms between a Boolean and a string.
+ * Transforms between a boolean and a string.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @author Florian Eckerstorfer <florian@eckerstorfer.org>
@@ -39,13 +39,13 @@ class BooleanToStringTransformer implements DataTransformerInterface
     }
 
     /**
-     * Transforms a Boolean into a string.
+     * Transforms a boolean into a string.
      *
-     * @param Boolean $value Boolean value.
+     * @param boolean $value boolean value.
      *
      * @return string String value.
      *
-     * @throws UnexpectedTypeException if the given value is not a Boolean
+     * @throws UnexpectedTypeException if the given value is not a boolean
      */
     public function transform($value)
     {
@@ -54,18 +54,18 @@ class BooleanToStringTransformer implements DataTransformerInterface
         }
 
         if (!is_bool($value)) {
-            throw new UnexpectedTypeException($value, 'Boolean');
+            throw new UnexpectedTypeException($value, 'boolean');
         }
 
         return true === $value ? $this->trueValue : null;
     }
 
     /**
-     * Transforms a string into a Boolean.
+     * Transforms a string into a boolean.
      *
      * @param string $value String value.
      *
-     * @return Boolean Boolean value.
+     * @return boolean boolean value.
      *
      * @throws UnexpectedTypeException if the given value is not a string
      */

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToArrayTransformer.php
@@ -32,7 +32,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
      * @param string  $inputTimezone  The input timezone
      * @param string  $outputTimezone The output timezone
      * @param array   $fields         The date fields
-     * @param Boolean $pad            Whether to use padding
+     * @param boolean $pad            Whether to use padding
      *
      * @throws UnexpectedTypeException if a timezone is not a string
      */
@@ -45,7 +45,7 @@ class DateTimeToArrayTransformer extends BaseDateTimeTransformer
         }
 
         $this->fields = $fields;
-        $this->pad = (Boolean) $pad;
+        $this->pad = (boolean) $pad;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -23,22 +23,22 @@ class MergeCollectionListener implements EventSubscriberInterface
 {
     /**
      * Whether elements may be added to the collection
-     * @var Boolean
+     * @var boolean
      */
     private $allowAdd;
 
     /**
      * Whether elements may be removed from the collection
-     * @var Boolean
+     * @var boolean
      */
     private $allowDelete;
 
     /**
      * Creates a new listener.
      *
-     * @param Boolean $allowAdd Whether values might be added to the
+     * @param boolean $allowAdd Whether values might be added to the
      *                                collection.
-     * @param Boolean $allowDelete Whether values might be removed from the
+     * @param boolean $allowDelete Whether values might be removed from the
      *                                collection.
      */
     public function __construct($allowAdd = false, $allowDelete = false)

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -41,13 +41,13 @@ class ResizeFormListener implements EventSubscriberInterface
 
     /**
      * Whether children could be added to the group
-     * @var Boolean
+     * @var boolean
      */
     protected $allowAdd;
 
     /**
      * Whether children could be removed from the group
-     * @var Boolean
+     * @var boolean
      */
     protected $allowDelete;
 

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderInterface.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderInterface.php
@@ -43,7 +43,7 @@ interface CsrfProviderInterface
      * @param string $intention The intention used when generating the CSRF token
      * @param string $token     The token supplied by the browser
      *
-     * @return Boolean Whether the token supplied by the browser is correct
+     * @return boolean Whether the token supplied by the browser is correct
      */
     function isCsrfTokenValid($intention, $token);
 }

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -119,7 +119,7 @@ class FormValidator extends ConstraintValidator
      *
      * @param  FormInterface $form The form to test.
      *
-     * @return Boolean Whether the graph walker may walk the data.
+     * @return boolean Whether the graph walker may walk the data.
      */
     private function allowDataWalking(FormInterface $form)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/MappingRule.php
@@ -74,7 +74,7 @@ class MappingRule
      *
      * @param string $propertyPath The property path to match against the rule.
      *
-     * @return Boolean Whether the property path is a prefix of the rule or not.
+     * @return boolean Whether the property path is a prefix of the rule or not.
      */
     public function isPrefix($propertyPath)
     {

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -41,7 +41,7 @@ class ViolationMapper implements ViolationMapperInterface
     private $rules = array();
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $allowNonSynchronized;
 
@@ -302,7 +302,7 @@ class ViolationMapper implements ViolationMapperInterface
     }
 
     /**
-     * @return Boolean
+     * @return boolean
      */
     private function isValidScope()
     {

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapperInterface.php
@@ -26,7 +26,7 @@ interface ViolationMapperInterface
      * @param ConstraintViolation $violation The violation to map.
      * @param FormInterface       $form      The root form of the tree
      *                                       to map it to.
-     * @param Boolean             $allowNonSynchronized Whether to allow
+     * @param boolean             $allowNonSynchronized Whether to allow
      *                                       mapping to non-synchronized forms.
      */
     function mapViolation(ConstraintViolation $violation, FormInterface $form, $allowNonSynchronized = false);

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -219,7 +219,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
      *
      * @param  integer $index The element index.
      *
-     * @return Boolean Whether the element maps to a form.
+     * @return boolean Whether the element maps to a form.
      *
      * @throws \OutOfBoundsException If the offset is invalid.
      */

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -36,7 +36,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * localized string (3) is presented to and modified by the user.
  *
  * In most cases, format (1) and format (2) will be the same. For example,
- * a checkbox field uses a Boolean value for both internal processing and
+ * a checkbox field uses a boolean value for both internal processing and
  * storage in the object. In these cases you simply need to set a value
  * transformer to convert between formats (2) and (3). You can do this by
  * calling addViewTransformer().
@@ -83,7 +83,7 @@ class Form implements \IteratorAggregate, FormInterface
 
     /**
      * Whether this form is bound
-     * @var Boolean
+     * @var boolean
      */
     private $bound = false;
 
@@ -115,7 +115,7 @@ class Form implements \IteratorAggregate, FormInterface
      * Whether the data in model, normalized and view format is
      * synchronized. Data may not be synchronized if transformation errors
      * occur.
-     * @var Boolean
+     * @var boolean
      */
     private $synchronized = true;
 
@@ -254,7 +254,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether the form has a parent.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasParent()
     {
@@ -274,7 +274,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether the form is the root of the form tree.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isRoot()
     {
@@ -286,7 +286,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @param  string $name The name of the attribute.
      *
-     * @return Boolean Whether the attribute exists.
+     * @return boolean Whether the attribute exists.
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link getConfig()} and {@link FormConfigInterface::hasAttribute()} instead.
@@ -649,7 +649,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether errors bubble up to the parent.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link getConfig()} and {@link FormConfigInterface::getErrorBubbling()} instead.
@@ -662,7 +662,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether the form is bound.
      *
-     * @return Boolean true if the form is bound to input values, false otherwise
+     * @return boolean true if the form is bound to input values, false otherwise
      */
     public function isBound()
     {
@@ -672,7 +672,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether the data in the different formats is synchronized.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isSynchronized()
     {
@@ -682,7 +682,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether the form is empty.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isEmpty()
     {
@@ -698,7 +698,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether the form is valid.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isValid()
     {
@@ -724,7 +724,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether or not there are errors.
      *
-     * @return Boolean true if form is bound and not valid
+     * @return boolean true if form is bound and not valid
      */
     public function hasErrors()
     {
@@ -822,7 +822,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns whether the form has children.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link count()} instead.
@@ -895,7 +895,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @param string $name The name of the child
      *
-     * @return Boolean true if the widget exists, false otherwise
+     * @return boolean true if the widget exists, false otherwise
      */
     public function offsetExists($name)
     {

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -66,7 +66,7 @@ interface FormBuilderInterface extends FormConfigEditorInterface, \Traversable, 
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      */
     function has($name);
 
@@ -110,7 +110,7 @@ interface FormBuilderInterface extends FormConfigEditorInterface, \Traversable, 
     /**
      * Returns whether the builder has a parent.
      *
-     * @return Boolean
+     * @return boolean
      */
     function hasParent();
 }

--- a/src/Symfony/Component/Form/FormConfig.php
+++ b/src/Symfony/Component/Form/FormConfig.php
@@ -39,17 +39,17 @@ class FormConfig implements FormConfigEditorInterface
     private $propertyPath;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $mapped = true;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $byReference = true;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $virtual = false;
 
@@ -79,17 +79,17 @@ class FormConfig implements FormConfigEditorInterface
     private $validators = array();
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $required = true;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $disabled = false;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $errorBubbling = false;
 
@@ -553,7 +553,7 @@ class FormConfig implements FormConfigEditorInterface
      */
     public function setDisabled($disabled)
     {
-        $this->disabled = (Boolean) $disabled;
+        $this->disabled = (boolean) $disabled;
 
         return $this;
     }
@@ -573,7 +573,7 @@ class FormConfig implements FormConfigEditorInterface
      */
     public function setErrorBubbling($errorBubbling)
     {
-        $this->errorBubbling = null === $errorBubbling ? null : (Boolean) $errorBubbling;
+        $this->errorBubbling = null === $errorBubbling ? null : (boolean) $errorBubbling;
 
         return $this;
     }
@@ -583,7 +583,7 @@ class FormConfig implements FormConfigEditorInterface
      */
     public function setRequired($required)
     {
-        $this->required = (Boolean) $required;
+        $this->required = (boolean) $required;
 
         return $this;
     }
@@ -686,7 +686,7 @@ class FormConfig implements FormConfigEditorInterface
      *
      * @param string $name The tested form name.
      *
-     * @return Boolean Whether the name is valid.
+     * @return boolean Whether the name is valid.
      */
     static public function isValidName($name)
     {

--- a/src/Symfony/Component/Form/FormConfigEditorInterface.php
+++ b/src/Symfony/Component/Form/FormConfigEditorInterface.php
@@ -60,7 +60,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
      * view to the normalized format.
      *
      * @param DataTransformerInterface $viewTransformer
-     * @param Boolean                  $forcePrepend if set to true, prepend instead of appending
+     * @param boolean                  $forcePrepend if set to true, prepend instead of appending
      *
      * @return self The configuration object.
      */
@@ -82,7 +82,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
      * normalized to the model format.
      *
      * @param DataTransformerInterface $modelTransformer
-     * @param Boolean                  $forceAppend if set to true, append instead of prepending
+     * @param boolean                  $forceAppend if set to true, append instead of prepending
      *
      * @return self The configuration object.
      */
@@ -126,7 +126,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
     /**
      * Set whether the form is disabled.
      *
-     * @param  Boolean $disabled Whether the form is disabled
+     * @param  boolean $disabled Whether the form is disabled
      *
      * @return self The configuration object.
      */
@@ -144,7 +144,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
     /**
      * Sets whether errors bubble up to the parent.
      *
-     * @param  Boolean $errorBubbling
+     * @param  boolean $errorBubbling
      *
      * @return self The configuration object.
      */
@@ -153,7 +153,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
     /**
      * Sets whether this field is required to be filled out when bound.
      *
-     * @param Boolean $required
+     * @param boolean $required
      *
      * @return self The configuration object.
      */
@@ -174,7 +174,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
      * Sets whether the form should be mapped to an element of its
      * parent's data.
      *
-     * @param  Boolean $mapped Whether the form should be mapped.
+     * @param  boolean $mapped Whether the form should be mapped.
      *
      * @return self The configuration object.
      */
@@ -183,7 +183,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
     /**
      * Sets whether the form's data should be modified by reference.
      *
-     * @param  Boolean $byReference Whether the data should be
+     * @param  boolean $byReference Whether the data should be
      * modified by reference.
      *
      * @return self The configuration object.
@@ -193,7 +193,7 @@ interface FormConfigEditorInterface extends FormConfigInterface
     /**
      * Sets whether the form should be virtual.
      *
-     * @param  Boolean $virtual Whether the form should be virtual.
+     * @param  boolean $virtual Whether the form should be virtual.
      *
      * @return self The configuration object.
      */

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -43,14 +43,14 @@ interface FormConfigInterface
      * Returns whether the form should be mapped to an element of its
      * parent's data.
      *
-     * @return Boolean Whether the form is mapped.
+     * @return boolean Whether the form is mapped.
      */
     function getMapped();
 
     /**
      * Returns whether the form's data should be modified by reference.
      *
-     * @return Boolean Whether to modify the form's data by reference.
+     * @return boolean Whether to modify the form's data by reference.
      */
     function getByReference();
 
@@ -61,7 +61,7 @@ interface FormConfigInterface
      * should ignore virtual forms and map to the children of the
      * virtual form instead.
      *
-     * @return Boolean Whether the form is virtual.
+     * @return boolean Whether the form is virtual.
      */
     function getVirtual();
 
@@ -105,21 +105,21 @@ interface FormConfigInterface
     /**
      * Returns whether the form is required.
      *
-     * @return Boolean Whether the form is required.
+     * @return boolean Whether the form is required.
      */
     function getRequired();
 
     /**
      * Returns whether the form is disabled.
      *
-     * @return Boolean Whether the form is disabled.
+     * @return boolean Whether the form is disabled.
      */
     function getDisabled();
 
     /**
      * Returns whether errors attached to the form will bubble to its parent.
      *
-     * @return Boolean Whether errors will bubble up.
+     * @return boolean Whether errors will bubble up.
      */
     function getErrorBubbling();
 
@@ -142,7 +142,7 @@ interface FormConfigInterface
      *
      * @param  string $name The attribute name.
      *
-     * @return Boolean Whether the attribute exists.
+     * @return boolean Whether the attribute exists.
      */
     function hasAttribute($name);
 
@@ -182,7 +182,7 @@ interface FormConfigInterface
      *
      * @param  string $name The option name,
      *
-     * @return Boolean Whether the option exists.
+     * @return boolean Whether the option exists.
      */
     function hasOption($name);
 

--- a/src/Symfony/Component/Form/FormExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormExtensionInterface.php
@@ -32,7 +32,7 @@ interface FormExtensionInterface
      *
      * @param string $name The name of the type
      *
-     * @return Boolean Whether the type is supported by this extension
+     * @return boolean Whether the type is supported by this extension
      */
     function hasType($name);
 
@@ -50,7 +50,7 @@ interface FormExtensionInterface
      *
      * @param string $name The name of the type
      *
-     * @return Boolean Whether the given type has extensions
+     * @return boolean Whether the given type has extensions
      */
     function hasTypeExtensions($name);
 

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -131,7 +131,7 @@ interface FormFactoryInterface
      *
      * @param string $name The name of the type
      *
-     * @return Boolean Whether the type is supported
+     * @return boolean Whether the type is supported
      */
     function hasType($name);
 

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -37,7 +37,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the form has a parent.
      *
-     * @return Boolean
+     * @return boolean
      */
     function hasParent();
 
@@ -64,7 +64,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @param string $name The name of the child
      *
-     * @return Boolean
+     * @return boolean
      */
     function has($name);
 
@@ -140,7 +140,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the field is bound.
      *
-     * @return Boolean true if the form is bound to input values, false otherwise
+     * @return boolean true if the form is bound to input values, false otherwise
      */
     function isBound();
 
@@ -170,7 +170,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the form is valid.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isValid();
 
@@ -181,7 +181,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * will always return false. Otherwise the value set with setRequired()
      * is returned.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isRequired();
 
@@ -194,21 +194,21 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      * Forms whose parents are disabled are considered disabled regardless of
      * their own state.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isDisabled();
 
     /**
      * Returns whether the form is empty.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isEmpty();
 
     /**
      * Returns whether the data in the different formats is synchronized.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isSynchronized();
 
@@ -231,7 +231,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the field is the root of the form tree.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isRoot();
 

--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -34,7 +34,7 @@ class FormView implements \IteratorAggregate, FormViewInterface
      * Row implicitly includes widget, however certain rendering mechanisms
      * have to skip widget rendering when a row is rendered.
      *
-     * @var Boolean
+     * @var boolean
      */
     private $rendered = false;
 
@@ -217,7 +217,7 @@ class FormView implements \IteratorAggregate, FormViewInterface
     /**
      * Returns whether this view has any children.
      *
-     * @return Boolean Whether the view has children.
+     * @return boolean Whether the view has children.
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link count()} instead.
@@ -252,7 +252,7 @@ class FormView implements \IteratorAggregate, FormViewInterface
      *
      * @param string $name The child name
      *
-     * @return Boolean Whether the child view exists
+     * @return boolean Whether the child view exists
      */
     public function offsetExists($name)
     {

--- a/src/Symfony/Component/Form/FormViewInterface.php
+++ b/src/Symfony/Component/Form/FormViewInterface.php
@@ -26,7 +26,7 @@ interface FormViewInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the view was already rendered.
      *
-     * @return Boolean Whether this view's widget is rendered.
+     * @return boolean Whether this view's widget is rendered.
      */
     function isRendered();
 
@@ -56,7 +56,7 @@ interface FormViewInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether this view has a parent.
      *
-     * @return Boolean Whether this view has a parent
+     * @return boolean Whether this view has a parent
      */
     function hasParent();
 
@@ -99,7 +99,7 @@ interface FormViewInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @param string $name The name of the child
      *
-     * @return Boolean Whether the child with the given name exists
+     * @return boolean Whether the child with the given name exists
      */
     function has($name);
 
@@ -127,7 +127,7 @@ interface FormViewInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @param string $name The variable name.
      *
-     * @return Boolean Whether the variable exists.
+     * @return boolean Whether the variable exists.
      */
     function hasVar($name);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -54,7 +54,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @param FormConfigInterface $config
-     * @param Boolean $synchronized
+     * @param boolean $synchronized
      * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getForm(FormConfigInterface $config, $synchronized = true)

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -500,7 +500,7 @@ class ChoiceTypeTest extends TypeTestCase
     }
 
     /*
-     * We need this functionality to create choice fields for Boolean types,
+     * We need this functionality to create choice fields for boolean types,
      * e.g. false => 'No', true => 'Yes'
      */
     public function testSetDataSingleNonExpandedAcceptsBoolean()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -29,6 +29,6 @@ class MoneyTypeTest extends LocalizedTestCase
 
         $form = $this->factory->create('money', null, array('currency' => 'JPY'));
         $view = $form->createView();
-        $this->assertTrue((Boolean) strstr($view->getVar('money_pattern'), '¥'));
+        $this->assertTrue((boolean) strstr($view->getVar('money_pattern'), '¥'));
     }
 }

--- a/src/Symfony/Component/Form/UnmodifiableFormConfig.php
+++ b/src/Symfony/Component/Form/UnmodifiableFormConfig.php
@@ -38,17 +38,17 @@ class UnmodifiableFormConfig implements FormConfigInterface
     private $propertyPath;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $mapped;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $byReference;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $virtual;
 
@@ -78,17 +78,17 @@ class UnmodifiableFormConfig implements FormConfigInterface
     private $validators;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $required;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $disabled;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $errorBubbling;
 

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -196,7 +196,7 @@ abstract class FormUtil
      *
      * @param mixed $choice A choice
      *
-     * @return Boolean Whether the choice is a group
+     * @return boolean Whether the choice is a group
      */
     static public function isChoiceGroup($choice)
     {
@@ -209,7 +209,7 @@ abstract class FormUtil
      * @param mixed $choice The choice
      * @param mixed $value  the value
      *
-     * @return Boolean Whether the choice is selected
+     * @return boolean Whether the choice is selected
      */
     static public function isChoiceSelected($choice, $value)
     {

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -50,7 +50,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     private $length;
 
     /**
-     * Contains a Boolean for each property in $elements denoting whether this
+     * Contains a boolean for each property in $elements denoting whether this
      * element is an index. It is a property otherwise.
      * @var array
      */
@@ -355,7 +355,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
      *
      * @param object|array $objectOrArray The object or array to read from.
      * @param string       $property      The property to read.
-     * @param Boolean      $isIndex       Whether to interpret the property as index.
+     * @param boolean      $isIndex       Whether to interpret the property as index.
      *
      * @return mixed The value of the read property
      *
@@ -428,7 +428,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
      * @param object|array $objectOrArray The object or array to write to.
      * @param string       $property      The property to write.
      * @param string|null  $singular      The singular form of the property name or null.
-     * @param Boolean      $isIndex       Whether to interpret the property as index.
+     * @param boolean      $isIndex       Whether to interpret the property as index.
      * @param mixed        $value         The value to write.
      *
      * @throws InvalidPropertyException      If the property does not exist.
@@ -594,7 +594,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
      * @param  string           $methodName The method name.
      * @param  integer          $parameters The number of parameters.
      *
-     * @return Boolean Whether the method is public and has $parameters
+     * @return boolean Whether the method is public and has $parameters
      *                                      required parameters.
      */
     private function isAccessible(ReflectionClass $class, $methodName, $parameters)

--- a/src/Symfony/Component/Form/Util/PropertyPathInterface.php
+++ b/src/Symfony/Component/Form/Util/PropertyPathInterface.php
@@ -73,7 +73,7 @@ interface PropertyPathInterface extends \Traversable
      *
      * @param  integer $index The index in the property path
      *
-     * @return Boolean Whether the element at this index is a property
+     * @return boolean Whether the element at this index is a property
      *
      * @throws \OutOfBoundsException If the offset is invalid.
      */
@@ -84,7 +84,7 @@ interface PropertyPathInterface extends \Traversable
      *
      * @param  integer $index The index in the property path
      *
-     * @return Boolean Whether the element at this index is an array index
+     * @return boolean Whether the element at this index is an array index
      *
      * @throws \OutOfBoundsException If the offset is invalid.
      */

--- a/src/Symfony/Component/Form/Util/PropertyPathIteratorInterface.php
+++ b/src/Symfony/Component/Form/Util/PropertyPathIteratorInterface.php
@@ -20,7 +20,7 @@ interface PropertyPathIteratorInterface extends \Iterator, \SeekableIterator
      * Returns whether the current element in the property path is an array
      * index.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isIndex();
 
@@ -28,7 +28,7 @@ interface PropertyPathIteratorInterface extends \Iterator, \SeekableIterator
      * Returns whether the current element in the property path is a property
      * name.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isProperty();
 }

--- a/src/Symfony/Component/HttpFoundation/Cookie.php
+++ b/src/Symfony/Component/HttpFoundation/Cookie.php
@@ -36,8 +36,8 @@ class Cookie
      * @param integer|string|\DateTime $expire   The time the cookie expires
      * @param string                   $path     The path on the server in which the cookie will be available on
      * @param string                   $domain   The domain that the cookie is available to
-     * @param Boolean                  $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
-     * @param Boolean                  $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
+     * @param boolean                  $secure   Whether the cookie should only be transmitted over a secure HTTPS connection from the client
+     * @param boolean                  $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      *
      * @api
      */
@@ -68,8 +68,8 @@ class Cookie
         $this->domain = $domain;
         $this->expire = $expire;
         $this->path = empty($path) ? '/' : $path;
-        $this->secure = (Boolean) $secure;
-        $this->httpOnly = (Boolean) $httpOnly;
+        $this->secure = (boolean) $secure;
+        $this->httpOnly = (boolean) $httpOnly;
     }
 
     /**
@@ -173,7 +173,7 @@ class Cookie
     /**
      * Checks whether the cookie should only be transmitted over a secure HTTPS connection from the client.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -185,7 +185,7 @@ class Cookie
     /**
      * Checks whether the cookie will be made accessible only through the HTTP protocol.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -197,7 +197,7 @@ class Cookie
     /**
      * Whether this cookie is about to be cleared
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -29,7 +29,7 @@ class File extends \SplFileInfo
      * Constructs a new file from the given path.
      *
      * @param string  $path      The path to the file
-     * @param Boolean $checkPath Whether to check the path or not
+     * @param boolean $checkPath Whether to check the path or not
      *
      * @throws FileNotFoundException If the given path is not a file
      *

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -41,7 +41,7 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
     /**
      * Returns whether this guesser is supported on the current OS
      *
-     * @return Boolean
+     * @return boolean
      */
     static public function isSupported()
     {

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileinfoMimeTypeGuesser.php
@@ -24,7 +24,7 @@ class FileinfoMimeTypeGuesser implements MimeTypeGuesserInterface
     /**
      * Returns whether this guesser is supported on the current OS/PHP setup
      *
-     * @return Boolean
+     * @return boolean
      */
     static public function isSupported()
     {

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -30,7 +30,7 @@ class UploadedFile extends File
      *
      * Local files are used in test mode hence the code should not enforce HTTP uploads.
      *
-     * @var Boolean
+     * @var boolean
      */
     private $test = false;
 
@@ -81,7 +81,7 @@ class UploadedFile extends File
      * @param string  $mimeType     The type of the file as provided by PHP
      * @param integer $size         The file size
      * @param integer $error        The error constant of the upload (one of PHP's UPLOAD_ERR_XXX constants)
-     * @param Boolean $test         Whether the test mode is active
+     * @param boolean $test         Whether the test mode is active
      *
      * @throws FileException         If file_uploads is disabled
      * @throws FileNotFoundException If the file does not exist
@@ -98,7 +98,7 @@ class UploadedFile extends File
         $this->mimeType = $mimeType ?: 'application/octet-stream';
         $this->size = $size;
         $this->error = $error ?: UPLOAD_ERR_OK;
-        $this->test = (Boolean) $test;
+        $this->test = (boolean) $test;
 
         parent::__construct($path, UPLOAD_ERR_OK === $this->error);
     }
@@ -166,7 +166,7 @@ class UploadedFile extends File
     /**
      * Returns whether the file was uploaded successfully.
      *
-     * @return Boolean  True if no error occurred during uploading
+     * @return boolean  True if no error occurred during uploading
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -119,7 +119,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string  $key     The header name
      * @param mixed   $default The default value
-     * @param Boolean $first   Whether to return the first value or all header values
+     * @param boolean $first   Whether to return the first value or all header values
      *
      * @return string|array The first header value if $first is true, an array of values otherwise
      *
@@ -149,7 +149,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string       $key     The key
      * @param string|array $values  The value or an array of values
-     * @param Boolean      $replace Whether to replace the actual value of not (true by default)
+     * @param boolean      $replace Whether to replace the actual value of not (true by default)
      *
      * @api
      */
@@ -175,7 +175,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      *
      * @param string $key The HTTP header
      *
-     * @return Boolean true if the parameter exists, false otherwise
+     * @return boolean true if the parameter exists, false otherwise
      *
      * @api
      */
@@ -190,7 +190,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
      * @param string $key   The HTTP header name
      * @param string $value The HTTP value
      *
-     * @return Boolean true if the value is contained in the header, false otherwise
+     * @return boolean true if the value is contained in the header, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -165,7 +165,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @param string $key The key
      *
-     * @return Boolean true if the parameter exists, false otherwise
+     * @return boolean true if the parameter exists, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -474,7 +474,7 @@ class Request
      *
      * @param string  $key     the key
      * @param mixed   $default the default value
-     * @param Boolean $deep    is parameter deep in multidimensional array
+     * @param boolean $deep    is parameter deep in multidimensional array
      *
      * @return mixed
      */
@@ -814,7 +814,7 @@ class Request
     /**
      * Checks whether the request is secure or not.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1041,7 +1041,7 @@ class Request
      *
      * @param string $method Uppercase request method (GET, POST etc).
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isMethod($method)
     {
@@ -1051,7 +1051,7 @@ class Request
     /**
      * Checks whether the method is safe or not.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1063,7 +1063,7 @@ class Request
     /**
      * Returns the request body content.
      *
-     * @param Boolean $asResource If true, a resource will be returned
+     * @param boolean $asResource If true, a resource will be returned
      *
      * @return string|resource The request body content or a resource to read the body stream.
      */
@@ -1097,7 +1097,7 @@ class Request
     }
 
     /**
-     * @return Boolean
+     * @return boolean
      */
     public function isNoCache()
     {
@@ -1210,7 +1210,7 @@ class Request
      * It works if your JavaScript library set an X-Requested-With HTTP header.
      * It is known to work with Prototype, Mootools, jQuery.
      *
-     * @return Boolean true if the request is an XMLHttpRequest, false otherwise
+     * @return boolean true if the request is an XMLHttpRequest, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/RequestMatcherInterface.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcherInterface.php
@@ -25,7 +25,7 @@ interface RequestMatcherInterface
      *
      * @param Request $request The request to check for a match
      *
-     * @return Boolean true if the request matches, false otherwise
+     * @return boolean true if the request matches, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -439,7 +439,7 @@ class Response
      * Responses with neither a freshness lifetime (Expires, max-age) nor cache
      * validator (Last-Modified, ETag) are considered uncacheable.
      *
-     * @return Boolean true if the response is worth caching, false otherwise
+     * @return boolean true if the response is worth caching, false otherwise
      *
      * @api
      */
@@ -463,7 +463,7 @@ class Response
      * origin. A response is considered fresh when it includes a Cache-Control/max-age
      * indicator or Expiration header and the calculated age is less than the freshness lifetime.
      *
-     * @return Boolean true if the response is fresh, false otherwise
+     * @return boolean true if the response is fresh, false otherwise
      *
      * @api
      */
@@ -476,7 +476,7 @@ class Response
      * Returns true if the response includes headers that can be used to validate
      * the response with the origin server using a conditional GET request.
      *
-     * @return Boolean true if the response is validateable, false otherwise
+     * @return boolean true if the response is validateable, false otherwise
      *
      * @api
      */
@@ -527,7 +527,7 @@ class Response
      * When present, the TTL of the response should not be overridden to be
      * greater than the value provided by the origin.
      *
-     * @return Boolean true if the response must be revalidated by a cache, false otherwise
+     * @return boolean true if the response must be revalidated by a cache, false otherwise
      *
      * @api
      */
@@ -807,7 +807,7 @@ class Response
      * Sets the ETag value.
      *
      * @param string  $etag The ETag unique identifier
-     * @param Boolean $weak Whether you want a weak ETag or not
+     * @param boolean $weak Whether you want a weak ETag or not
      *
      * @return Response
      *
@@ -908,13 +908,13 @@ class Response
     /**
      * Returns true if the response includes a Vary header.
      *
-     * @return Boolean true if the response includes a Vary header, false otherwise
+     * @return boolean true if the response includes a Vary header, false otherwise
      *
      * @api
      */
     public function hasVary()
     {
-        return (Boolean) $this->headers->get('Vary');
+        return (boolean) $this->headers->get('Vary');
     }
 
     /**
@@ -937,7 +937,7 @@ class Response
      * Sets the Vary header.
      *
      * @param string|array $headers
-     * @param Boolean      $replace Whether to replace the actual value of not (true by default)
+     * @param boolean      $replace Whether to replace the actual value of not (true by default)
      *
      * @return Response
      *
@@ -959,7 +959,7 @@ class Response
      *
      * @param Request $request A Request instance
      *
-     * @return Boolean true if the Response validators match the Request, false otherwise
+     * @return boolean true if the Response validators match the Request, false otherwise
      *
      * @api
      */
@@ -984,7 +984,7 @@ class Response
     /**
      * Is response invalid?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -996,7 +996,7 @@ class Response
     /**
      * Is response informative?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1008,7 +1008,7 @@ class Response
     /**
      * Is response successful?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1020,7 +1020,7 @@ class Response
     /**
      * Is the response a redirect?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1032,7 +1032,7 @@ class Response
     /**
      * Is there a client error?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1044,7 +1044,7 @@ class Response
     /**
      * Was there a server side error?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1056,7 +1056,7 @@ class Response
     /**
      * Is the response OK?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1068,7 +1068,7 @@ class Response
     /**
      * Is the reponse forbidden?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1080,7 +1080,7 @@ class Response
     /**
      * Is the response a not found error?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1094,7 +1094,7 @@ class Response
      *
      * @param string $location
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -1106,7 +1106,7 @@ class Response
     /**
      * Is the response empty?
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBagInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/AttributeBagInterface.php
@@ -25,7 +25,7 @@ interface AttributeBagInterface extends SessionBagInterface
      *
      * @param string $name The attribute name
      *
-     * @return Boolean true if the attribute is defined, false otherwise
+     * @return boolean true if the attribute is defined, false otherwise
      */
     function has($name);
 

--- a/src/Symfony/Component/HttpFoundation/Session/Session.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Session.php
@@ -308,7 +308,7 @@ class Session implements SessionInterface, \IteratorAggregate, \Countable
     /**
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      *
      * @deprecated since 2.1, will be removed from 2.3
      */

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -23,7 +23,7 @@ interface SessionInterface
     /**
      * Starts the session storage.
      *
-     * @return Boolean True if session started.
+     * @return boolean True if session started.
      *
      * @throws \RuntimeException If session fails to start.
      *
@@ -78,7 +78,7 @@ interface SessionInterface
      *                          to expire with browser session. Time is in seconds, and is
      *                          not a Unix timestamp.
      *
-     * @return Boolean True if session invalidated, false if error.
+     * @return boolean True if session invalidated, false if error.
      *
      * @api
      */
@@ -88,13 +88,13 @@ interface SessionInterface
      * Migrates the current session to a new session id while maintaining all
      * session attributes.
      *
-     * @param Boolean $destroy  Whether to delete the old session or leave it to garbage collection.
+     * @param boolean $destroy  Whether to delete the old session or leave it to garbage collection.
      * @param integer $lifetime Sets the cookie lifetime for the session cookie. A null value
      *                          will leave the system settings unchanged, 0 sets the cookie
      *                          to expire with browser session. Time is in seconds, and is
      *                          not a Unix timestamp.
      *
-     * @return Boolean True if session migrated, false if error.
+     * @return boolean True if session migrated, false if error.
      *
      * @api
      */
@@ -114,7 +114,7 @@ interface SessionInterface
      *
      * @param string $name The attribute name
      *
-     * @return Boolean true if the attribute is defined, false otherwise
+     * @return boolean true if the attribute is defined, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/AbstractProxy.php
@@ -58,7 +58,7 @@ abstract class AbstractProxy
     /**
      * Returns true if this handler wraps an internal PHP session save handler using \SessionHandler.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isWrapper()
     {
@@ -68,7 +68,7 @@ abstract class AbstractProxy
     /**
      * Has a session started?
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isActive()
     {
@@ -78,7 +78,7 @@ abstract class AbstractProxy
     /**
      * Sets the active flag.
      *
-     * @param Boolean $flag
+     * @param boolean $flag
      */
     public function setActive($flag)
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Proxy/NativeProxy.php
@@ -32,7 +32,7 @@ class NativeProxy extends AbstractProxy
     /**
      * Returns true if this handler wraps an internal PHP session save handler using \SessionHandler.
      *
-     * @return Boolean False.
+     * @return boolean False.
      */
     public function isWrapper()
     {

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/SessionStorageInterface.php
@@ -82,13 +82,13 @@ interface SessionStorageInterface
      * Note regenerate+destroy should not clear the session data in memory
      * only delete the session data from persistent storage.
      *
-     * @param Boolean $destroy  Destroy session when regenerating?
+     * @param boolean $destroy  Destroy session when regenerating?
      * @param integer $lifetime Sets the cookie lifetime for the session cookie. A null value
      *                          will leave the system settings unchanged, 0 sets the cookie
      *                          to expire with browser session. Time is in seconds, and is
      *                          not a Unix timestamp.
      *
-     * @return Boolean True if session regenerated, false if error
+     * @return boolean True if session regenerated, false if error
      *
      * @throws \RuntimeException If an error occurs while regenerating this storage
      *

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerAggregate.php
@@ -51,7 +51,7 @@ class CacheWarmerAggregate implements CacheWarmerInterface
     /**
      * Checks whether this warmer is optional or not.
      *
-     * @return Boolean always true
+     * @return boolean always true
      */
     public function isOptional()
     {

--- a/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerInterface.php
+++ b/src/Symfony/Component/HttpKernel/CacheWarmer/CacheWarmerInterface.php
@@ -26,7 +26,7 @@ interface CacheWarmerInterface extends WarmableInterface
      * A warmer should return true if the cache can be
      * generated incrementally and on-demand.
      *
-     * @return Boolean true if the warmer is optional, false otherwise
+     * @return boolean true if the warmer is optional, false otherwise
      */
     function isOptional();
 }

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -47,7 +47,7 @@ class ControllerResolver implements ControllerResolverInterface
      *
      * @param Request $request A Request instance
      *
-     * @return mixed|Boolean A PHP callable representing the Controller,
+     * @return mixed|boolean A PHP callable representing the Controller,
      *                       or false if this resolver is not able to determine the controller
      *
      * @throws \InvalidArgumentException|\LogicException If the controller can't be found

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolverInterface.php
@@ -38,7 +38,7 @@ interface ControllerResolverInterface
      *
      * @param Request $request A Request instance
      *
-     * @return mixed|Boolean A PHP callable representing the Controller,
+     * @return mixed|boolean A PHP callable representing the Controller,
      *                       or false if this resolver is not able to determine the controller
      *
      * @throws \InvalidArgumentException|\LogicException If the controller can't be found

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -113,7 +113,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if the debug is enabled.
      *
-     * @return Boolean true if debug is enabled, false otherwise
+     * @return boolean true if debug is enabled, false otherwise
      */
     public function isDebug()
     {
@@ -123,7 +123,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if the XDebug is enabled.
      *
-     * @return Boolean true if XDebug is enabled, false otherwise
+     * @return boolean true if XDebug is enabled, false otherwise
      */
     public function hasXDebug()
     {
@@ -133,7 +133,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if EAccelerator is enabled.
      *
-     * @return Boolean true if EAccelerator is enabled, false otherwise
+     * @return boolean true if EAccelerator is enabled, false otherwise
      */
     public function hasEAccelerator()
     {
@@ -143,7 +143,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if APC is enabled.
      *
-     * @return Boolean true if APC is enabled, false otherwise
+     * @return boolean true if APC is enabled, false otherwise
      */
     public function hasApc()
     {
@@ -153,7 +153,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if XCache is enabled.
      *
-     * @return Boolean true if XCache is enabled, false otherwise
+     * @return boolean true if XCache is enabled, false otherwise
      */
     public function hasXCache()
     {
@@ -163,7 +163,7 @@ class ConfigDataCollector extends DataCollector
     /**
      * Returns true if any accelerator is enabled.
      *
-     * @return Boolean true if any accelerator is enabled, false otherwise
+     * @return boolean true if any accelerator is enabled, false otherwise
      */
     public function hasAccelerator()
     {

--- a/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ExceptionDataCollector.php
@@ -43,7 +43,7 @@ class ExceptionDataCollector extends DataCollector
     /**
      * Checks if the exception is not null.
      *
-     * @return Boolean true if the exception is not null, false otherwise
+     * @return boolean true if the exception is not null, false otherwise
      */
     public function hasException()
     {

--- a/src/Symfony/Component/HttpKernel/Debug/ContainerAwareTraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ContainerAwareTraceableEventDispatcher.php
@@ -268,7 +268,7 @@ class ContainerAwareTraceableEventDispatcher extends ContainerAwareEventDispatch
      * Updates the stopwatch data in the profile hierarchy.
      *
      * @param string  $token          Profile token
-     * @param Boolean $updateChildren Whether to update the children altogether
+     * @param boolean $updateChildren Whether to update the children altogether
      */
     private function updateProfiles($token, $updateChildren)
     {
@@ -289,7 +289,7 @@ class ContainerAwareTraceableEventDispatcher extends ContainerAwareEventDispatch
      * Update the profiles with the timing info and saves them.
      *
      * @param Profile $profile        The root profile
-     * @param Boolean $updateChildren Whether to update the children altogether
+     * @param boolean $updateChildren Whether to update the children altogether
      */
     private function saveStopwatchInfoInProfile(Profile $profile, $updateChildren)
     {

--- a/src/Symfony/Component/HttpKernel/Event/GetResponseEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseEvent.php
@@ -61,7 +61,7 @@ class GetResponseEvent extends KernelEvent
     /**
      * Returns whether a response was set
      *
-     * @return Boolean Whether a response was set
+     * @return boolean Whether a response was set
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ProfilerListener.php
@@ -42,15 +42,15 @@ class ProfilerListener implements EventSubscriberInterface
      *
      * @param Profiler                $profiler           A Profiler instance
      * @param RequestMatcherInterface $matcher            A RequestMatcher instance
-     * @param Boolean                 $onlyException      true if the profiler only collects data when an exception occurs, false otherwise
-     * @param Boolean                 $onlyMasterRequests true if the profiler only collects data when the request is a master request, false otherwise
+     * @param boolean                 $onlyException      true if the profiler only collects data when an exception occurs, false otherwise
+     * @param boolean                 $onlyMasterRequests true if the profiler only collects data when the request is a master request, false otherwise
      */
     public function __construct(Profiler $profiler, RequestMatcherInterface $matcher = null, $onlyException = false, $onlyMasterRequests = false)
     {
         $this->profiler = $profiler;
         $this->matcher = $matcher;
-        $this->onlyException = (Boolean) $onlyException;
-        $this->onlyMasterRequests = (Boolean) $onlyMasterRequests;
+        $this->onlyException = (boolean) $onlyException;
+        $this->onlyMasterRequests = (boolean) $onlyMasterRequests;
         $this->children = new \SplObjectStorage();
         $this->profiles = array();
     }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -56,7 +56,7 @@ class Esi
      *
      * @param Request $request A Request instance
      *
-     * @return Boolean true if one surrogate has ESI/1.0 capability, false otherwise
+     * @return boolean true if one surrogate has ESI/1.0 capability, false otherwise
      */
     public function hasSurrogateEsiCapability(Request $request)
     {
@@ -99,7 +99,7 @@ class Esi
      *
      * @param Response $response A Response instance
      *
-     * @return Boolean true if the Response needs to be parsed, false otherwise
+     * @return boolean true if the Response needs to be parsed, false otherwise
      */
     public function needsEsiParsing(Response $response)
     {
@@ -107,7 +107,7 @@ class Esi
             return false;
         }
 
-        return (Boolean) preg_match('#content="[^"]*ESI/1.0[^"]*"#', $control);
+        return (boolean) preg_match('#content="[^"]*ESI/1.0[^"]*"#', $control);
     }
 
     /**
@@ -115,7 +115,7 @@ class Esi
      *
      * @param string  $uri          A URI
      * @param string  $alt          An alternate URI
-     * @param Boolean $ignoreErrors Whether to ignore errors or not
+     * @param boolean $ignoreErrors Whether to ignore errors or not
      * @param string  $comment      A comment to add as an esi:include tag
      */
     public function renderIncludeTag($uri, $alt = null, $ignoreErrors = true, $comment = '')
@@ -181,7 +181,7 @@ class Esi
      * @param HttpCache $cache        An HttpCache instance
      * @param string    $uri          The main URI
      * @param string    $alt          An alternative URI
-     * @param Boolean   $ignoreErrors Whether to ignore errors or not
+     * @param boolean   $ignoreErrors Whether to ignore errors or not
      */
     public function handle(HttpCache $cache, $uri, $alt, $ignoreErrors)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -232,7 +232,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Forwards the Request to the backend without storing the Response in the cache.
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   Whether to process exceptions
+     * @param boolean $catch   Whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -247,7 +247,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Invalidates non-safe methods (like POST, PUT, and DELETE).
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   Whether to process exceptions
+     * @param boolean $catch   Whether to process exceptions
      *
      * @return Response A Response instance
      *
@@ -285,7 +285,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * it triggers "miss" processing.
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   whether to process exceptions
+     * @param boolean $catch   whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -337,7 +337,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param Request  $request A Request instance
      * @param Response $entry   A Response instance to validate
-     * @param Boolean  $catch   Whether to process exceptions
+     * @param boolean  $catch   Whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -398,7 +398,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * This methods is triggered when the cache missed or a reload is required.
      *
      * @param Request $request A Request instance
-     * @param Boolean $catch   whether to process exceptions
+     * @param boolean $catch   whether to process exceptions
      *
      * @return Response A Response instance
      */
@@ -432,7 +432,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * Forwards the Request to the backend and returns the Response.
      *
      * @param Request  $request A Request instance
-     * @param Boolean  $catch   Whether to catch exceptions or not
+     * @param boolean  $catch   Whether to catch exceptions or not
      * @param Response $entry   A Response instance (the stale entry if present, null otherwise)
      *
      * @return Response A Response instance
@@ -471,7 +471,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * @param Request  $request A Request instance
      * @param Response $entry   A Response instance
      *
-     * @return Boolean true if the cache entry if fresh enough, false otherwise
+     * @return boolean true if the cache entry if fresh enough, false otherwise
      */
     protected function isFreshEnough(Request $request, Response $entry)
     {
@@ -492,7 +492,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      * @param Request  $request A Request instance
      * @param Response $entry   A Response instance
      *
-     * @return Boolean true if the cache entry can be returned even if it is staled, false otherwise
+     * @return boolean true if the cache entry can be returned even if it is staled, false otherwise
      */
     protected function lock(Request $request, Response $entry)
     {
@@ -624,7 +624,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @param Request $request A Request instance
      *
-     * @return Boolean true if the Request is private, false otherwise
+     * @return boolean true if the Request is private, false otherwise
      */
     private function isPrivateRequest(Request $request)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -67,7 +67,7 @@ class Store implements StoreInterface
      *
      * @param Request $request A Request instance
      *
-     * @return Boolean|string true if the lock is acquired, the path to the current lock otherwise
+     * @return boolean|string true if the lock is acquired, the path to the current lock otherwise
      */
     public function lock(Request $request)
     {
@@ -234,7 +234,7 @@ class Store implements StoreInterface
      * @param array  $env1 A Request HTTP header array
      * @param array  $env2 A Request HTTP header array
      *
-     * @return Boolean true if the the two environments match, false otherwise
+     * @return boolean true if the the two environments match, false otherwise
      */
     private function requestsMatch($vary, $env1, $env2)
     {
@@ -277,7 +277,7 @@ class Store implements StoreInterface
      *
      * @param string $url A URL
      *
-     * @return Boolean true if the URL exists and has been purged, false otherwise
+     * @return boolean true if the URL exists and has been purged, false otherwise
      */
     public function purge($url)
     {

--- a/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
@@ -58,7 +58,7 @@ interface StoreInterface
      *
      * @param Request $request A Request instance
      *
-     * @return Boolean|string true if the lock is acquired, the path to the current lock otherwise
+     * @return boolean|string true if the lock is acquired, the path to the current lock otherwise
      */
     function lock(Request $request);
 
@@ -74,7 +74,7 @@ interface StoreInterface
      *
      * @param string $url A URL
      *
-     * @return Boolean true if the URL exists and has been purged, false otherwise
+     * @return boolean true if the URL exists and has been purged, false otherwise
      */
     function purge($url);
 

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -58,7 +58,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      * @param Request $request A Request instance
      * @param integer $type    The type of the request
      *                          (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     * @param Boolean $catch Whether to catch exceptions or not
+     * @param boolean $catch Whether to catch exceptions or not
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -35,7 +35,7 @@ interface HttpKernelInterface
      * @param Request $request A Request instance
      * @param integer $type    The type of the request
      *                          (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     * @param Boolean $catch Whether to catch exceptions or not
+     * @param boolean $catch Whether to catch exceptions or not
      *
      * @return Response A Response instance
      *

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -69,14 +69,14 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      * Constructor.
      *
      * @param string  $environment The environment
-     * @param Boolean $debug       Whether to enable debugging or not
+     * @param boolean $debug       Whether to enable debugging or not
      *
      * @api
      */
     public function __construct($environment, $debug)
     {
         $this->environment = $environment;
-        $this->debug = (Boolean) $debug;
+        $this->debug = (boolean) $debug;
         $this->booted = false;
         $this->rootDir = $this->getRootDir();
         $this->name = preg_replace('/[^a-zA-Z0-9_]+/', '', basename($this->rootDir));
@@ -220,7 +220,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param string $class A class name
      *
-     * @return Boolean true if the class belongs to an active bundle, false otherwise
+     * @return boolean true if the class belongs to an active bundle, false otherwise
      *
      * @api
      */
@@ -239,7 +239,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      * Returns a bundle and optionally its descendants by its name.
      *
      * @param string  $name  Bundle name
-     * @param Boolean $first Whether to return the first bundle only or together with its descendants
+     * @param boolean $first Whether to return the first bundle only or together with its descendants
      *
      * @return BundleInterface|Array A BundleInterface instance or an array of BundleInterface instances if $first is false
      *
@@ -281,7 +281,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param string  $name  A resource name to locate
      * @param string  $dir   A directory where to look for the resource first
-     * @param Boolean $first Whether to return the first path or paths for all matching bundles
+     * @param boolean $first Whether to return the first path or paths for all matching bundles
      *
      * @return string|array The absolute path of the resource or an array if $first is false
      *
@@ -372,7 +372,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     /**
      * Checks if debug mode is enabled.
      *
-     * @return Boolean true if debug mode is enabled, false otherwise
+     * @return boolean true if debug mode is enabled, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -75,7 +75,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      *
      * @param string $class A class name
      *
-     * @return Boolean true if the class belongs to an active bundle, false otherwise
+     * @return boolean true if the class belongs to an active bundle, false otherwise
      *
      * @api
      */
@@ -85,7 +85,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      * Returns a bundle and optionally its descendants by its name.
      *
      * @param string  $name  Bundle name
-     * @param Boolean $first Whether to return the first bundle only or together with its descendants
+     * @param boolean $first Whether to return the first bundle only or together with its descendants
      *
      * @return BundleInterface|Array A BundleInterface instance or an array of BundleInterface instances if $first is false
      *
@@ -114,7 +114,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      *
      * @param string  $name  A resource name to locate
      * @param string  $dir   A directory where to look for the resource first
-     * @param Boolean $first Whether to return the first path or paths for all matching bundles
+     * @param boolean $first Whether to return the first path or paths for all matching bundles
      *
      * @return string|array The absolute path of the resource or an array if $first is false
      *
@@ -146,7 +146,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Checks if debug mode is enabled.
      *
-     * @return Boolean true if debug mode is enabled, false otherwise
+     * @return boolean true if debug mode is enabled, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -86,7 +86,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
      *
      * @param Profile $profile A Profile instance
      *
-     * @return Boolean Write operation successful
+     * @return boolean Write operation successful
      */
     public function write(Profile $profile)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -235,13 +235,13 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
 
         return $profiles;
     }
-    
+
     /**
      * Returns whether data for the given token already exists in storage.
      *
      * @param string $token The profile token
      *
-     * @return Boolean
+     * @return boolean
      */
     protected function has($token)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -84,7 +84,7 @@ class Profiler
      *
      * @param Profile $profile A Profile instance
      *
-     * @return Boolean
+     * @return boolean
      */
     public function saveProfile(Profile $profile)
     {
@@ -221,7 +221,7 @@ class Profiler
      *
      * @param string $name A collector name
      *
-     * @return Boolean
+     * @return boolean
      */
     public function has($name)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/ProfilerStorageInterface.php
@@ -46,7 +46,7 @@ interface ProfilerStorageInterface
      *
      * @param Profile $profile A Profile instance
      *
-     * @return Boolean Write operation successful
+     * @return boolean Write operation successful
      */
     function write(Profile $profile);
 

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -327,7 +327,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
      * @param int    $expiration
      * @param int    $serializer
      *
-     * @return Boolean
+     * @return boolean
      */
     private function setValue($key, $value, $expiration = 0, $serializer = self::REDIS_SERIALIZER_NONE)
     {
@@ -344,7 +344,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
      * @param string $value
      * @param int    $expiration
      *
-     * @return Boolean
+     * @return boolean
      */
     private function appendValue($key, $value, $expiration = 0)
     {
@@ -365,7 +365,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
      *
      * @param array $key
      *
-     * @return Boolean
+     * @return boolean
      */
     private function delete(array $keys)
     {

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -49,6 +49,6 @@ class KernelForTest extends Kernel
 
     public function setIsBooted($value)
     {
-        $this->booted = (Boolean) $value;
+        $this->booted = (boolean) $value;
     }
 }

--- a/src/Symfony/Component/Locale/Resources/stubs/functions.php
+++ b/src/Symfony/Component/Locale/Resources/stubs/functions.php
@@ -16,7 +16,7 @@ use Symfony\Component\Locale\Stub\StubIntl;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  * @param  integer $errorCode  The error code returned by intl_get_error_code()
- * @return Boolean Whether the error code indicates an error
+ * @return boolean Whether the error code indicates an error
  * @see    Symfony\Component\Locale\Stub\StubIntl::isFailure
  */
 function intl_is_failure($errorCode)
@@ -28,7 +28,7 @@ function intl_is_failure($errorCode)
  * Stub implementation for the intl_get_error_code function of the intl extension
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- * @return Boolean The error code of the last intl function call or
+ * @return boolean The error code of the last intl function call or
  *                 StubIntl::U_ZERO_ERROR if no error occurred
  * @see    Symfony\Component\Locale\Stub\StubIntl::getErrorCode
  */
@@ -41,7 +41,7 @@ function intl_get_error_code()
  * Stub implementation for the intl_get_error_code function of the intl extension
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- * @return Boolean The error message of the last intl function call or
+ * @return boolean The error message of the last intl function call or
  *                 "U_ZERO_ERROR" if no error occurred
  * @see    Symfony\Component\Locale\Stub\StubIntl::getErrorMessage
  */

--- a/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
@@ -200,7 +200,7 @@ class FullTransformer
      *
      * @param string $quoteMatch The string to check
      *
-     * @return Boolean              true if matches, false otherwise
+     * @return boolean              true if matches, false otherwise
      */
     public function isQuoteMatch($quoteMatch)
     {
@@ -274,7 +274,7 @@ class FullTransformer
      * @param DateTime $dateTime The DateTime object to be used to calculate the timestamp
      * @param array    $options  An array with the matched values to be used to calculate the timestamp
      *
-     * @return Boolean|int        The calculated timestamp or false if matched date is invalid
+     * @return boolean|int        The calculated timestamp or false if matched date is invalid
      */
     protected function calculateUnixTimestamp(\DateTime $dateTime, array $options)
     {

--- a/src/Symfony/Component/Locale/Stub/StubCollator.php
+++ b/src/Symfony/Component/Locale/Stub/StubCollator.php
@@ -90,7 +90,7 @@ class StubCollator
      *                           StubCollator::SORT_NUMERIC - compare items numerically
      *                           StubCollator::SORT_STRING - compare items as strings
      *
-     * @return Boolean           True on success or false on failure
+     * @return boolean           True on success or false on failure
      */
     public function asort(&$array, $sortFlag = self::SORT_REGULAR)
     {
@@ -111,7 +111,7 @@ class StubCollator
      * @param string $str1 The first string to compare
      * @param string $str2 The second string to compare
      *
-     * @return Boolean|int     Return the comparison result or false on failure:
+     * @return boolean|int     Return the comparison result or false on failure:
      *                         1 if $str1 is greater than $str2
      *                         0 if $str1 is equal than $str2
      *                         -1 if $str1 is less than $str2
@@ -130,7 +130,7 @@ class StubCollator
      *
      * @param int $attr An attribute specifier, one of the attribute constants
      *
-     * @return Boolean|int   The attribute value on success or false on error
+     * @return boolean|int   The attribute value on success or false on error
      *
      * @see    http://www.php.net/manual/en/collator.getattribute.php
      *
@@ -192,7 +192,7 @@ class StubCollator
     /**
      * Get current collator's strength
      *
-     * @return Boolean|int   The current collator's strength or false on failure
+     * @return boolean|int   The current collator's strength or false on failure
      *
      * @see    http://www.php.net/manual/en/collator.getstrength.php
      *
@@ -209,7 +209,7 @@ class StubCollator
      * @param int $attr An attribute specifier, one of the attribute constants
      * @param int $val  The attribute value, one of the attribute value constants
      *
-     * @return Boolean       True on success or false on failure
+     * @return boolean       True on success or false on failure
      *
      * @see    http://www.php.net/manual/en/collator.setattribute.php
      *
@@ -231,7 +231,7 @@ class StubCollator
      *                           StubCollator::IDENTICAL
      *                           StubCollator::DEFAULT
      *
-     * @return Boolean           True on success or false on failure
+     * @return boolean           True on success or false on failure
      *
      * @see    http://www.php.net/manual/en/collator.setstrength.php
      *
@@ -247,7 +247,7 @@ class StubCollator
      *
      * @param  array   &$arr   Array of strings to sort
      *
-     * @return Boolean         True on success or false on failure
+     * @return boolean         True on success or false on failure
      *
      * @see    http://www.php.net/manual/en/collator.sortwithsortkeys.php
      *
@@ -267,7 +267,7 @@ class StubCollator
      *                             StubCollator::SORT_NUMERIC
      *                             StubCollator::SORT_STRING
      *
-     * @return Boolean             True on success or false on failure
+     * @return boolean             True on success or false on failure
      *
      * @see    http://www.php.net/manual/en/collator.sort.php
      *

--- a/src/Symfony/Component/Locale/Stub/StubIntl.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntl.php
@@ -69,7 +69,7 @@ abstract class StubIntl
      *
      * @param integer $errorCode The error code returned by StubIntl::getErrorCode()
      *
-     * @return Boolean
+     * @return boolean
      */
     static public function isFailure($errorCode)
     {

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -96,7 +96,7 @@ class StubIntlDateFormatter
     private $dateTimeZone;
 
     /**
-     * @var Boolean
+     * @var boolean
      */
     private $unitializedTimeZoneId = false;
 
@@ -391,7 +391,7 @@ class StubIntlDateFormatter
      *
      * @param string $calendar The calendar to use. Default is IntlDateFormatter::GREGORIAN.
      *
-     * @return Boolean            true on success or false on failure
+     * @return boolean            true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/intldateformatter.setcalendar.php
      *
@@ -410,9 +410,9 @@ class StubIntlDateFormatter
      * patterns, parsing as much as possible to obtain a value. Extra space, unrecognized tokens, or
      * invalid values ("February 30th") are not accepted.
      *
-     * @param Boolean $lenient Sets whether the parser is lenient or not, default is false (strict)
+     * @param boolean $lenient Sets whether the parser is lenient or not, default is false (strict)
      *
-     * @return Boolean            true on success or false on failure
+     * @return boolean            true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/intldateformatter.setlenient.php
      *
@@ -430,7 +430,7 @@ class StubIntlDateFormatter
      *
      * @param string $pattern A pattern string in conformance with the ICU IntlDateFormatter documentation
      *
-     * @return Boolean            true on success or false on failure
+     * @return boolean            true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/intldateformatter.setpattern.php
      * @see    http://userguide.icu-project.org/formatparse/datetime
@@ -451,7 +451,7 @@ class StubIntlDateFormatter
      *                               If NULL or the empty string, the default time zone for the
      *                               runtime is used.
      *
-     * @return Boolean               true on success or false on failure
+     * @return boolean               true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/intldateformatter.settimezoneid.php
      */

--- a/src/Symfony/Component/Locale/Stub/StubLocale.php
+++ b/src/Symfony/Component/Locale/Stub/StubLocale.php
@@ -226,7 +226,7 @@ class StubLocale
      *
      * @param string  $langtag      The language tag to check
      * @param string  $locale       The language range to check against
-     * @param Boolean $canonicalize
+     * @param boolean $canonicalize
      *
      * @return string             The corresponding locale code
      *
@@ -423,7 +423,7 @@ class StubLocale
      *
      * @param array   $langtag      A list of the language tags to compare to locale
      * @param string  $locale       The locale to use as the language range when matching
-     * @param Boolean $canonicalize If true, the arguments will be converted to canonical form before matching
+     * @param boolean $canonicalize If true, the arguments will be converted to canonical form before matching
      * @param string  $default      The locale to use if no match is found
      *
      * @see    http://www.php.net/manual/en/locale.lookup.php
@@ -456,7 +456,7 @@ class StubLocale
      *
      * @param string $locale The locale code
      *
-     * @return Boolean            true on success or false on failure
+     * @return boolean            true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/locale.parselocale.php
      *

--- a/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubNumberFormatter.php
@@ -320,7 +320,7 @@ class StubNumberFormatter
      * @param number $value The value to format
      * @param int    $type  Type of the formatting, one of the format type constants
      *
-     * @return Boolean|string                         The formatted value or false on error
+     * @return boolean|string                         The formatted value or false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.format.php
      *
@@ -364,7 +364,7 @@ class StubNumberFormatter
      *
      * @param int $attr An attribute specifier, one of the numeric attribute constants
      *
-     * @return Boolean|int       The attribute value on success or false on error
+     * @return boolean|int       The attribute value on success or false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.getattribute.php
      */
@@ -414,7 +414,7 @@ class StubNumberFormatter
     /**
      * Returns the formatter's pattern
      *
-     * @return Boolean|string     The pattern string used by the formatter or false on error
+     * @return boolean|string     The pattern string used by the formatter or false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.getpattern.php
      *
@@ -430,7 +430,7 @@ class StubNumberFormatter
      *
      * @param int $attr A symbol specifier, one of the format symbol constants
      *
-     * @return Boolean|string        The symbol value or false on error
+     * @return boolean|string        The symbol value or false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.getsymbol.php
      *
@@ -446,7 +446,7 @@ class StubNumberFormatter
      *
      * @param int $attr An attribute specifier, one of the text attribute constants
      *
-     * @return Boolean|string        The attribute value or false on error
+     * @return boolean|string        The attribute value or false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.gettextattribute.php
      *
@@ -464,7 +464,7 @@ class StubNumberFormatter
      * @param string $currency Parameter to receive the currency name (reference)
      * @param int    $position Offset to begin the parsing on return this value will hold the offset at which the parsing ended
      *
-     * @return Boolean|string           The parsed numeric value of false on error
+     * @return boolean|string           The parsed numeric value of false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.parsecurrency.php
      *
@@ -482,7 +482,7 @@ class StubNumberFormatter
      * @param string $type     Type of the formatting, one of the format type constants. NumberFormatter::TYPE_DOUBLE by default
      * @param int    $position Offset to begin the parsing on return this value will hold the offset at which the parsing ended
      *
-     * @return Boolean|string                               The parsed value of false on error
+     * @return boolean|string                               The parsed value of false on error
      *
      * @see    http://www.php.net/manual/en/numberformatter.parse.php
      *
@@ -528,7 +528,7 @@ class StubNumberFormatter
      * @param int $attr  An attribute specifier, one of the numeric attribute constants
      * @param int $value The attribute value
      *
-     * @return Boolean                                     true on success or false on failure
+     * @return boolean                                     true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/numberformatter.setattribute.php
      *
@@ -574,7 +574,7 @@ class StubNumberFormatter
      *
      * @param string $pattern A pattern string in conformance with the ICU DecimalFormat documentation
      *
-     * @return Boolean            true on success or false on failure
+     * @return boolean            true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/numberformatter.setpattern.php
      * @see    http://www.icu-project.org/apiref/icu4c/classDecimalFormat.html#_details
@@ -592,7 +592,7 @@ class StubNumberFormatter
      * @param int    $attr  A symbol specifier, one of the format symbol constants
      * @param string $value The value for the symbol
      *
-     * @return Boolean           true on success or false on failure
+     * @return boolean           true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/numberformatter.setsymbol.php
      *
@@ -609,7 +609,7 @@ class StubNumberFormatter
      * @param int $attr  An attribute specifier, one of the text attribute constants
      * @param int $value The attribute value
      *
-     * @return Boolean           true on success or false on failure
+     * @return boolean           true on success or false on failure
      *
      * @see    http://www.php.net/manual/en/numberformatter.settextattribute.php
      *
@@ -769,7 +769,7 @@ class StubNumberFormatter
      *
      * @param string $attr The attribute name
      *
-     * @return Boolean         true if the value was set by client, false otherwise
+     * @return boolean         true if the value was set by client, false otherwise
      */
     private function isInitializedAttribute($attr)
     {
@@ -842,7 +842,7 @@ class StubNumberFormatter
      *
      * @param int $value The rounding mode value to check
      *
-     * @return Boolean        true if the rounding mode is invalid, false otherwise
+     * @return boolean        true if the rounding mode is invalid, false otherwise
      */
     private function isInvalidRoundingMode($value)
     {
@@ -855,7 +855,7 @@ class StubNumberFormatter
 
     /**
      * Returns the normalized value for the GROUPING_USED attribute. Any value that can be converted to int will be
-     * cast to Boolean and then to int again. This way, negative values are converted to 1 and string values to 0.
+     * cast to boolean and then to int again. This way, negative values are converted to 1 and string values to 0.
      *
      * @param mixed $value The value to be normalized
      *
@@ -863,7 +863,7 @@ class StubNumberFormatter
      */
     private function normalizeGroupingUsedValue($value)
     {
-        return (int) (Boolean) (int) $value;
+        return (int) (boolean) (int) $value;
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -33,7 +33,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
     private $lazy = array();
 
     /**
-     * A list of Boolean locks for each LazyOption.
+     * A list of boolean locks for each LazyOption.
      * @var array
      */
     private $lock = array();
@@ -46,7 +46,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      * process. If any option is changed after being read, all evaluated
      * lazy options that depend on this option would become invalid.
      *
-     * @var Boolean
+     * @var boolean
      */
     private $reading = false;
 
@@ -192,7 +192,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      *
      * @param string $option The option name.
      *
-     * @return Boolean Whether the option exists.
+     * @return boolean Whether the option exists.
      */
     public function has($option)
     {
@@ -263,7 +263,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      *
      * @param string $option The option name.
      *
-     * @return Boolean Whether the option exists.
+     * @return boolean Whether the option exists.
      *
      * @see \ArrayAccess::offsetExists()
      */
@@ -412,7 +412,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      *
      * @param mixed $value The option value to test.
      *
-     * @return Boolean Whether it is a lazy option closure.
+     * @return boolean Whether it is a lazy option closure.
      */
     static private function isEvaluatedLazily($value)
     {

--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -175,7 +175,7 @@ interface OptionsResolverInterface
      *
      * @param string $option The name of the option.
      *
-     * @return Boolean Whether the option is known.
+     * @return boolean Whether the option is known.
      */
     function isKnown($option);
 
@@ -188,7 +188,7 @@ interface OptionsResolverInterface
      *
      * @param string $option The name of the option.
      *
-     * @return Boolean Whether the option is required.
+     * @return boolean Whether the option is required.
      */
     function isRequired($option);
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -429,7 +429,7 @@ class Process
     /**
      * Checks if the process ended successfully.
      *
-     * @return Boolean true if the process ended successfully, false otherwise
+     * @return boolean true if the process ended successfully, false otherwise
      *
      * @api
      */
@@ -445,7 +445,7 @@ class Process
      *
      * It always returns false on Windows.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -477,7 +477,7 @@ class Process
      *
      * It always returns false on Windows.
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */
@@ -507,7 +507,7 @@ class Process
     /**
      * Checks if the process is currently running.
      *
-     * @return Boolean true if the process is currently running, false otherwise
+     * @return boolean true if the process is currently running, false otherwise
      */
     public function isRunning()
     {
@@ -637,7 +637,7 @@ class Process
 
     public function setEnhanceWindowsCompatibility($enhance)
     {
-        $this->enhanceWindowsCompatibility = (Boolean) $enhance;
+        $this->enhanceWindowsCompatibility = (boolean) $enhance;
     }
 
     /**
@@ -709,7 +709,7 @@ class Process
      * Handles the windows file handles fallbacks
      *
      * @param mixed $callback A valid PHP callback
-     * @param Boolean $closeEmptyHandles if true, handles that are empty will be assumed closed
+     * @param boolean $closeEmptyHandles if true, handles that are empty will be assumed closed
      */
     private function processFileHandles($callback, $closeEmptyHandles = false)
     {

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -73,7 +73,7 @@ class UrlGenerator implements UrlGeneratorInterface
     /**
      * Enables or disables the exception on incorrect parameters.
      *
-     * @param Boolean $enabled
+     * @param boolean $enabled
      */
     public function setStrictParameters($enabled)
     {
@@ -83,7 +83,7 @@ class UrlGenerator implements UrlGeneratorInterface
     /**
      * Gets the strict check of incorrect parameters.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function getStrictParameters()
     {

--- a/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGeneratorInterface.php
@@ -31,7 +31,7 @@ interface UrlGeneratorInterface extends RequestContextAwareInterface
      *
      * @param string  $name       The name of the route
      * @param mixed   $parameters An array of parameters
-     * @param Boolean $absolute   Whether to generate an absolute URL
+     * @param boolean $absolute   Whether to generate an absolute URL
      *
      * @return string The generated URL
      *

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -77,7 +77,7 @@ EOF;
     /**
      * Generates the code for the match method implementing UrlMatcherInterface.
      *
-     * @param Boolean $supportsRedirections Whether redirections are supported by the base class
+     * @param boolean $supportsRedirections Whether redirections are supported by the base class
      *
      * @return string Match method as PHP code
      */
@@ -121,7 +121,7 @@ EOF;
      * Generates PHP code recursively to match a RouteCollection with all child routes and child collections.
      *
      * @param RouteCollection $routes               A RouteCollection instance
-     * @param Boolean         $supportsRedirections Whether redirections are supported by the base class
+     * @param boolean         $supportsRedirections Whether redirections are supported by the base class
      * @param string|null     $parentPrefix         The prefix of the parent collection used to optimize the code
      *
      * @return string PHP code
@@ -167,7 +167,7 @@ EOF;
      *
      * @param Route       $routes               A Route instance
      * @param string      $name                 The name of the Route
-     * @param Boolean     $supportsRedirections Whether redirections are supported by the base class
+     * @param boolean     $supportsRedirections Whether redirections are supported by the base class
      * @param string|null $parentPrefix         The prefix of the parent collection used to optimize the code
      *
      * @return string PHP code

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -240,7 +240,7 @@ class RequestContext
      *
      * @param string $name A parameter name
      *
-     * @return Boolean true if the parameter value is set, false otherwise
+     * @return boolean true if the parameter value is set, false otherwise
      */
     public function hasParameter($name)
     {

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -229,7 +229,7 @@ class Route
      *
      * @param string $name A variable name
      *
-     * @return Boolean true if the default value is set, false otherwise
+     * @return boolean true if the default value is set, false otherwise
      */
     public function hasDefault($name)
     {

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -302,7 +302,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
      *
      * @param string $name The route name
      *
-     * @return Boolean true when found
+     * @return boolean true when found
      */
     private function removeRecursively($name)
     {
@@ -329,7 +329,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
      *
      * @param RouteCollection $collection A RouteCollection instance
      *
-     * @return Boolean
+     * @return boolean
      */
     private function hasCollection(RouteCollection $collection)
     {

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -281,7 +281,7 @@ SELECTCLAUSE;
      * object identities.
      *
      * @param ObjectIdentityInterface $oid
-     * @param Boolean                 $directChildrenOnly
+     * @param boolean                 $directChildrenOnly
      * @return string
      */
     protected function getFindChildrenSql(ObjectIdentityInterface $oid, $directChildrenOnly)

--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -404,9 +404,9 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
      * @param integer      $securityIdentityId
      * @param string       $strategy
      * @param integer      $mask
-     * @param Boolean      $granting
-     * @param Boolean      $auditSuccess
-     * @param Boolean      $auditFailure
+     * @param boolean      $granting
+     * @param boolean      $auditSuccess
+     * @param boolean      $auditFailure
      * @return string
      */
     protected function getInsertAccessControlEntrySql($classId, $objectIdentityId, $field, $aceOrder, $securityIdentityId, $strategy, $mask, $granting, $auditSuccess, $auditFailure)
@@ -480,7 +480,7 @@ QUERY;
      *
      * @param string  $identifier
      * @param integer $classId
-     * @param Boolean $entriesInheriting
+     * @param boolean $entriesInheriting
      * @return string
      */
     protected function getInsertObjectIdentitySql($identifier, $classId, $entriesInheriting)

--- a/src/Symfony/Component/Security/Acl/Domain/Acl.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Acl.php
@@ -54,7 +54,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * @param ObjectIdentityInterface             $objectIdentity
      * @param PermissionGrantingStrategyInterface $permissionGrantingStrategy
      * @param array                               $loadedSids
-     * @param Boolean                             $entriesInheriting
+     * @param boolean                             $entriesInheriting
      */
     public function __construct($id, ObjectIdentityInterface $objectIdentity, PermissionGrantingStrategyInterface $permissionGrantingStrategy, array $loadedSids = array(), $entriesInheriting)
     {
@@ -451,7 +451,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * @param integer                   $index
      * @param integer                   $mask
      * @param SecurityIdentityInterface $sid
-     * @param Boolean                   $granting
+     * @param boolean                   $granting
      * @param string                    $strategy
      * @throws \OutOfBoundsException
      * @throws \InvalidArgumentException
@@ -500,7 +500,7 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      * @param string                    $field
      * @param integer                   $mask
      * @param SecurityIdentityInterface $sid
-     * @param Boolean                   $granting
+     * @param boolean                   $granting
      * @param string                    $strategy
      * @throws \InvalidArgumentException
      * @throws \OutOfBoundsException
@@ -581,8 +581,8 @@ class Acl implements AuditableAclInterface, NotifyPropertyChanged
      *
      * @param array   &$aces
      * @param integer $index
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param boolean $auditSuccess
+     * @param boolean $auditFailure
      * @throws \OutOfBoundsException
      */
     private function updateAuditing(array &$aces, $index, $auditSuccess, $auditFailure)

--- a/src/Symfony/Component/Security/Acl/Domain/AuditLogger.php
+++ b/src/Symfony/Component/Security/Acl/Domain/AuditLogger.php
@@ -25,7 +25,7 @@ abstract class AuditLogger implements AuditLoggerInterface
     /**
      * Performs some checks if logging was requested
      *
-     * @param Boolean        $granted
+     * @param boolean        $granted
      * @param EntryInterface $ace
      */
     public function logIfNeeded($granted, EntryInterface $ace)
@@ -44,7 +44,7 @@ abstract class AuditLogger implements AuditLoggerInterface
     /**
      * This method is only called when logging is needed
      *
-     * @param Boolean        $granted
+     * @param boolean        $granted
      * @param EntryInterface $ace
      */
     abstract protected function doLog($granted, EntryInterface $ace);

--- a/src/Symfony/Component/Security/Acl/Domain/Entry.php
+++ b/src/Symfony/Component/Security/Acl/Domain/Entry.php
@@ -39,9 +39,9 @@ class Entry implements AuditableEntryInterface
      * @param SecurityIdentityInterface $sid
      * @param string                    $strategy
      * @param integer                   $mask
-     * @param Boolean                   $granting
-     * @param Boolean                   $auditFailure
-     * @param Boolean                   $auditSuccess
+     * @param boolean                   $granting
+     * @param boolean                   $auditFailure
+     * @param boolean                   $auditSuccess
      */
     public function __construct($id, AclInterface $acl, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
     {
@@ -125,7 +125,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      */
     public function setAuditFailure($boolean)
     {
@@ -138,7 +138,7 @@ class Entry implements AuditableEntryInterface
      * Do never call this method directly. Use the respective methods on the
      * AclInterface instead.
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      */
     public function setAuditSuccess($boolean)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/FieldEntry.php
+++ b/src/Symfony/Component/Security/Acl/Domain/FieldEntry.php
@@ -33,9 +33,9 @@ class FieldEntry extends Entry implements FieldEntryInterface
      * @param SecurityIdentityInterface $sid
      * @param string                    $strategy
      * @param integer                   $mask
-     * @param Boolean                   $granting
-     * @param Boolean                   $auditFailure
-     * @param Boolean                   $auditSuccess
+     * @param boolean                   $granting
+     * @param boolean                   $auditFailure
+     * @param boolean                   $auditSuccess
      */
     public function __construct($id, AclInterface $acl, $field, SecurityIdentityInterface $sid, $strategy, $mask, $granting, $auditFailure, $auditSuccess)
     {

--- a/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
@@ -130,8 +130,8 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      * @param array        $aces               An array of ACE to check against
      * @param array        $masks              An array of permission masks
      * @param array        $sids               An array of SecurityIdentityInterface implementations
-     * @param Boolean      $administrativeMode True turns off audit logging
-     * @return Boolean true, or false; either granting, or denying access respectively.
+     * @param boolean      $administrativeMode True turns off audit logging
+     * @return boolean true, or false; either granting, or denying access respectively.
      */
     private function hasSufficientPermissions(AclInterface $acl, array $aces, array $masks, array $sids, $administrativeMode)
     {
@@ -189,7 +189,7 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      *
      * @param integer        $requiredMask
      * @param EntryInterface $ace
-     * @return Boolean
+     * @return boolean
      */
     private function isAceApplicable($requiredMask, EntryInterface $ace)
     {

--- a/src/Symfony/Component/Security/Acl/Model/AclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclInterface.php
@@ -70,7 +70,7 @@ interface AclInterface extends \Serializable
     /**
      * Whether this ACL is inheriting ACEs from a parent ACL.
      *
-     * @return Boolean
+     * @return boolean
      */
     function isEntriesInheriting();
 
@@ -80,8 +80,8 @@ interface AclInterface extends \Serializable
      * @param string  $field
      * @param array   $masks
      * @param array   $securityIdentities
-     * @param Boolean $administrativeMode
-     * @return Boolean
+     * @param boolean $administrativeMode
+     * @return boolean
      */
     function isFieldGranted($field, array $masks, array $securityIdentities, $administrativeMode = false);
 
@@ -91,8 +91,8 @@ interface AclInterface extends \Serializable
      * @throws NoAceFoundException when no ACE was applicable for this request
      * @param array   $masks
      * @param array   $securityIdentities
-     * @param Boolean $administrativeMode
-     * @return Boolean
+     * @param boolean $administrativeMode
+     * @return boolean
      */
     function isGranted(array $masks, array $securityIdentities, $administrativeMode = false);
 
@@ -100,7 +100,7 @@ interface AclInterface extends \Serializable
      * Whether the ACL has loaded ACEs for all of the passed security identities
      *
      * @param mixed $securityIdentities an implementation of SecurityIdentityInterface, or an array thereof
-     * @return Boolean
+     * @return boolean
      */
     function isSidLoaded($securityIdentities);
 }

--- a/src/Symfony/Component/Security/Acl/Model/AclProviderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclProviderInterface.php
@@ -22,7 +22,7 @@ interface AclProviderInterface
      * Retrieves all child object identities from the database
      *
      * @param ObjectIdentityInterface $parentOid
-     * @param Boolean                 $directChildrenOnly
+     * @param boolean                 $directChildrenOnly
      * @return array returns an array of child 'ObjectIdentity's
      */
     function findChildren(ObjectIdentityInterface $parentOid, $directChildrenOnly = false);

--- a/src/Symfony/Component/Security/Acl/Model/AuditLoggerInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AuditLoggerInterface.php
@@ -22,7 +22,7 @@ interface AuditLoggerInterface
      * This method is called whenever access is granted, or denied, and
      * administrative mode is turned off.
      *
-     * @param Boolean        $granted
+     * @param boolean        $granted
      * @param EntryInterface $ace
      */
     function logIfNeeded($granted, EntryInterface $ace);

--- a/src/Symfony/Component/Security/Acl/Model/AuditableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AuditableAclInterface.php
@@ -22,8 +22,8 @@ interface AuditableAclInterface extends MutableAclInterface
      * Updates auditing for class-based ACE
      *
      * @param integer $index
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param boolean $auditSuccess
+     * @param boolean $auditFailure
      */
     function updateClassAuditing($index, $auditSuccess, $auditFailure);
 
@@ -32,8 +32,8 @@ interface AuditableAclInterface extends MutableAclInterface
      *
      * @param integer $index
      * @param string  $field
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param boolean $auditSuccess
+     * @param boolean $auditFailure
      */
     function updateClassFieldAuditing($index, $field, $auditSuccess, $auditFailure);
 
@@ -41,8 +41,8 @@ interface AuditableAclInterface extends MutableAclInterface
      * Updates auditing for object-based ACE
      *
      * @param integer $index
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param boolean $auditSuccess
+     * @param boolean $auditFailure
      */
     function updateObjectAuditing($index, $auditSuccess, $auditFailure);
 
@@ -51,8 +51,8 @@ interface AuditableAclInterface extends MutableAclInterface
      *
      * @param integer $index
      * @param string  $field
-     * @param Boolean $auditSuccess
-     * @param Boolean $auditFailure
+     * @param boolean $auditSuccess
+     * @param boolean $auditFailure
      */
     function updateObjectFieldAuditing($index, $field, $auditSuccess, $auditFailure);
 }

--- a/src/Symfony/Component/Security/Acl/Model/AuditableEntryInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AuditableEntryInterface.php
@@ -21,14 +21,14 @@ interface AuditableEntryInterface extends EntryInterface
     /**
      * Whether auditing for successful grants is turned on
      *
-     * @return Boolean
+     * @return boolean
      */
     function isAuditFailure();
 
     /**
      * Whether auditing for successful denies is turned on
      *
-     * @return Boolean
+     * @return boolean
      */
     function isAuditSuccess();
 }

--- a/src/Symfony/Component/Security/Acl/Model/EntryInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/EntryInterface.php
@@ -59,7 +59,7 @@ interface EntryInterface extends \Serializable
     /**
      * Returns whether this ACE is granting, or denying
      *
-     * @return Boolean
+     * @return boolean
      */
     function isGranting();
 }

--- a/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/MutableAclInterface.php
@@ -64,7 +64,7 @@ interface MutableAclInterface extends AclInterface
      * @param SecurityIdentityInterface $sid
      * @param integer                   $mask
      * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param boolean                   $granting
      * @param string                    $strategy
      */
     function insertClassAce(SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -76,7 +76,7 @@ interface MutableAclInterface extends AclInterface
      * @param SecurityIdentityInterface $sid
      * @param integer                   $mask
      * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param boolean                   $granting
      * @param string                    $strategy
      */
     function insertClassFieldAce($field, SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -87,7 +87,7 @@ interface MutableAclInterface extends AclInterface
      * @param SecurityIdentityInterface $sid
      * @param integer                   $mask
      * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param boolean                   $granting
      * @param string                    $strategy
      */
     function insertObjectAce(SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -99,7 +99,7 @@ interface MutableAclInterface extends AclInterface
      * @param SecurityIdentityInterface $sid
      * @param integer                   $mask
      * @param integer                   $index
-     * @param Boolean                   $granting
+     * @param boolean                   $granting
      * @param string                    $strategy
      */
     function insertObjectFieldAce($field, SecurityIdentityInterface $sid, $mask, $index = 0, $granting = true, $strategy = null);
@@ -107,7 +107,7 @@ interface MutableAclInterface extends AclInterface
     /**
      * Sets whether entries are inherited
      *
-     * @param Boolean $boolean
+     * @param boolean $boolean
      */
     function setEntriesInheriting($boolean);
 

--- a/src/Symfony/Component/Security/Acl/Model/ObjectIdentityInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/ObjectIdentityInterface.php
@@ -28,7 +28,7 @@ interface ObjectIdentityInterface
      * Example for Object Equality: $object1->getId() === $object2->getId()
      *
      * @param ObjectIdentityInterface $identity
-     * @return Boolean
+     * @return boolean
      */
     function equals(ObjectIdentityInterface $identity);
 

--- a/src/Symfony/Component/Security/Acl/Model/PermissionGrantingStrategyInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/PermissionGrantingStrategyInterface.php
@@ -24,8 +24,8 @@ interface PermissionGrantingStrategyInterface
      * @param AclInterface $acl
      * @param array        $masks
      * @param array        $sids
-     * @param Boolean      $administrativeMode
-     * @return Boolean
+     * @param boolean      $administrativeMode
+     * @return boolean
      */
     function isGranted(AclInterface $acl, array $masks, array $sids, $administrativeMode = false);
 
@@ -36,9 +36,9 @@ interface PermissionGrantingStrategyInterface
      * @param string       $field
      * @param array        $masks
      * @param array        $sids
-     * @param Boolean      $administrativeMode
+     * @param boolean      $administrativeMode
      *
-     * @return Boolean
+     * @return boolean
      */
     function isFieldGranted(AclInterface $acl, $field, array $masks, array $sids, $administrativeMode = false);
 }

--- a/src/Symfony/Component/Security/Acl/Permission/PermissionMapInterface.php
+++ b/src/Symfony/Component/Security/Acl/Permission/PermissionMapInterface.php
@@ -34,7 +34,7 @@ interface PermissionMapInterface
      * Whether this map contains the given permission
      *
      * @param string $permission
-     * @return Boolean
+     * @return boolean
      */
     function contains($permission);
 }

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -134,7 +134,7 @@ class AclVoter implements VoterInterface
      *
      * @param string $class The class name
      *
-     * @return Boolean
+     * @return boolean
      */
     public function supportsClass($class)
     {

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -38,7 +38,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
      * Constructor.
      *
      * @param AuthenticationProviderInterface[] $providers        An array of AuthenticationProviderInterface instances
-     * @param Boolean                           $eraseCredentials Whether to erase credentials after authentication or not
+     * @param boolean                           $eraseCredentials Whether to erase credentials after authentication or not
      */
     public function __construct(array $providers, $eraseCredentials = true)
     {
@@ -47,7 +47,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
         }
 
         $this->providers = $providers;
-        $this->eraseCredentials = (Boolean) $eraseCredentials;
+        $this->eraseCredentials = (boolean) $eraseCredentials;
     }
 
     public function setEventDispatcher(EventDispatcherInterface $dispatcher)

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationTrustResolverInterface.php
@@ -28,7 +28,7 @@ interface AuthenticationTrustResolverInterface
      *
      * @param TokenInterface $token
      *
-     * @return Boolean
+     * @return boolean
      */
     function isAnonymous(TokenInterface $token = null);
 
@@ -38,7 +38,7 @@ interface AuthenticationTrustResolverInterface
      *
      * @param TokenInterface $token
      *
-     * @return Boolean
+     * @return boolean
      */
     function isRememberMe(TokenInterface $token = null);
 
@@ -47,7 +47,7 @@ interface AuthenticationTrustResolverInterface
      *
      * @param TokenInterface $token
      *
-     * @return Boolean
+     * @return boolean
      */
     function isFullFledged(TokenInterface $token = null);
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/AuthenticationProviderInterface.php
@@ -29,7 +29,7 @@ interface AuthenticationProviderInterface extends AuthenticationManagerInterface
      *
      * @param TokenInterface $token A TokenInterface instance
      *
-     * @return Boolean true if the implementation supports the Token, false otherwise
+     * @return boolean true if the implementation supports the Token, false otherwise
      */
      function supports(TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -38,7 +38,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
      * @param UserCheckerInterface    $userChecker                An UserCheckerInterface instance
      * @param string                  $providerKey                The provider key
      * @param EncoderFactoryInterface $encoderFactory             An EncoderFactoryInterface instance
-     * @param Boolean                 $hideUserNotFoundExceptions Whether to hide user not found exception or not
+     * @param boolean                 $hideUserNotFoundExceptions Whether to hide user not found exception or not
      */
     public function __construct(UserProviderInterface $userProvider, UserCheckerInterface $userChecker, $providerKey, EncoderFactoryInterface $encoderFactory, $hideUserNotFoundExceptions = true)
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -36,7 +36,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
      *
      * @param UserCheckerInterface $userChecker                An UserCheckerInterface interface
      * @param string               $providerKey                A provider key
-     * @param Boolean              $hideUserNotFoundExceptions Whether to hide user not found exception or not
+     * @param boolean              $hideUserNotFoundExceptions Whether to hide user not found exception or not
      */
     public function __construct(UserCheckerInterface $userChecker, $providerKey, $hideUserNotFoundExceptions = true)
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -126,7 +126,7 @@ abstract class AbstractToken implements TokenInterface
      */
     public function setAuthenticated($authenticated)
     {
-        $this->authenticated = (Boolean) $authenticated;
+        $this->authenticated = (boolean) $authenticated;
     }
 
     /**
@@ -180,7 +180,7 @@ abstract class AbstractToken implements TokenInterface
      *
      * @param string $name The attribute name
      *
-     * @return Boolean true if the attribute exists, false otherwise
+     * @return boolean true if the attribute exists, false otherwise
      */
     public function hasAttribute($name)
     {
@@ -239,7 +239,7 @@ abstract class AbstractToken implements TokenInterface
         }
 
         if ($this->user instanceof EquatableInterface) {
-            return ! (Boolean) $this->user->isEqualTo($user);
+            return ! (boolean) $this->user->isEqualTo($user);
         }
 
         if ($this->user->getPassword() !== $user->getPassword()) {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -67,14 +67,14 @@ interface TokenInterface extends \Serializable
     /**
      * Returns whether the user is authenticated or not.
      *
-     * @return Boolean true if the token has been authenticated, false otherwise
+     * @return boolean true if the token has been authenticated, false otherwise
      */
     function isAuthenticated();
 
     /**
      * Sets the authenticated flag.
      *
-     * @param Boolean $isAuthenticated The authenticated flag
+     * @param boolean $isAuthenticated The authenticated flag
      */
     function setAuthenticated($isAuthenticated);
 
@@ -102,7 +102,7 @@ interface TokenInterface extends \Serializable
      *
      * @param string $name The attribute name
      *
-     * @return Boolean true if the attribute exists, false otherwise
+     * @return boolean true if the attribute exists, false otherwise
      */
     function hasAttribute($name);
 

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManager.php
@@ -32,8 +32,8 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
      *
      * @param VoterInterface[] $voters                             An array of VoterInterface instances
      * @param string           $strategy                           The vote strategy
-     * @param Boolean          $allowIfAllAbstainDecisions         Whether to grant access if all voters abstained or not
-     * @param Boolean          $allowIfEqualGrantedDeniedDecisions Whether to grant access if result are equals
+     * @param boolean          $allowIfAllAbstainDecisions         Whether to grant access if all voters abstained or not
+     * @param boolean          $allowIfEqualGrantedDeniedDecisions Whether to grant access if result are equals
      */
     public function __construct(array $voters, $strategy = 'affirmative', $allowIfAllAbstainDecisions = false, $allowIfEqualGrantedDeniedDecisions = true)
     {
@@ -43,8 +43,8 @@ class AccessDecisionManager implements AccessDecisionManagerInterface
 
         $this->voters = $voters;
         $this->strategy = 'decide'.ucfirst($strategy);
-        $this->allowIfAllAbstainDecisions = (Boolean) $allowIfAllAbstainDecisions;
-        $this->allowIfEqualGrantedDeniedDecisions = (Boolean) $allowIfEqualGrantedDeniedDecisions;
+        $this->allowIfAllAbstainDecisions = (boolean) $allowIfAllAbstainDecisions;
+        $this->allowIfEqualGrantedDeniedDecisions = (boolean) $allowIfEqualGrantedDeniedDecisions;
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/AccessDecisionManagerInterface.php
@@ -27,7 +27,7 @@ interface AccessDecisionManagerInterface
      * @param array          $attributes An array of attributes associated with the method being invoked
      * @param object         $object     The object to secure
      *
-     * @return Boolean true if the access is granted, false otherwise
+     * @return boolean true if the access is granted, false otherwise
      */
     function decide(TokenInterface $token, array $attributes, $object = null);
 
@@ -36,7 +36,7 @@ interface AccessDecisionManagerInterface
      *
      * @param string $attribute An attribute
      *
-     * @return Boolean true if this decision manager supports the attribute, false otherwise
+     * @return boolean true if this decision manager supports the attribute, false otherwise
      */
     function supportsAttribute($attribute);
 

--- a/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
+++ b/src/Symfony/Component/Security/Core/Authorization/Voter/VoterInterface.php
@@ -29,7 +29,7 @@ interface VoterInterface
      *
      * @param string $attribute An attribute
      *
-     * @return Boolean true if this Voter supports the attribute, false otherwise
+     * @return boolean true if this Voter supports the attribute, false otherwise
      */
     function supportsAttribute($attribute);
 

--- a/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BasePasswordEncoder.php
@@ -73,7 +73,7 @@ abstract class BasePasswordEncoder implements PasswordEncoderInterface
      * @param string $password1 The first password
      * @param string $password2 The second password
      *
-     * @return Boolean true if the two passwords are the same, false otherwise
+     * @return boolean true if the two passwords are the same, false otherwise
      */
     protected function comparePasswords($password1, $password2)
     {

--- a/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/MessageDigestPasswordEncoder.php
@@ -26,7 +26,7 @@ class MessageDigestPasswordEncoder extends BasePasswordEncoder
      * Constructor.
      *
      * @param string  $algorithm          The digest algorithm to use
-     * @param Boolean $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param boolean $encodeHashAsBase64 Whether to base64 encode the password hash
      * @param integer $iterations         The number of iterations to use to stretch the password hash
      */
     public function __construct($algorithm = 'sha512', $encodeHashAsBase64 = true, $iterations = 5000)

--- a/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PasswordEncoderInterface.php
@@ -35,7 +35,7 @@ interface PasswordEncoderInterface
      * @param string $raw     A raw password
      * @param string $salt    The salt
      *
-     * @return Boolean true if the password is valid, false otherwise
+     * @return boolean true if the password is valid, false otherwise
      */
     function isPasswordValid($encoded, $raw, $salt);
 }

--- a/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/PlaintextPasswordEncoder.php
@@ -23,7 +23,7 @@ class PlaintextPasswordEncoder extends BasePasswordEncoder
     /**
      * Constructor.
      *
-     * @param Boolean $ignorePasswordCase Compare password case-insensitive
+     * @param boolean $ignorePasswordCase Compare password case-insensitive
      */
     public function __construct($ignorePasswordCase = false)
     {

--- a/src/Symfony/Component/Security/Core/SecurityContext.php
+++ b/src/Symfony/Component/Security/Core/SecurityContext.php
@@ -36,7 +36,7 @@ class SecurityContext implements SecurityContextInterface
      *
      * @param AuthenticationManagerInterface      $authenticationManager An AuthenticationManager instance
      * @param AccessDecisionManagerInterface|null $accessDecisionManager An AccessDecisionManager instance
-     * @param Boolean                             $alwaysAuthenticate
+     * @param boolean                             $alwaysAuthenticate
      */
     public function __construct(AuthenticationManagerInterface $authenticationManager, AccessDecisionManagerInterface $accessDecisionManager, $alwaysAuthenticate = false)
     {
@@ -53,7 +53,7 @@ class SecurityContext implements SecurityContextInterface
      * @param mixed      $attributes
      * @param mixed|null $object
      *
-     * @return Boolean
+     * @return boolean
      */
     public final function isGranted($attributes, $object = null)
     {

--- a/src/Symfony/Component/Security/Core/SecurityContextInterface.php
+++ b/src/Symfony/Component/Security/Core/SecurityContextInterface.php
@@ -44,7 +44,7 @@ interface SecurityContextInterface
      * @param array $attributes
      * @param mixed $object
      *
-     * @return Boolean
+     * @return boolean
      */
     function isGranted($attributes, $object = null);
 }

--- a/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
+++ b/src/Symfony/Component/Security/Core/User/AdvancedUserInterface.php
@@ -43,7 +43,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw an AccountExpiredException and prevent login.
      *
-     * @return Boolean true if the user's account is non expired, false otherwise
+     * @return boolean true if the user's account is non expired, false otherwise
      *
      * @see AccountExpiredException
      */
@@ -55,7 +55,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw a LockedException and prevent login.
      *
-     * @return Boolean true if the user is not locked, false otherwise
+     * @return boolean true if the user is not locked, false otherwise
      *
      * @see LockedException
      */
@@ -67,7 +67,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw a CredentialsExpiredException and prevent login.
      *
-     * @return Boolean true if the user's credentials are non expired, false otherwise
+     * @return boolean true if the user's credentials are non expired, false otherwise
      *
      * @see CredentialsExpiredException
      */
@@ -79,7 +79,7 @@ interface AdvancedUserInterface extends UserInterface
      * Internally, if this method returns false, the authentication system
      * will throw a DisabledException and prevent login.
      *
-     * @return Boolean true if the user is enabled, false otherwise
+     * @return boolean true if the user is enabled, false otherwise
      *
      * @see DisabledException
      */

--- a/src/Symfony/Component/Security/Core/User/EquatableInterface.php
+++ b/src/Symfony/Component/Security/Core/User/EquatableInterface.php
@@ -31,7 +31,7 @@ interface EquatableInterface
      *
      * @param UserInterface $user
      *
-     * @return Boolean
+     * @return boolean
      */
     function isEqualTo(UserInterface $user);
 }

--- a/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/User/UserProviderInterface.php
@@ -70,7 +70,7 @@ interface UserProviderInterface
      *
      * @param string $class
      *
-     * @return Boolean
+     * @return boolean
      */
     function supportsClass($class);
 }

--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -35,14 +35,14 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
      * @param HttpKernelInterface $kernel
      * @param HttpUtils           $httpUtils  An HttpUtils instance
      * @param string              $loginPath  The path to the login form
-     * @param Boolean             $useForward Whether to forward or redirect to the login form
+     * @param boolean             $useForward Whether to forward or redirect to the login form
      */
     public function __construct(HttpKernelInterface $kernel, HttpUtils $httpUtils, $loginPath, $useForward = false)
     {
         $this->httpKernel = $kernel;
         $this->httpUtils = $httpUtils;
         $this->loginPath = $loginPath;
-        $this->useForward = (Boolean) $useForward;
+        $this->useForward = (boolean) $useForward;
     }
 
     /**

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -165,7 +165,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
      *
      * @param Request $request
      *
-     * @return Boolean
+     * @return boolean
      */
     protected function requiresAuthentication(Request $request)
     {

--- a/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/LogoutListener.php
@@ -126,7 +126,7 @@ class LogoutListener implements ListenerInterface
      *
      * @param Request $request
      *
-     * @return Boolean
+     * @return boolean
      */
     protected function requiresLogout(Request $request)
     {

--- a/src/Symfony/Component/Security/Http/HttpUtils.php
+++ b/src/Symfony/Component/Security/Http/HttpUtils.php
@@ -99,7 +99,7 @@ class HttpUtils
      * @param Request $request A Request instance
      * @param string  $path    A path (an absolute path (/foo) or a route name (foo))
      *
-     * @return Boolean true if the path is the same as the one from the Request, false otherwise
+     * @return boolean true if the path is the same as the one from the Request, false otherwise
      */
     public function checkRequestPath(Request $request, $path)
     {

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -275,7 +275,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
      *
      * @param Request $request
      *
-     * @return Boolean
+     * @return boolean
      */
     protected function isRememberMeRequested(Request $request)
     {

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -73,7 +73,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      * @param string $hash1 The first hash
      * @param string $hash2 The second hash
      *
-     * @return Boolean true if the two hashes are the same, false otherwise
+     * @return boolean true if the two hashes are the same, false otherwise
      */
     private function compareHashes($hash1, $hash2)
     {

--- a/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/DecoderInterface.php
@@ -32,7 +32,7 @@ interface DecoderInterface
      * Checks whether the serializer can decode from given format
      *
      * @param string $format format name
-     * @return Boolean
+     * @return boolean
      */
     function supportsDecoding($format);
 }

--- a/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
+++ b/src/Symfony/Component/Serializer/Encoder/EncoderInterface.php
@@ -32,7 +32,7 @@ interface EncoderInterface
      * Checks whether the serializer can encode to given format
      *
      * @param string $format format name
-     * @return Boolean
+     * @return boolean
      */
     function supportsEncoding($format);
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -86,7 +86,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
       * Checks whether the serializer can encode to given format
       *
       * @param string $format format name
-      * @return Boolean
+      * @return boolean
       */
      public function supportsEncoding($format)
      {
@@ -97,7 +97,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
       * Checks whether the serializer can decode from given format
       *
       * @param string $format format name
-      * @return Boolean
+      * @return boolean
       */
      public function supportsDecoding($format)
      {
@@ -126,7 +126,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * @param DOMNode $node
      * @param string  $val
      *
-     * @return Boolean
+     * @return boolean
      */
     final protected function appendXMLString($node, $val)
     {
@@ -145,7 +145,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * @param DOMNode $node
      * @param string  $val
      *
-     * @return Boolean
+     * @return boolean
      */
     final protected function appendText($node, $val)
     {
@@ -159,7 +159,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * @param DOMNode $node
      * @param string  $val
      *
-     * @return Boolean
+     * @return boolean
      */
     final protected function appendCData($node, $val)
     {
@@ -173,7 +173,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * @param DOMNode             $node
      * @param DOMDocumentFragment $fragment
      *
-     * @return Boolean
+     * @return boolean
      */
     final protected function appendDocumentFragment($node, $fragment)
     {
@@ -191,7 +191,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      *
      * @param string $name
      *
-     * @return Boolean
+     * @return boolean
      */
     final protected function isElementNameValid($name)
     {
@@ -253,7 +253,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * @param DOMNode      $parentNode
      * @param array|object $data       data
      *
-     * @return Boolean
+     * @return boolean
      */
     private function buildXml($parentNode, $data)
     {
@@ -317,7 +317,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * @param string       $nodeName
      * @param string       $key
      *
-     * @return Boolean
+     * @return boolean
      */
     private function appendNode($parentNode, $data, $nodeName, $key = null)
     {
@@ -339,7 +339,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      *
      * @param string $val
      *
-     * @return Boolean
+     * @return boolean
      */
     private function needsCdataWrapping($val)
     {
@@ -352,7 +352,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      * @param DOMNode $node
      * @param mixed   $val
      *
-     * @return Boolean
+     * @return boolean
      */
     private function selectNodeType($node, $val)
     {

--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -40,7 +40,7 @@ class CustomNormalizer extends SerializerAwareNormalizer implements NormalizerIn
      *
      * @param mixed  $data   Data to normalize.
      * @param string $format The format being (de-)serialized from or into.
-     * @return Boolean
+     * @return boolean
      */
     public function supportsNormalization($data, $format = null)
     {
@@ -53,7 +53,7 @@ class CustomNormalizer extends SerializerAwareNormalizer implements NormalizerIn
      * @param mixed  $data   Data to denormalize from.
      * @param string $type   The class to which the data should be denormalized.
      * @param string $format The format being deserialized from.
-     * @return Boolean
+     * @return boolean
      */
     public function supportsDenormalization($data, $type, $format = null)
     {

--- a/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/DenormalizerInterface.php
@@ -34,7 +34,7 @@ interface DenormalizerInterface
      * @param mixed  $data   Data to denormalize from.
      * @param string $type   The class to which the data should be denormalized.
      * @param string $format The format being deserialized from.
-     * @return Boolean
+     * @return boolean
      */
     function supportsDenormalization($data, $type, $format = null);
 }

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -158,7 +158,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
      * Checks if the given class has any get{Property} method.
      *
      * @param string $class
-     * @return Boolean
+     * @return boolean
      */
     private function supports($class)
     {
@@ -177,7 +177,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
      * Checks if a method's name is get.* and can be called without parameters.
      *
      * @param ReflectionMethod $method the method to check
-     * @return Boolean whether the method is a getter.
+     * @return boolean whether the method is a getter.
      */
     private function isGetMethod(\ReflectionMethod $method)
     {

--- a/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
+++ b/src/Symfony/Component/Serializer/Normalizer/NormalizerInterface.php
@@ -32,7 +32,7 @@ interface NormalizerInterface
      *
      * @param mixed  $data   Data to normalize.
      * @param string $format The format being (de-)serialized from or into.
-     * @return Boolean
+     * @return boolean
      */
     function supportsNormalization($data, $format = null);
 }

--- a/src/Symfony/Component/Templating/DelegatingEngine.php
+++ b/src/Symfony/Component/Templating/DelegatingEngine.php
@@ -80,7 +80,7 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return Boolean true if the template exists, false otherwise
+     * @return boolean true if the template exists, false otherwise
      *
      * @api
      */
@@ -106,7 +106,7 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return Boolean true if this class supports the given template, false otherwise
+     * @return boolean true if this class supports the given template, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/EngineInterface.php
+++ b/src/Symfony/Component/Templating/EngineInterface.php
@@ -51,7 +51,7 @@ interface EngineInterface
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return Boolean true if the template exists, false otherwise
+     * @return boolean true if the template exists, false otherwise
      *
      * @api
      */
@@ -62,7 +62,7 @@ interface EngineInterface
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return Boolean true if this class supports the given template, false otherwise
+     * @return boolean true if this class supports the given template, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/Helper/SlotsHelper.php
+++ b/src/Symfony/Component/Templating/Helper/SlotsHelper.php
@@ -112,7 +112,7 @@ class SlotsHelper extends Helper
      * @param string $name    The slot name
      * @param string $default The default slot content
      *
-     * @return Boolean true if the slot is defined or if a default content has been provided, false otherwise
+     * @return boolean true if the slot is defined or if a default content has been provided, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/Loader/CacheLoader.php
+++ b/src/Symfony/Component/Templating/Loader/CacheLoader.php
@@ -46,7 +46,7 @@ class CacheLoader extends Loader
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|Boolean false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|boolean false if the template cannot be loaded, a Storage instance otherwise
      */
     public function load(TemplateReferenceInterface $template)
     {

--- a/src/Symfony/Component/Templating/Loader/ChainLoader.php
+++ b/src/Symfony/Component/Templating/Loader/ChainLoader.php
@@ -51,7 +51,7 @@ class ChainLoader extends Loader
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|Boolean false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|boolean false if the template cannot be loaded, a Storage instance otherwise
      */
     public function load(TemplateReferenceInterface $template)
     {
@@ -70,7 +70,7 @@ class ChainLoader extends Loader
      * @param TemplateReferenceInterface $template A template
      * @param integer                    $time     The last modification time of the cached template (timestamp)
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isFresh(TemplateReferenceInterface $template, $time)
     {

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -43,7 +43,7 @@ class FilesystemLoader extends Loader
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|Boolean false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|boolean false if the template cannot be loaded, a Storage instance otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Templating/Loader/LoaderInterface.php
@@ -27,7 +27,7 @@ interface LoaderInterface
      *
      * @param TemplateReferenceInterface $template A template
      *
-     * @return Storage|Boolean false if the template cannot be loaded, a Storage instance otherwise
+     * @return Storage|boolean false if the template cannot be loaded, a Storage instance otherwise
      *
      * @api
      */
@@ -39,7 +39,7 @@ interface LoaderInterface
      * @param TemplateReferenceInterface $template A template
      * @param integer                    $time     The last modification time of the cached template (timestamp)
      *
-     * @return Boolean
+     * @return boolean
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -112,7 +112,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return Boolean true if the template exists, false otherwise
+     * @return boolean true if the template exists, false otherwise
      *
      * @api
      */
@@ -132,7 +132,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param mixed $name A template name or a TemplateReferenceInterface instance
      *
-     * @return Boolean true if this class supports the given resource, false otherwise
+     * @return boolean true if this class supports the given resource, false otherwise
      *
      * @api
      */
@@ -199,7 +199,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param string $name The helper name
      *
-     * @return Boolean true if the helper is defined, false otherwise
+     * @return boolean true if the helper is defined, false otherwise
      *
      * @api
      */
@@ -281,7 +281,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param string $name The helper name
      *
-     * @return Boolean true if the helper is defined, false otherwise
+     * @return boolean true if the helper is defined, false otherwise
      *
      * @api
      */
@@ -446,7 +446,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
                  * @return string the escaped value
                  */
                 function ($value) use ($that) {
-                    // Numbers and Boolean values get turned into strings which can cause problems
+                    // Numbers and boolean values get turned into strings which can cause problems
                     // with type comparisons (e.g. === or is_int() etc).
                     return is_string($value) ? htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, $that->getCharset(), false) : $value;
                 },

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -70,7 +70,7 @@ interface MessageCatalogueInterface
      * @param string $id     The message id
      * @param string $domain The domain name
      *
-     * @return Boolean true if the message has a translation, false otherwise
+     * @return boolean true if the message has a translation, false otherwise
      *
      * @api
      */
@@ -82,7 +82,7 @@ interface MessageCatalogueInterface
      * @param string $id     The message id
      * @param string $domain The domain name
      *
-     * @return Boolean true if the message has a translation, false otherwise
+     * @return boolean true if the message has a translation, false otherwise
      *
      * @api
      */

--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -102,7 +102,7 @@ class ConstraintViolationList implements \IteratorAggregate, \Countable, \ArrayA
      *
      * @param  integer $offset The violation offset.
      *
-     * @return Boolean Whether the offset exists.
+     * @return boolean Whether the offset exists.
      */
     public function has($offset)
     {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -69,7 +69,7 @@ class EmailValidator extends ConstraintValidator
      *
      * @param string $host Hostname
      *
-     * @return Boolean
+     * @return boolean
      */
     private function checkMX($host)
     {
@@ -81,7 +81,7 @@ class EmailValidator extends ConstraintValidator
      *
      * @param string $host Hostname
      *
-     * @return Boolean
+     * @return boolean
      */
     private function checkHost($host)
     {

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -27,7 +27,7 @@ class RangeValidator extends ConstraintValidator
      * @param mixed      $value      The value that should be validated
      * @param Constraint $constraint The constraint for the validation
      *
-     * @return Boolean Whether or not the value is valid
+     * @return boolean Whether or not the value is valid
      *
      * @api
      */

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -213,7 +213,7 @@ class ClassMetadata extends ElementMetadata
      *
      * @param string $property The name of the property
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasMemberMetadatas($property)
     {
@@ -269,7 +269,7 @@ class ClassMetadata extends ElementMetadata
     /**
      * Returns whether this class has an overridden default group sequence.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasGroupSequence()
     {

--- a/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
@@ -75,7 +75,7 @@ abstract class ElementMetadata
     /**
      * Returns whether this element has any constraints.
      *
-     * @return Boolean
+     * @return boolean
      */
     public function hasConstraints()
     {

--- a/src/Symfony/Component/Validator/Mapping/Loader/LoaderInterface.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/LoaderInterface.php
@@ -20,7 +20,7 @@ interface LoaderInterface
      *
      * @param ClassMetadata $metadata A metadata
      *
-     * @return Boolean
+     * @return boolean
      */
     function loadClassMetadata(ClassMetadata $metadata);
 }

--- a/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/MemberMetadata.php
@@ -111,7 +111,7 @@ abstract class MemberMetadata extends ElementMetadata
     /**
      * Returns whether this member is public
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isPublic()
     {
@@ -121,7 +121,7 @@ abstract class MemberMetadata extends ElementMetadata
     /**
      * Returns whether this member is protected
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isProtected()
     {
@@ -131,7 +131,7 @@ abstract class MemberMetadata extends ElementMetadata
     /**
      * Returns whether this member is private
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isPrivate()
     {
@@ -141,7 +141,7 @@ abstract class MemberMetadata extends ElementMetadata
     /**
      * Returns whether objects stored in this member should be validated
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isCascaded()
     {
@@ -152,7 +152,7 @@ abstract class MemberMetadata extends ElementMetadata
      * Returns whether arrays or traversable objects stored in this member
      * should be traversed and validated in each entry
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isCollectionCascaded()
     {
@@ -163,7 +163,7 @@ abstract class MemberMetadata extends ElementMetadata
      * Returns whether arrays or traversable objects stored in this member
      * should be traversed recursively for inner arrays/traversable objects
      *
-     * @return Boolean
+     * @return boolean
      */
     public function isCollectionCascadedDeeply()
     {

--- a/src/Symfony/Component/Validator/ValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ValidatorFactory.php
@@ -88,7 +88,7 @@ class ValidatorFactory implements ValidatorContextInterface
      * @param array $mappingFiles A list of XML or YAML file names
      *                                      where mapping information can be
      *                                      found. Can be empty.
-     * @param Boolean $annotations Whether to use annotations for
+     * @param boolean $annotations Whether to use annotations for
      *                                      retrieving mapping information
      * @param string $staticMethod The name of the static method to
      *                                      use, if static method loading should

--- a/src/Symfony/Component/Yaml/Escaper.php
+++ b/src/Symfony/Component/Yaml/Escaper.php
@@ -43,7 +43,7 @@ class Escaper
      *
      * @param string $value A PHP value
      *
-     * @return Boolean True if the value would require double quotes.
+     * @return boolean True if the value would require double quotes.
      */
     static public function requiresDoubleQuoting($value)
     {
@@ -67,7 +67,7 @@ class Escaper
      *
      * @param string $value A PHP value
      *
-     * @return Boolean True if the value would require single quotes.
+     * @return boolean True if the value would require single quotes.
      */
     static public function requiresSingleQuoting($value)
     {

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -156,7 +156,7 @@ class Inline
      * @param string $delimiters
      * @param array  $stringDelimiters
      * @param integer &$i
-     * @param Boolean $evaluate
+     * @param boolean $evaluate
      *
      * @return string A YAML string
      *

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -325,7 +325,7 @@ class Parser
     /**
      * Moves the parser to the next line.
      *
-     * @return Boolean
+     * @return boolean
      */
     private function moveToNextLine()
     {
@@ -464,7 +464,7 @@ class Parser
     /**
      * Returns true if the next line is indented.
      *
-     * @return Boolean Returns true if the next line is indented, false otherwise
+     * @return boolean Returns true if the next line is indented, false otherwise
      */
     private function isNextLineIndented()
     {
@@ -492,7 +492,7 @@ class Parser
     /**
      * Returns true if the current line is blank or if it is a comment line.
      *
-     * @return Boolean Returns true if the current line is empty or if it is a comment line, false otherwise
+     * @return boolean Returns true if the current line is empty or if it is a comment line, false otherwise
      */
     private function isCurrentLineEmpty()
     {
@@ -502,7 +502,7 @@ class Parser
     /**
      * Returns true if the current line is blank.
      *
-     * @return Boolean Returns true if the current line is blank, false otherwise
+     * @return boolean Returns true if the current line is blank, false otherwise
      */
     private function isCurrentLineBlank()
     {
@@ -512,7 +512,7 @@ class Parser
     /**
      * Returns true if the current line is a comment line.
      *
-     * @return Boolean Returns true if the current line is a comment line, false otherwise
+     * @return boolean Returns true if the current line is a comment line, false otherwise
      */
     private function isCurrentLineComment()
     {
@@ -567,7 +567,7 @@ class Parser
     /**
      * Returns true if the next line starts unindented collection
      *
-     * @return Boolean Returns true if the next line starts unindented collection, false otherwise
+     * @return boolean Returns true if the next line starts unindented collection, false otherwise
      */
     private function isNextLineUnIndentedCollection()
     {
@@ -599,7 +599,7 @@ class Parser
     /**
      * Returns true if the string is unindented collection item
      *
-     * @return Boolean Returns true if the string is unindented collection item, false otherwise
+     * @return boolean Returns true if the string is unindented collection item, false otherwise
      */
     private function isStringUnIndentedCollectionItem($string)
     {


### PR DESCRIPTION
Standardize `boolean` type to use only lowercase instead of uppercase.

Actually, Symfony uses more often `Boolean` instead of `boolean`.

Why using lowercase ?
- Each types are actually lowercase (string, integer, float, object, etc ...) it's convenient to identify a type by use lowercase.
- Uppercase types are reserved to objects. We could have a class called `Boolean`, nothing on PHP prohibits that.
- Some ide's (ex PhpStorm) dosn't recognize Boolean as a type but a class.

I know this implies big changes for a little capital gain ... what's yours points of view ?
