### PR TITLE
[FrameworkBundle][Command] ContainerDebugCommand

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -32,7 +32,7 @@ class ContainerDebugCommand extends ContainerAwareCommand
     /**
      * @var ContainerBuilder
      */
-    private $containerBuilder;
+    protected $containerBuilder;
 
     /**
      * @see Command
@@ -209,7 +209,7 @@ EOF
      *
      * @return \Symfony\Component\DependencyInjection\Definition|\Symfony\Component\DependencyInjection\Alias
      */
-    private function resolveServiceDefinition($serviceId)
+    protected function resolveServiceDefinition($serviceId)
     {
         if ($this->containerBuilder->hasDefinition($serviceId)) {
             return $this->containerBuilder->getDefinition($serviceId);


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

I'm currently working on a command to debug (service) listeners. I wanted to extend the ContainerDebugCommand from the FrameworkBundle but I found that the method resolveServiceDefinition($serviceId) was private so it avoids its usage from children.

This PR changes the visibility so it allows the re-use of this method when extending.
