### PR TITLE
[2.2] [Security] Added Pbkdf2PasswordEncoder

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+* Added PBKDF2 Password encoder
+
 2.1.0
 -----
 

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -378,6 +378,8 @@ class MainConfiguration implements ConfigurationInterface
                         ->beforeNormalization()->ifString()->then(function($v) { return array('algorithm' => $v); })->end()
                         ->children()
                             ->scalarNode('algorithm')->cannotBeEmpty()->end()
+                            ->scalarNode('hash_algorithm')->info('Name of hashing algorithm for PBKDF2 (i.e. sha256, sha512, etc..) See hash_algos() for a list of supported algorithms.')->defaultValue('sha512')->end()
+                            ->scalarNode('key_length')->defaultValue(40)->end()
                             ->booleanNode('ignore_case')->defaultFalse()->end()
                             ->booleanNode('encode_as_base64')->defaultTrue()->end()
                             ->scalarNode('iterations')->defaultValue(5000)->end()

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -449,6 +449,21 @@ class SecurityExtension extends Extension
             );
         }
 
+        // pbkdf2 encoder
+        if ('pbkdf2' === $config['algorithm']) {
+            $arguments = array(
+                $config['hash_algorithm'],
+                $config['encode_as_base64'],
+                $config['iterations'],
+                $config['key_length'],
+            );
+
+            return array(
+                'class' => new Parameter('security.encoder.pbkdf2.class'),
+                'arguments' => $arguments,
+            );
+        }
+
         // message digest encoder
         $arguments = array(
             $config['algorithm'],

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -12,6 +12,7 @@
         <parameter key="security.encoder_factory.generic.class">Symfony\Component\Security\Core\Encoder\EncoderFactory</parameter>
         <parameter key="security.encoder.digest.class">Symfony\Component\Security\Core\Encoder\MessageDigestPasswordEncoder</parameter>
         <parameter key="security.encoder.plain.class">Symfony\Component\Security\Core\Encoder\PlaintextPasswordEncoder</parameter>
+        <parameter key="security.encoder.pbkdf2.class">Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder</parameter>
 
         <parameter key="security.user.provider.in_memory.class">Symfony\Component\Security\Core\User\InMemoryUserProvider</parameter>
         <parameter key="security.user.provider.in_memory.user.class">Symfony\Component\Security\Core\User\User</parameter>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -15,6 +15,13 @@ $container->loadFromExtension('security', array(
         'JMS\FooBundle\Entity\User4' => array(
             'id' => 'security.encoder.foo',
         ),
+        'JMS\FooBundle\Entity\User5' => array(
+            'algorithm' => 'pbkdf2',
+            'hash_algorithm' => 'sha1',
+            'encode_as_base64' => false,
+            'iterations' => 5,
+            'key_length' => 30,
+        ),
     ),
     'providers' => array(
         'default' => array(

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -16,6 +16,8 @@
 
         <encoder class="JMS\FooBundle\Entity\User4" id="security.encoder.foo" />
 
+        <encoder class="JMS\FooBundle\Entity\User5" algorithm="pbkdf2" hash-algorithm="sha1" encode-as-base64="false" iterations="5" key-length="30" />
+
         <provider name="default">
             <memory>
                 <user name="foo" password="foo" roles="ROLE_USER" />

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -10,6 +10,12 @@ security:
             algorithm: md5
         JMS\FooBundle\Entity\User4:
             id: security.encoder.foo
+        JMS\FooBundle\Entity\User5:
+            algorithm: pbkdf2
+            hash_algorithm: sha1
+            encode_as_base64: false
+            iterations: 5
+            key_length: 30
 
     providers:
         default:

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -145,6 +145,10 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
                 'arguments' => array('md5', true, 5000),
             ),
             'JMS\FooBundle\Entity\User4' => new Reference('security.encoder.foo'),
+            'JMS\FooBundle\Entity\User5' => array(
+                'class' => new Parameter('security.encoder.pbkdf2.class'),
+                'arguments' => array('sha1', false, 5, 30),
+            ),
         )), $container->getDefinition('security.encoder_factory.generic')->getArguments());
     }
 

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+* Added PBKDF2 Password encoder
+
 2.1.0
 -----
 

--- a/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/Pbkdf2PasswordEncoder.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Encoder;
+
+/**
+ * Pbkdf2PasswordEncoder uses the PBKDF2 (Password-Based Key Derivation Function 2).
+ *
+ * Providing a high level of Cryptographic security,
+ *  PBKDF2 is recommended by the National Institute of Standards and Technology (NIST).
+ *
+ * But also warrants a warning, using PBKDF2 (with a high number of iterations) slows down the process.
+ * PBKDF2 should be used with caution and care.
+ *
+ * @author Sebastiaan Stok <s.stok@rollerscapes.net>
+ * @author Andrew Johnson
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Pbkdf2PasswordEncoder extends BasePasswordEncoder
+{
+    private $algorithm;
+    private $encodeHashAsBase64;
+    private $iterations;
+    private $length;
+
+    /**
+     * Constructor.
+     *
+     * @param string  $algorithm          The digest algorithm to use
+     * @param Boolean $encodeHashAsBase64 Whether to base64 encode the password hash
+     * @param integer $iterations         The number of iterations to use to stretch the password hash
+     * @param integer $length             Length of derived key to create
+     */
+    public function __construct($algorithm = 'sha512', $encodeHashAsBase64 = true, $iterations = 1000, $length = 40)
+    {
+        $this->algorithm = $algorithm;
+        $this->encodeHashAsBase64 = $encodeHashAsBase64;
+        $this->iterations = $iterations;
+        $this->length = $length;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \LogicException when the algorithm is not supported
+     */
+    public function encodePassword($raw, $salt)
+    {
+        if (!in_array($this->algorithm, hash_algos(), true)) {
+            throw new \LogicException(sprintf('The algorithm "%s" is not supported.', $this->algorithm));
+        }
+
+        if (function_exists('hash_pbkdf2')) {
+            $digest = hash_pbkdf2($this->algorithm, $raw, $salt, $this->iterations, $this->length, true);
+        } else {
+            $digest = $this->hashPbkdf2($this->algorithm, $raw, $salt, $this->iterations, $this->length);
+        }
+
+        return $this->encodeHashAsBase64 ? base64_encode($digest) : bin2hex($digest);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isPasswordValid($encoded, $raw, $salt)
+    {
+        return $this->comparePasswords($encoded, $this->encodePassword($raw, $salt));
+    }
+
+    private function hashPbkdf2($algorithm, $password, $salt, $iterations, $length = 0)
+    {
+        // Number of blocks needed to create the derived key
+        $blocks = ceil($length / strlen(hash($algorithm, null, true)));
+        $digest = '';
+
+        for ($i = 1; $i <= $blocks; $i++) {
+            $ib = $block = hash_hmac($algorithm, $salt . pack('N', $i), $password, true);
+
+            // Iterations
+            for ($j = 1; $j < $iterations; $j++) {
+                $ib ^= ($block = hash_hmac($algorithm, $block, $password, true));
+            }
+
+            $digest .= $ib;
+        }
+
+        return substr($digest, 0, $this->length);
+    }
+}

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/Pbkdf2PasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/Pbkdf2PasswordEncoderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Tests\Core\Encoder;
+
+use Symfony\Component\Security\Core\Encoder\Pbkdf2PasswordEncoder;
+
+class Pbkdf2PasswordEncoderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testIsPasswordValid()
+    {
+        $encoder = new Pbkdf2PasswordEncoder('sha256', false, 1, 40);
+
+        $this->assertTrue($encoder->isPasswordValid('c1232f10f62715fda06ae7c0a2037ca19b33cf103b727ba56d870c11f290a2ab106974c75607c8a3', 'password', ''));
+    }
+
+    public function testEncodePassword()
+    {
+        $encoder = new Pbkdf2PasswordEncoder('sha256', false, 1, 40);
+        $this->assertSame('c1232f10f62715fda06ae7c0a2037ca19b33cf103b727ba56d870c11f290a2ab106974c75607c8a3', $encoder->encodePassword('password', ''));
+
+        $encoder = new Pbkdf2PasswordEncoder('sha256', true, 1, 40);
+        $this->assertSame('wSMvEPYnFf2gaufAogN8oZszzxA7cnulbYcMEfKQoqsQaXTHVgfIow==', $encoder->encodePassword('password', ''));
+
+        $encoder = new Pbkdf2PasswordEncoder('sha256', false, 2, 40);
+        $this->assertSame('8bc2f9167a81cdcfad1235cd9047f1136271c1f978fcfcb35e22dbeafa4634f6fd2214218ed63ebb', $encoder->encodePassword('password', ''));
+    }
+
+    /**
+     * @expectedException LogicException
+     */
+    public function testEncodePasswordAlgorithmDoesNotExist()
+    {
+        $encoder = new Pbkdf2PasswordEncoder('foobar');
+        $encoder->encodePassword('password', '');
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This adds the PBKDF2 derived key mechanism (as defined in http://www.ietf.org/rfc/rfc2898.txt) for the Password encoder.

The original implementation comes from http://www.itnewb.com/tutorial/Encrypting-Passwords-with-PHP-for-Storage-Using-the-RSA-PBKDF2-Standard and does not contain any restrictive copyright. I have included the original author.
