### PR TITLE
[DependencyInjection] Problem with unescaping class arguments

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -732,7 +732,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
             require_once $this->getParameterBag()->resolveValue($definition->getFile());
         }
 
-        $arguments = $this->resolveServices($this->getParameterBag()->resolveValue($definition->getArguments()));
+        $arguments = $this->resolveServices($this->getParameterBag()->resolveAndUnescapeValue($definition->getArguments()));
 
         if (null !== $definition->getFactoryMethod()) {
             if (null !== $definition->getFactoryClass()) {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -291,4 +291,14 @@ class ParameterBag implements ParameterBagInterface
 
         return $value;
     }
+
+    /**
+     * Resolves parameters inside a string and unescape result
+     *
+     * @see resolveValue, unescapeValue
+     */
+    public function resolveAndUnescapeValue($value, array $resolving = array())
+    {
+        return $this->unescapeValue($this->resolveValue($value, $resolving));
+    }
 }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBagInterface.php
@@ -103,4 +103,15 @@ interface ParameterBagInterface
      * @return mixed
      */
     function escapeValue($value);
+
+    /**
+     * Replaces parameter placeholders (%name%) by their values and unescape (%%) result.
+     *
+     * @param mixed $value A value
+     *
+     * @throws ParameterNotFoundException if a placeholder references a parameter that does not exist
+     * @throws ParameterCircularReferenceException if a circular reference if detected
+     * @throws RuntimeException when a given parameter has a type problem.
+     */
+    function resolveAndUnescapeValue($value);
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -251,9 +251,9 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     {
         $builder = new ContainerBuilder();
         $builder->register('bar', 'stdClass');
-        $builder->register('foo1', 'FooClass')->addArgument(array('foo' => '%value%', '%value%' => 'foo', new Reference('bar')));
+        $builder->register('foo1', 'FooClass')->addArgument(array('foo' => '%value%', '%value%' => 'foo', new Reference('bar'), '%%unescape_it%%'));
         $builder->setParameter('value', 'bar');
-        $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo', $builder->get('bar')), $builder->get('foo1')->arguments, '->createService() replaces parameters and service references in the arguments provided by the service definition');
+        $this->assertEquals(array('foo' => 'bar', 'bar' => 'foo', $builder->get('bar'), '%unescape_it%'), $builder->get('foo1')->arguments, '->createService() replaces parameters and service references in the arguments provided by the service definition');
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -241,4 +241,14 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
             array('50% is less than 100%', '50% is less than 100%', 'Text between % signs is allowed, if there are spaces.'),
         );
     }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ParameterBag\ParameterBag::resolveAndUnescapeValue
+     */
+    public function testResolveAndUnescapeValue()
+    {
+        $bag = new ParameterBag();
+        $this->assertEquals('foo', $bag->resolveAndUnescapeValue('foo'), 'There is nothing to unescape.');
+        $this->assertEquals('%foo%', $bag->resolveAndUnescapeValue('%%foo%%'), 'String should be unescaped.');
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Hello!
I've got an error when I tried to use DI to initiate Monolog logger with next settings:

```
services:
  logger_formatter:
    class:        \Monolog\Formatter\LineFormatter
    arguments:    [ "[%%datetime%%] %%channel%%.%%level_name%%: %%message%% %%context%%\n" ]  
  logger_handler:
    class:        \Monolog\Handler\StreamHandler
    arguments:
      - app.log
      - <?php echo \Monolog\Logger::DEBUG, PHP_EOL; ?>
    calls:
      - [ setFormatter, [ @logger_formatter ]]
  logger:
    class:        \Monolog\Logger
    arguments:    [ 'logger_name' ]
    calls:
      - [ pushHandler, [ @logger_handler ]]
```

If I set argument for service logger_formatter with single % (like "[%datetime%]…") then DI threw exception that it could not resolve reference because there was non-existent parameter "datetime".
If I set argument with double % (like "[%%datetime%%]…") then DI transferred parameter to the LineFormatter object without unescaping, and LineFormatter did not work properly.
The problem was in ContainerBuilder, because there was no unescaping class parameters.

I’ve fixed problem and added tests to cover such case. 
