### PR TITLE
[Form] [Validator] added a check for constraints option actually being present

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -69,9 +69,11 @@ class FormValidator extends ConstraintValidator
             // Validate the data against the constraints defined
             // in the form
             $constraints = $config->getOption('constraints');
-            foreach ($constraints as $constraint) {
-                foreach ($groups as $group) {
-                    $graphWalker->walkConstraint($constraint, $form->getData(), $group, $path . 'data');
+            if ($constraints) {
+                foreach ($constraints as $constraint) {
+                    foreach ($groups as $group) {
+                        $graphWalker->walkConstraint($constraint, $form->getData(), $group, $path . 'data');
+                    }
                 }
             }
         } else {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

I'm not sure exactly for reasons but when trying to bind a form with custom fields the `constraints` option is null, which means that whole application crashes with the `wrong argument supplied for foreach...` error.

Example would be https://github.com/Inori/LexikFormFilterBundle/blob/master/Filter/Extension/Type/ChoiceFilterType.php which is a relatively simple extension of `ChoiceType` and doesn't override it's default options...
