### PR TITLE
[HttpFoundation][Sessions] Losing session in case of many concurrent requests.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/FileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/FileSessionHandler.php
@@ -70,6 +70,7 @@ class FileSessionHandler implements \SessionHandlerInterface
     public function read($id)
     {
         $path = $this->getPath().$id;
+        $data = '';
         if (is_readable($path)) {
             $handle = fopen($path, 'r');
             flock($handle, LOCK_SH);
@@ -78,8 +79,6 @@ class FileSessionHandler implements \SessionHandlerInterface
             }
             flock($handle, LOCK_UN);
             fclose($handle);
-        } else {
-            $data = '';
         }
 
         return $data;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/FileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/FileSessionHandler.php
@@ -81,6 +81,7 @@ class FileSessionHandler implements \SessionHandlerInterface
         } else {
             $data = '';
         }
+
         return $data;
     }
 
@@ -93,9 +94,10 @@ class FileSessionHandler implements \SessionHandlerInterface
         $handle = fopen($path, 'a');
         flock($handle, LOCK_EX);
         ftruncate($handle, 0);
-        $success = (bool)fwrite($handle, $data);
+        $success = (bool) fwrite($handle, $data);
         flock($handle, LOCK_UN);
         fclose($handle);
+
         return $success;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -93,6 +93,7 @@ class MockFileSessionStorage extends MockArraySessionStorage
     public function save()
     {
         $this->handler->write($this->id, serialize($this->data));
+        $this->handler->close();
 
         // this is needed for Silex, where the session object is re-used across requests
         // in functional tests. In Symfony, the container is rebooted, so we don't have

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/FileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/FileSessionHandlerTest.php
@@ -30,10 +30,15 @@ class FileSessionStorageTest extends \PHPUnit_Framework_TestCase
      */
     private $path;
 
+    /**
+     * @var string
+     */
+    private $prefix = 'mocksess_';
+
     public function setUp()
     {
         $this->path = sys_get_temp_dir().'/filesessionhandler';
-        $this->handler = new FileSessionHandler($this->path, 'mocksess_');
+        $this->handler = new FileSessionHandler($this->path, $this->prefix);
 
         parent::setUp();
     }
@@ -73,26 +78,27 @@ class FileSessionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function testDestroy()
     {
-        $this->handler->write('456', 'data');
+        $pathPrefix = $this->path.'/'.$this->prefix;
+        file_put_contents($pathPrefix.'456', 'data');
         $this->handler->destroy('123');
-        $this->assertEquals('data', $this->handler->read('456'));
+        $this->assertEquals('data', file_get_contents($pathPrefix . '456'));
         $this->handler->destroy('456');
-        $this->assertEmpty($this->handler->read('456'));
+        $this->assertFalse(is_file($pathPrefix . '456'));
     }
 
     public function testGc()
     {
-        $prefix = $this->path.'/mocksess_';
-        $this->handler->write('1', 'data');
+        $prefix = $this->path.'/'.$this->prefix;
+        file_put_contents($prefix.'1', 'data');
         touch($prefix.'1', time()-86400);
 
-        $this->handler->write('2', 'data');
+        file_put_contents($prefix.'2', 'data');
         touch($prefix.'2', time()-3600);
 
-        $this->handler->write('3', 'data');
+        file_put_contents($prefix.'3', 'data');
         touch($prefix.'3', time()-300);
 
-        $this->handler->write('4', 'data');
+        file_put_contents($prefix.'4', 'data');
 
         $this->handler->gc(90000);
         $this->assertEquals(4, count(glob($this->path.'/*')));

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/FileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/FileSessionHandlerTest.php
@@ -109,4 +109,13 @@ class FileSessionStorageTest extends \PHPUnit_Framework_TestCase
         $this->handler->gc(200);
         $this->assertEquals(1, count(glob($this->path.'/*')));
     }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testOneSessionAtTime()
+    {
+        $this->handler->read(1);
+        $this->handler->read(2);
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

When symfony handling many request of one session many instances try read and write session file. The first phase of writing the file is empty and then write session data. If script load an empty file then session will be incorrect. Easiest way to prevent this behaviour is use flock function which allows to control file usage.
