### PR TITLE
[Form] Camelize 'add' and 'remove' methods in the PropertyPath

### DIFF
--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -535,8 +535,8 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     private function findAdderAndRemover(\ReflectionClass $reflClass, $singular)
     {
         if (null !== $singular) {
-            $addMethod = 'add' . ucfirst($singular);
-            $removeMethod = 'remove' . ucfirst($singular);
+            $addMethod = 'add' . $this->camelize($singular);
+            $removeMethod = 'remove' . $this->camelize($singular);
 
             if (!$this->isAccessible($reflClass, $addMethod, 1)) {
                 throw new InvalidPropertyException(sprintf(
@@ -558,7 +558,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
         }
 
         // The plural form is the last element of the property path
-        $plural = ucfirst($this->elements[$this->length - 1]);
+        $plural = $this->camelize($this->elements[$this->length - 1]);
 
         // Any of the two methods is required, but not yet known
         $singulars = (array) FormUtil::singularify($plural);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/acasademont/symfony.png?branch=camelize_property_path_add_and_remove_methods)](http://travis-ci.org/acasademont/symfony)
Fixes the following tickets: -
License of the code: MIT
Documentation PR: -

This issue camelizes the 'add' and 'remove' methods, as it is already done with the 'set' method.
This fixes a problem with properties like 'custom_messages', where the 'add' and 'remove' methods are 'addCustom_message' and 'removeCustom_message' instead of 'addCustomMessage' and 'removeCustomMessage'.
