### PR TITLE
Allow to pass a routes list to RouterDebugCommand::outputRoutes()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -74,11 +74,13 @@ EOF
         }
     }
 
-    protected function outputRoutes(OutputInterface $output)
+    protected function outputRoutes(OutputInterface $output, $routes = null)
     {
-        $routes = array();
-        foreach ($this->getContainer()->get('router')->getRouteCollection()->all() as $name => $route) {
-            $routes[$name] = $route->compile();
+        if (null === $routes) {
+            $routes = array();
+            foreach ($this->getContainer()->get('router')->getRouteCollection()->all() as $name => $route) {
+                $routes[$name] = $route->compile();
+            }
         }
 
         $output->writeln($this->getHelper('formatter')->formatSection('router', 'Current routes'));


### PR DESCRIPTION
I just reverted to Symfony 2.0's signature, which made it simple to display only a subset of the routes of the application. This is particularly useful for FOSJsRoutingBundle's fos:js-routing:debug command, which allows to filter the list of javascript-exposed routes.
