### PR TITLE
[HttpKernel] removed the storage of the current locale in the session

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.1.0
 -----
 
+ * [BC BREAK] the current locale for the user is not stored anymore in the session
  * added the HTTP method to the profiler storage
  * updated all listeners to implement EventSubscriberInterface
  * added TimeDataCollector

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -36,18 +36,10 @@ class LocaleListener implements EventSubscriberInterface
     {
         $request = $event->getRequest();
 
-        if ($request->hasPreviousSession()) {
-            $request->setDefaultLocale($request->getSession()->get('_locale', $this->defaultLocale));
-        } else {
-            $request->setDefaultLocale($this->defaultLocale);
-        }
+        $request->setDefaultLocale($this->defaultLocale);
 
         if ($locale = $request->attributes->get('_locale')) {
             $request->setLocale($locale);
-
-            if ($request->hasPreviousSession()) {
-                $request->getSession()->set('_locale', $request->getLocale());
-            }
         }
 
         if (null !== $this->router) {

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -34,23 +34,6 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fr', $request->getLocale());
     }
 
-    public function testDefaultLocaleWithSession()
-    {
-        $request = Request::create('/');
-        session_name('foo');
-        $request->cookies->set('foo', 'value');
-
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\Session', array('get'), array(), '', true);
-        $session->expects($this->once())->method('get')->will($this->returnValue('es'));
-        $request->setSession($session);
-
-        $listener = new LocaleListener('fr');
-        $event = $this->getEvent($request);
-
-        $listener->onKernelRequest($event);
-        $this->assertEquals('es', $request->getLocale());
-    }
-
     public function testLocaleFromRequestAttribute()
     {
         $request = Request::create('/');
@@ -60,12 +43,6 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $request->attributes->set('_locale', 'es');
         $listener = new LocaleListener('fr');
         $event = $this->getEvent($request);
-
-        // also updates the session _locale value
-        $session = $this->getMock('Symfony\Component\HttpFoundation\Session\Session', array('set', 'get'), array(), '', true);
-        $session->expects($this->once())->method('set')->with('_locale', 'es');
-        $session->expects($this->once())->method('get')->with('_locale')->will($this->returnValue('es'));
-        $request->setSession($session);
 
         $listener->onKernelRequest($event);
         $this->assertEquals('es', $request->getLocale());


### PR DESCRIPTION
Before this commit, the current locale was stored in the session (if one
was already started). That way, for the next requests, even if the
request locale attribute was not set, the locale was "restored".

But this is a really bad practice as it means that the same URL can have
a different content depending on the previous requests. It would have
been better if the Vary header was set but the locale can be different
from the value coming from the Accept-Language anyway.

This is a BC break but fortunately, you can restore the 2.0 behavior by
creating a simple event listener that contains the logic removed by this
commit.
