### PR TITLE
[HttpKernel] allowed classes to compile to be prepended

### DIFF
--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -12,9 +12,74 @@
 namespace Symfony\Component\ClassLoader\Tests;
 
 use Symfony\Component\ClassLoader\ClassCollectionLoader;
+use Symfony\Component\ClassLoader\UniversalClassLoader;
 
 class ClassCollectionLoaderTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @dataProvider getDifferentOrders
+     */
+    public function testClassReordering(array $classes)
+    {
+        $loader = new UniversalClassLoader();
+        $loader->registerNamespace('ClassesWithParents', __DIR__.'/Fixtures');
+        $loader->register();
+
+        $expected = <<<EOF
+<?php  
+
+namespace ClassesWithParents
+{
+
+interface CInterface {}
+}
+ 
+
+namespace ClassesWithParents
+{
+
+class B implements CInterface {}
+}
+ 
+
+namespace ClassesWithParents
+{
+
+class A extends B {}
+}
+
+EOF;
+
+        $dir = sys_get_temp_dir();
+        $fileName = uniqid('symfony_');
+
+        ClassCollectionLoader::load($classes, $dir, $fileName, true);
+        $cachedContent = @file_get_contents($dir.'/'.$fileName.'.php');
+
+        $this->assertEquals($expected, $cachedContent);
+    }
+    
+    public function getDifferentOrders()
+    {
+        return array(
+            array(array(
+                'ClassesWithParents\\A',
+                'ClassesWithParents\\CInterface',
+                'ClassesWithParents\\B',
+            )),
+            array(array(
+                'ClassesWithParents\\B',
+                'ClassesWithParents\\A',
+                'ClassesWithParents\\CInterface',
+            )),
+            array(array(
+                'ClassesWithParents\\CInterface',
+                'ClassesWithParents\\B',
+                'ClassesWithParents\\A',
+            )),
+        );
+    }
+
     public function testFixNamespaceDeclarations()
     {
         $source = <<<EOF

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/A.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/A.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace ClassesWithParents;
+
+class A extends B {}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/B.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/B.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace ClassesWithParents;
+
+class B implements CInterface {}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/CInterface.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/CInterface.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace ClassesWithParents;
+
+interface CInterface {}


### PR DESCRIPTION
I had an issue when registering JMSDIExtraBundle before the frameworkBundle, because the bundle is adding a class to compile wich extends a class to compile added by the frameworkbundle (https://github.com/schmittjoh/JMSDiExtraBundle/blob/master/HttpKernel/ControllerResolver.php#L39).

In my kernel, the bundle was registered before the frameworkbundle, if it's the case, the class is writed before the symfony core class in the cache file, so it will trigger the autoloader to load the symfony core class, then we'll have a fatal error because we're declaring 2 times the same class.

I'm suggesting to add a way to prepend the classes to compile added by an extension, this way we could force classes from the core bundle to pe prepended, and avoid this kind of error with other bundles adding classes extending core classes or implementing core interface. I've also added it to the frameworkbundle.
