### PR TITLE
[2.2] Multi-lined quoted parameters

### DIFF
--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -84,6 +84,13 @@ EOF
         while (true) {
             $command = $this->readline();
 
+            // enabling multiple lines when quoted
+            preg_filter('/\"/', '"', $command, -1, $count);
+            while ($count%2>0) { // unended quoted string
+                $command.= "\\n".readline(' > ');
+                preg_filter('/\"/', '"', $command, -1, $count);
+            }
+
             if (false === $command) {
                 $this->output->writeln("\n");
 


### PR DESCRIPTION
I added a few lines to the Shell.php file, so the user can now pass quoted arguments to commands, continue to write then in the next lines, and then close the quoted param.

The called command will receive this param with \n for each line the user used.
