### PR TITLE
[Finder] '*' and '?' are considered are glob pattern rather than delimit...

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -12,3 +12,5 @@ CHANGELOG
  * added searching based on the file content via Finder::contains() and
    Finder::notContains()
  * added support for the != operator in the Comparator
+ * [BC BREAK] filter expressions (used for file name and content) are no more
+   considered as regexps but glob patterns when they are enclosed in '*' or '?'

--- a/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/MultiplePcreFilterIterator.php
@@ -58,7 +58,7 @@ abstract class MultiplePcreFilterIterator extends \FilterIterator
             $end = substr($m[1], -1);
 
             if ($start === $end) {
-                return !preg_match('/[[:alnum:] \\\\]/', $start);
+                return !preg_match('/[*?[:alnum:] \\\\]/', $start);
             }
 
             if ($start === '{' && $end === '}') {

--- a/src/Symfony/Component/Finder/Tests/Iterator/MultiplePcreFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/MultiplePcreFilterIteratorTest.php
@@ -38,6 +38,8 @@ class MultiplePcreFilterIteratorTest extends \PHPUnit_Framework_TestCase
             array('/foo/imsxu', true, 'valid regex with multiple modifiers'),
             array('#foo#', true, '"#" is a valid delimiter'),
             array('{foo}', true, '"{,}" is a valid delimiter pair'),
+            array('*foo.*', false, '"*" is not considered as a valid delimiter'),
+            array('?foo.?', false, '"?" is not considered as a valid delimiter'),
         );
     }
 }


### PR DESCRIPTION
...ers (fix #4664)
