### PR TITLE
fixed dutch translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.nl.xlf
@@ -52,7 +52,7 @@
             </trans-unit>
             <trans-unit id="13">
                 <source>This value is not a valid email address.</source>
-                <target>Deze waarde is geen geldig emailadres.</target>
+                <target>Deze waarde is geen geldig e-mailadres.</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>The file could not be found.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>Deze waarde is te lang. Het mag maximaal {{ limit }} teken bevatten.|Deze waarde is te lang. Het mag maximaal {{ limit }} tekens bevatten.</target>
+                <target>Deze waarde is te lang. Hij mag maximaal {{ limit }} teken bevatten.|Deze waarde is te lang. Hij mag maximaal {{ limit }} tekens bevatten.</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,7 +84,7 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>Deze waarde is te kort. Het moet tenminste {{ limit }} teken bevatten.|Deze waarde is te kort. Het moet tenminste {{ limit }} tekens bevatten.</target>
+                <target>Deze waarde is te kort. Hij moet tenminste {{ limit }} teken bevatten.|Deze waarde is te kort. Hij moet tenminste {{ limit }} tekens bevatten.</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>
@@ -164,7 +164,7 @@
             </trans-unit>
             <trans-unit id="44">
                 <source>The image width is too small ({{ width }}px). Minimum width expected is {{ min_width }}px.</source>
-                <target>De afbeelding is niet breed genoeg ({{ width }}px). De minimaal verwachtte breedte is {{ min_width }}px.</target>
+                <target>De afbeelding is niet breed genoeg ({{ width }}px). De minimaal verwachte breedte is {{ min_width }}px.</target>
             </trans-unit>
             <trans-unit id="45">
                 <source>The image height is too big ({{ height }}px). Allowed maximum height is {{ max_height }}px.</source>
@@ -172,7 +172,7 @@
             </trans-unit>
             <trans-unit id="46">
                 <source>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</source>
-                <target>De afbeelding is niet hoog genoeg ({{ height }}px). De minimaal verwachtte hoogte is {{ min_height }}px.</target>
+                <target>De afbeelding is niet hoog genoeg ({{ height }}px). De minimaal verwachte hoogte is {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="47">
                 <source>This value should be the user current password.</source>


### PR DESCRIPTION
mostly reverts a859f7

e-mailadres: http://www.onzetaal.nl/taaladvies/advies/e-mailadres-emailadres
"waarde" is not a neutral word, so it cannot be referred to as "het"
"verwachte" here is an adjective, not a verb - http://www.leestrainer.nl/Leerlijn%20werkwoorden/als%20bijvnm%20schrijven.htm
