### PR TITLE
[Config] Add a new expression ->ifFalse() to the ExprBuilder

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -73,6 +73,27 @@ class ExprBuilder
     }
 
     /**
+     * Sets a negative closure to use as tests.
+     *
+     * @param \Closure $closure, if null is provide, it just tests if the value is false.
+     *
+     * @return ExprBuilder
+     */
+    public function ifFalse(\Closure $closure = null)
+    {
+        if (null === $closure) {
+            $finalClosure = function($v) { return false === $v; };
+        }
+        else {
+            $finalClosure = function($v) use ($closure) { return ! $closure($v); };
+        }
+
+        $this->ifPart = $finalClosure;
+
+        return $this;
+    }
+
+    /**
      * Tests if the value is a string.
      *
      * @return ExprBuilder

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/ExprBuilderTest.php
@@ -35,6 +35,12 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertFinalizedValueIs('new_value', $test, array('key'=>true));
 
         $test = $this->getTestBuilder()
+            ->ifTrue()
+            ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs(false, $test, array('key'=>false));
+
+        $test = $this->initScenario()
             ->ifTrue( function($v){ return true; })
             ->then($this->returnClosure('new_value'))
         ->end();
@@ -43,6 +49,33 @@ class ExprBuilderTest extends \PHPUnit_Framework_TestCase
         $test = $this->getTestBuilder()
             ->ifTrue( function($v){ return false; })
             ->then($this->returnClosure('new_value'))
+        ->end();
+        $this->assertFinalizedValueIs('value',$test);
+    }
+
+    public function testIfFalseExpression()
+    {
+        $test = $this->getTestBuilder()
+            ->ifFalse()
+            ->then( function($v){ return 'new_value'; })
+        ->end();
+        $this->assertFinalizedValueIs('new_value',$test, array('key'=>false));
+
+        $test = $this->getTestBuilder()
+            ->ifFalse()
+            ->then( function($v){ return 'new_value'; })
+        ->end();
+        $this->assertFinalizedValueIs(true,$test, array('key'=>true));
+
+        $test = $this->getTestBuilder()
+            ->ifFalse( function($v){ return false; })
+            ->then( $this->returnClosure('new_value') )
+        ->end();
+        $this->assertFinalizedValueIs('new_value',$test);
+
+        $test = $this->getTestBuilder()
+            ->ifFalse( function($v){ return true; })
+            ->then( $this->returnClosure('new_value') )
         ->end();
         $this->assertFinalizedValueIs('value',$test);
     }


### PR DESCRIPTION
This PR allow to write validator like this:

```
->scalarNode('foo')
    ->validate()
        ->ifFalse(function($v){return is_int($v)})
        ->thenInvalid('Must be an integer')
    ->end()
->end()
```

Instead of the actual double negation:

```
->scalarNode('foo')
    ->validate()
        ->ifTrue(function($v){return ! is_int($v)})
        ->thenInvalid('Must be an integer')
    ->end()
->end()
```
