### PR TITLE
made the charset overridable (closes #2072)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -46,7 +46,21 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('charset')->info('general configuration')->end()
+                ->scalarNode('charset')
+                    ->defaultNull()
+                    ->beforeNormalization()
+                        ->ifTrue(function($v) { return null !== $v; })
+                        ->then(function($v) {
+                            $message = 'The charset setting is deprecated. Just remove it from your configuration file.';
+
+                            if ('UTF-8' !== $v) {
+                                $messages .= sprintf(' You need to define a getCharset() method in your Application Kernel class that returns "%s".', $v);
+                            }
+
+                            throw new \RuntimeException($message);
+                        })
+                    ->end()
+                ->end()
                 ->scalarNode('trust_proxy_headers')->defaultFalse()->end()
                 ->scalarNode('secret')->isRequired()->end()
                 ->scalarNode('ide')->defaultNull()->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -60,9 +60,6 @@ class FrameworkExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
-        if (isset($config['charset'])) {
-            $container->setParameter('kernel.charset', $config['charset']);
-        }
         $container->setParameter('kernel.secret', $config['secret']);
 
         $container->setParameter('kernel.trust_proxy_headers', $config['trust_proxy_headers']);

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -21,6 +21,7 @@
             <xsd:element name="annotations" type="annotations" minOccurs="0" maxOccurs="1" />
         </xsd:all>
 
+        <!-- charset is deprecated and will be removed in 2.2 -->
         <xsd:attribute name="charset" type="xsd:string" />
         <xsd:attribute name="trust-proxy-headers" type="xsd:string" />
         <xsd:attribute name="ide" type="xsd:string" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/config/framework.yml
@@ -1,5 +1,4 @@
 framework:
-    charset:       UTF-8
     secret:        test
     csrf_protection:
         enabled: true

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/config/framework.yml
@@ -1,5 +1,4 @@
 framework:
-    charset:       UTF-8
     secret:        test
     csrf_protection:
         enabled: true

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.1.0
 -----
 
+ * [BC BREAK] the charset is now configured via the Kernel::getCharset() method
  * [BC BREAK] the current locale for the user is not stored anymore in the session
  * added the HTTP method to the profiler storage
  * updated all listeners to implement EventSubscriberInterface

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -468,6 +468,18 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
+     * Gets the charset of the application.
+     *
+     * @return string The charset
+     *
+     * @api
+     */
+    public function getCharset()
+    {
+        return 'UTF-8';
+    }
+
+    /**
      * Initializes the data structures related to the bundle management.
      *
      *  - the bundles property maps a bundle name to the bundle instance,
@@ -601,7 +613,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 'kernel.cache_dir'       => $this->getCacheDir(),
                 'kernel.logs_dir'        => $this->getLogDir(),
                 'kernel.bundles'         => $bundles,
-                'kernel.charset'         => 'UTF-8',
+                'kernel.charset'         => $this->getCharset(),
                 'kernel.container_class' => $this->getContainerClass(),
             ),
             $this->getEnvParameters()

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -196,4 +196,13 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      * @api
      */
     function getLogDir();
+
+    /**
+     * Gets the charset of the application.
+     *
+     * @return string The charset
+     *
+     * @api
+     */
+    function getCharset();
 }


### PR DESCRIPTION
The charset was configurable in a configuration file but it never worked:

```
framework:
    charset: ISO-8859-1
```

Now, like for the cache and log dirs, you can configure the charset by
overriding the getCharset() method in the app kernel:

```
public function getCharset()
{
    return 'ISO-8859-1';
}
```
