### PR TITLE
[FrameworkBundle] Display an error message when 'session.auto_start' is ...

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -190,7 +190,16 @@ class Configuration implements ConfigurationInterface
                     ->info('session configuration')
                     ->canBeUnset()
                     ->children()
-                        ->booleanNode('auto_start')->info('DEPRECATED! Session starts on demand')->end()
+                        ->booleanNode('auto_start')
+                            ->info('DEPRECATED! Session starts on demand')
+                            ->defaultNull()
+                            ->beforeNormalization()
+                                ->ifTrue(function($v) { return null !== $v; })
+                                ->then(function($v) {
+                                    throw new \RuntimeException('The auto_start setting is deprecated. Just remove it from your configuration file.');
+                                })
+                            ->end()
+                        ->end()
                         ->scalarNode('storage_id')->defaultValue('session.storage.native')->end()
                         ->scalarNode('handler_id')->defaultValue('session.handler.native_file')->end()
                         ->scalarNode('name')->end()


### PR DESCRIPTION
...used (deprecated)
