### PR TITLE
[Test] Remove the static code out of WebTestCase

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class WebTestCase extends BaseWebTestCase
 {
-    static public function assertRedirect($response, $location)
+    public function assertRedirect($response, $location)
     {
-        self::assertTrue($response->isRedirect(), 'Response is not a redirect, got status code: '.$response->getStatusCode());
-        self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
+        $this->assertTrue($response->isRedirect(), 'Response is not a redirect, got status code: '.$response->getStatusCode());
+        $this->assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
     protected function setUp()
@@ -42,16 +42,16 @@ class WebTestCase extends BaseWebTestCase
         $fs->remove($dir);
     }
 
-    static protected function getKernelClass()
+    protected function getKernelClass()
     {
         require_once __DIR__.'/app/AppKernel.php';
 
         return 'Symfony\Bundle\FrameworkBundle\Tests\Functional\AppKernel';
     }
 
-    static protected function createKernel(array $options = array())
+    protected function createKernel(array $options = array())
     {
-        $class = self::getKernelClass();
+        $class = $this->getKernelClass();
 
         if (!isset($options['test_case'])) {
             throw new \InvalidArgumentException('The option "test_case" must be set.');

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/WebTestCase.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class WebTestCase extends BaseWebTestCase
 {
-    static public function assertRedirect($response, $location)
+    public function assertRedirect($response, $location)
     {
-        self::assertTrue($response->isRedirect(), 'Response is not a redirect, got status code: '.substr($response, 0, 2000));
-        self::assertEquals('http://localhost'.$location, $response->headers->get('Location'));
+        $this->assertTrue($response->isRedirect(), 'Response is not a redirect, got status code: '.substr($response, 0, 2000));
+        $this->assertEquals('http://localhost'.$location, $response->headers->get('Location'));
     }
 
     protected function setUp()
@@ -42,16 +42,16 @@ class WebTestCase extends BaseWebTestCase
         $fs->remove($dir);
     }
 
-    static protected function getKernelClass()
+    protected function getKernelClass()
     {
         require_once __DIR__.'/app/AppKernel.php';
 
         return 'Symfony\Bundle\SecurityBundle\Tests\Functional\AppKernel';
     }
 
-    static protected function createKernel(array $options = array())
+    protected function createKernel(array $options = array())
     {
-        $class = self::getKernelClass();
+        $class = $this->getKernelClass();
 
         if (!isset($options['test_case'])) {
             throw new \InvalidArgumentException('The option "test_case" must be set.');


### PR DESCRIPTION
There was some static in the WebTestCase which can cause problems. Like all static code.
So this PR is only about removing the static keyword.

Bug fix: yesno
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
