### PR TITLE
Classloader optimization

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -116,17 +116,12 @@ class FrameworkExtension extends Extension
 
             'Symfony\\Component\\Config\\FileLocator',
 
-            'Symfony\\Component\\EventDispatcher\\EventDispatcherInterface',
-            'Symfony\\Component\\EventDispatcher\\EventDispatcher',
             'Symfony\\Component\\EventDispatcher\\Event',
-            'Symfony\\Component\\EventDispatcher\\EventSubscriberInterface',
             'Symfony\\Component\\EventDispatcher\\ContainerAwareEventDispatcher',
 
-            'Symfony\\Component\\HttpKernel\\HttpKernel',
             'Symfony\\Component\\HttpKernel\\EventListener\\ResponseListener',
             'Symfony\\Component\\HttpKernel\\EventListener\\RouterListener',
             'Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver',
-            'Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface',
             'Symfony\\Component\\HttpKernel\\Event\\KernelEvent',
             'Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent',
             'Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent',
@@ -140,7 +135,6 @@ class FrameworkExtension extends Extension
             'Symfony\\Bundle\\FrameworkBundle\\Controller\\ControllerResolver',
             // Cannot be included because annotations will parse the big compiled class file
             // 'Symfony\\Bundle\\FrameworkBundle\\Controller\\Controller',
-            'Symfony\\Bundle\\FrameworkBundle\\HttpKernel',
         ));
     }
 
@@ -263,13 +257,8 @@ class FrameworkExtension extends Extension
         $container->setParameter('request_listener.https_port', $config['https_port']);
 
         $this->addClassesToCompile(array(
-            'Symfony\\Component\\Routing\\Matcher\\UrlMatcherInterface',
-            'Symfony\\Component\\Routing\\Generator\\UrlGeneratorInterface',
-            'Symfony\\Component\\Routing\\RouterInterface',
             'Symfony\\Component\\Routing\\Matcher\\UrlMatcher',
             'Symfony\\Component\\Routing\\Generator\\UrlGenerator',
-            'Symfony\\Component\\Routing\\Matcher\\RedirectableUrlMatcherInterface',
-            'Symfony\\Component\\Routing\\RequestContextAwareInterface',
             'Symfony\\Component\\Routing\\RequestContext',
             'Symfony\\Component\\Routing\\Router',
             'Symfony\\Bundle\\FrameworkBundle\\Routing\\RedirectableUrlMatcher',
@@ -313,7 +302,6 @@ class FrameworkExtension extends Extension
 
         $this->addClassesToCompile(array(
             'Symfony\\Bundle\\FrameworkBundle\\EventListener\\SessionListener',
-            'Symfony\\Component\\HttpFoundation\\Session\\Storage\\SessionStorageInterface',
             'Symfony\\Component\\HttpFoundation\\Session\\Storage\\NativeSessionStorage',
             'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Handler\\FileSessionHandler',
             'Symfony\\Component\\HttpFoundation\\Session\\Storage\\Proxy\\AbstractProxy',
@@ -405,14 +393,6 @@ class FrameworkExtension extends Extension
 
         $this->addClassesToCompile(array(
             'Symfony\\Bundle\\FrameworkBundle\\Templating\\GlobalVariables',
-            'Symfony\\Bundle\\FrameworkBundle\\Templating\\EngineInterface',
-            'Symfony\\Component\\Templating\\StreamingEngineInterface',
-            'Symfony\\Component\\Templating\\TemplateNameParserInterface',
-            'Symfony\\Component\\Templating\\TemplateNameParser',
-            'Symfony\\Component\\Templating\\EngineInterface',
-            'Symfony\\Component\\Config\\FileLocatorInterface',
-            'Symfony\\Component\\Templating\\TemplateReferenceInterface',
-            'Symfony\\Component\\Templating\\TemplateReference',
             'Symfony\\Bundle\\FrameworkBundle\\Templating\\TemplateReference',
             'Symfony\\Bundle\\FrameworkBundle\\Templating\\TemplateNameParser',
             $container->findDefinition('templating.locator')->getClass(),
@@ -420,9 +400,6 @@ class FrameworkExtension extends Extension
 
         if (in_array('php', $config['engines'], true)) {
             $this->addClassesToCompile(array(
-                'Symfony\\Component\\Templating\\PhpEngine',
-                'Symfony\\Component\\Templating\\Loader\\LoaderInterface',
-                'Symfony\\Component\\Templating\\Storage\\Storage',
                 'Symfony\\Component\\Templating\\Storage\\FileStorage',
                 'Symfony\\Bundle\\FrameworkBundle\\Templating\\PhpEngine',
                 'Symfony\\Bundle\\FrameworkBundle\\Templating\\Loader\\FilesystemLoader',

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -91,21 +91,14 @@ class SecurityExtension extends Extension
         // add some required classes for compilation
         $this->addClassesToCompile(array(
             'Symfony\\Component\\Security\\Http\\Firewall',
-            'Symfony\\Component\\Security\\Http\\FirewallMapInterface',
             'Symfony\\Component\\Security\\Core\\SecurityContext',
-            'Symfony\\Component\\Security\\Core\\SecurityContextInterface',
             'Symfony\\Component\\Security\\Core\\User\\UserProviderInterface',
             'Symfony\\Component\\Security\\Core\\Authentication\\AuthenticationProviderManager',
-            'Symfony\\Component\\Security\\Core\\Authentication\\AuthenticationManagerInterface',
             'Symfony\\Component\\Security\\Core\\Authorization\\AccessDecisionManager',
-            'Symfony\\Component\\Security\\Core\\Authorization\\AccessDecisionManagerInterface',
             'Symfony\\Component\\Security\\Core\\Authorization\\Voter\\VoterInterface',
-
             'Symfony\\Bundle\\SecurityBundle\\Security\\FirewallMap',
             'Symfony\\Bundle\\SecurityBundle\\Security\\FirewallContext',
-
             'Symfony\\Component\\HttpFoundation\\RequestMatcher',
-            'Symfony\\Component\\HttpFoundation\\RequestMatcherInterface',
         ));
     }
 
@@ -181,7 +174,6 @@ class SecurityExtension extends Extension
         }
 
         $this->addClassesToCompile(array(
-            'Symfony\\Component\\Security\\Http\\AccessMapInterface',
             'Symfony\\Component\\Security\\Http\\AccessMap',
         ));
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -92,14 +92,12 @@ class TwigExtension extends Extension
 
         $this->addClassesToCompile(array(
             'Twig_Environment',
-            'Twig_ExtensionInterface',
             'Twig_Extension',
             'Twig_Extension_Core',
             'Twig_Extension_Escaper',
             'Twig_Extension_Optimizer',
             'Twig_LoaderInterface',
             'Twig_Markup',
-            'Twig_TemplateInterface',
             'Twig_Template',
         ));
     }

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -42,9 +42,14 @@ class ClassCollectionLoader
 
         self::$loaded[$name] = true;
 
+        $declared = array_merge(get_declared_classes(), get_declared_interfaces());
+        if (function_exists('get_declared_traits')) {
+            $declared = array_merge($declared, get_declared_traits());
+        }
+
         if ($adaptive) {
             // don't include already declared classes
-            $classes = array_diff($classes, get_declared_classes(), get_declared_interfaces());
+            $classes = array_diff($classes, $declared);
 
             // the cache is different depending on which classes are already declared
             $name = $name.'-'.substr(md5(implode('|', $classes)), 0, 5);

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/ATrait.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/ATrait.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ClassesWithParents;
+
+trait ATrait
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/BTrait.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/BTrait.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ClassesWithParents;
+
+trait BTrait
+{
+    use ATrait;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/CTrait.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/CTrait.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ClassesWithParents;
+
+trait CTrait
+{
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/D.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/D.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ClassesWithParents;
+
+class D extends A
+{
+    use BTrait;
+}

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/E.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/ClassesWithParents/E.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace ClassesWithParents;
+
+class E extends D
+{
+    use CTrait;
+}


### PR DESCRIPTION
The first commit fixes support for PHP 5.4 trait.

The second one does several things:
- it optimizes the recent merge so that the reflection class instance is only loaded once;
- we use the fact that we now get all class dependencies to automatically add all class dependencies to the map.
