### PR TITLE
[Validator] Fixing UniqueEntityValidator bug when using Oracle database

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -66,6 +66,13 @@ class UniqueEntityValidator extends ConstraintValidator
                 throw new ConstraintDefinitionException('Only field names mapped by Doctrine can be validated for uniqueness.');
             }
 
+            // If the column used is of number type, first check conversion before checking unicity.
+            if (in_array($class->fieldMappings[$fieldName]['type'], array('integer', 'smallint', 'bigint'))) {
+                if (!is_numeric($class->reflFields[$fieldName]->getValue($entity))) {
+                    return true;
+                }
+            }
+
             $criteria[$fieldName] = $class->reflFields[$fieldName]->getValue($entity);
 
             if (null === $criteria[$fieldName]) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets:
Todo: 
License of the code: MIT
Documentation PR: 
### Summary

When using Symfony/Doctrine with Oracle database a type conversion bug might appear when using the UniqueEntity constraint. The pair field type and value type is not checked before calling database for unicity check causing Oracle to throw exceptions. 
### Details

An entity containing an numeric id fields. 

``` php
<?php 
     /**
     * @ORM\Id
     * @ORM\Column(type = "integer")
     */
    private $id;
```

An UniqueEntity based on the id.     

``` php
<?php 
    /**
     * @DoctrineAssert\UniqueEntity(fields = {"id"})
     */
    class MyEntity
```

If in a form you enter a **string** value for the `id`, the call to the database is done anyway. When using MySQL this behaviour seems to be ok (Comparison of strings and integer). While Oracle is throwing an **ORA-01722 error.**
### Solution

Adding a string-numeric conversion check **before** submitting it to the database. 
