### PR TITLE
[Form] Fixed: Empty forms can be compound too

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -24,7 +24,7 @@ class PropertyPathMapper implements DataMapperInterface
     public function mapDataToForms($data, array $forms)
     {
         if (!empty($data) && !is_array($data) && !is_object($data)) {
-            throw new UnexpectedTypeException($data, 'Object, array or empty');
+            throw new UnexpectedTypeException($data, 'object, array or empty');
         }
 
         if (!empty($data)) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -42,6 +42,7 @@ class FormType extends AbstractType
             ->setMapped($options['mapped'])
             ->setByReference($options['by_reference'])
             ->setVirtual($options['virtual'])
+            ->setCompound($options['compound'])
             ->setData($options['data'])
             ->setDataMapper(new PropertyPathMapper())
         ;
@@ -116,7 +117,7 @@ class FormType extends AbstractType
             'multipart'          => false,
             'attr'               => $options['attr'],
             'label_attr'         => $options['label_attr'],
-            'compound'           => $options['compound'],
+            'compound'           => $form->getConfig()->getCompound(),
             'types'              => $types,
             'translation_domain' => $translationDomain,
         ));
@@ -160,7 +161,7 @@ class FormType extends AbstractType
             }
 
             return function (FormInterface $form) {
-                return count($form) > 0 ? array() : '';
+                return $form->getConfig()->getCompound() ? array() : '';
             };
         };
 

--- a/src/Symfony/Component/Form/FormConfig.php
+++ b/src/Symfony/Component/Form/FormConfig.php
@@ -54,6 +54,11 @@ class FormConfig implements FormConfigEditorInterface
     private $virtual = false;
 
     /**
+     * @var Boolean
+     */
+    private $compound = true;
+
+    /**
      * @var array
      */
     private $types = array();
@@ -359,6 +364,14 @@ class FormConfig implements FormConfigEditorInterface
     /**
      * {@inheritdoc}
      */
+    public function getCompound()
+    {
+        return $this->compound;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getTypes()
     {
         return $this->types;
@@ -628,6 +641,16 @@ class FormConfig implements FormConfigEditorInterface
     public function setVirtual($virtual)
     {
         $this->virtual = $virtual;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setCompound($compound)
+    {
+        $this->compound = $compound;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigEditorInterface.php
+++ b/src/Symfony/Component/Form/FormConfigEditorInterface.php
@@ -200,6 +200,17 @@ interface FormConfigEditorInterface extends FormConfigInterface
     function setVirtual($virtual);
 
     /**
+     * Sets whether the form should be compound.
+     *
+     * @param  Boolean $compound Whether the form should be compound.
+     *
+     * @return self The configuration object.
+     *
+     * @see FormConfigInterface::getCompound()
+     */
+    function setCompound($compound);
+
+    /**
      * Set the types.
      *
      * @param array $types An array FormTypeInterface

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -66,6 +66,17 @@ interface FormConfigInterface
     function getVirtual();
 
     /**
+     * Returns whether the form is compound.
+     *
+     * This property is independent of whether the form actually has
+     * children. A form can be compound and have no children at all, like
+     * for example an empty collection form.
+     *
+     * @return Boolean Whether the form is compound.
+     */
+    function getCompound();
+
+    /**
      * Returns the form types used to construct the form.
      *
      * @return array An array of {@link FormTypeInterface} instances.

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -18,7 +18,7 @@ class CollectionTypeTest extends TypeTestCase
     public function testContainsNoChildByDefault()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+            'type' => 'text',
         ));
 
         $this->assertCount(0, $form);
@@ -27,7 +27,7 @@ class CollectionTypeTest extends TypeTestCase
     public function testSetDataAdjustsSize()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+            'type' => 'text',
             'options' => array(
                 'max_length' => 20,
             ),
@@ -53,7 +53,7 @@ class CollectionTypeTest extends TypeTestCase
     public function testThrowsExceptionIfObjectIsNotTraversable()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+            'type' => 'text',
         ));
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
         $form->setData(new \stdClass());
@@ -62,7 +62,7 @@ class CollectionTypeTest extends TypeTestCase
     public function testNotResizedIfBoundWithMissingData()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+            'type' => 'text',
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
         $form->bind(array('foo@bar.com'));
@@ -70,13 +70,13 @@ class CollectionTypeTest extends TypeTestCase
         $this->assertTrue($form->has('0'));
         $this->assertTrue($form->has('1'));
         $this->assertEquals('foo@bar.com', $form[0]->getData());
-        $this->assertNull($form[1]->getData());
+        $this->assertEquals('', $form[1]->getData());
     }
 
     public function testResizedDownIfBoundWithMissingDataAndAllowDelete()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+            'type' => 'text',
             'allow_delete' => true,
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
@@ -91,7 +91,7 @@ class CollectionTypeTest extends TypeTestCase
     public function testNotResizedIfBoundWithExtraData()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+            'type' => 'text',
         ));
         $form->setData(array('foo@bar.com'));
         $form->bind(array('foo@foo.com', 'bar@bar.com'));
@@ -104,7 +104,7 @@ class CollectionTypeTest extends TypeTestCase
     public function testResizedUpIfBoundWithExtraDataAndAllowAdd()
     {
         $form = $this->factory->create('collection', null, array(
-            'type' => 'form',
+            'type' => 'text',
             'allow_add' => true,
         ));
         $form->setData(array('foo@bar.com'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -21,7 +21,7 @@ class RepeatedTypeTest extends TypeTestCase
         parent::setUp();
 
         $this->form = $this->factory->create('repeated', null, array(
-            'type' => 'form',
+            'type' => 'text',
         ));
         $this->form->setData(null);
     }
@@ -37,7 +37,7 @@ class RepeatedTypeTest extends TypeTestCase
     public function testSetOptions()
     {
         $form = $this->factory->create('repeated', null, array(
-            'type'    => 'form',
+            'type'    => 'text',
             'options' => array('label' => 'Global'),
         ));
 
@@ -51,7 +51,7 @@ class RepeatedTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('repeated', null, array(
             // the global required value cannot be overriden
-            'type'           => 'form',
+            'type'           => 'text',
             'first_options'  => array('label' => 'Test', 'required' => false),
             'second_options' => array('label' => 'Test2')
         ));
@@ -66,7 +66,7 @@ class RepeatedTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('repeated', null, array(
             'required' => false,
-            'type'     => 'form',
+            'type'     => 'text',
         ));
 
         $this->assertFalse($form['first']->isRequired());
@@ -76,7 +76,7 @@ class RepeatedTypeTest extends TypeTestCase
     public function testSetOptionsPerChildAndOverwrite()
     {
         $form = $this->factory->create('repeated', null, array(
-            'type'           => 'form',
+            'type'           => 'text',
             'options'        => array('label' => 'Label'),
             'second_options' => array('label' => 'Second label')
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -148,12 +148,14 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->will($this->returnValue($valid));
 
         $form = $this->factory
-            ->create('form', null, array(
+            ->createBuilder('form', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_provider' => $this->csrfProvider,
                 'intention' => '%INTENTION%',
                 'compound' => true,
-            ));
+            ))
+            ->add('child', 'text')
+            ->getForm();
 
         $form->bind(array(
             'child' => 'foobar',
@@ -173,12 +175,14 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->method('isCsrfTokenValid');
 
         $form = $this->factory
-            ->create('form', null, array(
+            ->createBuilder('form', null, array(
                 'csrf_field_name' => 'csrf',
                 'csrf_provider' => $this->csrfProvider,
                 'intention' => '%INTENTION%',
                 'compound' => true,
-            ));
+            ))
+            ->add('child', 'text')
+            ->getForm();
 
         $form->bind(array(
             'child' => 'foobar',

--- a/src/Symfony/Component/Form/UnmodifiableFormConfig.php
+++ b/src/Symfony/Component/Form/UnmodifiableFormConfig.php
@@ -53,6 +53,11 @@ class UnmodifiableFormConfig implements FormConfigInterface
     private $virtual;
 
     /**
+     * @var Boolean
+     */
+    private $compound;
+
+    /**
      * @var array
      */
     private $types;
@@ -135,6 +140,7 @@ class UnmodifiableFormConfig implements FormConfigInterface
         $this->mapped = $config->getMapped();
         $this->byReference = $config->getByReference();
         $this->virtual = $config->getVirtual();
+        $this->compound = $config->getCompound();
         $this->types = $config->getTypes();
         $this->clientTransformers = $config->getViewTransformers();
         $this->normTransformers = $config->getModelTransformers();
@@ -196,6 +202,14 @@ class UnmodifiableFormConfig implements FormConfigInterface
     public function getVirtual()
     {
         return $this->virtual;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCompound()
+    {
+        return $this->compound;
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4480
Todo: -
