### PR TITLE
[WIP][Form] Add theming support for collections

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -235,8 +235,7 @@ class FormExtension extends \Twig_Extension
             }
         }
 
-        $custom = '_'.$view->getVar('id');
-        $rendering = $custom.$section;
+        $rendering = $view->getVar('id').$section;
         $blocks = $this->getBlocks($view);
 
         if (isset($this->varStack[$rendering])) {
@@ -245,7 +244,7 @@ class FormExtension extends \Twig_Extension
             $this->varStack[$rendering]['variables'] = array_replace_recursive($this->varStack[$rendering]['variables'], $variables);
         } else {
             $types = $view->getVar('types');
-            $types[] = $custom;
+            $types[] = '_'.$view->getVar('theme_id');
             $typeIndex = count($types) - 1;
             $this->varStack[$rendering] = array(
                 'variables' => array_replace_recursive($view->getVars(), $variables),

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -237,8 +237,7 @@ class FormHelper extends Helper
 
         $template = null;
 
-        $custom = '_'.$view->getVar('id');
-        $rendering = $custom.$section;
+        $rendering = $view->getVar('id').$section;
 
         if (isset($this->varStack[$rendering])) {
             $typeIndex = $this->varStack[$rendering]['typeIndex'] - 1;
@@ -246,7 +245,7 @@ class FormHelper extends Helper
             $variables = array_replace_recursive($this->varStack[$rendering]['variables'], $variables);
         } else {
             $types = $view->getVar('types');
-            $types[] = $custom;
+            $types[] = '_'.$view->getVar('theme_id');
             $typeIndex = count($types) - 1;
             $variables = array_replace_recursive($view->getVars(), $variables);
             $this->varStack[$rendering]['types'] = $types;

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -51,6 +51,7 @@ class CollectionType extends AbstractType
         $view->addVars(array(
             'allow_add'    => $options['allow_add'],
             'allow_delete' => $options['allow_delete'],
+            'collection'   => true,
         ));
 
         if ($form->getConfig()->hasAttribute('prototype')) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -137,6 +137,12 @@ class FormType extends AbstractType
         }
 
         $view->setVar('multipart', $multipart);
+
+        $parent = $view->getParent();
+        $themeId = null !== $parent && $parent->getVar('collection', false)
+            ? $parent->getVar('id').'_children'
+            : $view->getVar('id');
+        $view->setVar('theme_id', $themeId);
     }
 
     /**


### PR DESCRIPTION
**This is a work in progress**

This is an attempt to allow form collection theming.

Before this PR, it was not possible to apply a theme to all the children of a collection, you would have needed to cretate one block per child:

```
{% block _form_collection_0_label %}
    {# ... #}
{% endblock %}
```

You can now create a single theme that will be applied to all the children:

```
{% block _form_collection_children_label %}
    {# ... #}
{% endblock %}
```

@Burgov, @bschussek, everybody, any feedback ?

Todo:
- Apply the theme to the prototype,
- Add tests,
- Restore BC (i.e. ability to theme a single children which must take precedence over the new theme),
- Changelog,
- Doc.

fix: #2806
