### PR TITLE
[2.2] [Validator] Add Luhn validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Luhn.php
+++ b/src/Symfony/Component/Validator/Constraints/Luhn.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Metadata for the LuhnValidator.
+ *
+ * @Annotation
+ */
+class Luhn extends Constraint
+{
+    public $message = 'Invalid card number';
+}

--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates a PAN using the LUHN Algorithm
+ *
+ * For a list of example card numbers that are used to test this
+ * class, please see the LuhnValidatorTest class.
+ *
+ * @see    http://en.wikipedia.org/wiki/Luhn_algorithm
+ * @author Tim Nagel <t.nagel@infinite.net.au>
+ * @author Greg Knapp http://gregk.me/2011/php-implementation-of-bank-card-luhn-algorithm/
+ */
+class LuhnValidator extends ConstraintValidator
+{
+    /**
+     * Validates a creditcard number with the Luhn algorithm.
+     *
+     * @param mixed      $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_numeric($value)) {
+            $this->context->addViolation($constraint->message);
+
+            return;
+        }
+
+        $length = strlen($value);
+        $oddLength = $length % 2;
+        for ($sum = 0, $i = $length - 1; $i >= 0; $i--) {
+            $digit = (int) $value[$i];
+            $sum += (($i % 2) === $oddLength) ? array_sum(str_split($digit * 2)) : $digit;
+        }
+
+        if (($sum % 10) !== 0) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Luhn;
+use Symfony\Component\Validator\Constraints\LuhnValidator;
+
+class LuhnValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $context;
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $this->validator = new LuhnValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    protected function tearDown()
+    {
+        $this->context = null;
+        $this->validator = null;
+    }
+
+    public function testNullIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate(null, new Luhn());
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate('', new Luhn());
+    }
+
+    /**
+     * @dataProvider getValidNumbers
+     */
+    public function testValidNumbers($number)
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($number, new Luhn());
+    }
+
+    public function getValidNumbers()
+    {
+        return array(
+            array('42424242424242424242'),
+            array('378282246310005'),
+            array('371449635398431'),
+            array('378734493671000'),
+            array('5610591081018250'),
+            array('30569309025904'),
+            array('38520000023237'),
+            array('6011111111111117'),
+            array('6011000990139424'),
+            array('3530111333300000'),
+            array('3566002020360505'),
+            array('5555555555554444'),
+            array('5105105105105100'),
+            array('4111111111111111'),
+            array('4012888888881881'),
+            array('4222222222222'),
+            array('5019717010103742'),
+            array('6331101999990016'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidNumbers
+     */
+    public function testInvalidNumbers($number)
+    {
+        $constraint = new Luhn();
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with($constraint->message);
+
+        $this->validator->validate($number, $constraint);
+    }
+
+    public function getInvalidNumbers()
+    {
+        return array(
+            array('1234567812345678'),
+            array('4222222222222222'),
+        );
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: Adding documentation if this PR is blessed.
License of the code: MIT

I submitted these validators to JMSPaymentCoreBundle, because they're payment related, but @schmittjoh feels that they're a better choice for adding to Symfony2.

See schmittjoh/JMSPaymentCoreBundle#52 for the original submission.
