### PR TITLE
Ignore validation exception so we get a more informative error message

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -345,7 +345,7 @@ EOF
         ;
 
         $current = libxml_use_internal_errors(true);
-        $valid = $dom->schemaValidateSource($source);
+        $valid = @$dom->schemaValidateSource($source);
         foreach ($tmpfiles as $tmpfile) {
             @unlink($tmpfile);
         }


### PR DESCRIPTION
Ignore validation exception so we get a more informative error message from $this->getXmlErrors().

This is consistent with https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Translation/Loader/XliffFileLoader.php#L82
