### PR TITLE
When serializing a Route, don't serialize the compiled route.

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Routing;
  *
  * @api
  */
-class Route
+class Route implements \Serializable
 {
     private $pattern;
     private $defaults;
@@ -53,6 +53,25 @@ class Route
     public function __clone()
     {
         $this->compiled = null;
+    }
+
+    public function serialize()
+    {
+        return serialize(array(
+            'pattern' => $this->pattern,
+            'default' => $this->default,
+            'requirements' => $this->requirements,
+            'options' => $this->options,
+        ));
+    }
+
+    public function unserialize($data)
+    {
+        $data = unserialize($data);
+        $this->pattern = $data['pattern'];
+        $this->default = $data['default'];
+        $this->requirements = $data['requirements'];
+        $this->options = $data['options'];
     }
 
     /**


### PR DESCRIPTION
The compiled route typically has a reference to the Route.  The Route of course has a reference to the compiled route.  This is a circular reference.  That can sometimes cause issues, say for var_export().  I ran into this issue while serializing route objects, but it could happen in other cases, too.

In any event, since the compiled route object is simply derived data I see no reason to keep it around.  If we serialize a Route, we just want the basic route information.  We can recompile later if needs be.  As a nice side-effect, this makes the serialized string much smaller.
