### PR TITLE
[Form] Fixed singularification of 'data'

### DIFF
--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -41,6 +41,9 @@ abstract class FormUtil
         // Fourth entry: Whether the suffix may succeed a consonant
         // Fifth entry: singular suffix, normal
 
+        // data (data)
+        array('atad', 4, true, true, 'data'),
+
         // bacteria (bacterium), criteria (criterion), phenomena (phenomenon)
         array('a', 1, true, true, array('on', 'um')),
 


### PR DESCRIPTION
"Data" was singularified to "Daton" and "Datum". My adder and remover are called "addData" and "removeData".

I had to put this rule first in the map, because the singularify method stops looking after it has matched, and it matched the first (now second) rule.

Another option is for singularify to keep looking for singulars even if it has found some
