### PR TITLE
Fix error variable name.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -54,7 +54,7 @@ class Configuration implements ConfigurationInterface
                             $message = 'The charset setting is deprecated. Just remove it from your configuration file.';
 
                             if ('UTF-8' !== $v) {
-                                $messages .= sprintf(' You need to define a getCharset() method in your Application Kernel class that returns "%s".', $v);
+                                $message .= sprintf(' You need to define a getCharset() method in your Application Kernel class that returns "%s".', $v);
                             }
 
                             throw new \RuntimeException($message);


### PR DESCRIPTION
If a user has a custom charset (not UTF-8), a message should appear, but the variable name is wrong, and we got this message : 

```
Notice: Undefined variable: messages in C:\Work\Project\vendor\symfony\symfony\src\Symfony\Bundle\FrameworkBundle\DependencyInjection\Configuration.php line 57
```
