### PR TITLE
[Component][HttpKernel] fixed testGetRootDir() on Win

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -292,7 +292,15 @@ EOF;
     {
         $kernel = new KernelForTest('test', true);
 
-        $this->assertEquals(__DIR__.DIRECTORY_SEPARATOR.'Fixtures', $kernel->getRootDir());
+        $rootDir = __DIR__.DIRECTORY_SEPARATOR.'Fixtures';
+
+        // getRootDir() returns path with slashes
+        // without conversion test fails on Windows
+        if (defined('PHP_WINDOWS_VERSION_MAJOR')) {
+            $rootDir = strtr($rootDir, '\\', '/');
+        }
+
+        $this->assertEquals($rootDir, $kernel->getRootDir());
     }
 
     public function testGetName()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/gajdaw/symfony.png?branch=kernel_test_fix)](http://travis-ci.org/gajdaw/symfony)
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Method `getRootDir()` returns path containing slashes. On Windows machine `__DIR__` and `DIRECTORY_SEPARATOR` are backslashes. To pass the test on win machine we have to translate `\` into `/`.
