### PR TITLE
[Form] Refactored config variable naming to be more consistent

### DIFF
--- a/src/Symfony/Component/Form/UnmodifiableFormConfig.php
+++ b/src/Symfony/Component/Form/UnmodifiableFormConfig.php
@@ -65,12 +65,12 @@ class UnmodifiableFormConfig implements FormConfigInterface
     /**
      * @var array
      */
-    private $clientTransformers;
+    private $viewTransformers;
 
     /**
      * @var array
      */
-    private $normTransformers;
+    private $modelTransformers;
 
     /**
      * @var DataMapperInterface
@@ -142,8 +142,8 @@ class UnmodifiableFormConfig implements FormConfigInterface
         $this->virtual = $config->getVirtual();
         $this->compound = $config->getCompound();
         $this->types = $config->getTypes();
-        $this->clientTransformers = $config->getViewTransformers();
-        $this->normTransformers = $config->getModelTransformers();
+        $this->viewTransformers = $config->getViewTransformers();
+        $this->modelTransformers = $config->getModelTransformers();
         $this->dataMapper = $config->getDataMapper();
         $this->validators = $config->getValidators();
         $this->required = $config->getRequired();
@@ -225,7 +225,7 @@ class UnmodifiableFormConfig implements FormConfigInterface
      */
     public function getViewTransformers()
     {
-        return $this->clientTransformers;
+        return $this->viewTransformers;
     }
 
     /**
@@ -233,7 +233,7 @@ class UnmodifiableFormConfig implements FormConfigInterface
      */
     public function getModelTransformers()
     {
-        return $this->normTransformers;
+        return $this->modelTransformers;
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Since `clientTransformer` is renamed to `viewTransformer` everywhere, I think for consistency reasons config variable name should be changed too..
