### PR TITLE
[Security] fixed in_memory provider example

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -303,9 +303,11 @@ class MainConfiguration implements ConfigurationInterface
                     ->example(array(
                         'memory' => array(
                             'name' => 'memory',
-                            'users' => array(
-                                'foo' => array('password' => 'foo', 'roles' => 'ROLE_USER'),
-                                'bar' => array('password' => 'bar', 'roles' => '[ROLE_USER, ROLE_ADMIN]')
+                            'memory' => array(
+                                'users' => array(
+                                    'foo' => array('password' => 'foo', 'roles' => 'ROLE_USER'),
+                                    'bar' => array('password' => 'bar', 'roles' => '[ROLE_USER, ROLE_ADMIN]')
+                                ),
                             )
                         ),
                         'entity' => array('entity' => array('class' => 'SecurityBundle:User', 'property' => 'username'))


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

This fixes the in_memory provider configuration example shown by config:dump-reference
