### PR TITLE
[Component][HttpKernel] issue #4719 test and fix

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
@@ -70,16 +70,15 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
 
             if (!isset($result[$itemToken])) {
                 --$limit;
+                $result[$itemToken]  = array(
+                    'token'  => $itemToken,
+                    'ip'     => $itemIp,
+                    'method' => $itemMethod,
+                    'url'    => $itemUrl,
+                    'time'   => $itemTime,
+                    'parent' => $itemParent,
+                );
             }
-
-            $result[$itemToken]  = array(
-                'token'  => $itemToken,
-                'ip'     => $itemIp,
-                'method' => $itemMethod,
-                'url'    => $itemUrl,
-                'time'   => $itemTime,
-                'parent' => $itemParent,
-            );
         }
 
         usort($result, function($a, $b) {

--- a/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/BaseMemcacheProfilerStorage.php
@@ -68,6 +68,10 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
+            if (!isset($result[$itemToken])) {
+                --$limit;
+            }
+
             $result[$itemToken]  = array(
                 'token'  => $itemToken,
                 'ip'     => $itemIp,
@@ -76,7 +80,6 @@ abstract class BaseMemcacheProfilerStorage implements ProfilerStorageInterface
                 'time'   => $itemTime,
                 'parent' => $itemParent,
             );
-            --$limit;
         }
 
         usort($result, function($a, $b) {

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -76,6 +76,10 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
+            if (!isset($result[$csvToken])) {
+                --$limit;
+            }
+
             $result[$csvToken] = array(
                 'token'  => $csvToken,
                 'ip'     => $csvIp,
@@ -84,7 +88,6 @@ class FileProfilerStorage implements ProfilerStorageInterface
                 'time'   => $csvTime,
                 'parent' => $csvParent,
             );
-            --$limit;
         }
 
         fclose($file);

--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -78,16 +78,15 @@ class FileProfilerStorage implements ProfilerStorageInterface
 
             if (!isset($result[$csvToken])) {
                 --$limit;
+                $result[$csvToken] = array(
+                    'token'  => $csvToken,
+                    'ip'     => $csvIp,
+                    'method' => $csvMethod,
+                    'url'    => $csvUrl,
+                    'time'   => $csvTime,
+                    'parent' => $csvParent,
+                );
             }
-
-            $result[$csvToken] = array(
-                'token'  => $csvToken,
-                'ip'     => $csvIp,
-                'method' => $csvMethod,
-                'url'    => $csvUrl,
-                'time'   => $csvTime,
-                'parent' => $csvParent,
-            );
         }
 
         fclose($file);

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -78,6 +78,10 @@ class RedisProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
+            if (!isset($result[$itemToken])) {
+                --$limit;
+            }
+
             $result[$itemToken] = array(
                 'token'  => $itemToken,
                 'ip'     => $itemIp,
@@ -86,7 +90,6 @@ class RedisProfilerStorage implements ProfilerStorageInterface
                 'time'   => $itemTime,
                 'parent' => $itemParent,
             );
-            --$limit;
         }
 
         usort($result, function($a, $b) {

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -80,16 +80,15 @@ class RedisProfilerStorage implements ProfilerStorageInterface
 
             if (!isset($result[$itemToken])) {
                 --$limit;
+                $result[$itemToken] = array(
+                    'token'  => $itemToken,
+                    'ip'     => $itemIp,
+                    'method' => $itemMethod,
+                    'url'    => $itemUrl,
+                    'time'   => $itemTime,
+                    'parent' => $itemParent,
+                );
             }
-
-            $result[$itemToken] = array(
-                'token'  => $itemToken,
-                'ip'     => $itemIp,
-                'method' => $itemMethod,
-                'url'    => $itemUrl,
-                'time'   => $itemTime,
-                'parent' => $itemParent,
-            );
         }
 
         usort($result, function($a, $b) {

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/AbstractProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/AbstractProfilerStorageTest.php
@@ -209,6 +209,20 @@ abstract class AbstractProfilerStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $this->getStorage()->find('127.0.0.1', '', 10, 'GET'), '->purge() removes all items from index');
     }
 
+    public function testDuplicates()
+    {
+        for ($i = 1; $i <= 5; $i++) {
+            $profile = new Profile('foo' . $i);
+            $profile->setIp('127.0.0.1');
+            $profile->setUrl('http://example.net/');
+            $profile->setMethod('GET');
+            $this->getStorage()->write($profile);
+            $this->getStorage()->write($profile);
+            $this->getStorage()->write($profile);
+        }
+        $this->assertCount(3, $this->getStorage()->find('127.0.0.1', 'http://example.net/', 3, 'GET'), '->find() method returns incorrect number of entries');
+    }
+
     /**
      * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
      */


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/gajdaw/symfony.png?branch=profile_index_unique_test)](http://travis-ci.org/gajdaw/symfony)
Fixes the following tickets: #4719
Todo: -
License of the code: MIT
Documentation PR: -

When we store profile multiple times:

```
->write($profile1);
->write($profile1);
->write($profile1);

->write($profile2);
->write($profile2);
->write($profile2);
```

it is duplicated in the index. Next search restricted to 2 items :

```
->find('', '', 2)
```

returns only one item. The reason is that each duplicate decreases counter of returned items.
