### PR TITLE
[Form] Fixed FormBuilder to maintain order of its children

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -139,3 +139,4 @@ CHANGELOG
  * deprecated `getChildren` in Form and FormBuilder in favor of `all`
  * deprecated `hasChildren` in Form and FormBuilder in favor of `count`
  * FormBuilder now implements \IteratorAggregate
+ * FormBuilder now maintains the order when explicitely adding form builders as children

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -103,6 +103,8 @@ class FormBuilder extends FormConfig implements \IteratorAggregate, FormBuilderI
             throw new CircularReferenceException(is_string($type) ? $this->getFormFactory()->getType($type) : $type);
         }
 
+        // Add to "children" to maintain order
+        $this->children[$child] = null;
         $this->unresolvedChildren[$child] = array(
             'type'    => $type,
             'options' => $options,


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4693
Todo: -
