### PR TITLE
[2.2] [Security] Add an option to disable the hasPreviousSession() check in AbstractAuthenticationListener

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -36,6 +36,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
         'use_referer'                    => false,
         'failure_path'                   => null,
         'failure_forward'                => false,
+        'require_previous_session'       => true,
     );
 
     public function create(ContainerBuilder $container, $id, $config, $userProviderId, $defaultEntryPointId)

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -98,6 +98,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
             'use_referer'                    => false,
             'failure_path'                   => null,
             'failure_forward'                => false,
+            'require_previous_session'       => true,
         ), $options);
         $this->logger = $logger;
         $this->dispatcher = $dispatcher;
@@ -132,7 +133,7 @@ abstract class AbstractAuthenticationListener implements ListenerInterface
         }
 
         try {
-            if (!$request->hasPreviousSession()) {
+            if ($this->options['require_previous_session'] && !$request->hasPreviousSession()) {
                 throw new SessionUnavailableException('Your session has timed out, or you have disabled cookies.');
             }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/adrienbrault/symfony.png?branch=security-feature)](http://travis-ci.org/adrienbrault/symfony)
Fixes the following tickets: #3703
Todo: Add this option to the symfony doc security configuration reference
License of the code: MIT
Documentation PR: N/A

As stated in #3703, all authentication listeners that inherit from AbstractAuthenticationListener, only work when a previous session has been created.
This PR allows to change the default behavior in the security.yml file.

Example:

``` yml
security:
    firewalls:
        secured_area:
            pattern:    ^/demo/secured/
            form_login:
                check_path: /demo/secured/login_check
                login_path: /demo/secured/login
                require_previous_session: false # The default value is true
            logout:
                path:   /demo/secured/logout
                target: /demo/
            #anonymous: ~
            #http_basic:
            #    realm: "Secured Demo Area"
```

PS: While removing my old commit, it closed the #4774 PR ...
