### PR TITLE
[HttpKernel] Ticket #4719. Each call of FileProfilerStorage->write method adds row to index file.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/FileProfilerStorage.php
@@ -129,10 +129,13 @@ class FileProfilerStorage implements ProfilerStorageInterface
     {
         $file = $this->getFilename($profile->getToken());
 
-        // Create directory
-        $dir = dirname($file);
-        if (!is_dir($dir)) {
-            mkdir($dir, 0777, true);
+        $profileIndexed = is_file($file);
+        if (!$profileIndexed) {
+            // Create directory
+            $dir = dirname($file);
+            if (!is_dir($dir)) {
+                mkdir($dir, 0777, true);
+            }
         }
 
         // Store profile
@@ -151,20 +154,22 @@ class FileProfilerStorage implements ProfilerStorageInterface
             return false;
         }
 
-        // Add to index
-        if (false === $file = fopen($this->getIndexFilename(), 'a')) {
-            return false;
-        }
+        if (!$profileIndexed) {
+            // Add to index
+            if (false === $file = fopen($this->getIndexFilename(), 'a')) {
+                return false;
+            }
 
-        fputcsv($file, array(
-            $profile->getToken(),
-            $profile->getIp(),
-            $profile->getMethod(),
-            $profile->getUrl(),
-            $profile->getTime(),
-            $profile->getParentToken(),
-        ));
-        fclose($file);
+            fputcsv($file, array(
+                $profile->getToken(),
+                $profile->getIp(),
+                $profile->getMethod(),
+                $profile->getUrl(),
+                $profile->getTime(),
+                $profile->getParentToken(),
+            ));
+            fclose($file);
+        }
 
         return true;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/FileProfilerStorageTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests\Profiler;
 
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
+use Symfony\Component\HttpKernel\Profiler\Profile;
 
 class FileProfilerStorageTest extends AbstractProfilerStorageTest
 {
@@ -56,5 +57,29 @@ class FileProfilerStorageTest extends AbstractProfilerStorageTest
     protected function getStorage()
     {
         return self::$storage;
+    }
+
+    public function testMultiRowIndexFile()
+    {
+        $iteration = 3;
+        for($i = 0; $i < $iteration; $i++) {
+            $profile = new Profile('token' . $i);
+            $profile->setIp('127.0.0.' . $i);
+            $profile->setUrl('http://foo.bar/' . $i);
+            $storage = $this->getStorage();
+
+            $storage->write($profile);
+            $storage->write($profile);
+            $storage->write($profile);
+        }
+
+        $handle = fopen(self::$tmpDir . '/index.csv', 'r');
+        for($i = 0; $i < $iteration; $i++) {
+            $row = fgetcsv($handle);
+            $this->assertEquals('token' . $i, $row[0]);
+            $this->assertEquals('127.0.0.' . $i, $row[1]);
+            $this->assertEquals('http://foo.bar/' . $i, $row[3]);
+        }
+        $this->assertFalse(fgetcsv($handle));
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Each call of FileProfilerStorage->write method adds row to index file even if profiler dump is only updated. Event dispatcher in kernel call several times write method to save fresh profiler info. I add condition which checks if profiler file already exist then ignore add row to index file.
