### PR TITLE
[Security] Fix typo in docblock

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -51,7 +51,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
     }
 
     /**
-     * @{inheritdoc}
+     * {@inheritdoc}
      */
     protected function requiresAuthentication(Request $request)
     {


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: 
Fixes the following tickets: 
Todo: 
License of the code: MIT
Documentation PR:
