### PR TITLE
[Form] Ensure there is a session before getting the session id

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/SessionCsrfProvider.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/SessionCsrfProvider.php
@@ -50,6 +50,8 @@ class SessionCsrfProvider extends DefaultCsrfProvider
      */
     protected function getSessionId()
     {
+        $this->session->start();
+
         return $this->session->getId();
     }
 }


### PR DESCRIPTION
Solves "The CSRF token is invalid. Please try to resubmit the form" error when a form is generated before the session is started.
