### PR TITLE
[ClassCollectionLoader] added a way to push tags when dumping classes

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -103,13 +103,19 @@ class ClassCollectionLoader
 
             $c = preg_replace(array('/^\s*<\?php/', '/\?>\s*$/'), '', file_get_contents($class->getFileName()));
 
-            // add namespace declaration for global code
+            // fakes namespace declaration for global code
             if (!$class->inNamespace()) {
-                $c = "\nnamespace\n{\n".self::stripComments($c)."\n}\n";
-            } else {
-                $c = self::fixNamespaceDeclarations('<?php '.$c);
-                $c = preg_replace('/^\s*<\?php/', '', $c);
+                $c = "\nnamespace;\n".$c."\n";
             }
+
+            $c = self::fixNamespaceDeclarations('<?php '.$c);
+            $c = preg_replace('/^\s*<\?php/', '', $c);
+            $isTaggable = $class->implementsInterface('Symfony\Component\ClassLoader\TaggableInterface');
+            if ($isTaggable && !$class->isAbstract()) {
+                $c = self::dumpTags($class, $c);
+            }
+            // replace multiple new lines with a single newline
+            $c = preg_replace(array('/\s+$/Sm', '/\n+/S'), "\n", $c);
 
             $content .= $c;
         }
@@ -201,37 +207,6 @@ class ClassCollectionLoader
     }
 
     /**
-     * Removes comments from a PHP source string.
-     *
-     * We don't use the PHP php_strip_whitespace() function
-     * as we want the content to be readable and well-formatted.
-     *
-     * @param string $source A PHP string
-     *
-     * @return string The PHP string with the comments removed
-     */
-    static private function stripComments($source)
-    {
-        if (!function_exists('token_get_all')) {
-            return $source;
-        }
-
-        $output = '';
-        foreach (token_get_all($source) as $token) {
-            if (is_string($token)) {
-                $output .= $token;
-            } elseif (!in_array($token[0], array(T_COMMENT, T_DOC_COMMENT))) {
-                $output .= $token[1];
-            }
-        }
-
-        // replace multiple new lines with a single newline
-        $output = preg_replace(array('/\s+$/Sm', '/\n+/S'), "\n", $output);
-
-        return $output;
-    }
-
-    /**
      * Gets an ordered array of passed classes including all their dependencies.
      *
      * @param array $classes
@@ -307,5 +282,24 @@ class ClassCollectionLoader
         }
 
         return $classes;
+    }
+
+    static private function dumpTags(\ReflectionClass $class, $output)
+    {
+        $m = $class->getMethod('dumpTags');
+        $tags = $m->invoke(null, $class);
+
+        $constants = "\n";
+        foreach ($tags as $name => $value) {
+            $constants .= "const $name = '$value';\n";
+        }
+
+        $output = preg_replace(
+            '/^([ \t]*)((?:[\w \t]+ )?(class|trait) [\w, \t\\\\]+?)[ \s]*{\s*$/m',
+            "\\1\\2\\1{\n$constants",
+            $output
+        );
+
+        return $output;
     }
 }

--- a/src/Symfony/Component/ClassLoader/TaggableInterface.php
+++ b/src/Symfony/Component/ClassLoader/TaggableInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\ClassLoader;
+
+/**
+ * TaggableInterface.
+ */
+interface TaggableInterface
+{
+    static public function dumpTags(\ReflectionClass $class);
+}

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -15,6 +15,7 @@
             "homepage": "http://symfony.com/contributors"
         }
     ],
+    "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3"
     },

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\HttpKernel\Bundle;
 use Symfony\Component\DependencyInjection\ContainerAware;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\ClassLoader\TaggableInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Finder\Finder;
 
@@ -25,7 +26,7 @@ use Symfony\Component\Finder\Finder;
  *
  * @api
  */
-abstract class Bundle extends ContainerAware implements BundleInterface
+abstract class Bundle extends ContainerAware implements BundleInterface, TaggableInterface
 {
     protected $name;
     protected $reflected;
@@ -122,6 +123,10 @@ abstract class Bundle extends ContainerAware implements BundleInterface
      */
     public function getPath()
     {
+        if (defined('static::BUNDLE_PATH')) {
+            return static::BUNDLE_PATH;
+        }
+
         if (null === $this->reflected) {
             $this->reflected = new \ReflectionObject($this);
         }
@@ -190,5 +195,10 @@ abstract class Bundle extends ContainerAware implements BundleInterface
                 $application->add($r->newInstance());
             }
         }
+    }
+    
+    static public function dumpTags(\ReflectionClass $class)
+    {
+        return array('BUNDLE_PATH' => dirname($class->getFileName()));
     }
 }


### PR DESCRIPTION
This allows constants to be pushed in a class definition if it implements a given interface. A use case would be for example bundles, we could push their path locations, then we would be able to register them in a cache file :

```
namespace MyNamespace
{
class MyBundle extends Bundle
{
const BUNDLE_PATH = '/var/www/path/to/my/bundle';
// ...
}
```

What do you think?
