### PR TITLE
[2.2] [OptionsResolver] Added closure for allowed types

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -316,10 +316,13 @@ class OptionsResolver implements OptionsResolverInterface
             $value = $options[$option];
             $allowedTypes = (array) $allowedTypes;
 
-            foreach ($allowedTypes as $type) {
-                $isFunction = 'is_' . $type;
-
-                if (function_exists($isFunction) && $isFunction($value)) {
+            foreach ($allowedTypes as &$type) {
+                if ($type instanceof \Closure) {
+                    if (true === $type($value)) {
+                        continue 2;
+                    }
+                    $type = 'Closure';
+                } elseif (function_exists($isFunction = 'is_' . $type) && $isFunction($value)) {
                     continue 2;
                 } elseif ($value instanceof $type) {
                     continue 2;

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -313,7 +313,28 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
             'one' => true,
         ), $this->resolver->resolve($options));
     }
+    
+     public function testResolveSucceedsIfOptionTypeAllowedPassClosure()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => '1',
+        ));
 
+        $this->resolver->setAllowedTypes(array(
+            'one' => function($value) {
+                return is_string($value);
+            }
+        ));
+
+        $options = array(
+            'one' => 'one',
+        );
+
+        $this->assertEquals(array(
+            'one' => 'one',
+        ), $this->resolver->resolve($options));
+    }
+    
     public function testResolveSucceedsIfOptionTypeAllowedPassObject()
     {
         $this->resolver->setDefaults(array(

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -314,7 +314,7 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         ), $this->resolver->resolve($options));
     }
     
-     public function testResolveSucceedsIfOptionTypeAllowedPassClosure()
+    public function testResolveSucceedsIfOptionTypeAllowedPassClosure()
     {
         $this->resolver->setDefaults(array(
             'one' => '1',


### PR DESCRIPTION
Added closure as validation type so custom types (like making sure an array is array[string]) can be validated.
