### PR TITLE
[Form] Fixed: ChoiceType omits the "empty_value" option if the choices contain an empty element

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -141,3 +141,4 @@ CHANGELOG
  * FormBuilder now implements \IteratorAggregate
  * [BC BREAK] compound forms now always need a data mapper
  * FormBuilder now maintains the order when explicitely adding form builders as children
+ * ChoiceType now doesn't add the empty value anymore if the choices already contain an empty element

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -81,8 +81,14 @@ class ChoiceType extends AbstractType
             'preferred_choices' => $options['choice_list']->getPreferredViews(),
             'choices'           => $options['choice_list']->getRemainingViews(),
             'separator'         => '-------------------',
-            'empty_value'       => $options['empty_value'],
+            'empty_value'       => null,
         ));
+
+        // Check if the choices already contain the empty value
+        // Only add the empty value option if this is not the case
+        if (0 === count($options['choice_list']->getIndicesForValues(array('')))) {
+            $view->setVar('empty_value', $options['empty_value']);
+        }
 
         if ($options['multiple'] && !$options['expanded']) {
             // Add "[]" to the name in case a select tag with multiple options is

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -613,6 +613,23 @@ class ChoiceTypeTest extends TypeTestCase
         $this->assertEquals($viewValue, $view->getVar('empty_value'));
     }
 
+    /**
+     * @dataProvider getOptionsWithEmptyValue
+     */
+    public function testDontPassEmptyValueIfContainedInChoices($multiple, $expanded, $required, $emptyValue, $viewValue)
+    {
+        $form = $this->factory->create('choice', null, array(
+            'multiple' => $multiple,
+            'expanded' => $expanded,
+            'required' => $required,
+            'empty_value' => $emptyValue,
+            'choices' => array('a' => 'A', '' => 'Empty'),
+        ));
+        $view = $form->createView();
+
+        $this->assertNull($view->getVar('empty_value'));
+    }
+
     public function getOptionsWithEmptyValue()
     {
         return array(


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3854, #3864
Todo: -
