### PR TITLE
Update upgrade to 2.1 documentation concerning form_label

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -191,7 +191,7 @@
     implementations of this interface to reflect this change.
 
   * The `UserPassword` constraint has moved from the Security Bundle to the Security Component:
-    
+
      Before:
 
      ```
@@ -635,6 +635,20 @@
     removed or made private. Instead of the first two, you can now use
     `getChoices()` and `getChoicesByValues()`. For the latter two, no
     replacement exists.
+
+  * HTML attributes are now passed in the `label_attr` variable for the `form_label` function instead of `attr`.
+
+    Before:
+
+    ```
+    {{ form_label(form.name, 'Your Name', { 'attr': {'class': 'foo'} }) }}
+    ```
+
+    After:
+
+    ```
+    {{ form_label(form.name, 'Your Name', { 'label_attr': {'class': 'foo'} }) }}
+    ```
 
   * `EntitiesToArrayTransformer` and `EntityToIdTransformer` were removed.
     The former was replaced by `CollectionToArrayTransformer` in combination

--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -636,7 +636,7 @@
     `getChoices()` and `getChoicesByValues()`. For the latter two, no
     replacement exists.
 
-  * HTML attributes are now passed in the `label_attr` variable for the `form_label` function instead of `attr`.
+  * HTML attributes are now passed in the `label_attr` variable for the `form_label` function.
 
     Before:
 


### PR DESCRIPTION
The way HTML attributes are passed for the `form_label` function has changed since this commit :
https://github.com/symfony/symfony/commit/167e64f79992f6366108fde1548e2a2c9552d3c6

I also made a PR for the documentation:
https://github.com/symfony/symfony-docs/pull/1542
