### PR TITLE
[Form] Prevented duplicate validation of form constraints

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -937,6 +937,24 @@
     ));
     ```
 
+    Be aware that constraints will now only be validated if they belong
+    to the validated group! So if you validate a form in group "Custom"
+    and previously did:
+
+    ```
+    $builder->add('name', 'text', array(
+        'validation_constraint' => new NotBlank(),
+    ));
+    ```
+
+    Then you need to add the constraint to the group "Custom" now:
+
+    ```
+    $builder->add('name', 'text', array(
+        'constraints' => new NotBlank(array('groups' => 'Custom')),
+    ));
+    ```
+
 ### Validator
 
   * The methods `setMessage()`, `getMessageTemplate()` and

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -144,3 +144,4 @@ CHANGELOG
  * ChoiceType now doesn't add the empty value anymore if the choices already contain an empty element
  * DateType, TimeType and DateTimeType now show empty values again if not required
  * [BC BREAK] fixed rendering of errors for DateType, BirthdayType and similar ones
+ * [BC BREAK] fixed: form constraints are only validated if they belong to the validated group

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -71,7 +71,12 @@ class FormValidator extends ConstraintValidator
             $constraints = $config->getOption('constraints');
             foreach ($constraints as $constraint) {
                 foreach ($groups as $group) {
-                    $graphWalker->walkConstraint($constraint, $form->getData(), $group, $path . 'data');
+                    if (in_array($group, $constraint->groups)) {
+                        $graphWalker->walkConstraint($constraint, $form->getData(), $group, $path . 'data');
+
+                        // Prevent duplicate validation
+                        continue 2;
+                    }
                 }
             }
         } else {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -19,6 +19,8 @@ use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\Extension\Validator\Constraints\FormValidator;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\GlobalExecutionContext;
 use Symfony\Component\Validator\ExecutionContext;
 
@@ -88,8 +90,8 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $context = $this->getExecutionContext();
         $graphWalker = $context->getGraphWalker();
         $object = $this->getMock('\stdClass');
-        $constraint1 = $this->getMock('Symfony\Component\Validator\Constraint');
-        $constraint2 = $this->getMock('Symfony\Component\Validator\Constraint');
+        $constraint1 = new NotNull(array('groups' => array('group1', 'group2')));
+        $constraint2 = new NotBlank(array('groups' => 'group2'));
 
         $options = array(
             'validation_groups' => array('group1', 'group2'),
@@ -112,12 +114,6 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('walkConstraint')
             ->with($constraint1, $object, 'group1', 'data');
         $graphWalker->expects($this->at(3))
-            ->method('walkConstraint')
-            ->with($constraint1, $object, 'group2', 'data');
-        $graphWalker->expects($this->at(4))
-            ->method('walkConstraint')
-            ->with($constraint2, $object, 'group1', 'data');
-        $graphWalker->expects($this->at(5))
             ->method('walkConstraint')
             ->with($constraint2, $object, 'group2', 'data');
 
@@ -153,8 +149,8 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $context = $this->getExecutionContext();
         $graphWalker = $context->getGraphWalker();
         $object = $this->getMock('\stdClass');
-        $constraint1 = $this->getMock('Symfony\Component\Validator\Constraint');
-        $constraint2 = $this->getMock('Symfony\Component\Validator\Constraint');
+        $constraint1 = new NotNull(array('groups' => array('group1', 'group2')));
+        $constraint2 = new NotBlank(array('groups' => 'group2'));
 
         $parent = $this->getBuilder('parent', null, array('cascade_validation' => false))
             ->setCompound(true)
@@ -173,12 +169,6 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('walkConstraint')
             ->with($constraint1, $object, 'group1', 'data');
         $graphWalker->expects($this->at(1))
-            ->method('walkConstraint')
-            ->with($constraint1, $object, 'group2', 'data');
-        $graphWalker->expects($this->at(2))
-            ->method('walkConstraint')
-            ->with($constraint2, $object, 'group1', 'data');
-        $graphWalker->expects($this->at(3))
             ->method('walkConstraint')
             ->with($constraint2, $object, 'group2', 'data');
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: _yes_ (at least that can be argued. I consider it a correction of incorrectly implemented functionality)
Symfony2 tests pass: yes
Fixes the following tickets: #4427
Todo: -
