### PR TITLE
[Form] Fixed the "data" option to supersede default data set in the model

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -145,3 +145,4 @@ CHANGELOG
  * DateType, TimeType and DateTimeType now show empty values again if not required
  * [BC BREAK] fixed rendering of errors for DateType, BirthdayType and similar ones
  * [BC BREAK] fixed: form constraints are only validated if they belong to the validated group
+ * fixed: the "data" option supersedes default values from the model

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -42,7 +42,8 @@ class FormType extends AbstractType
             ->setByReference($options['by_reference'])
             ->setVirtual($options['virtual'])
             ->setCompound($options['compound'])
-            ->setData($options['data'])
+            ->setData(isset($options['data']) ? $options['data'] : null)
+            ->setDataLocked(isset($options['data']))
             ->setDataMapper($options['compound'] ? new PropertyPathMapper() : null)
         ;
 
@@ -181,7 +182,6 @@ class FormType extends AbstractType
         };
 
         $resolver->setDefaults(array(
-            'data'               => null,
             'data_class'         => $dataClass,
             'empty_data'         => $emptyData,
             'trim'               => true,
@@ -201,6 +201,12 @@ class FormType extends AbstractType
             'compound'           => true,
             'translation_domain' => null,
             'inline'             => $inline,
+        ));
+
+        // If data is given, the form is locked to that data
+        // (independent of its value)
+        $resolver->setOptional(array(
+            'data',
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -331,6 +331,11 @@ class Form implements \IteratorAggregate, FormInterface
             throw new AlreadyBoundException('You cannot change the data of a bound form');
         }
 
+        // Don't allow modifications of the configured data if the data is locked
+        if ($this->config->getDataLocked() && $modelData !== $this->config->getData()) {
+            return $this;
+        }
+
         if (is_object($modelData) && !$this->config->getByReference()) {
             $modelData = clone $modelData;
         }

--- a/src/Symfony/Component/Form/FormConfig.php
+++ b/src/Symfony/Component/Form/FormConfig.php
@@ -119,6 +119,11 @@ class FormConfig implements FormConfigEditorInterface
     private $dataClass;
 
     /**
+     * @var Boolean
+     */
+    private $dataLocked;
+
+    /**
      * @var array
      */
     private $options;
@@ -510,6 +515,14 @@ class FormConfig implements FormConfigEditorInterface
     /**
      * {@inheritdoc}
      */
+    public function getDataLocked()
+    {
+        return $this->dataLocked;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getOptions()
     {
         return $this->options;
@@ -671,6 +684,16 @@ class FormConfig implements FormConfigEditorInterface
     public function setData($data)
     {
         $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDataLocked($locked)
+    {
+        $this->dataLocked = $locked;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigEditorInterface.php
+++ b/src/Symfony/Component/Form/FormConfigEditorInterface.php
@@ -227,4 +227,17 @@ interface FormConfigEditorInterface extends FormConfigInterface
      * @return self The configuration object.
      */
     public function setData($data);
+
+    /**
+     * Locks the form's data to the data passed in the configuration.
+     *
+     * A form with locked data is restricted to the data passed in
+     * this configuration. The data can only be modified then by
+     * binding the form.
+     *
+     * @param  Boolean $locked Whether to lock the default data.
+     *
+     * @return self The configuration object.
+     */
+    public function setDataLocked($locked);
 }

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -182,6 +182,17 @@ interface FormConfigInterface
     public function getDataClass();
 
     /**
+     * Returns whether the form's data is locked.
+     *
+     * A form with locked data is restricted to the data passed in
+     * this configuration. The data can only be modified then by
+     * binding the form.
+     *
+     * @return Boolean Whether the data is locked.
+     */
+    public function getDataLocked();
+
+    /**
      * Returns all options passed during the construction of the form.
      *
      * @return array The passed options.

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -633,4 +633,16 @@ class FormTypeTest extends TypeTestCase
         $view = $form->createView();
         $this->assertFalse($view->getVar('valid'));
     }
+
+    public function testDataOptionSupersedesSetDataCalls()
+    {
+        $form = $this->factory->create('form', null, array(
+            'data' => 'default',
+            'compound' => false,
+        ));
+
+        $form->setData('foobar');
+
+        $this->assertSame('default', $form->getData());
+    }
 }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -23,10 +23,10 @@ use Symfony\Component\Form\Tests\Fixtures\FixedFilterListener;
 
 class SimpleFormTest extends AbstractFormTest
 {
-    public function testDataIsInitializedEmpty()
+    public function testDataIsInitializedToConfiguredValue()
     {
         $model = new FixedDataTransformer(array(
-            '' => 'foo',
+            'default' => 'foo',
         ));
         $view = new FixedDataTransformer(array(
             'foo' => 'bar',
@@ -35,9 +35,10 @@ class SimpleFormTest extends AbstractFormTest
         $config = new FormConfig('name', null, $this->dispatcher);
         $config->addViewTransformer($view);
         $config->addModelTransformer($model);
+        $config->setData('default');
         $form = new Form($config);
 
-        $this->assertNull($form->getData());
+        $this->assertSame('default', $form->getData());
         $this->assertSame('foo', $form->getNormData());
         $this->assertSame('bar', $form->getViewData());
     }
@@ -374,6 +375,18 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertNull($form->getData());
         $this->assertNull($form->getNormData());
         $this->assertSame('', $form->getViewData());
+    }
+
+    public function testSetDataIsIgnoredIfDataIsLocked()
+    {
+        $form = $this->getBuilder()
+            ->setData('default')
+            ->setDataLocked(true)
+            ->getForm();
+
+        $form->setData('foobar');
+
+        $this->assertSame('default', $form->getData());
     }
 
     public function testBindConvertsEmptyToNullIfNoTransformer()

--- a/src/Symfony/Component/Form/UnmodifiableFormConfig.php
+++ b/src/Symfony/Component/Form/UnmodifiableFormConfig.php
@@ -117,6 +117,11 @@ class UnmodifiableFormConfig implements FormConfigInterface
     private $dataClass;
 
     /**
+     * @var Boolean
+     */
+    private $dataLocked;
+
+    /**
      * @var array
      */
     private $options;
@@ -152,6 +157,7 @@ class UnmodifiableFormConfig implements FormConfigInterface
         $this->attributes = $config->getAttributes();
         $this->data = $config->getData();
         $this->dataClass = $config->getDataClass();
+        $this->dataLocked = $config->getDataLocked();
         $this->options = $config->getOptions();
     }
 
@@ -323,6 +329,14 @@ class UnmodifiableFormConfig implements FormConfigInterface
     public function getDataClass()
     {
         return $this->dataClass;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDataLocked()
+    {
+        return $this->dataLocked;
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3899
Todo: -
