### PR TITLE
[TwigBundle] Fixed error message

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
@@ -74,7 +74,7 @@ EOF
         }
 
         if (0 !== strpos($filename, '@') && !is_readable($filename)) {
-            throw new \RuntimeException("File or directory '%s' is not readable");
+            throw new \RuntimeException(sprintf('File or directory "%s" is not readable', $filename));
         }
 
         $files = array();


### PR DESCRIPTION
Small fix to display the filename that cannot be read in the Twig Lint command.
