### PR TITLE
[Router] Null default value route regression

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -114,6 +114,10 @@ class Router extends BaseRouter implements WarmableInterface
     {
         $container = $this->container;
 
+        if (null === $value) {
+            return null;
+        }
+
         $escapedValue = preg_replace_callback('/%%|%([^%\s]+)%/', function ($match) use ($container, $value) {
             // skip %%
             if (!isset($match[1])) {

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -144,6 +144,19 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
         $router->getRouteCollection()->get('foo');
     }
 
+    public function testDefaultValueNullAsEmptyStringRegression()
+    {
+        $routes = new RouteCollection();
+        $routes->add('foo', new Route('foo', array('foo' => null), array('foo' => '\d+')));
+
+        $sc = $this->getServiceContainer($routes);
+
+        $router = new Router($sc, 'foo');
+
+        $route = $router->getRouteCollection()->get('foo');
+        $this->assertNull($route->getDefault('foo'));
+    }
+
     private function getServiceContainer(RouteCollection $routes)
     {
         $loader = $this->getMock('Symfony\Component\Config\Loader\LoaderInterface');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4823
Todo: 
License of the code: MIT
Documentation PR: 

---

The commit by @vicb 0555913fbbad5ce29b7dd836155f832d5cfc288f introduces a regression in the handling of default values that are null, while there are requirements still set for this value.

This is a failing test case and fix for the issue.
