### PR TITLE
[FrameworkBundle] Changed DelegatingEngine::renderResponse to use specified engine's renderResponse

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/DelegatingEngine.php
@@ -84,12 +84,6 @@ class DelegatingEngine extends BaseDelegatingEngine implements EngineInterface
      */
     public function renderResponse($view, array $parameters = array(), Response $response = null)
     {
-        if (null === $response) {
-            $response = new Response();
-        }
-
-        $response->setContent($this->render($view, $parameters));
-
-        return $response;
+        return $this->getEngine($view)->renderResponse($view, $parameters, $response);
     }
 }


### PR DESCRIPTION
Currently the DelegatingEngine in the FrameworkBundle has a renderResponse method that creates a new response, it should use the engine's renderResponse since EngineInterface requires a renderResponse to be defined and gives more flexibly to change the response object when creating a new templating engine.

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
