### PR TITLE
[Form] FormBuilder Bug Fix: remove() was not properly removing children

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -144,7 +144,7 @@ class FormBuilder extends FormConfig implements \IteratorAggregate, FormBuilderI
     {
         unset($this->unresolvedChildren[$name]);
 
-        if (isset($this->children[$name])) {
+        if (array_key_exists($name, $this->children)) {
             if ($this->children[$name] instanceof self) {
                 $this->children[$name]->setParent(null);
             }

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -134,6 +134,15 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->builder->has('foo'));
     }
 
+    // https://github.com/symfony/symfony/pull/4826
+    public function testRemoveAndGetForm()
+    {
+        $this->builder->add('foo', 'text');
+        $this->builder->remove('foo');
+        $form = $this->builder->getForm();
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
+    }
+
     public function testCreateNoTypeNo()
     {
         $this->factory->expects($this->once())


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4803
License of the code: MIT

FormBuilder initially sets unresolved children as NULL, until resolved.
 If FormBuilder::remove() is called before that child is resolved, the
if statement turns false, because isset(null) is false, when it should
be true.  Instead, we should check to see if the key exists, and if so,
process and unset it.

Closes #4803
