### PR TITLE
[Form] Fixed errors not to be added onto non-synchronized forms

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Validator/DelegatingValidator.php
@@ -66,14 +66,18 @@ class DelegatingValidator implements FormValidatorInterface
                         foreach ($propertyPath->getElements() as $element) {
                             $children = $child->getChildren();
                             if (!isset($children[$element])) {
-                                $form->addError($error);
+                                if ($form->isSynchronized()) {
+                                    $form->addError($error);
+                                }
                                 break;
                             }
 
                             $child = $children[$element];
                         }
 
-                        $child->addError($error);
+                        if ($child->isSynchronized()) {
+                            $child->addError($error);
+                        }
                     }
                 }
             } elseif (count($violations = $this->validator->validate($form))) {
@@ -85,12 +89,16 @@ class DelegatingValidator implements FormValidatorInterface
 
                     foreach ($mapping as $mappedPath => $child) {
                         if (preg_match($mappedPath, $propertyPath)) {
-                            $child->addError($error);
+                            if ($child->isSynchronized()) {
+                                $child->addError($error);
+                            }
                             continue 2;
                         }
                     }
 
-                    $form->addError($error);
+                    if ($form->isSynchronized()) {
+                        $form->addError($error);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4686
Todo: -
