### PR TITLE
[Form] Also display the hint about adder/remover on invalid property access

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
@@ -78,6 +78,13 @@ class PropertyPathCollectionTest_CarNoAdderAndRemover
     public function getAxes() {}
 }
 
+class PropertyPathCollectionTest_CarNoAdderAndRemoverWithProperty
+{
+    protected $axes = array();
+
+    public function getAxes() {}
+}
+
 class PropertyPathCollectionTest_CompositeCar
 {
     public function getStructure() {}
@@ -244,17 +251,15 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider noAdderRemoverData
      */
-    public function testNoAdderAndRemoverThrowsSensibleError($path, $message)
+    public function testNoAdderAndRemoverThrowsSensibleError($car, $path, $message)
     {
-        $car = $this->getMock(__CLASS__ . '_CarNoAdderAndRemover');
-        $axesBefore = $this->getCollection(array(1 => 'second', 3 => 'fourth'));
-        $axesAfter = $this->getCollection(array(0 => 'first', 1 => 'second', 2 => 'third'));
+        $axes = $this->getCollection(array(0 => 'first', 1 => 'second', 2 => 'third'));
 
         try {
-            $path->setValue($car, $axesAfter);
+            $path->setValue($car, $axes);
             $this->fail('An expected exception was not thrown!');
-        } catch (\Symfony\Component\Form\Exception\InvalidPropertyException $e) {
-            $this->assertEquals(str_replace("{class}", get_class($car), $message), $e->getMessage());
+        } catch (\Symfony\Component\Form\Exception\FormException $e) {
+            $this->assertEquals($message, $e->getMessage());
         }
     }
 
@@ -262,24 +267,40 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $data = array();
 
+        $car = $this->getMock(__CLASS__ . '_CarNoAdderAndRemover');
         $propertyPath = new PropertyPath('axes');
         $expectedMessage = sprintf(
             'Neither element "axes" nor method "setAxes()" exists in class '
-                .'"{class}", nor could adders and removers be found based on the '
+                .'"%s", nor could adders and removers be found based on the '
                 .'guessed singulars: %s (provide a singular by suffixing the '
                 .'property path with "|{singular}" to override the guesser)',
+            get_class($car),
             implode(', ', (array) $singulars = FormUtil::singularify('Axes'))
         );
-        $data[] = array($propertyPath, $expectedMessage);
+        $data[] = array($car, $propertyPath, $expectedMessage);
 
         $propertyPath = new PropertyPath('axes|boo');
         $expectedMessage = sprintf(
             'Neither element "axes" nor method "setAxes()" exists in class '
-                .'"{class}", nor could adders and removers be found based on the '
+                .'"%s", nor could adders and removers be found based on the '
                 .'passed singular: %s',
+            get_class($car),
             'boo'
         );
-        $data[] = array($propertyPath, $expectedMessage);
+        $data[] = array($car, $propertyPath, $expectedMessage);
+
+        $car = $this->getMock(__CLASS__ . '_CarNoAdderAndRemoverWithProperty');
+        $propertyPath = new PropertyPath('axes');
+        $expectedMessage = sprintf(
+            'Property "axes" is not public in class "%s", nor could adders and '
+                .'removers be found based on the guessed singulars: %s '
+                .'(provide a singular by suffixing the property path with '
+                .'"|{singular}" to override the guesser). Maybe you should '
+                .'create the method "setAxes()"?',
+            get_class($car),
+            implode(', ', (array) $singulars = FormUtil::singularify('Axes'))
+        );
+        $data[] = array($car, $propertyPath, $expectedMessage);
 
         return $data;
     }

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -516,7 +516,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 $objectOrArray->$property = $value;
             } elseif ($reflClass->hasProperty($property)) {
                 if (!$reflClass->getProperty($property)->isPublic()) {
-                    throw new PropertyAccessDeniedException(sprintf('Property "%s" is not public in class "%s". Maybe you should create the method "%s()"?', $property, $reflClass->name, $setter));
+                    throw new PropertyAccessDeniedException(sprintf('Property "%s" is not public in class "%s"%s. Maybe you should create the method "%s()"?', $property, $reflClass->name, $adderRemoverError, $setter));
                 }
 
                 $objectOrArray->$property = $value;


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -

This PR follows up #4777. In this case the hint about adders and removers is also added when a property is found, but is not public, a common case.
