### PR TITLE
[Form] Removed unused option "inline" that was introduced by accident

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -178,11 +178,6 @@ class FormType extends AbstractType
             return false !== $options['property_path'];
         };
 
-        // Compound forms are not displayed inline
-        $inline = function (Options $options) {
-            return !$options['compound'];
-        };
-
         $resolver->setDefaults(array(
             'data_class'         => $dataClass,
             'empty_data'         => $emptyData,
@@ -202,7 +197,6 @@ class FormType extends AbstractType
             'virtual'            => false,
             'compound'           => true,
             'translation_domain' => null,
-            'inline'             => $inline,
         ));
 
         // If data is given, the form is locked to that data


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
