### PR TITLE
Issue 4752

### DIFF
--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -25,11 +25,6 @@ class OutputFormatter implements OutputFormatterInterface
      */
     const FORMAT_PATTERN = '#(\\\\?)<(/?)([a-z][a-z0-9_=;-]+)?>([^\\\\<]*)#is';
 
-    /**
-     * The escape sequence for LG char.
-     */
-    const LG_CHAR_ESCAPING = '\\';
-
     private $decorated;
     private $styles = array();
     private $styleStack;
@@ -154,7 +149,7 @@ class OutputFormatter implements OutputFormatterInterface
     {
         $message = preg_replace_callback(self::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
 
-        return str_replace(self::LG_CHAR_ESCAPING.'<', '<', $message);
+        return str_replace('\\<', '<', $message);
     }
 
     /**
@@ -167,7 +162,7 @@ class OutputFormatter implements OutputFormatterInterface
     private function replaceStyle($match)
     {
         // we got "\<" escaped char
-        if (self::LG_CHAR_ESCAPING === $match[1]) {
+        if ('\\' === $match[1]) {
             return $match[0];
         }
 

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -23,11 +23,28 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * The pattern to phrase the format.
      */
-    const FORMAT_PATTERN = '#<(/?)([a-z][a-z0-9_=;-]+)?>([^<]*)#is';
+    const FORMAT_PATTERN = '#(\\\\?)<(/?)([a-z][a-z0-9_=;-]+)?>([^\\\\<]*)#is';
+
+    /**
+     * The escape sequence for LG char.
+     */
+    const LG_CHAR_ESCAPING = '\\';
 
     private $decorated;
     private $styles = array();
     private $styleStack;
+
+    /**
+     * Escapes "<" special char in given text.
+     *
+     * @param string $text Text to escape
+     *
+     * @return string Escaped text
+     */
+    public static function escape($text)
+    {
+        return preg_replace('/([^\\\\]?)</is', '$1\\<', $text);
+    }
 
     /**
      * Initializes console output formatter.
@@ -135,7 +152,9 @@ class OutputFormatter implements OutputFormatterInterface
      */
     public function format($message)
     {
-        return preg_replace_callback(self::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
+        $message = preg_replace_callback(self::FORMAT_PATTERN, array($this, 'replaceStyle'), $message);
+
+        return str_replace(self::LG_CHAR_ESCAPING.'<', '<', $message);
     }
 
     /**
@@ -147,35 +166,40 @@ class OutputFormatter implements OutputFormatterInterface
      */
     private function replaceStyle($match)
     {
-        if ('' === $match[2]) {
-            if ('/' === $match[1]) {
+        // we got "\<" escaped char
+        if (self::LG_CHAR_ESCAPING === $match[1]) {
+            return $match[0];
+        }
+
+        if ('' === $match[3]) {
+            if ('/' === $match[2]) {
                 // we got "</>" tag
                 $this->styleStack->pop();
 
-                return $this->applyStyle($this->styleStack->getCurrent(), $match[3]);
+                return $this->applyStyle($this->styleStack->getCurrent(), $match[4]);
             }
 
             // we got "<>" tag
-            return '<>'.$match[3];
+            return '<>'.$match[4];
         }
 
-        if (isset($this->styles[strtolower($match[2])])) {
-            $style = $this->styles[strtolower($match[2])];
+        if (isset($this->styles[strtolower($match[3])])) {
+            $style = $this->styles[strtolower($match[3])];
         } else {
-            $style = $this->createStyleFromString($match[2]);
+            $style = $this->createStyleFromString($match[3]);
 
             if (false === $style) {
                 return $match[0];
             }
         }
 
-        if ('/' === $match[1]) {
+        if ('/' === $match[2]) {
             $this->styleStack->pop($style);
         } else {
             $this->styleStack->push($style);
         }
 
-        return $this->applyStyle($this->styleStack->getCurrent(), $match[3]);
+        return $this->applyStyle($this->styleStack->getCurrent(), $match[4]);
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Helper;
 
+use Symfony\Component\Console\Formatter\OutputFormatter;
+
 /**
  * The Formatter class provides helpers to format messages.
  *
@@ -48,6 +50,7 @@ class FormatterHelper extends Helper
         $len = 0;
         $lines = array();
         foreach ($messages as $message) {
+            $message = OutputFormatter::escape($message);
             $lines[] = sprintf($large ? '  %s  ' : ' %s ', $message);
             $len = max($this->strlen($message) + ($large ? 4 : 2), $len);
         }

--- a/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
+++ b/src/Symfony/Component/Console/Tests/Formatter/OutputFormatterTest.php
@@ -22,6 +22,14 @@ class FormatterStyleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("foo<>bar", $formatter->format('foo<>bar'));
     }
 
+    public function testLGCharEscaping()
+    {
+        $formatter = new OutputFormatter(true);
+        $this->assertEquals("foo<bar", $formatter->format('foo\\<bar'));
+        $this->assertEquals("<info>some info</info>", $formatter->format('\\<info>some info\\</info>'));
+        $this->assertEquals("\\<info>some info\\</info>", OutputFormatter::escape('<info>some info</info>'));
+    }
+
     public function testBundledStyles()
     {
         $formatter = new OutputFormatter(true);

--- a/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/FormatterHelperTest.php
@@ -68,4 +68,17 @@ class FormatterHelperTest extends \PHPUnit_Framework_TestCase
             '::formatBlock() formats a message in a block'
         );
     }
+
+    public function testFormatBlockLGEscaping()
+    {
+        $formatter = new FormatterHelper();
+
+        $this->assertEquals(
+            '<error>                            </error>' . "\n" .
+            '<error>  \<info>some info\</info>  </error>' . "\n" .
+            '<error>                            </error>',
+            $formatter->formatBlock('<info>some info</info>', 'error', true),
+            '::formatBlock() escapes \'<\' chars'
+        );
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4752

This PR adds possibility to escape `<` chars with `\` to avoid formatting mess.
In addition, `FormatterHelper::formatBlock()` method auto-escapes messages.
