### PR TITLE
Fixed non-object call in get form line 201 in FormBuilder

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -198,7 +198,9 @@ class FormBuilder extends FormConfig implements \IteratorAggregate, FormBuilderI
         $form = new Form($this);
 
         foreach ($this->children as $child) {
-            $form->add($child->getForm());
+            if(is_object($child)) {
+                $form->add($child->getForm());
+            }
         }
 
         return $form;


### PR DESCRIPTION
Hello,
after updating vendors on production server ive encountered:

Fatal error: Call to a member function getForm() on a non-object in /var/www/pr/shared/vendor/symfony/symfony/src/Symfony/Component/Form/FormBuilder.php

After quick lookout, i found that on line 201 the $child was null. I had to add this quick fix to the server. 
Im wondering if enyone encountered the similar problem?
