### PR TITLE
[Config][EnumNode] Fluent Interface is broken

### DIFF
--- a/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
+++ b/src/Symfony/Component/Config/Definition/Builder/EnumNodeDefinition.php
@@ -23,6 +23,8 @@ class EnumNodeDefinition extends ScalarNodeDefinition
         }
 
         $this->values = $values;
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
`values()` function did not return the object, this breaking the fluent interface.

Added a `return $this` so that usage of this node works as expected:

```
->enumNode('foo')->values(array('a', 'b'))->end()
```
