### PR TITLE
[EventDispatcher] Event if first listener added

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -92,6 +92,9 @@ class EventDispatcher implements EventDispatcherInterface
      */
     public function addListener($eventName, $listener, $priority = 0)
     {
+        if (!$this->hasListeners($eventName)) {
+            $this->dispatch('eventdispatcher.event_used.'. $eventName);
+        }
         $this->listeners[$eventName][$priority][] = $listener;
         unset($this->sorted[$eventName]);
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

The EventDispatcher will now dispatch a event if the first listener was added.
And thus letting the other code that something wants to know if a event happend.

This could be usage full in many cases.
The thing I find it usefull for the POSIX signals in PHP.
This way I can listen for a signal only if somewere in the code something wants to listen to it.
That way PHP won't listen for a signal if not necessary.
