### PR TITLE
Allow Kernel::$name to be overridden by subclasses

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -79,7 +79,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         $this->debug = (Boolean) $debug;
         $this->booted = false;
         $this->rootDir = $this->getRootDir();
-        $this->name = preg_replace('/[^a-zA-Z0-9_]+/', '', basename($this->rootDir));
+        $this->name = $this->getName();
         $this->classes = array();
 
         if ($this->debug) {
@@ -354,6 +354,10 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     public function getName()
     {
+        if (null === $this->name) {
+            $this->name = preg_replace('/[^a-zA-Z0-9_]+/', '', basename($this->rootDir));
+        }
+
         return $this->name;
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForOverrideName.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForOverrideName.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures;
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+class KernelForOverrideName extends Kernel
+{
+    protected $name = 'overridden';
+
+    public function registerBundles()
+    {
+
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest;
+use Symfony\Component\HttpKernel\Tests\Fixtures\KernelForOverrideName;
 use Symfony\Component\HttpKernel\Tests\Fixtures\FooBarBundle;
 
 class KernelTest extends \PHPUnit_Framework_TestCase
@@ -308,6 +309,13 @@ EOF;
         $kernel = new KernelForTest('test', true);
 
         $this->assertEquals('Fixtures', $kernel->getName());
+    }
+
+    public function testOverrideGetName()
+    {
+        $kernel = new KernelForOverrideName('test', true);
+
+        $this->assertEquals('overridden', $kernel->getName());
     }
 
     public function testSerialize()


### PR DESCRIPTION
Because the name of the kernel is calculated in the constructor,
any child class that had overriden the kernel name, will be
ignored.

By setting the kernel name in the child class, we can avoid having
to execute the regex to calculate the name upon every construction
of a Kernel.

A test (and a kernel fixture) is added to prove that the override
works correctly.

Note: the Kernel API has not been touched, so there should be no
issues with BC.

What do you think?
