### PR TITLE
[Form] Fixed tests and renamed the options "data_timezone" and "user_timezone"

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -970,6 +970,28 @@
     ));
     ```
 
+  * The options "data_timezone" and "user_timezone" in `DateType`,
+    `DateTimeType` and `TimeType` were deprecated and will be removed in
+    Symfony 2.3. They were renamed to "model_timezone" and "view_timezone".
+
+    Before:
+
+    ```
+    $builder->add('scheduledFor', 'date', array(
+        'data_timezone' => 'UTC',
+        'user_timezone' => 'America/New_York',
+    ));
+    ```
+
+    After:
+
+    ```
+    $builder->add('scheduledFor', 'date', array(
+        'model_timezone' => 'UTC',
+        'view_timezone' => 'America/New_York',
+    ));
+    ```
+
 ### Validator
 
   * The methods `setMessage()`, `getMessageTemplate()` and

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -154,3 +154,5 @@ CHANGELOG
  * added the option "format" to DateTimeType
  * [BC BREAK] DateTimeType now outputs RFC 3339 dates by default, as generated and
    consumed by HTML5 browsers, if the widget is "single_text"
+ * deprecated the options "data_timezone" and "user_timezone" in DateType, DateTimeType and TimeType
+   and renamed them to "model_timezone" and "view_timezone"

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -94,13 +94,13 @@ class DateTimeType extends AbstractType
         if ('single_text' === $options['widget']) {
             if (self::HTML5_FORMAT === $pattern) {
                 $builder->addViewTransformer(new DateTimeToRfc3339Transformer(
-                    $options['data_timezone'],
-                    $options['user_timezone']
+                    $options['model_timezone'],
+                    $options['view_timezone']
                 ));
             } else {
                 $builder->addViewTransformer(new DateTimeToLocalizedStringTransformer(
-                    $options['data_timezone'],
-                    $options['user_timezone'],
+                    $options['model_timezone'],
+                    $options['view_timezone'],
                     $dateFormat,
                     $timeFormat,
                     $calendar,
@@ -145,7 +145,7 @@ class DateTimeType extends AbstractType
 
             $builder
                 ->addViewTransformer(new DataTransformerChain(array(
-                    new DateTimeToArrayTransformer($options['data_timezone'], $options['user_timezone'], $parts),
+                    new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts),
                     new ArrayToPartsTransformer(array(
                         'date' => $dateParts,
                         'time' => $timeParts,
@@ -158,15 +158,15 @@ class DateTimeType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'])
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'])
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['data_timezone'], $options['data_timezone'])
+                new DateTimeToTimestampTransformer($options['model_timezone'], $options['model_timezone'])
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['data_timezone'], $options['data_timezone'], $parts)
+                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], $parts)
             ));
         }
     }
@@ -205,25 +205,38 @@ class DateTimeType extends AbstractType
             return $options['widget'];
         };
 
+        // BC until Symfony 2.3
+        $modelTimezone = function (Options $options) {
+            return $options['data_timezone'];
+        };
+
+        // BC until Symfony 2.3
+        $viewTimezone = function (Options $options) {
+            return $options['user_timezone'];
+        };
+
         $resolver->setDefaults(array(
-            'input'         => 'datetime',
-            'data_timezone' => null,
-            'user_timezone' => null,
-            'format'        => self::HTML5_FORMAT,
-            'date_format'   => null,
-            'widget'        => null,
-            'date_widget'   => $dateWidget,
-            'time_widget'   => $timeWidget,
-            'with_seconds'  => false,
+            'input'          => 'datetime',
+            'model_timezone' => $modelTimezone,
+            'view_timezone'  => $viewTimezone,
+            // Deprecated timezone options
+            'data_timezone'  => null,
+            'user_timezone'  => null,
+            'format'         => self::HTML5_FORMAT,
+            'date_format'    => null,
+            'widget'         => null,
+            'date_widget'    => $dateWidget,
+            'time_widget'    => $timeWidget,
+            'with_seconds'   => false,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
-            'by_reference'  => false,
+            'by_reference'   => false,
             // If initialized with a \DateTime object, FormType initializes
             // this option to "\DateTime". Since the internal, normalized
             // representation is not \DateTime, but an array, we need to unset
             // this option.
-            'data_class'    => null,
-            'compound'      => $compound,
+            'data_class'     => null,
+            'compound'       => $compound,
         ));
 
         // Don't add some defaults in order to preserve the defaults

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -58,8 +58,8 @@ class DateType extends AbstractType
 
         if ('single_text' === $options['widget']) {
             $builder->addViewTransformer(new DateTimeToLocalizedStringTransformer(
-                $options['data_timezone'],
-                $options['user_timezone'],
+                $options['model_timezone'],
+                $options['view_timezone'],
                 $dateFormat,
                 $timeFormat,
                 $calendar,
@@ -104,7 +104,7 @@ class DateType extends AbstractType
                 ->add('month', $options['widget'], $monthOptions)
                 ->add('day', $options['widget'], $dayOptions)
                 ->addViewTransformer(new DateTimeToArrayTransformer(
-                    $options['data_timezone'], $options['user_timezone'], array('year', 'month', 'day')
+                    $options['model_timezone'], $options['view_timezone'], array('year', 'month', 'day')
                 ))
                 ->setAttribute('formatter', $formatter)
             ;
@@ -112,15 +112,15 @@ class DateType extends AbstractType
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], 'Y-m-d')
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'Y-m-d')
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['data_timezone'], $options['data_timezone'])
+                new DateTimeToTimestampTransformer($options['model_timezone'], $options['model_timezone'])
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['data_timezone'], $options['data_timezone'], array('year', 'month', 'day'))
+                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], array('year', 'month', 'day'))
             ));
         }
     }
@@ -185,6 +185,16 @@ class DateType extends AbstractType
             );
         };
 
+        // BC until Symfony 2.3
+        $modelTimezone = function (Options $options) {
+            return $options['data_timezone'];
+        };
+
+        // BC until Symfony 2.3
+        $viewTimezone = function (Options $options) {
+            return $options['user_timezone'];
+        };
+
         $resolver->setDefaults(array(
             'years'          => range(date('Y') - 5, date('Y') + 5),
             'months'         => range(1, 12),
@@ -192,6 +202,9 @@ class DateType extends AbstractType
             'widget'         => 'choice',
             'input'          => 'datetime',
             'format'         => self::HTML5_FORMAT,
+            'model_timezone' => $modelTimezone,
+            'view_timezone'  => $viewTimezone,
+            // Deprecated timezone options
             'data_timezone'  => null,
             'user_timezone'  => null,
             'empty_value'    => $emptyValue,

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -37,7 +37,7 @@ class TimeType extends AbstractType
         }
 
         if ('single_text' === $options['widget']) {
-            $builder->addViewTransformer(new DateTimeToStringTransformer($options['data_timezone'], $options['user_timezone'], $format));
+            $builder->addViewTransformer(new DateTimeToStringTransformer($options['model_timezone'], $options['view_timezone'], $format));
         } else {
             $hourOptions = $minuteOptions = $secondOptions = array();
 
@@ -92,20 +92,20 @@ class TimeType extends AbstractType
                 $builder->add('second', $options['widget'], $secondOptions);
             }
 
-            $builder->addViewTransformer(new DateTimeToArrayTransformer($options['data_timezone'], $options['user_timezone'], $parts, 'text' === $options['widget']));
+            $builder->addViewTransformer(new DateTimeToArrayTransformer($options['model_timezone'], $options['view_timezone'], $parts, 'text' === $options['widget']));
         }
 
         if ('string' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToStringTransformer($options['data_timezone'], $options['data_timezone'], 'H:i:s')
+                new DateTimeToStringTransformer($options['model_timezone'], $options['model_timezone'], 'H:i:s')
             ));
         } elseif ('timestamp' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToTimestampTransformer($options['data_timezone'], $options['data_timezone'])
+                new DateTimeToTimestampTransformer($options['model_timezone'], $options['model_timezone'])
             ));
         } elseif ('array' === $options['input']) {
             $builder->addModelTransformer(new ReversedTransformer(
-                new DateTimeToArrayTransformer($options['data_timezone'], $options['data_timezone'], $parts)
+                new DateTimeToArrayTransformer($options['model_timezone'], $options['model_timezone'], $parts)
             ));
         }
     }
@@ -155,6 +155,16 @@ class TimeType extends AbstractType
             );
         };
 
+        // BC until Symfony 2.3
+        $modelTimezone = function (Options $options) {
+            return $options['data_timezone'];
+        };
+
+        // BC until Symfony 2.3
+        $viewTimezone = function (Options $options) {
+            return $options['user_timezone'];
+        };
+
         $resolver->setDefaults(array(
             'hours'          => range(0, 23),
             'minutes'        => range(0, 59),
@@ -162,6 +172,9 @@ class TimeType extends AbstractType
             'widget'         => 'choice',
             'input'          => 'datetime',
             'with_seconds'   => false,
+            'model_timezone' => $modelTimezone,
+            'view_timezone'  => $viewTimezone,
+            // Deprecated timezone options
             'data_timezone'  => null,
             'user_timezone'  => null,
             'empty_value'    => $emptyValue,

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -964,8 +964,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
         $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'widget' => 'single_text',
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
@@ -984,8 +984,8 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
             'date_widget' => 'choice',
             'time_widget' => 'choice',
             'widget' => 'single_text',
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -964,13 +964,15 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
         $form = $this->factory->createNamed('name', 'datetime', '2011-02-03 04:05:06', array(
             'input' => 'string',
             'widget' => 'single_text',
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
     [@type="datetime"]
     [@name="name"]
-    [@value="2011-02-03T04:05:06+01:00"]
+    [@value="2011-02-03T04:05:06Z"]
 '
         );
     }
@@ -982,13 +984,15 @@ abstract class AbstractLayoutTest extends \PHPUnit_Framework_TestCase
             'date_widget' => 'choice',
             'time_widget' => 'choice',
             'widget' => 'single_text',
+            'data_timezone' => 'UTC',
+            'user_timezone' => 'UTC',
         ));
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input
     [@type="datetime"]
     [@name="name"]
-    [@value="2011-02-03T04:05:06+01:00"]
+    [@value="2011-02-03T04:05:06Z"]
 '
         );
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -16,8 +16,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_dateTime()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
             'input' => 'datetime',
@@ -43,8 +43,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_string()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
@@ -68,8 +68,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_timestamp()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'timestamp',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
@@ -95,8 +95,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_withSeconds()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
             'input' => 'datetime',
@@ -126,8 +126,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_differentTimezones()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'America/New_York',
-            'user_timezone' => 'Pacific/Tahiti',
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Pacific/Tahiti',
             'date_widget' => 'choice',
             'time_widget' => 'choice',
             'input' => 'string',
@@ -157,8 +157,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_differentTimezonesDateTime()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'America/New_York',
-            'user_timezone' => 'Pacific/Tahiti',
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Pacific/Tahiti',
             'widget' => 'single_text',
             'input' => 'datetime',
         ));
@@ -176,8 +176,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_stringSingleText()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -191,8 +191,8 @@ class DateTimeTypeTest extends LocalizedTestCase
     public function testSubmit_stringSingleText_withSeconds()
     {
         $form = $this->factory->create('datetime', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
             'with_seconds' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -45,8 +45,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromSingleTextDateTimeWithDefaultFormat()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'datetime',
         ));
@@ -61,8 +61,8 @@ class DateTypeTest extends LocalizedTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'datetime',
         ));
@@ -77,8 +77,8 @@ class DateTypeTest extends LocalizedTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'string',
         ));
@@ -93,8 +93,8 @@ class DateTypeTest extends LocalizedTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'timestamp',
         ));
@@ -111,8 +111,8 @@ class DateTypeTest extends LocalizedTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
             'input' => 'array',
         ));
@@ -132,8 +132,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromText()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'text',
         ));
 
@@ -154,8 +154,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromChoice()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -176,8 +176,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromChoiceEmpty()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
             'required' => false,
         ));
@@ -197,8 +197,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromInputDateTimeDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'datetime',
@@ -213,8 +213,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromInputStringDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'string',
@@ -229,8 +229,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromInputTimestampDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'timestamp',
@@ -247,8 +247,8 @@ class DateTypeTest extends LocalizedTestCase
     public function testSubmitFromInputRawDifferentPattern()
     {
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'format' => 'MM*yyyy*dd',
             'widget' => 'single_text',
             'input' => 'array',
@@ -316,8 +316,8 @@ class DateTypeTest extends LocalizedTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'data_timezone' => 'America/New_York',
-            'user_timezone' => 'Pacific/Tahiti',
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Pacific/Tahiti',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -331,8 +331,8 @@ class DateTypeTest extends LocalizedTestCase
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
-            'data_timezone' => 'America/New_York',
-            'user_timezone' => 'Pacific/Tahiti',
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Pacific/Tahiti',
             'input' => 'datetime',
             'widget' => 'single_text',
         ));
@@ -437,8 +437,8 @@ class DateTypeTest extends LocalizedTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'single_text',
         ));
 
@@ -452,8 +452,8 @@ class DateTypeTest extends LocalizedTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -471,8 +471,8 @@ class DateTypeTest extends LocalizedTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 
@@ -490,8 +490,8 @@ class DateTypeTest extends LocalizedTestCase
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
         $form = $this->factory->create('date', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'widget' => 'choice',
         ));
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -18,8 +18,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_dateTime()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
         ));
 
@@ -39,8 +39,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_string()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
         ));
 
@@ -58,8 +58,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_timestamp()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'timestamp',
         ));
 
@@ -79,8 +79,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_array()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'array',
         ));
 
@@ -98,8 +98,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_datetimeSingleText()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'widget' => 'single_text',
         ));
@@ -113,8 +113,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_arraySingleText()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
         ));
@@ -133,8 +133,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_arraySingleTextWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'array',
             'widget' => 'single_text',
             'with_seconds' => true,
@@ -155,8 +155,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSubmit_stringSingleText()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'string',
             'widget' => 'single_text',
         ));
@@ -170,8 +170,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSetData_withSeconds()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'UTC',
-            'user_timezone' => 'UTC',
+            'model_timezone' => 'UTC',
+            'view_timezone' => 'UTC',
             'input' => 'datetime',
             'with_seconds' => true,
         ));
@@ -184,8 +184,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSetData_differentTimezones()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'America/New_York',
-            'user_timezone' => 'Asia/Hong_Kong',
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'string',
             'with_seconds' => true,
         ));
@@ -210,8 +210,8 @@ class TimeTypeTest extends LocalizedTestCase
     public function testSetData_differentTimezonesDateTime()
     {
         $form = $this->factory->create('time', null, array(
-            'data_timezone' => 'America/New_York',
-            'user_timezone' => 'Asia/Hong_Kong',
+            'model_timezone' => 'America/New_York',
+            'view_timezone' => 'Asia/Hong_Kong',
             'input' => 'datetime',
             'with_seconds' => true,
         ));


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

The option names were renamed for better consistency with the terms "model data" or "model format" and "view data" or "view format".
