### PR TITLE
[Locale] Fixed error resetting in StubIntlDateFormatter::parse()

### DIFF
--- a/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
@@ -151,6 +151,9 @@ class FullTransformer
                 }
             }
 
+            // reset error code and message
+            StubIntl::setError(StubIntl::U_ZERO_ERROR);
+
             return $this->calculateUnixTimestamp($dateTime, $options);
         }
 

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -378,10 +378,8 @@ class StubIntlDateFormatter
         $timestamp = $transformer->parse($dateTime, $value);
 
         // behave like the intl extension. FullTransformer::parse() set the proper error
-        if (false === $timestamp) {
-            $this->errorCode = StubIntl::getErrorCode();
-            $this->errorMessage = StubIntl::getErrorMessage();
-        }
+        $this->errorCode = StubIntl::getErrorCode();
+        $this->errorMessage = StubIntl::getErrorMessage();
 
         return $timestamp;
     }

--- a/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
@@ -859,6 +859,24 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         );
     }
 
+    /*
+     * https://github.com/symfony/symfony/issues/4242
+     */
+    public function testParseAfterErrorIntl()
+    {
+        $this->testParseErrorIntl('y-MMMMM-d', '1970-J-1');
+        $this->testParseIntl('y-M-d', '1970-1-1', 0);
+    }
+
+    /*
+     * https://github.com/symfony/symfony/issues/4242
+     */
+    public function testParseAfterErrorStub()
+    {
+        $this->testParseErrorStub('y-MMMMM-d', '1970-J-1');
+        $this->testParseStub('y-M-d', '1970-1-1', 0);
+    }
+
     /**
      * Just to document the differences between the stub and the intl implementations. The intl can parse
      * any of the tested formats alone. The stub does not implement them as it would be needed to add more


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4242
Todo: -
