### PR TITLE
[Security] Fix the default authentication handlers config definition

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -111,13 +111,13 @@
         <service id="security.authentication.success_handler" class="%security.authentication.success_handler.class%" abstract="true" public="false">
             <argument type="service" id="security.http_utils" />
             <argument />
-            <argument />
+            <argument type="collection" /> <!-- Options -->
         </service>
 
         <service id="security.authentication.failure_handler" class="%security.authentication.failure_handler.class%" abstract="true" public="false">
             <argument type="service" id="http_kernel" />
             <argument type="service" id="security.http_utils" />
-            <argument />
+            <argument type="collection" /> <!-- Options -->
             <argument type="service" id="logger" on-invalid="null" />
         </service>
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=fix-security-default-authentication-handlers-config)](http://travis-ci.org/asm89/symfony)
License of the code: MIT

Options should be a collection, when you use the default handler definition as a parent you will get an error that the argument of the constructor is a string and not an array, because for your own service the extension of the security bundle will not replace the arguments.
