### PR TITLE
[Security] Remove hard dependency on $providerKey for default auth success handler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -175,8 +175,8 @@ abstract class AbstractFactory implements SecurityFactoryInterface
         $successHandlerId = 'security.authentication.success_handler.'.$id;
 
         $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator('security.authentication.success_handler'));
-        $successHandler->replaceArgument(1, $id);
-        $successHandler->replaceArgument(2, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
+        $successHandler->replaceArgument(1, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
+        $successHandler->addMethodCall('setProviderKey', array($id));
 
         return $successHandlerId;
     }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -110,7 +110,6 @@
 
         <service id="security.authentication.success_handler" class="%security.authentication.success_handler.class%" abstract="true" public="false">
             <argument type="service" id="security.http_utils" />
-            <argument />
             <argument type="collection" /> <!-- Options -->
         </service>
 

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -35,13 +35,11 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
      * Constructor.
      *
      * @param HttpUtils $httpUtils
-     * @param string    $providerKey
      * @param array     $options   Options for processing a successful authentication attempt.
      */
-    public function __construct(HttpUtils $httpUtils, $providerKey, array $options)
+    public function __construct(HttpUtils $httpUtils, array $options)
     {
         $this->httpUtils   = $httpUtils;
-        $this->providerKey = $providerKey;
 
         $this->options = array_merge(array(
             'always_use_default_target_path' => false,
@@ -58,6 +56,27 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
     public function onAuthenticationSuccess(Request $request, TokenInterface $token)
     {
         return $this->httpUtils->createRedirectResponse($request, $this->determineTargetUrl($request));
+    }
+
+
+    /**
+     * Get the provider key.
+     *
+     * @return string
+     */
+    public function getProviderKey()
+    {
+        return $this->providerKey;
+    }
+
+    /**
+     * Set the provider key.
+     *
+     * @param string $providerKey
+     */
+    public function setProviderKey($providerKey)
+    {
+        $this->providerKey = $providerKey;
     }
 
     /**
@@ -77,9 +96,8 @@ class DefaultAuthenticationSuccessHandler implements AuthenticationSuccessHandle
             return $targetUrl;
         }
 
-        $session = $request->getSession();
-        if ($targetUrl = $session->get('_security.'.$this->providerKey.'.target_path')) {
-            $session->remove('_security.'.$this->providerKey.'.target_path');
+        if (null !== $this->providerKey && $targetUrl = $request->getSession()->get('_security.'.$this->providerKey.'.target_path')) {
+            $request->getSession()->remove('_security.'.$this->providerKey.'.target_path');
 
             return $targetUrl;
         }


### PR DESCRIPTION
Bug fix: yes?
Feature addition: yes?
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=fix-default-auth-successhandler-extension)](http://travis-ci.org/asm89/symfony)
License of the code: MIT

In 8ffaafa86741a03ecb2f91e3d67802f4c6baf36b a hard dependency was introduced between the default authentication success handling code and the active firewall. This makes sense. However, for people implementing their own success handler this makes it impossible to extend the default class as the `$providerKey` is set in the extension of the security bundle.

This PR makes the dependency a soft one so people can extend the class and use the default definition as a parent for their own service. However it is the responsibility of the developers to set the appropriate `$providerKey` if they want to use the target url saved in the session. Imo this is the right way as the developer should also set the appropriate options for the parent class in the overriding constructor.
