### PR TITLE
[DoctrineBridge] Added an option to choose the subpath for the violation

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -25,6 +25,7 @@ class UniqueEntity extends Constraint
     public $service = 'doctrine.orm.validator.unique';
     public $em = null;
     public $fields = array();
+    public $errorPath = null;
 
     public function getRequiredOptions()
     {

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -47,6 +47,10 @@ class UniqueEntityValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint->fields, 'array');
         }
 
+        if (null !== $constraint->errorPath && !is_string($constraint->errorPath)) {
+            throw new UnexpectedTypeException($constraint->errorPath, 'string or null');
+        }
+
         $fields = (array) $constraint->fields;
 
         if (0 === count($fields)) {
@@ -114,6 +118,8 @@ class UniqueEntityValidator extends ConstraintValidator
             return;
         }
 
-        $this->context->addViolationAtSubPath($fields[0], $constraint->message, array(), $criteria[$fields[0]]);
+        $errorPath = null !== $constraint->errorPath ? $constraint->errorPath : $fields[0];
+
+        $this->context->addViolationAtSubPath($errorPath, $constraint->message, array(), $criteria[$fields[0]]);
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3866
Todo: -

By default, the UniqueEntityValidator maps the violation on the first
field of the UniqueEntity constraint. The new option allows to control
this behavior if a better mapping is suited.
