### PR TITLE
[Controller] [FrameworkBundle] Added function to quicker create jsonResponses

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -38,3 +38,4 @@ CHANGELOG
    parser: TemplateFilenameParser::parse().
  * [BC BREAK] Kernel parameters are replaced by their value whereever they appear
    in Route patterns, requirements and defaults. Use '%%' as the escaped value for '%'.
+ * Added createJsonResponse() to the controller.

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -126,6 +126,28 @@ class Controller extends ContainerAware
     }
 
     /**
+     * Returns a Response.
+     *
+     * This will return a Response with Content-Typ application/json for a ajax call.
+     *
+     * Usage example:
+     *   return $this->createJsonResponse(200,array('message'=>'Hello'))
+     *
+     * @param integer $status
+     * @param array $data
+     *
+     * @return Response
+     */
+    public function createJsonResponse($status,array $data=array())
+    {
+    	$data['status']=$status;
+    
+    	return new Response(json_encode($data),200,array(
+    			'Content-Type'=>'application/json'
+    	));
+    }
+    
+    /**
      * Returns a NotFoundHttpException.
      *
      * This will result in a 404 response code. Usage example:


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo:
License of the code: MIT
Documentation PR:

This function does only make it quicker to create json responses. Refer to http://symfony2forum.org/threads/5-Using-Symfony2-jQuery-and-Ajax

The function could be replaced with:

``` php
new Response(json_encode($return),200,array('Content-Type'=>'application/json')); 
```

But there is a lot to write for a common response. 
