### PR TITLE
[translation] making symfony/config a dependency

### DIFF
--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": ">=5.3.3"
+        "symfony/config": "2.1.*",
     },
     "require-dev": {
-        "symfony/config": "2.1.*",
         "symfony/yaml": "2.1.*"
     },
     "suggest": {


### PR DESCRIPTION
If you try to use the translation component in silex, you'll get a fatal error because of the config component missing. I moved it to the require section from the require-dev.
