### PR TITLE
[Routing] Can't generate a route with dash (-) in the pattern and the parameter

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -66,6 +66,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/app.php/testing/bar', $url);
     }
 
+    public function testRelativeUrlWithParametersWhichContainsDash()
+    {
+        $routes = $this->getRoutes('test', new Route('/testing-{foo}'));
+        $url = $this->getGenerator($routes)->generate('test', array('foo' => 'bar-baz'));
+
+        $this->assertEquals('/app.php/testing-bar-baz', $url);
+    }
+
     public function testRelativeUrlWithNullParameter()
     {
         $routes = $this->getRoutes('test', new Route('/testing.{format}', array('format' => null)));


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: no
Fixes the following tickets: ~
Todo: Fix the failing test
License of the code: MIT
Documentation PR: ~

Hey!

I'm currently trying to generate a route with this pattern: `/foo-{slug}`. If my slug contains one or more dashes, the route can't be generated (I got an 500 error).

```
InvalidParameterException: Parameter "foo" for route "test" must match "[^\-]+" ("bar-baz" given).
```

I have added a failing tests.

Tell me if you need more information.
