### PR TITLE
[2.2] [WIP] [Security] Add method to retrieve ACLs by SecurityIdentities

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.1.0
 -----
 
+ * added AclProvider::findAclsBySids() 
  * [BC BREAK] The signature of ExceptionListener has changed
  * changed the HttpUtils constructor signature to take a UrlGenerator and a UrlMatcher instead of a Router
  * EncoderFactoryInterface::getEncoder() can now also take a class name as an argument

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Security\Tests\Acl\Dbal;
 use Symfony\Component\Security\Acl\Dbal\AclProvider;
 use Symfony\Component\Security\Acl\Domain\PermissionGrantingStrategy;
 use Symfony\Component\Security\Acl\Domain\ObjectIdentity;
+use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Dbal\Schema;
 use Doctrine\DBAL\DriverManager;
 
@@ -120,6 +121,33 @@ class AclProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Security\Acl\Domain\UserSecurityIdentity', $sid);
         $this->assertEquals('john.doe', $sid->getUsername());
         $this->assertEquals('SomeClass', $sid->getClass());
+    }
+
+    public function testFindAclBySecurityIdentity()
+    {
+        $provider = $this->getProvider();
+        $sid1 = new UserSecurityIdentity('john.doe', 'SomeClass');
+        $sid2 = new UserSecurityIdentity('john.doe@foo.com', 'MyClass');
+        $sid3 = new UserSecurityIdentity('123', 'FooClass');
+
+        $tests = array(
+            array($sid1,2),
+            array($sid2,2),
+            array($sid3,1)
+        );
+
+        $total = 0;
+        $sids = array();
+
+        foreach ($tests as $item) {
+            list($sid, $count) = $item;
+            $this->assertCount($count, $provider->findAclsBySids(array($sid)));
+
+            $total += $count;
+            $sids[] = $sid;
+            $this->assertCount($total, $provider->findAclsBySids($sids));
+        }
+
     }
 
     protected function setUp()


### PR DESCRIPTION
Current implementation did not allow to fetch specific ACLs based on
SecurityIdentities. Note that this implementation is not performace
oriented and should reuse the code for hydration of ACLs and ACEs.

Changelog was updated to reflect the change.

@schmittjoh what are your thoughts on this?

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: no | Unrelated tests do not pass, Related tests pass
Fixes the following tickets: -
Todo: Update code performance
License of the code: MIT
Documentation PR: -
