### PR TITLE
[2.2] added a way to enable the profiler for the very next request in a functional test

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+ * added Client::enableProfiler()
+
 2.1.0
 -----
 

--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -65,15 +65,13 @@ class Client extends BaseClient
     /**
      * Enables the profiler for the very next request.
      *
-     * @throws \LogicException if the profiler is not configured in the service container
+     * If the profiler is not enabled, the call to this method does nothing.
      */
     public function enableProfiler()
     {
-        if (!$this->kernel->getContainer()->has('profiler')) {
-            throw new \LogicException('You cannot enable the profiler as it is not configured in the service container.');
+        if ($this->kernel->getContainer()->has('profiler')) {
+            $this->profiler = true;
         }
-
-        $this->profiler = true;
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -135,6 +135,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('only_exceptions')->defaultFalse()->end()
                         ->booleanNode('only_master_requests')->defaultFalse()->end()
+                        ->booleanNode('enabled')->defaultTrue()->end()
                         ->scalarNode('dsn')->defaultValue('file:%kernel.cache_dir%/profiler')->end()
                         ->scalarNode('username')->defaultValue('')->end()
                         ->scalarNode('password')->defaultValue('')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -229,6 +229,10 @@ class FrameworkExtension extends Extension
                 }
             }
         }
+
+        if (!$config['enabled']) {
+            $container->getDefinition('profiler')->addMethodCall('disable', array());
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -50,6 +50,7 @@
 
         <xsd:attribute name="only-exceptions" type="xsd:string" />
         <xsd:attribute name="only-master-requests" type="xsd:string" />
+        <xsd:attribute name="enabled" type="xsd:string" />
         <xsd:attribute name="dsn" type="xsd:string" />
         <xsd:attribute name="username" type="xsd:string" />
         <xsd:attribute name="password" type="xsd:string" />

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -13,6 +13,7 @@ $container->loadFromExtension('framework', array(
     ),
     'profiler' => array(
         'only_exceptions' => true,
+        'enabled' => false,
     ),
     'router' => array(
         'resource'     => '%kernel.root_dir%/config/routing.xml',

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -10,7 +10,7 @@
         <framework:csrf-protection enabled="true" field-name="_csrf" />
         <framework:form />
         <framework:esi enabled="true" />
-        <framework:profiler only-exceptions="true" />
+        <framework:profiler only-exceptions="true" enabled="false" />
         <framework:router resource="%kernel.root_dir%/config/routing.xml" type="xml" />
         <framework:session gc-maxlifetime="90000" gc-probability="1" gc-divisor="108" storage-id="session.storage.native" handler-id="session.handler.native_file" name="_SYMFONY" cookie-lifetime="86400" cookie-path="/" cookie-domain="example.com" cookie-secure="true" cookie-httponly="true" save-path="/path/to/sessions" />
         <framework:templating assets-version="SomeVersionScheme" cache="/path/to/cache" >

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -9,6 +9,7 @@ framework:
         enabled: true
     profiler:
         only_exceptions: true
+        enabled: false
     router:
         resource:     %kernel.root_dir%/config/routing.xml
         type:         xml

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -48,6 +48,9 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('data_collector.config'), '->registerProfilerConfiguration() loads collectors.xml');
         $this->assertTrue($container->getParameter('profiler_listener.only_exceptions'));
         $this->assertEquals('%profiler_listener.only_exceptions%', $container->getDefinition('profiler_listener')->getArgument(2));
+
+        $calls = $container->getDefinition('profiler')->getMethodCalls();
+        $this->assertEquals('disable', $calls[0][0]);
     }
 
     public function testRouter()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Controller/ProfilerController.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\DependencyInjection\ContainerAware;
+
+class ProfilerController extends ContainerAware
+{
+    public function indexAction()
+    {
+        return new Response('Hello');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/Bundle/TestBundle/Resources/config/routing.yml
@@ -17,3 +17,7 @@ session_setflash:
 session_showflash:
     pattern: /session_showflash
     defaults: { _controller: TestBundle:Session:showFlash}
+
+profiler:
+    pattern: /profiler
+    defaults: { _controller: TestBundle:Profiler:index }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/ProfilerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Functional;
+
+/**
+ * @group functional
+ */
+class ProfilerTest extends WebTestCase
+{
+    /**
+     * @dataProvider getConfigs
+     */
+    public function testProfilerIsDisabled($insulate)
+    {
+        $client = $this->createClient(array('test_case' => 'Profiler', 'root_config' => 'config.yml'));
+        if ($insulate) {
+            $client->insulate();
+        }
+
+        $client->request('GET', '/profiler');
+        $this->assertFalse($client->getProfile());
+
+        // enable the profiler for the next request
+        $client->enableProfiler();
+        $crawler = $client->request('GET', '/profiler');
+        $profile = $client->getProfile();
+        $this->assertTrue(is_object($profile));
+
+        $client->request('GET', '/profiler');
+        $this->assertFalse($client->getProfile());
+    }
+
+    public function getConfigs()
+    {
+        return array(
+            array(false),
+            array(true),
+        );
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Profiler/bundles.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Profiler/bundles.php
@@ -1,0 +1,9 @@
+<?php
+
+use Symfony\Bundle\FrameworkBundle\Tests\Functional\Bundle\TestBundle\TestBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+return array(
+    new FrameworkBundle(),
+    new TestBundle(),
+);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Profiler/config.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Profiler/config.yml
@@ -1,0 +1,6 @@
+imports:
+    - { resource: ../config/default.yml }
+
+framework:
+    profiler:
+        enabled: false

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Profiler/routing.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/app/Profiler/routing.yml
@@ -1,0 +1,2 @@
+_sessiontest_bundle:
+    resource: @TestBundle/Resources/config/routing.yml

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -52,6 +52,14 @@ class Profiler
     }
 
     /**
+     * Enables the profiler.
+     */
+    public function enable()
+    {
+        $this->enabled = true;
+    }
+
+    /**
      * Loads the Profile for the given Response.
      *
      * @param Response $response A Response instance


### PR DESCRIPTION
Bug fix: yes/no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4307
Todo: -
License of the code: MIT
Documentation PR: should be done before merging

After merging this PR, we need to disable the profiler in the test environment in Symfony SE.
