### PR TITLE
Removed PHP 5.3.3 from the travis build as we require 5.3.4 now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3.3
   - 5.3
   - 5.4
 


### PR DESCRIPTION
This will fix the travis build.

We cannot add 5.3.4 to replace 5.3.3 as it is not available on Travis IIRC. @lsmith77 could you confirm this ?
