### PR TITLE
[Form] Added an exception for invalid type services

### DIFF
--- a/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
+++ b/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
@@ -43,7 +43,13 @@ class DependencyInjectionExtension implements FormExtensionInterface
             throw new \InvalidArgumentException(sprintf('The field type "%s" is not registered with the service container.', $name));
         }
 
-        return $this->container->get($this->typeServiceIds[$name]);
+        $type = $this->container->get($this->typeServiceIds[$name]);
+
+        if ($type->getName() !== $name) {
+            throw new \InvalidArgumentException(sprintf('The type name specified for the service %s does not match the actual name', $this->typeServiceIds[$name]));
+        }
+
+        return $type;
     }
 
     public function hasType($name)


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/stof/symfony.png?branch=form_safeguard)](http://travis-ci.org/stof/symfony) (Travis fails randomly for the performance test)
Fixes the following tickets: -
Todo: -

Before the introduction of the FormRegistry, the getName() method was
never used for types registered through the DI container. The
FormRegistry now uses the getName() method and missconfigured services
will trigger a notice.
This was reported in FriendsOfSymfony/FOSCommentBundle#234
