### PR TITLE
[TwigBundle] Improved logs display on exception page

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception.css
@@ -83,6 +83,10 @@ build: 56
     color: #AA3333;
     background: #f9ecec;
 }
+.sf-exceptionreset #logs .traces li.warning {
+    font-style: normal;
+    background: #ffcc00;
+}
 /* fix for Opera not liking empty <li> */
 .sf-exceptionreset .traces li:after {
     content: "\00A0";

--- a/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/logs.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Resources/views/Exception/logs.html.twig
@@ -1,7 +1,7 @@
 <ol class="traces logs">
     {% for log in logs %}
-        <li{% if log.priorityName in ['EMERG', 'ERR', 'CRIT', 'ALERT', 'ERROR', 'CRITICAL'] %} class="error"{% endif %}>
-            {{ log.message }}
+        <li{% if log.priority >= 400 %} class="error"{% elseif log.priority >= 300 %} class="warning"{% endif %}>
+            {{ log.priorityName }} - {{ log.message }}
         </li>
     {% endfor %}
 </ol>


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
- Add the priority level in front of log entries
- Better display of warnings
