### PR TITLE
[Propel1Bridge][Form] ModelType name is invalid

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/Type/ModelType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/ModelType.php
@@ -65,6 +65,6 @@ class ModelType extends AbstractType
 
     public function getName()
     {
-        return 'propel_model';
+        return 'model';
     }
 }


### PR DESCRIPTION
Since 6489a65960a05b6a5a4f5c5074b941a6765c6381 "[Form] Added an exception for invalid type services" Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension requires form type names to match the service name.

This fixes exception "The type name specified for the service propel.form.type.model does not match the actual name"
