### PR TITLE
[Form] '@group benchmark' for form performance tests

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -93,6 +93,8 @@ class EntityTypePerformanceTest extends FormPerformanceTestCase
     /**
      * This test case is realistic in collection forms where each
      * row contains the same entity field.
+     *
+     * @group benchmark
      */
     public function testCollapsedEntityField()
     {

--- a/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
@@ -18,6 +18,8 @@ class CompoundFormPerformanceTest extends FormPerformanceTestCase
 {
     /**
      * Create a compound form multiple times, as happens in a collection form
+     *
+     * @group benchmark
      */
     public function testArrayBasedForm()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
@@ -21,6 +21,8 @@ class ChoiceTypePerformanceTest extends FormPerformanceTestCase
     /**
      * This test case is realistic in collection forms where each
      * row contains the same choice field.
+     *
+     * @group benchmark
      */
     public function testSameChoiceFieldCreatedMultipleTimes()
     {


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=form-performance)](http://travis-ci.org/asm89/symfony)
License of the code: MIT

I think a PR or note about this has been rejected before, but since build statuses on PRs sometimes seem to fail if travis is busy I think moving the form performance tests to `@group benchmark` should be reconsidered.

Edit: even master is currently failing on this
