### PR TITLE
[Security] Implemented the Serializable interface in the Role class

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.1.0
 -----
 
+ * Added the Serializable interface on the Role class
  * [BC BREAK] The signature of ExceptionListener has changed
  * changed the HttpUtils constructor signature to take a UrlGenerator and a UrlMatcher instead of a Router
  * EncoderFactoryInterface::getEncoder() can now also take a class name as an argument

--- a/src/Symfony/Component/Security/Core/Role/Role.php
+++ b/src/Symfony/Component/Security/Core/Role/Role.php
@@ -17,7 +17,7 @@ namespace Symfony\Component\Security\Core\Role;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Role implements RoleInterface
+class Role implements RoleInterface, \Serializable
 {
     private $role;
 
@@ -37,5 +37,21 @@ class Role implements RoleInterface
     public function getRole()
     {
         return $this->role;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize($this->role);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        $this->role = unserialize($serialized);
     }
 }

--- a/src/Symfony/Component/Security/Core/Role/SwitchUserRole.php
+++ b/src/Symfony/Component/Security/Core/Role/SwitchUserRole.php
@@ -45,4 +45,22 @@ class SwitchUserRole extends Role
     {
         return $this->source;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function serialize()
+    {
+        return serialize(array(parent::serialize(), $this->source));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
+    {
+        list($parent, $this->source) = unserialize($serialized);
+
+        parent::unserialize($parent);
+    }
 }


### PR DESCRIPTION
The Role class is serialized in the session for each role of the user. Implementing the Serializable interface allows to reduce the size of the data.
