### PR TITLE
Further improving the MessageSelector exception

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -74,7 +74,7 @@ class MessageSelector
 
         $position = PluralizationRules::get($number, $locale);
         if (!isset($standardRules[$position])) {
-            throw new \InvalidArgumentException(sprintf('Unable to choose a translation for "%s" with locale "%s".', $message, $locale));
+            throw new \InvalidArgumentException(sprintf('Unable to choose a translation for "%s" with locale "%s". Double check that this translation has the correct plural options (e.g. "There is one apple|There is %%count%% apples").', $message, $locale));
         }
 
         return $standardRules[$position];


### PR DESCRIPTION
Hey guys!

The goal is just to give the users a better starting point when they see this exception.

See previous change in #4173 and conversation in #4207

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4207
Todo: -
License of the code: MIT
Documentation PR: n/a

Thanks!
