### PR TITLE
[Validator] Added inheritDoc phpdoc for validate methods

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/AllValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/AllValidator.php
@@ -23,12 +23,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class AllValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/BlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/BlankValidator.php
@@ -22,12 +22,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class BlankValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CallbackValidator.php
@@ -26,12 +26,7 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
 class CallbackValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $object     The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($object, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -28,12 +28,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class ChoiceValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -25,12 +25,7 @@ use Symfony\Component\Validator\Constraints\Collection\Required;
 class CollectionValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/CountValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountValidator.php
@@ -21,10 +21,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class CountValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/CountryValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CountryValidator.php
@@ -25,12 +25,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class CountryValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/DateValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateValidator.php
@@ -25,12 +25,7 @@ class DateValidator extends ConstraintValidator
     const PATTERN = '/^(\d{4})-(\d{2})-(\d{2})$/';
 
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/EmailValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/EmailValidator.php
@@ -23,12 +23,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class EmailValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/FalseValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FalseValidator.php
@@ -22,12 +22,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class FalseValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/FileValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/FileValidator.php
@@ -26,12 +26,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class FileValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/ImageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ImageValidator.php
@@ -22,6 +22,9 @@ use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
  */
 class ImageValidator extends FileValidator
 {
+    /**
+     * {@inheritDoc}
+     */
     public function validate($value, Constraint $constraint)
     {
         $violations = count($this->context->getViolations());

--- a/src/Symfony/Component/Validator/Constraints/IpValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IpValidator.php
@@ -26,12 +26,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class IpValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LanguageValidator.php
@@ -25,12 +25,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class LanguageValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/LengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LengthValidator.php
@@ -21,10 +21,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class LengthValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LocaleValidator.php
@@ -25,12 +25,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class LocaleValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLengthValidator.php
@@ -25,12 +25,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class MaxLengthValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/MaxValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxValidator.php
@@ -24,12 +24,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class MaxValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constrain for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLengthValidator.php
@@ -25,12 +25,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class MinLengthValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotBlankValidator.php
@@ -22,12 +22,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class NotBlankValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NotNullValidator.php
@@ -22,12 +22,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class NotNullValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/NullValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NullValidator.php
@@ -22,12 +22,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class NullValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/RangeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RangeValidator.php
@@ -20,12 +20,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class RangeValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @return Boolean Whether or not the value is valid
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/RegexValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/RegexValidator.php
@@ -26,12 +26,7 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 class RegexValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/TimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TimeValidator.php
@@ -25,12 +25,7 @@ class TimeValidator extends ConstraintValidator
     const PATTERN = '/^(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/';
 
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/TrueValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TrueValidator.php
@@ -22,12 +22,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class TrueValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/TypeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/TypeValidator.php
@@ -22,12 +22,7 @@ use Symfony\Component\Validator\ConstraintValidator;
 class TypeValidator extends ConstraintValidator
 {
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {

--- a/src/Symfony/Component/Validator/Constraints/UrlValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/UrlValidator.php
@@ -38,12 +38,7 @@ class UrlValidator extends ConstraintValidator
         $~ixu';
 
     /**
-     * Checks if the passed value is valid.
-     *
-     * @param mixed      $value      The value that should be validated
-     * @param Constraint $constraint The constraint for the validation
-     *
-     * @api
+     * {@inheritDoc}
      */
     public function validate($value, Constraint $constraint)
     {


### PR DESCRIPTION
Was instructed by @stof to do this for a PR on comparison validators and noticed none of the validators used inheritDoc.

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: n/a
Todo: I haven't looked around too much, but I assume if none of the validators followed this standard that there would be a fair few other classes not using. Obviously not a big issue though
License of the code: MIT
Documentation PR: n/a
