### PR TITLE
[Form] added a bc break note about the tag alias matching

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -172,3 +172,4 @@ CHANGELOG
  * ChoiceType now caches its created choice lists to improve performance
  * [BC BREAK] Rows of a collection field cannot be themed individually anymore. All rows in the collection
    field now have the same block names, which contains "entry" where it previously contained the row index.
+ * [BC BREAK] When registering a type through the DI extension, the tag alias has to match the actual type name.


### PR DESCRIPTION
6489a65960a05b6a5a4f5c5074b941a6765c6381 is a BC break if we were relying on the previous behavior.
