### PR TITLE
[2.2][Security] AuthenticationException enhancements

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -527,6 +527,11 @@ class FrameworkExtension extends Extension
 
                 $dirs[] = dirname($r->getFilename()).'/Resources/translations';
             }
+            if (class_exists('Symfony\Component\Security\Core\Exception\AuthenticationException')) {
+                $r = new \ReflectionClass('Symfony\Component\Security\Core\Exception\AuthenticationException');
+
+                $dirs[] = dirname($r->getFilename()).'/../../Resources/translations';
+            }
             $overridePath = $container->getParameter('kernel.root_dir').'/Resources/%s/translations';
             foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
                 $reflection = new \ReflectionClass($class);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -205,6 +205,11 @@ abstract class FrameworkExtensionTest extends TestCase
             $files,
             '->registerTranslatorConfiguration() finds Form translation resources'
         );
+        $this->assertContains(
+            'Symfony/Component/Security/Resources/translations/exceptions.en.xlf',
+            $files,
+            '->registerTranslatorConfiguration() finds Security translation resources'
+        );
 
         $calls = $container->getDefinition('translator.default')->getMethodCalls();
         $this->assertEquals('fr', $calls[0][1][0]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -206,7 +206,7 @@ abstract class FrameworkExtensionTest extends TestCase
             '->registerTranslatorConfiguration() finds Form translation resources'
         );
         $this->assertContains(
-            'Symfony/Component/Security/Resources/translations/exceptions.en.xlf',
+            'Symfony/Component/Security/Resources/translations/security.en.xlf',
             $files,
             '->registerTranslatorConfiguration() finds Security translation resources'
         );

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -29,7 +29,8 @@
         "doctrine/common": ">=2.2,<2.4-dev"
     },
     "require-dev": {
-        "symfony/finder": "2.2.*"
+        "symfony/finder": "2.2.*",
+        "symfony/security": "2.2.*"
     },
     "suggest": {
         "symfony/console": "2.2.*",

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -37,4 +37,5 @@ CHANGELOG
  * [BC BREAK] The constructor of `AuthenticationException` and all child
    classes now matches the constructor of `\Exception`. The extra information
    getters and setters are removed. There are now dedicated getters/setters for
-   token (`AuthenticationException') and user (`AccountStatusException`).
+   token (`AuthenticationException'), user (`AccountStatusException`) and
+   username (`UsernameNotFoundException`).

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -34,3 +34,6 @@ CHANGELOG
    `AbstractAuthenticationListener` has changed.
  * [BC BREAK] moved the default logout success handling to a separate class. The
    order of arguments in the constructor of `LogoutListener` has changed.
+ * [BC BREAK] The constructor of `AuthenticationException` and all child
+   classes now matches the constructor of `\Exception`. Extra information
+   should be passed via the `setExtraInformation` setter.

--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -35,5 +35,6 @@ CHANGELOG
  * [BC BREAK] moved the default logout success handling to a separate class. The
    order of arguments in the constructor of `LogoutListener` has changed.
  * [BC BREAK] The constructor of `AuthenticationException` and all child
-   classes now matches the constructor of `\Exception`. Extra information
-   should be passed via the `setExtraInformation` setter.
+   classes now matches the constructor of `\Exception`. The extra information
+   getters and setters are removed. There are now dedicated getters/setters for
+   token (`AuthenticationException') and user (`AccountStatusException`).

--- a/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
+++ b/src/Symfony/Component/Security/Core/Authentication/AuthenticationProviderManager.php
@@ -77,7 +77,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
                     break;
                 }
             } catch (AccountStatusException $e) {
-                $e->setExtraInformation($token);
+                $e->setToken($token);
 
                 throw $e;
             } catch (AuthenticationException $e) {
@@ -105,7 +105,7 @@ class AuthenticationProviderManager implements AuthenticationManagerInterface
             $this->eventDispatcher->dispatch(AuthenticationEvents::AUTHENTICATION_FAILURE, new AuthenticationFailureEvent($token, $lastException));
         }
 
-        $lastException->setExtraInformation($token);
+        $lastException->setToken($token);
 
         throw $lastException;
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -90,7 +90,9 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
         } catch (UsernameNotFoundException $notFound) {
             throw $notFound;
         } catch (\Exception $repositoryProblem) {
-            throw new AuthenticationServiceException($repositoryProblem->getMessage(), $token, 0, $repositoryProblem);
+            $ex = new AuthenticationServiceException($repositoryProblem->getMessage(), 0, $repositoryProblem);
+            $ex->setExtraInformation($token);
+            throw $ex;
         }
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -88,6 +88,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
 
             return $user;
         } catch (UsernameNotFoundException $notFound) {
+            $notFound->setUsername($username);
             throw $notFound;
         } catch (\Exception $repositoryProblem) {
             $ex = new AuthenticationServiceException($repositoryProblem->getMessage(), 0, $repositoryProblem);

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/DaoAuthenticationProvider.php
@@ -91,7 +91,7 @@ class DaoAuthenticationProvider extends UserAuthenticationProvider
             throw $notFound;
         } catch (\Exception $repositoryProblem) {
             $ex = new AuthenticationServiceException($repositoryProblem->getMessage(), 0, $repositoryProblem);
-            $ex->setExtraInformation($token);
+            $ex->setToken($token);
             throw $ex;
         }
     }

--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -71,6 +71,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
             if ($this->hideUserNotFoundExceptions) {
                 throw new BadCredentialsException('Bad credentials', 0, $notFound);
             }
+            $notFound->setUsername($username);
 
             throw $notFound;
         }

--- a/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
@@ -24,6 +24,6 @@ class AccountExpiredException extends AccountStatusException
      */
     public function getMessageKey()
     {
-        return 'security.exception.account_expired_exception';
+        return 'Account has expired.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountExpiredException.php
@@ -15,7 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * AccountExpiredException is thrown when the user account has expired.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class AccountExpiredException extends AccountStatusException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.account_expired_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -11,12 +11,36 @@
 
 namespace Symfony\Component\Security\Core\Exception;
 
+use Symfony\Component\Security\Core\User\UserInterface;
+
 /**
  * AccountStatusException is the base class for authentication exceptions
  * caused by the user account status.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 abstract class AccountStatusException extends AuthenticationException
 {
+    private $user;
+
+    /**
+     * Get the user.
+     *
+     * @return UserInterface
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * Set the user.
+     *
+     * @param UserInterface $user
+     */
+    public function setUser(UserInterface $user)
+    {
+        $this->user = $user;
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -60,10 +60,8 @@ abstract class AccountStatusException extends AuthenticationException
      */
     public function unserialize($str)
     {
-        list(
-            $this->user,
-            $parentData
-        ) = unserialize($str);
+        list($this->user, $parentData) = unserialize($str);
+
         parent::unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AccountStatusException.php
@@ -43,4 +43,27 @@ abstract class AccountStatusException extends AuthenticationException
     {
         $this->user = $user;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function serialize()
+    {
+        return serialize(array(
+            $this->user,
+            parent::serialize(),
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unserialize($str)
+    {
+        list(
+            $this->user,
+            $parentData
+        ) = unserialize($str);
+        parent::unserialize($parentData);
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
@@ -16,7 +16,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * because no Token is available.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class AuthenticationCredentialsNotFoundException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.authentication_credentials_not_found_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationCredentialsNotFoundException.php
@@ -25,6 +25,6 @@ class AuthenticationCredentialsNotFoundException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.authentication_credentials_not_found_exception';
+        return 'Authentication credentials could not be found.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Exception;
 
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+
 /**
  * AuthenticationException is the base class for all authentication exceptions.
  *
@@ -19,16 +21,26 @@ namespace Symfony\Component\Security\Core\Exception;
  */
 class AuthenticationException extends \RuntimeException implements \Serializable
 {
-    private $extraInformation;
+    private $token;
 
-    public function getExtraInformation()
+    /**
+     * Get the token.
+     *
+     * @return TokenInterface
+     */
+    public function getToken()
     {
-        return $this->extraInformation;
+        return $this->token;
     }
 
-    public function setExtraInformation($extraInformation)
+    /**
+     * Set the token.
+     *
+     * @param TokenInterface $token
+     */
+    public function setToken(TokenInterface $token)
     {
-        $this->extraInformation = $extraInformation;
+        $this->token = $token;
     }
 
     public function serialize()

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -52,4 +52,24 @@ class AuthenticationException extends \RuntimeException implements \Serializable
             $this->line
         ) = unserialize($str);
     }
+
+    /**
+     * Message key to be used by the translation component.
+     *
+     * @return string
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.authentication_exception';
+    }
+
+    /**
+     * Message data to be used by the translation component.
+     *
+     * @return array
+     */
+    public function getMessageData()
+    {
+        return array();
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -72,7 +72,7 @@ class AuthenticationException extends \RuntimeException implements \Serializable
      */
     public function getMessageKey()
     {
-        return 'security.exception.authentication_exception';
+        return 'An authentication exception occurred.';
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -46,7 +46,7 @@ class AuthenticationException extends \RuntimeException implements \Serializable
     public function serialize()
     {
         return serialize(array(
-            $this->extraInformation,
+            $this->token,
             $this->code,
             $this->message,
             $this->file,
@@ -57,7 +57,7 @@ class AuthenticationException extends \RuntimeException implements \Serializable
     public function unserialize($str)
     {
         list(
-            $this->extraInformation,
+            $this->token,
             $this->code,
             $this->message,
             $this->file,

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationException.php
@@ -15,17 +15,11 @@ namespace Symfony\Component\Security\Core\Exception;
  * AuthenticationException is the base class for all authentication exceptions.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class AuthenticationException extends \RuntimeException implements \Serializable
 {
     private $extraInformation;
-
-    public function __construct($message, $extraInformation = null, $code = 0, \Exception $previous = null)
-    {
-        parent::__construct($message, $code, $previous);
-
-        $this->extraInformation = $extraInformation;
-    }
 
     public function getExtraInformation()
     {

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
@@ -15,7 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * AuthenticationServiceException is thrown when an authentication request could not be processed due to a system problem.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class AuthenticationServiceException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.authentication_service_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
+++ b/src/Symfony/Component/Security/Core/Exception/AuthenticationServiceException.php
@@ -24,6 +24,6 @@ class AuthenticationServiceException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.authentication_service_exception';
+        return 'Authentication request could not be processed due to a system problem.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
+++ b/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
@@ -15,11 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * BadCredentialsException is thrown when the user credentials are invalid.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class BadCredentialsException extends AuthenticationException
 {
-    public function __construct($message, $code = 0, \Exception $previous = null)
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
     {
-        parent::__construct($message, null, $code, $previous);
+        return 'security.exception.bad_credentials_exception';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
+++ b/src/Symfony/Component/Security/Core/Exception/BadCredentialsException.php
@@ -24,6 +24,6 @@ class BadCredentialsException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.bad_credentials_exception';
+        return 'Invalid credentials.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
@@ -16,7 +16,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * detects that a presented cookie has already been used by someone else.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class CookieTheftException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.cookie_theft_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CookieTheftException.php
@@ -25,6 +25,6 @@ class CookieTheftException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.cookie_theft_exception';
+        return 'Cookie has already been used by someone else.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
@@ -15,7 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * CredentialsExpiredException is thrown when the user account credentials have expired.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class CredentialsExpiredException extends AccountStatusException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.credentials_expired_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/CredentialsExpiredException.php
@@ -24,6 +24,6 @@ class CredentialsExpiredException extends AccountStatusException
      */
     public function getMessageKey()
     {
-        return 'security.exception.credentials_expired_exception';
+        return 'Credentials have expired.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/DisabledException.php
+++ b/src/Symfony/Component/Security/Core/Exception/DisabledException.php
@@ -15,7 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * DisabledException is thrown when the user account is disabled.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class DisabledException extends AccountStatusException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.disabled_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/DisabledException.php
+++ b/src/Symfony/Component/Security/Core/Exception/DisabledException.php
@@ -24,6 +24,6 @@ class DisabledException extends AccountStatusException
      */
     public function getMessageKey()
     {
-        return 'security.exception.disabled_exception';
+        return 'Account is disabled.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
@@ -17,7 +17,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * This is the case when a user is anonymous and the resource to be displayed has an access role.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class InsufficientAuthenticationException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.insufficient_authentication_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InsufficientAuthenticationException.php
@@ -26,6 +26,6 @@ class InsufficientAuthenticationException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.insufficient_authentication_exception';
+        return 'Not privileged to request the resource.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
@@ -24,6 +24,6 @@ class InvalidCsrfTokenException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.invalid_csrf_token_exception';
+        return 'Invalid CSRF token.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
+++ b/src/Symfony/Component/Security/Core/Exception/InvalidCsrfTokenException.php
@@ -15,7 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * This exception is thrown when the csrf token is invalid.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class InvalidCsrfTokenException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.invalid_csrf_token_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/LockedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/LockedException.php
@@ -24,6 +24,6 @@ class LockedException extends AccountStatusException
      */
     public function getMessageKey()
     {
-        return 'security.exception.locked_exception';
+        return 'Account is locked.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/LockedException.php
+++ b/src/Symfony/Component/Security/Core/Exception/LockedException.php
@@ -15,7 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * LockedException is thrown if the user account is locked.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class LockedException extends AccountStatusException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.locked_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/NonceExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/NonceExpiredException.php
@@ -27,6 +27,6 @@ class NonceExpiredException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.nonce_expired_exception';
+        return 'Digest nonce has expired.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/NonceExpiredException.php
+++ b/src/Symfony/Component/Security/Core/Exception/NonceExpiredException.php
@@ -18,7 +18,15 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
  * the digest nonce has expired.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class NonceExpiredException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.nonce_expired_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
@@ -25,6 +25,6 @@ class ProviderNotFoundException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.provider_not_found_exception';
+        return 'No authentication provider found to support the authentication token.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/ProviderNotFoundException.php
@@ -16,7 +16,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * supports an authentication Token.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class ProviderNotFoundException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.provider_not_found_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
+++ b/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
@@ -30,6 +30,6 @@ class SessionUnavailableException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.session_unavailable_exception';
+        return 'No session available, it either timed out or cookies are not enabled.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
+++ b/src/Symfony/Component/Security/Core/Exception/SessionUnavailableException.php
@@ -21,7 +21,15 @@ namespace Symfony\Component\Security\Core\Exception;
  *        request.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class SessionUnavailableException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.session_unavailable_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
@@ -1,5 +1,4 @@
 <?php
-namespace Symfony\Component\Security\Core\Exception;
 
 /*
  * This file is part of the Symfony package.
@@ -9,6 +8,8 @@ namespace Symfony\Component\Security\Core\Exception;
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
+namespace Symfony\Component\Security\Core\Exception;
 
 /**
  * TokenNotFoundException is thrown if a Token cannot be found.
@@ -23,6 +24,6 @@ class TokenNotFoundException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.token_not_found_exception';
+        return 'No token could be found.';
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/TokenNotFoundException.php
@@ -14,7 +14,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * TokenNotFoundException is thrown if a Token cannot be found.
  *
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class TokenNotFoundException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.token_not_found_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -26,7 +26,7 @@ class UsernameNotFoundException extends AuthenticationException
      */
     public function getMessageKey()
     {
-        return 'security.exception.username_not_found_exception';
+        return 'Username could not be found.';
     }
 
     /**

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -19,11 +19,33 @@ namespace Symfony\Component\Security\Core\Exception;
  */
 class UsernameNotFoundException extends AuthenticationException
 {
+    private $username;
+
     /**
      * {@inheritDoc}
      */
     public function getMessageKey()
     {
         return 'security.exception.username_not_found_exception';
+    }
+
+    /**
+     * Get the username.
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Set the username.
+     *
+     * @param string $username
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -15,7 +15,15 @@ namespace Symfony\Component\Security\Core\Exception;
  * UsernameNotFoundException is thrown if a User cannot be found by its username.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Alexander <iam.asm89@gmail.com>
  */
 class UsernameNotFoundException extends AuthenticationException
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function getMessageKey()
+    {
+        return 'security.exception.username_not_found_exception';
+    }
 }

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -65,10 +65,8 @@ class UsernameNotFoundException extends AuthenticationException
      */
     public function unserialize($str)
     {
-        list(
-            $this->username,
-            $parentData
-        ) = unserialize($str);
+        list($this->username, $parentData) = unserialize($str);
+
         parent::unserialize($parentData);
     }
 }

--- a/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
+++ b/src/Symfony/Component/Security/Core/Exception/UsernameNotFoundException.php
@@ -48,4 +48,27 @@ class UsernameNotFoundException extends AuthenticationException
     {
         $this->username = $username;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function serialize()
+    {
+        return serialize(array(
+            $this->username,
+            parent::serialize(),
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function unserialize($str)
+    {
+        list(
+            $this->username,
+            $parentData
+        ) = unserialize($str);
+        parent::unserialize($parentData);
+    }
 }

--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -44,7 +44,9 @@ class ChainUserProvider implements UserProviderInterface
             }
         }
 
-        throw new UsernameNotFoundException(sprintf('There is no user with name "%s".', $username));
+        $ex = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $username));
+        $ex->setUsername($username);
+        throw $ex;
     }
 
     /**
@@ -66,7 +68,9 @@ class ChainUserProvider implements UserProviderInterface
         }
 
         if ($supportedUserFound) {
-            throw new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
+            $ex = new UsernameNotFoundException(sprintf('There is no user with name "%s".', $user->getUsername()));
+            $ex->setUsername($user->getUsername());
+            throw $ex;
         } else {
             throw new UnsupportedUserException(sprintf('The account "%s" is not supported.', get_class($user)));
         }

--- a/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/InMemoryUserProvider.php
@@ -68,7 +68,10 @@ class InMemoryUserProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
         if (!isset($this->users[strtolower($username)])) {
-            throw new UsernameNotFoundException(sprintf('Username "%s" does not exist.', $username));
+            $ex = new UsernameNotFoundException(sprintf('Username "%s" does not exist.', $username));
+            $ex->setUsername($username);
+
+            throw $ex;
         }
 
         $user = $this->users[strtolower($username)];

--- a/src/Symfony/Component/Security/Core/User/UserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/UserChecker.php
@@ -55,7 +55,7 @@ class UserChecker implements UserCheckerInterface
         }
 
         if (!$user->isEnabled()) {
-            throw new DisabledException('User account is disabled.');
+            $ex = new DisabledException('User account is disabled.');
             $ex->setUser($user);
             throw $ex;
         }

--- a/src/Symfony/Component/Security/Core/User/UserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/UserChecker.php
@@ -33,7 +33,9 @@ class UserChecker implements UserCheckerInterface
         }
 
         if (!$user->isCredentialsNonExpired()) {
-            throw new CredentialsExpiredException('User credentials have expired.', $user);
+            $ex = new CredentialsExpiredException('User credentials have expired.');
+            $ex->setExtraInformation($user);
+            throw $ex;
         }
     }
 
@@ -47,15 +49,21 @@ class UserChecker implements UserCheckerInterface
         }
 
         if (!$user->isAccountNonLocked()) {
-            throw new LockedException('User account is locked.', $user);
+            $ex = new LockedException('User account is locked.');
+            $ex->setExtraInformation($user);
+            throw $ex;
         }
 
         if (!$user->isEnabled()) {
-            throw new DisabledException('User account is disabled.', $user);
+            throw new DisabledException('User account is disabled.');
+            $ex->setExtraInformation($user);
+            throw $ex;
         }
 
         if (!$user->isAccountNonExpired()) {
-            throw new AccountExpiredException('User account has expired.', $user);
+            $ex = new AccountExpiredException('User account has expired.');
+            $ex->setExtraInformation($user);
+            throw $ex;
         }
     }
 }

--- a/src/Symfony/Component/Security/Core/User/UserChecker.php
+++ b/src/Symfony/Component/Security/Core/User/UserChecker.php
@@ -34,7 +34,7 @@ class UserChecker implements UserCheckerInterface
 
         if (!$user->isCredentialsNonExpired()) {
             $ex = new CredentialsExpiredException('User credentials have expired.');
-            $ex->setExtraInformation($user);
+            $ex->setUser($user);
             throw $ex;
         }
     }
@@ -50,19 +50,19 @@ class UserChecker implements UserCheckerInterface
 
         if (!$user->isAccountNonLocked()) {
             $ex = new LockedException('User account is locked.');
-            $ex->setExtraInformation($user);
+            $ex->setUser($user);
             throw $ex;
         }
 
         if (!$user->isEnabled()) {
             throw new DisabledException('User account is disabled.');
-            $ex->setExtraInformation($user);
+            $ex->setUser($user);
             throw $ex;
         }
 
         if (!$user->isAccountNonExpired()) {
             $ex = new AccountExpiredException('User account has expired.');
-            $ex->setExtraInformation($user);
+            $ex->setUser($user);
             throw $ex;
         }
     }

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -106,7 +106,9 @@ class ExceptionListener
                 }
 
                 try {
-                    $response = $this->startAuthentication($request, new InsufficientAuthenticationException('Full authentication is required to access this resource.', $token, 0, $exception));
+                    $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
+                    $insufficientAuthenticationException->setExtraInformation($token);
+                    $response = $this->startAuthentication($request, $insufficientAuthenticationException);
                 } catch (\Exception $e) {
                     $event->setException($e);
 

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -107,7 +107,7 @@ class ExceptionListener
 
                 try {
                     $insufficientAuthenticationException = new InsufficientAuthenticationException('Full authentication is required to access this resource.', 0, $exception);
-                    $insufficientAuthenticationException->setExtraInformation($token);
+                    $insufficientAuthenticationException->setToken($token);
                     $response = $this->startAuthentication($request, $insufficientAuthenticationException);
                 } catch (\Exception $e) {
                     $event->setException($e);

--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -43,7 +43,7 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
             $user = $this->getUserProvider($class)->loadUserByUsername($username);
         } catch (\Exception $ex) {
             if (!$ex instanceof AuthenticationException) {
-                $ex = new AuthenticationException($ex->getMessage(), null, $ex->getCode(), $ex);
+                $ex = new AuthenticationException($ex->getMessage(), $ex->getCode(), $ex);
             }
 
             throw $ex;

--- a/src/Symfony/Component/Security/Resources/translations/exceptions.en.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/exceptions.en.xlf
@@ -50,6 +50,22 @@
                 <source>security.exception.username_not_found_exception</source>
                 <target>Username could not be found.</target>
             </trans-unit>
+            <trans-unit id="13">
+                <source>security.exception.account_expired_exception</source>
+                <target>Account has expired.</target>
+            </trans-unit>
+            <trans-unit id="14">
+                <source>security.exception.credentials_expired_exception</source>
+                <target>Credentials have expired.</target>
+            </trans-unit>
+            <trans-unit id="15">
+                <source>security.exception.credentials_expired_exception</source>
+                <target>Account is disabled.</target>
+            </trans-unit>
+            <trans-unit id="16">
+                <source>security.exception.credentials_expired_exception</source>
+                <target>Account is locked.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Security/Resources/translations/exceptions.en.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/exceptions.en.xlf
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="file.ext">
+        <body>
+            <trans-unit id="1">
+                <source>security.exception.authentication_exception</source>
+                <target>An authentication exception occured.</target>
+            </trans-unit>
+            <trans-unit id="2">
+                <source>security.exception.authentication_credentials_not_found_exception</source>
+                <target>Authentication credentials could not be found.</target>
+            </trans-unit>
+            <trans-unit id="3">
+                <source>security.exception.authentication_service_exception</source>
+                <target>Authentication request could not be processed due to a system problem.</target>
+            </trans-unit>
+            <trans-unit id="4">
+                <source>security.exception.bad_credentials_exception</source>
+                <target>Invalid credentials.</target>
+            </trans-unit>
+            <trans-unit id="5">
+                <source>security.exception.cookie_theft_exception</source>
+                <target>Cookie has already been used by someone else.</target>
+            </trans-unit>
+            <trans-unit id="6">
+                <source>security.exception.insufficient_authentication_exception</source>
+                <target>Not priviliged to request the resource.</target>
+            </trans-unit>
+            <trans-unit id="7">
+                <source>security.exception.invalid_csrf_token_exception</source>
+                <target>Invalid CSRF token.</target>
+            </trans-unit>
+            <trans-unit id="8">
+                <source>security.exception.nonce_expired_exception</source>
+                <target>Digest nonce has expired.</target>
+            </trans-unit>
+            <trans-unit id="9">
+                <source>security.exception.provider_not_found_exception</source>
+                <target>No authentication provider found to support the authentication token.</target>
+            </trans-unit>
+            <trans-unit id="10">
+                <source>security.exception.session_unavailable_exception</source>
+                <target>No session available.</target>
+            </trans-unit>
+            <trans-unit id="11">
+                <source>security.exception.token_not_found_exception</source>
+                <target>No token could be found.</target>
+            </trans-unit>
+            <trans-unit id="12">
+                <source>security.exception.username_not_found_exception</source>
+                <target>Username could not be found.</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/src/Symfony/Component/Security/Resources/translations/security.en.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.en.xlf
@@ -3,67 +3,67 @@
     <file source-language="en" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="1">
-                <source>security.exception.authentication_exception</source>
-                <target>An authentication exception occured.</target>
+                <source>An authentication exception occurred.</source>
+                <target>An authentication exception occurred.</target>
             </trans-unit>
             <trans-unit id="2">
-                <source>security.exception.authentication_credentials_not_found_exception</source>
+                <source>Authentication credentials could not be found.</source>
                 <target>Authentication credentials could not be found.</target>
             </trans-unit>
             <trans-unit id="3">
-                <source>security.exception.authentication_service_exception</source>
+                <source>Authentication request could not be processed due to a system problem.</source>
                 <target>Authentication request could not be processed due to a system problem.</target>
             </trans-unit>
             <trans-unit id="4">
-                <source>security.exception.bad_credentials_exception</source>
+                <source>Invalid credentials.</source>
                 <target>Invalid credentials.</target>
             </trans-unit>
             <trans-unit id="5">
-                <source>security.exception.cookie_theft_exception</source>
+                <source>Cookie has already been used by someone else.</source>
                 <target>Cookie has already been used by someone else.</target>
             </trans-unit>
             <trans-unit id="6">
-                <source>security.exception.insufficient_authentication_exception</source>
-                <target>Not priviliged to request the resource.</target>
+                <source>Not privileged to request the resource.</source>
+                <target>Not privileged to request the resource.</target>
             </trans-unit>
             <trans-unit id="7">
-                <source>security.exception.invalid_csrf_token_exception</source>
+                <source>Invalid CSRF token.</source>
                 <target>Invalid CSRF token.</target>
             </trans-unit>
             <trans-unit id="8">
-                <source>security.exception.nonce_expired_exception</source>
+                <source>Digest nonce has expired.</source>
                 <target>Digest nonce has expired.</target>
             </trans-unit>
             <trans-unit id="9">
-                <source>security.exception.provider_not_found_exception</source>
+                <source>No authentication provider found to support the authentication token.</source>
                 <target>No authentication provider found to support the authentication token.</target>
             </trans-unit>
             <trans-unit id="10">
-                <source>security.exception.session_unavailable_exception</source>
-                <target>No session available.</target>
+                <source>No session available, it either timed out or cookies are not enabled.</source>
+                <target>No session available, it either timed out or cookies are not enabled.</target>
             </trans-unit>
             <trans-unit id="11">
-                <source>security.exception.token_not_found_exception</source>
+                <source>No token could be found.</source>
                 <target>No token could be found.</target>
             </trans-unit>
             <trans-unit id="12">
-                <source>security.exception.username_not_found_exception</source>
+                <source>Username could not be found.</source>
                 <target>Username could not be found.</target>
             </trans-unit>
             <trans-unit id="13">
-                <source>security.exception.account_expired_exception</source>
+                <source>Account has expired.</source>
                 <target>Account has expired.</target>
             </trans-unit>
             <trans-unit id="14">
-                <source>security.exception.credentials_expired_exception</source>
+                <source>Credentials have expired.</source>
                 <target>Credentials have expired.</target>
             </trans-unit>
             <trans-unit id="15">
-                <source>security.exception.credentials_expired_exception</source>
+                <source>Account is disabled.</source>
                 <target>Account is disabled.</target>
             </trans-unit>
             <trans-unit id="16">
-                <source>security.exception.credentials_expired_exception</source>
+                <source>Account is locked.</source>
                 <target>Account is locked.</target>
             </trans-unit>
         </body>

--- a/src/Symfony/Component/Security/Tests/Core/Authentication/AuthenticationProviderManagerTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Authentication/AuthenticationProviderManagerTest.php
@@ -37,7 +37,7 @@ class AuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
             $manager->authenticate($token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
             $this->fail();
         } catch (ProviderNotFoundException $e) {
-            $this->assertSame($token, $e->getExtraInformation());
+            $this->assertSame($token, $e->getToken());
         }
     }
 
@@ -51,7 +51,7 @@ class AuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
             $manager->authenticate($token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
             $this->fail();
         } catch (AccountStatusException $e) {
-            $this->assertSame($token, $e->getExtraInformation());
+            $this->assertSame($token, $e->getToken());
         }
     }
 
@@ -65,7 +65,7 @@ class AuthenticationProviderManagerTest extends \PHPUnit_Framework_TestCase
             $manager->authenticate($token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface'));
             $this->fail();
         } catch (AuthenticationException $e) {
-            $this->assertSame($token, $e->getExtraInformation());
+            $this->assertSame($token, $e->getToken());
         }
     }
 


### PR DESCRIPTION
Bug fix: semi
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/asm89/symfony.png?branch=issue-837)](http://travis-ci.org/asm89/symfony)
Fixes the following tickets: #837
License of the code: MIT

This PR adds the functionality discussed in #837 and changes the constructor of the `AuthenticationException` to match that of `\Exception`. This PR will allow developers to show a translated (save) authentication exception message to the user. :)

_Todo:_ 
- Add some functional test to check that the exceptions can indeed be translated?
- Get feedback on the current English messages
