### PR TITLE
[Security] Changed logger channel for default auth failure handler

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_listeners.xml
@@ -120,6 +120,7 @@
         </service>
 
         <service id="security.authentication.failure_handler" class="%security.authentication.failure_handler.class%" abstract="true" public="false">
+            <tag name="monolog.logger" channel="security" />
             <argument type="service" id="http_kernel" />
             <argument type="service" id="security.http_utils" />
             <argument type="collection" /> <!-- Options -->


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Bug fix for 2.1 only.
