### PR TITLE
[2.2] [FrameworkBundle] Tag support in container debug

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -858,6 +858,21 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
+     * Returns all tags the defined services use.
+     *
+     * @return array An array of tags
+     */
+    public function findTags()
+    {
+        $tags = array();
+        foreach ($this->getDefinitions() as $id => $definition) {
+            $tags = array_merge(array_keys($definition->getTags()), $tags);
+        }
+
+        return array_unique($tags);
+    }
+
+    /**
      * Returns the Service Conditionals.
      *
      * @param mixed $value An array of conditionals to return.


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: n/a
License of the code: MIT

This PR allows finding all services with a specified tag in the container:

```
> app/console container:debug --tag=form.type
[container] Public services
Service Id           Scope     Class Name
form.type.birthday   container Symfony\Component\Form\Extension\Core\Type\BirthdayType
form.type.checkbox   container Symfony\Component\Form\Extension\Core\Type\CheckboxType
form.type.choice     container Symfony\Component\Form\Extension\Core\Type\ChoiceType
form.type.collection container Symfony\Component\Form\Extension\Core\Type\CollectionType
form.type.country    container Symfony\Component\Form\Extension\Core\Type\CountryType
[ ... ]
```

Also, it adds more info on used tags when requesting info of a service:

Before:

```
> app/console container:debug data_collector.request
[container] Information for service data_collector.request

Service Id       data_collector.request
Class            Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector
Tags             kernel.event_listener, data_collector
Scope            container
Public           yes
Synthetic        no
Required File    -
```

After:

```
> app/console container:debug data_collector.request
[container] Information for service data_collector.request

Service Id       data_collector.request
Class            Symfony\Bundle\FrameworkBundle\DataCollector\RequestDataCollector
Tags
    - kernel.event_listener          (event: kernel.controller, method: onKernelController)
    - data_collector                 (template: WebProfilerBundle:Collector:request, id: request, priority: 255)
Scope            container
Public           yes
Synthetic        no
Required File    -
```
