### PR TITLE
[2.2] [Serializer] Configurable Serializer

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -39,11 +39,11 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         $this->format = $format;
 
         if (null !== $data && !is_scalar($data)) {
-            $root = $this->dom->createElement($this->rootNodeName);
+            $root = $this->dom->createElement($this->getRealRootNodeName());
             $this->dom->appendChild($root);
             $this->buildXml($root, $data);
         } else {
-            $this->appendNode($this->dom, $data, $this->rootNodeName);
+            $this->appendNode($this->dom, $data, $this->getRealRootNodeName());
         }
 
         return $this->dom->saveXML();
@@ -301,7 +301,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
                 $root = $parentNode->parentNode;
                 $root->removeChild($parentNode);
 
-                return $this->appendNode($root, $data, $this->rootNodeName);
+                return $this->appendNode($root, $data, $this->getRealRootNodeName());
             }
 
             return $this->appendNode($parentNode, $data, 'data');
@@ -380,4 +380,21 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
 
         return true;
     }
+
+    /**
+     * Get real XML root node name, taking serializer options into account.
+     */
+    private function getRealRootNodeName()
+    {
+        if ( ! $this->serializer) {
+            return $this->rootNodeName;
+        }
+
+        $options = $this->serializer->getOptions();
+
+        return isset($options['xml_root_node_name'])
+            ? $options['xml_root_node_name']
+            : $this->rootNodeName;
+    }
+
 }

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -386,7 +386,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
      */
     private function getRealRootNodeName()
     {
-        if ( ! $this->serializer) {
+        if (!$this->serializer) {
             return $this->rootNodeName;
         }
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -390,10 +390,10 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
             return $this->rootNodeName;
         }
 
-        $options = $this->serializer->getOptions();
+        $context = $this->serializer->getContext();
 
-        return isset($options['xml_root_node_name'])
-            ? $options['xml_root_node_name']
+        return isset($context['xml_root_node_name'])
+            ? $context['xml_root_node_name']
             : $this->rootNodeName;
     }
 

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -42,9 +42,9 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     protected $normalizers       = array();
     protected $normalizerCache   = array();
     protected $denormalizerCache = array();
-    protected $options           = array();
+    protected $options;
 
-    public function __construct(array $normalizers = array(), array $encoders = array(), array $options = array())
+    public function __construct(array $normalizers = array(), array $encoders = array())
     {
         foreach ($normalizers as $normalizer) {
             if ($normalizer instanceof SerializerAwareInterface) {
@@ -68,7 +68,6 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         }
         $this->encoder = new ChainEncoder($realEncoders);
         $this->decoder = new ChainDecoder($decoders);
-        $this->options = $options;
     }
 
     /**
@@ -80,7 +79,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
             throw new UnexpectedValueException('Serialization for the format '.$format.' is not supported');
         }
 
-        $this->options = array_merge($this->options, $options);
+        $this->options = $options;
 
         if ($this->encoder->needsNormalization($format)) {
             $data = $this->normalize($data, $format);
@@ -98,7 +97,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
             throw new UnexpectedValueException('Deserialization for the format '.$format.' is not supported');
         }
 
-        $this->options = array_merge($this->options, $options);
+        $this->options = $options;
 
         $data = $this->decode($data, $format);
 

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -42,7 +42,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     protected $normalizers       = array();
     protected $normalizerCache   = array();
     protected $denormalizerCache = array();
-    protected $options;
+    protected $context;
 
     public function __construct(array $normalizers = array(), array $encoders = array())
     {
@@ -73,13 +73,13 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     /**
      * {@inheritdoc}
      */
-    final public function serialize($data, $format, array $options = array())
+    final public function serialize($data, $format, array $context = array())
     {
         if (!$this->supportsEncoding($format)) {
             throw new UnexpectedValueException('Serialization for the format '.$format.' is not supported');
         }
 
-        $this->options = $options;
+        $this->context = $context;
 
         if ($this->encoder->needsNormalization($format)) {
             $data = $this->normalize($data, $format);
@@ -91,13 +91,13 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     /**
      * {@inheritdoc}
      */
-    final public function deserialize($data, $type, $format, array $options = array())
+    final public function deserialize($data, $type, $format, array $context = array())
     {
         if (!$this->supportsDecoding($format)) {
             throw new UnexpectedValueException('Deserialization for the format '.$format.' is not supported');
         }
 
-        $this->options = $options;
+        $this->context = $context;
 
         $data = $this->decode($data, $format);
 
@@ -297,8 +297,8 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     /**
      * {@inheritdoc}
      */
-    public function getOptions()
+    public function getContext()
     {
-        return $this->options;
+        return $this->context;
     }
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -27,7 +27,7 @@ interface SerializerInterface
      *
      * @return string
      */
-    function serialize($data, $format, array $options = array());
+    public function serialize($data, $format, array $options = array());
 
     /**
      * Deserializes data into the given type.
@@ -39,12 +39,12 @@ interface SerializerInterface
      *
      * @return mixed
      */
-    function deserialize($data, $type, $format, array $options = array());
+    public function deserialize($data, $type, $format, array $options = array());
 
     /**
      * Get current options of the serializer
      *
      * @return array
      */
-    function getOptions();
+    public function getOptions();
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -21,11 +21,13 @@ interface SerializerInterface
     /**
      * Serializes data in the appropriate format
      *
-     * @param mixed  $data   any data
-     * @param string $format format name
+     * @param mixed  $data    any data
+     * @param string $format  format name
+     * @param array  $options options normalizers/encoders have access to
+     *
      * @return string
      */
-    public function serialize($data, $format);
+    function serialize($data, $format, array $options = array());
 
     /**
      * Deserializes data into the given type.
@@ -33,6 +35,16 @@ interface SerializerInterface
      * @param mixed  $data
      * @param string $type
      * @param string $format
+     * @param array  $options
+     *
+     * @return mixed
      */
-    public function deserialize($data, $type, $format);
+    function deserialize($data, $type, $format, array $options = array());
+
+    /**
+     * Get current options of the serializer
+     *
+     * @return array
+     */
+    function getOptions();
 }

--- a/src/Symfony/Component/Serializer/SerializerInterface.php
+++ b/src/Symfony/Component/Serializer/SerializerInterface.php
@@ -23,11 +23,11 @@ interface SerializerInterface
      *
      * @param mixed  $data    any data
      * @param string $format  format name
-     * @param array  $options options normalizers/encoders have access to
+     * @param array  $context options normalizers/encoders have access to
      *
      * @return string
      */
-    public function serialize($data, $format, array $options = array());
+    public function serialize($data, $format, array $context = array());
 
     /**
      * Deserializes data into the given type.
@@ -35,16 +35,16 @@ interface SerializerInterface
      * @param mixed  $data
      * @param string $type
      * @param string $format
-     * @param array  $options
+     * @param array  $context
      *
      * @return mixed
      */
-    public function deserialize($data, $type, $format, array $options = array());
+    public function deserialize($data, $type, $format, array $context = array());
 
     /**
      * Get current options of the serializer
      *
      * @return array
      */
-    public function getOptions();
+    public function getContext();
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -175,6 +175,23 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($source, $this->encoder->encode($obj, 'xml'));
     }
 
+    public function testEncodeSerializerXmlRootNodeNameOption()
+    {
+        $options = array('xml_root_node_name' => 'test');
+        $this->encoder = new XmlEncoder;
+        $serializer = new Serializer(array(), array('xml' => new XmlEncoder()), $options);
+        $this->encoder->setSerializer($serializer);
+
+        $array = array(
+            'person' => array('@gender' => 'M', '#' => 'Peter'),
+        );
+
+        $expected = '<?xml version="1.0"?>'."\n".
+            '<test><person gender="M">Peter</person></test>'."\n";
+
+        $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+    }
+
     public function testDecode()
     {
         $source = $this->getXmlSource();

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -179,7 +179,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
     {
         $options = array('xml_root_node_name' => 'test');
         $this->encoder = new XmlEncoder;
-        $serializer = new Serializer(array(), array('xml' => new XmlEncoder()), $options);
+        $serializer = new Serializer(array(), array('xml' => new XmlEncoder()));
         $this->encoder->setSerializer($serializer);
 
         $array = array(
@@ -189,7 +189,7 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $expected = '<?xml version="1.0"?>'."\n".
             '<test><person gender="M">Peter</person></test>'."\n";
 
-        $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
+        $this->assertEquals($expected, $serializer->serialize($array, 'xml', $options));
     }
 
     public function testDecode()


### PR DESCRIPTION
Allow options to be passed to SerializerInterface#serialize and #unserialize. Thsee options are available to all encoders/decoders/normalizers that implement SerializerAwareInterface.

Bug fix: no
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: Ticket GH-4907
License of the code: MIT
Todo:
- Discussion if this is the right approach.
- Add a setOptions() method
- Merging of global and invocation options? Or only allow invocation specific methods?

This is one attempt to solve GH-4907
