### PR TITLE
Added more verbose message for exception when form types have wrong getName

### DIFF
--- a/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
+++ b/src/Symfony/Component/Form/Extension/DependencyInjection/DependencyInjectionExtension.php
@@ -46,7 +46,12 @@ class DependencyInjectionExtension implements FormExtensionInterface
         $type = $this->container->get($this->typeServiceIds[$name]);
 
         if ($type->getName() !== $name) {
-            throw new \InvalidArgumentException(sprintf('The type name specified for the service %s does not match the actual name', $this->typeServiceIds[$name]));
+            throw new \InvalidArgumentException(
+                sprintf('The type name specified for the service "%s" does not match the actual name. Expected "%s", given "%s"',
+                    $this->typeServiceIds[$name],
+                    $name,
+                    $type->getName()
+                ));
         }
 
         return $type;


### PR DESCRIPTION
PR based on discussion of commit introduces exception when custom form type have no getName method. https://github.com/symfony/symfony/commit/6489a65960a05b6a5a4f5c5074b941a6765c6381
