### PR TITLE
[Templating] Cached the result of escape() in order to improve performance

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -38,6 +38,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected $charset;
     protected $cache;
     protected $escapers;
+    protected $escaperCache;
     protected $globals;
     protected $parser;
 
@@ -334,6 +335,16 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      */
     public function escape($value, $context = 'html')
     {
+        // If we deal with a scalar value, we can cache the result to increase
+        // the performance when the same value is escaped multiple times (e.g. loops)
+        if (is_scalar($value)) {
+            if (!isset($this->escaperCache[$context][$value])) {
+                $this->escaperCache[$context][$value] = call_user_func($this->getEscaper($context), $value);
+            }
+
+            return $this->escaperCache[$context][$value];
+        }
+
         return call_user_func($this->getEscaper($context), $value);
     }
 
@@ -372,6 +383,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     public function setEscaper($context, $escaper)
     {
         $this->escapers[$context] = $escaper;
+        $this->escaperCache[$context] = array();
     }
 
     /**
@@ -489,6 +501,8 @@ class PhpEngine implements EngineInterface, \ArrayAccess
                     return $value;
                 },
         );
+
+        $this->escaperCache = array();
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

This improvement gains **400ms** of rendering speed on [this particular example page](http://advancedform.gpserver.dk/app_dev.php/taxclasses/1).
