### PR TITLE
[2.2] [Filesystem] Add createEmptyFile and getTemporayFiles methods

### DIFF
--- a/src/Symfony/Component/Filesystem/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Filesystem/Exception/InvalidArgumentException.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Filesystem\Exception;
+
+/**
+ * Exception class thrown when a filesystem operation failure happens
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ *
+ * @api
+ */
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+
+}

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Filesystem;
 
+use Symfony\Component\Filesystem\Exception\InvalidArgumentException;
 use Symfony\Component\Filesystem\Exception\IOException;
 
 /**
@@ -389,6 +390,87 @@ class Filesystem
         }
 
         return false;
+    }
+
+    /**
+     * Get an array of temporary files.
+     *
+     * Temporary files are created inside the system temporary folder. You must
+     * removed them manually at the end of use.
+     *
+     * @param integer $quantity  The quantity of temporary files requested
+     * @param string  $prefix    The prefix of the files
+     * @param string  $suffix    The suffix of the files
+     * @param string  $extension The extension of the files
+     * @param integer $maxTry    The maximum number of trials to create one temporary file
+     *
+     * @return array An array of filenames
+     *
+     * @throws InvalidArgumentException In case you provide a wrong argument
+     * @throws IOException               In case of failure
+     */
+    public function getTemporaryFiles($quantity = 1, $prefix = null, $suffix = null, $extension = null, $maxTry = 65536)
+    {
+        if ($quantity < 1) {
+            throw new InvalidArgumentException('Invalid temporary files quantity');
+        }
+
+        $files = array();
+
+        while ($quantity > 0) {
+            $files[] = $this->createEmptyFile(sys_get_temp_dir(), $prefix, $suffix, $extension, $maxTry);
+            $quantity --;
+        }
+
+        return $files;
+    }
+
+    /**
+     * Create an empty file in the specified directory.
+     *
+     * The new file is created in the requested directory and will fit the
+     * the given parameters. Please note that the filename contains some
+     * random caracters.
+     *
+     * @param  string  $basePath  The directory where to create the file
+     * @param  string  $prefix    The prefix of the file
+     * @param  string  $suffix    The suffix of the file
+     * @param  string  $extension The extension of the file
+     * @param  integer $maxTry    The maximum number of trials to create the file
+     *
+     * @return string  The path of the created file
+     *
+     * @throws IOException in case of failure
+     */
+    public function createEmptyFile($basePath, $prefix = null, $suffix = null, $extension = null, $maxTry = 65536)
+    {
+        if (false === is_dir($basePath) || false === is_writeable($basePath)) {
+            throw new IOException(sprintf('`%s` should be a writeable directory', $basePath));
+        }
+
+        if ($suffix === null && $extension === null) {
+            if (false === $file = @tempnam($basePath, $prefix)) {
+                throw new IOException('Unable to generate a temporary filename');
+            }
+
+            return $file;
+        }
+
+        while ($maxTry > 0) {
+            $file = $basePath . DIRECTORY_SEPARATOR
+                . $prefix . base_convert(mt_rand(0x19A100, 0x39AA3FF), 10, 36) . $suffix
+                . ( $extension ? '.' . $extension : '');
+
+            if (false === file_exists($file)) {
+                $this->touch($file);
+
+                return $file;
+            }
+
+            $maxTry --;
+        }
+
+        throw new IOException('Unable to generate a temporary filename');
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/romainneutron/symfony.png?branch=TemporaryFiles)](http://travis-ci.org/romainneutron/symfony)
Documentation: symfony/symfony-docs#1670
License of the code: MIT

---

`Filesystem::createEmptyFile`
createEmptyFile should be used to get an empty new file in a specified directory :

example : 
This creates a new file in "/datas/store" which will have a name matching `image\w{5}_thumb.jpg` :

``` php
<?php
$file = $filesystem->createEmptyFile('/datas/store', 'image', '_thumb', 'jpg');
```

basic usage only requires the target folder :

``` php
<?php
// return the filename of a new empty file in "./datas"
$file = $filesystem->createEmptyFile('./datas');
```

---

`Filesystem::getTemporaryFiles`
getTemporaryFiles should be used to get a set of empty new temporary files

example :
This create 5 temporary files with the prefix "image", the suffix "preview" and the extension "png" :

``` php
<?php
$files = $filesystem->getTemporaryFiles(5, 'image', 'preview', 'png');
```

basic usage only requires the number of requested files :

``` php
<?php
// return an array of 12 new temporary files
$files = $filesystem->getTemporaryFiles(12);
```
