### PR TITLE
[Form] Fixed DoctrineType to use getManagerForClass() if no EM name is given

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -8,3 +8,4 @@ CHANGELOG
  * added a session storage for Doctrine DBAL
  * DoctrineOrmTypeGuesser now guesses "collection" for array Doctrine type
  * DoctrineType now caches its choice lists in order to improve performance
+ * DoctrineType now uses ManagerRegistry::getManagerForClass() if the option "em" is not set


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4125
Todo: -
