### PR TITLE
[HttpKernel] Revert automatic response statusCode setting in the exception handler

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\HttpKernel;
 
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -192,23 +191,10 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             throw $e;
         }
 
-        $response = $event->getResponse();
-
-        // ensure that we actually have an error response
-        if (!$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
-            if ($e instanceof HttpExceptionInterface) {
-                // keep the HTTP status code and headers
-                $response->setStatusCode($e->getStatusCode());
-                $response->headers->add($e->getHeaders());
-            } else {
-                $response->setStatusCode(500);
-            }
-        }
-
         try {
-            return $this->filterResponse($response, $request, $type);
+            return $this->filterResponse($event->getResponse(), $request, $type);
         } catch (\Exception $e) {
-            return $response;
+            return $event->getResponse();
         }
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -14,11 +14,8 @@ namespace Symfony\Component\HttpKernel\Tests;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class HttpKernelTest extends \PHPUnit_Framework_TestCase
@@ -62,38 +59,8 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         });
 
         $kernel = new HttpKernel($dispatcher, $this->getResolver(function () { throw new \RuntimeException('foo'); }));
-        $response = $kernel->handle(new Request());
 
-        $this->assertEquals('500', $response->getStatusCode());
-        $this->assertEquals('foo', $response->getContent());
-    }
-
-    public function testHandleExceptionWithARedirectionResponse()
-    {
-        $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(KernelEvents::EXCEPTION, function ($event) {
-            $event->setResponse(new RedirectResponse('/login', 301));
-        });
-
-        $kernel = new HttpKernel($dispatcher, $this->getResolver(function () { throw new AccessDeniedHttpException(); }));
-        $response = $kernel->handle(new Request());
-
-        $this->assertEquals('301', $response->getStatusCode());
-        $this->assertEquals('/login', $response->headers->get('Location'));
-    }
-
-    public function testHandleHttpException()
-    {
-        $dispatcher = new EventDispatcher();
-        $dispatcher->addListener(KernelEvents::EXCEPTION, function ($event) {
-            $event->setResponse(new Response($event->getException()->getMessage()));
-        });
-
-        $kernel = new HttpKernel($dispatcher, $this->getResolver(function () { throw new MethodNotAllowedHttpException(array('POST')); }));
-        $response = $kernel->handle(new Request());
-
-        $this->assertEquals('405', $response->getStatusCode());
-        $this->assertEquals('POST', $response->headers->get('Allow'));
+        $this->assertEquals('foo', $kernel->handle(new Request())->getContent());
     }
 
     public function testHandleWhenAListenerReturnsAResponse()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
License of the code: MIT

Revert symfony/HttpKernel@538a38c4919a982c1f68ad129178a0e3bb78a4c5 as it disables response code tweakability in a `KernelEvents::EXCEPTION` listener 

For example Silex is using this event for error handling ([see line 354-386](https://github.com/fabpot/Silex/blob/master/src/Silex/Application.php#L354)), and as described in fabpot/Silex#438 Response statusCode tweak in a such error handler could be very usefull.

Comments welcome.
