### PR TITLE
[Process] Fixed a problem on RHEL5 where the exit code was incorrect

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -290,7 +290,7 @@ class Process
             }
         }
 
-        $this->processInformation = proc_get_status($this->process);
+        $this->updateStatus();
     }
 
     /**
@@ -308,7 +308,7 @@ class Process
      */
     public function wait($callback = null)
     {
-        $this->processInformation = proc_get_status($this->process);
+        $this->updateStatus();
         $callback = $this->buildCallback($callback);
         while ($this->pipes || (defined('PHP_WINDOWS_VERSION_BUILD') && $this->fileHandles)) {
             if (defined('PHP_WINDOWS_VERSION_BUILD') && $this->fileHandles) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

RHEL5 will intermittently result in an exit code of -1 due to `proc_get_status()` being called after the process has completed but outside of `updateStatus()` which saves the exit code.

See composer/composer#876
