### PR TITLE
Change FormRenderer renderSection method visibility to public

### DIFF
--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -214,7 +214,7 @@ class FormRenderer implements FormRendererInterface
      *
      * @throws Exception\FormException If no fitting template was found.
      */
-    protected function renderSection(FormViewInterface $view, $section, array $variables = array())
+    public function renderSection(FormViewInterface $view, $section, array $variables = array())
     {
         $renderOnlyOnce = in_array($section, array('row', 'widget'));
 


### PR DESCRIPTION
The whole thing was born from this issue genemu/GenemuFormBundle#119. The `Genemu/Bundle/FormBundle/Twig/Extension/FormExtension` class of the bundles used to use the `render` method of the `Symfony/Bridge/Twig/Extension/FormExtension` class, but with the refactoring in commit 629093ed25304c839a35afa0c0e841d57115f6ee the method no longer exsists. 

It looks to me like the right solution would be to use the new method `renderSection` of the `Symfony/Component/Form/FormRenderer` class, of which the `FormExtension` has an instance in the public instance variable `$renderer`.

The whole think does not work if the `renderSection` method is `protected`, this is the Fatal Error:

```
Fatal error: Call to protected method Symfony\Component\Form\FormRenderer::renderSection() 
from context 'Genemu\Bundle\FormBundle\Twig\Extension\FormExtension' 
in /path/to/my/project/vendor/genemu/form-bundle/Genemu/Bundle/FormBundle/Twig/Extension/FormExtension.php
on line 56
```

Simply switching the method visibility from protected to public does the trick. 

Now my question is _is there a reason for the method being protected in the first place?_ if not please accept this PR, otherwise the [genemu/GenemuFormBundle](https://github.com/genemu/GenemuFormBundle) have to do a little refactoring themselves.

Thanks ;)
