### PR TITLE
[Doctrine] [Bridge] Add a "repositoryMethod" option to the uniqueEntity validator

### DIFF
--- a/src/Symfony/Bridge/Doctrine/CHANGELOG.md
+++ b/src/Symfony/Bridge/Doctrine/CHANGELOG.md
@@ -9,3 +9,4 @@ CHANGELOG
  * DoctrineOrmTypeGuesser now guesses "collection" for array Doctrine type
  * DoctrineType now caches its choice lists in order to improve performance
  * DoctrineType now uses ManagerRegistry::getManagerForClass() if the option "em" is not set
+ * UniqueEntity validation constraint now accepts a "repositoryMethod" option that will be used to check for uniqueness instead of the default "findBy"

--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -47,6 +47,42 @@ class UniqueValidatorTest extends DoctrineOrmTestCase
         return $registry;
     }
 
+    protected function createRepositoryMock()
+    {
+        $repository = $this->getMock('Doctrine\Common\Persistence\ObjectRepository');
+
+        return $repository;
+    }
+
+    protected function createEntityManagerMock($repositoryMock)
+    {
+        $em = $this->getMockBuilder('Doctrine\Common\Persistence\ObjectManager')
+            ->getMock()
+        ;
+        $em->expects($this->any())
+             ->method('getRepository')
+             ->will($this->returnValue($repositoryMock))
+        ;
+
+        $classMetadata = $this->getMock('Doctrine\Common\Persistence\Mapping\ClassMetadata');
+        $classMetadata
+            ->expects($this->any())
+            ->method('hasField')
+            ->will($this->returnValue(true))
+        ;
+        $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $classMetadata->reflFields = array('name' => $refl);
+        $em->expects($this->any())
+             ->method('getClassMetadata')
+             ->will($this->returnValue($classMetadata))
+        ;
+
+        return $em;
+    }
+
     protected function createMetadataFactoryMock($metadata)
     {
         $metadataFactory = $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface');
@@ -69,7 +105,7 @@ class UniqueValidatorTest extends DoctrineOrmTestCase
         return $validatorFactory;
     }
 
-    public function createValidator($entityManagerName, $em, $validateClass = null, $uniqueFields = null, $errorPath = null)
+    public function createValidator($entityManagerName, $em, $validateClass = null, $uniqueFields = null, $errorPath = null, $repositoryMethod = 'findBy')
     {
         if (!$validateClass) {
             $validateClass = 'Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIdentEntity';
@@ -83,7 +119,12 @@ class UniqueValidatorTest extends DoctrineOrmTestCase
         $uniqueValidator = new UniqueEntityValidator($registry);
 
         $metadata = new ClassMetadata($validateClass);
-        $metadata->addConstraint(new UniqueEntity(array('fields' => $uniqueFields, 'em' => $entityManagerName, 'errorPath' => $errorPath)));
+        $metadata->addConstraint(new UniqueEntity(array(
+            'fields' => $uniqueFields,
+            'em' => $entityManagerName,
+            'errorPath' => $errorPath,
+            'repositoryMethod' => $repositoryMethod
+        )));
 
         $metadataFactory = $this->createMetadataFactoryMock($metadata);
         $validatorFactory = $this->createValidatorFactory($uniqueValidator);
@@ -192,6 +233,23 @@ class UniqueValidatorTest extends DoctrineOrmTestCase
 
         $violationsList = $validator->validate($entity2);
         $this->assertEquals(1, $violationsList->count(), 'Violation found on entity with conflicting entity existing in the database.');
+    }
+
+    public function testValidateUniquenessUsingCustiomRepositoryMethod()
+    {
+        $entityManagerName = 'foo';
+        $repository = $this->createRepositoryMock();
+        $repository->expects($this->any())
+             ->method('findByCustom')
+             ->will($this->returnValue(array()))
+        ;
+        $em = $this->createEntityManagerMock($repository);
+        $validator = $this->createValidator($entityManagerName, $em, null, array(), null, 'findByCustom');
+
+        $entity1 = new SingleIdentEntity(1, 'foo');
+
+        $violationsList = $validator->validate($entity1);
+        $this->assertEquals(0, $violationsList->count(), 'Violation is using custom repository method.');
     }
 
     /**

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntity.php
@@ -24,6 +24,7 @@ class UniqueEntity extends Constraint
     public $message = 'This value is already used.';
     public $service = 'doctrine.orm.validator.unique';
     public $em = null;
+    public $repositoryMethod = 'findBy';
     public $fields = array();
     public $errorPath = null;
 

--- a/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
+++ b/src/Symfony/Bridge/Doctrine/Validator/Constraints/UniqueEntityValidator.php
@@ -100,7 +100,7 @@ class UniqueEntityValidator extends ConstraintValidator
         }
 
         $repository = $em->getRepository($className);
-        $result = $repository->findBy($criteria);
+        $result = $repository->{$constraint->repositoryMethod}($criteria);
 
         /* If the result is a MongoCursor, it must be advanced to the first
          * element. Rewinding should have no ill effect if $result is another


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~

This allows to configure the repository method used to verify uniqueness of entity.  
Before, it was always using `findBy`.
