### PR TITLE
[Validator] Fix bug order for constraint, property, getter and group-seq...

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd
+++ b/src/Symfony/Component/Validator/Mapping/Loader/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd
@@ -51,11 +51,11 @@
         definitions.
       ]]></xsd:documentation>
     </xsd:annotation>
-    <xsd:sequence>
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
       <xsd:element name="constraint" type="constraint" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="property" type="property" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="getter" type="getter" minOccurs="0" maxOccurs="unbounded" />
-    </xsd:sequence>
+    </xsd:choice>
     <xsd:attribute name="name" type="xsd:string" use="required" />
   </xsd:complexType>
   


### PR DESCRIPTION
Actually, there is a bug that force developers to write validation.xml file with the following nodes order:
- constraint
- property
- getter

So that's not possible to have the following XML (because I need to write my property(ies) first).

``` xml
<?xml version="1.0" encoding="UTF-8" ?>
<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping http://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">

    <class name="Application\Eko\MyBundle\Entity\MyEntity">
        <getter property="isBar">
            <constraint name="True">
                <option name="message">My error message</option>
            </constraint>
        </getter>

        <property name="foo">
            <constraint name="NotBlank" />
        </property>
    </class>

</constraint-mapping>
```

The XML below result in the following exception:

```
[ERROR 1871] Element '{http://symfony.com/schema/dic/constraint-mapping}property': This element is not expected. Expected is ( {http://symfony.com/schema/dic/constraint-mapping}getter ). (in /var/www/myproject/src/Application/Eko/MyBundle/Resources/config/validation.xml - line 14, column 0)
```

This is due to the sequence element that needs to respect the order given in the schema file.

The choice element is doing the same thing and permit to have a free order of elements so I have replaced the sequence by a choice element.

For more information: http://www.w3.org/TR/xmlschema-0/#ref17
