### PR TITLE
[Security] fixes multiple overlapping definitions of DefaultFailureHandler and DefaultSuccessHandler in AbstractFactory

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -172,7 +172,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
             return $config['success_handler'];
         }
 
-        $successHandlerId = 'security.authentication.success_handler.'.$id;
+        $successHandlerId = 'security.authentication.success_handler.'.$id.'.'.str_replace('-', '_', $this->getKey());
 
         $successHandler = $container->setDefinition($successHandlerId, new DefinitionDecorator('security.authentication.success_handler'));
         $successHandler->replaceArgument(1, array_intersect_key($config, $this->defaultSuccessHandlerOptions));
@@ -187,7 +187,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
             return $config['failure_handler'];
         }
 
-        $id = 'security.authentication.failure_handler.'.$id;
+        $id = 'security.authentication.failure_handler.'.$id.'.'.str_replace('-', '_', $this->getKey());
 
         $failureHandler = $container->setDefinition($id, new DefinitionDecorator('security.authentication.failure_handler'));
         $failureHandler->replaceArgument(2, array_intersect_key($config, $this->defaultFailureHandlerOptions));

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Security/Factory/AbstractFactoryTest.php
@@ -54,7 +54,7 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
 
         $definition = $container->getDefinition('abstract_listener.foo');
         $arguments = $definition->getArguments();
-        $this->assertEquals(new Reference('security.authentication.failure_handler.foo'), $arguments['index_6']);
+        $this->assertEquals(new Reference('security.authentication.failure_handler.foo.abstract_factory'), $arguments['index_6']);
     }
 
     public function testDefaultSuccessHandler()
@@ -67,7 +67,7 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
 
         $definition = $container->getDefinition('abstract_listener.foo');
         $arguments = $definition->getArguments();
-        $this->assertEquals(new Reference('security.authentication.success_handler.foo'), $arguments['index_5']);
+        $this->assertEquals(new Reference('security.authentication.success_handler.foo.abstract_factory'), $arguments['index_5']);
     }
 
     protected function callFactory($id, $config, $userProviderId, $defaultEntryPointId)
@@ -83,6 +83,11 @@ class AbstractFactoryTest extends \PHPUnit_Framework_TestCase
             ->expects($this->atLeastOnce())
             ->method('getListenerId')
             ->will($this->returnValue('abstract_listener'))
+        ;
+        $factory
+            ->expects($this->any())
+            ->method('getKey')
+            ->will($this->returnValue('abstract_factory'))
         ;
 
         $container = new ContainerBuilder();


### PR DESCRIPTION
If more than one listener extends AbstractFactory, you'll have multiple calls to createAuthenticationFailureHandler and createAuthenticationSuccessHandler with the same id.

Implicitly it's going to use the one generated by the last factory generating unexpected behavior.

This is related to commits 915704c0717c1b13f44468e51638761e71682da5 and c6aa392df7b1b68d7f5be0b858bd93e97a5a6cdc
