### PR TITLE
Rename unmodifiable to immutable

### DIFF
--- a/src/Symfony/Component/EventDispatcher/CHANGELOG.md
+++ b/src/Symfony/Component/EventDispatcher/CHANGELOG.md
@@ -13,4 +13,4 @@ CHANGELOG
  * added GenericEvent event class
  * added the possibility for subscribers to subscribe several times for the
    same event
- * added UnmodifiableEventDispatcher
+ * added ImmutableEventDispatcher

--- a/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\EventDispatcher;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class UnmodifiableEventDispatcher implements EventDispatcherInterface
+class ImmutableEventDispatcher implements EventDispatcherInterface
 {
     /**
      * The proxied dispatcher.

--- a/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/ImmutableEventDispatcherTest.php
@@ -12,13 +12,13 @@
 namespace Symfony\Component\EventDispatcher\Tests;
 
 use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\EventDispatcher\UnmodifiableEventDispatcher;
+use Symfony\Component\EventDispatcher\ImmutableEventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class UnmodifiableEventDispatcherTest extends \PHPUnit_Framework_TestCase
+class ImmutableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -26,14 +26,14 @@ class UnmodifiableEventDispatcherTest extends \PHPUnit_Framework_TestCase
     private $innerDispatcher;
 
     /**
-     * @var UnmodifiableEventDispatcher
+     * @var ImmutableEventDispatcher
      */
     private $dispatcher;
 
     protected function setUp()
     {
         $this->innerDispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->dispatcher = new UnmodifiableEventDispatcher($this->innerDispatcher);
+        $this->dispatcher = new ImmutableEventDispatcher($this->innerDispatcher);
     }
 
     public function testDispatchDelegates()

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -126,8 +126,8 @@ class Form implements \IteratorAggregate, FormInterface
      */
     public function __construct(FormConfigInterface $config)
     {
-        if (!$config instanceof UnmodifiableFormConfig) {
-            $config = new UnmodifiableFormConfig($config);
+        if (!$config instanceof ImmutableFormConfig) {
+            $config = new ImmutableFormConfig($config);
         }
 
         // Compound forms always need a data mapper, otherwise calls to
@@ -152,7 +152,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns the configuration of the form.
      *
-     * @return UnmodifiableFormConfig The form's immutable configuration.
+     * @return ImmutableFormConfig The form's immutable configuration.
      */
     public function getConfig()
     {
@@ -562,7 +562,7 @@ class Form implements \IteratorAggregate, FormInterface
             // Synchronize representations - must not change the content!
             $modelData = $this->normToModel($normData);
             $viewData = $this->normToView($normData);
-            
+
             $synchronized = true;
         } catch (TransformationFailedException $e) {
         }

--- a/src/Symfony/Component/Form/ImmutableFormConfig.php
+++ b/src/Symfony/Component/Form/ImmutableFormConfig.php
@@ -12,14 +12,14 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Util\PropertyPath;
-use Symfony\Component\EventDispatcher\UnmodifiableEventDispatcher;
+use Symfony\Component\EventDispatcher\ImmutableEventDispatcher;
 
 /**
  * A read-only form configuration.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class UnmodifiableFormConfig implements FormConfigInterface
+class ImmutableFormConfig implements FormConfigInterface
 {
     /**
      * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
@@ -134,8 +134,8 @@ class UnmodifiableFormConfig implements FormConfigInterface
     public function __construct(FormConfigInterface $config)
     {
         $dispatcher = $config->getEventDispatcher();
-        if (!$dispatcher instanceof UnmodifiableEventDispatcher) {
-            $dispatcher = new UnmodifiableEventDispatcher($dispatcher);
+        if (!$dispatcher instanceof ImmutableEventDispatcher) {
+            $dispatcher = new ImmutableEventDispatcher($dispatcher);
         }
 
         $this->dispatcher = $dispatcher;


### PR DESCRIPTION
Maybe it's just me, but it sounded really wrong. The EventDispatcher one was added in 2.1 so no BC break. I don't know about the Form one, but I guess it's just used internally anyway.
