### PR TITLE
[2.2] [FrameworkBundle] avoid trying to resolve container placeholders on arrays on router _defaults

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -114,6 +114,14 @@ class Router extends BaseRouter implements WarmableInterface
     {
         $container = $this->container;
 
+        if (is_array($value)) {
+            foreach ($value as $key => $val) {
+                $value[$key] = $this->resolveString($val);
+            }
+
+            return $value;
+        }
+
         if (null === $value || false === $value || true === $value || is_object($value)) {
             return $value;
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -27,6 +27,8 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
                 'foo'    => 'before_%parameter.foo%',
                 'bar'    => '%parameter.bar%_after',
                 'baz'    => '%%unescaped%%',
+                'boo'    => array('%parameter%', '%%escaped_parameter%%', array('%bee_parameter%', 'bee')),
+                'bee'    => array('bee', 'bee'),
             ),
             array(
             )
@@ -39,6 +41,12 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
         $sc->expects($this->at(3))->method('hasParameter')->will($this->returnValue(true));
         $sc->expects($this->at(4))->method('getParameter')->will($this->returnValue('bar'));
 
+        $sc->expects($this->at(5))->method('hasParameter')->will($this->returnValue(true));
+        $sc->expects($this->at(6))->method('getParameter')->will($this->returnValue('boo'));
+
+        $sc->expects($this->at(7))->method('hasParameter')->will($this->returnValue(true));
+        $sc->expects($this->at(8))->method('getParameter')->will($this->returnValue('foo_bee'));
+
         $router = new Router($sc, 'foo');
         $route = $router->getRouteCollection()->get('foo');
 
@@ -47,6 +55,8 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
                 'foo' => 'before_foo',
                 'bar' => 'bar_after',
                 'baz' => '%unescaped%',
+                'boo' => array('boo', '%escaped_parameter%', array('foo_bee', 'bee')),
+                'bee' => array('bee', 'bee'),
             ),
             $route->getDefaults()
         );


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~

Permits to pass arrays in route `_defaults`.
