### PR TITLE
Moved symfony/config from the "recommend" dependency to the "suggest" dependancy

### DIFF
--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -18,10 +18,8 @@
     "require": {
         "php": ">=5.3.2"
     },
-    "recommend": {
-        "symfony/config": "self.version"
-    },
     "suggest": {
+        "symfony/config": "self.version"
         "symfony/yaml": "self.version"
     },
     "autoload": {


### PR DESCRIPTION
Moved symfony/config from the "recommend" dependency to the "suggest" dependency. Cannot find "recommend" in composer documentation
