### PR TITLE
[OptionsResolver] Renamed filters to normalizers

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -114,7 +114,7 @@ abstract class DoctrineType extends AbstractType
             return $choiceListCache[$hash];
         };
 
-        $emFilter = function (Options $options, $em) use ($registry) {
+        $emNormalizer = function (Options $options, $em) use ($registry) {
             /* @var ManagerRegistry $registry */
             if (null !== $em) {
                 return $registry->getManager($em);
@@ -134,8 +134,8 @@ abstract class DoctrineType extends AbstractType
             'group_by'          => null,
         ));
 
-        $resolver->setFilters(array(
-            'em' => $emFilter,
+        $resolver->setNormalizers(array(
+            'em' => $emNormalizer,
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -157,7 +157,7 @@ class ChoiceType extends AbstractType
             return $options['required'] ? null : '';
         };
 
-        $emptyValueFilter = function (Options $options, $emptyValue) {
+        $emptyValueNormalizer = function (Options $options, $emptyValue) {
             if ($options['multiple'] || $options['expanded']) {
                 // never use an empty value for these cases
                 return null;
@@ -186,8 +186,8 @@ class ChoiceType extends AbstractType
             'compound'          => $compound,
         ));
 
-        $resolver->setFilters(array(
-            'empty_value' => $emptyValueFilter,
+        $resolver->setNormalizers(array(
+            'empty_value' => $emptyValueNormalizer,
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -74,7 +74,7 @@ class CollectionType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $optionsFilter = function (Options $options, $value) {
+        $optionsNormalizer = function (Options $options, $value) {
             $value['block_name'] = 'entry';
 
             return $value;
@@ -89,8 +89,8 @@ class CollectionType extends AbstractType
             'options'        => array(),
         ));
 
-        $resolver->setFilters(array(
-            'options' => $optionsFilter,
+        $resolver->setNormalizers(array(
+            'options' => $optionsNormalizer,
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -164,7 +164,7 @@ class DateType extends AbstractType
             return $options['required'] ? null : '';
         };
 
-        $emptyValueFilter = function (Options $options, $emptyValue) use ($emptyValueDefault) {
+        $emptyValueNormalizer = function (Options $options, $emptyValue) use ($emptyValueDefault) {
             if (is_array($emptyValue)) {
                 $default = $emptyValueDefault($options);
 
@@ -216,8 +216,8 @@ class DateType extends AbstractType
             'compound'       => $compound,
         ));
 
-        $resolver->setFilters(array(
-            'empty_value' => $emptyValueFilter,
+        $resolver->setNormalizers(array(
+            'empty_value' => $emptyValueNormalizer,
         ));
 
         $resolver->setAllowedValues(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -134,7 +134,7 @@ class TimeType extends AbstractType
             return $options['required'] ? null : '';
         };
 
-        $emptyValueFilter = function (Options $options, $emptyValue) use ($emptyValueDefault) {
+        $emptyValueNormalizer = function (Options $options, $emptyValue) use ($emptyValueDefault) {
             if (is_array($emptyValue)) {
                 $default = $emptyValueDefault($options);
 
@@ -186,8 +186,8 @@ class TimeType extends AbstractType
             'compound'       => $compound,
         ));
 
-        $resolver->setFilters(array(
-            'empty_value' => $emptyValueFilter,
+        $resolver->setNormalizers(array(
+            'empty_value' => $emptyValueNormalizer,
         ));
 
         $resolver->setAllowedValues(array(

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -59,7 +59,7 @@ class FormTypeValidatorExtension extends AbstractTypeExtension
         };
 
         // Make sure that validation groups end up as null, closure or array
-        $validationGroupsFilter = function (Options $options, $groups) {
+        $validationGroupsNormalizer = function (Options $options, $groups) {
             if (empty($groups)) {
                 return null;
             }
@@ -72,7 +72,7 @@ class FormTypeValidatorExtension extends AbstractTypeExtension
         };
 
         // Constraint should always be converted to an array
-        $constraintsFilter = function (Options $options, $constraints) {
+        $constraintsNormalizer = function (Options $options, $constraints) {
             return is_object($constraints) ? array($constraints) : (array) $constraints;
         };
 
@@ -88,9 +88,9 @@ class FormTypeValidatorExtension extends AbstractTypeExtension
             'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
         ));
 
-        $resolver->setFilters(array(
-            'validation_groups' => $validationGroupsFilter,
-            'constraints'       => $constraintsFilter,
+        $resolver->setNormalizers(array(
+            'validation_groups' => $validationGroupsNormalizer,
+            'constraints'       => $constraintsNormalizer,
         ));
     }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -54,10 +54,10 @@ class OptionsResolver implements OptionsResolverInterface
     private $allowedTypes = array();
 
     /**
-     * A list of filters transforming each resolved options.
+     * A list of normalizers transforming each resolved options.
      * @var array
      */
-    private $filters = array();
+    private $normalizers = array();
 
     /**
      * Creates a new instance.
@@ -190,11 +190,11 @@ class OptionsResolver implements OptionsResolverInterface
     /**
      * {@inheritdoc}
      */
-    public function setFilters(array $filters)
+    public function setNormalizers(array $normalizers)
     {
-        $this->validateOptionsExistence($filters);
+        $this->validateOptionsExistence($normalizers);
 
-        $this->filters = array_replace($this->filters, $filters);
+        $this->normalizers = array_replace($this->normalizers, $normalizers);
 
         return $this;
     }
@@ -232,7 +232,7 @@ class OptionsResolver implements OptionsResolverInterface
         }
 
         // Apply filters
-        foreach ($this->filters as $option => $filter) {
+        foreach ($this->normalizers as $option => $filter) {
             $combinedOptions->overload($option, $filter);
         }
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -148,9 +148,9 @@ interface OptionsResolverInterface
     public function addAllowedTypes(array $allowedTypes);
 
     /**
-     * Sets filters that are applied on resolved options.
+     * Sets normalizers that are applied on resolved options.
      *
-     * The filters should be closures with the following signature:
+     * The normalizers should be closures with the following signature:
      *
      * <code>
      * function (Options $options, $value)
@@ -159,13 +159,13 @@ interface OptionsResolverInterface
      * The second parameter passed to the closure is the value of
      * the option.
      *
-     * The closure should return the filtered value.
+     * The closure should return the normalized value.
      *
-     * @param array $filters An array of filter closures.
+     * @param array $normalizers An array of closures.
      *
      * @return OptionsResolverInterface The resolver instance.
      */
-    public function setFilters(array $filters);
+    public function setNormalizers(array $normalizers);
 
     /**
      * Returns whether an option is known.

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -538,13 +538,13 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->resolver->isRequired('foo'));
     }
 
-    public function testFiltersTransformFinalOptions()
+    public function testNormalizersTransformFinalOptions()
     {
         $this->resolver->setDefaults(array(
             'foo' => 'bar',
             'bam' => 'baz',
         ));
-        $this->resolver->setFilters(array(
+        $this->resolver->setNormalizers(array(
             'foo' => function (Options $options, $value) {
                 return $options['bam'] . '[' . $value . ']';
             },


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

This PR fixes the naming to be in line with the Serializer component.
