### PR TITLE
[Form] Restored BC in AbstractType::getDefaultOptions() and getAllowedOptionValues()

### DIFF
--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -52,19 +52,21 @@ abstract class AbstractType implements FormTypeInterface
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults($this->getDefaultOptions());
-        $resolver->addAllowedValues($this->getAllowedOptionValues());
+        $resolver->setDefaults($this->getDefaultOptions(array()));
+        $resolver->addAllowedValues($this->getAllowedOptionValues(array()));
     }
 
     /**
      * Returns the default options for this type.
+     *
+     * @param array $options Unsupported as of Symfony 2.1.
      *
      * @return array The default options
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      *             Use {@link setDefaultOptions()} instead.
      */
-    public function getDefaultOptions()
+    public function getDefaultOptions(array $options)
     {
         return array();
     }
@@ -72,12 +74,14 @@ abstract class AbstractType implements FormTypeInterface
     /**
      * Returns the allowed option values for each option (if any).
      *
+     * @param array $options Unsupported as of Symfony 2.1.
+     *
      * @return array The allowed option values
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      *             Use {@link setDefaultOptions()} instead.
      */
-    public function getAllowedOptionValues()
+    public function getAllowedOptionValues(array $options)
     {
         return array();
     }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -106,8 +106,6 @@ CHANGELOG
  * removed superfluous methods from DataMapperInterface
    * `mapFormToData`
    * `mapDataToForm`
- * [BC BREAK] FormType::getDefaultOptions() and FormType::getAllowedOptionValues()
-   don't receive an options array anymore.
  * added `setDefaultOptions` to FormTypeInterface and FormTypeExtensionInterface
    which accepts an OptionsResolverInterface instance
  * deprecated the methods `getDefaultOptions` and `getAllowedOptionValues`


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4960
Todo: -
