### PR TITLE
[Form] Disabled manual singulars in PropertyPath until the syntax is finalized

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
@@ -211,6 +211,8 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
 
     public function testSetValueCallsCustomAdderAndRemover()
     {
+        $this->markTestSkipped('This feature is temporarily disabled as of 2.1');
+
         $car = $this->getMock(__CLASS__ . '_CarCustomSingular');
         $axesBefore = $this->getCollection(array(1 => 'second', 3 => 'fourth'));
         $axesAfter = $this->getCollection(array(0 => 'first', 1 => 'second', 2 => 'third'));
@@ -300,6 +302,9 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
         );
         $data[] = array($car, $propertyPath, $expectedMessage);
 
+        /*
+        Temporarily disabled in 2.1
+
         $propertyPath = new PropertyPath('axes|boo');
         $expectedMessage = sprintf(
             'Neither element "axes" nor method "setAxes()" exists in class '
@@ -309,6 +314,7 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
             'boo'
         );
         $data[] = array($car, $propertyPath, $expectedMessage);
+         */
 
         $car = $this->getMock(__CLASS__ . '_CarNoAdderAndRemoverWithProperty');
         $propertyPath = new PropertyPath('axes');

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -95,6 +95,8 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
 
     public function testGetValueIgnoresSingular()
     {
+        $this->markTestSkipped('This feature is temporarily disabled as of 2.1');
+
         $object = (object) array('children' => 'Many');
 
         $path = new PropertyPath('children|child');

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -118,8 +118,9 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 $element = $matches[3];
                 $this->isIndex[] = true;
             }
-
-            $pos = strpos($element, self::SINGULAR_SEPARATOR);
+            // Disabled this behaviour as the syntax is not yet final
+            //$pos = strpos($element, self::SINGULAR_SEPARATOR);
+            $pos = false;
             $singular = null;
 
             if (false !== $pos) {


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
