### PR TITLE
removed unneeded class to compile

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -256,7 +256,6 @@ class FrameworkExtension extends Extension
         $container->setParameter('request_listener.https_port', $config['https_port']);
 
         $this->addClassesToCompile(array(
-            'Symfony\\Component\\Routing\\Matcher\\UrlMatcher',
             'Symfony\\Component\\Routing\\Generator\\UrlGenerator',
             'Symfony\\Component\\Routing\\RequestContext',
             'Symfony\\Component\\Routing\\Router',


### PR DESCRIPTION
As the redirectable matcher a few lines below is a child class.

I'm not sure if it's the other one that should be removed instead? As it's not always required, when using the apache matcher for example.
