### PR TITLE
[2.1] Don't use \Collator for Locale when not properly configured

### DIFF
--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -67,7 +67,12 @@ class Locale extends \Locale
                 $countries = array_merge(self::getDisplayCountries($fallbackLocale), $countries);
             }
 
-            $collator->asort($countries);
+            if ($collator instanceof \Collator) {
+                $collator->asort($countries);
+            }
+            else {
+                asort($countries);
+            }
 
             self::$countries[$locale] = $countries;
         }


### PR DESCRIPTION
Problem on some WAMP configurations. new \Collator() return false ... 
Can't use asort Collator method, fixed for using simple assort function in this case.
