### PR TITLE
[Form] Made original data of a form and choices accessible in templates

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -124,7 +124,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name'
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView('1', 'Foo'), 2 => new ChoiceView('2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     public function testSetDataToUninitializedEntityWithNonRequiredToString()
@@ -140,7 +140,7 @@ class EntityTypeTest extends TypeTestCase
             'required' => false,
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView('1', 'Foo'), 2 => new ChoiceView('2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     public function testSetDataToUninitializedEntityWithNonRequiredQueryBuilder()
@@ -159,7 +159,7 @@ class EntityTypeTest extends TypeTestCase
             'query_builder' => $qb
         ));
 
-        $this->assertEquals(array(1 => new ChoiceView('1', 'Foo'), 2 => new ChoiceView('2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
     /**
@@ -503,7 +503,7 @@ class EntityTypeTest extends TypeTestCase
 
         $field->bind('2');
 
-        $this->assertEquals(array(1 => new ChoiceView('1', 'Foo'), 2 => new ChoiceView('2', 'Bar')), $field->createView()->vars['choices']);
+        $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
         $this->assertSame('2', $field->getClientData());
@@ -530,9 +530,9 @@ class EntityTypeTest extends TypeTestCase
 
         $this->assertSame('2', $field->getClientData());
         $this->assertEquals(array(
-            'Group1' => array(1 => new ChoiceView('1', 'Foo'), 2 => new ChoiceView('2', 'Bar')),
-            'Group2' => array(3 => new ChoiceView('3', 'Baz')),
-            '4' => new ChoiceView('4', 'Boo!')
+            'Group1' => array(1 => new ChoiceView($item1, '1', 'Foo'), 2 => new ChoiceView($item2, '2', 'Bar')),
+            'Group2' => array(3 => new ChoiceView($item3, '3', 'Baz')),
+            '4' => new ChoiceView($item4, '4', 'Boo!')
         ), $field->createView()->vars['choices']);
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/FormExtensionDivLayoutTest.php
@@ -134,7 +134,7 @@ class FormExtensionDivLayoutTest extends AbstractDivLayoutTest
      */
     public function testIsChoiceSelected($expected, $choice, $value)
     {
-        $choice = new ChoiceView($choice, $choice . ' label');
+        $choice = new ChoiceView($choice, $choice, $choice . ' label');
 
         $this->assertSame($expected, $this->extension->isSelectedChoice($choice, $value));
     }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -175,3 +175,5 @@ CHANGELOG
    * `isChoiceSelected`
  * [BC BREAK] renamed method `renderBlock` in FormHelper to `block` and changed its signature
  * made FormView properties public and deprecated their accessor methods
+ * made the normalized data of a form accessible in the template through the variable "form.vars.data"
+ * made the original data of a choice accessible in the template through the property "choice.data"

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -339,7 +339,7 @@ class ChoiceList implements ChoiceListInterface
             throw new InvalidConfigurationException('The value created by the choice list is of type "' . gettype($value) . '", but should be a string.');
         }
 
-        $view = new ChoiceView($value, $label);
+        $view = new ChoiceView($choice, $value, $label);
 
         $this->choices[$index] = $this->fixChoice($choice);
         $this->values[$index] = $value;

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -116,6 +116,7 @@ class FormType extends AbstractType
             'errors'             => $form->getErrors(),
             'valid'              => $form->isBound() ? $form->isValid() : true,
             'value'              => $form->getViewData(),
+            'data'               => $form->getNormData(),
             'disabled'           => $form->isDisabled(),
             'required'           => $form->isRequired(),
             'max_length'         => $options['max_length'],

--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -19,6 +19,13 @@ namespace Symfony\Component\Form\Extension\Core\View;
 class ChoiceView
 {
     /**
+     * The original choice value.
+     *
+     * @var mixed
+     */
+    public $data;
+
+    /**
      * The view representation of the choice.
      *
      * @var string
@@ -35,11 +42,13 @@ class ChoiceView
     /**
      * Creates a new ChoiceView.
      *
+     * @param mixed  $data  The original choice.
      * @param string $value The view representation of the choice.
      * @param string $label The label displayed to humans.
      */
-    public function __construct($value, $label)
+    public function __construct($data, $value, $label)
     {
+        $this->data = $data;
         $this->value = $value;
         $this->label = $label;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ChoiceListTest.php
@@ -69,8 +69,8 @@ class ChoiceListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4), $this->list->getChoices());
         $this->assertSame(array('0', '1', '2', '3'), $this->list->getValues());
-        $this->assertEquals(array(1 => new ChoiceView('1', 'B')), $this->list->getPreferredViews());
-        $this->assertEquals(array(0 => new ChoiceView('0', 'A'), 2 => new ChoiceView('2', 'C'), 3 => new ChoiceView('3', 'D')), $this->list->getRemainingViews());
+        $this->assertEquals(array(1 => new ChoiceView($this->obj2, '1', 'B')), $this->list->getPreferredViews());
+        $this->assertEquals(array(0 => new ChoiceView($this->obj1, '0', 'A'), 2 => new ChoiceView($this->obj3, '2', 'C'), 3 => new ChoiceView($this->obj4, '3', 'D')), $this->list->getRemainingViews());
     }
 
     public function testInitNestedArray()
@@ -78,12 +78,12 @@ class ChoiceListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4), $this->list->getChoices());
         $this->assertSame(array('0', '1', '2', '3'), $this->list->getValues());
         $this->assertEquals(array(
-            'Group 1' => array(1 => new ChoiceView('1', 'B')),
-            'Group 2' => array(2 => new ChoiceView('2', 'C'))
+            'Group 1' => array(1 => new ChoiceView($this->obj2, '1', 'B')),
+            'Group 2' => array(2 => new ChoiceView($this->obj3, '2', 'C'))
         ), $this->list->getPreferredViews());
         $this->assertEquals(array(
-            'Group 1' => array(0 => new ChoiceView('0', 'A')),
-            'Group 2' => array(3 => new ChoiceView('3', 'D'))
+            'Group 1' => array(0 => new ChoiceView($this->obj1, '0', 'A')),
+            'Group 2' => array(3 => new ChoiceView($this->obj4, '3', 'D'))
         ), $this->list->getRemainingViews());
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/LazyChoiceListTest.php
@@ -49,12 +49,12 @@ class LazyChoiceListTest extends \PHPUnit_Framework_TestCase
 
     public function testGetPreferredViews()
     {
-        $this->assertEquals(array(1 => new ChoiceView('b', 'B')), $this->list->getPreferredViews());
+        $this->assertEquals(array(1 => new ChoiceView('b', 'b', 'B')), $this->list->getPreferredViews());
     }
 
     public function testGetRemainingViews()
     {
-        $this->assertEquals(array(0 => new ChoiceView('a', 'A'), 2 => new ChoiceView('c', 'C')), $this->list->getRemainingViews());
+        $this->assertEquals(array(0 => new ChoiceView('a', 'a', 'A'), 2 => new ChoiceView('c', 'c', 'C')), $this->list->getRemainingViews());
     }
 
     public function testGetIndicesForChoices()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
@@ -81,8 +81,8 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4), $this->list->getChoices());
         $this->assertSame(array('0', '1', '2', '3'), $this->list->getValues());
-        $this->assertEquals(array(1 => new ChoiceView('1', 'B')), $this->list->getPreferredViews());
-        $this->assertEquals(array(0 => new ChoiceView('0', 'A'), 2 => new ChoiceView('2', 'C'), 3 => new ChoiceView('3', 'D')), $this->list->getRemainingViews());
+        $this->assertEquals(array(1 => new ChoiceView($this->obj2, '1', 'B')), $this->list->getPreferredViews());
+        $this->assertEquals(array(0 => new ChoiceView($this->obj1, '0', 'A'), 2 => new ChoiceView($this->obj3, '2', 'C'), 3 => new ChoiceView($this->obj4, '3', 'D')), $this->list->getRemainingViews());
     }
 
     public function testInitNestedArray()
@@ -90,12 +90,12 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4), $this->list->getChoices());
         $this->assertSame(array('0', '1', '2', '3'), $this->list->getValues());
         $this->assertEquals(array(
-            'Group 1' => array(1 => new ChoiceView('1', 'B')),
-            'Group 2' => array(2 => new ChoiceView('2', 'C'))
+            'Group 1' => array(1 => new ChoiceView($this->obj2, '1', 'B')),
+            'Group 2' => array(2 => new ChoiceView($this->obj3, '2', 'C'))
         ), $this->list->getPreferredViews());
         $this->assertEquals(array(
-            'Group 1' => array(0 => new ChoiceView('0', 'A')),
-            'Group 2' => array(3 => new ChoiceView('3', 'D'))
+            'Group 1' => array(0 => new ChoiceView($this->obj1, '0', 'A')),
+            'Group 2' => array(3 => new ChoiceView($this->obj4, '3', 'D'))
         ), $this->list->getRemainingViews());
     }
 
@@ -123,14 +123,14 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4, $obj5, $obj6), $this->list->getChoices());
         $this->assertSame(array('0', '1', '2', '3', '4', '5'), $this->list->getValues());
         $this->assertEquals(array(
-            'Group 1' => array(1 => new ChoiceView('1', 'B')),
-            'Group 2' => array(2 => new ChoiceView('2', 'C'))
+            'Group 1' => array(1 => new ChoiceView($this->obj2, '1', 'B')),
+            'Group 2' => array(2 => new ChoiceView($this->obj3, '2', 'C'))
         ), $this->list->getPreferredViews());
         $this->assertEquals(array(
-            'Group 1' => array(0 => new ChoiceView('0', 'A')),
-            'Group 2' => array(3 => new ChoiceView('3', 'D')),
-            4 => new ChoiceView('4', 'E'),
-            5 => new ChoiceView('5', 'F'),
+            'Group 1' => array(0 => new ChoiceView($this->obj1, '0', 'A')),
+            'Group 2' => array(3 => new ChoiceView($this->obj4, '3', 'D')),
+            4 => new ChoiceView($obj5, '4', 'E'),
+            5 => new ChoiceView($obj6, '5', 'F'),
         ), $this->list->getRemainingViews());
     }
 
@@ -172,8 +172,8 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4), $this->list->getChoices());
         $this->assertSame(array('10', '20', '30', '40'), $this->list->getValues());
-        $this->assertEquals(array(1 => new ChoiceView('20', 'B'), 2 => new ChoiceView('30', 'C')), $this->list->getPreferredViews());
-        $this->assertEquals(array(0 => new ChoiceView('10', 'A'), 3 => new ChoiceView('40', 'D')), $this->list->getRemainingViews());
+        $this->assertEquals(array(1 => new ChoiceView($this->obj2, '20', 'B'), 2 => new ChoiceView($this->obj3, '30', 'C')), $this->list->getPreferredViews());
+        $this->assertEquals(array(0 => new ChoiceView($this->obj1, '10', 'A'), 3 => new ChoiceView($this->obj4, '40', 'D')), $this->list->getRemainingViews());
     }
 
     public function testInitArrayUsesToString()
@@ -189,7 +189,7 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array($this->obj1, $this->obj2, $this->obj3, $this->obj4), $this->list->getChoices());
         $this->assertSame(array('0', '1', '2', '3'), $this->list->getValues());
-        $this->assertEquals(array(0 => new ChoiceView('0', 'A'), 1 => new ChoiceView('1', 'B'), 2 => new ChoiceView('2', 'C'), 3 => new ChoiceView('3', 'D')), $this->list->getRemainingViews());
+        $this->assertEquals(array(0 => new ChoiceView($this->obj1, '0', 'A'), 1 => new ChoiceView($this->obj2, '1', 'B'), 2 => new ChoiceView($this->obj3, '2', 'C'), 3 => new ChoiceView($this->obj4, '3', 'D')), $this->list->getRemainingViews());
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/SimpleChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/SimpleChoiceListTest.php
@@ -55,8 +55,8 @@ class SimpleChoiceListTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame(array(0 => 'a', 1 => 'b', 2 => 'c'), $this->list->getChoices());
         $this->assertSame(array(0 => 'a', 1 => 'b', 2 => 'c'), $this->list->getValues());
-        $this->assertEquals(array(1 => new ChoiceView('b', 'B')), $this->list->getPreferredViews());
-        $this->assertEquals(array(0 => new ChoiceView('a', 'A'), 2 => new ChoiceView('c', 'C')), $this->list->getRemainingViews());
+        $this->assertEquals(array(1 => new ChoiceView('b', 'b', 'B')), $this->list->getPreferredViews());
+        $this->assertEquals(array(0 => new ChoiceView('a', 'a', 'A'), 2 => new ChoiceView('c', 'c', 'C')), $this->list->getRemainingViews());
     }
 
     public function testInitNestedArray()
@@ -64,12 +64,12 @@ class SimpleChoiceListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array(0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd'), $this->list->getChoices());
         $this->assertSame(array(0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd'), $this->list->getValues());
         $this->assertEquals(array(
-            'Group 1' => array(1 => new ChoiceView('b', 'B')),
-            'Group 2' => array(2 => new ChoiceView('c', 'C'))
+            'Group 1' => array(1 => new ChoiceView('b', 'b', 'B')),
+            'Group 2' => array(2 => new ChoiceView('c', 'c', 'C'))
         ), $this->list->getPreferredViews());
         $this->assertEquals(array(
-            'Group 1' => array(0 => new ChoiceView('a', 'A')),
-            'Group 2' => array(3 => new ChoiceView('d', 'D'))
+            'Group 1' => array(0 => new ChoiceView('a', 'a', 'A')),
+            'Group 2' => array(3 => new ChoiceView('d', 'd', 'D'))
         ), $this->list->getRemainingViews());
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -654,10 +654,10 @@ class ChoiceTypeTest extends TypeTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('a', 'A'),
-            new ChoiceView('b', 'B'),
-            new ChoiceView('c', 'C'),
-            new ChoiceView('d', 'D'),
+            new ChoiceView('a', 'a', 'A'),
+            new ChoiceView('b', 'b', 'B'),
+            new ChoiceView('c', 'c', 'C'),
+            new ChoiceView('d', 'd', 'D'),
         ), $view->vars['choices']);
     }
 
@@ -671,12 +671,12 @@ class ChoiceTypeTest extends TypeTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            0 => new ChoiceView('a', 'A'),
-            2 => new ChoiceView('c', 'C'),
+            0 => new ChoiceView('a', 'a', 'A'),
+            2 => new ChoiceView('c', 'c', 'C'),
         ), $view->vars['choices']);
         $this->assertEquals(array(
-            1 => new ChoiceView('b', 'B'),
-            3 => new ChoiceView('d', 'D'),
+            1 => new ChoiceView('b', 'b', 'B'),
+            3 => new ChoiceView('d', 'd', 'D'),
         ), $view->vars['preferred_choices']);
     }
 
@@ -690,21 +690,40 @@ class ChoiceTypeTest extends TypeTestCase
 
         $this->assertEquals(array(
             'Symfony' => array(
-                0 => new ChoiceView('a', 'Bernhard'),
-                2 => new ChoiceView('c', 'Kris'),
+                0 => new ChoiceView('a', 'a', 'Bernhard'),
+                2 => new ChoiceView('c', 'c', 'Kris'),
             ),
             'Doctrine' => array(
-                4 => new ChoiceView('e', 'Roman'),
+                4 => new ChoiceView('e', 'e', 'Roman'),
             ),
         ), $view->vars['choices']);
         $this->assertEquals(array(
             'Symfony' => array(
-                1 => new ChoiceView('b', 'Fabien'),
+                1 => new ChoiceView('b', 'b', 'Fabien'),
             ),
             'Doctrine' => array(
-                3 => new ChoiceView('d', 'Jon'),
+                3 => new ChoiceView('d', 'd', 'Jon'),
             ),
         ), $view->vars['preferred_choices']);
+    }
+
+    public function testPassChoiceDataToView()
+    {
+        $obj1 = (object) array('value' => 'a', 'label' => 'A');
+        $obj2 = (object) array('value' => 'b', 'label' => 'B');
+        $obj3 = (object) array('value' => 'c', 'label' => 'C');
+        $obj4 = (object) array('value' => 'd', 'label' => 'D');
+        $form = $this->factory->create('choice', null, array(
+            'choice_list' => new ObjectChoiceList(array($obj1, $obj2, $obj3, $obj4), 'label', array(), null, 'value'),
+        ));
+        $view = $form->createView();
+
+        $this->assertEquals(array(
+            new ChoiceView($obj1, 'a', 'A'),
+            new ChoiceView($obj2, 'b', 'B'),
+            new ChoiceView($obj3, 'c', 'C'),
+            new ChoiceView($obj4, 'd', 'D'),
+        ), $view->vars['choices']);
     }
 
     public function testAdjustFullNameForMultipleNonExpanded()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CountryTypeTest.php
@@ -24,11 +24,11 @@ class CountryTypeTest extends LocalizedTestCase
         $choices = $view->vars['choices'];
 
         // Don't check objects for identity
-        $this->assertContains(new ChoiceView('DE', 'Deutschland'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('GB', 'Vereinigtes Königreich'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('US', 'Vereinigte Staaten'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('FR', 'Frankreich'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('MY', 'Malaysia'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('DE', 'DE', 'Deutschland'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('GB', 'GB', 'Vereinigtes Königreich'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('US', 'US', 'Vereinigte Staaten'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('FR', 'FR', 'Frankreich'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('MY', 'MY', 'Malaysia'), $choices, '', false, false);
     }
 
     public function testUnknownCountryIsNotIncluded()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -355,8 +355,8 @@ class DateTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('2010', '2010'),
-            new ChoiceView('2011', '2011'),
+            new ChoiceView('2010', '2010', '2010'),
+            new ChoiceView('2011', '2011', '2011'),
         ), $view['year']->vars['choices']);
     }
 
@@ -369,8 +369,8 @@ class DateTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('6', '06'),
-            new ChoiceView('7', '07'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['month']->vars['choices']);
     }
 
@@ -384,8 +384,8 @@ class DateTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('1', 'Jän'),
-            new ChoiceView('4', 'Apr')
+            new ChoiceView('1', '1', 'Jän'),
+            new ChoiceView('4', '4', 'Apr')
         ), $view['month']->vars['choices']);
     }
 
@@ -399,8 +399,8 @@ class DateTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('1', 'Jänner'),
-            new ChoiceView('4', 'April'),
+            new ChoiceView('1', '1', 'Jänner'),
+            new ChoiceView('4', '4', 'April'),
         ), $view['month']->vars['choices']);
     }
 
@@ -414,8 +414,8 @@ class DateTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('1', 'Jänner'),
-            new ChoiceView('4', 'April'),
+            new ChoiceView('1', '1', 'Jänner'),
+            new ChoiceView('4', '4', 'April'),
         ), $view['month']->vars['choices']);
     }
 
@@ -428,8 +428,8 @@ class DateTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('6', '06'),
-            new ChoiceView('7', '07'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['day']->vars['choices']);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -645,4 +645,18 @@ class FormTypeTest extends TypeTestCase
 
         $this->assertSame('default', $form->getData());
     }
+
+    public function testNormDataIsPassedToView()
+    {
+        $view = $this->factory->createBuilder('form')
+            ->addViewTransformer(new FixedDataTransformer(array(
+                'foo' => 'bar',
+            )))
+            ->setData('foo')
+            ->getForm()
+            ->createView();
+
+        $this->assertSame('foo', $view->vars['data']);
+        $this->assertSame('bar', $view->vars['value']);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LanguageTypeTest.php
@@ -23,11 +23,11 @@ class LanguageTypeTest extends LocalizedTestCase
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
-        $this->assertContains(new ChoiceView('en', 'Englisch'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('en_GB', 'Britisches Englisch'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('en_US', 'Amerikanisches Englisch'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('fr', 'Französisch'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('my', 'Birmanisch'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en', 'en', 'Englisch'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'Britisches Englisch'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en_US', 'en_US', 'Amerikanisches Englisch'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('fr', 'fr', 'Französisch'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('my', 'my', 'Birmanisch'), $choices, '', false, false);
     }
 
     public function testMultipleLanguagesIsNotIncluded()
@@ -36,6 +36,6 @@ class LanguageTypeTest extends LocalizedTestCase
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
-        $this->assertNotContains(new ChoiceView('mul', 'Mehrsprachig'), $choices, '', false, false);
+        $this->assertNotContains(new ChoiceView('mul', 'mul', 'Mehrsprachig'), $choices, '', false, false);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -23,8 +23,8 @@ class LocaleTypeTest extends LocalizedTestCase
         $view = $form->createView();
         $choices = $view->vars['choices'];
 
-        $this->assertContains(new ChoiceView('en', 'Englisch'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('en_GB', 'Englisch (Vereinigtes Königreich)'), $choices, '', false, false);
-        $this->assertContains(new ChoiceView('zh_Hant_MO', 'Chinesisch (traditionell, Sonderverwaltungszone Macao)'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en', 'en', 'Englisch'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'Englisch (Vereinigtes Königreich)'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'Chinesisch (traditionell, Sonderverwaltungszone Macao)'), $choices, '', false, false);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -244,8 +244,8 @@ class TimeTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('6', '06'),
-            new ChoiceView('7', '07'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['hour']->vars['choices']);
     }
 
@@ -258,8 +258,8 @@ class TimeTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('6', '06'),
-            new ChoiceView('7', '07'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['minute']->vars['choices']);
     }
 
@@ -273,8 +273,8 @@ class TimeTypeTest extends LocalizedTestCase
         $view = $form->createView();
 
         $this->assertEquals(array(
-            new ChoiceView('6', '06'),
-            new ChoiceView('7', '07'),
+            new ChoiceView('6', '6', '06'),
+            new ChoiceView('7', '7', '07'),
         ), $view['second']->vars['choices']);
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -22,9 +22,9 @@ class TimezoneTypeTest extends TypeTestCase
         $choices = $view->vars['choices'];
 
         $this->assertArrayHasKey('Africa', $choices);
-        $this->assertContains(new ChoiceView('Africa/Kinshasa', 'Kinshasa'), $choices['Africa'], '', false, false);
+        $this->assertContains(new ChoiceView('Africa/Kinshasa', 'Africa/Kinshasa', 'Kinshasa'), $choices['Africa'], '', false, false);
 
         $this->assertArrayHasKey('America', $choices);
-        $this->assertContains(new ChoiceView('America/New_York', 'New York'), $choices['America'], '', false, false);
+        $this->assertContains(new ChoiceView('America/New_York', 'America/New_York', 'New York'), $choices['America'], '', false, false);
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4171
Todo: -

Now you can access the normalized data of a form in the template:

```
form.vars.data
```

You can also access the original data of a choice, for example the entities in an entity type:

```
choice.data
```
