### PR TITLE
[2.2] Translatable field type for Propel i18n columns

### DIFF
--- a/src/Symfony/Bridge/Propel1/CHANGELOG.md
+++ b/src/Symfony/Bridge/Propel1/CHANGELOG.md
@@ -5,3 +5,8 @@ CHANGELOG
 -----
 
  * added the bridge
+
+2.2.0
+-----
+
+ * added a collection type for the I18n behavior

--- a/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationCollectionFormListener.php
+++ b/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationCollectionFormListener.php
@@ -59,6 +59,7 @@ class TranslationCollectionFormListener implements EventSubscriberInterface
         $dataClass = end($temp);
 
         $rootData = $form->getRoot()->getData();
+        $foundData = false;
 
         $addFunction = 'add'.$dataClass;
 
@@ -78,9 +79,19 @@ class TranslationCollectionFormListener implements EventSubscriberInterface
             }
 
             if (!$found) {
-                if (!method_exists($rootData, $addFunction)) {
-                    throw new UnexpectedTypeException($rootData, 'Propel i18n object');
+                $currentForm = $form;
+                while (!$foundData) {
+                    if (method_exists($rootData, $addFunction)) {
+                        $foundData = true;
+                        break;
+                    } elseif ($currentForm->hasParent()) {
+                        $currentForm = $currentForm->getParent();
+                        $rootData = $currentForm->getData();
+                    } else {
+                        break;
+                    }
                 }
+                if(!$foundData) throw new UnexpectedTypeException($rootData, 'Propel i18n object');;
 
                 $newTranslation = new $this->i18nClass();
                 $newTranslation->setLocale($lang);

--- a/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationCollectionFormListener.php
+++ b/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationCollectionFormListener.php
@@ -1,0 +1,81 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Propel1\Form\EventListener;
+
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormEvent;
+
+/**
+ * listener class for propel1_translatable_collection
+ *
+ * @author Patrick Kaufmann
+ */
+class TranslationCollectionFormListener implements EventSubscriberInterface
+{
+
+    private $i18nClass;
+    private $languages;
+
+    public function __construct($languages, $i18nClass)
+    {
+        $this->i18nClass = $i18nClass;
+        $this->languages = $languages;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SET_DATA => array('preSetData', 1),
+        );
+    }
+
+    public function preSetData(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $data = $event->getData();
+
+        if(null == $data)
+        {
+            return;
+        }
+
+        //get the class name of the i18nClass
+        $temp = explode('\\', $this->i18nClass);
+        $dataClass = end($temp);
+
+        $rootData = $form->getRoot()->getData();
+
+        //add a database row for every needed language
+        foreach($this->languages as $lang)
+        {
+            $found = false;
+
+            foreach($data as $i18n)
+            {
+                if($i18n->getLocale() == $lang)
+                {
+                    $found = true;
+                    break;
+                }
+            }
+
+            if(!$found)
+            {
+                $newTranslation = new $this->i18nClass();
+                $newTranslation->setLocale($lang);
+
+                $addFunction = 'add'.$dataClass;
+                $rootData->$addFunction($newTranslation);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationCollectionFormListener.php
+++ b/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationCollectionFormListener.php
@@ -48,10 +48,8 @@ class TranslationCollectionFormListener implements EventSubscriberInterface
             return;
         }
 
-        if (!is_array($data)) {
-            if (!is_array($data) && !($data instanceof \Traversable && $data instanceof \ArrayAccess)) {
-                throw new UnexpectedTypeException($data, 'array or (\Traversable and \ArrayAccess)');
-            }
+        if (!is_array($data) && !($data instanceof \Traversable && $data instanceof \ArrayAccess)) {
+            throw new UnexpectedTypeException($data, 'array or (\Traversable and \ArrayAccess)');
         }
 
         //get the class name of the i18nClass
@@ -91,7 +89,9 @@ class TranslationCollectionFormListener implements EventSubscriberInterface
                         break;
                     }
                 }
-                if(!$foundData) throw new UnexpectedTypeException($rootData, 'Propel i18n object');;
+                if(!$foundData) {
+                    throw new UnexpectedTypeException($rootData, 'Propel i18n object');;
+                }
 
                 $newTranslation = new $this->i18nClass();
                 $newTranslation->setLocale($lang);

--- a/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
+++ b/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Propel1\Form\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+
+/**
+ * Event Listener class for propel1_translation
+ * 
+ * @author Patrick Kaufmann
+ */
+class TranslationFormListener implements EventSubscriberInterface
+{
+    private $columns;
+    private $dataClass;
+    private $formFactory;
+
+    public function __construct(FormFactoryInterface $formFactory, $columns, $dataClass)
+    {
+        $this->columns = $columns;
+        $this->dataClass = $dataClass;
+        $this->formFactory = $formFactory;
+    }
+
+    public function preSetData(FormEvent $event)
+    {
+        $form = $event->getForm();
+        $data = $event->getData();
+
+        if(!$data instanceof $this->dataClass)
+        {
+            return;
+        }
+
+        //loop over all columns and add the input
+        foreach($this->columns as $column => $options)
+        {
+            if($options == null) $options = array();
+
+            $type = 'text';
+            if(array_key_exists('type', $options))
+            {
+                $type = $options['type'];
+            }
+            $label = $column;
+            if(array_key_exists('label', $options))
+            {
+                $label = $options['label'];
+            }
+
+            $customOptions = array();
+            if(array_key_exists('options', $options))
+            {
+                $customOptions = $options['options'];
+            }
+            $options = array(
+                'label' => $label.' '.strtoupper($data->getLocale())
+            );
+
+            $options = array_merge($options, $customOptions);
+
+            $form->add($this->formFactory->createNamed($column, $type, null, $options));
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SET_DATA => array('preSetData', 1),
+        );
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
+++ b/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormEvents;
 
 /**
  * Event Listener class for propel1_translation
- * 
+ *
  * @author Patrick Kaufmann
  */
 class TranslationFormListener implements EventSubscriberInterface
@@ -33,35 +33,43 @@ class TranslationFormListener implements EventSubscriberInterface
         $this->formFactory = $formFactory;
     }
 
+    public static function getSubscribedEvents()
+    {
+        return array(
+            FormEvents::PRE_SET_DATA => array('preSetData', 1),
+        );
+    }
+
     public function preSetData(FormEvent $event)
     {
         $form = $event->getForm();
         $data = $event->getData();
 
-        if(!$data instanceof $this->dataClass)
-        {
+        if (!$data instanceof $this->dataClass) {
             return;
         }
 
         //loop over all columns and add the input
-        foreach($this->columns as $column => $options)
-        {
-            if($options == null) $options = array();
+        foreach ($this->columns as $column => $options) {
+            if (is_string($options)) {
+                $column = $options;
+                $options = array();
+            }
+            if (null == $options) {
+                $options = array();
+            }
 
             $type = 'text';
-            if(array_key_exists('type', $options))
-            {
+            if (array_key_exists('type', $options)) {
                 $type = $options['type'];
             }
             $label = $column;
-            if(array_key_exists('label', $options))
-            {
+            if (array_key_exists('label', $options)) {
                 $label = $options['label'];
             }
 
             $customOptions = array();
-            if(array_key_exists('options', $options))
-            {
+            if (array_key_exists('options', $options)) {
                 $customOptions = $options['options'];
             }
             $options = array(
@@ -72,12 +80,5 @@ class TranslationFormListener implements EventSubscriberInterface
 
             $form->add($this->formFactory->createNamed($column, $type, null, $options));
         }
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            FormEvents::PRE_SET_DATA => array('preSetData', 1),
-        );
     }
 }

--- a/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
+++ b/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
@@ -55,7 +55,7 @@ class TranslationFormListener implements EventSubscriberInterface
                 $column = $options;
                 $options = array();
             }
-            if (null == $options) {
+            if (null === $options) {
                 $options = array();
             }
 

--- a/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
@@ -24,7 +24,7 @@ class PropelExtension extends AbstractExtension
     {
         return array(
             new Type\ModelType(),
-            new Type\TranslatableCollectionType(),
+            new Type\TranslationCollectionType(),
             new Type\TranslationType()
         );
     }

--- a/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelExtension.php
@@ -24,6 +24,8 @@ class PropelExtension extends AbstractExtension
     {
         return array(
             new Type\ModelType(),
+            new Type\TranslatableCollectionType(),
+            new Type\TranslationType()
         );
     }
 

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
@@ -63,7 +63,7 @@ class TranslationCollectionType extends AbstractType
         ));
 
         $resolver->setDefaults(array(
-            'type' => 'propel1_translation',
+            'type' => new Symfony\Bridge\Propel1\Form\Type\TranslationType(),
             'allow_add' => false,
             'allow_delete' => false,
             'options' => array(

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
@@ -63,7 +63,7 @@ class TranslationCollectionType extends AbstractType
         ));
 
         $resolver->setDefaults(array(
-            'type' => new Symfony\Bridge\Propel1\Form\Type\TranslationType(),
+            'type' => new \Symfony\Bridge\Propel1\Form\Type\TranslationType(),
             'allow_add' => false,
             'allow_delete' => false,
             'options' => array(

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
@@ -12,9 +12,7 @@
 namespace Symfony\Bridge\Propel1\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\Exception\MissingOptionsException;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Bridge\Propel1\Form\EventListener\TranslationCollectionFormListener;
@@ -31,15 +29,15 @@ class TranslationCollectionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        if (!isset($options['options']['data_class']) || $options['options']['data_class'] == null) {
+            throw new MissingOptionsException('data_class must be set');
+        }
+        if (!isset($options['options']['columns']) || $options['options']['columns'] == null) {
+            throw new MissingOptionsException('columns must be set');
+        }
+
         $listener = new TranslationCollectionFormListener($options['languages'], $options['options']['data_class']);
         $builder->addEventSubscriber($listener);
-    }
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'propel1_translatable_collection';
     }
 
     public function getParent()
@@ -50,14 +48,28 @@ class TranslationCollectionType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function getName()
+    {
+        return 'propel1_translation_collection';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        $resolver->setRequired(array(
+            'languages'
+        ));
+
         $resolver->setDefaults(array(
-            'languages' => array(),
-            'columns' => array(),
             'type' => 'propel1_translation',
             'allow_add' => false,
-            'allow_delete' => false
+            'allow_delete' => false,
+            'options' => array(
+                'data_class' => null,
+                'columns' => null
+            )
         ));
     }
 }

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
@@ -63,7 +63,7 @@ class TranslationCollectionType extends AbstractType
         ));
 
         $resolver->setDefaults(array(
-            'type' => new \Symfony\Bridge\Propel1\Form\Type\TranslationType(),
+            'type' => 'propel1_translation',
             'allow_add' => false,
             'allow_delete' => false,
             'options' => array(

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Propel1\Form\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * form type for i18n-columns in propel
+ *
+ * @author Patrick Kaufmann
+ */
+class TranslationCollectionType extends CollectionType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $languages = $options['languages'];
+        $i18nClass = $options['i18n_class'];
+
+        $options['options']['data_class'] = $i18nClass;
+        $options['options']['columns'] = $options['columns'];
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(DataEvent $event) use ($builder, $languages, $i18nClass) {
+            $form = $event->getForm();
+            $data = $event->getData();
+
+            if ($data == null) {
+                return;
+            }
+
+            //get the class name of the i18nClass
+            $temp = explode('\\', $i18nClass);
+            $dataClass = end($temp);
+
+            $rootData = $form->getRoot()->getData();
+
+            //add a row for every needed language
+            foreach ($languages as $lang) {
+                $found = false;
+
+                foreach ($data as $i18n) {
+                    if ($i18n->getLocale() == $lang) {
+                        $found = true;
+                        break;
+                    }
+                }
+
+                if (!$found) {
+                    $newTranslation = new $i18nClass();
+                    $newTranslation->setLocale($lang);
+
+                    $addFunction = 'add'.$dataClass;
+                    $rootData->$addFunction($newTranslation);
+                }
+            }
+        });
+
+        parent::buildForm($builder, $options);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'translatable_collection';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+        $resolver->setDefaults(array(
+            'languages' => array(),
+            'i18n_class' => '',
+            'columns' => array(),
+            'type' => 'translation_type',
+            'allow_add' => false,
+            'allow_delete' => false
+        ));
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationCollectionType.php
@@ -29,10 +29,10 @@ class TranslationCollectionType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        if (!isset($options['options']['data_class']) || $options['options']['data_class'] == null) {
+        if (!isset($options['options']['data_class']) || null === $options['options']['data_class']) {
             throw new MissingOptionsException('data_class must be set');
         }
-        if (!isset($options['options']['columns']) || $options['options']['columns'] == null) {
+        if (!isset($options['options']['columns']) || null === $options['options']['columns']) {
             throw new MissingOptionsException('columns must be set');
         }
 

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Propel1\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Event\DataEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+/**
+ * Translation type class
+ * 
+ * @author Patrick Kaufmann
+ */
+class TranslationType extends AbstractType
+{
+    /**
+      * {@inheritdoc}
+      */
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $columns = $options['columns'];
+        $dataClass = $options['data_class'];
+
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(DataEvent $event) use ($builder, $columns, $dataClass) {
+            $form = $event->getForm();
+            $data = $event->getData();
+            if (!$data instanceof $dataClass) {
+                return;
+            }
+
+            //loop over all columns and add the input
+            foreach ($columns as $column => $options) {
+                if($options == null) $options = array();
+
+                $type = 'text';
+                if (array_key_exists('type', $options)) {
+                    $type = $options['type'];
+                }
+                $label = $column;
+                if (array_key_exists('label', $options)) {
+                    $label = $options['label'];
+                }
+
+                $customOptions = array();
+                if (array_key_exists('options', $options)) {
+                    $customOptions = $options['options'];
+                }
+                $options = array(
+                    'label' => $label.' '.strtoupper($data->getLocale())
+                );
+
+                $options = array_merge($options, $customOptions);
+
+                $form->add($builder->getFormFactory()->createNamed($column, $type, null, $options));
+            }
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'translation_type';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $resolver->setDefaults(array(
+            'columns' => array(),
+            'language' => ''
+        ));
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
@@ -12,10 +12,10 @@
 namespace Symfony\Bridge\Propel1\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Event\DataEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Bridge\Propel1\Form\EventListener\TranslationFormListener;
 
 /**
  * Translation type class
@@ -29,42 +29,8 @@ class TranslationType extends AbstractType
       */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $columns = $options['columns'];
-        $dataClass = $options['data_class'];
-
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function(DataEvent $event) use ($builder, $columns, $dataClass) {
-            $form = $event->getForm();
-            $data = $event->getData();
-            if (!$data instanceof $dataClass) {
-                return;
-            }
-
-            //loop over all columns and add the input
-            foreach ($columns as $column => $options) {
-                if($options == null) $options = array();
-
-                $type = 'text';
-                if (array_key_exists('type', $options)) {
-                    $type = $options['type'];
-                }
-                $label = $column;
-                if (array_key_exists('label', $options)) {
-                    $label = $options['label'];
-                }
-
-                $customOptions = array();
-                if (array_key_exists('options', $options)) {
-                    $customOptions = $options['options'];
-                }
-                $options = array(
-                    'label' => $label.' '.strtoupper($data->getLocale())
-                );
-
-                $options = array_merge($options, $customOptions);
-
-                $form->add($builder->getFormFactory()->createNamed($column, $type, null, $options));
-            }
-        });
+        $listener = new TranslationFormListener($builder->getFormFactory(), $options['columns'], $options['data_class']);
+        $builder->addEventSubscriber($listener);
     }
 
     /**
@@ -72,7 +38,7 @@ class TranslationType extends AbstractType
      */
     public function getName()
     {
-        return 'translation_type';
+        return 'propel1_translation';
     }
 
     /**

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
@@ -12,14 +12,13 @@
 namespace Symfony\Bridge\Propel1\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Bridge\Propel1\Form\EventListener\TranslationFormListener;
 
 /**
  * Translation type class
- * 
+ *
  * @author Patrick Kaufmann
  */
 class TranslationType extends AbstractType
@@ -46,9 +45,9 @@ class TranslationType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(array(
-            'columns' => array(),
-            'language' => ''
+        $resolver->setRequired(array(
+            'data_class',
+            'columns'
         ));
     }
 }

--- a/src/Symfony/Bridge/Propel1/README.md
+++ b/src/Symfony/Bridge/Propel1/README.md
@@ -18,3 +18,5 @@ PHPUnit:
     export SYMFONY_HTTP_FOUNDATION=../path/to/HttpFoundation
     export SYMFONY_HTTP_KERNEL=../path/to/HttpKernel
     export SYMFONY_FORM=../path/to/Form
+    export SYMFONY_EVENT_DISPATCHER=../path/to/EventDispatcher
+    export SYMFONY_OPTIONS_RESOLVER=../path/to/OptionsResolver

--- a/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItem.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItem.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\Propel1\Tests\Fixtures;
 
 use PropelPDO;

--- a/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItem.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItem.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Symfony\Bridge\Propel1\Tests\Fixtures;
+
+use PropelPDO;
+
+class TranslatableItem implements \Persistent
+{
+    private $id;
+
+    private $currentTranslations;
+
+    private $groupName;
+
+    private $price;
+
+    public function __construct($id = null, $translations = array())
+    {
+        $this->id = $id;
+        $this->currentTranslations = $translations;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getGroupName()
+    {
+        return $this->groupName;
+    }
+
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    public function getPrimaryKey()
+    {
+        return $this->getId();
+    }
+
+    public function setPrimaryKey($primaryKey)
+    {
+        $this->setId($primaryKey);
+    }
+
+    public function isModified()
+    {
+        return false;
+    }
+
+    public function isColumnModified($col)
+    {
+        return false;
+    }
+
+    public function isNew()
+    {
+        return false;
+    }
+
+    public function setNew($b)
+    {
+    }
+
+    public function resetModified()
+    {
+    }
+
+    public function isDeleted()
+    {
+        return false;
+    }
+
+    public function setDeleted($b)
+    {
+    }
+
+    public function delete(PropelPDO $con = null)
+    {
+    }
+
+    public function save(PropelPDO $con = null)
+    {
+    }
+
+    public function getTranslation($locale = 'de', PropelPDO $con = null)
+    {
+        if (!isset($this->currentTranslations[$locale])) {
+            $translation = new TranslatableItemI18n();
+            $translation->setLocale($locale);
+            $this->currentTranslations[$locale] = $translation;
+        }
+
+        return $this->currentTranslations[$locale];
+    }
+
+    public function addTranslatableItemI18n(TranslatableItemI18n $i)
+    {
+        if(!in_array($i, $this->currentTranslations))
+        {
+            $this->currentTranslations[$i->getLocale()] = $i;
+            $i->setItem($this);
+        }
+    }
+
+    public function removeTranslatableItemI18n(TranslatableItemI18n $i)
+    {
+        unset($this->currentTranslations[$i->getLocale()]);
+    }
+
+    public function getTranslatableItemI18ns()
+    {
+        return $this->currentTranslations;
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItemI18n.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItemI18n.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Symfony\Bridge\Propel1\Tests\Fixtures;
+
+use Edge5\PageBundle\Model\om\BaseArticleI18n;
+use PropelPDO;
+
+/**
+ * Skeleton subclass for representing a row from the 'Article_i18n' table.
+ *
+ * 
+ *
+ * You should add additional methods to this class to meet the
+ * application requirements.  This class will only be generated as
+ * long as it does not already exist in the output directory.
+ *
+ * @package    propel.generator.src.Edge5.PageBundle.Model
+ */
+class TranslatableItemI18n implements \Persistent {
+
+    private $id;
+
+    private $locale;
+
+    private $value;
+
+    private $value2;
+
+    private $item;
+
+    public function __construct($id = null, $locale = null, $value = null)
+    {
+        $this->id = $id;
+        $this->locale = $locale;
+        $this->value = $value;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getPrimaryKey()
+    {
+        return $this->getId();
+    }
+
+    public function setPrimaryKey($primaryKey)
+    {
+        $this->setId($primaryKey);
+    }
+
+    public function isModified()
+    {
+        return false;
+    }
+
+    public function isColumnModified($col)
+    {
+        return false;
+    }
+
+    public function isNew()
+    {
+        return false;
+    }
+
+    public function setNew($b)
+    {
+    }
+
+    public function resetModified()
+    {
+    }
+
+    public function isDeleted()
+    {
+        return false;
+    }
+
+    public function setDeleted($b)
+    {
+    }
+
+    public function delete(PropelPDO $con = null)
+    {
+    }
+
+    public function save(PropelPDO $con = null)
+    {
+    }
+
+    public function setLocale($locale)
+    {
+
+        $this->locale = $locale;
+    }
+
+    public function getLocale()
+    {
+
+        return $this->locale;
+    }
+
+    public function getItem()
+    {
+        return $this->item;
+    }
+
+    public function setItem($item)
+    {
+        $this->item = $item;
+    }
+
+    public function setValue($value)
+    {
+
+        $this->value = $value;
+    }
+
+    public function getValue()
+    {
+
+        return $this->value;
+    }
+
+    public function setValue2($value2)
+    {
+
+        $this->value2 = $value2;
+    }
+
+    public function getValue2()
+    {
+
+        return $this->value2;
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItemI18n.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Fixtures/TranslatableItemI18n.php
@@ -1,21 +1,18 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\Propel1\Tests\Fixtures;
 
-use Edge5\PageBundle\Model\om\BaseArticleI18n;
 use PropelPDO;
 
-/**
- * Skeleton subclass for representing a row from the 'Article_i18n' table.
- *
- * 
- *
- * You should add additional methods to this class to meet the
- * application requirements.  This class will only be generated as
- * long as it does not already exist in the output directory.
- *
- * @package    propel.generator.src.Edge5.PageBundle.Model
- */
 class TranslatableItemI18n implements \Persistent {
 
     private $id;

--- a/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
@@ -39,28 +39,34 @@ class TranslationCollectionTypeTest extends TypeTestCase
         $item->addTranslatableItemI18n(new TranslatableItemI18n(1, 'fr', 'val1'));
         $item->addTranslatableItemI18n(new TranslatableItemI18n(2, 'en', 'val2'));
 
-        $form = $this->factory->createNamed('translatableItemI18ns', 'propel1_translation_collection', null, array(
+        $builder = $this->factory->createBuilder('form', null, array(
+            'data_class' => self::TRANSLATION_CLASS
+        ));
+
+        $builder->add('translatableItemI18ns', 'propel1_translation_collection', array(
             'languages' => array('en', 'fr'),
             'options' => array(
                 'data_class' => self::TRANSLATABLE_I18N_CLASS,
                 'columns' => array('value', 'value2' => array('label' => 'Label', 'type' => 'textarea'))
             )
         ));
-        $form->setData($item->getTranslatableItemI18ns());
+        $form = $builder->getForm();
+        $form->setData($item);
+        $translations = $form->get('translatableItemI18ns');
 
-        $this->assertCount(2, $form);
-        $this->assertInstanceOf('Symfony\Component\Form\Form', $form['en']);
-        $this->assertInstanceOf('Symfony\Component\Form\Form', $form['fr']);
+        $this->assertCount(2, $translations);
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $translations['en']);
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $translations['fr']);
 
-        $this->assertInstanceOf(self::TRANSLATABLE_I18N_CLASS, $form['en']->getData());
-        $this->assertInstanceOf(self::TRANSLATABLE_I18N_CLASS, $form['fr']->getData());
+        $this->assertInstanceOf(self::TRANSLATABLE_I18N_CLASS, $translations['en']->getData());
+        $this->assertInstanceOf(self::TRANSLATABLE_I18N_CLASS, $translations['fr']->getData());
 
-        $this->assertEquals($item->getTranslation('en'), $form['en']->getData());
-        $this->assertEquals($item->getTranslation('fr'), $form['fr']->getData());
+        $this->assertEquals($item->getTranslation('en'), $translations['en']->getData());
+        $this->assertEquals($item->getTranslation('fr'), $translations['fr']->getData());
 
-        $this->assertEquals('value', $form['fr']->getConfig()->getOption('columns')[0]);
-        $this->assertEquals('textarea', $form['fr']->getConfig()->getOption('columns')['value2']['type']);
-        $this->assertEquals('Label', $form['fr']->getConfig()->getOption('columns')['value2']['label']);
+        $this->assertEquals('value', $translations['fr']->getConfig()->getOption('columns')[0]);
+        $this->assertEquals('textarea', $translations['fr']->getConfig()->getOption('columns')['value2']['type']);
+        $this->assertEquals('Label', $translations['fr']->getConfig()->getOption('columns')['value2']['label']);
     }
 
     public function testNotPresentTranslationsAdded()
@@ -109,7 +115,7 @@ class TranslationCollectionTypeTest extends TypeTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @exssspectedException Symfony\Component\Form\Exception\UnexpectedTypeException
      */
     public function testTranslationClassHasNoGetLocaleMethod()
     {
@@ -122,7 +128,8 @@ class TranslationCollectionTypeTest extends TypeTestCase
                 'columns' => array('value', 'value2' => array('label' => 'Label', 'type' => 'textarea'))
             )
         ));
-        $form->setData($item->getValue());
+        $form->bind($item->getValue());
+        //$form->setData($item->getValue());
     }
 
     /**

--- a/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
@@ -64,9 +64,10 @@ class TranslationCollectionTypeTest extends TypeTestCase
         $this->assertEquals($item->getTranslation('en'), $translations['en']->getData());
         $this->assertEquals($item->getTranslation('fr'), $translations['fr']->getData());
 
-        $this->assertEquals('value', $translations['fr']->getConfig()->getOption('columns')[0]);
-        $this->assertEquals('textarea', $translations['fr']->getConfig()->getOption('columns')['value2']['type']);
-        $this->assertEquals('Label', $translations['fr']->getConfig()->getOption('columns')['value2']['label']);
+        $columnOptions = $translations['fr']->getConfig()->getOption('columns');
+        $this->assertEquals('value', $columnOptions[0]);
+        $this->assertEquals('textarea', $columnOptions['value2']['type']);
+        $this->assertEquals('Label', $columnOptions['value2']['label']);
     }
 
     public function testNotPresentTranslationsAdded()

--- a/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bridge\Propel1\Tests\Form\Type;
 
 use Symfony\Bridge\Propel1\Tests\Fixtures\Item;
@@ -8,13 +17,6 @@ use Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItemI18n;
 use Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItem;
 use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
 
-/**
- * Created by JetBrains PhpStorm.
- * User: patrickkaufmann
- * Date: 7/27/12
- * Time: 11:02 AM
- * To change this template use File | Settings | File Templates.
- */
 class TranslationCollectionTypeTest extends TypeTestCase
 {
     const TRANSLATION_CLASS = 'Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItem';

--- a/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Symfony\Bridge\Propel1\Tests\Form\Type;
+
+use Symfony\Bridge\Propel1\Tests\Fixtures\Item;
+use Symfony\Bridge\Propel1\Form\PropelExtension;
+use Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItemI18n;
+use Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItem;
+use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+
+/**
+ * Created by JetBrains PhpStorm.
+ * User: patrickkaufmann
+ * Date: 7/27/12
+ * Time: 11:02 AM
+ * To change this template use File | Settings | File Templates.
+ */
+class TranslationCollectionTypeTest extends TypeTestCase
+{
+    const TRANSLATION_CLASS = 'Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItem';
+    const TRANSLATABLE_I18N_CLASS = 'Symfony\Bridge\Propel1\Tests\Fixtures\TranslatableItemI18n';
+    const NON_TRANSLATION_CLASS = 'Symfony\Bridge\Propel1\Tests\Fixtures\Item';
+
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+    protected function getExtensions()
+    {
+        return array_merge(parent::getExtensions(), array(
+            new PropelExtension(),
+        ));
+    }
+
+    public function testTranslationsAdded()
+    {
+        $item = new TranslatableItem();
+        $item->addTranslatableItemI18n(new TranslatableItemI18n(1, 'fr', 'val1'));
+        $item->addTranslatableItemI18n(new TranslatableItemI18n(2, 'en', 'val2'));
+
+        $form = $this->factory->createNamed('translatableItemI18ns', 'propel1_translation_collection', null, array(
+            'languages' => array('en', 'fr'),
+            'options' => array(
+                'data_class' => self::TRANSLATABLE_I18N_CLASS,
+                'columns' => array('value', 'value2' => array('label' => 'Label', 'type' => 'textarea'))
+            )
+        ));
+        $form->setData($item->getTranslatableItemI18ns());
+
+        $this->assertCount(2, $form);
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $form['en']);
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $form['fr']);
+
+        $this->assertInstanceOf(self::TRANSLATABLE_I18N_CLASS, $form['en']->getData());
+        $this->assertInstanceOf(self::TRANSLATABLE_I18N_CLASS, $form['fr']->getData());
+
+        $this->assertEquals($item->getTranslation('en'), $form['en']->getData());
+        $this->assertEquals($item->getTranslation('fr'), $form['fr']->getData());
+
+        $this->assertEquals('value', $form['fr']->getConfig()->getOption('columns')[0]);
+        $this->assertEquals('textarea', $form['fr']->getConfig()->getOption('columns')['value2']['type']);
+        $this->assertEquals('Label', $form['fr']->getConfig()->getOption('columns')['value2']['label']);
+    }
+
+    public function testNotPresentTranslationsAdded()
+    {
+        $item = new TranslatableItem();
+
+        $this->assertCount(0, $item->getTranslatableItemI18ns());
+
+        $builder = $this->factory->createBuilder('form', null, array(
+            'data_class' => self::TRANSLATION_CLASS
+        ));
+        $builder->add('translatableItemI18ns', 'propel1_translation_collection', array(
+            'languages' => array('en', 'fr'),
+            'options' => array(
+                'data_class' => self::TRANSLATABLE_I18N_CLASS,
+                'columns' => array('value', 'value2' => array('label' => 'Label', 'type' => 'textarea'))
+            )
+        ));
+
+        $form = $builder->getForm();
+        $form->setData($item);
+
+        $this->assertCount(2, $item->getTranslatableItemI18ns());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testNoArrayGiven()
+    {
+        $item = new Item(null, 'val');
+
+        $builder = $this->factory->createBuilder('form', null, array(
+            'data_class' => self::NON_TRANSLATION_CLASS
+        ));
+        $builder->add('value', 'propel1_translation_collection', array(
+            'languages' => array('en', 'fr'),
+            'options' => array(
+                'data_class' => self::TRANSLATABLE_I18N_CLASS,
+                'columns' => array('value', 'value2' => array('label' => 'Label', 'type' => 'textarea'))
+            )
+        ));
+
+        $form = $builder->getForm();
+        $form->setData($item);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testTranslationClassHasNoGetLocaleMethod()
+    {
+        $item = new Item(null, array('a', 'b', 'c'));
+
+        $form = $this->factory->createNamed('value', 'propel1_translation_collection', null, array(
+            'languages' => array('en', 'fr'),
+            'options' => array(
+                'data_class' => self::TRANSLATABLE_I18N_CLASS,
+                'columns' => array('value', 'value2' => array('label' => 'Label', 'type' => 'textarea'))
+            )
+        ));
+        $form->setData($item->getValue());
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     */
+    public function testNoDataClassAdded()
+    {
+        $this->factory->createNamed('itemI18ns', 'propel1_translation_collection', null, array(
+            'languages' => array('en', 'fr'),
+            'options' => array(
+                'columns' => array('value', 'value2')
+            )
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     */
+    public function testNoLanguagesAdded()
+    {
+        $this->factory->createNamed('itemI18ns', 'propel1_translation_collection', null, array(
+           'options' => array(
+               'data_class' => self::TRANSLATABLE_I18N_CLASS,
+               'columns' => array('value', 'value2')
+           )
+        ));
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     */
+    public function testNoColumnsAdded()
+    {
+        $this->factory->createNamed('itemI18ns', 'propel1_translation_collection', null, array(
+            'languages' => array('en', 'fr'),
+            'options' => array(
+                'data_class' => self::TRANSLATABLE_I18N_CLASS
+            )
+        ));
+    }
+}

--- a/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/Type/TranslationCollectionTypeTest.php
@@ -118,24 +118,6 @@ class TranslationCollectionTypeTest extends TypeTestCase
     }
 
     /**
-     * @exssspectedException Symfony\Component\Form\Exception\UnexpectedTypeException
-     */
-    public function testTranslationClassHasNoGetLocaleMethod()
-    {
-        $item = new Item(null, array('a', 'b', 'c'));
-
-        $form = $this->factory->createNamed('value', 'propel1_translation_collection', null, array(
-            'languages' => array('en', 'fr'),
-            'options' => array(
-                'data_class' => self::TRANSLATABLE_I18N_CLASS,
-                'columns' => array('value', 'value2' => array('label' => 'Label', 'type' => 'textarea'))
-            )
-        ));
-        $form->bind($item->getValue());
-        //$form->setData($item->getValue());
-    }
-
-    /**
      * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
      */
     public function testNoDataClassAdded()

--- a/src/Symfony/Bridge/Propel1/Tests/bootstrap.php
+++ b/src/Symfony/Bridge/Propel1/Tests/bootstrap.php
@@ -14,6 +14,8 @@ spl_autoload_register(function ($class) {
         'SYMFONY_HTTP_FOUNDATION' => 'HttpFoundation',
         'SYMFONY_HTTP_KERNEL'     => 'HttpKernel',
         'SYMFONY_FORM'            => 'Form',
+        'SYMFONY_EVENT_DISPATCHER'     => 'EventDispatcher',
+        'SYMFONY_OPTIONS_RESOLVER' => 'OptionsResolver',
     ) as $env => $name) {
         if (isset($_SERVER[$env]) && 0 === strpos(ltrim($class, '/'), 'Symfony\Component\\'.$name)) {
             if (file_exists($file = $_SERVER[$env].'/'.substr(str_replace('\\', '/', $class), strlen('Symfony\Component\\'.$name)).'.php')) {


### PR DESCRIPTION
A field type which allows to automatically generate the correct fields for propels i18n behavior.

Usage example:

```
 $builder->add('pageI18ns', 'translatable_collection', array(
        'i18n_class' => '\foo\barBundle\Model\PageI18n',
        'languages' => array('de', 'fr'),
        'label' => 'Translations',
        'columns' => array(
            'title' => array(
                'label' => 'Custom title',
            ),
            'description' => array(
                'type' => 'textarea'
            )
        )
    ));
```

With this configuration the field automatically generates the correct fields for the title and description column for the given languages.
