### PR TITLE
[HttpKernel] HTTP kernel exception handling update

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -159,7 +159,7 @@ class HttpKernel extends BaseHttpKernel
 
         $level = ob_get_level();
         try {
-            $response = $this->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
+            $response = $this->handle($subRequest, HttpKernelInterface::SUB_REQUEST, HttpKernelInterface::EXCEPTIONS_OFF);
 
             if (!$response->isSuccessful()) {
                 throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $request->getUri(), $response->getStatusCode()));

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -73,7 +73,7 @@ class ExceptionListener implements EventSubscriberInterface
         $request->setMethod('GET');
 
         try {
-            $response = $event->getKernel()->handle($request, HttpKernelInterface::SUB_REQUEST, true);
+            $response = $event->getKernel()->handle($request, HttpKernelInterface::SUB_REQUEST, HttpKernelInterface::EXCEPTIONS_ON);
         } catch (\Exception $e) {
             $message = sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage());
             if (null !== $this->logger) {

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -188,7 +188,7 @@ class Esi
         $subRequest = Request::create($uri, 'get', array(), $cache->getRequest()->cookies->all(), array(), $cache->getRequest()->server->all());
 
         try {
-            $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
+            $response = $cache->handle($subRequest, HttpKernelInterface::SUB_REQUEST, HttpKernelInterface::EXCEPTIONS_AUTOTUNE);
 
             if (!$response->isSuccessful()) {
                 throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $subRequest->getUri(), $response->getStatusCode()));

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -168,7 +168,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @api
      */
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = HttpKernelInterface::EXCEPTIONS_AUTOTUNE)
     {
         // FIXME: catch exceptions and implement a 500 error page here? -> in Varnish, there is a built-in error page mechanism
         if (HttpKernelInterface::MASTER_REQUEST === $type) {
@@ -437,7 +437,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
      *
      * @return Response A Response instance
      */
-    protected function forward(Request $request, $catch = false, Response $entry = null)
+    protected function forward(Request $request, $catch = HttpKernelInterface::EXCEPTIONS_OFF, Response $entry = null)
     {
         if ($this->esi) {
             $this->esi->addSurrogateEsiCapability($request);

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -23,6 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
  */
 interface HttpKernelInterface
 {
+    const EXCEPTIONS_OFF = false;
+    const EXCEPTIONS_ON = 'on';
+    const EXCEPTIONS_AUTOTUNE = true;
+
     const MASTER_REQUEST = 1;
     const SUB_REQUEST = 2;
 
@@ -35,7 +39,9 @@ interface HttpKernelInterface
      * @param Request $request A Request instance
      * @param integer $type    The type of the request
      *                          (one of HttpKernelInterface::MASTER_REQUEST or HttpKernelInterface::SUB_REQUEST)
-     * @param Boolean $catch Whether to catch exceptions or not
+     * @param Boolean $mode    The exception handling mode, one of the HttpKernelInterface::EXCEPTIONS_OFF
+     *                          HttpKernelInterface::EXCEPTIONS_ON or HttpKernelInterface::EXCEPTIONS_AUTOTUNE)
+     *                          Default to HttpKernelInterface::EXCEPTIONS_AUTOTUNE
      *
      * @return Response A Response instance
      *
@@ -43,5 +49,5 @@ interface HttpKernelInterface
      *
      * @api
      */
-    public function handle(Request $request, $type = self::MASTER_REQUEST, $catch = true);
+    public function handle(Request $request, $type = self::MASTER_REQUEST, $mode = HttpKernelInterface::EXCEPTIONS_AUTOTUNE);
 }

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
 interface HttpKernelInterface
 {
     const EXCEPTIONS_OFF = false;
-    const EXCEPTIONS_ON = 'on';
+    const EXCEPTIONS_ON = "on";
     const EXCEPTIONS_AUTOTUNE = true;
 
     const MASTER_REQUEST = 1;

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -184,7 +184,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @api
      */
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = HttpKernelInterface::EXCEPTIONS_AUTOTUNE)
     {
         if (false === $this->booted) {
             $this->boot();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -936,7 +936,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
     public function testShouldNotCatchExceptions()
     {
-        $this->catchExceptions(false);
+        $this->catchExceptions(HttpKernelInterface::EXCEPTIONS_OFF);
 
         $this->setNextResponse();
         $this->request('GET', '/');

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -149,7 +149,7 @@ class HttpCacheTestCase extends \PHPUnit_Framework_TestCase
         $this->kernel = new TestMultipleHttpKernel($responses);
     }
 
-    public function catchExceptions($catch = true)
+    public function catchExceptions($catch = HttpKernelInterface::EXCEPTIONS_AUTOTUNE)
     {
         $this->catch = $catch;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTestCase.php
@@ -99,12 +99,12 @@ class HttpCacheTestCase extends \PHPUnit_Framework_TestCase
 
     public function assertExceptionsAreCaught()
     {
-        $this->assertTrue($this->kernel->isCatchingExceptions());
+        $this->assertEquals(HttpKernelInterface::EXCEPTIONS_AUTOTUNE, $this->kernel->isCatchingExceptions());
     }
 
     public function assertExceptionsAreNotCaught()
     {
-        $this->assertFalse($this->kernel->isCatchingExceptions());
+        $this->assertEquals(HttpKernelInterface::EXCEPTIONS_OFF, $this->kernel->isCatchingExceptions());
     }
 
     public function request($method, $uri = '/', $server = array(), $cookies = array(), $esi = false)

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -41,7 +41,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
     {
         $kernel = new HttpKernel(new EventDispatcher(), $this->getResolver(function () { throw new \RuntimeException(); }));
 
-        $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, true);
+        $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, HttpKernelInterface::EXCEPTIONS_ON);
     }
 
     /**
@@ -51,7 +51,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
     {
         $kernel = new HttpKernel(new EventDispatcher(), $this->getResolver(function () { throw new \RuntimeException(); }));
 
-        $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, false);
+        $kernel->handle(new Request(), HttpKernelInterface::MASTER_REQUEST, HttpKernelInterface::EXCEPTIONS_OFF);
     }
 
     public function testHandleWhenControllerThrowsAnExceptionAndRawIsFalse()
@@ -65,6 +65,20 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         $response = $kernel->handle(new Request());
 
         $this->assertEquals('500', $response->getStatusCode());
+        $this->assertEquals('foo', $response->getContent());
+    }
+
+    public function testHandleWhenControllerThrowsAnExceptionAndRawIsFalseAndModeIsNotAuto()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::EXCEPTION, function ($event) {
+            $event->setResponse(new Response($event->getException()->getMessage()));
+        });
+
+        $kernel = new HttpKernel($dispatcher, $this->getResolver(function () { throw new \RuntimeException('foo'); }));
+        $response = $kernel->handle(new Request(),HttpKernelInterface::MASTER_REQUEST, HttpKernelInterface::EXCEPTIONS_ON);
+
+        $this->assertEquals('200', $response->getStatusCode());
         $this->assertEquals('foo', $response->getContent());
     }
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -164,7 +164,7 @@ class KernelTest extends \PHPUnit_Framework_TestCase
     public function testHandleCallsHandleOnHttpKernel()
     {
         $type = HttpKernelInterface::MASTER_REQUEST;
-        $catch = true;
+        $catch = HttpKernelInterface::EXCEPTIONS_AUTOTUNE;
         $request = new Request();
 
         $httpKernelMock = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernel')
@@ -190,7 +190,7 @@ class KernelTest extends \PHPUnit_Framework_TestCase
     public function testHandleBootsTheKernel()
     {
         $type = HttpKernelInterface::MASTER_REQUEST;
-        $catch = true;
+        $catch = HttpKernelInterface::EXCEPTIONS_AUTOTUNE;
         $request = new Request();
 
         $httpKernelMock = $this->getMockBuilder('Symfony\Component\HttpKernel\HttpKernel')

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -128,7 +128,7 @@ class ExceptionListener
                         $subRequest = $this->httpUtils->createRequest($request, $this->errorPage);
                         $subRequest->attributes->set(SecurityContextInterface::ACCESS_DENIED_ERROR, $exception);
 
-                        $response = $event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, true);
+                        $response = $event->getKernel()->handle($subRequest, HttpKernelInterface::SUB_REQUEST, HttpKernelInterface::EXCEPTIONS_AUTOTUNE);
                     } else {
                         return;
                     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/romainneutron/symfony.png?branch=HttpKernelExceptionHandling)](http://travis-ci.org/romainneutron/symfony)
License of the code: MIT

Update to HttpKernel::handle, allow to specify exception handling mode

Introduce three way to handle errors :
- do not handle (throws exception)
- Handle and tune the response automatically (ensure an error response)
- Handle and return the response forged in a user defined exception handler

This last example allows a user to return a 200 response even if an exception has been thrown.
