### PR TITLE
[Form] Fixed variable passing from outer to inner blocks of the same FormView instance

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -249,7 +249,7 @@
 {% block form_row %}
 {% spaceless %}
     <div>
-        {{ form_label(form, label|default(null)) }}
+        {{ form_label(form) }}
         {{ form_errors(form) }}
         {{ form_widget(form) }}
     </div>

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_table_layout.html.twig
@@ -4,7 +4,7 @@
 {% spaceless %}
     <tr>
         <td>
-            {{ form_label(form, label|default(null)) }}
+            {{ form_label(form) }}
         </td>
         <td>
             {{ form_errors(form) }}

--- a/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Node/SearchAndRenderBlockNodeTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Node;
+
+use Symfony\Bridge\Twig\Tests\TestCase;
+use Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode;
+
+class SearchAndRenderBlockNodeTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (version_compare(\Twig_Environment::VERSION, '1.5.0', '<')) {
+            $this->markTestSkipped('Requires Twig version to be at least 1.5.0.');
+        }
+    }
+
+    public function testCompileWidget()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getExtension(\'form\')->renderer->searchAndRenderBlock(%s, \'widget\')',
+                $this->getVariableGetter('form')
+             ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function testCompileWidgetWithVariables()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+            new \Twig_Node_Expression_Array(array(
+                new \Twig_Node_Expression_Constant('foo', 0),
+                new \Twig_Node_Expression_Constant('bar', 0),
+            ), 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_widget', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getExtension(\'form\')->renderer->searchAndRenderBlock(%s, \'widget\', array("foo" => "bar"))',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function testCompileLabelWithLabel()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+            new \Twig_Node_Expression_Constant('my label', 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getExtension(\'form\')->renderer->searchAndRenderBlock(%s, \'label\', array("label" => "my label"))',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function testCompileLabelWithNullLabel()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+            new \Twig_Node_Expression_Constant(null, 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getExtension(\'form\')->renderer->searchAndRenderBlock(%s, \'label\', array("label" => null))',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function testCompileLabelWithDefaultLabel()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getExtension(\'form\')->renderer->searchAndRenderBlock(%s, \'label\')',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function testCompileLabelWithAttributes()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+            new \Twig_Node_Expression_Constant(null, 0),
+            new \Twig_Node_Expression_Array(array(
+                new \Twig_Node_Expression_Constant('foo', 0),
+                new \Twig_Node_Expression_Constant('bar', 0),
+            ), 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getExtension(\'form\')->renderer->searchAndRenderBlock(%s, \'label\', array("foo" => "bar", "label" => null))',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    public function testCompileLabelWithLabelAndAttributes()
+    {
+        $arguments = new \Twig_Node(array(
+            new \Twig_Node_Expression_Name('form', 0),
+            new \Twig_Node_Expression_Constant('value in argument', 0),
+            new \Twig_Node_Expression_Array(array(
+                new \Twig_Node_Expression_Constant('foo', 0),
+                new \Twig_Node_Expression_Constant('bar', 0),
+                new \Twig_Node_Expression_Constant('label', 0),
+                new \Twig_Node_Expression_Constant('value in attributes', 0),
+            ), 0),
+        ));
+
+        $node = new SearchAndRenderBlockNode('form_label', $arguments, 0);
+
+        $compiler = new \Twig_Compiler(new \Twig_Environment());
+
+        $this->assertEquals(
+            sprintf(
+                '$this->env->getExtension(\'form\')->renderer->searchAndRenderBlock(%s, \'label\', array("foo" => "bar", "label" => _twig_default_filter("value in argument", "value in attributes")))',
+                $this->getVariableGetter('form')
+            ),
+            trim($compiler->compile($node)->getSource())
+        );
+    }
+
+    protected function getVariableGetter($name)
+    {
+        if (version_compare(phpversion(), '5.4.0RC1', '>=')) {
+            return sprintf('(isset($context["%s"]) ? $context["%s"] : null)', $name, $name);
+        }
+
+        return sprintf('$this->getContext($context, "%s")', $name);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/form_row.html.php
@@ -1,5 +1,5 @@
 <div>
-    <?php echo $view['form']->label($form, isset($label) ? $label : null) ?>
+    <?php echo $view['form']->label($form) ?>
     <?php echo $view['form']->errors($form) ?>
     <?php echo $view['form']->widget($form) ?>
 </div>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/FormTable/form_row.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/FormTable/form_row.html.php
@@ -1,6 +1,6 @@
 <tr>
     <td>
-        <?php echo $view['form']->label($form, isset($label) ? $label : null) ?>
+        <?php echo $view['form']->label($form) ?>
     </td>
     <td>
         <?php echo $view['form']->errors($form) ?>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/FormHelper.php
@@ -125,7 +125,7 @@ class FormHelper extends Helper
      */
     public function label(FormView $view, $label = null, array $variables = array())
     {
-        if ($label !== null) {
+        if (null !== $label) {
             $variables += array('label' => $label);
         }
 

--- a/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractDivLayoutTest.php
@@ -38,13 +38,17 @@ abstract class AbstractDivLayoutTest extends AbstractLayoutTest
     public function testRowOverrideVariables()
     {
         $view = $this->factory->createNamed('name', 'text')->createView();
-        $html = $this->renderRow($view, array('label' => 'foo&bar'));
+        $html = $this->renderRow($view, array(
+            'attr' => array('class' => 'my&class'),
+            'label' => 'foo&bar',
+            'label_attr' => array('class' => 'my&label&class'),
+        ));
 
         $this->assertMatchesXpath($html,
 '/div
     [
-        ./label[@for="name"][.="[trans]foo&bar[/trans]"]
-        /following-sibling::input[@id="name"]
+        ./label[@for="name"][@class="my&label&class required"][.="[trans]foo&bar[/trans]"]
+        /following-sibling::input[@id="name"][@class="my&class"]
     ]
 '
         );

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -225,7 +225,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
-    public function testLabelWithCustomOptionsPassedDirectly()
+    public function testLabelWithCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', 'text');
         $html = $this->renderLabel($form->createView(), null, array(
@@ -242,7 +242,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         );
     }
 
-    public function testLabelWithCustomTextAndCustomOptionsPassedDirectly()
+    public function testLabelWithCustomTextAndCustomAttributesPassedDirectly()
     {
         $form = $this->factory->createNamed('name', 'text');
         $html = $this->renderLabel($form->createView(), 'Custom label', array(
@@ -253,6 +253,27 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $this->assertMatchesXpath($html,
 '/label
+    [@for="name"]
+    [@class="my&class required"]
+    [.="[trans]Custom label[/trans]"]
+'
+        );
+    }
+
+    // https://github.com/symfony/symfony/issues/5029
+    public function testLabelWithCustomTextAsOptionAndCustomAttributesPassedDirectly()
+    {
+        $form = $this->factory->createNamed('name', 'text', null, array(
+            'label' => 'Custom label',
+        ));
+        $html = $this->renderLabel($form->createView(), null, array(
+            'label_attr' => array(
+                'class' => 'my&class'
+            ),
+        ));
+
+        $this->assertMatchesXpath($html,
+            '/label
     [@for="name"]
     [@class="my&class required"]
     [.="[trans]Custom label[/trans]"]


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5029
Todo: -

This PR fixes two bugs.

The first bug is described in #5029. The second parameter to the "form_label" function in Twig, if given, always overwrote whatever label was defined previously.

```
{# null would overwrite whatever is currently set #}
form_label(form, null, { ... })
```

The second bug affected passing variables from outer to inner blocks. In the following example, "label_attr" would not be forwarded to the "form_label" function.

```
form_row(form, { "label_attr": { "class": "my_class" }})
```

Both bugs are fixed now.
