### PR TITLE
[HttpKernel] Add special header to customize Response StatusCode in Error context

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -168,7 +168,13 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 
         $this->dispatcher->dispatch(KernelEvents::RESPONSE, $event);
 
-        return $event->getResponse();
+        $response = $event->getResponse();
+        
+        if ($response->headers->has(HttpKernelInterface::HEADER_STATUSCODE)) {
+            $response->headers->remove(HttpKernelInterface::HEADER_STATUSCODE);
+        }
+
+        return $response;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -201,7 +201,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
                 $response->setStatusCode($e->getStatusCode());
                 $response->headers->add($e->getHeaders());
             } else {
-                $response->setStatusCode(500);
+                $response->setStatusCode($response->headers->get(HttpKernelInterface::HEADER_STATUSCODE, 500));
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernelInterface.php
@@ -27,6 +27,12 @@ interface HttpKernelInterface
     const SUB_REQUEST = 2;
 
     /**
+     * Use this header to customize the Response StatusCode in case an exception
+     * is catch in an error handler
+     */
+    const HEADER_STATUSCODE = 'Symfony-StatusCode';
+
+    /**
      * Handles a Request to convert it to a Response.
      *
      * When $catch is true, the implementation must catch all exceptions

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -68,6 +68,22 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $response->getContent());
     }
 
+    public function testHandleWhenControllerThrowsAnExceptionAndGotHeader()
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener(KernelEvents::EXCEPTION, function ($event) {
+            $response = new Response($event->getException()->getMessage());
+            $response->headers->set(HttpKernelInterface::HEADER_STATUSCODE, 200);
+            $event->setResponse($response);
+        });
+
+        $kernel = new HttpKernel($dispatcher, $this->getResolver(function () { throw new \RuntimeException('foo'); }));
+        $response = $kernel->handle(new Request());
+
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals('foo', $response->getContent());
+    }
+
     public function testHandleExceptionWithARedirectionResponse()
     {
         $dispatcher = new EventDispatcher();

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -82,6 +82,7 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('foo', $response->getContent());
+        $this->assertFalse($response->headers->has(HttpKernelInterface::HEADER_STATUSCODE));
     }
 
     public function testHandleExceptionWithARedirectionResponse()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes [![Build Status](https://secure.travis-ci.org/romainneutron/symfony.png?branch=ResponseHeader)](http://travis-ci.org/romainneutron/symfony)
License of the code: MIT

As described here fabpot/Silex#438

Add special header to customize Response StatusCode when an exception has been thrown.

This is useful as HttpKernel set response statuscode to 500 by default if the exception do not implement HttpExceptionInterface.

See test for example
