### PR TITLE
[Form] Fixed failing UniqueValidatorTest when Doctrine Common 2.2 is loaded

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Validator/Constraints/UniqueValidatorTest.php
@@ -75,6 +75,7 @@ class UniqueValidatorTest extends DoctrineOrmTestCase
         ;
         $refl = $this->getMockBuilder('Doctrine\Common\Reflection\StaticReflectionProperty')
             ->disableOriginalConstructor()
+            ->setMethods(array('getValue'))
             ->getMock()
         ;
         $refl


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
