### PR TITLE
[Security] add docblocks to InteractiveLoginEvent

### DIFF
--- a/src/Symfony/Component/Security/Http/Event/InteractiveLoginEvent.php
+++ b/src/Symfony/Component/Security/Http/Event/InteractiveLoginEvent.php
@@ -27,11 +27,17 @@ class InteractiveLoginEvent extends Event
         $this->authenticationToken = $authenticationToken;
     }
 
+    /**
+     * @return Request
+     */
     public function getRequest()
     {
         return $this->request;
     }
 
+    /**
+     * @return TokenInterface
+     */
     public function getAuthenticationToken()
     {
         return $this->authenticationToken;


### PR DESCRIPTION
It is simply to enable autocompletion in my IDE. Happy to hear any reason why I should be able to code without this :)
