### PR TITLE
[Form] Fixed: setData() is now guaranteed to be invoked before bind()

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -526,6 +526,13 @@ class Form implements \IteratorAggregate, FormInterface
             return $this;
         }
 
+        // The data must be initialized if it was not initialized yet.
+        // This is necessary to guarantee that the *_SET_DATA listeners
+        // are always invoked before bind() takes place.
+        if (!$this->initialized) {
+            $this->setData($this->config->getData());
+        }
+
         // Don't convert NULL to a string here in order to determine later
         // whether an empty value has been submitted or whether no value has
         // been submitted at all. This is important for processing checkboxes
@@ -630,7 +637,6 @@ class Form implements \IteratorAggregate, FormInterface
         $this->viewData = $viewData;
         $this->extraData = $extraData;
         $this->synchronized = $synchronized;
-        $this->initialized = true;
 
         $event = new FormEvent($this, $viewData);
         $this->config->getEventDispatcher()->dispatch(FormEvents::POST_BIND, $event);

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -45,6 +45,28 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame('bar', $form->getViewData());
     }
 
+    // https://github.com/symfony/symfony/commit/d4f4038f6daf7cf88ca7c7ab089473cce5ebf7d8#commitcomment-1632879
+    public function testDataIsInitializedFromBind()
+    {
+        $mock = $this->getMockBuilder('\stdClass')
+            ->setMethods(array('preSetData', 'preBind'))
+            ->getMock();
+        $mock->expects($this->at(0))
+            ->method('preSetData');
+        $mock->expects($this->at(1))
+            ->method('preBind');
+
+        $config = new FormConfig('name', null, $this->dispatcher);
+        $config->addEventListener(FormEvents::PRE_SET_DATA, array($mock, 'preSetData'));
+        $config->addEventListener(FormEvents::PRE_BIND, array($mock, 'preBind'));
+        $form = new Form($config);
+
+        // no call to setData() or similar where the object would be
+        // initialized otherwise
+
+        $form->bind('foobar');
+    }
+
     /**
      * @expectedException Symfony\Component\Form\Exception\AlreadyBoundException
      */


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: see the comments in d4f4038f6daf7cf88ca7c7ab089473cce5ebf7d8
Todo: -
