### PR TITLE
[OptionsResolver] Improved the performance of normalizers

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -152,7 +152,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         $this->options = array();
 
         foreach ($options as $option => $value) {
-            $this->set($option, $value);
+            $this->overload($option, $value);
         }
     }
 

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -190,7 +190,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
             $params = $reflClosure->getParameters();
 
             if (isset($params[0]) && null !== ($class = $params[0]->getClass()) && __CLASS__ === $class->name) {
-                $currentValue = isset($this->options[$option]) ? $this->options[$option] : null;
+                $currentValue = isset($params[1]) && isset($this->options[$option]) ? $this->options[$option] : null;
                 $value = new LazyOption($value, $currentValue);
 
                 // Store which options are lazy for more efficient resolving

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -54,12 +54,6 @@ class OptionsResolver implements OptionsResolverInterface
     private $allowedTypes = array();
 
     /**
-     * A list of normalizers transforming each resolved options.
-     * @var array
-     */
-    private $normalizers = array();
-
-    /**
      * Creates a new instance.
      */
     public function __construct()
@@ -194,7 +188,9 @@ class OptionsResolver implements OptionsResolverInterface
     {
         $this->validateOptionsExistence($normalizers);
 
-        $this->normalizers = array_replace($this->normalizers, $normalizers);
+        foreach ($normalizers as $option => $normalizer) {
+            $this->defaultOptions->setNormalizer($option, $normalizer);
+        }
 
         return $this;
     }
@@ -229,11 +225,6 @@ class OptionsResolver implements OptionsResolverInterface
         // Override options set by the user
         foreach ($options as $option => $value) {
             $combinedOptions->set($option, $value);
-        }
-
-        // Apply filters
-        foreach ($this->normalizers as $option => $filter) {
-            $combinedOptions->overload($option, $filter);
         }
 
         // Resolve options

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
@@ -156,6 +156,23 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('dynamic', $this->options->get('foo'));
     }
 
+    public function testPreviousValueIsNotEvaluatedIfNoSecondArgument()
+    {
+        $test = $this;
+
+        // defined by superclass
+        $this->options->set('foo', function (Options $options) use ($test) {
+            $test->fail('Should not be called');
+        });
+
+        // defined by subclass, no $previousValue argument defined!
+        $this->options->overload('foo', function (Options $options) use ($test) {
+            return 'dynamic';
+        });
+
+        $this->assertEquals('dynamic', $this->options->get('foo'));
+    }
+
     public function testLazyOptionCanAccessOtherOptions()
     {
         $test = $this;

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
@@ -79,6 +79,16 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->options->remove('foo');
     }
 
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
+     */
+    public function testSetNormalizerNotSupportedAfterGet()
+    {
+        $this->options->set('foo', 'bar');
+        $this->options->get('foo');
+        $this->options->setNormalizer('foo', function () {});
+    }
+
     public function testSetLazyOption()
     {
         $test = $this;
@@ -182,6 +192,66 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('dynamic', $this->options->get('bam'));
     }
 
+    public function testNormalizer()
+    {
+        $this->options->set('foo', 'bar');
+
+        $this->options->setNormalizer('foo', function () {
+            return 'normalized';
+        });
+
+        $this->assertEquals('normalized', $this->options->get('foo'));
+    }
+
+    public function testNormalizerReceivesUnnormalizedValue()
+    {
+        $this->options->set('foo', 'bar');
+
+        $this->options->setNormalizer('foo', function (Options $options, $value) {
+            return 'normalized[' . $value . ']';
+        });
+
+        $this->assertEquals('normalized[bar]', $this->options->get('foo'));
+    }
+
+    public function testNormalizerCanAccessOtherOptions()
+    {
+        $test = $this;
+
+        $this->options->set('foo', 'bar');
+        $this->options->set('bam', 'baz');
+
+        $this->options->setNormalizer('bam', function (Options $options) use ($test) {
+            /* @var \PHPUnit_Framework_TestCase $test */
+            $test->assertEquals('bar', $options->get('foo'));
+
+            return 'normalized';
+        });
+
+        $this->assertEquals('bar', $this->options->get('foo'));
+        $this->assertEquals('normalized', $this->options->get('bam'));
+    }
+
+    public function testNormalizerCanAccessOtherLazyOptions()
+    {
+        $test = $this;
+
+        $this->options->set('foo', function (Options $options) {
+            return 'bar';
+        });
+        $this->options->set('bam', 'baz');
+
+        $this->options->setNormalizer('bam', function (Options $options) use ($test) {
+            /* @var \PHPUnit_Framework_TestCase $test */
+            $test->assertEquals('bar', $options->get('foo'));
+
+            return 'normalized';
+        });
+
+        $this->assertEquals('bar', $this->options->get('foo'));
+        $this->assertEquals('normalized', $this->options->get('bam'));
+    }
+
     /**
      * @expectedException Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
      */
@@ -196,6 +266,85 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->options->get('foo');
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
+     */
+    public function testFailForCyclicDependenciesBetweenNormalizers()
+    {
+        $this->options->set('foo', 'bar');
+        $this->options->set('bam', 'baz');
+
+        $this->options->setNormalizer('foo', function (Options $options) {
+            $options->get('bam');
+        });
+
+        $this->options->setNormalizer('bam', function (Options $options) {
+            $options->get('foo');
+        });
+
+        $this->options->get('foo');
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\OptionDefinitionException
+     */
+    public function testFailForCyclicDependenciesBetweenNormalizerAndLazyOption()
+    {
+        $this->options->set('foo', function (Options $options) {
+            $options->get('bam');
+        });
+        $this->options->set('bam', 'baz');
+
+        $this->options->setNormalizer('bam', function (Options $options) {
+            $options->get('foo');
+        });
+
+        $this->options->get('foo');
+    }
+
+    public function testAllInvokesEachLazyOptionOnlyOnce()
+    {
+        $test = $this;
+        $i = 1;
+
+        $this->options->set('foo', function (Options $options) use ($test, &$i) {
+            $test->assertSame(1, $i);
+            ++$i;
+
+            // Implicitly invoke lazy option for "bam"
+            $options->get('bam');
+        });
+        $this->options->set('bam', function (Options $options) use ($test, &$i) {
+            $test->assertSame(2, $i);
+            ++$i;
+        });
+
+        $this->options->all();
+    }
+
+    public function testAllInvokesEachNormalizerOnlyOnce()
+    {
+        $test = $this;
+        $i = 1;
+
+        $this->options->set('foo', 'bar');
+        $this->options->set('bam', 'baz');
+
+        $this->options->setNormalizer('foo', function (Options $options) use ($test, &$i) {
+            $test->assertSame(1, $i);
+            ++$i;
+
+            // Implicitly invoke normalizer for "bam"
+            $options->get('bam');
+        });
+        $this->options->setNormalizer('bam', function (Options $options) use ($test, &$i) {
+            $test->assertSame(2, $i);
+            ++$i;
+        });
+
+        $this->options->all();
     }
 
     public function testReplaceClearsAndSets()


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Normalizers are now stored in the Options instance only once. Previously, normalizers were stored in Options upon resolving, which meant that they were added a lot of time if the same resolver was used for many different options arrays.

This improvement led to an improvement of 30ms on http://advancedform.gpserver.dk/app_dev.php/taxclasses/1
