### PR TITLE
[Validator] Fixed: StaticMethodLoader does not invoke methods of interfaces anymore

### DIFF
--- a/src/Symfony/Component/Validator/CHANGELOG.md
+++ b/src/Symfony/Component/Validator/CHANGELOG.md
@@ -26,3 +26,4 @@ CHANGELOG
  * added Range constraint
  * deprecated the Min and Max constraints
  * deprecated the MinLength and MaxLength constraints
+ * fixed StaticMethodLoader not to invoke interface methods

--- a/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
@@ -28,9 +28,10 @@ class StaticMethodLoader implements LoaderInterface
      */
     public function loadClassMetadata(ClassMetadata $metadata)
     {
+        /** @var \ReflectionClass $reflClass */
         $reflClass = $metadata->getReflectionClass();
 
-        if ($reflClass->hasMethod($this->methodName)) {
+        if (!$reflClass->isInterface() && $reflClass->hasMethod($this->methodName)) {
             $reflMethod = $reflClass->getMethod($this->methodName);
 
             if (!$reflMethod->isStatic()) {

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -55,6 +55,21 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->loadClassMetadata($metadata);
         $this->assertSame(1, count($metadata->getConstraints()));
     }
+
+    public function testLoadClassMetadataIgnoresInterfaces()
+    {
+        $loader = new StaticMethodLoader('loadMetadata');
+        $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderInterface');
+
+        $loader->loadClassMetadata($metadata);
+
+        $this->assertSame(0, count($metadata->getConstraints()));
+    }
+}
+
+interface StaticLoaderInterface
+{
+    public static function loadMetadata(ClassMetadata $metadata);
 }
 
 class StaticLoaderEntity


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #3179
Todo: -
