### PR TITLE
fixed error on pdosession storage for oracle db. Related to clob data

### DIFF
--- a/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/SessionStorage/PdoSessionStorage.php
@@ -181,7 +181,8 @@ class PdoSessionStorage extends NativeSessionStorage
             $sessionRows = $stmt->fetchAll(\PDO::FETCH_NUM);
 
             if (count($sessionRows) == 1) {
-                return base64_decode($sessionRows[0][0]);
+                $session = is_resource($sessionRows[0][0]) ? stream_get_contents($sessionRows[0][0]) : $sessionRows[0][0];
+                return base64_decode($session);
             }
 
             // session does not exist, create it


### PR DESCRIPTION
Did a change on 2.0 branch to fix this error

https://github.com/symfony/symfony/issues/3255

Tested on mysql and Oracle DB.

I also ran a phpunit test before commit:

phpunit tests/Symfony/Tests/Component/HttpFoundation/SessionStorage/PdoSessionStorageTest.php 
PHPUnit 3.6.10 by Sebastian Bergmann.

Time: 0 seconds, Memory: 2.75Mb

OK (3 tests, 5 assertions)

Time: 0 seconds, Memory: 2.75Mb
