### PR TITLE
[2.2] [Validator] Added CardScheme validator

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CardScheme.php
+++ b/src/Symfony/Component/Validator/Constraints/CardScheme.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Metadata for the CardSchemeValidator.
+ *
+ * @Annotation
+ */
+class CardScheme extends Constraint
+{
+    public $message = 'Unsupported card type or invalid card number';
+    public $schemes;
+
+    public function getDefaultOption()
+    {
+        return 'schemes';
+    }
+
+    public function getRequiredOptions()
+    {
+        return array('schemes');
+    }
+}

--- a/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CardSchemeValidator.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * Validates that a card number belongs to a specified scheme.
+ *
+ * @see http://en.wikipedia.org/wiki/Bank_card_number
+ * @author Tim Nagel <t.nagel@infinite.net.au>
+ */
+class CardSchemeValidator extends ConstraintValidator
+{
+    protected $schemes = array(
+        'AMEX' => array(
+            '/^(3[47])([0-9]{13})/'
+        ),
+        'CHINA_UNIONPAY' => array(
+            '/^(62)([0-9]{16,19}/'
+        ),
+        'DINERS' => array(
+            '/^(36)([0-9]{12})/',
+            '/^(30[0-5])([0-9]{11})/',
+            '/^(5[45])([0-9]{14})/'
+        ),
+        'DISCOVER' => array(
+            '/^(6011)([0-9]{12})/',
+            '/^(64[4-9])([0-9]{13})/',
+            '/^(65)([0-9]{14})/',
+            '/^(622)(12[6-9]|1[3-9][0-9]|[2-8][0-9][0-9]|91[0-9]|92[0-5])([0-9]{10})/'
+        ),
+        'INSTAPAYMENT' => array(
+            '/^(63[7-9])([0-9]{13})/'
+        ),
+        'JCB' => array(
+            '/^(352[8-9]|35[3-8][0-9])([0-9]{12})/'
+        ),
+        'LASER' => array(
+            '/^(6304|670[69]|6771)([0-9]{12, 15})/'
+        ),
+        'MAESTRO' => array(
+            '/^(5018|5020|5038|6304|6759|6761|676[23]|0604)([0-9]{8, 15})/'
+        ),
+        'MASTERCARD' => array(
+            '/^(5[1-5])([0-9]{14})/'
+        ),
+        'VISA' => array(
+            '/^(4)([0-9]{12})/'
+        ),
+    );
+
+    /**
+     * Validates a creditcard belongs to a specified scheme.
+     *
+     * @param mixed $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_numeric($value)) {
+            $this->context->addViolation($constraint->message);
+        }
+
+        $schemes = array_flip($constraint->schemes);
+        $schemeRegexes = array_intersect_key($this->schemes, $schemes);
+
+        foreach ($schemeRegexes as $regexes) {
+            foreach ($regexes as $regex) {
+                if (preg_match($regex, $value)) {
+                    return;
+                }
+            }
+        }
+
+        $this->context->addViolation($constraint->message);
+    }
+}

--- a/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CardSchemeValidatorTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\CardScheme;
+use Symfony\Component\Validator\Constraints\CardSchemeValidator;
+
+class CardSchemeValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $context;
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $this->validator = new CardSchemeValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    protected function tearDown()
+    {
+        $this->context = null;
+        $this->validator = null;
+    }
+
+    public function testNullIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate(null, new CardScheme(array('schemes' => array())));
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate('', new CardScheme(array('schemes' => array())));
+    }
+
+    /**
+     * @dataProvider getValidNumbers
+     */
+    public function testValidNumbers($scheme, $number)
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($number, new CardScheme(array('schemes' => array($scheme))));
+    }
+
+    public function getValidNumbers()
+    {
+        return array(
+            array('VISA', '42424242424242424242'),
+            array('AMEX', '378282246310005'),
+            array('AMEX', '371449635398431'),
+            array('AMEX', '378734493671000'),
+            array('DINERS', '30569309025904'),
+            array('DISCOVER', '6011111111111117'),
+            array('DISCOVER', '6011000990139424'),
+            array('JCB', '3530111333300000'),
+            array('JCB', '3566002020360505'),
+            array('MASTERCARD', '5555555555554444'),
+            array('MASTERCARD', '5105105105105100'),
+            array('VISA', '4111111111111111'),
+            array('VISA', '4012888888881881'),
+            array('VISA', '4222222222222'),
+        );
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: Adding documentation
License of the code: MIT

CardScheme separated into its own PR from #4734 as requested by @fabpot
