### PR TITLE
[Routing] Fixed alteration of $_SERVER

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Matcher/ApacheUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/ApacheUrlMatcherTest.php
@@ -17,6 +17,18 @@ use Symfony\Component\Routing\Matcher\ApacheUrlMatcher;
 
 class ApacheUrlMatcherTest extends \PHPUnit_Framework_TestCase
 {
+    protected $server;
+
+    protected function setUp()
+    {
+        $this->server = $_SERVER;
+    }
+
+    protected function tearDown()
+    {
+        $_SERVER = $this->server;
+    }
+
     /**
      * @dataProvider getMatchData
      */


### PR DESCRIPTION
For test purpose [a method](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Routing/Tests/Matcher/ApacheUrlMatcherTest.php#L29) is altering $_SERVER variable.

One visible effect : phpunit crashes when trying to render coverage as it use $_SERVER['REQUEST_TIME'] which just have been unsetted by this test method. 
