### PR TITLE
[FrameworkBundle] AssetsInstallCommand. Made 'web' as a default folder.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AssetsInstallCommand.php
@@ -33,7 +33,7 @@ class AssetsInstallCommand extends ContainerAwareCommand
         $this
             ->setName('assets:install')
             ->setDefinition(array(
-                new InputArgument('target', InputArgument::REQUIRED, 'The target directory (usually "web")'),
+                new InputArgument('target', InputArgument::OPTIONAL, 'The target directory', 'web'),
             ))
             ->addOption('symlink', null, InputOption::VALUE_NONE, 'Symlinks the assets instead of copying it')
             ->addOption('relative', null, InputOption::VALUE_NONE, 'Make relative symlinks')


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: not sure
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT

> 'The target directory (usually "web")'

It is indeed a folder that's usually used to install assets, why not making it as a default value?
