### PR TITLE
[OptionsResolver] Allow empty input arrays when needed

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -54,6 +54,14 @@ class OptionsResolver implements OptionsResolverInterface
     private $allowedTypes = array();
 
     /**
+     * A flag to indicate whether the resolve phase should be ignored when the input
+     * array is empty
+     *
+     * @var bool
+     */
+    private $allowEmpty = false;
+
+    /**
      * Creates a new instance.
      */
     public function __construct()
@@ -196,6 +204,27 @@ class OptionsResolver implements OptionsResolverInterface
     }
 
     /**
+     * Updates the flag to allow empty input arrays to ignore the
+     * resolve phase
+     *
+     * @param boolean $allowEmpty
+     */
+    public function setAllowEmpty($allowEmpty)
+    {
+        $this->allowEmpty = $allowEmpty;
+    }
+
+    /**
+     * Returns the current value of the "allow empty" flag
+     *
+     * @return boolean
+     */
+    public function getAllowEmpty()
+    {
+        return $this->allowEmpty;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function isKnown($option)
@@ -216,6 +245,10 @@ class OptionsResolver implements OptionsResolverInterface
      */
     public function resolve(array $options = array())
     {
+        if ($this->getAllowEmpty() && !sizeof($options)) {
+            return $options;
+        }
+
         $this->validateOptionsExistence($options);
         $this->validateOptionsCompleteness($options);
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -633,4 +633,12 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
             'three' => '3',
         ), $clone->resolve());
     }
+
+    public function testResolveOnAllowEmpty()
+    {
+        $this->resolver->setRequired(array('one'));
+        $this->resolver->setAllowEmpty(true);
+
+        $this->assertEquals(array(), $this->resolver->resolve(array()));
+    }
 }


### PR DESCRIPTION
A small fix to allow empty input arrays when needed.
