### PR TITLE
[Filesystem] Fixed 5 tests on windows

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -31,7 +31,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->filesystem = new Filesystem();
-        $this->workspace = sys_get_temp_dir().DIRECTORY_SEPARATOR.time().rand(0, 1000);
+        $this->workspace = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.time().rand(0, 1000);
         mkdir($this->workspace, 0777, true);
     }
 

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -319,7 +319,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         mkdir($basePath);
         mkdir($basePath.'dir');
         // create symlink to unexisting file
-        symlink($basePath.'file', $basePath.'link');
+        @symlink($basePath.'file', $basePath.'link');
 
         $this->filesystem->remove($basePath);
 
@@ -700,6 +700,8 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
         $link1 = $this->workspace.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'link';
         $link2 = $this->workspace.DIRECTORY_SEPARATOR.'dir'.DIRECTORY_SEPARATOR.'subdir'.DIRECTORY_SEPARATOR.'link';
+
+        touch($file);
 
         $this->filesystem->symlink($file, $link1);
         $this->filesystem->symlink($file, $link2);


### PR DESCRIPTION
Fixing 3 test expecting wrong folders : 

```
-'C:\Users\pascal\AppData\Local\Temp\\1343425847694\file'
+'C:\Users\pascal\AppData\Local\Temp\1343425847694\file'
```

Fixed 2 tests on Windows caused by symlink function throwing error when first argument is not existent :

```
symlink(): Could not fetch file information(error 2)
```
