### PR TITLE
[2.2] add support for optional custom error message for Configura...

### DIFF
--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -204,7 +204,10 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         foreach ($this->children as $name => $child) {
             if (!array_key_exists($name, $value)) {
                 if ($child->isRequired()) {
-                    $ex = new InvalidConfigurationException(sprintf('The child node "%s" at path "%s" must be configured.', $name, $this->getPath()));
+                    $ex = new InvalidConfigurationException(sprintf('The child node "%s" at path "%s" must be configured.',
+                        $name,
+                        $this->getPath()
+                    ));
                     $ex->setPath($this->getPath());
                     $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -205,6 +205,9 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
             if (!array_key_exists($name, $value)) {
                 if ($child->isRequired()) {
                     $msg = sprintf('The child node "%s" at path "%s" must be configured.', $name, $this->getPath());
+                    if (null !== $this->getInfo()) {
+                        $msg .= sprintf("\nHint: %s.", $this->getInfo());
+                    }
                     $ex = new InvalidConfigurationException($msg);
                     $ex->setPath($this->getPath());
 
@@ -238,11 +241,15 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     protected function validateType($value)
     {
         if (!is_array($value) && (!$this->allowFalse || false !== $value)) {
-            $ex = new InvalidTypeException(sprintf(
+            $msg = sprintf(
                 'Invalid type for path "%s". Expected array, but got %s',
                 $this->getPath(),
                 gettype($value)
-            ));
+            );
+            if (null !== $this->getInfo()) {
+                $msg .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+            $ex = new InvalidTypeException($msg);
             $ex->setPath($this->getPath());
 
             throw $ex;
@@ -275,6 +282,9 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         // if extra fields are present, throw exception
         if (count($value) && !$this->ignoreExtraKeys) {
             $msg = sprintf('Unrecognized options "%s" under "%s"', implode(', ', array_keys($value)), $this->getPath());
+            if (null !== $this->getInfo()) {
+                $msg .= sprintf("\nHint: %s.", $this->getInfo());
+            }
             $ex = new InvalidConfigurationException($msg);
             $ex->setPath($this->getPath());
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -204,12 +204,9 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         foreach ($this->children as $name => $child) {
             if (!array_key_exists($name, $value)) {
                 if ($child->isRequired()) {
-                    $msg = sprintf('The child node "%s" at path "%s" must be configured.', $name, $this->getPath());
-                    if (null !== $this->getInfo()) {
-                        $msg .= sprintf("\nHint: %s.", $this->getInfo());
-                    }
-                    $ex = new InvalidConfigurationException($msg);
+                    $ex = new InvalidConfigurationException(sprintf('The child node "%s" at path "%s" must be configured.', $name, $this->getPath()));
                     $ex->setPath($this->getPath());
+                    $ex->setHint($this->getInfo());
 
                     throw $ex;
                 }
@@ -246,11 +243,9 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
                 $this->getPath(),
                 gettype($value)
             );
-            if (null !== $this->getInfo()) {
-                $msg .= sprintf("\nHint: %s.", $this->getInfo());
-            }
             $ex = new InvalidTypeException($msg);
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
 
             throw $ex;
         }
@@ -281,12 +276,9 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
         // if extra fields are present, throw exception
         if (count($value) && !$this->ignoreExtraKeys) {
-            $msg = sprintf('Unrecognized options "%s" under "%s"', implode(', ', array_keys($value)), $this->getPath());
-            if (null !== $this->getInfo()) {
-                $msg .= sprintf("\nHint: %s.", $this->getInfo());
-            }
-            $ex = new InvalidConfigurationException($msg);
+            $ex = new InvalidConfigurationException(sprintf('Unrecognized options "%s" under "%s"', implode(', ', array_keys($value)), $this->getPath()));
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
 
             throw $ex;
         }

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -204,10 +204,7 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
         foreach ($this->children as $name => $child) {
             if (!array_key_exists($name, $value)) {
                 if ($child->isRequired()) {
-                    $ex = new InvalidConfigurationException(sprintf('The child node "%s" at path "%s" must be configured.',
-                        $name,
-                        $this->getPath()
-                    ));
+                    $ex = new InvalidConfigurationException(sprintf('The child node "%s" at path "%s" must be configured.', $name, $this->getPath()));
                     $ex->setPath($this->getPath());
                     $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/ArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/ArrayNode.php
@@ -238,12 +238,11 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
     protected function validateType($value)
     {
         if (!is_array($value) && (!$this->allowFalse || false !== $value)) {
-            $msg = sprintf(
+            $ex = new InvalidTypeException(sprintf(
                 'Invalid type for path "%s". Expected array, but got %s',
                 $this->getPath(),
                 gettype($value)
-            );
-            $ex = new InvalidTypeException($msg);
+            ));
             $ex->setPath($this->getPath());
             $ex->setHint($this->getInfo());
 
@@ -276,7 +275,10 @@ class ArrayNode extends BaseNode implements PrototypeNodeInterface
 
         // if extra fields are present, throw exception
         if (count($value) && !$this->ignoreExtraKeys) {
-            $ex = new InvalidConfigurationException(sprintf('Unrecognized options "%s" under "%s"', implode(', ', array_keys($value)), $this->getPath()));
+            $ex = new InvalidConfigurationException(sprintf('Unrecognized options "%s" under "%s"',
+                implode(', ', array_keys($value)),
+                $this->getPath()
+            ));
             $ex->setPath($this->getPath());
             $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -287,13 +287,14 @@ abstract class BaseNode implements NodeInterface
             } catch (Exception $correctEx) {
                 throw $correctEx;
             } catch (\Exception $invalid) {
-                $message = sprintf(
-                    'Invalid configuration for path "%s": %s',
-                    $this->getPath(),
-                    $invalid->getMessage()
+                $ex = new InvalidConfigurationException(
+                    sprintf('Invalid configuration for path "%s": %s',
+                        $this->getPath(),
+                        $invalid->getMessage()
+                    ),
+                    $invalid->getCode(),
+                    $invalid
                 );
-
-                $ex = new InvalidConfigurationException($message, $invalid->getCode(), $invalid);
                 $ex->setHint($this->getInfo());
 
                 throw $ex;

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -292,10 +292,11 @@ abstract class BaseNode implements NodeInterface
                     $this->getPath(),
                     $invalid->getMessage()
                 );
-                if (null !== $this->getInfo()) {
-                    $message .= sprintf("\nHint: %s.", $this->getInfo());
-                }
-                throw new InvalidConfigurationException($message, $invalid->getCode(), $invalid);
+
+                $ex = new InvalidConfigurationException($message, $invalid->getCode(), $invalid);
+                $ex->setHint($this->getInfo());
+
+                throw $ex;
             }
         }
 

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -287,11 +287,15 @@ abstract class BaseNode implements NodeInterface
             } catch (Exception $correctEx) {
                 throw $correctEx;
             } catch (\Exception $invalid) {
-                throw new InvalidConfigurationException(sprintf(
+                $message = sprintf(
                     'Invalid configuration for path "%s": %s',
                     $this->getPath(),
                     $invalid->getMessage()
-                ), $invalid->getCode(), $invalid);
+                );
+                if (null !== $this->getInfo()) {
+                    $message .= sprintf("\nHint: %s.", $this->getInfo());
+                }
+                throw new InvalidConfigurationException($message, $invalid->getCode(), $invalid);
             }
         }
 

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -31,9 +31,6 @@ class BooleanNode extends ScalarNode
                 $this->getPath(),
                 gettype($value)
             );
-            if (null !== $this->getInfo()) {
-                $message .= sprintf("\nHint: %s.", $this->getInfo());
-            }
             $ex = new InvalidTypeException($message);
             $ex->setPath($this->getPath());
 

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -26,12 +26,11 @@ class BooleanNode extends ScalarNode
     protected function validateType($value)
     {
         if (!is_bool($value)) {
-            $message = sprintf(
+            $ex = new InvalidTypeException(sprintf(
                 'Invalid type for path "%s". Expected boolean, but got %s.',
                 $this->getPath(),
                 gettype($value)
-            );
-            $ex = new InvalidTypeException($message);
+            ));
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/BooleanNode.php
+++ b/src/Symfony/Component/Config/Definition/BooleanNode.php
@@ -26,11 +26,15 @@ class BooleanNode extends ScalarNode
     protected function validateType($value)
     {
         if (!is_bool($value)) {
-            $ex = new InvalidTypeException(sprintf(
+            $message = sprintf(
                 'Invalid type for path "%s". Expected boolean, but got %s.',
                 $this->getPath(),
                 gettype($value)
-            ));
+            );
+            if (null !== $this->getInfo()) {
+                $message .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+            $ex = new InvalidTypeException($message);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -18,7 +18,11 @@ class EnumNode extends ScalarNode
     {
         $values = array_unique($values);
         if (count($values) <= 1) {
-            throw new \InvalidArgumentException('$values must contain at least two distinct elements.');
+            $message = '$values must contain at least two distinct elements.';
+            if (null !== $this->getInfo()) {
+                $message .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+            throw new \InvalidArgumentException($message);
         }
 
         parent::__construct($name, $parent);
@@ -35,11 +39,16 @@ class EnumNode extends ScalarNode
         $value = parent::finalizeValue($value);
 
         if (!in_array($value, $this->values, true)) {
-            $ex = new InvalidConfigurationException(sprintf(
+            $message = sprintf(
                 'The value %s is not allowed for path "%s". Permissible values: %s',
                 json_encode($value),
                 $this->getPath(),
-                implode(', ', array_map('json_encode', $this->values))));
+                implode(', ', array_map('json_encode', $this->values))
+            );
+            if (null !== $this->getInfo()) {
+                $message .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+            $ex = new InvalidConfigurationException($message);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -18,9 +18,7 @@ class EnumNode extends ScalarNode
     {
         $values = array_unique($values);
         if (count($values) <= 1) {
-            $message = '$values must contain at least two distinct elements.';
-
-            throw new \InvalidArgumentException($message);
+            throw new \InvalidArgumentException('$values must contain at least two distinct elements.');
         }
 
         parent::__construct($name, $parent);
@@ -37,13 +35,12 @@ class EnumNode extends ScalarNode
         $value = parent::finalizeValue($value);
 
         if (!in_array($value, $this->values, true)) {
-            $message = sprintf(
+            $ex = new InvalidConfigurationException(sprintf(
                 'The value %s is not allowed for path "%s". Permissible values: %s',
                 json_encode($value),
                 $this->getPath(),
                 implode(', ', array_map('json_encode', $this->values))
-            );
-            $ex = new InvalidConfigurationException($message);
+            ));
             $ex->setPath($this->getPath());
             $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/EnumNode.php
+++ b/src/Symfony/Component/Config/Definition/EnumNode.php
@@ -19,9 +19,7 @@ class EnumNode extends ScalarNode
         $values = array_unique($values);
         if (count($values) <= 1) {
             $message = '$values must contain at least two distinct elements.';
-            if (null !== $this->getInfo()) {
-                $message .= sprintf("\nHint: %s.", $this->getInfo());
-            }
+
             throw new \InvalidArgumentException($message);
         }
 
@@ -45,11 +43,9 @@ class EnumNode extends ScalarNode
                 $this->getPath(),
                 implode(', ', array_map('json_encode', $this->values))
             );
-            if (null !== $this->getInfo()) {
-                $message .= sprintf("\nHint: %s.", $this->getInfo());
-            }
             $ex = new InvalidConfigurationException($message);
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
 
             throw $ex;
         }

--- a/src/Symfony/Component/Config/Definition/Exception/InvalidConfigurationException.php
+++ b/src/Symfony/Component/Config/Definition/Exception/InvalidConfigurationException.php
@@ -30,4 +30,11 @@ class InvalidConfigurationException extends Exception
     {
         return $this->path;
     }
+
+    public function setHint($info)
+    {
+        if (null !== $info) {
+            $this->message .= sprintf("\nHint: %s.", $info);
+        }
+    }
 }

--- a/src/Symfony/Component/Config/Definition/FloatNode.php
+++ b/src/Symfony/Component/Config/Definition/FloatNode.php
@@ -31,7 +31,11 @@ class FloatNode extends NumericNode
         }
 
         if (!is_float($value)) {
-            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected float, but got %s.', $this->getPath(), gettype($value)));
+            $message = sprintf('Invalid type for path "%s". Expected float, but got %s.', $this->getPath(), gettype($value));
+            if (null !== $this->getInfo()) {
+                $message .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+            $ex = new InvalidTypeException($message);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/FloatNode.php
+++ b/src/Symfony/Component/Config/Definition/FloatNode.php
@@ -31,7 +31,10 @@ class FloatNode extends NumericNode
         }
 
         if (!is_float($value)) {
-            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected float, but got %s.', $this->getPath(), gettype($value)));
+            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected float, but got %s.',
+                $this->getPath(),
+                gettype($value)
+            ));
             $ex->setPath($this->getPath());
             $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/FloatNode.php
+++ b/src/Symfony/Component/Config/Definition/FloatNode.php
@@ -31,12 +31,9 @@ class FloatNode extends NumericNode
         }
 
         if (!is_float($value)) {
-            $message = sprintf('Invalid type for path "%s". Expected float, but got %s.', $this->getPath(), gettype($value));
-            if (null !== $this->getInfo()) {
-                $message .= sprintf("\nHint: %s.", $this->getInfo());
-            }
-            $ex = new InvalidTypeException($message);
+            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected float, but got %s.', $this->getPath(), gettype($value)));
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
 
             throw $ex;
         }

--- a/src/Symfony/Component/Config/Definition/IntegerNode.php
+++ b/src/Symfony/Component/Config/Definition/IntegerNode.php
@@ -26,12 +26,9 @@ class IntegerNode extends NumericNode
     protected function validateType($value)
     {
         if (!is_int($value)) {
-            $message = sprintf('Invalid type for path "%s". Expected int, but got %s.', $this->getPath(), gettype($value));
-            if (null !== $this->getInfo()) {
-                $message .= sprintf("\nHint: %s.", $this->getInfo());
-            }
-            $ex = new InvalidTypeException($message);
+            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected int, but got %s.', $this->getPath(), gettype($value)));
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
 
             throw $ex;
         }

--- a/src/Symfony/Component/Config/Definition/IntegerNode.php
+++ b/src/Symfony/Component/Config/Definition/IntegerNode.php
@@ -26,7 +26,10 @@ class IntegerNode extends NumericNode
     protected function validateType($value)
     {
         if (!is_int($value)) {
-            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected int, but got %s.', $this->getPath(), gettype($value)));
+            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected int, but got %s.',
+                $this->getPath(),
+                gettype($value)
+            ));
             $ex->setPath($this->getPath());
             $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/IntegerNode.php
+++ b/src/Symfony/Component/Config/Definition/IntegerNode.php
@@ -26,7 +26,11 @@ class IntegerNode extends NumericNode
     protected function validateType($value)
     {
         if (!is_int($value)) {
-            $ex = new InvalidTypeException(sprintf('Invalid type for path "%s". Expected int, but got %s.', $this->getPath(), gettype($value)));
+            $message = sprintf('Invalid type for path "%s". Expected int, but got %s.', $this->getPath(), gettype($value));
+            if (null !== $this->getInfo()) {
+                $message .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+            $ex = new InvalidTypeException($message);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -45,6 +45,9 @@ class NumericNode extends ScalarNode
             $errorMsg = sprintf('The value %s is too big for path "%s". Should be less than: %s', $value, $this->getPath(), $this->max);
         }
         if (isset($errorMsg)) {
+            if (null !== $this->getInfo()) {
+                $errorMsg .= sprintf("\nHint: %s.", $this->getInfo());
+            }
             $ex = new InvalidConfigurationException($errorMsg);
             $ex->setPath($this->getPath());
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -45,11 +45,10 @@ class NumericNode extends ScalarNode
             $errorMsg = sprintf('The value %s is too big for path "%s". Should be less than: %s', $value, $this->getPath(), $this->max);
         }
         if (isset($errorMsg)) {
-            if (null !== $this->getInfo()) {
-                $errorMsg .= sprintf("\nHint: %s.", $this->getInfo());
-            }
             $ex = new InvalidConfigurationException($errorMsg);
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
+
             throw $ex;
         }
 

--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -138,7 +138,7 @@ class PrototypedArrayNode extends ArrayNode
     /**
      * Retrieves the default value.
      *
-     * The default value could be either explicited or derived from the prototype
+     * The default value could be either made explicit or derived from the prototype
      * default value.
      *
      * @return array The default value

--- a/src/Symfony/Component/Config/Definition/ScalarNode.php
+++ b/src/Symfony/Component/Config/Definition/ScalarNode.php
@@ -34,13 +34,11 @@ class ScalarNode extends VariableNode
     protected function validateType($value)
     {
         if (!is_scalar($value) && null !== $value) {
-            $message = sprintf(
+            $ex = new InvalidTypeException(sprintf(
                 'Invalid type for path "%s". Expected scalar, but got %s.',
                 $this->getPath(),
                 gettype($value)
-            );
-
-            $ex = new InvalidTypeException($message);
+            ));
             $ex->setPath($this->getPath());
             $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/ScalarNode.php
+++ b/src/Symfony/Component/Config/Definition/ScalarNode.php
@@ -34,11 +34,16 @@ class ScalarNode extends VariableNode
     protected function validateType($value)
     {
         if (!is_scalar($value) && null !== $value) {
-            $ex = new InvalidTypeException(sprintf(
+            $message = sprintf(
                 'Invalid type for path "%s". Expected scalar, but got %s.',
                 $this->getPath(),
                 gettype($value)
-            ));
+            );
+            if (null !== $this->getInfo()) {
+                $message .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+
+            $ex = new InvalidTypeException($message);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/ScalarNode.php
+++ b/src/Symfony/Component/Config/Definition/ScalarNode.php
@@ -39,12 +39,10 @@ class ScalarNode extends VariableNode
                 $this->getPath(),
                 gettype($value)
             );
-            if (null !== $this->getInfo()) {
-                $message .= sprintf("\nHint: %s.", $this->getInfo());
-            }
 
             $ex = new InvalidTypeException($message);
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
 
             throw $ex;
         }

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -83,11 +83,16 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     protected function finalizeValue($value)
     {
         if (!$this->allowEmptyValue && empty($value)) {
-            $ex = new InvalidConfigurationException(sprintf(
+            $message = sprintf(
                 'The path "%s" cannot contain an empty value, but got %s.',
                 $this->getPath(),
                 json_encode($value)
-            ));
+            );
+            if (null !== $this->getInfo()) {
+                $message .= sprintf("\nHint: %s.", $this->getInfo());
+            }
+
+            $ex = new InvalidConfigurationException($message);
             $ex->setPath($this->getPath());
 
             throw $ex;

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -83,13 +83,11 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
     protected function finalizeValue($value)
     {
         if (!$this->allowEmptyValue && empty($value)) {
-            $message = sprintf(
+            $ex = new InvalidConfigurationException(sprintf(
                 'The path "%s" cannot contain an empty value, but got %s.',
                 $this->getPath(),
                 json_encode($value)
-            );
-
-            $ex = new InvalidConfigurationException($message);
+            ));
             $ex->setPath($this->getPath());
             $ex->setHint($this->getInfo());
 

--- a/src/Symfony/Component/Config/Definition/VariableNode.php
+++ b/src/Symfony/Component/Config/Definition/VariableNode.php
@@ -88,12 +88,10 @@ class VariableNode extends BaseNode implements PrototypeNodeInterface
                 $this->getPath(),
                 json_encode($value)
             );
-            if (null !== $this->getInfo()) {
-                $message .= sprintf("\nHint: %s.", $this->getInfo());
-            }
 
             $ex = new InvalidConfigurationException($message);
             $ex->setPath($this->getPath());
+            $ex->setHint($this->getInfo());
 
             throw $ex;
         }

--- a/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ScalarNodeTest.php
@@ -57,4 +57,42 @@ class ScalarNodeTest extends \PHPUnit_Framework_TestCase
             array(new \stdClass()),
         );
     }
+
+    public function testNormalizeThrowsExceptionWithoutErrorMessage()
+    {
+        $value = array(array('foo' => 'bar'));
+        $node = new ScalarNode('test');
+
+        $expectedMessage = sprintf(
+            'Invalid type for path "%s". Expected scalar, but got %s.',
+            $node->getPath(),
+            gettype($value)
+        );
+
+        $this->setExpectedException(
+            'Symfony\Component\Config\Definition\Exception\InvalidTypeException', $expectedMessage
+        );
+
+        $node->normalize($value);
+    }
+
+    public function testNormalizeThrowsExceptionWithErrorMessage()
+    {
+        $value = array(array('foo' => 'bar'));
+        $node = new ScalarNode('test');
+        $node->setInfo('This is a custom error message');
+
+        $expectedMessage = sprintf(
+            'Invalid type for path "%s". Expected scalar, but got %s.'.
+                "\nHint: ".$node->getInfo(),
+            $node->getPath(),
+            gettype($value)
+        );
+
+        $this->setExpectedException(
+            'Symfony\Component\Config\Definition\Exception\InvalidTypeException', $expectedMessage
+        );
+
+        $node->normalize($value);
+    }
 }


### PR DESCRIPTION
RFC: ref #1666

Basically this is the start, but i wanted to ask which one of these options is better:
1. extend/override the base Exception class to include the custom error message
   this requires a modification of the throw specific expection passing Exception($this) meaning it is getting
   the current node or the node from which the exception is being thrown
2. propagate the changes in every class that throws exception similar than this PR
   this would require changes in every particular class

Please vote whether 1 or 2 is more fit

Thanks to all symfony2 community :D
