### PR TITLE
OptionsResolver: normalizer fix

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -504,7 +504,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         $normalizer = $this->normalizers[$option];
 
         $this->lock[$option] = true;
-        $this->options[$option] = $normalizer($this, $this->options[$option]);
+        $this->options[$option] = $normalizer($this, array_key_exists($option, $this->options) ? $this->options[$option] : null);
         unset($this->lock[$option]);
 
         // The option is now normalized

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -143,6 +143,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
 
         $this->options = array();
         $this->lazy = array();
+        $this->normalizers = array();
 
         foreach ($options as $option => $value) {
             $this->overload($option, $value);

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
@@ -469,4 +469,49 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($this->options->has('foo'));
     }
+
+    public function testRemoveOptionAndNormalizer()
+    {
+        $this->options->set('foo1', 'bar');
+        $this->options->setNormalizer('foo1', function (Options $options) {
+            return '';
+        });
+        $this->options->set('foo2', 'bar');
+        $this->options->setNormalizer('foo2', function (Options $options) {
+            return '';
+        });
+
+        $this->options->remove('foo2');
+        $this->assertEquals(array('foo1' => ''), $this->options->all());
+    }
+
+    public function testReplaceOptionAndNormalizer()
+    {
+        $this->options->set('foo1', 'bar');
+        $this->options->setNormalizer('foo1', function (Options $options) {
+            return '';
+        });
+        $this->options->set('foo2', 'bar');
+        $this->options->setNormalizer('foo2', function (Options $options) {
+            return '';
+        });
+
+        $this->options->replace(array('foo1' => 'new'));
+        $this->assertEquals(array('foo1' => 'new'), $this->options->all());
+    }
+
+    public function testClearOptionAndNormalizer()
+    {
+        $this->options->set('foo1', 'bar');
+        $this->options->setNormalizer('foo1', function (Options $options) {
+            return '';
+        });
+        $this->options->set('foo2', 'bar');
+        $this->options->setNormalizer('foo2', function (Options $options) {
+            return '';
+        });
+
+        $this->options->clear();
+        $this->assertEmpty($this->options->all());
+    }
 }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
@@ -514,4 +514,15 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $this->options->clear();
         $this->assertEmpty($this->options->all());
     }
+
+    public function testNormalizerWithoutCorrespondingOption()
+    {
+        $test = $this;
+
+        $this->options->setNormalizer('foo', function (Options $options, $previousValue) use ($test) {
+            $test->assertNull($previousValue);
+            return '';
+        });
+        $this->assertEquals(array('foo' => ''), $this->options->all());
+    }
 }


### PR DESCRIPTION
setNormalizer() -> replace() -> all() would generate an error.
