### PR TITLE
[Form] Fixed ResolvedFormType to really be replaceable

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -247,11 +247,10 @@
     reasons. It is now not possible anymore to use custom implementations of
     `FormBuilderInterface` for specific form types.
 
-    If you are in such a situation, you can subclass `FormRegistry` instead and override
-    `resolveType` to return a custom `ResolvedFormTypeInterface` implementation, within
-    which you can create your own `FormBuilderInterface` implementation. You should
-    register this custom registry class under the service name "form.registry" in order
-    to replace the default implementation.
+    If you are in such a situation, you can implement a custom `ResolvedFormTypeInterface`
+    where you create your own `FormBuilderInterface` implementation. You also need to
+    register a custom `ResolvedFormTypeFactoryInterface` implementation under the service
+    name "form.resolved_type_factory" in order to replace the default implementation.
 
   * If you previously inherited from `FieldType`, you should now inherit from
     `FormType`. You should also set the option `compound` to `false` if your field

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -5,13 +5,17 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="form.extension.class">Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension</parameter>
+        <parameter key="form.resolved_type_factory.class">Symfony\Component\Form\ResolvedFormTypeFactory</parameter>
         <parameter key="form.registry.class">Symfony\Component\Form\FormRegistry</parameter>
         <parameter key="form.factory.class">Symfony\Component\Form\FormFactory</parameter>
+        <parameter key="form.extension.class">Symfony\Component\Form\Extension\DependencyInjection\DependencyInjectionExtension</parameter>
         <parameter key="form.type_guesser.validator.class">Symfony\Component\Form\Extension\Validator\ValidatorTypeGuesser</parameter>
     </parameters>
 
     <services>
+        <!-- ResolvedFormTypeFactory -->
+        <service id="form.resolved_type_factory" class="%form.resolved_type_factory.class%" />
+
         <!-- FormRegistry -->
         <service id="form.registry" class="%form.registry.class%">
             <argument type="collection">
@@ -23,11 +27,13 @@
                 -->
                 <argument type="service" id="form.extension" />
             </argument>
+            <argument type="service" id="form.resolved_type_factory" />
         </service>
 
         <!-- FormFactory -->
         <service id="form.factory" class="%form.factory.class%">
             <argument type="service" id="form.registry" />
+            <argument type="service" id="form.resolved_type_factory" />
         </service>
 
         <!-- DependencyInjectionExtension -->

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -152,12 +152,12 @@ CHANGELOG
  * deprecated the options "data_timezone" and "user_timezone" in DateType, DateTimeType and TimeType
    and renamed them to "model_timezone" and "view_timezone"
  * fixed: TransformationFailedExceptions thrown in the model transformer are now caught by the form
- * added FormRegistry and ResolvedFormTypeInterface
+ * added FormRegistryInterface, ResolvedFormTypeInterface and ResolvedFormTypeFactoryInterface
  * deprecated FormFactory methods
    * `addType`
    * `hasType`
    * `getType`
- * [BC BREAK] FormFactory now expects a FormRegistryInterface as constructor argument
+ * [BC BREAK] FormFactory now expects a FormRegistryInterface and a ResolvedFormTypeFactoryInterface as constructor argument
  * [BC BREAK] The method `createBuilder` in FormTypeInterface is not supported anymore for performance reasons
  * [BC BREAK] Removed `setTypes` from FormBuilder
  * deprecated AbstractType methods

--- a/src/Symfony/Component/Form/FormRegistryInterface.php
+++ b/src/Symfony/Component/Form/FormRegistryInterface.php
@@ -22,6 +22,10 @@ interface FormRegistryInterface
      * Adds a form type.
      *
      * @param ResolvedFormTypeInterface $type The type
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
+     *             form extensions or type registration in the Dependency
+     *             Injection Container instead.
      */
     public function addType(ResolvedFormTypeInterface $type);
 
@@ -47,18 +51,6 @@ interface FormRegistryInterface
      * @return Boolean Whether the type is supported
      */
     public function hasType($name);
-
-    /**
-     * Resolves a form type.
-     *
-     * @param FormTypeInterface $type
-     *
-     * @return ResolvedFormTypeInterface
-     *
-     * @throws Exception\UnexpectedTypeException if the types parent {@link FormTypeInterface::getParent()} is not a string
-     * @throws Exception\FormException           if the types parent can not be retrieved from any extension
-     */
-    public function resolveType(FormTypeInterface $type);
 
     /**
      * Returns the guesser responsible for guessing types.

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -35,7 +35,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
     private $typeExtensions;
 
     /**
-     * @var ResolvedFormType
+     * @var ResolvedFormTypeInterface
      */
     private $parent;
 
@@ -44,7 +44,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
      */
     private $optionsResolver;
 
-    public function __construct(FormTypeInterface $innerType, array $typeExtensions = array(), ResolvedFormType $parent = null)
+    public function __construct(FormTypeInterface $innerType, array $typeExtensions = array(), ResolvedFormTypeInterface $parent = null)
     {
         if (!preg_match('/^[a-z0-9_]*$/i', $innerType->getName())) {
             throw new FormException(sprintf(
@@ -148,7 +148,16 @@ class ResolvedFormType implements ResolvedFormTypeInterface
         return $view;
     }
 
-    private function buildForm(FormBuilderInterface $builder, array $options)
+    /**
+     * Configures a form builder for the type hierarchy.
+     *
+     * This method is protected in order to allow implementing classes
+     * to change or call it in re-implementations of {@link createBuilder()}.
+     *
+     * @param FormBuilderInterface $builder The builder to configure.
+     * @param array                $options The options used for the configuration.
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if (null !== $this->parent) {
             $this->parent->buildForm($builder, $options);
@@ -162,7 +171,19 @@ class ResolvedFormType implements ResolvedFormTypeInterface
         }
     }
 
-    private function buildView(FormView $view, FormInterface $form, array $options)
+    /**
+     * Configures a form view for the type hierarchy.
+     *
+     * This method is protected in order to allow implementing classes
+     * to change or call it in re-implementations of {@link createView()}.
+     *
+     * It is called before the children of the view are built.
+     *
+     * @param FormView      $view    The form view to configure.
+     * @param FormInterface $form    The form corresponding to the view.
+     * @param array         $options The options used for the configuration.
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         if (null !== $this->parent) {
             $this->parent->buildView($view, $form, $options);
@@ -176,7 +197,19 @@ class ResolvedFormType implements ResolvedFormTypeInterface
         }
     }
 
-    private function finishView(FormView $view, FormInterface $form, array $options)
+    /**
+     * Finishes a form view for the type hierarchy.
+     *
+     * This method is protected in order to allow implementing classes
+     * to change or call it in re-implementations of {@link createView()}.
+     *
+     * It is called after the children of the view have been built.
+     *
+     * @param FormView      $view    The form view to configure.
+     * @param FormInterface $form    The form corresponding to the view.
+     * @param array         $options The options used for the configuration.
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options)
     {
         if (null !== $this->parent) {
             $this->parent->finishView($view, $form, $options);
@@ -190,7 +223,15 @@ class ResolvedFormType implements ResolvedFormTypeInterface
         }
     }
 
-    private function getOptionsResolver()
+    /**
+     * Returns the configured options resolver used for this type.
+     *
+     * This method is protected in order to allow implementing classes
+     * to change or call it in re-implementations of {@link createBuilder()}.
+     *
+     * @return \Symfony\Component\OptionsResolver\OptionsResolverInterface The options resolver.
+     */
+    public function getOptionsResolver()
     {
         if (null === $this->optionsResolver) {
             if (null !== $this->parent) {

--- a/src/Symfony/Component/Form/ResolvedFormTypeFactory.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class ResolvedFormTypeFactory implements ResolvedFormTypeFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createResolvedType(FormTypeInterface $type, array $typeExtensions, ResolvedFormTypeInterface $parent = null)
+    {
+        return new ResolvedFormType($type, $typeExtensions, $parent);
+    }
+}

--- a/src/Symfony/Component/Form/ResolvedFormTypeFactoryInterface.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeFactoryInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form;
+
+/**
+ * Creates ResolvedFormTypeInterface instances.
+ *
+ * This interface allows you to use your custom ResolvedFormTypeInterface
+ * implementation, within which you can customize the concrete FormBuilderInterface
+ * implementations or FormView subclasses that are used by the framework.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+interface ResolvedFormTypeFactoryInterface
+{
+    /**
+     * Resolves a form type.
+     *
+     * @param FormTypeInterface         $type
+     * @param array                     $typeExtensions
+     * @param ResolvedFormTypeInterface $parent
+     *
+     * @return ResolvedFormTypeInterface
+     *
+     * @throws Exception\UnexpectedTypeException if the types parent {@link FormTypeInterface::getParent()} is not a string
+     * @throws Exception\FormException           if the types parent can not be retrieved from any extension
+     */
+    public function createResolvedType(FormTypeInterface $type, array $typeExtensions, ResolvedFormTypeInterface $parent = null);
+}

--- a/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
@@ -67,4 +67,41 @@ interface ResolvedFormTypeInterface
      * @return FormView The created form view.
      */
     public function createView(FormInterface $form, FormView $parent = null);
+
+    /**
+     * Configures a form builder for the type hierarchy.
+     *
+     * @param FormBuilderInterface $builder The builder to configure.
+     * @param array                $options The options used for the configuration.
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options);
+
+    /**
+     * Configures a form view for the type hierarchy.
+     *
+     * It is called before the children of the view are built.
+     *
+     * @param FormView      $view    The form view to configure.
+     * @param FormInterface $form    The form corresponding to the view.
+     * @param array         $options The options used for the configuration.
+     */
+    public function buildView(FormView $view, FormInterface $form, array $options);
+
+    /**
+     * Finishes a form view for the type hierarchy.
+     *
+     * It is called after the children of the view have been built.
+     *
+     * @param FormView      $view    The form view to configure.
+     * @param FormInterface $form    The form corresponding to the view.
+     * @param array         $options The options used for the configuration.
+     */
+    public function finishView(FormView $view, FormInterface $form, array $options);
+
+    /**
+     * Returns the configured options resolver used for this type.
+     *
+     * @return \Symfony\Component\OptionsResolver\OptionsResolverInterface The options resolver.
+     */
+    public function getOptionsResolver();
 }

--- a/src/Symfony/Component/Form/Tests/FormFactoryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormFactoryTest.php
@@ -45,6 +45,11 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
     private $registry;
 
     /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    private $resolvedTypeFactory;
+
+    /**
      * @var FormFactory
      */
     private $factory;
@@ -55,10 +60,11 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The "EventDispatcher" component is not available');
         }
 
+        $this->resolvedTypeFactory = $this->getMock('Symfony\Component\Form\ResolvedFormTypeFactoryInterface');
         $this->guesser1 = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
         $this->guesser2 = $this->getMock('Symfony\Component\Form\FormTypeGuesserInterface');
         $this->registry = $this->getMock('Symfony\Component\Form\FormRegistryInterface');
-        $this->factory = new FormFactory($this->registry);
+        $this->factory = new FormFactory($this->registry, $this->resolvedTypeFactory);
 
         $this->registry->expects($this->any())
             ->method('getTypeGuesser')
@@ -73,8 +79,8 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $type = new FooType();
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
-            ->method('resolveType')
+        $this->resolvedTypeFactory->expects($this->once())
+            ->method('createResolvedType')
             ->with($type)
             ->will($this->returnValue($resolvedType));
 
@@ -136,15 +142,10 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
         $type = $this->getMockType();
         $resolvedType = $this->getMockResolvedType();
 
-        $this->registry->expects($this->once())
-            ->method('resolveType')
+        $this->resolvedTypeFactory->expects($this->once())
+            ->method('createResolvedType')
             ->with($type)
             ->will($this->returnValue($resolvedType));
-
-        // The type is also implicitly added to the registry
-        $this->registry->expects($this->once())
-            ->method('addType')
-            ->with($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
@@ -158,11 +159,6 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $options = array('a' => '1', 'b' => '2');
         $resolvedType = $this->getMockResolvedType();
-
-        // The type is also implicitly added to the registry
-        $this->registry->expects($this->once())
-            ->method('addType')
-            ->with($resolvedType);
 
         $resolvedType->expects($this->once())
             ->method('createBuilder')
@@ -555,7 +551,7 @@ class FormFactoryTest extends \PHPUnit_Framework_TestCase
     {
         return $this->getMockBuilder('Symfony\Component\Form\FormFactory')
             ->setMethods($methods)
-            ->setConstructorArgs(array($this->registry))
+            ->setConstructorArgs(array($this->registry, $this->resolvedTypeFactory))
             ->getMock();
     }
 

--- a/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests;
 
 use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\ResolvedFormTypeFactory;
 use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\Form\Extension\Core\CoreExtension;
 
@@ -20,6 +21,11 @@ use Symfony\Component\Form\Extension\Core\CoreExtension;
  */
 class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ResolvedFormTypeFactory
+     */
+    protected $resolvedTypeFactory;
+
     /**
      * @var FormRegistry
      */
@@ -36,8 +42,9 @@ class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The "EventDispatcher" component is not available');
         }
 
-        $this->registry = new FormRegistry($this->getExtensions());
-        $this->factory = new FormFactory($this->registry);
+        $this->resolvedTypeFactory = new ResolvedFormTypeFactory();
+        $this->registry = new FormRegistry($this->getExtensions(), $this->resolvedTypeFactory);
+        $this->factory = new FormFactory($this->registry, $this->resolvedTypeFactory);
     }
 
     protected function getExtensions()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes (FormFactory constructor signature)
Symfony2 tests pass: yes
Fixes the following tickets: #5100
Todo: -
