### PR TITLE
[OptionsResolver] Fix Options::has() when the value is null

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -247,7 +247,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
      */
     public function has($option)
     {
-        return isset($this->options[$option]);
+        return array_key_exists($option, $this->options);
     }
 
     /**

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
@@ -462,4 +462,11 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expectedResult, iterator_to_array($this->options, true));
     }
+
+    public function testHasWithNullValue()
+    {
+        $this->options->set('foo', null);
+
+        $this->assertTrue($this->options->has('foo'));
+    }
 }


### PR DESCRIPTION
`isset()` would have returned `false` when the value is `null`
