### PR TITLE
[RFC][Routing] Add an interface for configuring strict_parameters

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -169,7 +169,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('type')->end()
                         ->scalarNode('http_port')->defaultValue(80)->end()
                         ->scalarNode('https_port')->defaultValue(443)->end()
-                        ->scalarNode('strict_parameters')
+                        ->scalarNode('strict_requirements')
                             ->info(
                                 'set to false to disable exceptions when a route is '.
                                 'generated with invalid parameters (and return null instead)'

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -246,7 +246,7 @@ class FrameworkExtension extends Extension
         $router = $container->findDefinition('router.default');
 
         $argument = $router->getArgument(2);
-        $argument['strict_parameters'] = $config['strict_parameters'];
+        $argument['strict_requirements'] = $config['strict_requirements'];
         if (isset($config['type'])) {
             $argument['resource_type'] = $config['type'];
         }

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -22,5 +22,5 @@ CHANGELOG
    been used anyway without creating inconsistencies
  * [BC BREAK] RouteCollection::remove also removes a route from parent
    collections (not only from its children)
- * added strict_parameters option to disable exceptions (and generate empty
+ * added strict_requirements option to disable exceptions (and generate empty
    URLs instead) when generating a route with an invalid parameter value

--- a/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
+++ b/src/Symfony/Component/Routing/Generator/ConfigurableRequirementsInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Generator;
+
+/**
+ * ConfigurableRequirementsInterface must be implemented by URL generators in order
+ * to be able to configure whether an exception should be generated when the
+ * parameters do not match the requirements.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface ConfigurableRequirementsInterface
+{
+    /**
+     * Enables or disables the exception on incorrect parameters.
+     *
+     * @param Boolean $enabled
+     */
+    public function setStrictRequirements($enabled);
+
+    /**
+     * Gets the strict check of incorrect parameters.
+     *
+     * @return Boolean
+     */
+    public function isStrictRequirements();
+}

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -26,10 +26,10 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
  *
  * @api
  */
-class UrlGenerator implements UrlGeneratorInterface
+class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface
 {
     protected $context;
-    protected $strictParameters = true;
+    protected $strictRequirements = true;
     protected $logger;
 
     /**
@@ -95,23 +95,19 @@ class UrlGenerator implements UrlGeneratorInterface
     }
 
     /**
-     * Enables or disables the exception on incorrect parameters.
-     *
-     * @param Boolean $enabled
+     * {@inheritdoc}
      */
-    public function setStrictParameters($enabled)
+    public function setStrictRequirements($enabled)
     {
-        $this->strictParameters = $enabled;
+        $this->strictRequirements = (Boolean) $enabled;
     }
 
     /**
-     * Gets the strict check of incorrect parameters.
-     *
-     * @return Boolean
+     * {@inheritdoc}
      */
-    public function getStrictParameters()
+    public function isStrictRequirements()
     {
-        return $this->strictParameters;
+        return $this->strictRequirements;
     }
 
     /**
@@ -155,7 +151,7 @@ class UrlGenerator implements UrlGeneratorInterface
                         // check requirement
                         if ($tparams[$token[3]] && !preg_match('#^'.$token[2].'$#', $tparams[$token[3]])) {
                             $message = sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given).', $token[3], $name, $token[2], $tparams[$token[3]]);
-                            if ($this->strictParameters) {
+                            if ($this->strictRequirements) {
                                 throw new InvalidParameterException($message);
                             }
 

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Routing;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 
 /**
  * The Router class is an example of the integration of all pieces of the
@@ -77,7 +78,7 @@ class Router implements RouterInterface
             'matcher_dumper_class'   => 'Symfony\\Component\\Routing\\Matcher\\Dumper\\PhpMatcherDumper',
             'matcher_cache_class'    => 'ProjectUrlMatcher',
             'resource_type'          => null,
-            'strict_parameters'      => true,
+            'strict_requirements'    => true,
         );
 
         // check option names and live merge, if errors are encountered Exception will be thrown
@@ -244,8 +245,8 @@ class Router implements RouterInterface
             $this->generator = new $class($this->context, $this->logger);
         }
 
-        if (false === $this->options['strict_parameters']) {
-            $this->generator->setStrictParameters(false);
+        if ($this->generator instanceof ConfigurableRequirementsInterface) {
+            $this->generator->setStrictRequirements($this->options['strict_requirements']);
         }
 
         return $this->generator;

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -169,7 +169,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
     {
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', array('foo' => '1'), array('foo' => 'd+')));
         $generator = $this->getGenerator($routes);
-        $generator->setStrictParameters(false);
+        $generator->setStrictRequirements(false);
         $this->assertNull($generator->generate('test', array('foo' => 'bar'), true));
     }
 
@@ -184,7 +184,7 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $logger->expects($this->once())
             ->method('err');
         $generator = $this->getGenerator($routes, array(), $logger);
-        $generator->setStrictParameters(false);
+        $generator->setStrictRequirements(false);
         $this->assertNull($generator->generate('test', array('foo' => 'bar'), true));
     }
 


### PR DESCRIPTION
This is a proposal to fix #4697 (related to #4592).

The main point left to discuss was the name of the interface, which is now `LenientInterface`. We could change the name to anything else is someone has a better idea.

@stof @Tobion what do you think ?
