### PR TITLE
[Templating] PHP templating engine speed-ups

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -38,7 +38,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected $charset;
     protected $cache;
     protected $escapers;
-    protected $escaperCache;
+    protected static $escaperCache;
     protected $globals;
     protected $parser;
 
@@ -335,14 +335,18 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      */
     public function escape($value, $context = 'html')
     {
+        if (is_numeric($value)) {
+            return $value;
+        }
+
         // If we deal with a scalar value, we can cache the result to increase
         // the performance when the same value is escaped multiple times (e.g. loops)
         if (is_scalar($value)) {
-            if (!isset($this->escaperCache[$context][$value])) {
-                $this->escaperCache[$context][$value] = call_user_func($this->getEscaper($context), $value);
+            if (!isset(self::$escaperCache[$context][$value])) {
+                self::$escaperCache[$context][$value] = call_user_func($this->getEscaper($context), $value);
             }
 
-            return $this->escaperCache[$context][$value];
+            return self::$escaperCache[$context][$value];
         }
 
         return call_user_func($this->getEscaper($context), $value);
@@ -383,7 +387,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     public function setEscaper($context, $escaper)
     {
         $this->escapers[$context] = $escaper;
-        $this->escaperCache[$context] = array();
+        self::$escaperCache[$context] = array();
     }
 
     /**
@@ -502,7 +506,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
                 },
         );
 
-        $this->escaperCache = array();
+        self::$escaperCache = array();
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/dlsniper/symfony.png?branch=php-engine-escape-cache)](http://travis-ci.org/dlsniper/symfony)
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~

This PR should improve the speed for rendering the form present here: https://github.com/dlsniper/symfony-standard . On my computer, Ubuntu 12.04 Apache 2.2.22 + mod_php 5.3.10 default packages from Ubuntu on a core i7 I get about 30-40ms improvement / request with the first commit and with the second one I get a further smaller boost and also a small memory usage decrease.
