### PR TITLE
Read from annotations to be true by default

### DIFF
--- a/src/Symfony/Component/Validator/ValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ValidatorFactory.php
@@ -98,7 +98,7 @@ class ValidatorFactory implements ValidatorContextInterface
      *                                      has neither the extension ".xml" nor
      *                                      ".yml" nor ".yaml"
      */
-    public static function buildDefault(array $mappingFiles = array(), $annotations = false, $staticMethod = null)
+    public static function buildDefault(array $mappingFiles = array(), $annotations = true, $staticMethod = null)
     {
         $xmlMappingFiles = array();
         $yamlMappingFiles = array();


### PR DESCRIPTION
The class annotation states that the mapping should be read from annotations by default.
If $annotations is set to false by default, it doesn't do that, and the buildDefault function throws a MappingException when called with no arguments.

Or perhaps the class annotation instructions are outdated and there's a BC break?
