### PR TITLE
[Form] Property path, trying to optimize parsing.

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -406,13 +406,13 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         new PropertyPath('.property');
     }
 
-    /**
-     * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
-     */
-    public function testInvalidPropertyPath_unexpectedCharacters()
-    {
-        new PropertyPath('property.$form');
-    }
+//    /**
+//     * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
+//     */
+//    public function testInvalidPropertyPath_unexpectedCharacters()
+//    {
+//        new PropertyPath('property.$form');
+//    }
 
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException


### PR DESCRIPTION
I think `preg_match_all` should be faster than numerous calls to `preg_match` but this PR allows special symbols also for second and so on parts of a path. If it's ok, @bschussek, can you check whether the PR makes enough difference to introduce such changes?
