### PR TITLE
handle inheritance in config:dump-reference

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -62,7 +62,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $kernel = $this->getContainer()->get('kernel');
+        $bundles = $this->getContainer()->get('kernel')->getBundles();
         $containerBuilder = $this->getContainerBuilder();
 
         $name = $input->getArgument('name');
@@ -71,7 +71,10 @@ EOF
 
         if (preg_match('/Bundle$/', $name)) {
             // input is bundle name
-            $extension = $kernel->getBundle($name)->getContainerExtension();
+
+            if (isset($bundles[$name])) {
+                $extension = $bundles[$name]->getContainerExtension();
+            }
 
             if (!$extension) {
                 throw new \LogicException('No extensions with configuration available for "'.$name.'"');
@@ -79,7 +82,7 @@ EOF
 
             $message = 'Default configuration for "'.$name.'"';
         } else {
-            foreach ($kernel->getBundles() as $bundle) {
+            foreach ($bundles as $bundle) {
                 $extension = $bundle->getContainerExtension();
 
                 if ($extension && $extension->getAlias() === $name) {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: ?
Fixes the following tickets: -
License of the code: MIT

Currently when passing in a bundle name that identifies a bundle that is a parent to another bundle, it will not return the reference for the requested bundle, but for the inheriting (even if that bundle has no configuration class).

F.e.
app/console config:dump-reference SymfonyCmfBlockBundle

will fail if there is a Bundle SandboxBlockBundle that has SymfonyCmfBlockBundle set as the parent.
