### PR TITLE
[Routing] Fixed handling of optional parameters with text suffix in the route (/foo-{bar}-{baz}.html)

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -141,7 +141,8 @@ class UrlMatcher implements UrlMatcherInterface
     {
         $parameters = $defaults;
         foreach ($params as $key => $value) {
-            if (!is_int($key)) {
+            // empty value in matches ($params) means not-matched optional parameter
+            if (!is_int($key) && !empty($value)) {
                 $parameters[$key] = rawurldecode($value);
             }
         }

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -69,7 +69,10 @@ class RouteCompiler implements RouteCompilerInterface
             $token = $tokens[$i];
             if ('variable' === $token[0] && $route->hasDefault($token[3])) {
                 $firstOptional = $i;
+            } elseif ('text' === $token[0]) {
+                continue;
             } else {
+                // the case for variable w/o default value
                 break;
             }
         }
@@ -110,15 +113,10 @@ class RouteCompiler implements RouteCompilerInterface
                 // When the only token is an optional variable token, the separator is required
                 return sprintf('%s(?P<%s>%s)?', preg_quote($token[1], '#'), $token[3], $token[2]);
             } else {
-                $nbTokens = count($tokens);
                 $regexp = sprintf('%s(?P<%s>%s)', preg_quote($token[1], '#'), $token[3], $token[2]);
                 if ($index >= $firstOptional) {
                     // Enclose each optional tokens in a subpattern to make it optional
-                    $regexp = "(?:$regexp";
-                    if ($nbTokens - 1 == $index) {
-                        // Close the optional subpatterns
-                        $regexp .= str_repeat(")?", $nbTokens - $firstOptional);
-                    }
+                    $regexp = "(?:$regexp)?";
                 }
 
                 return $regexp;

--- a/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
+++ b/tests/Symfony/Tests/Component/Routing/Matcher/UrlMatcherTest.php
@@ -118,6 +118,30 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher = new UrlMatcher($collection, new RequestContext(), array());
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'foo'), $matcher->match('/foo'));
         $this->assertEquals(array('_route' => 'bar', 'bar' => 'bar'), $matcher->match('/'));
+
+        // Route with 1 optional variable and text suffix at the end
+        $collection = new RouteCollection();
+        $collection->add('bar', new Route('/bar-{foo}.html', array('foo' => 'foo'), array('foo' => 'foo|bar')));
+        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $this->assertEquals(array('_route' => 'bar', 'foo' => 'foo'), $matcher->match('/bar.html'));
+        $this->assertEquals(array('_route' => 'bar', 'foo' => 'foo'), $matcher->match('/bar-foo.html'));
+        $this->assertEquals(array('_route' => 'bar', 'foo' => 'bar'), $matcher->match('/bar-bar.html'));
+
+        // Route with 2 optional variables and text suffix at the end
+        $collection = new RouteCollection();
+        $collection->add(
+            'bar',
+            new Route(
+                '/bar-{foo}-{baz}.html',
+                array('foo' => 'foo', 'baz' => '1'),
+                array('foo' => 'foo|bar', 'baz' => '\d')
+            )
+        );
+        $matcher = new UrlMatcher($collection, new RequestContext(), array());
+        $this->assertEquals(array('_route' => 'bar', 'foo' => 'foo', 'baz' => 1), $matcher->match('/bar.html'));
+        $this->assertEquals(array('_route' => 'bar', 'foo' => 'foo', 'baz' => 1), $matcher->match('/bar-foo.html'));
+        $this->assertEquals(array('_route' => 'bar', 'foo' => 'foo', 'baz' => 2), $matcher->match('/bar-foo-2.html'));
+        $this->assertEquals(array('_route' => 'bar', 'foo' => 'foo', 'baz' => 2), $matcher->match('/bar-2.html'));
     }
 
     public function testMatchWithPrefixes()

--- a/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
+++ b/tests/Symfony/Tests/Component/Routing/RouteCompilerTest.php
@@ -68,7 +68,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with several variables that have default values',
                 array('/foo/{bar}/{foobar}', array('bar' => 'bar', 'foobar' => '')),
-                '/foo', '#^/foo(?:/(?P<bar>[^/]+?)(?:/(?P<foobar>[^/]+?))?)?$#s', array('bar', 'foobar'), array(
+                '/foo', '#^/foo(?:/(?P<bar>[^/]+?))?(?:/(?P<foobar>[^/]+?))?$#s', array('bar', 'foobar'), array(
                     array('variable', '/', '[^/]+?', 'foobar'),
                     array('variable', '/', '[^/]+?', 'bar'),
                     array('text', '/foo'),
@@ -95,6 +95,23 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                 array('/{bar}', array('bar' => 'bar'), array('bar' => '(foo|bar)')),
                 '', '#^/(?P<bar>(foo|bar))?$#s', array('bar'), array(
                     array('variable', '/', '(foo|bar)', 'bar'),
+                )),
+            array(
+                'Route with optional variable and suffix',
+                array('/foo-{bar}.html', array('bar' => 'bar'), array('bar' => '(foo|bar)')),
+                '/foo', '#^/foo(?:\-(?P<bar>(foo|bar)))?\.html$#s', array('bar'), array(
+                    array('text', '.html'),
+                    array('variable', '-', '(foo|bar)', 'bar'),
+                    array('text', '/foo'),
+                )),
+            array(
+                'Route with several optional variables and suffix',
+                array('/foo-{bar}-{baz}.html', array('bar' => 'bar', 'baz' => 'baz'), array('bar' => '(foo|bar)', 'baz' => '(baz|zab)')),
+                '/foo', '#^/foo(?:\-(?P<bar>(foo|bar)))?(?:\-(?P<baz>(baz|zab)))?\.html$#s', array('bar', 'baz'), array(
+                    array('text', '.html'),
+                    array('variable', '-', '(baz|zab)', 'baz'),
+                    array('variable', '-', '(foo|bar)', 'bar'),
+                    array('text', '/foo'),
                 )),
         );
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/kostiklv/symfony.png?branch=routes-w-optional-params-and-suffix)](http://travis-ci.org/kostiklv/symfony)
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

The routes containing a suffix (such as fake .html extensions) following optional variables were not handled correctly. RouteCompiler was looking for the index of the first optional variable, but if the first token (starting from the end) was not a variable, but text, it was just breaking out, assuming there are no optional variables. 

Fixing the detection of first optional variable lead to a problem with one of the test cases (for route '/{bar}/foo'). The RouteCompiler was creating nested optional subpatterns for optional variables, and closing them at once by calculating the difference between total number of tokens and the first optional variable's token, but it was assuming that last token (which should have closed the subpatterns) is always variable's token. 

To fix that, and also a problem with correct matching of several optional variables with different requirements, I have changed it to create sequential optional subpatterns instead of nesting them. This change resulted in incorrect merging of defaults, when optional subpattern was returning an empty match (it was not possible before, because of nesting subpatterns), so I fixed mergeDefaults in UrlMatcher to skip empty matches (and effectively use defaults instead).

This fixes the following cases (which I've added to RouteCompiler's and UrlMatcher's tests):
/bar-{foo}.html (with default for foo)
/bar-{foo}-{baz}.html (with defaults for both foo and baz)

I had to adjust one of the existing RouteCompiler's tests (since the regexp has changed), but note that none of existing UrlMatcher tests were changed, meaning the fix is not breaking anything in the matching process.

I've first faced the issue while trying to create the following URL structure:
/products.html - lists first page of products, sorted by popularity
/products-by-name.html - lists first page, sorted by name
/products-2.html - the second page, by popularity
/products-by-price-2.html - the second page, by price

(more details in my [Google Groups post](https://groups.google.com/forum/?fromgroups#!topic/symfony2/5kvtqg4Xc4Y)) 
