### PR TITLE
[BrowserKit] New createRequest method on Client

### DIFF
--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -6,3 +6,4 @@ CHANGELOG
 
  * [BC BREAK] The CookieJar internals have changed to allow cookies with the
    same name on different sub-domains/sub-paths
+ * added new createRequest method to Client

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -250,7 +250,7 @@ abstract class Client
         $server['HTTP_HOST'] = parse_url($uri, PHP_URL_HOST);
         $server['HTTPS'] = 'https' == parse_url($uri, PHP_URL_SCHEME);
 
-        $request = new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
+        $request = $this->createRequest($method, $uri, $parameters, $files, $server, $content);
 
         $this->request = $this->filterRequest($request);
 
@@ -275,6 +275,23 @@ abstract class Client
         }
 
         return $this->crawler = $this->createCrawlerFromContent($request->getUri(), $response->getContent(), $response->getHeader('Content-Type'));
+    }
+
+    /**
+     * Create a new request instance.
+     *
+     * @param string  $method        The request method
+     * @param string  $uri           The URI to fetch
+     * @param array   $parameters    The Request parameters
+     * @param array   $files         The files
+     * @param array   $server        The server parameters (HTTP headers are referenced with a HTTP_ prefix as PHP does)
+     * @param string  $content       The raw body data
+     *
+     * @return Request A request instance
+     */
+    protected function createRequest($method, $uri, $parameters, $files, $server, $content)
+    {
+        return new Request($uri, $method, $parameters, $files, $this->cookieJar->allValues($uri), $server, $content);
     }
 
     /**


### PR DESCRIPTION
This provides a new `createRequest` method on the BrowserKit Client class, allowing users of the component to override the Request creation process and, for example, inject an extension of the HttpFoundation Request class instead of being forced to use the base class.

Use case for me was when working on a framework that I wanted to provide functional testing for using the BrowserKit and HttpKernel components; however, because my framework extends the base HttpFoundation Request class, I am unable to integrate with this component.
