### PR TITLE
[OptionsResolver] validateOptionTypes raises error for optional, nonexistant option values

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -312,6 +312,10 @@ class OptionsResolver implements OptionsResolverInterface
     private function validateOptionTypes(array $options)
     {
         foreach ($this->allowedTypes as $option => $allowedTypes) {
+            if (!isset($options[$option])) {
+                continue;
+            }
+
             $value = $options[$option];
             $allowedTypes = (array) $allowedTypes;
 

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -312,7 +312,7 @@ class OptionsResolver implements OptionsResolverInterface
     private function validateOptionTypes(array $options)
     {
         foreach ($this->allowedTypes as $option => $allowedTypes) {
-            if (!isset($options[$option])) {
+            if (!array_key_exists($option, $options)) {
                 continue;
             }
 

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -381,6 +381,27 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         ), $this->resolver->resolve($options));
     }
 
+    public function testResolveSucceedsIfOptionalWithTypeAndWithoutValue()
+    {
+        $this->resolver->setOptional(array(
+            'one',
+            'two',
+        ));
+
+        $this->resolver->setAllowedTypes(array(
+            'one' => 'string',
+            'two' => 'int',
+        ));
+
+        $options = array(
+            'two' => 1,
+        );
+
+        $this->assertEquals(array(
+            'two' => 1,
+        ), $this->resolver->resolve($options));
+    }
+
     /**
      * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */


### PR DESCRIPTION
The [`OptionsResolver#validateOptionTypes`](https://github.com/symfony/OptionsResolver/blob/master/OptionsResolver.php#L315) method should check if a given option value exists before trying to test its type:

``` php
<?php
// Two optional 'one' and 'two' options that, if they exist, must be a string and int respectively
$resolver = new OptionsResolver();
$resolver->setOptional(array('one', 'two'))->setAllowedTypes(array('one' => 'string', 'two' => 'int'));

// Correctly fails as wrong type
$resolver->resolve(array('one' => 1, 'two' => 'alpha'));

// Correctly succeeds
$resolver->resolve(array('one' => 'alpha', 'two' => 1));

// Raises error "Undefined index: two", see OptionsResolver.php line 315
$resolver->resolve(array('one' => 'alpha'));
```
