### PR TITLE
[Form] Add extra data attributes for collections

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -31,8 +31,18 @@
 
 {% block collection_widget %}
 {% spaceless %}
+    {% set attr = attr|merge({'data-collection': true}) %}
+
     {% if prototype is defined %}
-        {% set attr = attr|merge({'data-prototype': form_row(prototype) }) %}
+        {% set attr = attr|merge({'data-collection-prototype': form_row(prototype)}) %}
+    {% endif %}
+
+    {% if allow_delete is defined %}
+        {% set attr = attr|merge({'data-collection-delete': allow_delete}) %}
+    {% endif %}
+
+    {% if allow_add is defined %}
+        {% set attr = attr|merge({'data-collection-add': allow_add}) %}
     {% endif %}
     {{ block('form_widget') }}
 {% endspaceless %}


### PR DESCRIPTION
PR for discussion.

Bug fix: no
Feature addition: yes
Backwards compatibility break: yes (user implementation of javascript)
Symfony2 tests pass: yes

I've added 3 extra data-\* attributes to collections in twig templates and renamed the prototype attribute for easier js manipulation.

New attributes:
- `data-collection`: This is a collection and all children are form types
- `data-collection-add`: Allow adding of new elements
- `data-collection-delete`: Allow deletion of elements (new and existing)

Renamed:
- `data-prototype` -> `data-collection-protoype`: Namespace prototype in the collection.

This should make javascript integration much smoother.

Example js:

``` js
$('[data-collection]').each(function(){
    var $collection = $(this);
    var count = $collection.children().length;
    var prototypeString = $collection.data('collectionPrototype');
    var $deleteLink = $("<button class='delete'>Remove</button>");
    var $addLink = $("<button class='add'>Add</button>");

    if($collection.data('collectionDelete')) {
        $collection.children().append($deleteLink.clone());
        $collection.on('click', '.delete', function(){
            event.preventDefault();
            $(this).parent().remove();
        })
    }

    if($collection.data('collectionAdd')) {
        $addLink.click(function(event){
            event.preventDefault();
            newPrototypeString = prototypeString.replace(/__name__/g, count);
            $newPrototype = $(newPrototypeString);
            $newPrototype.append($deleteLink.clone());
            $newPrototype.insertBefore($addLink);
            count++;
        });
        $collection.append($addLink);
    }
})
```
