### PR TITLE
[2.2] [Yaml] added a means to determine the last index parsed by the inline YAML parser

### DIFF
--- a/src/Symfony/Component/Yaml/CHANGELOG.md
+++ b/src/Symfony/Component/Yaml/CHANGELOG.md
@@ -6,3 +6,5 @@ CHANGELOG
 
  * Yaml::parse() does not evaluate loaded files as PHP files by default
    anymore (call Yaml::enablePhpParsing() to get back the old behavior)
+ * Inline::parse() now permits the last parsed index to be determined
+   through an optional by-reference parameter

--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -26,10 +26,11 @@ class Inline
      * Converts a YAML string to a PHP array.
      *
      * @param string $value A YAML string
+     * @param integer &$i The last index that was parsed
      *
      * @return array A PHP array representing the YAML string
      */
-    public static function parse($value)
+    public static function parse($value, &$i = 0)
     {
         $value = trim($value);
 
@@ -44,13 +45,12 @@ class Inline
 
         switch ($value[0]) {
             case '[':
-                $result = self::parseSequence($value);
+                $result = self::parseSequence($value, $i);
                 break;
             case '{':
-                $result = self::parseMapping($value);
+                $result = self::parseMapping($value, $i);
                 break;
             default:
-                $i = 0;
                 $result = self::parseScalar($value, null, array('"', "'"), $i);
 
                 // some comment can end the scalar

--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -21,6 +21,13 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         foreach ($this->getTestsForParse() as $yaml => $value) {
             $this->assertEquals($value, Inline::parse($yaml), sprintf('::parse() converts an inline YAML to a PHP structure (%s)', $yaml));
         }
+
+        foreach ($this->getTestsForParseIndex() as $yaml => $index) {
+            $actualIndex = 0;
+            Inline::parse($yaml, $actualIndex);
+
+            $this->assertEquals($index, $actualIndex, sprintf('::parse() sets $i to the last index parsed (%s)', $yaml));
+        }
     }
 
     public function testDump()
@@ -161,6 +168,29 @@ class InlineTest extends \PHPUnit_Framework_TestCase
 
             '[foo, bar: { foo: bar }]' => array('foo', '1' => array('bar' => array('foo' => 'bar'))),
             '[foo, \'@foo.baz\', { \'%foo%\': \'foo is %foo%\', bar: \'%foo%\' }, true, \'@service_container\']' => array('foo', '@foo.baz', array('%foo%' => 'foo is %foo%', 'bar' => '%foo%',), true, '@service_container',),
+        );
+    }
+
+    protected function getTestsForParseIndex()
+    {
+        return array(
+            '' => 0,
+            ' ' => 0,
+            'null' => 4,
+            'false' => 5,
+            'true' => 4,
+            '12' => 2,
+            '"quoted string"' => 15,
+
+            // sequences
+            '[foo, bar]' => 9,
+            '[foo, bar] baz' => 9,
+            '[foo, bar, baz]' => 14,
+
+            // mappings
+            '{foo: bar}' => 9,
+            '{foo: bar} baz' => 9,
+            '{foo: bar, baz: qux}' => 19,
         );
     }
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

I have a use-case where inline YAML is embedded in another syntax. this allows me to consume valid YAML input while possible, and then resume parsing the other syntax.

Most of the class already supports passing an index argument by reference to track the current parser position (but all methods are private and it's not currently used internally?), so all this change entails is to pass on the by-reference parameter from the main parse() method to the other methods that already support it.
