### PR TITLE
Modified Symfony\Component\DependencyInjection\Container::underscore

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -462,6 +462,6 @@ class Container implements IntrospectableContainerInterface
      */
     public static function underscore($id)
     {
-        return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr($id, '_', '.')));
+        return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z0-9])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr($id, '_', '.')));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -462,6 +462,6 @@ class Container implements IntrospectableContainerInterface
      */
     public static function underscore($id)
     {
-        return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z0-9])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr($id, '_', '.')));
+        return strtolower(preg_replace(array('/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'), array('\\1_\\2', '\\1_\\2'), strtr($id, '_', '.')));
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -390,6 +390,51 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         return $reflection->getValue($obj);
     }
+    
+    public function underscorCase()
+    {
+        return array(
+            array(
+              "VendornameBundlename",
+              "vendorname_bundlename",
+            ),
+            array(
+              "VENDORNAMEBundlename",
+              "vendorname_bundlename",
+            ),
+            array(
+              "VENDORI18n",
+              "vendori18n",
+            ),
+            array(
+              "VendorI18n",
+              "vendor_i18n",
+            ),
+            array(
+              "VENDOR18n",
+              "vendor18n",
+            ),
+            array(
+              "Vendor18n",
+              "vendor18n",
+            ),
+            array(
+              "vendori18n",
+              "vendori18n",
+            )
+        );
+    }
+    
+    /**
+     * @dataProvider underscorCase
+     */
+    public function testUnderscore($id, $expected)
+    {
+        $sc     = new Container();
+        $result = $sc->underscore($id);
+        
+        $this->assertEquals($expected, $result, "test for " . $id);
+    }
 }
 
 class ProjectServiceContainer extends Container


### PR DESCRIPTION
If you have a bundle called VendorI18n, now underscore return "vendor_i18n" instead of "vendori18n"
