### PR TITLE
[Yaml] Allow custom indentation level for nested nodes

### DIFF
--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -19,6 +19,23 @@ namespace Symfony\Component\Yaml;
 class Dumper
 {
     /**
+     * The amount of spaces to use for indentation of nested nodes.
+     *
+     * @var integer
+     */
+    protected $indentation = 4;
+
+    /**
+     * Sets the indentation.
+     *
+     * @param integer $num The amount of spaces to use for intendation of nested nodes.
+     */
+    public function setIndentation($num)
+    {
+        $this->indentation = $num;
+    }
+
+    /**
      * Dumps a PHP value to YAML.
      *
      * @param mixed   $input  The PHP value
@@ -44,7 +61,7 @@ class Dumper
                     $prefix,
                     $isAHash ? Inline::dump($key).':' : '-',
                     $willBeInlined ? ' ' : "\n",
-                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + 4)
+                    $this->dump($value, $inline - 1, $willBeInlined ? 0 : $indent + $this->indentation)
                 ).($willBeInlined ? "\n" : '');
             }
         }

--- a/src/Symfony/Component/Yaml/Dumper.php
+++ b/src/Symfony/Component/Yaml/Dumper.php
@@ -32,7 +32,7 @@ class Dumper
      */
     public function setIndentation($num)
     {
-        $this->indentation = $num;
+        $this->indentation = (int) $num;
     }
 
     /**

--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -97,14 +97,16 @@ class Yaml
      *
      * @param array   $array  PHP array
      * @param integer $inline The level where you switch to inline YAML
+     * @param integer $indent The amount of spaces to use for indentation of nested nodes.
      *
      * @return string A YAML string representing the original PHP array
      *
      * @api
      */
-    public static function dump($array, $inline = 2)
+    public static function dump($array, $inline = 2, $indent = 4)
     {
         $yaml = new Dumper();
+        $yaml->setIndentation($indent);
 
         return $yaml->dump($array, $inline);
     }


### PR DESCRIPTION
YAML does not specify an absolute indentation level, but a consistent indentation of nested nodes only: http://yaml.org/spec/current.html#indentation%20space/

Projects that are generally using 2 spaces for indentation should be able to retain consistency with their coding standards by supplying a custom value for the new $indent parameter for Yaml::dump() and Dumper::dump().

The new parameter is a backwards-compatible API addition and defaults to the previous default of 4 (which was changed from 2 via PR #2242 only recently).

The old $indent parameter is renamed to $level, and remains to be used internally only.
