### PR TITLE
No console commands are loading because an incorrect "use" statement

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\HttpKernel\Bundle;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Application.


### PR DESCRIPTION
.../Application.php

Issue must be related to commit 7a5f6142405c599cf0eb54e80c98e54e41ab4fdf (merged 2.0), specifically this file src/Symfony/Bundle/FrameworkBundle/Console/Application.php, lines 86-88. 

Presumably to do "instanceof Bundle" correct class has to be imported at the top of the file:

instead of 
use Symfony\Component\HttpKernel\Bundle;

this should be
use Symfony\Component\HttpKernel\Bundle\Bundle;
