### PR TITLE
use Symfony\Component\HttpKernel\Bundle seems to be incomplete

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -17,7 +17,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\HttpKernel\Bundle;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Application.


### PR DESCRIPTION
Fixed wrong use of namespace `Symfony\Component\HttpKernel\Bundle\Bundle`
