### PR TITLE
Fix/role security identity

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -30,10 +30,16 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function __construct($role)
     {
+        if (!is_string($role) && !($role instanceof RoleInterface)) {
+            throw new \InvalidArgumentException('$role must be a string or object implementing RoleInterface.');
+        }
         if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
-
+        if (empty($role)) {
+            throw new \InvalidArgumentException('$role must not be empty.');
+        }
+        
         $this->role = $role;
     }
 

--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * A SecurityIdentity implementation for roles
@@ -26,11 +26,11 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
     /**
      * Constructor
      *
-     * @param mixed $role a Role instance, or its string representation
+     * @param mixed $role an object implementing RoleInterface, or its string representation
      */
     public function __construct($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
 

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/RoleSecurityIdentityTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/RoleSecurityIdentityTest.php
@@ -30,7 +30,23 @@ class RoleSecurityIdentityTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('ROLE_FOO', $id->getRole());
     }
-
+    
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidParameterThrowsException()
+    {
+        $id = new RoleSecurityIdentity(0);
+    }
+    
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testEmptyParameterThrowsException()
+    {
+        $id = new RoleSecurityIdentity('');
+    }
+        
     /**
      * @dataProvider getCompareData
      */


### PR DESCRIPTION
We're using our own Role object that implements RoleInterface and the Acl didn't work because of the fact that RoleSecurityIdentity checked on the objects passed being an instance of Role instead of RoleInterface...

I also added some extra sanity checks in the constructor and tests for them.
