### PR TITLE
[Form] Fix UnexpectedTypeException from HttpFoundation extension

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationExtension.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationExtension.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\AbstractExtension;
  */
 class HttpFoundationExtension extends AbstractExtension
 {
-    protected function loadTypes()
+    protected function loadTypeExtensions()
     {
         return array(
             new Type\FormTypeHttpFoundationExtension(),


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -

Fixes exception thrown by the `AbstractExtension` because the wrong method has been implemented.

```
Uncaught exception 'Symfony\\Component\\Form\\Exception\\UnexpectedTypeException' with message 'Expected argument of type "Symfony\\Component\\Form\\FormTypeInterface", "Symfony\\Component\\Form\\Extension\\HttpFoundation\\Type\\FormTypeHttpFoundationExtension" given' in vendor/symfony/form/Symfony/Component/Form/AbstractExtension.php:153
```
