### PR TITLE
[DoctrineBridge] Fixed the testsuite

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -60,7 +60,7 @@ class DbalLoggerTest extends \PHPUnit_Framework_TestCase
         $dbalLogger
             ->expects($this->once())
             ->method('log')
-            ->with('SQL ({"utf8":"foo","nonutf8":null})')
+            ->with('SQL', array('utf8' => 'foo', 'nonutf8' => "\x7F\xFF"))
         ;
 
         $dbalLogger->startQuery('SQL', array(


### PR DESCRIPTION
In the master branch, the handling of non-utf8 values is done by Monolog as the data are passed through the context.
