### PR TITLE
[Config] Missing type argument passed to loader.

### DIFF
--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -72,7 +72,7 @@ abstract class FileLoader extends Loader
             }
             self::$loading[$resource] = true;
 
-            $ret = $loader->load($resource);
+            $ret = $loader->load($resource, $type);
 
             unset(self::$loading[$resource]);
 


### PR DESCRIPTION
In FileLoader the $type is not passed to the child loader.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
