### PR TITLE
Updated HttpFoundation and Locale for proper Composer autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,10 +62,11 @@
         "monolog/monolog": "dev-master"
     },
     "autoload": {
-        "psr-0": {
-            "Symfony": "src/",
-            "SessionHandlerInterface": "src/Symfony/Component/HttpFoundation/Resources/stubs"
-        }
+        "psr-0": { "Symfony": "src/" },
+        "classmap": [
+            "src/Symfony/Component/HttpFoundation/Resources/stubs",
+            "src/Symfony/Component/Locale/Resources/stubs"
+        ]
     },
     "minimum-stability": "dev",
     "extra": {

--- a/src/Symfony/Component/HttpFoundation/README.md
+++ b/src/Symfony/Component/HttpFoundation/README.md
@@ -31,7 +31,7 @@ the HTTP specification.
 Loading
 -------
 
-If you are using PHP 5.3.x you must add the following to your autoloader:
+If you are not using Composer but are using PHP 5.3.x, you must add the following to your autoloader:
 
     // SessionHandlerInterface
     if (!interface_exists('SessionHandlerInterface')) {

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -19,10 +19,8 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": {
-            "Symfony\\Component\\HttpFoundation": "",
-            "SessionHandlerInterface": "Symfony/Component/HttpFoundation/Resources/stubs"
-        }
+        "psr-0": { "Symfony\\Component\\HttpFoundation": "" },
+        "classmap": [ "Resources/stubs" ]
     },
     "target-dir": "Symfony/Component/HttpFoundation",
     "extra": {

--- a/src/Symfony/Component/Locale/README.md
+++ b/src/Symfony/Component/Locale/README.md
@@ -14,6 +14,9 @@ requires adding the following lines to your autoloader:
         $loader->registerPrefixFallback(__DIR__.'/../vendor/symfony/src/Symfony/Component/Locale/Resources/stubs');
     }
 
+If you are using Composer for autoloading, then you can even simplify it by
+removing the ``$loader->registerPrefixFallback`` line.
+
 Resources
 ---------
 

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -22,7 +22,8 @@
         "ext-intl": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Locale": "" }
+        "psr-0": { "Symfony\\Component\\Locale": "" },
+        "classmap": [ "Resources/stubs" ]
     },
     "target-dir": "Symfony/Component/Locale",
     "extra": {


### PR DESCRIPTION
This PR uses better Composer autoloading strategy for the stubs in HttpFoundation and Locale.

It also fixes a bug inside HttpFoundation's composer.json file where the path for SessionHandlerInterface was wrong.

[![Build Status](https://secure.travis-ci.org/jalliot/symfony.png?branch=autoloader-update)](http://travis-ci.org/jalliot/symfony)

After merging this PR and updating the vendors of the SE, you can also merge symfony/symfony-standard#387
