### PR TITLE
[Form] Add currency offset in money type pattern cache

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -104,14 +104,14 @@ class MoneyType extends AbstractType
             preg_match('/^([^\s\xc2\xa0]*)[\s\xc2\xa0]*123(?:[,.]0+)?[\s\xc2\xa0]*([^\s\xc2\xa0]*)$/u', $pattern, $matches);
 
             if (!empty($matches[1])) {
-                self::$patterns[\Locale::getDefault()] = $matches[1].' {{ widget }}';
+                self::$patterns[\Locale::getDefault()][$currency] = $matches[1].' {{ widget }}';
             } elseif (!empty($matches[2])) {
-                self::$patterns[\Locale::getDefault()] = '{{ widget }} '.$matches[2];
+                self::$patterns[\Locale::getDefault()][$currency] = '{{ widget }} '.$matches[2];
             } else {
-                self::$patterns[\Locale::getDefault()] = '{{ widget }}';
+                self::$patterns[\Locale::getDefault()][$currency] = '{{ widget }}';
             }
         }
 
-        return self::$patterns[\Locale::getDefault()];
+        return self::$patterns[\Locale::getDefault()][$currency];
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -34,8 +34,8 @@ class MoneyTypeTest extends LocalizedTestCase
 
     /**
      * Because of the bug, the money type will cache the first result of the
-	 * first request and return it on the second request with another currency.
-	 */
+     * first request and return it on the second request with another currency
+     */
     public function testMoneyPatternCacheBug()
     {
         \Locale::setDefault('lv_LV');
@@ -46,6 +46,6 @@ class MoneyTypeTest extends LocalizedTestCase
 
         $form = $this->factory->create('money', null, array('currency' => 'EUR'));
         $view = $form->createView();
-		$this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
+	    $this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -31,4 +31,21 @@ class MoneyTypeTest extends LocalizedTestCase
         $view = $form->createView();
         $this->assertTrue((Boolean) strstr($view->vars['money_pattern'], '¥'));
     }
+
+    /**
+     * Because of the bug, the money type will cache the first result of the
+	 * first request and return it on the second request with another currency.
+	 */
+    public function testMoneyPatternCacheBug()
+    {
+        \Locale::setDefault('lv_LV');
+
+        $form = $this->factory->create('money', null, array('currency' => 'JPY'));
+        $view = $form->createView();
+        $this->assertTrue((Boolean) strstr($view->vars['money_pattern'], '¥'));
+
+        $form = $this->factory->create('money', null, array('currency' => 'EUR'));
+        $view = $form->createView();
+		$this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -33,8 +33,9 @@ class MoneyTypeTest extends LocalizedTestCase
     }
 
     /**
-     * Because of the bug, the money type will cache the first result of the
-     * first request and return it on the second request with another currency
+     * Because of the bug reported in the pull request #5216, the money type
+     * object might cache the result of the first request and return the same
+     * value on the second request with another currency
      */
     public function testMoneyPatternCacheBug()
     {
@@ -46,6 +47,6 @@ class MoneyTypeTest extends LocalizedTestCase
 
         $form = $this->factory->create('money', null, array('currency' => 'EUR'));
         $view = $form->createView();
-	    $this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
+        $this->assertSame('{{ widget }} €', $view->vars['money_pattern']);
     }
 }


### PR DESCRIPTION
Currency offset was missing when generated money type pattern was cached and returned.
