### PR TITLE
[Filesystem] missing readlink breaking FilesystemTest class on Windows

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -33,6 +33,7 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->filesystem = new Filesystem();
         $this->workspace = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.time().rand(0, 1000);
         mkdir($this->workspace, 0777, true);
+        $this->workspace = realpath($this->workspace);
     }
 
     public function tearDown()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5233
Todo: 
License of the code: MIT
Documentation PR: 

fix for windows plateform

$file == 'C:\Users\USERNA~1...' before touch
$file == 'C:\Users\Username... after the touch and readlink so it can pass following assertEquals
