### PR TITLE
[TwigBundle] Do not check for Twig if templating.engines is not defined

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Compiler/ExceptionListenerPass.php
@@ -27,6 +27,10 @@ class ExceptionListenerPass implements CompilerPassInterface
             return;
         }
 
+        if (false === $container->hasDefinition('templating.engines')) {
+            return;
+        }
+
         // register the exception controller only if Twig is enabled
         $engines = $container->getParameter('templating.engines');
         if (!in_array('twig', $engines)) {


### PR DESCRIPTION
This causes problems if TwigBundle is used when no `templating.engines` exists. (using TwigBundle w/o FrameworkBundle)
