### PR TITLE
Fix for session_start() which doesn't check if the session has already started

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -143,7 +143,7 @@ class NativeSessionStorage implements SessionStorageInterface
         }
 
         // start the session
-        if (!session_start()) {
+        if ('' == session_id() && !session_start()) {
             throw new \RuntimeException('Failed to start the session');
         }
 


### PR DESCRIPTION
session_start() runs in the current logic for Native Sessions here without checking first if the session has already started previous to the code running.
