### PR TITLE
Fixes #5250 - Adding more specific debug bar reset CSS. 

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_style.html.twig
@@ -17,6 +17,10 @@
         bottom: 0;
         border-top: 1px solid #bbb;
     }
+    .sf-toolbarreset span, 
+    .sf-toolbarreset div {
+        font-size: 11px;
+    }
     .sf-toolbarreset img {
         width: auto;
         display: inline;
@@ -103,6 +107,11 @@
         vertical-align: middle;
         min-width: 6px;
         min-height: 13px;
+    }
+
+    .sf-toolbar-block .sf-toolbar-status abbr {
+        color: #fff;
+        border-bottom: 1px dotted black;
     }
 
     .sf-toolbar-block .sf-toolbar-status-green {


### PR DESCRIPTION
This prevents frameworks like Foundation from getting past the reset.

Fixes #5250
