### PR TITLE
[Form] Fixed undefined index in writeProperty when saving value arrays

### DIFF
--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -510,7 +510,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
 
                     if (is_array($previousValue) || $previousValue instanceof Traversable) {
                         foreach ($previousValue as $previousItem) {
-                            foreach ($value as $key => $item) {
+                            foreach ($itemsToAdd as $key => $item) {
                                 if ($item === $previousItem) {
                                     // Item found, don't add
                                     unset($itemsToAdd[$key]);


### PR DESCRIPTION
When removing an item from an array and the previous value contains more than one identical copy of that item, the second unset fails with undefined index.
