### PR TITLE
Undocumented BC break - choice field type template

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -530,11 +530,9 @@
     by default. Take care if your JavaScript relies on that. If you want to
     read the actual choice value, read the `value` attribute instead.
 
-  * In the choice field type's template, the structure of the `choices` variable
-    has changed.
-
-    The `choices` variable now contains `ChoiceView` objects with two getters,
-    `getValue()` and `getLabel()`, to access the choice data.
+  * In the choice field type's template, the `_form_is_choice_selected` method
+    used to identify a selected choice has been replaced with the `selectedchoice`
+    filter.
 
     Before:
 
@@ -549,9 +547,9 @@
     After:
 
     ```
-    {% for choice in choices %}
-        <option value="{{ choice.value }}"{% if _form_is_choice_selected(form, choice) %} selected="selected"{% endif %}>
-            {{ choice.label }}
+    {% for choice, label in choices %}
+        <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>
+            {{ label }}
         </option>
     {% endfor %}
     ```


### PR DESCRIPTION
The upgrade notes for the choice field template are out of date. They currently state:

```
The `choices` variable now contains `ChoiceView` objects with two getters,
getValue() and getLabel(), to access the choice data.
```

However these methods do not exist. I assume this is the result of a rollback to maintain BC? 

In addition to this, the `_form_is_choice_selected` twig function has been removed and replaced with a filter called `selectedchoice`. This is an undocumented BC break. I have attached an update to the notes to reflect these changes.
