### PR TITLE
[HttpFoundation][Sessions] NativeFileSession won't override the php.ini settings anymore

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/NativeFileSessionHandler.php
@@ -33,6 +33,13 @@ class NativeFileSessionHandler extends NativeSessionHandler
      */
     public function __construct($savePath = null)
     {
+        // We don't want to override the server settings in case the server is configured to handle sessions
+        // in something else than files. This makes it easy to configure servers to have sessions stored in
+        // memcached/redis or anything else from PHP.ini
+        if ('files' != ini_get('session.save_handler')) {
+            return;
+        }
+
         if (null === $savePath) {
             $savePath = ini_get('session.save_path');
         }


### PR DESCRIPTION
This is a redo of #5266 as I had to delete my repository for some other reasons.

Bug fix: yes - but in the 2.1 branch
Feature addition: no
Backwards compatibility break: not sure
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/dlsniper/symfony.png?branch=session-handler-fix)](http://travis-ci.org/dlsniper/symfony)
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~

Today I've noticed that the sessions are stored in files even if the configuration of the PHP server was to use the memcached driver to do so.
After a bit of digging I've noticed that the native storage solution Symfony2.1 comes with will override the server settings in the PHP.ini which is very bad as this is not the expected default behavior.
I think this should be solved before releasing 2.1 as the changes for the session subsystem are already major.
One other thing to add to this would be to force the sessions to be stored in files regardless of the settings in php.ini but for that I think we need to use a configuration option. If you think that it would be better to solve the problem that way then I'll gladly do it.

cc @fabpot @drak
