### PR TITLE
[EventDispatcher] Moving the $subject argument after $arguments for Gene...

### DIFF
--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -37,10 +37,10 @@ class GenericEvent extends Event implements \ArrayAccess
     /**
      * Encapsulate an event with $subject, $args, and $data.
      *
-     * @param mixed $subject   The subject of the event, usually an object.
      * @param array $arguments Arguments to store in the event.
+     * @param mixed $subject   The subject of the event, usually an object.
      */
-    public function __construct($subject = null, array $arguments = array())
+    public function __construct(array $arguments = array(), $subject = null)
     {
         $this->subject = $subject;
         $this->arguments = $arguments;
@@ -161,9 +161,7 @@ class GenericEvent extends Event implements \ArrayAccess
      */
     public function offsetUnset($key)
     {
-        if ($this->hasArgument($key)) {
-            unset($this->arguments[$key]);
-        }
+        unset($this->arguments[$key]);
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -34,7 +34,7 @@ class GenericEventTest extends \PHPUnit_Framework_TestCase
         parent::setUp();
 
         $this->subject = new \StdClass();
-        $this->event = new GenericEvent($this->subject, array('name' => 'Event'), 'foo');
+        $this->event = new GenericEvent(array('name' => 'Event'), $this->subject);
     }
 
     /**
@@ -50,7 +50,7 @@ class GenericEventTest extends \PHPUnit_Framework_TestCase
 
     public function test__construct()
     {
-        $this->assertEquals($this->event, new GenericEvent($this->subject, array('name' => 'Event')));
+        $this->assertEquals($this->event, new GenericEvent(array('name' => 'Event'), $this->subject));
     }
 
     /**


### PR DESCRIPTION
...ricEvent::__construct. Removing unnecessary check when calling unset.

I think it would be great to move subject after the arguments for the GenericEvent's constructor. I think that people will more often specify an array of arguments than they specify a subject. This is what I currently do in Guzzle. I'd love to be able to ditch Guzzle\Common\Event and just use Symfony's GenericEvent, but I'd need to see this change.
