### PR TITLE
[Form] Reintroduced the option "invalid_message_parameters"

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -87,7 +87,7 @@ class FormValidator extends ConstraintValidator
             // Mark the form with an error if it is not synchronized
             $this->context->addViolation(
                 $config->getOption('invalid_message'),
-                array('{{ value }}' => $clientDataAsString),
+                array_replace(array('{{ value }}' => $clientDataAsString), $config->getOption('invalid_message_parameters')),
                 $form->getViewData(),
                 null,
                 Form::ERR_INVALID

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -77,15 +77,16 @@ class FormTypeValidatorExtension extends AbstractTypeExtension
         };
 
         $resolver->setDefaults(array(
-            'error_mapping'         => array(),
-            'validation_groups'     => null,
+            'error_mapping'              => array(),
+            'validation_groups'          => null,
             // "validation_constraint" is deprecated. Use "constraints".
-            'validation_constraint' => null,
-            'constraints'           => $constraints,
-            'cascade_validation'    => false,
-            'invalid_message'       => 'This value is not valid.',
-            'extra_fields_message'  => 'This form should not contain extra fields.',
-            'post_max_size_message' => 'The uploaded file was too large. Please try to upload a smaller file.',
+            'validation_constraint'      => null,
+            'constraints'                => $constraints,
+            'cascade_validation'         => false,
+            'invalid_message'            => 'This value is not valid.',
+            'invalid_message_parameters' => array(),
+            'extra_fields_message'       => 'This form should not contain extra fields.',
+            'post_max_size_message'      => 'The uploaded file was too large. Please try to upload a smaller file.',
         ));
 
         $resolver->setNormalizers(array(


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5144
Todo: -
