### PR TITLE
Allowed array of emails for "to_email" parameter.

### DIFF
--- a/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/MonologBundle/DependencyInjection/Configuration.php
@@ -71,7 +71,13 @@ class Configuration implements ConfigurationInterface
                                 ->prototype('scalar')->end()
                             ->end()
                             ->scalarNode('from_email')->end() // swift_mailer and native_mailer
-                            ->scalarNode('to_email')->end() // swift_mailer and native_mailer
+                            ->arrayNode('to_email') // swift_mailer and native_mailer
+                                ->prototype('scalar')->end()
+                                ->beforeNormalization()
+                                    ->ifString()
+                                    ->then(function($v) { return array('id' => $v); })
+                                ->end()
+                            ->end()
                             ->scalarNode('subject')->end() // swift_mailer and native_mailer
                             ->arrayNode('email_prototype') // swift_mailer
                                 ->canBeUnset()


### PR DESCRIPTION
``` yaml

# app/config/config.yml

monolog:
    handlers:        
        swift:
            type:       swift_mailer
            from_email: error@localhost
            to_email:   [email1@mail.com, email2@mail.com]  # or as always to_email:  email1@mail.com
            subject:    An Error Occurred!
            level:      debug

```
