### PR TITLE
[HttpFoundation] fixed undefined offset for assoc arrays in HeaderBag

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -157,7 +157,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
     {
         $key = strtr(strtolower($key), '_', '-');
 
-        $values = (array) $values;
+        $values = array_values((array) $values);
 
         if (true === $replace || !isset($this->headers[$key])) {
             $this->headers[$key] = $values;

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -68,6 +68,14 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals( array('bar', 'bor'), $bag->get('foo', 'nope', false), '->get return all values as array');
     }
 
+    public function testSetAssociativeArray()
+    {
+        $bag = new HeaderBag();
+        $bag->set('foo', array('bad-assoc-index' => 'value'));
+        $this->assertSame('value', $bag->get('foo'));
+        $this->assertEquals(array('value'), $bag->get('foo', 'nope', false), 'assoc indices of multi-valued headers are ignored');
+    }
+
     /**
      * @covers Symfony\Component\HttpFoundation\HeaderBag::contains
      */


### PR DESCRIPTION
`get` is assuming the headers are zero-indexed. So something like this would otherwise create a php warning.

```
$bag->set('foo', array('bad-assoc-index' => 'value'));
$this->assertSame('value', $bag->get('foo'));
```
