### PR TITLE
Displaying var_dump with xdebug in exceptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception_layout.css
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/public/css/exception_layout.css
@@ -134,3 +134,8 @@ pre {
     white-space: normal;
     font-family: Arial, Helvetica, sans-serif;
 }
+
+pre.xdebug-var-dump{
+    white-space: pre;
+    font-family: monospace;
+}


### PR DESCRIPTION
When debugging code I often use `var_dump` to quickly look into variables. Since 2.1 alle output generated by `var_dump` is displayed in one line. http://screencast.com/t/11LuIlIdHsvP
It seems to be no problem for small objects, but it becomes a real pain when displaying huge arrays or objects.

This is caused by the changed word-wrapping for the pre tag introduced in #3827

With fix: http://screencast.com/t/GdA3dkpWxU
