### PR TITLE
[HttpKernel] Added stringification of array objects in RequestDataCollector

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -181,15 +181,15 @@ class RequestDataCollector extends DataCollector
      */
     private function attributeStringifier($value)
     {
-        if (is_object($value)) {
-            $result = sprintf('Object(%s)', get_class($value));
-            if (is_callable(array($value, '__toString'))) {
-                $result .= sprintf(' = %s', (string) $value);
-            }
-        } else if (is_array($value) || $value instanceof \Traversable) {
+        if (is_array($value) || $value instanceof \Traversable) {
             $result = array();
             foreach ($value as $k => $v) {
                 $result[$k] = $this->attributeStringifier($v);
+            }
+        } else if (is_object($value)) {
+            $result = sprintf('Object(%s)', get_class($value));
+            if (is_callable(array($value, '__toString'))) {
+                $result .= sprintf(' = %s', (string) $value);
             }
         } else {
             $result = $value;

--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -186,7 +186,7 @@ class RequestDataCollector extends DataCollector
             foreach ($value as $k => $v) {
                 $result[$k] = $this->attributeStringifier($v);
             }
-        } else if (is_object($value)) {
+        } elseif (is_object($value)) {
             $result = sprintf('Object(%s)', get_class($value));
             if (is_callable(array($value, '__toString'))) {
                 $result .= sprintf(' = %s', (string) $value);


### PR DESCRIPTION
If the request attributes has a key which has an array with objects (especially if they are doctrine entities) serialization will fail.
This fixes that problem.
