### PR TITLE
[WIP] [Form] Added a deletion_handler option to the collection type to handle deletion of entries

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -155,7 +155,7 @@ class ResizeFormListener implements EventSubscriberInterface
         if ($this->allowDelete) {
             foreach ($data as $name => $child) {
                 if (!$form->has($name)) {
-                    if (null != $this->deletionHandler) {
+                    if (null !== $this->deletionHandler) {
                         $deletionHandler = $this->deletionHandler;
                         $deletionHandler ($data[$name]);
                     }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -51,13 +51,20 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     protected $allowDelete;
 
-    public function __construct(FormFactoryInterface $factory, $type, array $options = array(), $allowAdd = false, $allowDelete = false)
+    /**
+     * Optional handler that gets called upon deletion of an item
+     * @var \Closure
+     */
+    protected $deletionHandler;
+
+    public function __construct(FormFactoryInterface $factory, $type, array $options = array(), $allowAdd = false, $allowDelete = false, $deletionHandler = null)
     {
         $this->factory = $factory;
         $this->type = $type;
         $this->allowAdd = $allowAdd;
         $this->allowDelete = $allowDelete;
         $this->options = $options;
+        $this->deletionHandler = $deletionHandler;
     }
 
     public static function getSubscribedEvents()
@@ -148,6 +155,10 @@ class ResizeFormListener implements EventSubscriberInterface
         if ($this->allowDelete) {
             foreach ($data as $name => $child) {
                 if (!$form->has($name)) {
+                    if (null != $this->deletionHandler) {
+                        $deletionHandler = $this->deletionHandler;
+                        $deletionHandler ($data[$name]);
+                    }
                     unset($data[$name]);
                 }
             }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -157,7 +157,7 @@ class ResizeFormListener implements EventSubscriberInterface
                 if (!$form->has($name)) {
                     if (null !== $this->deletionHandler) {
                         $deletionHandler = $this->deletionHandler;
-                        $deletionHandler ($data[$name]);
+                        $deletionHandler($data[$name]);
                     }
                     unset($data[$name]);
                 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -38,7 +38,8 @@ class CollectionType extends AbstractType
             $options['type'],
             $options['options'],
             $options['allow_add'],
-            $options['allow_delete']
+            $options['allow_delete'],
+            $options['deletion_handler']
         );
 
         $builder->addEventSubscriber($resizeListener);
@@ -81,12 +82,17 @@ class CollectionType extends AbstractType
         };
 
         $resolver->setDefaults(array(
-            'allow_add'      => false,
-            'allow_delete'   => false,
-            'prototype'      => true,
-            'prototype_name' => '__name__',
-            'type'           => 'text',
-            'options'        => array(),
+            'allow_add'        => false,
+            'allow_delete'     => false,
+            'prototype'        => true,
+            'prototype_name'   => '__name__',
+            'type'             => 'text',
+            'options'          => array(),
+            'deletion_handler' => null,
+        ));
+
+        $resolver->setAllowedTypes(array(
+            'deletion_handler' => array ('null', '\Closure'),
         ));
 
         $resolver->setNormalizers(array(


### PR DESCRIPTION
When allow_delete is enabled on a CollectionType form element, it's sometimes necessary to delete missing entries from the database through the ORM. Currently, adder/remover methods are called on the domain object that contains the collection, but the domain object isn't able to remove entries from the underlying database.

In many cases, the orphanRemoval option offered by Doctrine is a good way to handle this. I ran into trouble with (let's say) a StockMutation entity that was either owned by an Order or a StockCorrection entity (OneToMany on the Order and StockCorrection classes). When binding a form for an Order, all StockMutations that were part of a StockCorrection would be deleted by Doctrine as they're considered to be orphans.

Using this deletion_handler option, I can pass a closure to the form collection. This closure gets called whenever an entry is found to be deleted upon form submission, at which point it can i.e. call the remove method on Doctrine's EntityManager.

After creating this patch, I found that it's also possible to subclass the StockMutation class using single-table-inheritance. This allows me to use orphanRemoval without problems. However, since I created this patch already, I'd like to hear people's opinions and find out if there might be situations where this actually fulfills a requirement for anyone.

If so, I'll add the necessary tests as well to make this feature more complete.

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: n/a
Todo: Write tests
License of the code: MIT
Documentation PR: n/a
