### PR TITLE
[Form] Add magic getter method support to Entities

### DIFF
--- a/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
@@ -24,4 +24,11 @@ class Magician
     {
         return isset($this->$property) ? $this->$property : null;
     }
+
+    public function __call($method, $arguments) {
+        if (preg_match('/^(get|is|has)([A-Z].*)$/', $method, $matches)) {
+            return $this->{lcfirst($matches[2])};
+        }
+        return null;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
@@ -29,6 +29,5 @@ class Magician
         if (preg_match('/^(get|is|has)([A-Z].*)$/', $method, $matches)) {
             return $this->{lcfirst($matches[2])};
         }
-        return null;
     }
 }

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -310,6 +310,30 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Bernhard', $object->child['index']->firstName);
     }
 
+    public function testSetValueUpdateMagicGetMethod()
+    {
+        $object = new Magician();
+        $path = new PropertyPath('magicProperty');
+        $path->setValue($object, 'foobar');
+        $this->assertEquals($path->getValue($object), $object->getMagicProperty());
+    }
+
+    public function testSetValueUpdateMagicHasMethod()
+    {
+        $object = new Magician();
+        $path = new PropertyPath('magicProperty');
+        $path->setValue($object, 'foobar');
+        $this->assertEquals($path->getValue($object), $object->hasMagicProperty());
+    }
+
+    public function testSetValueUpdateMagicIsMethod()
+    {
+        $object = new Magician();
+        $path = new PropertyPath('magicProperty');
+        $path->setValue($object, 'foobar');
+        $this->assertEquals($path->getValue($object), $object->isMagicProperty());
+    }
+
     public function testSetValueUpdateMagicSet()
     {
         $object = new Magician();

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -420,13 +420,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
             $isser = 'is'.$camelProp;
             $hasser = 'has'.$camelProp;
 
-            if (is_callable(array($objectOrArray, $getter))) {
-                $result[self::VALUE] = $objectOrArray->$getter();
-            } elseif (is_callable(array($objectOrArray, $isser))) {
-                $result[self::VALUE] = $objectOrArray->$isser();
-            } elseif (is_callable(array($objectOrArray, $hasser))) {
-                $result[self::VALUE] = $objectOrArray->$hasser();
-            } elseif ($reflClass->hasMethod($getter)) {
+            if ($reflClass->hasMethod($getter)) {
                 if (!$reflClass->getMethod($getter)->isPublic()) {
                     throw new PropertyAccessDeniedException(sprintf('Method "%s()" is not public in class "%s"', $getter, $reflClass->name));
                 }
@@ -458,6 +452,12 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 // needed to support \stdClass instances
                 $result[self::VALUE] =& $objectOrArray->$property;
                 $result[self::IS_REF] = true;
+            } elseif (is_callable(array($objectOrArray, $getter))) {
+                $result[self::VALUE] = $objectOrArray->$getter();
+            } elseif (is_callable(array($objectOrArray, $isser))) {
+                $result[self::VALUE] = $objectOrArray->$isser();
+            } elseif (is_callable(array($objectOrArray, $hasser))) {
+                $result[self::VALUE] = $objectOrArray->$hasser();
             } else {
                 throw new InvalidPropertyException(sprintf('Neither property "%s" nor method "%s()" nor method "%s()" exists in class "%s"', $property, $getter, $isser, $reflClass->name));
             }

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -438,17 +438,15 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 }
 
                 $result[self::VALUE] = $objectOrArray->$hasser();
-            } elseif ($reflClass->hasMethod('__call')) {
-                // needed to support magic getters
-                if (is_callable(array($objectOrArray, $getter))) {
-                    $result[self::VALUE] = $objectOrArray->$getter();
-                } elseif (is_callable(array($objectOrArray, $isser))) {
-                    $result[self::VALUE] = $objectOrArray->$isser();
-                } elseif (is_callable(array($objectOrArray, $hasser))) {
-                    $result[self::VALUE] = $objectOrArray->$hasser();
-                } else {
-                    throw new InvalidPropertyException(sprintf('Neither property "%s" nor method "%s()" nor method "%s()" exists in class "%s"', $property, $getter, $isser, $reflClass->name));
-                }
+            } elseif ($reflClass->hasMethod('__call') &&
+                      is_callable(array($objectOrArray, $getter))) {
+                $result[self::VALUE] = $objectOrArray->$getter();
+            } elseif ($reflClass->hasMethod('__call') &&
+                      is_callable(array($objectOrArray, $isser))) {
+                $result[self::VALUE] = $objectOrArray->$isser();
+            } elseif ($reflClass->hasMethod('__call') &&
+                      is_callable(array($objectOrArray, $hasser))) {
+                $result[self::VALUE] = $objectOrArray->$hasser();
             } elseif ($reflClass->hasMethod('__get')) {
                 // needed to support magic method __get
                 $result[self::VALUE] = $objectOrArray->$property;

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -420,7 +420,13 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
             $isser = 'is'.$camelProp;
             $hasser = 'has'.$camelProp;
 
-            if ($reflClass->hasMethod($getter)) {
+            if (is_callable(array($objectOrArray, $getter))) {
+                $result[self::VALUE] = $objectOrArray->$getter();
+            } elseif (is_callable(array($objectOrArray, $isser))) {
+                $result[self::VALUE] = $objectOrArray->$isser();
+            } elseif (is_callable(array($objectOrArray, $hasser))) {
+                $result[self::VALUE] = $objectOrArray->$hasser();
+            } elseif ($reflClass->hasMethod($getter)) {
                 if (!$reflClass->getMethod($getter)->isPublic()) {
                     throw new PropertyAccessDeniedException(sprintf('Method "%s()" is not public in class "%s"', $getter, $reflClass->name));
                 }
@@ -437,15 +443,6 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                     throw new PropertyAccessDeniedException(sprintf('Method "%s()" is not public in class "%s"', $hasser, $reflClass->name));
                 }
 
-                $result[self::VALUE] = $objectOrArray->$hasser();
-            } elseif ($reflClass->hasMethod('__call') &&
-                      is_callable(array($objectOrArray, $getter))) {
-                $result[self::VALUE] = $objectOrArray->$getter();
-            } elseif ($reflClass->hasMethod('__call') &&
-                      is_callable(array($objectOrArray, $isser))) {
-                $result[self::VALUE] = $objectOrArray->$isser();
-            } elseif ($reflClass->hasMethod('__call') &&
-                      is_callable(array($objectOrArray, $hasser))) {
                 $result[self::VALUE] = $objectOrArray->$hasser();
             } elseif ($reflClass->hasMethod('__get')) {
                 // needed to support magic method __get

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -438,6 +438,17 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 }
 
                 $result[self::VALUE] = $objectOrArray->$hasser();
+            } elseif ($reflClass->hasMethod('__call')) {
+                // needed to support magic getters
+                if (is_callable(array($objectOrArray, $getter))) {
+                    $result[self::VALUE] = $objectOrArray->$getter();
+                } elseif (is_callable(array($objectOrArray, $isser))) {
+                    $result[self::VALUE] = $objectOrArray->$isser();
+                } elseif (is_callable(array($objectOrArray, $hasser))) {
+                    $result[self::VALUE] = $objectOrArray->$hasser();
+                } else {
+                    throw new InvalidPropertyException(sprintf('Neither property "%s" nor method "%s()" nor method "%s()" exists in class "%s"', $property, $getter, $isser, $reflClass->name));
+                }
             } elseif ($reflClass->hasMethod('__get')) {
                 // needed to support magic method __get
                 $result[self::VALUE] = $objectOrArray->$property;


### PR DESCRIPTION
When using Symfony Forms, it permits the implementation of magic getter methods in those Entities by using the `__call` magic method.

It basically allows one to do the following in an Entity:

```
public function __call($method, $arguments) {
    if (preg_match('/^(get|is|has)([A-Z].*)$/', $method, $matches)) {
        return $this->{lcfirst($matches[2])};
    }
    throw new \Exception(sprintf(
        'Method does not exist for class "%s".', get_class($this)
    ));
}
```
