### PR TITLE
Update src/Symfony/Component/DependencyInjection/Container.php

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -238,7 +238,7 @@ class Container implements IntrospectableContainerInterface
     {
         $id = strtolower($id);
 
-        if (isset($this->services[$id])) {
+        if (array_key_exists($id, $this->services)) {
             return $this->services[$id];
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -166,6 +166,18 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($sc->get('', ContainerInterface::NULL_ON_INVALID_REFERENCE));
     }
 
+    /**
+     * @covers Symfony\Component\DependencyInjection\Container::get
+     */
+    public function testGetAfterSetNull()
+    {
+        $sc = new ProjectServiceContainer();
+        $this->assertNotNull($sc->get('bar'));
+
+        $sc->set('bar' , null);
+        $this->assertNull($sc->get('bar'));
+    }
+
     public function testGetCircularReference()
     {
 


### PR DESCRIPTION
This throw an exception and should not with isset:

'something' exist as service

$this->container->set('something', null);

if (null !== $this->container->get('something')) {
    throw new \Exception('Should be null');
}
