### PR TITLE
[Form] Fixed: FormTypeInterface::getParent() supports returning FormTypeInterface instances again

### DIFF
--- a/src/Symfony/Component/Form/FormTypeInterface.php
+++ b/src/Symfony/Component/Form/FormTypeInterface.php
@@ -78,7 +78,11 @@ interface FormTypeInterface
     /**
      * Returns the name of the parent type.
      *
-     * @return string|null The name of the parent type if any, null otherwise.
+     * You can also return a type instance from this method, although doing so
+     * is discouraged because it leads to a performance penalty. The support
+     * for returning type instances may be dropped from future releases.
+     *
+     * @return string|null|FormTypeInterface The name of the parent type if any, null otherwise.
      */
     public function getParent();
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/FooSubTypeWithParentInstance.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FooSubTypeWithParentInstance.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+
+class FooSubTypeWithParentInstance extends AbstractType
+{
+    public function getName()
+    {
+        return 'foo_sub_type_parent_instance';
+    }
+
+    public function getParent()
+    {
+        return new FooType();
+    }
+}

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Tests\Fixtures\TestExtension;
+use Symfony\Component\Form\Tests\Fixtures\FooSubTypeWithParentInstance;
 use Symfony\Component\Form\Tests\Fixtures\FooSubType;
 use Symfony\Component\Form\Tests\Fixtures\FooTypeBazExtension;
 use Symfony\Component\Form\Tests\Fixtures\FooTypeBarExtension;
@@ -151,6 +152,35 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('foo_sub_type'));
 
         $this->assertSame($resolvedType, $this->registry->getType('foo_sub_type'));
+    }
+
+    public function testGetTypeConnectsParentIfGetParentReturnsInstance()
+    {
+        $type = new FooSubTypeWithParentInstance();
+        $parentResolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+        $resolvedType = $this->getMock('Symfony\Component\Form\ResolvedFormTypeInterface');
+
+        $this->extension1->addType($type);
+
+        $this->resolvedTypeFactory->expects($this->at(0))
+            ->method('createResolvedType')
+            ->with($this->isInstanceOf('Symfony\Component\Form\Tests\Fixtures\FooType'))
+            ->will($this->returnValue($parentResolvedType));
+
+        $this->resolvedTypeFactory->expects($this->at(1))
+            ->method('createResolvedType')
+            ->with($type, array(), $parentResolvedType)
+            ->will($this->returnValue($resolvedType));
+
+        $parentResolvedType->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('foo'));
+
+        $resolvedType->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('foo_sub_type_parent_instance'));
+
+        $this->assertSame($resolvedType, $this->registry->getType('foo_sub_type_parent_instance'));
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5221
Todo: -
