### PR TITLE
Fixed a typo

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -65,7 +65,7 @@ class CsrfValidationListener implements EventSubscriberInterface
 
         if ($form->isRoot() && $form->getConfig()->getOption('compound')) {
             if (!isset($data[$this->fieldName]) || !$this->csrfProvider->isCsrfTokenValid($this->intention, $data[$this->fieldName])) {
-                $form->addError(new FormError('The CSRF token is invalid. Please try to resubmit the form'));
+                $form->addError(new FormError('The CSRF token is invalid. Please try to resubmit the form.'));
             }
 
             unset($data[$this->fieldName]);


### PR DESCRIPTION
The CSRF error message won't be translated due to this typo even if the translator is enabled.
