### PR TITLE
[Routing] removed cyclic reference Route<->CompiledRoute

### DIFF
--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -18,7 +18,6 @@ namespace Symfony\Component\Routing;
  */
 class CompiledRoute
 {
-    private $route;
     private $variables;
     private $tokens;
     private $staticPrefix;
@@ -27,29 +26,17 @@ class CompiledRoute
     /**
      * Constructor.
      *
-     * @param Route  $route        A original Route instance
      * @param string $staticPrefix The static prefix of the compiled route
      * @param string $regex        The regular expression to use to match this route
      * @param array  $tokens       An array of tokens to use to generate URL for this route
      * @param array  $variables    An array of variables
      */
-    public function __construct(Route $route, $staticPrefix, $regex, array $tokens, array $variables)
+    public function __construct($staticPrefix, $regex, array $tokens, array $variables)
     {
-        $this->route = $route;
         $this->staticPrefix = $staticPrefix;
         $this->regex = $regex;
         $this->tokens = $tokens;
         $this->variables = $variables;
-    }
-
-    /**
-     * Returns the Route instance.
-     *
-     * @return Route A Route instance
-     */
-    public function getRoute()
-    {
-        return $this->route;
     }
 
     /**
@@ -90,45 +77,5 @@ class CompiledRoute
     public function getVariables()
     {
         return $this->variables;
-    }
-
-    /**
-     * Returns the pattern.
-     *
-     * @return string The pattern
-     */
-    public function getPattern()
-    {
-        return $this->route->getPattern();
-    }
-
-    /**
-     * Returns the options.
-     *
-     * @return array The options
-     */
-    public function getOptions()
-    {
-        return $this->route->getOptions();
-    }
-
-    /**
-     * Returns the defaults.
-     *
-     * @return array The defaults
-     */
-    public function getDefaults()
-    {
-        return $this->route->getDefaults();
-    }
-
-    /**
-     * Returns the requirements.
-     *
-     * @return array The requirements
-     */
-    public function getRequirements()
-    {
-        return $this->route->getRequirements();
     }
 }

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -90,8 +90,8 @@ EOF;
 
             $properties = array();
             $properties[] = $compiledRoute->getVariables();
-            $properties[] = $compiledRoute->getDefaults();
-            $properties[] = $compiledRoute->getRequirements();
+            $properties[] = $route->getDefaults();
+            $properties[] = $route->getRequirements();
             $properties[] = $compiledRoute->getTokens();
 
             $routes .= sprintf("        '%s' => %s,\n", $name, str_replace("\n", '', var_export($properties, true)));

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -271,14 +271,14 @@ EOF;
         }
 
         // optimize parameters array
-        if (true === $matches && $compiledRoute->getDefaults()) {
+        if (true === $matches && $route->getDefaults()) {
             $code .= sprintf("            return array_merge(\$this->mergeDefaults(\$matches, %s), array('_route' => '%s'));\n"
-                , str_replace("\n", '', var_export($compiledRoute->getDefaults(), true)), $name);
+                , str_replace("\n", '', var_export($route->getDefaults(), true)), $name);
         } elseif (true === $matches) {
             $code .= sprintf("            \$matches['_route'] = '%s';\n\n", $name);
             $code .= "            return \$matches;\n";
-        } elseif ($compiledRoute->getDefaults()) {
-            $code .= sprintf("            return %s;\n", str_replace("\n", '', var_export(array_merge($compiledRoute->getDefaults(), array('_route' => $name)), true)));
+        } elseif ($route->getDefaults()) {
+            $code .= sprintf("            return %s;\n", str_replace("\n", '', var_export(array_merge($route->getDefaults(), array('_route' => $name)), true)));
         } else {
             $code .= sprintf("            return array('_route' => '%s');\n", $name);
         }

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -85,7 +85,6 @@ class RouteCompiler implements RouteCompilerInterface
         }
 
         return new CompiledRoute(
-            $route,
             'text' === $tokens[0][0] ? $tokens[0][1] : '',
             self::REGEX_DELIMITER.'^'.$regexp.'$'.self::REGEX_DELIMITER.'s',
             array_reverse($tokens),

--- a/src/Symfony/Component/Routing/Tests/CompiledRouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/CompiledRouteTest.php
@@ -12,32 +12,15 @@
 namespace Symfony\Component\Routing\Tests;
 
 use Symfony\Component\Routing\CompiledRoute;
-use Symfony\Component\Routing\Route;
 
 class CompiledRouteTest extends \PHPUnit_Framework_TestCase
 {
     public function testAccessors()
     {
-        $route = new Route('/{foo}', array('foo' => 'bar'), array('foo' => '\d+'), array('foo' => 'bar'));
-
-        $compiled = new CompiledRoute($route, 'prefix', 'regex', array('tokens'), array('variables'));
-        $this->assertEquals($route, $compiled->getRoute(), '__construct() takes a route as its first argument');
-        $this->assertEquals('prefix', $compiled->getStaticPrefix(), '__construct() takes a static prefix as its second argument');
-        $this->assertEquals('regex', $compiled->getRegex(), '__construct() takes a regexp as its third argument');
-        $this->assertEquals(array('tokens'), $compiled->getTokens(), '__construct() takes an array of tokens as its fourth argument');
-        $this->assertEquals(array('variables'), $compiled->getVariables(), '__construct() takes an array of variables as its fifth argument');
-    }
-
-    public function testgetPatterngetDefaultsgetOptionsgetRequirements()
-    {
-        $route = new Route('/{foo}', array('foo' => 'bar'), array('foo' => '\d+'), array('foo' => 'bar'));
-
-        $compiled = new CompiledRoute($route, 'prefix', 'regex', array('tokens'), array('variables'));
-        $this->assertEquals('/{foo}', $compiled->getPattern(), '->getPattern() returns the route pattern');
-        $this->assertEquals(array('foo' => 'bar'), $compiled->getDefaults(), '->getDefaults() returns the route defaults');
-        $this->assertEquals(array('foo' => '\d+'), $compiled->getRequirements(), '->getRequirements() returns the route requirements');
-        $this->assertEquals(array_merge(array(
-            'compiler_class'     => 'Symfony\\Component\\Routing\\RouteCompiler',
-        ), array('foo' => 'bar')), $compiled->getOptions(), '->getOptions() returns the route options');
+        $compiled = new CompiledRoute('prefix', 'regex', array('tokens'), array('variables'));
+        $this->assertEquals('prefix', $compiled->getStaticPrefix(), '__construct() takes a static prefix as its first argument');
+        $this->assertEquals('regex', $compiled->getRegex(), '__construct() takes a regexp as its second argument');
+        $this->assertEquals(array('tokens'), $compiled->getTokens(), '__construct() takes an array of tokens as its third argument');
+        $this->assertEquals(array('variables'), $compiled->getVariables(), '__construct() takes an array of variables as its forth argument');
     }
 }


### PR DESCRIPTION
BC break: yes

I think we should remove this proxy behavior from CompiledRoute. Cyclic references are often not a good idea and in this case it doesn't even make sense. It's like an integrated decompiler ^^ when going from CompiledRoute -> Route.

It also conflicts with the single responsibility principle in OOP design as you would need to change the CompiledRoute class whenever you change the Route class.

It also mitigates problems like 

```
$compiled = $route->compile();
// $route is change by some other layer
$compiled->getRoute(); // is not in synch with $compiled anymore although this getter makes us believe that
```
