### PR TITLE
[Validator] Added missing fluent interface to ValidatorBuilder

### DIFF
--- a/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorBuilderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests;
+
+use Symfony\Component\Validator\ValidatorBuilder;
+use Symfony\Component\Validator\ValidatorBuilderInterface;
+
+class ValidatorBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ValidatorBuilderInterface
+     */
+    protected $builder;
+
+    protected function setUp()
+    {
+        $this->builder = new ValidatorBuilder();
+    }
+
+    protected function tearDown()
+    {
+        $this->builder = null;
+    }
+
+    public function testAddObjectInitializer()
+    {
+        $this->assertSame($this->builder, $this->builder->addObjectInitializer(
+            $this->getMock('Symfony\Component\Validator\ObjectInitializerInterface')
+        ));
+    }
+
+    public function testAddObjectInitializers()
+    {
+        $this->assertSame($this->builder, $this->builder->addObjectInitializers(array()));
+    }
+
+    public function testAddXmlMapping()
+    {
+        $this->assertSame($this->builder, $this->builder->addXmlMapping('mapping'));
+    }
+
+    public function testAddXmlMappings()
+    {
+        $this->assertSame($this->builder, $this->builder->addXmlMappings(array()));
+    }
+
+    public function testAddYamlMapping()
+    {
+        $this->assertSame($this->builder, $this->builder->addYamlMapping('mapping'));
+    }
+
+    public function testAddYamlMappings()
+    {
+        $this->assertSame($this->builder, $this->builder->addYamlMappings(array()));
+    }
+
+    public function testAddMethodMapping()
+    {
+        $this->assertSame($this->builder, $this->builder->addMethodMapping('mapping'));
+    }
+
+    public function testAddMethodMappings()
+    {
+        $this->assertSame($this->builder, $this->builder->addMethodMappings(array()));
+    }
+
+    public function testEnableAnnotationMapping()
+    {
+        if (!class_exists('Doctrine\Common\Annotations\AnnotationReader')) {
+            $this->markTestSkipped('Annotations is required for this test');
+        }
+
+        $this->assertSame($this->builder, $this->builder->enableAnnotationMapping());
+    }
+
+    public function testDisableAnnotationMapping()
+    {
+        $this->assertSame($this->builder, $this->builder->disableAnnotationMapping());
+    }
+
+    public function testSetMetadataFactory()
+    {
+        $this->assertSame($this->builder, $this->builder->setMetadataFactory(
+            $this->getMock('Symfony\Component\Validator\Mapping\ClassMetadataFactoryInterface'))
+        );
+    }
+
+    public function testSetMetadataCache()
+    {
+        $this->assertSame($this->builder, $this->builder->setMetadataCache($this->getMock(
+            'Symfony\Component\Validator\Mapping\Cache\CacheInterface'))
+        );
+    }
+
+    public function testSetConstraintValidatorFactory()
+    {
+        $this->assertSame($this->builder, $this->builder->setConstraintValidatorFactory(
+            $this->getMock('Symfony\Component\Validator\ConstraintValidatorFactoryInterface'))
+        );
+    }
+}

--- a/src/Symfony/Component/Validator/ValidatorBuilder.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilder.php
@@ -81,6 +81,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
     public function addObjectInitializer(ObjectInitializerInterface $initializer)
     {
         $this->initializers[] = $initializer;
+
+        return $this;
     }
 
     /**
@@ -89,6 +91,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
     public function addObjectInitializers(array $initializers)
     {
         $this->initializers = array_merge($this->initializers, $initializers);
+
+        return $this;
     }
 
     /**
@@ -101,6 +105,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->xmlMappings[] = $path;
+
+        return $this;
     }
 
     /**
@@ -113,6 +119,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->xmlMappings = array_merge($this->xmlMappings, $paths);
+
+        return $this;
     }
 
     /**
@@ -125,6 +133,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->yamlMappings[] = $path;
+
+        return $this;
     }
 
     /**
@@ -137,6 +147,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->yamlMappings = array_merge($this->yamlMappings, $paths);
+
+        return $this;
     }
 
     /**
@@ -149,6 +161,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->methodMappings[] = $methodName;
+
+        return $this;
     }
 
     /**
@@ -161,6 +175,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->methodMappings = array_merge($this->methodMappings, $methodNames);
+
+        return $this;
     }
 
     /**
@@ -181,6 +197,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->annotationReader = $annotationReader;
+
+        return $this;
     }
 
     /**
@@ -189,6 +207,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
     public function disableAnnotationMapping()
     {
         $this->annotationReader = null;
+
+        return $this;
     }
 
     /**
@@ -201,6 +221,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->metadataFactory = $metadataFactory;
+
+        return $this;
     }
 
     /**
@@ -213,6 +235,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
         
         $this->metadataCache = $cache;
+
+        return $this;
     }
 
     /**
@@ -221,6 +245,8 @@ class ValidatorBuilder implements ValidatorBuilderInterface
     public function setConstraintValidatorFactory(ConstraintValidatorFactoryInterface $validatorFactory)
     {
         $this->validatorFactory = $validatorFactory;
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/Validator/ValidatorBuilderInterface.php
+++ b/src/Symfony/Component/Validator/ValidatorBuilderInterface.php
@@ -26,6 +26,8 @@ interface ValidatorBuilderInterface
      * Adds an object initializer to the validator.
      *
      * @param ObjectInitializerInterface $initializer The initializer.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addObjectInitializer(ObjectInitializerInterface $initializer);
 
@@ -33,6 +35,8 @@ interface ValidatorBuilderInterface
      * Adds a list of object initializers to the validator.
      *
      * @param array $initializers The initializer.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addObjectInitializers(array $initializers);
 
@@ -40,6 +44,8 @@ interface ValidatorBuilderInterface
      * Adds an XML constraint mapping file to the validator.
      *
      * @param string $path The path to the mapping file.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addXmlMapping($path);
 
@@ -47,6 +53,8 @@ interface ValidatorBuilderInterface
      * Adds a list of XML constraint mapping files to the validator.
      *
      * @param array $paths The paths to the mapping files.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addXmlMappings(array $paths);
 
@@ -54,6 +62,8 @@ interface ValidatorBuilderInterface
      * Adds a YAML constraint mapping file to the validator.
      *
      * @param string $path The path to the mapping file.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addYamlMapping($path);
 
@@ -61,6 +71,8 @@ interface ValidatorBuilderInterface
      * Adds a list of YAML constraint mappings file to the validator.
      *
      * @param array $paths The paths to the mapping files.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addYamlMappings(array $paths);
 
@@ -68,6 +80,8 @@ interface ValidatorBuilderInterface
      * Enables constraint mapping using the given static method.
      *
      * @param string $methodName The name of the method.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addMethodMapping($methodName);
 
@@ -75,6 +89,8 @@ interface ValidatorBuilderInterface
      * Enables constraint mapping using the given static methods.
      *
      * @param array $methodNames The names of the methods.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function addMethodMappings(array $methodNames);
 
@@ -82,11 +98,15 @@ interface ValidatorBuilderInterface
      * Enables annotation based constraint mapping.
      *
      * @param Reader $annotationReader The annotation reader to be used.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function enableAnnotationMapping(Reader $annotationReader = null);
 
     /**
      * Disables annotation based constraint mapping.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function disableAnnotationMapping();
 
@@ -94,6 +114,8 @@ interface ValidatorBuilderInterface
      * Sets the class metadata factory used by the validator.
      *
      * @param ClassMetadataFactoryInterface $metadataFactory The metadata factory.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function setMetadataFactory(ClassMetadataFactoryInterface $metadataFactory);
 
@@ -101,6 +123,8 @@ interface ValidatorBuilderInterface
      * Sets the cache for caching class metadata.
      *
      * @param CacheInterface $cache The cache instance.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function setMetadataCache(CacheInterface $cache);
 
@@ -108,6 +132,8 @@ interface ValidatorBuilderInterface
      * Sets the constraint validator factory used by the validator.
      *
      * @param ConstraintValidatorFactoryInterface $validatorFactory The validator factory.
+     *
+     * @return ValidatorBuilderInterface The builder object.
      */
     public function setConstraintValidatorFactory(ConstraintValidatorFactoryInterface $validatorFactory);
 


### PR DESCRIPTION
The new ValidatorBuilder class seems to be intended to have a fluent interface, reasoning:
- Static Validation::createValidatorBuilder() method exists
- Consistency with other builders in the framework
- Component README actually uses fluent interface for examples.

This was not implemented though. This PR adds the fluent interface.

BC Break: No
Symfony2 Tests Pass: Yes
