### PR TITLE
[Form] don't allow users to force exceptions by submitting unexpected data

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Form\Exception\AlreadyBoundException;
-use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Util\FormUtil;
 use Symfony\Component\Form\Util\PropertyPath;
@@ -533,10 +532,6 @@ class Form implements \IteratorAggregate, FormInterface
         // (think of empty collection forms)
         if ($this->config->getCompound()) {
             if (!is_array($submittedData)) {
-                if (!FormUtil::isEmpty($submittedData)) {
-                    throw new UnexpectedTypeException($submittedData, 'array');
-                }
-
                 $submittedData = array();
             }
 

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -779,6 +779,25 @@ class SimpleFormTest extends AbstractFormTest
         $form->setData('foo');
     }
 
+    public function testBindingWrongDataIsIgnored()
+    {
+        $test = $this;
+
+        $child = $this->getBuilder('child', $this->dispatcher);
+        $child->addEventListener(FormEvents::PRE_BIND, function (FormEvent $event) use ($test) {
+            // child form doesn't receive the wrong data that is bound on parent
+            $test->assertNull($event->getData());
+        });
+
+        $parent = $this->getBuilder('parent', new EventDispatcher())
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->add($child)
+            ->getForm();
+
+        $parent->bind('not-an-array');
+    }
+
     protected function createForm()
     {
         return $this->getBuilder()->getForm();


### PR DESCRIPTION
fix #5334

This makes it more fault-tolerant by simply ignoring wrong stuff from hackers.

@bschussek: I didn't find any other UnexpectedTypeExceptions that could be invoked by simply submitting unexpected data. But I'm not 100% sure that there aren't any indirectly invokeable, e.g. in some listeners.
