### PR TITLE
[HttpKernel] fix KernelTest::testGetRootDir fails on Windows for branch 2.0

### DIFF
--- a/tests/Symfony/Tests/Component/HttpKernel/KernelTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/KernelTest.php
@@ -284,7 +284,7 @@ EOF;
     {
         $kernel = new KernelForTest('test', true);
 
-        $this->assertEquals(__DIR__, $kernel->getRootDir());
+        $this->assertEquals(__DIR__, realpath($kernel->getRootDir()));
     }
 
     public function testGetName()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5341
Todo: -
License of the code: MIT
Documentation PR: 
replace
$this->assertEquals(DIR, $kernel->getRootDir());
with
$this->assertEquals(DIR, realpath($kernel->getRootDir()));
line 287
