### PR TITLE
[FrameworkBundle] fixed *FrameworkExtensionTest::testTranslator fail on Windows on master branch

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -182,14 +182,15 @@ abstract class FrameworkExtensionTest extends TestCase
             }
         }
 
-        $files = array_map(function($resource) use ($resources) { return str_replace(realpath(__DIR__.'/../../../../..').'/', '', realpath($resource[1])); }, $resources);
+        $rootDirectory = str_replace('/', DIRECTORY_SEPARATOR, realpath(__DIR__.'/../../../../..').'/');
+        $files = array_map(function($resource) use ($rootDirectory, $resources) { return str_replace($rootDirectory, '', realpath($resource[1])); }, $resources);
         $this->assertContains(
-            'Symfony/Component/Validator/Resources/translations/validators.en.xlf',
+            str_replace('/', DIRECTORY_SEPARATOR, 'Symfony/Component/Validator/Resources/translations/validators.en.xlf'),
             $files,
             '->registerTranslatorConfiguration() finds Validator translation resources'
         );
         $this->assertContains(
-            'Symfony/Component/Form/Resources/translations/validators.en.xlf',
+            str_replace('/', DIRECTORY_SEPARATOR, 'Symfony/Component/Form/Resources/translations/validators.en.xlf'),
             $files,
             '->registerTranslatorConfiguration() finds Form translation resources'
         );


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5345
Todo: -
License of the code: MIT
Documentation PR:
fixed using some 
str_replace('/', DIRECTORY_SEPARATOR, <value>)
so it works on Windows because it replaces the / in \ and shouldn't affect linux based OS, since it will replace / with /.

Not very nice, but it works, if anyone wants to do better, he/she is most welcome.
