### PR TITLE
[Form] raise OutOfBoundsException instead of InvalidArgumentException in Form::get

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -910,7 +910,7 @@ class Form implements \IteratorAggregate, FormInterface
             return $this->children[$name];
         }
 
-        throw new \InvalidArgumentException(sprintf('Child "%s" does not exist.', $name));
+        throw new \OutOfBoundsException(sprintf('Child "%s" does not exist.', $name));
     }
 
     /**
@@ -932,7 +932,7 @@ class Form implements \IteratorAggregate, FormInterface
      *
      * @return FormInterface The child form
      *
-     * @throws \InvalidArgumentException If the named child does not exist.
+     * @throws \OutOfBoundsException If the named child does not exist.
      */
     public function offsetGet($name)
     {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -64,7 +64,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The child form
      *
-     * @throws \InvalidArgumentException If the named child does not exist.
+     * @throws \OutOfBoundsException If the named child does not exist.
      */
     public function get($name);
 


### PR DESCRIPTION
BC break: yes

Raise OutOfBoundsException instead of InvalidArgumentException in Form::get for inexistent form childs to be in line with PropertyPath, which also uses OutOfBoundsException for invalid indexes. OutOfBoundsException fits much better as it extends RuntimeException instead of LogicException and this error can typically not be detected at compile time.
