### PR TITLE
[Form] deprecated Form::hasErrors that isn't part of the Interface

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -770,18 +770,15 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
-     * Returns whether or not there are errors.
+     * Returns whether there are errors associated with this form.
      *
-     * @return Boolean true if form is bound and not valid
+     * @return Boolean
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Count
      *             {@link getErrors()} instead.
      */
     public function hasErrors()
     {
-        // Don't call isValid() here, as its semantics are slightly different
-        // Forms are not valid if their children are invalid, but
-        // hasErrors() returns only true if a form itself has errors
         return count($this->errors) > 0;
     }
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -754,7 +754,7 @@ class Form implements \IteratorAggregate, FormInterface
             throw new \LogicException('You cannot call isValid() on a form that is not bound.');
         }
 
-        if ($this->hasErrors()) {
+        if (count($this->errors) > 0) {
             return false;
         }
 
@@ -773,6 +773,9 @@ class Form implements \IteratorAggregate, FormInterface
      * Returns whether or not there are errors.
      *
      * @return Boolean true if form is bound and not valid
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3. Count
+     *             {@link getErrors()} instead.
      */
     public function hasErrors()
     {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -168,7 +168,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function addError(FormError $error);
 
     /**
-     * Returns whether the form is valid.
+     * Returns whether the form and all children are valid.
      *
      * @return Boolean
      */

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -124,9 +124,9 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
-        $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
         $this->assertEquals(array($this->getFormError()), $child->getErrors(), $child->getName() . ' should have an error, but has none');
-        $this->assertFalse($grandChild->hasErrors(), $grandChild->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName() . ' should not have an error, but has one');
     }
 
     public function testFollowDotRules()
@@ -149,9 +149,9 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
-        $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-        $this->assertFalse($child->hasErrors(), $child->getName() . ' should not have an error, but has one');
-        $this->assertFalse($grandChild->hasErrors(), $grandChild->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $child->getErrors(), $child->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName() . ' should not have an error, but has one');
         $this->assertEquals(array($this->getFormError()), $grandGrandChild->getErrors(), $grandGrandChild->getName() . ' should have an error, but has none');
     }
 
@@ -172,9 +172,9 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
-        $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-        $this->assertFalse($child->hasErrors(), $child->getName() . ' should not have an error, but has one');
-        $this->assertFalse($grandChild->hasErrors(), $grandChild->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $child->getErrors(), $child->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName() . ' should not have an error, but has one');
     }
 
     public function testAbortVirtualFormMappingIfNotSynchronized()
@@ -194,9 +194,9 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
-        $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-        $this->assertFalse($child->hasErrors(), $child->getName() . ' should not have an error, but has one');
-        $this->assertFalse($grandChild->hasErrors(), $grandChild->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $child->getErrors(), $child->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName() . ' should not have an error, but has one');
     }
 
     public function testAbortDotRuleMappingIfNotSynchronized()
@@ -218,9 +218,9 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         $this->mapper->mapViolation($violation, $parent);
 
-        $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-        $this->assertFalse($child->hasErrors(), $child->getName() . ' should not have an error, but has one');
-        $this->assertFalse($grandChild->hasErrors(), $grandChild->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $child->getErrors(), $child->getName() . ' should not have an error, but has one');
+        $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName() . ' should not have an error, but has one');
     }
 
     public function provideDefaultTests()
@@ -732,15 +732,15 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         if (self::LEVEL_0 === $target) {
             $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName() . ' should have an error, but has none');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName . ' should have an error, but has none');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } else {
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName. ' should have an error, but has none');
         }
     }
@@ -1199,20 +1199,20 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->mapper->mapViolation($violation, $parent);
 
         if ($target !== self::LEVEL_0) {
-            $this->assertFalse($distraction->hasErrors(), 'distraction should not have an error, but has one');
+            $this->assertCount(0, $distraction->getErrors(), 'distraction should not have an error, but has one');
         }
 
         if (self::LEVEL_0 === $target) {
             $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName() . ' should have an error, but has none');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName . ' should have an error, but has none');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } else {
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName. ' should have an error, but has none');
         }
     }
@@ -1385,24 +1385,24 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->mapper->mapViolation($violation, $parent);
 
         if (self::LEVEL_0 === $target) {
-            $this->assertFalse($errorChild->hasErrors(), $errorName . ' should not have an error, but has one');
+            $this->assertCount(0, $errorChild->getErrors(), $errorName . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName() . ' should have an error, but has none');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
-            $this->assertFalse($errorChild->hasErrors(), $errorName . ' should not have an error, but has one');
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $errorChild->getErrors(), $errorName . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName . ' should have an error, but has none');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } elseif (self::LEVEL_1B === $target) {
             $this->assertEquals(array($this->getFormError()), $errorChild->getErrors(), $errorName . ' should have an error, but has none');
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } else {
-            $this->assertFalse($errorChild->hasErrors(), $errorName . ' should not have an error, but has one');
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $errorChild->getErrors(), $errorName . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName. ' should have an error, but has none');
         }
     }
@@ -1449,15 +1449,15 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
 
         if (self::LEVEL_0 === $target) {
             $this->assertEquals(array($this->getFormError()), $parent->getErrors(), $parent->getName() . ' should have an error, but has none');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } elseif (self::LEVEL_1 === $target) {
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $child->getErrors(), $childName . ' should have an error, but has none');
-            $this->assertFalse($grandChild->hasErrors(), $grandChildName . ' should not have an error, but has one');
+            $this->assertCount(0, $grandChild->getErrors(), $grandChildName . ' should not have an error, but has one');
         } else {
-            $this->assertFalse($parent->hasErrors(), $parent->getName() . ' should not have an error, but has one');
-            $this->assertFalse($child->hasErrors(), $childName . ' should not have an error, but has one');
+            $this->assertCount(0, $parent->getErrors(), $parent->getName() . ' should not have an error, but has one');
+            $this->assertCount(0, $child->getErrors(), $childName . ' should not have an error, but has one');
             $this->assertEquals(array($this->getFormError()), $grandChild->getErrors(), $grandChildName. ' should have an error, but has none');
         }
     }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -231,12 +231,12 @@ class SimpleFormTest extends AbstractFormTest
     {
         $this->form->addError(new FormError('Error!'));
 
-        $this->assertTrue($this->form->hasErrors());
+        $this->assertCount(1, $this->form->getErrors());
     }
 
     public function testHasNoErrors()
     {
-        $this->assertFalse($this->form->hasErrors());
+        $this->assertCount(0, $this->form->getErrors());
     }
 
     /**


### PR DESCRIPTION
This method is not part of FormInterface, so I deprecated it as it cannot be used reliably. This is consistent with other hassers that were deprecated like `hasChildren` where one should use `count` instead.
