### PR TITLE
[Form] replaced UnexpectedValueException by InvalidArgumentException in Guess

### DIFF
--- a/src/Symfony/Component/Form/Guess/Guess.php
+++ b/src/Symfony/Component/Form/Guess/Guess.php
@@ -47,17 +47,6 @@ abstract class Guess
     const LOW_CONFIDENCE = 0;
 
     /**
-     * The list of allowed confidence values
-     * @var array
-     */
-    private static $confidences = array(
-        self::VERY_HIGH_CONFIDENCE,
-        self::HIGH_CONFIDENCE,
-        self::MEDIUM_CONFIDENCE,
-        self::LOW_CONFIDENCE,
-    );
-
-    /**
      * The confidence about the correctness of the value
      *
      * One of VERY_HIGH_CONFIDENCE, HIGH_CONFIDENCE, MEDIUM_CONFIDENCE
@@ -101,8 +90,9 @@ abstract class Guess
      */
     public function __construct($confidence)
     {
-        if (!in_array($confidence, self::$confidences)) {
-            throw new \InvalidArgumentException(sprintf('The confidence should be one of "%s"', implode('", "', self::$confidences)));
+        if (self::VERY_HIGH_CONFIDENCE !== $confidence && self::HIGH_CONFIDENCE !== $confidence && 
+            self::MEDIUM_CONFIDENCE !== $confidence && self::LOW_CONFIDENCE !== $confidence) {
+            throw new \InvalidArgumentException('The confidence should be one of the constants defined in Guess.');
         }
 
         $this->confidence = $confidence;

--- a/src/Symfony/Component/Form/Guess/Guess.php
+++ b/src/Symfony/Component/Form/Guess/Guess.php
@@ -97,12 +97,12 @@ abstract class Guess
      *
      * @param integer $confidence The confidence
      *
-     * @throws \UnexpectedValueException if the given value of confidence is unknown
+     * @throws \InvalidArgumentException if the given value of confidence is unknown
      */
     public function __construct($confidence)
     {
         if (!in_array($confidence, self::$confidences)) {
-            throw new \UnexpectedValueException(sprintf('The confidence should be one of "%s"', implode('", "', self::$confidences)));
+            throw new \InvalidArgumentException(sprintf('The confidence should be one of "%s"', implode('", "', self::$confidences)));
         }
 
         $this->confidence = $confidence;

--- a/src/Symfony/Component/Form/Tests/Guess/GuessTest.php
+++ b/src/Symfony/Component/Form/Tests/Guess/GuessTest.php
@@ -27,7 +27,7 @@ class GuessTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \UnexpectedValueException
+     * @expectedException \InvalidArgumentException
      */
     public function testGuessExpectsValidConfidence()
     {


### PR DESCRIPTION
BC break: yes

this is a better fit because the error is a logic exception (that can be detected at compile time, i.e. when writing the code) instead of a runtime exception
