### PR TITLE
[FrameworkBundle] non-permanent redirect to unknown location with 404

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -23,16 +23,16 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 class RedirectController extends ContainerAware
 {
     /**
-     * Redirects to another route.
+     * Redirects to another route with the given name.
      *
-     * It expects a route path parameter.
-     * By default, the response status code is 301.
+     * The response status code is 301 if the permanent parameter is false (default),
+     * and 302 if the redirection is permanent.
      *
-     * If the route is empty, the status code will be 410.
-     * If the permanent path parameter is set, the status code will be 302.
+     * In case the route name is empty, the status code will be 404 when permanent is false
+     * and 410 otherwise.
      *
-     * @param string  $route     The route pattern to redirect to
-     * @param Boolean $permanent Whether the redirect is permanent or not
+     * @param string  $route     The route name to redirect to
+     * @param Boolean $permanent Whether the redirection is permanent
      *
      * @return Response A Response instance
      */
@@ -51,13 +51,14 @@ class RedirectController extends ContainerAware
     /**
      * Redirects to a URL.
      *
-     * By default, the response status code is 301.
+     * The response status code is 301 if the permanent parameter is false (default),
+     * and 302 if the redirection is permanent.
      *
-     * If the path is empty, the status code will be 410.
-     * If the permanent flag is set, the status code will be 302.
+     * In case the path is empty, the status code will be 404 when permanent is false
+     * and 410 otherwise.
      *
-     * @param string  $path      The path to redirect to
-     * @param Boolean $permanent Whether the redirect is permanent or not
+     * @param string  $path      The absolute path or URL to redirect to
+     * @param Boolean $permanent Whether the redirection is permanent
      * @param Boolean $scheme    The URL scheme (null to keep the current one)
      * @param integer $httpPort  The HTTP port
      * @param integer $httpsPort The HTTPS port

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -38,7 +38,7 @@ class RedirectController extends ContainerAware
      */
     public function redirectAction($route, $permanent = false)
     {
-        if (!$route) {
+        if ('' == $route) {
             return new Response(null, $permanent ? 410 : 404);
         }
 
@@ -67,7 +67,7 @@ class RedirectController extends ContainerAware
      */
     public function urlRedirectAction($path, $permanent = false, $scheme = null, $httpPort = 80, $httpsPort = 443)
     {
-        if (!$path) {
+        if ('' == $path) {
             return new Response(null, $permanent ? 410 : 404);
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -39,7 +39,7 @@ class RedirectController extends ContainerAware
     public function redirectAction($route, $permanent = false)
     {
         if (!$route) {
-            return new Response(null, 410);
+            return new Response(null, $permanent ? 410 : 404);
         }
 
         $attributes = $this->container->get('request')->attributes->get('_route_params');
@@ -67,7 +67,7 @@ class RedirectController extends ContainerAware
     public function urlRedirectAction($path, $permanent = false, $scheme = null, $httpPort = 80, $httpsPort = 443)
     {
         if (!$path) {
-            return new Response(null, 410);
+            return new Response(null, $permanent ? 410 : 404);
         }
 
         $statusCode = $permanent ? 301 : 302;

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -29,11 +29,13 @@ class RedirectControllerTest extends TestCase
         $controller = new RedirectController();
         $controller->setContainer($container);
 
-        $returnResponse = $controller->redirectAction('');
-
+        $returnResponse = $controller->redirectAction('', true);
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
-
         $this->assertEquals(410, $returnResponse->getStatusCode());
+
+        $returnResponse = $controller->redirectAction('', false);
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
+        $this->assertEquals(404, $returnResponse->getStatusCode());
     }
 
     /**
@@ -102,11 +104,14 @@ class RedirectControllerTest extends TestCase
     public function testEmptyPath()
     {
         $controller = new RedirectController();
-        $returnResponse = $controller->urlRedirectAction('');
 
+        $returnResponse = $controller->urlRedirectAction('', true);
         $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
-
         $this->assertEquals(410, $returnResponse->getStatusCode());
+
+        $returnResponse = $controller->urlRedirectAction('', false);
+        $this->assertInstanceOf('\Symfony\Component\HttpFoundation\Response', $returnResponse);
+        $this->assertEquals(404, $returnResponse->getStatusCode());
     }
 
     public function testFullURL()


### PR DESCRIPTION
according to spec: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html see 410 Gone

bc break: tiny when omitting 2 parameter (I can avoid this with `func_num_args` but i think its not necessary and makes the code strange and inconsistent)
