### PR TITLE
[2.0] [HttpKernel] Add check to Store::unlock to ensure file exists

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -86,10 +86,14 @@ class Store implements StoreInterface
      * Releases the lock for the given Request.
      *
      * @param Request $request A Request instance
+     *
+     * @return Boolean False if the lock file does not exist or cannot be unlocked, true otherwise
      */
     public function unlock(Request $request)
     {
-        return @unlink($this->getPath($this->getCacheKey($request).'.lck'));
+        $file = $this->getPath($this->getCacheKey($request).'.lck');
+
+        return is_file($file) ? @unlink($file) : false;
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
@@ -66,6 +66,8 @@ interface StoreInterface
      * Releases the lock for the given Request.
      *
      * @param Request $request A Request instance
+     *
+     * @return Boolean False if the lock file does not exist or cannot be unlocked, true otherwise
      */
     public function unlock(Request $request);
 

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpCache/StoreTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpCache/StoreTest.php
@@ -19,8 +19,19 @@ use Symfony\Component\HttpKernel\HttpCache\Store;
 
 class StoreTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var Request
+     */
     protected $request;
+
+    /**
+     * @var Response
+     */
     protected $response;
+
+    /**
+     * @var Store
+     */
     protected $store;
 
     protected function setUp()
@@ -45,6 +56,19 @@ class StoreTest extends \PHPUnit_Framework_TestCase
     public function testReadsAnEmptyArrayWithReadWhenNothingCachedAtKey()
     {
         $this->assertEmpty($this->getStoreMetadata('/nothing'));
+    }
+
+    public function testUnlockFileThatDoesExist()
+    {
+        $cacheKey = $this->storeSimpleEntry();
+        $this->store->lock($this->request);
+
+        $this->assertTrue($this->store->unlock($this->request));
+    }
+
+    public function testUnlockFileThatDoesNotExist()
+    {
+        $this->assertFalse($this->store->unlock($this->request));
     }
 
     public function testRemovesEntriesForKeyWithPurge()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

I was seeing this error in my logs when using an `AppCache`:

```
Error 2: /var/www/beta.example.com/shared/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpCache/Store.php line 92: unlink(/var/www/beta.example.com/releases/20120827020525/app/cache/beta/http_cache/md/c2/88/66a911b5266a57bdd55131a47895b8861dfd.lck): No such file or directory
```

It was only occurring when the `http_cache` file was being primed (i.e. first load).

I've added a simple check to ensure that the file is a valid file before trying to unlink. I also added a missing `@return` docblock. Note: I've chosen to return `false` if the file does not exist as this seems to be the behaviour of the `purge` method.
