### PR TITLE
Added lockExists to Store interface, fixed locking bugs, added tests.

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -515,7 +515,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
             // wait for the lock to be released
             $wait = 0;
-            while ($this->store->lockExists($request) && $wait < 5000000) {
+            while ($this->store->isLocked($request) && $wait < 5000000) {
                 usleep(50000);
                 $wait += 50000;
             }

--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -515,7 +515,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
 
             // wait for the lock to be released
             $wait = 0;
-            while (is_file($lock) && $wait < 5000000) {
+            while ($this->store->lockExists($request) && $wait < 5000000) {
                 usleep(50000);
                 $wait += 50000;
             }

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -73,11 +73,11 @@ class Store implements StoreInterface
     {
         $path = $this->getPath($this->getCacheKey($request).'.lck');
         if (!is_dir(dirname($path)) && false === @mkdir(dirname($path), 0777, true)) {
-          return false;
+            return false;
         }
 
         $lock = @fopen($path, 'x');
-        if ($lock !== false) {
+        if (false !== $lock) {
             fclose($lock);
 
             $this->locks[] = $path;

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -97,9 +97,9 @@ class Store implements StoreInterface
         return @unlink($this->getPath($this->getCacheKey($request).'.lck'));
     }
 
-    public function lockExists(Request $request)
+    public function isLocked(Request $request)
     {
-      return is_file($this->getPath($this->getCacheKey($request).'.lck'));
+        return is_file($this->getPath($this->getCacheKey($request).'.lck'));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -71,15 +71,20 @@ class Store implements StoreInterface
      */
     public function lock(Request $request)
     {
-        if (false !== $lock = @fopen($path = $this->getPath($this->getCacheKey($request).'.lck'), 'x')) {
+        $path = $this->getPath($this->getCacheKey($request).'.lck');
+        if (!is_dir(dirname($path)) && false === @mkdir(dirname($path), 0777, true)) {
+          return false;
+        }
+
+        $lock = @fopen($path, 'x');
+        if ($lock !== false) {
             fclose($lock);
 
             $this->locks[] = $path;
 
             return true;
         }
-
-        return $path;
+        return !file_exists($path) ?: $path;
     }
 
     /**
@@ -90,6 +95,11 @@ class Store implements StoreInterface
     public function unlock(Request $request)
     {
         return @unlink($this->getPath($this->getCacheKey($request).'.lck'));
+    }
+
+    public function lockExists(Request $request)
+    {
+      return is_file($this->getPath($this->getCacheKey($request).'.lck'));
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
@@ -70,6 +70,15 @@ interface StoreInterface
     public function unlock(Request $request);
 
     /**
+     * Returns whether or not a lock exists.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return Boolean true if lock exists, false otherwise
+     */
+    public function lockExists(Request $request);
+
+    /**
      * Purges data for the given URL.
      *
      * @param string $url A URL

--- a/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
@@ -76,7 +76,7 @@ interface StoreInterface
      *
      * @return Boolean true if lock exists, false otherwise
      */
-    public function lockExists(Request $request);
+    public function isLocked(Request $request);
 
     /**
      * Purges data for the given URL.

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -194,6 +194,18 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(2, $this->getStoreMetadata($key));
     }
 
+    public function testLocking()
+    {
+        $req = Request::create('/test', 'get', array(), array(), array(), array('HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'));
+        $this->assertTrue($this->store->lock($req));
+
+        $path = $this->store->lock($req);
+        $this->assertTrue($this->store->lockExists($req));
+
+        $this->store->unlock($req);
+        $this->assertFalse($this->store->lockExists($req));
+    }
+
     protected function storeSimpleEntry($path = null, $headers = array())
     {
         if (null === $path) {

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -200,10 +200,10 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->store->lock($req));
 
         $path = $this->store->lock($req);
-        $this->assertTrue($this->store->lockExists($req));
+        $this->assertTrue($this->store->isLocked($req));
 
         $this->store->unlock($req);
-        $this->assertFalse($this->store->lockExists($req));
+        $this->assertFalse($this->store->isLocked($req));
     }
 
     protected function storeSimpleEntry($path = null, $headers = array())


### PR DESCRIPTION
While working on Drupal's HttpCache implementation, I discovered that the base HttpCache class does an is_file to check for a lock, which assumes a file-based cache is being used. This seems like a mistake since the rest of the Store interface is easily swappable. I added a lockExists method so that this is properly abstracted.

I also noticed there were no tests for the change I made, so I added some very basic locking tests. While adding those I found that the existing lock method is a bit broken. This line here:

``` php
<?php

if (false !== $lock = @fopen($path = $this->getPath($this->getCacheKey($request).'.lck'), 'x')) {
```

will return false if the file couldn't be written for any reason, but the rest of the method assumes that if $lock == false, the lock exists already. So if the file couldnt be written due to the parent directory not existing, $path will be returned as if it exists, which is clearly not the desired behavior.

I changed this to return false if the file couldnt be written and doesn't exist, $path if it exists, and true if the lock was created. It still doesn't feel great to have bool|string return values, but that's the best I could come up with atm. I also added a check for the parent directory that creates it if it doesn't exist. The new tests fail without it.

I also broke out that code a bit as it was very difficult to read.
