### PR TITLE
Issue #5307: HTML regexp when match is false

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Regex.php
+++ b/src/Symfony/Component/Validator/Constraints/Regex.php
@@ -62,6 +62,11 @@ class Regex extends Constraint
      * Convert the htmlPattern to a suitable format for HTML5 pattern.
      * Example: /^[a-z]+$/ would be converted to [a-z]+
      * However, if options are specified, it cannot be converted
+     * 
+     * Pattern is also ignored if match=false since the pattern should
+     * then be reversed before application.
+     *
+     * @todo reverse pattern in case match=false as per issue #5307
      *
      * @link http://dev.w3.org/html5/spec/single-page.html#the-pattern-attribute
      *
@@ -69,6 +74,11 @@ class Regex extends Constraint
      */
     private function getNonDelimitedPattern()
     {
+        // If match = false, pattern should not be added to HTML5 validation
+        if (!$this->match) {
+            return null;
+        }
+        
         if (preg_match('/^(.)(\^?)(.*?)(\$?)\1$/', $this->pattern, $matches)) {
             $delimiter = $matches[1];
             $start     = empty($matches[2]) ? '.*' : '';

--- a/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/RegexValidatorTest.php
@@ -162,6 +162,13 @@ class RegexValidatorTest extends \PHPUnit_Framework_TestCase
             'pattern' => '/[a-z]+/',
         ));
         $this->assertEquals('.*[a-z]+.*', $constraint->getHtmlPattern());
+        
+        // Dropped because of match=false
+        $constraint = new Regex(array(
+            'pattern' => '/[a-z]+/',
+            'match' => false
+        ));
+        $this->assertNull($constraint->getHtmlPattern());
     }
 
 }


### PR DESCRIPTION
When match is false the html5 validation regexp should be either inverted or not added.
Since we are in RC added a fix where this is not added, but marked a @todo so that this
can be revisited and we try to inverse the regexp instead.

Discussed in #5307.
