### PR TITLE
[TwigBundle][Configuration] Allow non scalar callable autoescape values.

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -115,7 +115,7 @@ class Configuration implements ConfigurationInterface
     {
         $rootNode
             ->children()
-                ->scalarNode('autoescape')->end()
+                ->variableNode('autoescape')->end()
                 ->scalarNode('base_template_class')->end()
                 ->scalarNode('cache')->defaultValue('%kernel.cache_dir%/twig')->end()
                 ->scalarNode('charset')->defaultValue('%kernel.charset%')->end()


### PR DESCRIPTION
This PR allows the twig autoescape value to be both strings and arrays (arrays as callable).
This may be applied to the 2.1 & 2.2 branches too.

Twig has allowed for some time to define the `autoescape` to be a callable. Before 1.8.2, we could define from Symfony configuration a callable like this :

``` yml
twig:
    autoescape: "SomeNameSpace\SomeClass::someStaticMethod"
```

but as of 1.8.3, twig no longer accepts callable defined as strings. Thus we should be allowed to use the following syntaxe :

``` yml
twig:
    autoescape: ["SomeNameSpace\SomeClass","someStaticMethod"]
    #or
    autoescape: [@someServiceId,"someMethod"]
```

Bug fix: yes
Feature addition: somehow: as a side effect, we can now define a callable as a method call (using `[@serviceId,"methodName"]`), previously only static method call were allowed (through `"someClass::staticMethodName"`)
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
