### PR TITLE
Add unit test demonstrating bad exit code getter for a failing process

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -218,7 +218,7 @@ class Process
                 array('pipe', 'w'), // stderr
                 array('pipe', 'w')  // last exit code is output on the fourth pipe and caught to work around --enable-sigchild
             );
-            $this->commandline = '('.$this->commandline.') 3>/dev/null; echo $? >&3';
+            $this->commandline = '('.$this->commandline.') 3>/dev/null; code=$?; echo $code >&3; exit $code';
         }
 
         $commandline = $this->commandline;

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -89,6 +89,19 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($called, 'The callback should be executed with the output');
     }
 
+    public function testExitCodeCommandFailed()
+    {
+        if (strpos(PHP_OS, "WIN") === 0) {
+            $this->markTestSkipped('Windows does not support POSIX exit code');
+        }
+
+        // such command run in bash return an exitcode 127
+        $process = new Process('nonexistingcommandIhopeneversomeonewouldnameacommandlikethis');
+        $process->run();
+
+        $this->assertGreaterThan(0, $process->getExitCode());
+    }
+
     public function testExitCodeText()
     {
         $process = new Process('');


### PR DESCRIPTION
Since symfony/symfony@7b63428698 exit code are not well handled anymore.

The unit test provided with this PR demonstrates it
