### PR TITLE
[2.2] [Process] Add getPid and sendSignal methods to Process

### DIFF
--- a/src/Symfony/Component/Process/Exception/LogicException.php
+++ b/src/Symfony/Component/Process/Exception/LogicException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Exception;
+
+/**
+ * LogicException for the Process Component.
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ */
+class LogicException extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -540,6 +540,18 @@ class Process
     }
 
     /**
+     * Return the Pid (process id), if applicable
+     *
+     * @return integer|null The process id if running, null otherwise
+     */
+    public function getPid()
+    {
+        $this->updateStatus();
+
+        return $this->isRunning() ? $this->processInformation['pid'] : null;
+    }
+
+    /**
      * Stops the process.
      *
      * @param float $timeout The timeout in seconds

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -557,25 +557,21 @@ class Process
     /**
      * Send a posix signal to the process
      *
-     * @param  integer $sig A valid posix signal (see http://www.php.net/manual/en/pcntl.constants.php)
+     * @param  integer $signal A valid posix signal (see http://www.php.net/manual/en/pcntl.constants.php)
      * @return Process
      *
      * @throws LogicException   In case the process is not running
      * @throws RuntimeException In case the environment does not support posix signals
      * @throws RuntimeException In case of failure
      */
-    public function sendSignal($sig)
+    public function signal($signal)
     {
         if (!$this->isRunning()) {
             throw new LogicException('Can not send signal on a non running process');
         }
 
-        if (!extension_loaded('posix')) {
-            throw new RuntimeException('Posix extension is required to send signals');
-        }
-
-        if (true !== posix_kill($this->getPid(), $sig)) {
-            throw new RuntimeException(sprintf('Error while sending signal : %s', posix_strerror(posix_get_last_error())));
+        if (true !== proc_terminate($this->process, $signal)) {
+            throw new RuntimeException('Error while sending signal');
         }
 
         return $this;

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -141,6 +141,16 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($process->isRunning());
     }
 
+    public function testGetPid()
+    {
+        $process = new Process('php -r "sleep(1);"');
+        $this->assertNull($process->getPid());
+        $process->start();
+        $this->assertGreaterThan(0, $process->getPid());
+        $process->wait();
+        $this->assertNull($process->getPid());
+    }
+
     public function testStop()
     {
         $process = new Process('php -r "while (true) {}"');

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Process\Tests;
 
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\RuntimeException;
 
 /**
  * @author Robert Schönthal <seroscho@googlemail.com>
@@ -149,6 +150,43 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertGreaterThan(0, $process->getPid());
         $process->wait();
         $this->assertNull($process->getPid());
+    }
+
+    public function testSendSignal()
+    {
+        $process = new Process('php -r "sleep(1);');
+        $process->start();
+        $process->sendSignal(SIGCONT);
+        $process->stop();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testSendKillSignal()
+    {
+        $process = new Process('php -r "sleep(1);');
+        $process->start();
+        $process->sendSignal(SIGKILL);
+        $process->wait();
+    }
+
+    public function testSendKillSignalAndCatch()
+    {
+        $process = new Process('php -r "sleep(1);');
+        $process->start();
+        $process->sendSignal(SIGKILL);
+
+        try {
+            $process->wait();
+            $this->fail('Should throw an exception as the signal stops the process');
+        } catch (RuntimeException $e) {
+
+        }
+
+        $this->assertFalse($process->isRunning());
+        $this->assertTrue($process->hasBeenSignaled());
+        $this->assertEquals(SIGKILL, $process->getTermSignal());
     }
 
     public function testStop()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This method is particularly nice for sending posix signal to a process

example of use :

``` php
// send a SIGCONT signal to the related process
posix_kill($process->getPid(), SIGCONT);
```

I've not implement the signal sender in the Process API because it requires posix environment, but I think could be nice to have it and throw an exception in case it's not supported.

What do you think about it ?
