### PR TITLE
Normalize exceptions

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -11,13 +11,13 @@
 
 namespace Symfony\Component\DependencyInjection\Loader;
 
+use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\SimpleXMLElement;
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 
@@ -213,7 +213,7 @@ class XmlFileLoader extends FileLoader
         if (!$dom->loadXML(file_get_contents($file), LIBXML_NONET | (defined('LIBXML_COMPACT') ? LIBXML_COMPACT : 0))) {
             libxml_disable_entity_loader($disableEntities);
 
-            throw new \InvalidArgumentException(implode("\n", $this->getXmlErrors($internalErrors)));
+            throw new InvalidArgumentException(implode("\n", $this->getXmlErrors($internalErrors)));
         }
         $dom->normalizeDocument();
 
@@ -222,7 +222,7 @@ class XmlFileLoader extends FileLoader
 
         foreach ($dom->childNodes as $child) {
             if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
-                throw new \InvalidArgumentException('Document types are not allowed.');
+                throw new InvalidArgumentException('Document types are not allowed.');
             }
         }
 

--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Serializer\Normalizer;
 
+use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\RuntimeException;
 
 /**
@@ -42,12 +43,14 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
      * Set normalization callbacks
      *
      * @param array $callbacks help normalize the result
+     *
+     * @throws InvalidArgumentException if a non-callable callback is set
      */
     public function setCallbacks(array $callbacks)
     {
         foreach ($callbacks as $attribute => $callback) {
             if (!is_callable($callback)) {
-                throw new \InvalidArgumentException(sprintf('The given callback for attribute "%s" is not callable.', $attribute));
+                throw new InvalidArgumentException(sprintf('The given callback for attribute "%s" is not callable.', $attribute));
             }
         }
         $this->callbacks = $callbacks;

--- a/src/Symfony/Component/Yaml/Exception/ParseException.php
+++ b/src/Symfony/Component/Yaml/Exception/ParseException.php
@@ -18,7 +18,7 @@ namespace Symfony\Component\Yaml\Exception;
  *
  * @api
  */
-class ParseException extends \RuntimeException implements ExceptionInterface
+class ParseException extends RuntimeException
 {
     private $parsedFile;
     private $parsedLine;

--- a/src/Symfony/Component/Yaml/Exception/RuntimeException.php
+++ b/src/Symfony/Component/Yaml/Exception/RuntimeException.php
@@ -12,12 +12,12 @@
 namespace Symfony\Component\Yaml\Exception;
 
 /**
- * Exception class thrown when an error occurs during dumping.
+ * Exception class thrown when an error occurs during parsing.
  *
- * @author Fabien Potencier <fabien@symfony.com>
+ * @author Romain Neutron <imprec@gmail.com>
  *
  * @api
  */
-class DumpException extends RuntimeException
+class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Yaml/Unescaper.php
+++ b/src/Symfony/Component/Yaml/Unescaper.php
@@ -130,7 +130,7 @@ class Unescaper
      *
      * @return string The string with the new encoding
      *
-     * @throws \RuntimeException if no suitable encoding function is found (iconv or mbstring)
+     * @throws RuntimeException if no suitable encoding function is found (iconv or mbstring)
      */
     private function convertEncoding($value, $to, $from)
     {
@@ -140,6 +140,6 @@ class Unescaper
             return iconv($from, $to, $value);
         }
 
-        throw new \RuntimeException('No suitable convert encoding function (install the iconv or mbstring extension).');
+        throw new RuntimeException('No suitable convert encoding function (install the iconv or mbstring extension).');
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This PR adds consistence to components which already have their own exception interface.

DependencyInjection, Serializer and Yaml now only throw their own scoped exceptions.

For other components, it's much more work and could introduce some bugs. It would be better to do it in Symfony 2.2.
