### PR TITLE
Removed the unnecessary file include

### DIFF
--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -14,4 +14,3 @@ if (!function_exists('intl_get_error_code')) {
 }
 
 AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
-AnnotationRegistry::registerFile(__DIR__.'/vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');


### PR DESCRIPTION
As of Doctrine 2.2, the ORM annotations can be found by the autoloader directly.

This will also avoid breaking the testsuite in case the dev deps have not been installed as the ORM would not be available in this case (the tests relying on the ORM should already be skipped when it is not available). See #5402
