### PR TITLE
[Form] Fixed PropertyPath to not modify Collection instances

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
@@ -168,6 +168,7 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
         $axesBefore = $this->getCollection(array(1 => 'second', 3 => 'fourth', 4 => 'fifth'));
         $axesMerged = $this->getCollection(array(1 => 'first', 2 => 'second', 3 => 'third'));
         $axesAfter = $this->getCollection(array(1 => 'second', 5 => 'first', 6 => 'third'));
+        $axesMergedCopy = is_object($axesMerged) ? clone $axesMerged : $axesMerged;
 
         // Don't use a mock in order to test whether the collections are
         // modified while iterating them
@@ -178,6 +179,9 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
         $path->setValue($car, $axesMerged);
 
         $this->assertEquals($axesAfter, $car->getAxes());
+
+        // The passed collection was not modified
+        $this->assertEquals($axesMergedCopy, $axesMerged);
     }
 
     public function testSetValueCallsAdderAndRemoverForNestedCollections()

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -485,7 +485,9 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 $methods = $this->findAdderAndRemover($reflClass, $singulars);
                 if (null !== $methods) {
                     // At this point the add and remove methods have been found
-                    $itemsToAdd = is_object($value) ? clone $value : $value;
+                    // Use iterator_to_array() instead of clone in order to prevent side effects
+                    // see https://github.com/symfony/symfony/issues/4670
+                    $itemsToAdd = is_object($value) ? iterator_to_array($value) : $value;
                     $itemToRemove = array();
                     $propertyValue = $this->readProperty($objectOrArray, $property, $isIndex);
                     $previousValue = $propertyValue[self::VALUE];


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #4670
Todo: -
