### PR TITLE
[2.2][DomCrawler] Added ability to set file as raw path to file field

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+ * added a way to set raw path to the file in FileFormField - necessary for
+   simulating HTTP requests
+
 2.1.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -77,6 +77,16 @@ class FileFormField extends FormField
     }
 
     /**
+     * Sets path to the file as string for simulating HTTP request
+     *
+     * @param string $path The path to the file
+     */
+    public function setFilePath($path)
+    {
+        parent::setValue($path);
+    }
+
+    /**
      * Initializes the form field.
      *
      * @throws \LogicException When node type is incorrect

--- a/src/Symfony/Component/DomCrawler/Tests/Field/FileFormFieldTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/Field/FileFormFieldTest.php
@@ -84,4 +84,14 @@ class FileFormFieldTest extends FormFieldTestCase
             $this->assertTrue(true, '->setErrorCode() throws a \InvalidArgumentException if the error code is not valid');
         }
     }
+
+    public function testSetRawFilePath()
+    {
+        $node = $this->createNode('input', '', array('type' => 'file'));
+        $field = new FileFormField($node);
+        $field->setFilePath(__FILE__);
+
+        $this->assertEquals(__FILE__, $field->getValue());
+    }
+
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

For description see #4674 (https://github.com/symfony/symfony/issues/4674#issuecomment-7811505)

Related PRs:

https://github.com/Behat/MinkBrowserKitDriver/pull/1
https://github.com/Behat/MinkGoutteDriver/pull/7
https://github.com/fabpot/Goutte/pull/77
