### PR TITLE
[Routing] allow URLs to be generated that include the default param

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -1,0 +1,11 @@
+﻿UPGRADE FROM 2.1 to 2.2
+=======================
+
+### Routing
+
+  * Added possibility to generate URLs that include the default param, whereas before a param
+    that equals the default value of an optional placeholder was never part of the URL.
+    Example: Given the route `new Route('/index.{_format}', array('_format' => 'html'));`
+    Previously generating this route with params `array('_format' => 'html')` resulted in `/index` 
+    which means one could not generate `/index.html` at all. This has been changed. You can of course
+    still generate just `/index` by passing array('_format' => null) or not passing the param at all.

--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -19,6 +19,12 @@ CHANGELOG
    check on URL generation completely by calling `setStrictRequirements(null)`. It
    improves performance in production environment as you should know that params always
    pass the requirements (otherwise it would break your link anyway).
+ * [BC BREAK] Added possibility to generate URLs that include the default param, whereas before
+   a param that equals the default value of an optional placeholder was never part of the URL.
+   Example: Given the route `new Route('/index.{_format}', array('_format' => 'html'));`
+   Previously generating this route with params `array('_format' => 'html')` resulted in `/index` 
+   which means one could not generate `/index.html` at all. This has been changed. You can of course
+   still generate just `/index` by passing array('_format' => null) or not passing the param at all.
 
 2.1.0
 -----

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -144,7 +144,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
         $optional = true;
         foreach ($tokens as $token) {
             if ('variable' === $token[0]) {
-                if (!$optional || !array_key_exists($token[3], $defaults) || (string) $mergedParams[$token[3]] !== (string) $defaults[$token[3]]) {
+                if (!$optional || !array_key_exists($token[3], $defaults) || isset($parameters[$token[3]]) || $this->context->hasParameter($token[3])) {
                     // check requirement
                     if (null !== $this->strictRequirements && !preg_match('#^'.$token[2].'$#', $mergedParams[$token[3]])) {
                         $message = sprintf('Parameter "%s" for route "%s" must match "%s" ("%s" given).', $token[3], $name, $token[2], $mergedParams[$token[3]]);

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -277,6 +277,17 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/app.php/foo', $this->getGenerator($routes)->generate('test', array('default' => 'foo')));
     }
 
+    public function testUrlWithDefaultIncluded()
+    {
+        $routes = $this->getRoutes('test', new Route('/index.{_format}', array('_format' => 'html'), array('_format' => '.*')));
+        $generator = $this->getGenerator($routes);
+
+        $this->assertSame('/app.php/index.html', $generator->generate('test', array('_format' => 'html')), 'parameter that equals default is included when explicitly given');
+        $this->assertSame('/app.php/index', $generator->generate('test'), 'the default is not included when param not given');
+        $this->assertSame('/app.php/index', $generator->generate('test', array('_format' => null)), 'null for an optional variable is ignored');
+        $this->assertSame('/app.php/index.', $generator->generate('test', array('_format' => '')), 'empty string is treated as-is (the requirement allows it)');
+    }
+
     public function testQueryParamSameAsDefault()
     {
         $routes = $this->getRoutes('test', new Route('/test', array('default' => 'value')));


### PR DESCRIPTION
BC break: yes (even if no test needed to be changed, so the old behavior was probably not even intended as no test for it existed)
Fixes #5180

This can be achieved by explicitly passing the parameter. Previously it just ignored the parameter that equals the default value. You can still omit optional variables by not passing it at all or passing null as param value.

Example:
Given the route `new Route('/index.{_format}', array('_format' => 'html'));`
Previously generating this route with params `array('_format' => 'html')` resulted in `/index` which means one could not generate `/index.html` at all. This has been changed. You can of course still generate just `/index` by passing array('_format' => null) or not passing the param at all.

I'm certain this is the best solution to the problem even if it slightly breaks bc. But IMO this is how it is supposed to work. Because when I pass a parameter explicitly, I want it to be included in the URL.
