### PR TITLE
load test

### DIFF
--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -173,4 +173,10 @@ EOF;
     {
         ClassCollectionLoader::load(array('SomeNotExistingClass'), '', 'foo', false);
     }
+
+    public function testLoadTwiceClass()
+    {
+        ClassCollectionLoader::load(array('Foo'), '', 'foo', false);
+        ClassCollectionLoader::load(array('Foo'), '', 'foo', false);
+    }
 }


### PR DESCRIPTION
Hi,

This patch add test that covers this situation

public static function load($classes, $cacheDir, $name, $autoReload, $adaptive = false, $extension = '.php')  
{  
  // each $name can only be loaded once per PHP process  
  if (isset(self::$loaded[$name])) {  
     return;  
}      

Best regards,
Michal
