### PR TITLE
[Form] error when instantiating the preloaded extension from the form factory builder

### DIFF
--- a/src/Symfony/Component/Form/FormFactoryBuilder.php
+++ b/src/Symfony/Component/Form/FormFactoryBuilder.php
@@ -145,9 +145,11 @@ class FormFactoryBuilder implements FormFactoryBuilderInterface
         $extensions = $this->extensions;
 
         if (count($this->types) > 0 || count($this->typeExtensions) > 0 || count($this->typeGuessers) > 0) {
-            $typeGuesser = count($this->typeGuessers) > 1
-                ? new FormTypeGuesserChain($this->typeGuessers)
-                : $this->typeGuessers[0];
+            if (count($this->typeGuessers) > 1) {
+                $typeGuesser = new FormTypeGuesserChain($this->typeGuessers);
+            } else {
+                $typeGuesser = isset($this->typeGuessers[0]) ? $this->typeGuessers[0] : null;
+            }
 
             $extensions[] = new PreloadedExtension($this->types, $this->typeExtensions, $typeGuesser);
         }

--- a/src/Symfony/Component/Form/PreloadedExtension.php
+++ b/src/Symfony/Component/Form/PreloadedExtension.php
@@ -38,11 +38,11 @@ class PreloadedExtension implements FormExtensionInterface
     /**
      * Creates a new preloaded extension.
      *
-     * @param array                    $types          The types that the extension should support.
-     * @param array                    $typeExtensions The type extensions that the extension should support.
-     * @param FormTypeGuesserInterface $typeGuesser    The guesser that the extension should support.
+     * @param array                         $types          The types that the extension should support.
+     * @param array                         $typeExtensions The type extensions that the extension should support.
+     * @param FormTypeGuesserInterface|null $typeGuesser    The guesser that the extension should support.
      */
-    public function __construct(array $types, array $typeExtensions, FormTypeGuesserInterface $typeGuesser)
+    public function __construct(array $types, array $typeExtensions, FormTypeGuesserInterface $typeGuesser = null)
     {
         $this->types = $types;
         $this->typeExtensions = $typeExtensions;


### PR DESCRIPTION
When registering a type or a type extension through the form factory builder, an error occurs when creating the factory if no type guesser is registered.
