### PR TITLE
[Routing] fix setting empty requirement

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -179,7 +179,7 @@ class Route implements \Serializable
      *
      * @param string $name An option name
      *
-     * @return mixed The option value
+     * @return mixed The option value or null when not given
      */
     public function getOption($name)
     {
@@ -236,7 +236,7 @@ class Route implements \Serializable
      *
      * @param string $name A variable name
      *
-     * @return mixed The default value
+     * @return mixed The default value or null when not given
      */
     public function getDefault($name)
     {
@@ -323,7 +323,7 @@ class Route implements \Serializable
      *
      * @param string $key The key
      *
-     * @return string The regex
+     * @return string|null The regex or null when not given
      */
     public function getRequirement($key)
     {
@@ -352,6 +352,8 @@ class Route implements \Serializable
      * Compiles the route.
      *
      * @return CompiledRoute A CompiledRoute instance
+     *
+     * @see RouteCompiler which is responsible for the compilation process
      */
     public function compile()
     {
@@ -371,19 +373,19 @@ class Route implements \Serializable
     private function sanitizeRequirement($key, $regex)
     {
         if (!is_string($regex)) {
-            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" must be a string', $key));
+            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" must be a string.', $key));
         }
 
-        if ('' === $regex) {
-            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" cannot be empty', $key));
-        }
-
-        if ('^' === $regex[0]) {
-            $regex = substr($regex, 1);
+        if ('' !== $regex && '^' === $regex[0]) {
+            $regex = (string) substr($regex, 1); // returns false for a single character
         }
 
         if ('$' === substr($regex, -1)) {
             $regex = substr($regex, 0, -1);
+        }
+
+        if ('' === $regex) {
+            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" cannot be empty.', $key));
         }
 
         return $regex;

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -42,7 +42,7 @@ class RouteCompiler implements RouteCompilerInterface
             $pos = $match[0][1] + strlen($match[0][0]);
             $var = $match[1][0];
 
-            if ($req = $route->getRequirement($var)) {
+            if (null !== $req = $route->getRequirement($var)) {
                 $regexp = $req;
             } else {
                 // Use the character preceding the variable as a separator

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -91,6 +91,13 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
                 )),
 
             array(
+                'Route with a requirement of 0',
+                array('/{bar}', array('bar' => null), array('bar' => '0')),
+                '', '#^/(?<bar>0)?$#s', array('bar'), array(
+                    array('variable', '/', '0', 'bar'),
+                )),
+
+            array(
                 'Route with an optional variable as the first segment with requirements',
                 array('/{bar}', array('bar' => 'bar'), array('bar' => '(foo|bar)')),
                 '', '#^/(?<bar>(foo|bar))?$#s', array('bar'), array(

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -112,7 +112,10 @@ class RouteTest extends \PHPUnit_Framework_TestCase
     {
         return array(
            array(''),
-           array(array())
+           array(array()),
+           array('^$'),
+           array('^'),
+           array('$')
         );
     }
 


### PR DESCRIPTION
First commit: A requirement of "^$" was overlooked and wasn't recognized as empty after stripping it in Route.
Second commit: Fixes a requirement of '0' that was ignored by the Compiler.
