### PR TITLE
[Routing] compile check for numeric named variables in pattern

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -23,8 +23,10 @@ class RouteCompiler implements RouteCompilerInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \LogicException If a variable is referenced more than once or if a required variable
-     *                         has a default value that doesn't meet its own requirement.
+     * @throws \LogicException  If a variable is referenced more than once or if a required variable
+     *                          has a default value that doesn't meet its own requirement.
+     * @throws \DomainException If a variable name is numeric because PHP raises an error for such
+     *                          subpatterns in PCRE and thus would break matching, e.g. "(?<123>.+)".
      */
     public function compile(Route $route)
     {
@@ -57,6 +59,9 @@ class RouteCompiler implements RouteCompilerInterface
 
             $tokens[] = array('variable', $match[0][0][0], $regexp, $var);
 
+            if (is_numeric($var)) {
+                throw new \DomainException(sprintf('Variable name "%s" cannot be numeric in route pattern "%s". Please use a different name.', $var, $route->getPattern()));
+            }
             if (in_array($var, $variables)) {
                 throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $route->getPattern(), $var));
             }

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -144,4 +144,23 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
         // irrelevant for both matching and generating URLs.
         $route->compile();
     }
+
+    /**
+     * @dataProvider getNumericVariableNames
+     * @expectedException \DomainException
+     */
+    public function testRouteWithNumericVariableName($name)
+    {
+        $route = new Route('/{'. $name . '}');
+        $route->compile();
+    }
+
+    public function getNumericVariableNames()
+    {
+        return array(
+           array('09'),
+           array('123'),
+           array('1e2')
+        );
+    }
 }


### PR DESCRIPTION
Because PHP raises an error for such subpatterns in PCRE and thus would break matching, e.g. this is not allowed as regex `(?<123>.+)`.
So add a compile time check for a non-working pattern like '/{123}'.
