### PR TITLE
[process] provide a restart method.

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -335,6 +335,7 @@ class Process
 
         $process = clone $this;
         $process->start($callback);
+
         return $process;
     }
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -145,17 +145,16 @@ class Process
 
     public function __clone()
     {
-        unset($this->exitcode);
-        unset($this->fallbackExitcode);
-        unset($this->processInformation);
-        unset($this->stdout);
-        unset($this->stderr);
-        unset($this->pipes);
-        unset($this->process);
-        unset($this->fileHandles);
-        unset($this->readBytes);
-
+        $this->exitcode = null;
+        $this->fallbackExitcode = null;
+        $this->processInformation = null;
+        $this->stdout = null;
+        $this->stderr = null;
+        $this->pipes = null;
+        $this->process = null;
         $this->status = self::STATUS_READY;
+        $this->fileHandles = null;
+        $this->readBytes = null;
     }
 
     /**

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -318,8 +318,8 @@ class Process
     /**
      * Restarts the process by cloning and invoking start().
      *
-     * @param Closure|string|array $callback A PHP callback to run whenever there is some
-     *                                       output available on STDOUT or STDERR
+     * @param callable $callback A PHP callback to run whenever there is some
+     *                           output available on STDOUT or STDERR
      *
      * @return Process The new process.
      *

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -143,6 +143,21 @@ class Process
         $this->stop();
     }
 
+    public function __clone()
+    {
+        unset($this->exitcode);
+        unset($this->fallbackExitcode);
+        unset($this->processInformation);
+        unset($this->stdout);
+        unset($this->stderr);
+        unset($this->pipes);
+        unset($this->process);
+        unset($this->fileHandles);
+        unset($this->readBytes);
+
+        $this->status = self::STATUS_READY;
+    }
+
     /**
      * Runs the process.
      *
@@ -298,6 +313,29 @@ class Process
         }
 
         $this->updateStatus();
+    }
+
+    /**
+     * Restarts the process by cloning and invoking start().
+     *
+     * @param Closure|string|array $callback A PHP callback to run whenever there is some
+     *                                       output available on STDOUT or STDERR
+     *
+     * @return Process The new process.
+     *
+     * @throws \RuntimeException When process can't be launch or is stopped
+     * @throws \RuntimeException When process is already running
+     * @see start()
+     */
+    public function restart($callback = null)
+    {
+        if ($this->isRunning()) {
+            throw new \RuntimeException('Process is already running');
+        }
+
+        $process = clone $this;
+        $process->start($callback);
+        return $process;
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -155,6 +155,15 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testRestart()
+    {
+      $process1 = new Process('php -r "echo getmypid();"');
+      $process1->run();
+      $process2 = $process1->restart();
+      usleep(300000); // wait for output
+      $this->assertNotEquals($process1->getOutput(), $process2->getOutput());
+    }
+
     public function testPhpDeadlock()
     {
         $this->markTestSkipped('Can course php to hang');

--- a/src/Symfony/Component/Process/Tests/ProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTest.php
@@ -160,7 +160,16 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
       $process1 = new Process('php -r "echo getmypid();"');
       $process1->run();
       $process2 = $process1->restart();
+
       usleep(300000); // wait for output
+
+      // Ensure that both processed finished and the output is numeric
+      $this->assertFalse($process1->isRunning());
+      $this->assertFalse($process2->isRunning());
+      $this->assertTrue(is_numeric($process1->getOutput()));
+      $this->assertTrue(is_numeric($process2->getOutput()));
+
+      // Ensure that restart returned a new process by check that the output is different
       $this->assertNotEquals($process1->getOutput(), $process2->getOutput());
     }
 


### PR DESCRIPTION
Pull request for issue #5452.

Another possibility would be to allow for either run() or start() scenarios, but I am not sure that is terribly useful since restart() with a new process lends itself to restarting longer running services when they crash and you want the old process so you can inspect the logs and what not.

Otherwise, something like this might work, but doesn't allow for run() to return status code. Someone can get around that by getting manually on returned process.

``` php
<?php
public function restart($method = 'start', $callback = null)
{
    if ($this->isRunning()) {
        throw new \RuntimeException('Process is already running');
    }

    if ($method != 'start' && $method != 'run') {
        throw new \RuntimeException('Method must be start or run');
    }

    $process = clone $this;
    $process->$method();
    return $process;
}
```
