### PR TITLE
[Process] add signal method.

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -579,6 +579,18 @@ class Process
         return $this->exitcode;
     }
 
+    /**
+     * Send signal to the process.
+     *
+     * @param int $signal Signal to send to process.
+     *
+     * @return Boolean The terminations status of the process.
+     */
+    public function signal($signal)
+    {
+      return proc_terminate($this->process, $signal);
+    }
+
     public function addOutput($line)
     {
         $this->stdout .= $line;

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -588,7 +588,7 @@ class Process
      */
     public function signal($signal)
     {
-      return proc_terminate($this->process, $signal);
+        return proc_terminate($this->process, $signal);
     }
 
     public function addOutput($line)


### PR DESCRIPTION
Pull request for issue #5454.

Perhaps a signal($signal) method instead of kill() since stop is already taking that role and looks like other issue already talking about sending SIGTERM vs SIGKILL and what not.

It might be a good idea to limit the signals you can send so you don't terminate using this function. Also probably a good idea to have a list of POSIX signals as constants.

Thoughts?
