### PR TITLE
[Security] Fixed digest authentication

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/AnalyzeServiceReferencesPass.php
@@ -116,7 +116,7 @@ class AnalyzeServiceReferencesPass implements RepeatablePassInterface
      *
      * @param string $id A full id or alias for a service definition.
      *
-     * @return Definition The definition related to the supplied id
+     * @return Definition|null The definition related to the supplied id
      */
     private function getDefinition($id)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -51,7 +51,7 @@ class CheckCircularReferencesPass implements CompilerPassInterface
      *
      * @param array $edges An array of Nodes
      *
-     * @throws \RuntimeException When a circular reference is found.
+     * @throws ServiceCircularReferenceException When a circular reference is found.
      */
     private function checkOutEdges(array $edges)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -116,7 +116,7 @@ class CheckReferenceValidityPass implements CompilerPassInterface
      * @param Reference  $reference
      * @param Definition $definition
      *
-     * @throws \RuntimeException when there is an issue with the Reference scope
+     * @throws ScopeWideningInjectionException|ScopeCrossingInjectionException when there is an issue with the Reference scope
      */
     private function validateScope(Reference $reference, Definition $definition = null)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/InlineServiceDefinitionsPass.php
@@ -70,6 +70,8 @@ class InlineServiceDefinitionsPass implements RepeatablePassInterface
      *
      * @param ContainerBuilder $container The ContainerBuilder
      * @param array            $arguments An array of arguments
+     *
+     * @return array
      */
     private function inlineArguments(ContainerBuilder $container, array $arguments)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RemoveUnusedDefinitionsPass.php
@@ -34,8 +34,6 @@ class RemoveUnusedDefinitionsPass implements RepeatablePassInterface
      * Processes the ContainerBuilder to remove unused definitions.
      *
      * @param ContainerBuilder $container
-     *
-     * @return void
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
@@ -27,6 +27,8 @@ class RepeatedPass implements CompilerPassInterface
      * Constructor.
      *
      * @param array $passes An array of RepeatablePassInterface objects
+     *
+     * @throws \InvalidArgumentException when the passes don't implement RepeatablePassInterface
      */
     public function __construct(array $passes)
     {
@@ -48,7 +50,7 @@ class RepeatedPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        $compiler = $container->getCompiler();
+        $container->getCompiler();
         $this->repeat = false;
         foreach ($this->passes as $pass) {
             $pass->process($container);

--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -97,6 +97,8 @@ class ReplaceAliasByActualDefinitionPass implements CompilerPassInterface
      * @param array  $arguments An array of Arguments
      * @param string $currentId The alias identifier
      * @param string $newId     The identifier the alias points to
+     *
+     * @return array
      */
     private function updateArgumentReferences(array $arguments, $currentId, $newId)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveDefinitionTemplatesPass.php
@@ -57,6 +57,8 @@ class ResolveDefinitionTemplatesPass implements CompilerPassInterface
      * @param DefinitionDecorator $definition
      *
      * @return Definition
+     *
+     * @throws \RuntimeException When the definition is invalid
      */
     private function resolveDefinition($id, DefinitionDecorator $definition)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveInvalidReferencesPass.php
@@ -70,6 +70,10 @@ class ResolveInvalidReferencesPass implements CompilerPassInterface
      *
      * @param array   $arguments    An array of Reference objects
      * @param Boolean $inMethodCall
+     *
+     * @return array
+     *
+     * @throws \RuntimeException When the config is invalid
      */
     private function processArguments(array $arguments, $inMethodCall = false)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ResolveParameterPlaceHoldersPass.php
@@ -27,6 +27,8 @@ class ResolveParameterPlaceHoldersPass implements CompilerPassInterface
      * Processes the ContainerBuilder to resolve parameter placeholders.
      *
      * @param ContainerBuilder $container
+     *
+     * @throws ParameterNotFoundException When an invalid parameter is referenced
      */
     public function process(ContainerBuilder $container)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -35,6 +35,8 @@ class ServiceReferenceGraph
      * Checks if the graph has a specific node.
      *
      * @param string $id Id to check
+     *
+     * @return Boolean
      */
     public function hasNode($id)
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -135,7 +135,7 @@ class Container implements ContainerInterface
      *
      * @return mixed  The parameter value
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws \InvalidArgumentException if the parameter is not defined
      *
      * @api
      */
@@ -177,6 +177,9 @@ class Container implements ContainerInterface
      * @param string $id      The service identifier
      * @param object $service The service instance
      * @param string $scope   The scope of the service
+     *
+     * @throws \RuntimeException When trying to set a service in an inactive scope
+     * @throws \InvalidArgumentException When trying to set a service in the prototype scope
      *
      * @api
      */
@@ -226,7 +229,8 @@ class Container implements ContainerInterface
      *
      * @return object The associated service
      *
-     * @throws \InvalidArgumentException if the service is not defined
+     * @throws ServiceCircularReferenceException When a circular reference is detected
+     * @throws ServiceNotFoundException When the service is not defined
      *
      * @see Reference
      *
@@ -287,7 +291,8 @@ class Container implements ContainerInterface
      *
      * @param string $name
      *
-     * @return void
+     * @throws \RuntimeException When the parent scope is inactive
+     * @throws \InvalidArgumentException When the scope does not exist
      *
      * @api
      */
@@ -333,8 +338,6 @@ class Container implements ContainerInterface
      *
      * @param string $name The name of the scope to leave
      *
-     * @return void
-     *
      * @throws \InvalidArgumentException if the scope is not active
      *
      * @api
@@ -374,7 +377,7 @@ class Container implements ContainerInterface
      *
      * @param ScopeInterface $scope
      *
-     * @return void
+     * @throws \InvalidArgumentException When the scope is invalid
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -58,6 +58,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      *
      * @return ExtensionInterface An extension instance
      *
+     * @throws \LogicException if the extension is not registered
+     *
      * @api
      */
     public function getExtension($name)
@@ -149,6 +151,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param array  $values    An array of values that customizes the extension
      *
      * @return ContainerBuilder The current instance
+     *
+     * @throws \LogicException if the container is frozen
      *
      * @api
      */
@@ -247,7 +251,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param object $service The service instance
      * @param string $scope   The scope
      *
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException if the container is frozen
      *
      * @api
      */
@@ -480,8 +484,11 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Sets an alias for an existing service.
      *
-     * @param string $alias The alias to create
-     * @param mixed  $id    The service to alias
+     * @param string        $alias The alias to create
+     * @param string|Alias  $id    The service to alias
+     *
+     * @throws \InvalidArgumentException if the id is not a string or an Alias
+     * @throws \InvalidArgumentException if the alias is for itself
      *
      * @api
      */
@@ -533,7 +540,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Gets all defined aliases.
      *
-     * @return array An array of aliases
+     * @return Alias[] An array of aliases
      *
      * @api
      */
@@ -612,7 +619,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Gets all service definitions.
      *
-     * @return array An array of Definition instances
+     * @return Definition[] An array of Definition instances
      *
      * @api
      */
@@ -627,7 +634,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param string     $id         The service identifier
      * @param Definition $definition A Definition instance
      *
-     * @throws BadMethodCallException
+     * @return Definition the service definition
+     *
+     * @throws \BadMethodCallException if the container is frozen
      *
      * @api
      */
@@ -708,8 +717,10 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param Definition $definition A service definition instance
      * @param string     $id         The service identifier
      *
-     * @return object              The service described by the service definition
+     * @return object The service described by the service definition
      *
+     * @throws \RuntimeException When the scope is inactive
+     * @throws \RuntimeException When the factory definition is incomplete
      * @throws \InvalidArgumentException When configure callable is not callable
      */
     private function createService(Definition $definition, $id)

--- a/src/Symfony/Component/DependencyInjection/ContainerInterface.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerInterface.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\DependencyInjection;
 
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+
 /**
  * ContainerInterface is the interface implemented by service container classes.
  *
@@ -46,7 +49,8 @@ interface ContainerInterface
      *
      * @return object The associated service
      *
-     * @throws \InvalidArgumentException if the service is not defined
+     * @throws ServiceCircularReferenceException When a circular reference is detected
+     * @throws ServiceNotFoundException When the service is not defined
      *
      * @see Reference
      *
@@ -72,7 +76,7 @@ interface ContainerInterface
      *
      * @return mixed  The parameter value
      *
-     * @throws  \InvalidArgumentException if the parameter is not defined
+     * @throws \InvalidArgumentException if the parameter is not defined
      *
      * @api
      */
@@ -104,8 +108,6 @@ interface ContainerInterface
      *
      * @param string $name
      *
-     * @return void
-     *
      * @api
      */
     public function enterScope($name);
@@ -115,8 +117,6 @@ interface ContainerInterface
      *
      * @param string $name
      *
-     * @return void
-     *
      * @api
      */
     public function leaveScope($name);
@@ -125,8 +125,6 @@ interface ContainerInterface
      * Adds a scope to the container
      *
      * @param ScopeInterface $scope
-     *
-     * @return void
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -240,6 +240,8 @@ class Definition
      *
      * @return Definition The current instance
      *
+     * @throws \OutOfBoundsException When the replaced argument does not exist
+     *
      * @api
      */
     public function replaceArgument($index, $argument)
@@ -271,6 +273,8 @@ class Definition
      * @param integer $index
      *
      * @return mixed The argument value
+     *
+     * @throws \OutOfBoundsException When the argument does not exist
      *
      * @api
      */
@@ -611,7 +615,7 @@ class Definition
     /**
      * Sets a configurator to call after the service is fully initialized.
      *
-     * @param mixed $callable A PHP callable
+     * @param callable $callable A PHP callable
      *
      * @return Definition The current instance
      *
@@ -627,7 +631,7 @@ class Definition
     /**
      * Gets the configurator to call after the service is fully initialized.
      *
-     * @return mixed The PHP callable to call
+     * @return callable The PHP callable to call
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
+++ b/src/Symfony/Component/DependencyInjection/DefinitionDecorator.php
@@ -26,7 +26,7 @@ class DefinitionDecorator extends Definition
     /**
      * Constructor.
      *
-     * @param Definition $parent The Definition instance to decorate.
+     * @param string $parent The id of Definition instance to decorate.
      *
      * @api
      */
@@ -41,7 +41,7 @@ class DefinitionDecorator extends Definition
     /**
      * Returns the Definition being decorated.
      *
-     * @return Definition
+     * @return string
      *
      * @api
      */
@@ -155,6 +155,8 @@ class DefinitionDecorator extends Definition
      * @param integer $index
      *
      * @return mixed The argument value
+     *
+     * @throws \OutOfBoundsException When the argument does not exist
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -184,6 +184,9 @@ class PhpDumper extends Dumper
      * @param Definition $definition
      *
      * @return string
+     *
+     * @throws \RuntimeException When the factory definition is incomplete
+     * @throws ServiceCircularReferenceException When a circular reference is detected
      */
     private function addServiceInlinedDefinitions($id, $definition)
     {

--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -62,9 +62,7 @@ class XmlDumper extends Dumper
     /**
      * Adds parameters.
      *
-     * @param DOMElement $parent
-     *
-     * @return void
+     * @param \DOMElement $parent
      */
     private function addParameters(\DOMElement $parent)
     {
@@ -85,10 +83,8 @@ class XmlDumper extends Dumper
     /**
      * Adds method calls.
      *
-     * @param array      $methodcalls
-     * @param DOMElement $parent
-     *
-     * @return void
+     * @param array       $methodcalls
+     * @param \DOMElement $parent
      */
     private function addMethodCalls(array $methodcalls, \DOMElement $parent)
     {
@@ -105,11 +101,9 @@ class XmlDumper extends Dumper
     /**
      * Adds a service.
      *
-     * @param Definition $definition
-     * @param string     $id
-     * @param DOMElement $parent
-     *
-     * @return void
+     * @param Definition  $definition
+     * @param string      $id
+     * @param \DOMElement $parent
      */
     private function addService($definition, $id, \DOMElement $parent)
     {
@@ -177,11 +171,9 @@ class XmlDumper extends Dumper
     /**
      * Adds a service alias.
      *
-     * @param string     $alias
-     * @param string     $id
-     * @param DOMElement $parent
-     *
-     * @return void
+     * @param string      $alias
+     * @param string      $id
+     * @param \DOMElement $parent
      */
     private function addServiceAlias($alias, $id, \DOMElement $parent)
     {
@@ -197,9 +189,7 @@ class XmlDumper extends Dumper
     /**
      * Adds services.
      *
-     * @param DOMElement $parent
-     *
-     * @return void
+     * @param \DOMElement $parent
      */
     private function addServices(\DOMElement $parent)
     {
@@ -222,12 +212,10 @@ class XmlDumper extends Dumper
     /**
      * Converts parameters.
      *
-     * @param array      $parameters
-     * @param string     $type
-     * @param DOMElement $parent
-     * @param string     $keyAttribute
-     *
-     * @return void
+     * @param array       $parameters
+     * @param string      $type
+     * @param \DOMElement $parent
+     * @param string      $keyAttribute
      */
     private function convertParameters($parameters, $type, \DOMElement $parent, $keyAttribute = 'key')
     {
@@ -291,6 +279,8 @@ class XmlDumper extends Dumper
      * Converts php types to xml types.
      *
      * @param mixed $value Value to convert
+     *
+     * @return string
      *
      * @throws \RuntimeException When trying to dump object or resource
      */

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\DependencyInjection\Dumper;
 
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Parameter;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -117,7 +119,7 @@ class YamlDumper extends Dumper
      * Adds a service alias
      *
      * @param string $alias
-     * @param string $id
+     * @param Alias  $id
      *
      * @return string
      */
@@ -177,6 +179,8 @@ class YamlDumper extends Dumper
      * Dumps the value to YAML format
      *
      * @param mixed $value
+     *
+     * @return mixed
      *
      * @throws \RuntimeException When trying to dump object or resource
      */

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -93,8 +93,6 @@ class XmlFileLoader extends FileLoader
      *
      * @param SimpleXMLElement $xml
      * @param string           $file
-     *
-     * @return void
      */
     private function parseImports(SimpleXMLElement $xml, $file)
     {
@@ -113,8 +111,6 @@ class XmlFileLoader extends FileLoader
      *
      * @param SimpleXMLElement $xml
      * @param string           $file
-     *
-     * @return void
      */
     private function parseDefinitions(SimpleXMLElement $xml, $file)
     {
@@ -133,8 +129,6 @@ class XmlFileLoader extends FileLoader
      * @param string           $id
      * @param SimpleXMLElement $service
      * @param string           $file
-     *
-     * @return void
      */
     private function parseDefinition($id, $service, $file)
     {
@@ -206,6 +200,8 @@ class XmlFileLoader extends FileLoader
      * Parses a XML file.
      *
      * @param string $file Path to a file
+     *
+     * @return SimpleXMLElement
      *
      * @throws \InvalidArgumentException When loading of XML file returns error
      */
@@ -299,8 +295,8 @@ class XmlFileLoader extends FileLoader
     /**
      * Validates an XML document.
      *
-     * @param DOMDocument $dom
-     * @param string      $file
+     * @param \DOMDocument $dom
+     * @param string       $file
      */
     private function validate(\DOMDocument $dom, $file)
     {
@@ -313,8 +309,6 @@ class XmlFileLoader extends FileLoader
      *
      * @param \DOMDocument $dom
      * @param string       $file
-     *
-     * @return void
      *
      * @throws \RuntimeException         When extension references a non-existent XSD file
      * @throws \InvalidArgumentException When xml doesn't validate its xsd schema
@@ -392,8 +386,6 @@ EOF
      * @param \DOMDocument $dom
      * @param string       $file
      *
-     * @return void
-     *
      * @throws  \InvalidArgumentException When non valid tag are found or no extension are found
      */
     private function validateExtensions(\DOMDocument $dom, $file)
@@ -419,6 +411,8 @@ EOF
 
     /**
      * Returns an array of XML errors.
+     *
+     * @param Boolean $internalErrors
      *
      * @return array
      */

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -83,8 +83,6 @@ class YamlFileLoader extends FileLoader
      *
      * @param array  $content
      * @param string $file
-     *
-     * @return void
      */
     private function parseImports($content, $file)
     {
@@ -103,8 +101,6 @@ class YamlFileLoader extends FileLoader
      *
      * @param array  $content
      * @param string $file
-     *
-     * @return void
      */
     private function parseDefinitions($content, $file)
     {
@@ -124,7 +120,7 @@ class YamlFileLoader extends FileLoader
      * @param array  $service
      * @param string $file
      *
-     * @return void
+     * @throws InvalidArgumentException When tags are invalid
      */
     private function parseDefinition($id, $service, $file)
     {
@@ -319,8 +315,6 @@ class YamlFileLoader extends FileLoader
      * Loads from Extensions
      *
      * @param array $content
-     *
-     * @return void
      */
     private function loadFromExtensions($content)
     {

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -84,7 +84,7 @@ class ParameterBag implements ParameterBagInterface
      *
      * @return mixed  The parameter value
      *
-     * @throws  ParameterNotFoundException if the parameter is not defined
+     * @throws ParameterNotFoundException if the parameter is not defined
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -232,7 +232,7 @@ abstract class Kernel implements KernelInterface
     public function getBundle($name, $first = true)
     {
         if (!isset($this->bundleMap[$name])) {
-            throw new \InvalidArgumentException(sprintf('Bundle "%s" does not exist or it is not enabled. Maybe you forgot to add it in the registerBundles() function of your %s.php file?', $name, get_class($this)));
+            throw new \InvalidArgumentException(sprintf('Bundle "%s" does not exist or it is not enabled. Maybe you forgot to add it in the registerBundles() method of your %s.php file?', $name, get_class($this)));
         }
 
         if (true === $first) {

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -141,11 +141,12 @@ class DigestData
     public function __construct($header)
     {
         $this->header = $header;
-        $parts = preg_split('/, /', $header);
+        preg_match_all('/(\w+)=("([^"]+)"|([^\s,$]+))/', $header, $matches, PREG_SET_ORDER);
         $this->elements = array();
-        foreach ($parts as $part) {
-            list($key, $value) = explode('=', $part);
-            $this->elements[$key] = '"' === $value[0] ? substr($value, 1, -1) : $value;
+        foreach ($matches as $matche) {
+            if (isset($matche[1]) && isset($matche[3])) {
+                $this->elements[$matche[1]] = isset($matche[4]) ? $matche[4] : $matche[3];
+            }
         }
     }
 
@@ -188,7 +189,7 @@ class DigestData
         $this->nonceExpiryTime = $nonceTokens[0];
 
         if (md5($this->nonceExpiryTime.':'.$entryPointKey) !== $nonceTokens[1]) {
-            new BadCredentialsException(sprintf('Nonce token compromised "%s".', $nonceAsPlainText));
+            throw new BadCredentialsException(sprintf('Nonce token compromised "%s".', $nonceAsPlainText));
         }
     }
 

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/DigestDataTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/DigestDataTest.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Tests\Http\Firewall;
+
+use Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener;
+use Symfony\Component\Security\Http\Firewall\DigestData;
+use Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint;
+
+class DigestDataTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        include_once __DIR__ . '/../../../Http/Firewall/DigestAuthenticationListener.php';
+    }
+
+    public function testGetResponse()
+    {
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('b52938fc9e6d7c01be7702ece9031b42', $digestAuth->getResponse());
+    }
+
+    public function testGetUsername()
+    {
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('user', $digestAuth->getUsername());
+    }
+
+    public function testValidateAndDecode()
+    {
+        $time = microtime(true);
+        $key = 'ThisIsAKey';
+        $nonce = base64_encode($time . ':' . md5($time . ':' . $key));
+
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", nonce="' . $nonce . '", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        try {
+            $digestAuth->validateAndDecode($key, 'Welcome, robot!');
+        } catch (\Exception $e) {
+            $this->fail(sprintf('testValidateAndDecode fail with message: %s', $e->getMessage()));
+        }
+    }
+
+    public function testCalculateServerDigest()
+    {
+        $username = 'user';
+        $realm = 'Welcome, robot!';
+        $password = 'pass,word=password';
+        $time = microtime(true);
+        $key = 'ThisIsAKey';
+        $nonce = base64_encode($time . ':' . md5($time . ':' . $key));
+        $nc = '00000001';
+        $cnonce = 'MDIwODkz';
+        $qop = 'auth';
+        $method = 'GET';
+        $uri = '/path/info?p1=5&p2=5';
+
+        $response = md5(
+            md5($username . ':' . $realm . ':' . $password) .
+            ':' . $nonce . ':' . $nc . ':' . $cnonce . ':' . $qop . ':' . md5($method . ':' . $uri)
+        );
+
+        $digest = sprintf('username="%s", realm="%s", nonce="%s", uri="%s", cnonce="%s", nc="%s", qop="%s", response="%s"',
+            $username, $realm, $nonce, $uri, $cnonce, $nc, $qop, $response
+        );
+
+        $digestAuth = new DigestData($digest);
+
+        $this->assertEquals($digestAuth->getResponse(), $digestAuth->calculateServerDigest($password, $method));
+    }
+
+    public function testIsNonceExpired()
+    {
+        $time = microtime(true) + 10;
+        $key = 'ThisIsAKey';
+        $nonce = base64_encode($time . ':' . md5($time . ':' . $key));
+
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", nonce="' . $nonce . '", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $digestAuth->validateAndDecode($key, 'Welcome, robot!');
+
+        $this->assertFalse($digestAuth->isNonceExpired());
+    }
+}


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Digest authentication fail if digest parameters contains `=` character or `,` string.

Example of digest authorization string which fail :

```
username="user", realm="Welcome, robot!", nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", response="a27542383c147b9270c75328f9866877"
```
