### PR TITLE
[Routing] default requirement of variable should not disallow previous char, but the slash

### DIFF
--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -40,7 +40,6 @@ class RouteCompiler implements RouteCompilerInterface
         $variables = array();
         $matches = array();
         $pos = 0;
-        $lastSeparator = '/';
 
         // Match all variables enclosed in "{}" and iterate over them. But we only want to match the innermost variable
         // in case of nested "{}", e.g. {foo{bar}}. This in ensured because \w does not match "{" or "}" itself.
@@ -55,7 +54,7 @@ class RouteCompiler implements RouteCompilerInterface
 
             if (in_array($varName, $variables)) {
                 throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $pattern, $varName));
-            }          
+            }
 
             if ($isSeparator && strlen($precedingText) > 1) {
                 $tokens[] = array('text', substr($precedingText, 0, -1));
@@ -63,17 +62,18 @@ class RouteCompiler implements RouteCompilerInterface
                 $tokens[] = array('text', $precedingText);
             }
 
-            // use the character preceding the variable as a separator
-            // save it for later use as default separator for variables that follow directly without having a preceding char e.g. "/{x}{y}"
-            if ($isSeparator) {
-                $lastSeparator = $precedingChar;
-            }
-
             $regexp = $route->getRequirement($varName);
             if (null === $regexp) {
-                // use the character following the variable (ignoring other placeholders) as a separator when it's not the same as the preceding separator
-                $nextSeparator = $this->findNextSeparator(substr($pattern, $pos));
-                $regexp = sprintf('[^%s]+', preg_quote($lastSeparator !== $nextSeparator ? $lastSeparator.$nextSeparator : $lastSeparator, self::REGEX_DELIMITER));
+                $followingPattern = (string) substr($pattern, $pos);
+                // Find the next static character after the variable that functions as a separator. By default, this separator and '/'
+                // are disallowed for the variable. This default requirement makes sure that optional variables can be matched at all
+                // and that the generating-matching-combination of URLs unambiguous, i.e. the params used for generating the URL are
+                // the same that will be matched. Example: new Route('/{page}.{_format}', array('_format' => 'html'))
+                // If {page} would also match the separating dot, {_format} would never match as {page} will eagerly consume everything.
+                // Also even if {_format} was not optional the requirement prevents that {page} matches something that was originally
+                // part of {_format} when generating the URL, e.g. _format = 'mobile.html'.
+                $nextSeparator = $this->findNextSeparator($followingPattern);
+                $regexp = sprintf('[^/%s]+', '/' !== $nextSeparator && '' !== $nextSeparator ? preg_quote($nextSeparator, self::REGEX_DELIMITER) : '');
             }
 
             $tokens[] = array('variable', $isSeparator ? $precedingChar : '', $regexp, $varName);

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -22,6 +22,13 @@ class RouteCompiler implements RouteCompilerInterface
     const REGEX_DELIMITER = '#';
 
     /**
+     * This string defines the characters that are automatically considered separators in front of
+     * optional placeholders (with default and no static text following). Such a single separator
+     * can be left out together with the optional placeholder from matching and generating URLs.
+     */
+    const SEPARATORS = '/,;.:-_~+*=@|';
+
+    /**
      * {@inheritDoc}
      *
      * @throws \LogicException If a variable is referenced more than once
@@ -33,7 +40,7 @@ class RouteCompiler implements RouteCompilerInterface
         $variables = array();
         $matches = array();
         $pos = 0;
-        $lastSeparator = '';
+        $lastSeparator = '/';
 
         // Match all variables enclosed in "{}" and iterate over them. But we only want to match the innermost variable
         // in case of nested "{}", e.g. {foo{bar}}. This in ensured because \w does not match "{" or "}" itself.
@@ -44,17 +51,21 @@ class RouteCompiler implements RouteCompilerInterface
             $precedingText = substr($pattern, $pos, $match[0][1] - $pos);
             $pos = $match[0][1] + strlen($match[0][0]);
             $precedingChar = strlen($precedingText) > 0 ? substr($precedingText, -1) : '';
+            $isSeparator = '' !== $precedingChar && false !== strpos(static::SEPARATORS, $precedingChar);
 
             if (in_array($varName, $variables)) {
                 throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $pattern, $varName));
+            }          
+
+            if ($isSeparator && strlen($precedingText) > 1) {
+                $tokens[] = array('text', substr($precedingText, 0, -1));
+            } elseif (!$isSeparator && strlen($precedingText) > 0) {
+                $tokens[] = array('text', $precedingText);
             }
 
-            if (strlen($precedingText) > 1) {
-                $tokens[] = array('text', substr($precedingText, 0, -1));
-            }
             // use the character preceding the variable as a separator
             // save it for later use as default separator for variables that follow directly without having a preceding char e.g. "/{x}{y}"
-            if ('' !== $precedingChar) {
+            if ($isSeparator) {
                 $lastSeparator = $precedingChar;
             }
 
@@ -65,7 +76,7 @@ class RouteCompiler implements RouteCompilerInterface
                 $regexp = sprintf('[^%s]+', preg_quote($lastSeparator !== $nextSeparator ? $lastSeparator.$nextSeparator : $lastSeparator, self::REGEX_DELIMITER));
             }
 
-            $tokens[] = array('variable', $precedingChar, $regexp, $varName);
+            $tokens[] = array('variable', $isSeparator ? $precedingChar : '', $regexp, $varName);
             $variables[] = $varName;
         }
 
@@ -103,7 +114,7 @@ class RouteCompiler implements RouteCompilerInterface
      *
      * @param string $pattern The route pattern
      *
-     * @return string The next static character (or empty string when none available)
+     * @return string The next static character that functions as separator (or empty string when none available)
      */
     private function findNextSeparator($pattern)
     {
@@ -114,7 +125,7 @@ class RouteCompiler implements RouteCompilerInterface
         // first remove all placeholders from the pattern so we can find the next real static character
         $pattern = preg_replace('#\{\w+\}#', '', $pattern);
 
-        return isset($pattern[0]) ? $pattern[0] : '';
+        return isset($pattern[0]) && false !== strpos(static::SEPARATORS, $pattern[0]) ? $pattern[0] : '';
     }
 
     /**

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\Routing;
  * RouteCompiler compiles Route instances to CompiledRoute instances.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Tobias Schultze <http://tobion.de>
  */
 class RouteCompiler implements RouteCompilerInterface
 {
@@ -28,42 +29,47 @@ class RouteCompiler implements RouteCompilerInterface
     public function compile(Route $route)
     {
         $pattern = $route->getPattern();
-        $len = strlen($pattern);
         $tokens = array();
         $variables = array();
+        $matches = array();
         $pos = 0;
-        preg_match_all('#.\{(\w+)\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        $lastSeparator = '';
+
+        // Match all variables enclosed in "{}" and iterate over them. But we only want to match the innermost variable
+        // in case of nested "{}", e.g. {foo{bar}}. This in ensured because \w does not match "{" or "}" itself.
+        preg_match_all('#\{\w+\}#', $pattern, $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
         foreach ($matches as $match) {
-            if ($text = substr($pattern, $pos, $match[0][1] - $pos)) {
-                $tokens[] = array('text', $text);
-            }
-
+            $varName = substr($match[0][0], 1, -1);
+            // get all static text preceding the current variable
+            $precedingText = substr($pattern, $pos, $match[0][1] - $pos);
             $pos = $match[0][1] + strlen($match[0][0]);
-            $var = $match[1][0];
+            $precedingChar = strlen($precedingText) > 0 ? substr($precedingText, -1) : '';
 
-            if ($req = $route->getRequirement($var)) {
-                $regexp = $req;
-            } else {
-                // Use the character preceding the variable as a separator
-                $separators = array($match[0][0][0]);
-
-                if ($pos !== $len) {
-                    // Use the character following the variable as the separator when available
-                    $separators[] = $pattern[$pos];
-                }
-                $regexp = sprintf('[^%s]+', preg_quote(implode('', array_unique($separators)), self::REGEX_DELIMITER));
+            if (in_array($varName, $variables)) {
+                throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $pattern, $varName));
             }
 
-            $tokens[] = array('variable', $match[0][0][0], $regexp, $var);
-
-            if (in_array($var, $variables)) {
-                throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $route->getPattern(), $var));
+            if (strlen($precedingText) > 1) {
+                $tokens[] = array('text', substr($precedingText, 0, -1));
+            }
+            // use the character preceding the variable as a separator
+            // save it for later use as default separator for variables that follow directly without having a preceding char e.g. "/{x}{y}"
+            if ('' !== $precedingChar) {
+                $lastSeparator = $precedingChar;
             }
 
-            $variables[] = $var;
+            $regexp = $route->getRequirement($varName);
+            if (null === $regexp) {
+                // use the character following the variable (ignoring other placeholders) as a separator when it's not the same as the preceding separator
+                $nextSeparator = $this->findNextSeparator(substr($pattern, $pos));
+                $regexp = sprintf('[^%s]+', preg_quote($lastSeparator !== $nextSeparator ? $lastSeparator.$nextSeparator : $lastSeparator, self::REGEX_DELIMITER));
+            }
+
+            $tokens[] = array('variable', $precedingChar, $regexp, $varName);
+            $variables[] = $varName;
         }
 
-        if ($pos < $len) {
+        if ($pos < strlen($pattern)) {
             $tokens[] = array('text', substr($pattern, $pos));
         }
 
@@ -90,6 +96,25 @@ class RouteCompiler implements RouteCompilerInterface
             array_reverse($tokens),
             $variables
         );
+    }
+
+    /**
+     * Returns the next static character in the Route pattern that will serve as a separator.
+     *
+     * @param string $pattern The route pattern
+     *
+     * @return string The next static character (or empty string when none available)
+     */
+    private function findNextSeparator($pattern)
+    {
+        if ('' == $pattern) {
+            // return empty string if pattern is empty or false (false which can be returned by substr)
+            return '';
+        }
+        // first remove all placeholders from the pattern so we can find the next real static character
+        $pattern = preg_replace('#\{\w+\}#', '', $pattern);
+
+        return isset($pattern[0]) ? $pattern[0] : '';
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -255,6 +255,19 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/app.php/a./.a/a../..a/...', $this->getGenerator($routes)->generate('test'));
     }
 
+    public function testAdjacentVariables()
+    {
+        $routes = $this->getRoutes('test', new Route('/{x}{y}{z}.{_format}', array('z' => 'default-z', '_format' => 'html'), array('y' => '\d+')));
+        $generator = $this->getGenerator($routes);
+        $this->assertSame('/app.php/foo123', $generator->generate('test', array('x' => 'foo', 'y' => '123')));
+        $this->assertSame('/app.php/foo123bar.xml', $generator->generate('test', array('x' => 'foo', 'y' => '123', 'z' => 'bar', '_format' => 'xml')));
+
+        // The default requirement for 'x' should not allow the separator '.' in this case because it would otherwise match everything
+        // and following optional variables like _format could never match.
+        $this->setExpectedException('Symfony\Component\Routing\Exception\InvalidParameterException');
+        $generator->generate('test', array('x' => 'do.t', 'y' => '123', 'z' => 'bar', '_format' => 'xml'));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array(), $logger = null)
     {
         $context = new RequestContext('/app.php');

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -268,6 +268,23 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $generator->generate('test', array('x' => 'do.t', 'y' => '123', 'z' => 'bar', '_format' => 'xml'));
     }
 
+    public function testOptionalVariableWithNoRealSeparator()
+    {
+        $routes = $this->getRoutes('test', new Route('/get{what}', array('what' => 'All')));
+        $generator = $this->getGenerator($routes);
+
+        $this->assertSame('/app.php/get', $generator->generate('test'));
+        $this->assertSame('/app.php/getSites', $generator->generate('test', array('what' => 'Sites')));
+    }
+
+    public function testRequiredVariableWithNoRealSeparator()
+    {
+        $routes = $this->getRoutes('test', new Route('/get{what}Suffix'));
+        $generator = $this->getGenerator($routes);
+
+        $this->assertSame('/app.php/getSitesSuffix', $generator->generate('test', array('what' => 'Sites')));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array(), $logger = null)
     {
         $context = new RequestContext('/app.php');

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -285,6 +285,33 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/app.php/getSitesSuffix', $generator->generate('test', array('what' => 'Sites')));
     }
 
+    public function testDefaultRequirementOfVariable()
+    {
+        $routes = $this->getRoutes('test', new Route('/{page}.{_format}'));
+        $generator = $this->getGenerator($routes);
+
+        $this->assertSame('/app.php/index.mobile.html', $generator->generate('test', array('page' => 'index', '_format' => 'mobile.html')));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Routing\Exception\InvalidParameterException
+     */
+    public function testDefaultRequirementOfVariableDisallowsSlash()
+    {
+        $routes = $this->getRoutes('test', new Route('/{page}.{_format}'));
+        $this->getGenerator($routes)->generate('test', array('page' => 'index', '_format' => 'sl/ash'));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Routing\Exception\InvalidParameterException
+     */
+    public function testDefaultRequirementOfVariableDisallowsNextSeparator()
+    {
+
+        $routes = $this->getRoutes('test', new Route('/{page}.{_format}'));
+        $this->getGenerator($routes)->generate('test', array('page' => 'do.t', '_format' => 'html'));
+    }
+
     protected function getGenerator(RouteCollection $routes, array $parameters = array(), $logger = null)
     {
         $context = new RequestContext('/app.php');

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -267,6 +267,39 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('what' => 'Sites', '_route' => 'test'), $matcher->match('/getSitesSuffix'));
     }
 
+    public function testDefaultRequirementOfVariable()
+    {
+        $coll = new RouteCollection();
+        $coll->add('test', new Route('/{page}.{_format}'));
+        $matcher = new UrlMatcher($coll, new RequestContext());
+
+        $this->assertEquals(array('page' => 'index', '_format' => 'mobile.html', '_route' => 'test'), $matcher->match('/index.mobile.html'));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testDefaultRequirementOfVariableDisallowsSlash()
+    {
+        $coll = new RouteCollection();
+        $coll->add('test', new Route('/{page}.{_format}'));
+        $matcher = new UrlMatcher($coll, new RequestContext());
+
+        $matcher->match('/index.sl/ash');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
+     */
+    public function testDefaultRequirementOfVariableDisallowsNextSeparator()
+    {
+        $coll = new RouteCollection();
+        $coll->add('test', new Route('/{page}.{_format}', array(), array('_format' => 'html|xml')));
+        $matcher = new UrlMatcher($coll, new RequestContext());
+
+        $matcher->match('/do.t.html');
+    }
+
     /**
      * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
      */

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -243,6 +243,30 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $matcher->match('/wxy.html');
     }
 
+    public function testOptionalVariableWithNoRealSeparator()
+    {
+        $coll = new RouteCollection();
+        $coll->add('test', new Route('/get{what}', array('what' => 'All')));
+        $matcher = new UrlMatcher($coll, new RequestContext());
+
+        $this->assertEquals(array('what' => 'All', '_route' => 'test'), $matcher->match('/get'));
+        $this->assertEquals(array('what' => 'Sites', '_route' => 'test'), $matcher->match('/getSites'));
+
+        // Usually the character in front of an optional parameter can be left out, e.g. with pattern '/get/{what}' just '/get' would match.
+        // But here the 't' in 'get' is not a separating character, so it makes no sense to match without it.
+        $this->setExpectedException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
+        $matcher->match('/ge');
+    }
+
+    public function testRequiredVariableWithNoRealSeparator()
+    {
+        $coll = new RouteCollection();
+        $coll->add('test', new Route('/get{what}Suffix'));
+        $matcher = new UrlMatcher($coll, new RequestContext());
+
+        $this->assertEquals(array('what' => 'Sites', '_route' => 'test'), $matcher->match('/getSitesSuffix'));
+    }
+
     /**
      * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
      */

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -223,6 +223,26 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'text1-text2-text3', 'bar' => 'text4', '_route' => 'test'), $matcher->match('/text1-text2-text3-text4-'));
     }
 
+    public function testAdjacentVariables()
+    {
+        $coll = new RouteCollection();
+        $coll->add('test', new Route('/{w}{x}{y}{z}.{_format}', array('z' => 'default-z', '_format' => 'html'), array('y' => 'y|Y')));
+
+        $matcher = new UrlMatcher($coll, new RequestContext());
+        // 'w' eagerly matches as much as possible and the other variables match the remaining chars.
+        // This also shows that the variables w-z must all exclude the separating char (the dot '.' in this case) by default requirement.
+        // Otherwise they would also comsume '.xml' and _format would never match as it's an optional variable.
+        $this->assertEquals(array('w' => 'wwwww', 'x' => 'x', 'y' => 'Y', 'z' => 'Z','_format' => 'xml', '_route' => 'test'), $matcher->match('/wwwwwxYZ.xml'));
+        // As 'y' has custom requirement and can only be of value 'y|Y', it will leave  'ZZZ' to variable z.
+        // So with carefully chosen requirements adjacent variables, can be useful.
+        $this->assertEquals(array('w' => 'wwwww', 'x' => 'x', 'y' => 'y', 'z' => 'ZZZ','_format' => 'html', '_route' => 'test'), $matcher->match('/wwwwwxyZZZ'));
+        // z and _format are optional.
+        $this->assertEquals(array('w' => 'wwwww', 'x' => 'x', 'y' => 'y', 'z' => 'default-z','_format' => 'html', '_route' => 'test'), $matcher->match('/wwwwwxy'));
+
+        $this->setExpectedException('Symfony\Component\Routing\Exception\ResourceNotFoundException');
+        $matcher->match('/wxy.html');
+    }
+
     /**
      * @expectedException Symfony\Component\Routing\Exception\ResourceNotFoundException
      */

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -114,6 +114,26 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             )),
 
             array(
+                'Route with nested placeholders',
+                array('/{static{var}static}'),
+                '/{stati', '#^/\{static(?<var>[^cs]+)static\}$#s', array('var'), array(
+                array('text', 'static}'),
+                array('variable', 'c', '[^cs]+', 'var'),
+                array('text', '/{stati'),
+            )),
+
+            array(
+                'Route without separator between variables',
+                array('/{w}{x}{y}{z}.{_format}', array('z' => 'default-z', '_format' => 'html'), array('y' => '(y|Y)')),
+                '', '#^/(?<w>[^/\.]+)(?<x>[^/\.]+)(?<y>(y|Y))(?:(?<z>[^/\.]+)(?:\.(?<_format>[^\.]+))?)?$#s', array('w', 'x', 'y', 'z', '_format'), array(
+                array('variable', '.', '[^\.]+', '_format'),
+                array('variable', '', '[^/\.]+', 'z'),
+                array('variable', '', '(y|Y)', 'y'),
+                array('variable', '', '[^/\.]+', 'x'),
+                array('variable', '/', '[^/\.]+', 'w'),
+            )),
+
+            array(
                 'Route with a format',
                 array('/foo/{bar}.{_format}'),
                 '/foo', '#^/foo/(?<bar>[^/\.]+)\.(?<_format>[^\.]+)$#s', array('bar', '_format'), array(

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -108,8 +108,8 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with a variable in last position',
                 array('/foo-{bar}'),
-                '/foo', '#^/foo\-(?<bar>[^\-]+)$#s', array('bar'), array(
-                array('variable', '-', '[^\-]+', 'bar'),
+                '/foo', '#^/foo\-(?<bar>[^/]+)$#s', array('bar'), array(
+                array('variable', '-', '[^/]+', 'bar'),
                 array('text', '/foo'),
             )),
 
@@ -125,8 +125,8 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route without separator between variables',
                 array('/{w}{x}{y}{z}.{_format}', array('z' => 'default-z', '_format' => 'html'), array('y' => '(y|Y)')),
-                '', '#^/(?<w>[^/\.]+)(?<x>[^/\.]+)(?<y>(y|Y))(?:(?<z>[^/\.]+)(?:\.(?<_format>[^\.]+))?)?$#s', array('w', 'x', 'y', 'z', '_format'), array(
-                array('variable', '.', '[^\.]+', '_format'),
+                '', '#^/(?<w>[^/\.]+)(?<x>[^/\.]+)(?<y>(y|Y))(?:(?<z>[^/\.]+)(?:\.(?<_format>[^/]+))?)?$#s', array('w', 'x', 'y', 'z', '_format'), array(
+                array('variable', '.', '[^/]+', '_format'),
                 array('variable', '', '[^/\.]+', 'z'),
                 array('variable', '', '(y|Y)', 'y'),
                 array('variable', '', '[^/\.]+', 'x'),
@@ -136,8 +136,8 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with a format',
                 array('/foo/{bar}.{_format}'),
-                '/foo', '#^/foo/(?<bar>[^/\.]+)\.(?<_format>[^\.]+)$#s', array('bar', '_format'), array(
-                array('variable', '.', '[^\.]+', '_format'),
+                '/foo', '#^/foo/(?<bar>[^/\.]+)\.(?<_format>[^/]+)$#s', array('bar', '_format'), array(
+                array('variable', '.', '[^/]+', '_format'),
                 array('variable', '/', '[^/\.]+', 'bar'),
                 array('text', '/foo'),
             )),

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -116,10 +116,10 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
             array(
                 'Route with nested placeholders',
                 array('/{static{var}static}'),
-                '/{stati', '#^/\{static(?<var>[^cs]+)static\}$#s', array('var'), array(
+                '/{static', '#^/\{static(?<var>[^/]+)static\}$#s', array('var'), array(
                 array('text', 'static}'),
-                array('variable', 'c', '[^cs]+', 'var'),
-                array('text', '/{stati'),
+                array('variable', '', '[^/]+', 'var'),
+                array('text', '/{static'),
             )),
 
             array(


### PR DESCRIPTION
BC break: tiny that probably nobody notices. As you can see, all tests for matching and generating URLs still pass without touching them. So the common usage is not influenced, instead it probably fixes cases that some people are not even aware of. See the related issue.

fixes #5238

This is based on 5423 and will be rebased later.
