### PR TITLE
[Process] Add signal and getPid methods

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -468,6 +468,27 @@ class Process
     }
 
     /**
+     * Returns the Pid (process identifier), if applicable.
+     *
+     * @return integer|null The process id if running, null otherwise
+     *
+     * @throws RuntimeException In case --enable-sigchild is activated
+     */
+    public function getPid()
+    {
+        if ($this->isSigchildEnabled()) {
+            throw new RuntimeException(
+                'This PHP has been compiled with --enable-sigchild.'
+                . ' The process identifier can not be retrieved.'
+            );
+        }
+
+        $this->updateStatus();
+
+        return $this->isRunning() ? $this->processInformation['pid'] : null;
+    }
+
+    /**
      * Returns the current output of the process (STDOUT).
      *
      * @return string The process output

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -387,6 +387,27 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertLessThan($timeout + $precision, $duration);
     }
 
+    public function testGetPid()
+    {
+        $process = $this->getProcess('php -r "sleep(1);"');
+        $process->start();
+        $this->assertGreaterThan(0, $process->getPid());
+        $process->stop();
+    }
+
+    public function testGetPidIsNullBeforeStart()
+    {
+        $process = $this->getProcess('php -r "sleep(1);"');
+        $this->assertNull($process->getPid());
+    }
+
+    public function testGetPidIsNullAfterRun()
+    {
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertNull($process->getPid());
+    }
+
     public function responsesCodeProvider()
     {
         return array(

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -50,9 +50,6 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Stop with timeout does not work on windows, it requires posix signals');
         }
-        if (!function_exists('pcntl_signal')) {
-            $this->markTestSkipped('This test require pcntl_signal function');
-        }
 
         // exec is mandatory here since we send a signal to the process
         // see https://github.com/symfony/symfony/issues/5030 about prepending

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -64,6 +64,30 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
     /**
      * @expectedException \Symfony\Component\Process\Exception\RuntimeException
      */
+    public function testGetPid()
+    {
+        parent::testGetPid();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testGetPidIsNullBeforeStart()
+    {
+        parent::testGetPidIsNullBeforeStart();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testGetPidIsNullAfterRun()
+    {
+        parent::testGetPidIsNullAfterRun();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
     public function testExitCodeText()
     {
         $process = $this->getProcess('qdfsmfkqsdfmqmsd');

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -113,6 +113,30 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
     }
 
     /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testSignal()
+    {
+        parent::testSignal();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessWithoutTermSignalIsNotSignaled()
+    {
+        parent::testProcessWithoutTermSignalIsNotSignaled();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testStopWithTimeoutIsActuallyWorking()
+    {
+        parent::testStopWithTimeoutIsActuallyWorking();
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -128,12 +128,9 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
         parent::testProcessWithoutTermSignalIsNotSignaled();
     }
 
-    /**
-     * @expectedException Symfony\Component\Process\Exception\RuntimeException
-     */
     public function testStopWithTimeoutIsActuallyWorking()
     {
-        parent::testStopWithTimeoutIsActuallyWorking();
+        $this->markTestSkipped('Stopping with signal is not supported in sigchild environment');
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
@@ -78,6 +78,22 @@ class SigchildEnabledProcessTest extends AbstractProcessTest
     }
 
     /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testSignal()
+    {
+        parent::testSignal();
+    }
+    
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessWithoutTermSignalIsNotSignaled()
+    {
+        parent::testProcessWithoutTermSignalIsNotSignaled();
+    }
+
+    /**
      * {@inheritdoc}
      */
     protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())

--- a/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
@@ -45,6 +45,30 @@ class SigchildEnabledProcessTest extends AbstractProcessTest
         parent::testProcessWithoutTermSignal();
     }
 
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testGetPid()
+    {
+        parent::testGetPid();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testGetPidIsNullBeforeStart()
+    {
+        parent::testGetPidIsNullBeforeStart();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testGetPidIsNullAfterRun()
+    {
+        parent::testGetPidIsNullAfterRun();
+    }
+
     public function testExitCodeText()
     {
         $process = $this->getProcess('qdfsmfkqsdfmqmsd');

--- a/src/Symfony/Component/Process/Tests/SignalListener.php
+++ b/src/Symfony/Component/Process/Tests/SignalListener.php
@@ -1,0 +1,16 @@
+<?php
+
+// required for signal handling
+declare(ticks = 1);
+
+pcntl_signal(SIGUSR1, function(){echo "Caught SIGUSR1"; exit;});
+
+$n=0;
+
+// ticks require activity to work - sleep(4); does not work
+while($n < 400) {
+    usleep(10000);
+    $n++;
+}
+
+return;

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -79,6 +79,57 @@ class SimpleProcessTest extends AbstractProcessTest
         parent::testIsNotSuccessful();
     }
 
+    public function testGetPid()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testGetPid();
+    }
+
+    public function testGetPidIsNullBeforeStart()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testGetPidIsNullBeforeStart();
+    }
+
+    public function testGetPidIsNullAfterRun()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testGetPidIsNullAfterRun();
+    }
+
+    public function testSignal()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testSignal();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\LogicException
+     */
+    public function testSignalProcessNotRunning()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testSignalProcessNotRunning();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testSignalWithWrongIntSignal()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testSignalWithWrongIntSignal();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testSignalWithWrongNonIntSignal()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testSignalWithWrongNonIntSignal();
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This PR replaces #5391 ; it adds :
- sigchild compatibility mode. This means that if you activate it you have access to this exitcode of the process in case your php has been compiled with --enable-sigchild. This can happen when you deal with Oracle databases.

``` php
$process->setEnhanceSigchildCompatibility(true);
```
- `getPid` method to get the actual process identifier of the process

``` php
$process->getPid();
```
- `signal` method to send Posix signal to the process

``` php
$process->signal(SIGHUP);
```
- Add optionnal `$signal` as second argument to `stop`method. If provided, the signal is sent at timeout to the process. Example of use :

``` php
$process->stop(5, SIGKILL);
```

Tests have been enhanced and now run both sigchild / non-sigchild mode.

By the way, tests are successful with a PHP compiled with the --enable-sigchild option ;)
