### PR TITLE
[DependencyInjection] Convert parameter name to lowercase when removing an element from ParameterBag

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -135,7 +135,7 @@ class ParameterBag implements ParameterBagInterface
      */
     public function remove($key)
     {
-        unset($this->parameters[$key]);
+        unset($this->parameters[strtolower($key)]);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ParameterBag/ParameterBagTest.php
@@ -54,6 +54,8 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         ));
         $bag->remove('foo');
         $this->assertEquals(array('bar' => 'bar'), $bag->all(), '->remove() removes a parameter');
+        $bag->remove('BAR');
+        $this->assertEquals(array(), $bag->all(), '->remove() converts key to lowercase before removing');
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5477
License of the code: MIT
