### PR TITLE
[HttpFoundation] Added possibility to disable base_64 encoding of session

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -144,9 +144,9 @@ class PdoSessionHandler implements \SessionHandlerInterface
             if (count($sessionRows) == 1) {
                 if ($this->dbOptions['base64_encode']) {
                     return base64_decode($sessionRows[0][0]);
-                } else {
-                    return $sessionRows[0][0];
-                }  
+                } 
+                
+                return $sessionRows[0][0]; 
             }
 
             // session does not exist, create it

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -51,9 +51,10 @@ class PdoSessionHandler implements \SessionHandlerInterface
 
         $this->pdo = $pdo;
         $this->dbOptions = array_merge(array(
-            'db_id_col'   => 'sess_id',
-            'db_data_col' => 'sess_data',
-            'db_time_col' => 'sess_time',
+            'db_id_col'     => 'sess_id',
+            'db_data_col'   => 'sess_data',
+            'db_time_col'   => 'sess_time',
+            'base64_encode' => true,
         ), $dbOptions);
     }
 
@@ -141,7 +142,11 @@ class PdoSessionHandler implements \SessionHandlerInterface
             $sessionRows = $stmt->fetchAll(\PDO::FETCH_NUM);
 
             if (count($sessionRows) == 1) {
-                return base64_decode($sessionRows[0][0]);
+                if ($this->dbOptions['base64_encode']) {
+                    return base64_decode($sessionRows[0][0]);
+                } else {
+                    return $sessionRows[0][0];
+                }  
             }
 
             // session does not exist, create it
@@ -164,8 +169,12 @@ class PdoSessionHandler implements \SessionHandlerInterface
         $dbIdCol   = $this->dbOptions['db_id_col'];
         $dbTimeCol = $this->dbOptions['db_time_col'];
 
-        //session data can contain non binary safe characters so we need to encode it
-        $encoded = base64_encode($data);
+        if ($this->dbOptions['base64_encode']) {
+            //session data can contain non binary safe characters so we need to encode it
+            $encoded = base64_encode($data);
+        } else {
+            $encoded = $data;
+        }
 
         try {
             if ('mysql' === $this->pdo->getAttribute(\PDO::ATTR_DRIVER_NAME)) {
@@ -218,8 +227,13 @@ class PdoSessionHandler implements \SessionHandlerInterface
 
         $sql = "INSERT INTO $dbTable ($dbIdCol, $dbDataCol, $dbTimeCol) VALUES (:id, :data, :time)";
 
-        //session data can contain non binary safe characters so we need to encode it
-        $encoded = base64_encode($data);
+        if ($this->dbOptions['base64_encode']) {
+            //session data can contain non binary safe characters so we need to encode it
+            $encoded = base64_encode($data);
+        } else {
+            $encoded = $data;
+        }
+        
         $stmt = $this->pdo->prepare($sql);
         $stmt->bindParam(':id', $id, \PDO::PARAM_STR);
         $stmt->bindParam(':data', $encoded, \PDO::PARAM_STR);

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -60,4 +60,19 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $storage->gc(-1);
         $this->assertEquals(0, count($this->pdo->query('SELECT * FROM sessions')->fetchAll()));
     }
+
+    public function testEncoding()
+    {
+        $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'sessions'), array());
+
+        $storage->write('foo', 'bar');    
+        $result = $this->pdo->query('SELECT * FROM sessions')->fetchAll();
+        $this->assertEquals(base64_encode('bar'), $result[0]['sess_data']);
+
+        $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'sessions', 'base64_encode' => false), array());
+
+        $storage->write('foo', 'bar');    
+        $result = $this->pdo->query('SELECT * FROM sessions')->fetchAll();
+        $this->assertEquals('bar', $result[0]['sess_data']);
+    }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -61,9 +61,6 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($this->pdo->query('SELECT * FROM sessions')->fetchAll()));
     }
 
-    /**
-     * This tests disabling the base64_encoding option.
-     */
     public function testEncoding()
     {
         $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'sessions'), array());

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -61,6 +61,9 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, count($this->pdo->query('SELECT * FROM sessions')->fetchAll()));
     }
 
+    /**
+     * This tests disabling the base64_encoding option.
+     */
     public function testEncoding()
     {
         $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'sessions'), array());


### PR DESCRIPTION
This may be necessary when sharing sessions with legacy applications. Added a setting called 'base64_encode' to the configuration array. By default, the base_64 encoding stays enabled, so it does not break BC. Unit tests included.

Please let me know what kind of documentation would need to be updated. 

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Todo: Update documentation
License of the code: MIT
