### PR TITLE
[DependencyInjection] Rename $key parameter to $name for consistency

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/ParameterBag.php
@@ -129,13 +129,13 @@ class ParameterBag implements ParameterBagInterface
     /**
      * Removes a parameter.
      *
-     * @param string $key The key
+     * @param string $name The parameter name
      *
      * @api
      */
-    public function remove($key)
+    public function remove($name)
     {
-        unset($this->parameters[strtolower($key)]);
+        unset($this->parameters[strtolower($name)]);
     }
 
     /**


### PR DESCRIPTION
When I worked on #5478, I noticed an inconsistency in parameter naming in the `ParameterBag#remove` method. This PR brings things in line with the rest of the class.

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
