### PR TITLE
Adding a missing annotation for the fluent interface for DIC builder

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -640,6 +640,8 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @param string     $id         The service identifier
      * @param Definition $definition A Definition instance
      *
+     * @return Definition A Definition instance
+     *
      * @throws BadMethodCallException When this ContainerBuilder is frozen
      *
      * @api


### PR DESCRIPTION
Hello,

Just a tiny contribution for a missing annotation for the fluent interface
provided by ContainerBuilder of the DI component

Florent
