### PR TITLE
Use the abstract method to get client IP

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -168,7 +168,7 @@ class Profiler
         $profile = new Profile(uniqid());
         $profile->setTime(time());
         $profile->setUrl($request->getUri());
-        $profile->setIp($request->server->get('REMOTE_ADDR'));
+        $profile->setIp($request->getClientIp());
         $profile->setMethod($request->getMethod());
 
         $response->headers->set('X-Debug-Token', $profile->getToken());


### PR DESCRIPTION
For applications behind a proxy, the profiler display the proxy IP for all tokens..
