### PR TITLE
[HttpKernel] Added a bit to convert incomplete objects in the error message

### DIFF
--- a/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
@@ -221,11 +221,26 @@ class FlattenException
                 $result[$key] = array('boolean', $value);
             } elseif (is_resource($value)) {
                 $result[$key] = array('resource', get_resource_type($value));
+            } elseif ($value instanceof \__PHP_Incomplete_Class) {
+                // Special case of object, is_object will return false
+                $result[$key] = array('incomplete-object', $this->getClassNameFromIncomplete($value));
+
             } else {
                 $result[$key] = array('string', (string) $value);
             }
         }
 
         return $result;
+    }
+
+    private function getClassNameFromIncomplete(\__PHP_Incomplete_Class $value)
+    {
+        $serial = serialize($value);
+        $parts  = explode(':', $serial, 4);
+
+        if ('O' === $parts[0] && strlen($parts[2]) -2 == $parts[1]) {
+            return substr($parts[2], 1, -1);
+        }
+        return '-- Error --';
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
@@ -234,7 +234,8 @@ class FlattenException
 
     private function getClassNameFromIncomplete(\__PHP_Incomplete_Class $value)
     {
-        $array  = new \ArrayObject($value);
+        $array = new \ArrayObject($value);
+
         return $array['__PHP_Incomplete_Class_Name'];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
@@ -224,7 +224,6 @@ class FlattenException
             } elseif ($value instanceof \__PHP_Incomplete_Class) {
                 // Special case of object, is_object will return false
                 $result[$key] = array('incomplete-object', $this->getClassNameFromIncomplete($value));
-
             } else {
                 $result[$key] = array('string', (string) $value);
             }

--- a/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FlattenException.php
@@ -234,12 +234,7 @@ class FlattenException
 
     private function getClassNameFromIncomplete(\__PHP_Incomplete_Class $value)
     {
-        $serial = serialize($value);
-        $parts  = explode(':', $serial, 4);
-
-        if ('O' === $parts[0] && strlen($parts[2]) -2 == $parts[1]) {
-            return substr($parts[2], 1, -1);
-        }
-        return '-- Error --';
+        $array  = new \ArrayObject($value);
+        return $array['__PHP_Incomplete_Class_Name'];
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
@@ -128,10 +128,42 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
 
     public function testSetTraceIncompleteClass()
     {
-        $exception = $this->createException(unserialize('O:14:"BogusTestClass":0:{}'));
-        $flattened = FlattenException::create($exception);
+        $flattened = FlattenException::create(new \Exception('test', 123));
+        $flattened->setTrace(
+            array(
+                array(
+                    'file' => __FILE__,
+                    'line' => 123,
+                    'function' => 'test',
+                    'args' => array(
+                        unserialize('O:14:"BogusTestClass":0:{}')
+                    ),
+                ),
+            ),
+            'foo.php', 123
+        );
 
-        $flattened->toArray();
-        $this->assertTrue(true, 'The above line should not throw');
+        $this->assertEquals(array(
+            array(
+                'message'=> 'test',
+                'class'=>'Exception',
+                'trace'=>array(
+                    array(
+                        'namespace'   => '', 'short_class' => '', 'class' => '','type' => '','function' => '',
+                        'file'        => 'foo.php', 'line' => 123,
+                        'args'        => array(),
+                    ),
+                    array(
+                        'namespace'   => '', 'short_class' => '', 'class' => '','type' => '','function' => 'test',
+                        'file'        => __FILE__, 'line' => 123,
+                        'args'        => array(
+                            array(
+                                'incomplete-object', 'BogusTestClass'
+                            ),
+                        ),
+                    )
+                ),
+            )
+        ),$flattened->toArray());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
@@ -101,7 +101,7 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
                     'args'        => array()
                 )),
             )
-        ),$flattened->toArray());
+        ), $flattened->toArray());
     }
 
     public function flattenDataProvider()
@@ -164,6 +164,6 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
                     )
                 ),
             )
-        ),$flattened->toArray());
+        ), $flattened->toArray());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
@@ -125,4 +125,13 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
     {
         return new \Exception();
     }
+
+    public function testSetTraceIncompleteClass()
+    {
+        $exception = $this->createException(unserialize('O:14:"BogusTestClass":0:{}'));
+        $flattened = FlattenException::create($exception);
+
+        $flattened->toArray();
+        $this->assertTrue(true, 'The above line should not throw');
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes*

\* no - errors in MongoDbSessionHandlerTest attempting to access private property, however running just src/Symfony/Component/HttpKernel does pass.

Objects of class __PHP_Incomplete_Class are only sometimes an object.

```
$object = unserialize('O:14:"BogusTestClass":0:{}');
$object instanceof __PHP_Incomplete_Class; // true
is_object($object); // false
gettype($object); // "object"
```

Since it is "not an object", the flatter attempts to turn it into a string, it triggers:

```
__PHP_Incomplete_Class could not be converted to string.
```

Which then hides the root error message.
