### PR TITLE
fix Fatal error: Cannot access private property

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php
@@ -23,7 +23,7 @@ class MongoDbSessionHandlerTest extends \PHPUnit_Framework_TestCase
      */
     private $mongo;
     private $storage;
-    private $options;
+    public $options;
 
     protected function setUp()
     {


### PR DESCRIPTION
The testsuite fails with fatal error with message:

``` plain
PHP Fatal error: Cannot access private property Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler\MongoDbSessionHandlerTest::$options
in src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/MongoDbSessionHandlerTest.php on line 85
```

on this system:

``` plain
PHP 5.3.13 with Suhosin-Patch (cli) (built: Jun 20 2012 17:05:20) 
Copyright (c) 1997-2012 The PHP Group
Zend Engine v2.3.0, Copyright (c) 1998-2012 Zend Technologies
    with Xdebug v2.1.3, Copyright (c) 2002-2012, by Derick Rethans
```

``` plain
PHPUnit 3.6.11 by Sebastian Bergmann
```
