### PR TITLE
[2.1][Process] Fix stop in non-sigchild environments

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -11,19 +11,19 @@
 
 namespace Symfony\Component\Process\Tests;
 
-use Symfony\Component\Process\Process;
-
 /**
  * @author Robert Schönthal <seroscho@googlemail.com>
  */
-class ProcessTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 {
+    protected abstract function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array());
+
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testNegativeTimeoutFromConstructor()
     {
-        new Process('', null, null, null, -1);
+        $this->getProcess('', null, null, null, -1);
     }
 
     /**
@@ -31,13 +31,13 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testNegativeTimeoutFromSetter()
     {
-        $p = new Process('');
+        $p = $this->getProcess('');
         $p->setTimeout(-1);
     }
 
     public function testNullTimeout()
     {
-        $p = new Process('');
+        $p = $this->getProcess('');
         $p->setTimeout(10);
         $p->setTimeout(null);
 
@@ -51,7 +51,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessResponses($expected, $getter, $code)
     {
-        $p = new Process(sprintf('php -r %s', escapeshellarg($code)));
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
         $p->run();
 
         $this->assertSame($expected, $p->$getter());
@@ -64,22 +64,21 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testProcessPipes($expected, $code)
     {
-        if (strpos(PHP_OS, "WIN") === 0) {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120 and https://bugs.php.net/bug.php?id=51800');
         }
 
-        $p = new Process(sprintf('php -r %s', escapeshellarg($code)));
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
         $p->setStdin($expected);
         $p->run();
 
         $this->assertSame($expected, $p->getOutput());
         $this->assertSame($expected, $p->getErrorOutput());
-        $this->assertSame(0, $p->getExitCode());
     }
 
     public function testCallbackIsExecutedForOutput()
     {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('echo \'foo\';')));
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg('echo \'foo\';')));
 
         $called = false;
         $p->run(function ($type, $buffer) use (&$called) {
@@ -91,12 +90,12 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testExitCodeCommandFailed()
     {
-        if (strpos(PHP_OS, "WIN") === 0) {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Windows does not support POSIX exit code');
         }
 
         // such command run in bash return an exitcode 127
-        $process = new Process('nonexistingcommandIhopeneversomeonewouldnameacommandlikethis');
+        $process = $this->getProcess('nonexistingcommandIhopeneversomeonewouldnameacommandlikethis');
         $process->run();
 
         $this->assertGreaterThan(0, $process->getExitCode());
@@ -104,7 +103,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testExitCodeText()
     {
-        $process = new Process('');
+        $process = $this->getProcess('');
         $r = new \ReflectionObject($process);
         $p = $r->getProperty('exitcode');
         $p->setAccessible(true);
@@ -115,7 +114,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testStartIsNonBlocking()
     {
-        $process = new Process('php -r "sleep(4);"');
+        $process = $this->getProcess('php -r "sleep(4);"');
         $start = microtime(true);
         $process->start();
         $end = microtime(true);
@@ -124,16 +123,21 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testUpdateStatus()
     {
-        $process = new Process('php -h');
-        $process->start();
-        usleep(300000); // wait for output
-        $this->assertEquals(0, $process->getExitCode());
+        $process = $this->getProcess('php -h');
+        $process->run();
         $this->assertTrue(strlen($process->getOutput()) > 0);
+    }
+
+    public function testGetExitCode()
+    {
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertEquals(0, $process->getExitCode());
     }
 
     public function testIsRunning()
     {
-        $process = new Process('php -r "sleep(1);"');
+        $process = $this->getProcess('php -r "sleep(1);"');
         $this->assertFalse($process->isRunning());
         $process->start();
         $this->assertTrue($process->isRunning());
@@ -143,16 +147,74 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testStop()
     {
-        $process = new Process('php -r "while (true) {}"');
+        $process = $this->getProcess('php -r "while (true) {}"');
         $process->start();
         $this->assertTrue($process->isRunning());
         $process->stop();
         $this->assertFalse($process->isRunning());
+    }
 
-        // skip this check on windows since it does not support signals
-        if (!defined('PHP_WINDOWS_VERSION_MAJOR')) {
-            $this->assertTrue($process->hasBeenSignaled());
+    public function testIsSuccessful()
+    {
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertTrue($process->isSuccessful());
+    }
+
+    public function testIsNotSuccessful()
+    {
+        $process = $this->getProcess('php -r "while (true) {}"');
+        $process->start();
+        $this->assertTrue($process->isRunning());
+        $process->stop();
+        $this->assertFalse($process->isSuccessful());
+    }
+
+    public function testProcessIsNotSignaled()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
         }
+
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertFalse($process->hasBeenSignaled());
+    }
+
+    public function testProcessWithoutTermSignal()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertEquals(0, $process->getTermSignal());
+    }
+
+    public function testProcessIsSignaledIfStopped()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        $process = $this->getProcess('php -r "while (true) {}"');
+        $process->start();
+        $process->stop();
+        $this->assertTrue($process->hasBeenSignaled());
+    }
+
+    public function testProcessWithTermSignal()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+
+        $process = $this->getProcess('php -r "while (true) {}"');
+        $process->start();
+        $process->stop();
+        $this->assertEquals(SIGTERM, $process->getTermSignal());
     }
 
     public function testPhpDeadlock()
@@ -161,7 +223,7 @@ class ProcessTest extends \PHPUnit_Framework_TestCase
 
         // Sleep doesn't work as it will allow the process to handle signals and close
         // file handles from the other end.
-        $process = new Process('php -r "while (true) {}"');
+        $process = $this->getProcess('php -r "while (true) {}"');
         $process->start();
 
         // PHP will deadlock when it tries to cleanup $process

--- a/src/Symfony/Component/Process/Tests/ProcessInSigchildEnvironment.php
+++ b/src/Symfony/Component/Process/Tests/ProcessInSigchildEnvironment.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\Process;
+
+class ProcessInSigchildEnvironment extends Process
+{
+    protected function isSigchildEnabled()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+class SigchildDisabledProcessTest extends AbstractProcessTest
+{
+
+    protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    {
+        $process = new ProcessInSigchildEnvironment($commandline, $cwd, $env, $stdin, $timeout, $options);
+        $process->setEnhanceSigchildCompatibility(false);
+
+        return $process;
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testGetExitCode()
+    {
+        parent::testGetExitCode();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testExitCodeCommandFailed()
+    {
+        parent::testExitCodeCommandFailed();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessIsSignaledIfStopped()
+    {
+        parent::testProcessIsSignaledIfStopped();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessWithTermSignal()
+    {
+        parent::testProcessWithTermSignal();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessIsNotSignaled()
+    {
+        parent::testProcessIsNotSignaled();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessWithoutTermSignal()
+    {
+        parent::testProcessWithoutTermSignal();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testExitCodeText()
+    {
+        $process = $this->getProcess('qdfsmfkqsdfmqmsd');
+        $process->run();
+
+        $process->getExitCodeText();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testIsSuccessful()
+    {
+        parent::testIsSuccessful();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testIsNotSuccessful()
+    {
+        parent::testIsNotSuccessful();
+    }
+}

--- a/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+class SigchildEnabledProcessTest extends AbstractProcessTest
+{
+
+    protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    {
+        $process = new ProcessInSigchildEnvironment($commandline, $cwd, $env, $stdin, $timeout, $options);
+        $process->setEnhanceSigchildCompatibility(true);
+
+        return $process;
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessIsSignaledIfStopped()
+    {
+        parent::testProcessIsSignaledIfStopped();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessWithTermSignal()
+    {
+        parent::testProcessWithTermSignal();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessIsNotSignaled()
+    {
+        parent::testProcessIsNotSignaled();
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testProcessWithoutTermSignal()
+    {
+        parent::testProcessWithoutTermSignal();
+    }
+
+    public function testExitCodeText()
+    {
+        $process = $this->getProcess('qdfsmfkqsdfmqmsd');
+        $process->run();
+
+        $this->assertInternalType('string', $process->getExitCodeText());
+    }
+
+}

--- a/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SimpleProcessTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\Process;
+
+class SimpleProcessTest extends AbstractProcessTest
+{
+
+    protected function skipIfPHPSigchild()
+    {
+        ob_start();
+        phpinfo(INFO_GENERAL);
+
+        if (false !== strpos(ob_get_clean(), '--enable-sigchild')) {
+            $this->markTestSkipped('Your PHP has been compiled with --enable-sigchild, this test can not be executed');
+        }
+    }
+
+    protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    {
+        return new Process($commandline, $cwd, $env, $stdin, $timeout, $options);
+    }
+
+    public function testGetExitCode()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testGetExitCode();
+    }
+
+    public function testExitCodeCommandFailed()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testExitCodeCommandFailed();
+    }
+
+    public function testProcessIsSignaledIfStopped()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testProcessIsSignaledIfStopped();
+    }
+
+    public function testProcessWithTermSignal()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testProcessWithTermSignal();
+    }
+
+    public function testProcessIsNotSignaled()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testProcessIsNotSignaled();
+    }
+
+    public function testProcessWithoutTermSignal()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testProcessWithoutTermSignal();
+    }
+
+    public function testExitCodeText()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testExitCodeText();
+    }
+
+    public function testIsSuccessful()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testIsSuccessful();
+    }
+
+    public function testIsNotSuccessful()
+    {
+        $this->skipIfPHPSigchild();
+        parent::testIsNotSuccessful();
+    }
+}


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Fix #5030 in half way.
- `proc_terminate` now sends the `SIGTERM` to the real process, not the sh (add the exec prefix to remove the wrapper as suggested by @schmittjoh). So now, process will stop, except if you're working with a PHP compiled with `--enable-sigchild`
- Add a Sigchild compatibility mode (activated only if PHP has been compiled with it)

This mode is required to use a hack to determine if the process finished with success when PHP has been compiled with the --enable-sigchild option
#5030 will be totally fixed in 2.2 with #5476 as it would allow to send a `SIGKILL` after timeout
