### PR TITLE
[2.2][Routing] Normalize exceptions in Routing Component

### DIFF
--- a/src/Symfony/Component/Routing/Annotation/Route.php
+++ b/src/Symfony/Component/Routing/Annotation/Route.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing\Annotation;
 
+use Symfony\Component\Routing\Exception\BadMethodCallException;
+
 /**
  * Annotation class for @Route().
  *
@@ -45,7 +47,7 @@ class Route
         foreach ($data as $key => $value) {
             $method = 'set'.$key;
             if (!method_exists($this, $method)) {
-                throw new \BadMethodCallException(sprintf("Unknown property '%s' on annotation '%s'.", $key, get_class($this)));
+                throw new BadMethodCallException(sprintf("Unknown property '%s' on annotation '%s'.", $key, get_class($this)));
             }
             $this->$method($value);
         }

--- a/src/Symfony/Component/Routing/Exception/BadMethodCallException.php
+++ b/src/Symfony/Component/Routing/Exception/BadMethodCallException.php
@@ -12,13 +12,10 @@
 namespace Symfony\Component\Routing\Exception;
 
 /**
- * Exception thrown when a route cannot be generated because of missing
- * mandatory parameters.
+ * BadMethodCallException for the Routing Component.
  *
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
- *
- * @api
+ * @author Romain Neutron <imprec@gmail.com>
  */
-class MissingMandatoryParametersException extends InvalidArgumentException
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Routing/Exception/DomainException.php
+++ b/src/Symfony/Component/Routing/Exception/DomainException.php
@@ -12,13 +12,11 @@
 namespace Symfony\Component\Routing\Exception;
 
 /**
- * Exception thrown when a route cannot be generated because of missing
- * mandatory parameters.
+ * Exception thrown if a value does not adhere to a defined valid data domain
+ * inside the Routing Component
  *
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
- *
- * @api
+ * @author Romain Neutron <imprec@gmail.com>
  */
-class MissingMandatoryParametersException extends InvalidArgumentException
+class DomainException extends \DomainException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Routing/Exception/InvalidArgumentException.php
+++ b/src/Symfony/Component/Routing/Exception/InvalidArgumentException.php
@@ -12,13 +12,11 @@
 namespace Symfony\Component\Routing\Exception;
 
 /**
- * Exception thrown when a route cannot be generated because of missing
- * mandatory parameters.
+ * Exception thrown if an argument does not match with the expected value inside
+ * the Routing Component
  *
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
- *
- * @api
+ * @author Romain Neutron <imprec@gmail.com>
  */
-class MissingMandatoryParametersException extends InvalidArgumentException
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Routing/Exception/InvalidParameterException.php
+++ b/src/Symfony/Component/Routing/Exception/InvalidParameterException.php
@@ -18,6 +18,6 @@ namespace Symfony\Component\Routing\Exception;
  *
  * @api
  */
-class InvalidParameterException extends \InvalidArgumentException implements ExceptionInterface
+class InvalidParameterException extends InvalidArgumentException
 {
 }

--- a/src/Symfony/Component/Routing/Exception/LogicException.php
+++ b/src/Symfony/Component/Routing/Exception/LogicException.php
@@ -12,13 +12,11 @@
 namespace Symfony\Component\Routing\Exception;
 
 /**
- * Exception thrown when a route cannot be generated because of missing
- * mandatory parameters.
+ * Exception that represents error in the program logic inside the Routing
+ * Component
  *
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
- *
- * @api
+ * @author Romain Neutron <imprec@gmail.com>
  */
-class MissingMandatoryParametersException extends InvalidArgumentException
+class LogicException extends \LogicException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
+++ b/src/Symfony/Component/Routing/Exception/MethodNotAllowedException.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Routing\Exception;
  *
  * @api
  */
-class MethodNotAllowedException extends \RuntimeException implements ExceptionInterface
+class MethodNotAllowedException extends RuntimeException
 {
     protected $allowedMethods;
 

--- a/src/Symfony/Component/Routing/Exception/ResourceNotFoundException.php
+++ b/src/Symfony/Component/Routing/Exception/ResourceNotFoundException.php
@@ -20,6 +20,6 @@ namespace Symfony\Component\Routing\Exception;
  *
  * @api
  */
-class ResourceNotFoundException extends \RuntimeException implements ExceptionInterface
+class ResourceNotFoundException extends RuntimeException
 {
 }

--- a/src/Symfony/Component/Routing/Exception/RouteNotFoundException.php
+++ b/src/Symfony/Component/Routing/Exception/RouteNotFoundException.php
@@ -18,6 +18,6 @@ namespace Symfony\Component\Routing\Exception;
  *
  * @api
  */
-class RouteNotFoundException extends \InvalidArgumentException implements ExceptionInterface
+class RouteNotFoundException extends InvalidArgumentException
 {
 }

--- a/src/Symfony/Component/Routing/Exception/RuntimeException.php
+++ b/src/Symfony/Component/Routing/Exception/RuntimeException.php
@@ -12,13 +12,10 @@
 namespace Symfony\Component\Routing\Exception;
 
 /**
- * Exception thrown when a route cannot be generated because of missing
- * mandatory parameters.
+ * RuntimeException for the Routing Component.
  *
- * @author Alexandre Salomé <alexandre.salome@gmail.com>
- *
- * @api
+ * @author Romain Neutron <imprec@gmail.com>
  */
-class MissingMandatoryParametersException extends InvalidArgumentException
+class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
 
@@ -88,12 +89,12 @@ abstract class AnnotationClassLoader implements LoaderInterface
      *
      * @return RouteCollection A RouteCollection instance
      *
-     * @throws \InvalidArgumentException When route can't be parsed
+     * @throws InvalidArgumentException When route can't be parsed
      */
     public function load($class, $type = null)
     {
         if (!class_exists($class)) {
-            throw new \InvalidArgumentException(sprintf('Class "%s" does not exist.', $class));
+            throw new InvalidArgumentException(sprintf('Class "%s" does not exist.', $class));
         }
 
         $globals = array(
@@ -105,7 +106,7 @@ abstract class AnnotationClassLoader implements LoaderInterface
 
         $class = new \ReflectionClass($class);
         if ($class->isAbstract()) {
-            throw new \InvalidArgumentException(sprintf('Annotations from class "%s" cannot be read as it is abstract.', $class));
+            throw new InvalidArgumentException(sprintf('Annotations from class "%s" cannot be read as it is abstract.', $class));
         }
 
         if ($annot = $this->reader->getClassAnnotation($class, $this->routeAnnotationClass)) {

--- a/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationDirectoryLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 use Symfony\Component\Config\Resource\DirectoryResource;
 
 /**
@@ -30,7 +31,7 @@ class AnnotationDirectoryLoader extends AnnotationFileLoader
      *
      * @return RouteCollection A RouteCollection instance
      *
-     * @throws \InvalidArgumentException When the directory does not exist or its routes cannot be parsed
+     * @throws InvalidArgumentException When the directory does not exist or its routes cannot be parsed
      */
     public function load($path, $type = null)
     {

--- a/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationFileLoader.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
+use Symfony\Component\Routing\Exception\RuntimeException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Loader\FileLoader;
 use Symfony\Component\Config\FileLocator;
@@ -36,7 +38,7 @@ class AnnotationFileLoader extends FileLoader
     public function __construct(FileLocator $locator, AnnotationClassLoader $loader, $paths = array())
     {
         if (!function_exists('token_get_all')) {
-            throw new \RuntimeException('The Tokenizer extension is required for the routing annotation loaders.');
+            throw new RuntimeException('The Tokenizer extension is required for the routing annotation loaders.');
         }
 
         parent::__construct($locator, $paths);
@@ -52,7 +54,7 @@ class AnnotationFileLoader extends FileLoader
      *
      * @return RouteCollection A RouteCollection instance
      *
-     * @throws \InvalidArgumentException When the file does not exist or its routes cannot be parsed
+     * @throws InvalidArgumentException When the file does not exist or its routes cannot be parsed
      */
     public function load($file, $type = null)
     {

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Loader\FileLoader;
 
@@ -33,7 +34,7 @@ class XmlFileLoader extends FileLoader
      *
      * @return RouteCollection A RouteCollection instance
      *
-     * @throws \InvalidArgumentException When a tag can't be parsed
+     * @throws InvalidArgumentException When a tag can't be parsed
      *
      * @api
      */
@@ -97,7 +98,7 @@ class XmlFileLoader extends FileLoader
                             $options[(string) $n->getAttribute('key')] = trim((string) $n->nodeValue);
                             break;
                         default:
-                            throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $n->tagName));
+                            throw new InvalidArgumentException(sprintf('Unable to parse tag "%s"', $n->tagName));
                     }
                 }
 
@@ -105,7 +106,7 @@ class XmlFileLoader extends FileLoader
                 $collection->addCollection($this->import($resource, ('' !== $type ? $type : null), false, $file), $prefix, $defaults, $requirements, $options);
                 break;
             default:
-                throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
+                throw new InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
         }
     }
 
@@ -126,7 +127,7 @@ class XmlFileLoader extends FileLoader
      * @param \DOMElement     $definition Route definition
      * @param string          $file       An XML file path
      *
-     * @throws \InvalidArgumentException When the definition cannot be parsed
+     * @throws InvalidArgumentException When the definition cannot be parsed
      */
     protected function parseRoute(RouteCollection $collection, \DOMElement $definition, $file)
     {
@@ -150,7 +151,7 @@ class XmlFileLoader extends FileLoader
                     $requirements[(string) $node->getAttribute('key')] = trim((string) $node->nodeValue);
                     break;
                 default:
-                    throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
+                    throw new InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
             }
         }
 
@@ -166,7 +167,7 @@ class XmlFileLoader extends FileLoader
      *
      * @return \DOMDocument
      *
-     * @throws \InvalidArgumentException When loading of XML file returns error
+     * @throws InvalidArgumentException When loading of XML file returns error
      */
     protected function loadFile($file)
     {
@@ -179,7 +180,7 @@ class XmlFileLoader extends FileLoader
         if (!$dom->loadXML(file_get_contents($file), LIBXML_NONET | (defined('LIBXML_COMPACT') ? LIBXML_COMPACT : 0))) {
             libxml_disable_entity_loader($disableEntities);
 
-            throw new \InvalidArgumentException(implode("\n", $this->getXmlErrors($internalErrors)));
+            throw new InvalidArgumentException(implode("\n", $this->getXmlErrors($internalErrors)));
         }
         $dom->normalizeDocument();
 
@@ -188,7 +189,7 @@ class XmlFileLoader extends FileLoader
 
         foreach ($dom->childNodes as $child) {
             if ($child->nodeType === XML_DOCUMENT_TYPE_NODE) {
-                throw new \InvalidArgumentException('Document types are not allowed.');
+                throw new InvalidArgumentException('Document types are not allowed.');
             }
         }
 
@@ -202,7 +203,7 @@ class XmlFileLoader extends FileLoader
      *
      * @param \DOMDocument $dom A loaded XML file
      *
-     * @throws \InvalidArgumentException When XML doesn't validate its XSD schema
+     * @throws InvalidArgumentException When XML doesn't validate its XSD schema
      */
     protected function validate(\DOMDocument $dom)
     {
@@ -212,7 +213,7 @@ class XmlFileLoader extends FileLoader
         libxml_clear_errors();
 
         if (!$dom->schemaValidate($location)) {
-            throw new \InvalidArgumentException(implode("\n", $this->getXmlErrors($current)));
+            throw new InvalidArgumentException(implode("\n", $this->getXmlErrors($current)));
         }
         libxml_use_internal_errors($current);
     }

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Config\Loader\FileLoader;
@@ -38,7 +39,7 @@ class YamlFileLoader extends FileLoader
      *
      * @return RouteCollection A RouteCollection instance
      *
-     * @throws \InvalidArgumentException When route can't be parsed
+     * @throws InvalidArgumentException When route can't be parsed
      *
      * @api
      */
@@ -58,7 +59,7 @@ class YamlFileLoader extends FileLoader
 
         // not an array
         if (!is_array($config)) {
-            throw new \InvalidArgumentException(sprintf('The file "%s" must contain a YAML array.', $file));
+            throw new InvalidArgumentException(sprintf('The file "%s" must contain a YAML array.', $file));
         }
 
         foreach ($config as $name => $config) {
@@ -99,7 +100,7 @@ class YamlFileLoader extends FileLoader
      * @param array           $config     Route definition
      * @param string          $file       A Yaml file path
      *
-     * @throws \InvalidArgumentException When config pattern is not defined for the given route
+     * @throws InvalidArgumentException When config pattern is not defined for the given route
      */
     protected function parseRoute(RouteCollection $collection, $name, $config, $file)
     {
@@ -108,7 +109,7 @@ class YamlFileLoader extends FileLoader
         $options = isset($config['options']) ? $config['options'] : array();
 
         if (!isset($config['pattern'])) {
-            throw new \InvalidArgumentException(sprintf('You must define a "pattern" for the "%s" route.', $name));
+            throw new InvalidArgumentException(sprintf('You must define a "pattern" for the "%s" route.', $name));
         }
 
         $route = new Route($config['pattern'], $defaults, $requirements, $options);
@@ -129,7 +130,7 @@ class YamlFileLoader extends FileLoader
     {
         foreach ($config as $key => $value) {
             if (!in_array($key, self::$availableKeys)) {
-                throw new \InvalidArgumentException(sprintf(
+                throw new InvalidArgumentException(sprintf(
                     'Yaml routing loader does not support given key: "%s". Expected one of the (%s).',
                     $key, implode(', ', self::$availableKeys)
                 ));

--- a/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/ApacheMatcherDumper.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing\Matcher\Dumper;
 
+use Symfony\Component\Routing\Exception\LogicException;
+
 /**
  * Dumps a set of Apache mod_rewrite rules.
  *
@@ -31,7 +33,7 @@ class ApacheMatcherDumper extends MatcherDumper
      *
      * @return string A string to be used as Apache rewrite rules
      *
-     * @throws \LogicException When the route regex is invalid
+     * @throws LogicException When the route regex is invalid
      */
     public function dump(array $options = array())
     {
@@ -53,7 +55,7 @@ class ApacheMatcherDumper extends MatcherDumper
             $delimiter = $regex[0];
             $regexPatternEnd = strrpos($regex, $delimiter);
             if (strlen($regex) < 2 || 0 === $regexPatternEnd) {
-                throw new \LogicException('The "%s" route regex "%s" is invalid', $name, $regex);
+                throw new LogicException('The "%s" route regex "%s" is invalid', $name, $regex);
             }
             $regex = preg_replace('/\?<.+?>/', '', substr($regex, 1, $regexPatternEnd - 1));
             $regex = '^'.self::escape(preg_quote($options['base_uri']).substr($regex, 1), ' ', '\\');

--- a/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/PhpMatcherDumper.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Routing\Matcher\Dumper;
 
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Exception\LogicException;
 
 /**
  * PhpMatcherDumper creates a PHP class able to match URLs for a given set of routes.
@@ -171,6 +172,8 @@ EOF;
      * @param string|null $parentPrefix         The prefix of the parent collection used to optimize the code
      *
      * @return string PHP code
+     *
+     * @throws LogicException  If a _scheme is provided for URL matchers that does not implement RedirectableUrlMatcherInterface
      */
     private function compileRoute(Route $route, $name, $supportsRedirections, $parentPrefix = null)
     {
@@ -258,7 +261,7 @@ EOF;
 
         if ($scheme = $route->getRequirement('_scheme')) {
             if (!$supportsRedirections) {
-                throw new \LogicException('The "_scheme" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.');
+                throw new LogicException('The "_scheme" requirement is only supported for URL matchers that implement RedirectableUrlMatcherInterface.');
             }
 
             $code .= <<<EOF

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Routing;
 
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
+
 /**
  * A Route describes a route and its parameters.
  *
@@ -373,7 +375,7 @@ class Route implements \Serializable
     private function sanitizeRequirement($key, $regex)
     {
         if (!is_string($regex)) {
-            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" must be a string.', $key));
+            throw new InvalidArgumentException(sprintf('Routing requirement for "%s" must be a string.', $key));
         }
 
         if ('' !== $regex && '^' === $regex[0]) {
@@ -385,7 +387,7 @@ class Route implements \Serializable
         }
 
         if ('' === $regex) {
-            throw new \InvalidArgumentException(sprintf('Routing requirement for "%s" cannot be empty.', $key));
+            throw new InvalidArgumentException(sprintf('Routing requirement for "%s" cannot be empty.', $key));
         }
 
         return $regex;

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing;
 
 use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 
 /**
  * A RouteCollection represents a set of Route instances as a tree structure.
@@ -109,14 +110,14 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * @param string $name  The route name
      * @param Route  $route A Route instance
      *
-     * @throws \InvalidArgumentException When route name contains non valid characters
+     * @throws InvalidArgumentException When route name contains non valid characters
      *
      * @api
      */
     public function add($name, Route $route)
     {
         if (!preg_match('/^[a-z0-9A-Z_.]+$/', $name)) {
-            throw new \InvalidArgumentException(sprintf('The provided route name "%s" contains non valid characters. A route name must only contain digits (0-9), letters (a-z and A-Z), underscores (_) and dots (.).', $name));
+            throw new InvalidArgumentException(sprintf('The provided route name "%s" contains non valid characters. A route name must only contain digits (0-9), letters (a-z and A-Z), underscores (_) and dots (.).', $name));
         }
 
         $this->remove($name);
@@ -189,7 +190,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * @param array           $requirements An array of requirements
      * @param array           $options      An array of options
      *
-     * @throws \InvalidArgumentException When the RouteCollection already exists in the tree
+     * @throws InvalidArgumentException When the RouteCollection already exists in the tree
      *
      * @api
      */
@@ -198,7 +199,7 @@ class RouteCollection implements \IteratorAggregate, \Countable
         // prevent infinite loops by recursive referencing
         $root = $this->getRoot();
         if ($root === $collection || $root->hasCollection($collection)) {
-            throw new \InvalidArgumentException('The RouteCollection already exists in the tree.');
+            throw new InvalidArgumentException('The RouteCollection already exists in the tree.');
         }
 
         // remove all routes with the same names in all existing collections

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -11,6 +11,9 @@
 
 namespace Symfony\Component\Routing;
 
+use Symfony\Component\Routing\Exception\DomainException;
+use Symfony\Component\Routing\Exception\LogicException;
+
 /**
  * RouteCompiler compiles Route instances to CompiledRoute instances.
  *
@@ -23,8 +26,8 @@ class RouteCompiler implements RouteCompilerInterface
     /**
      * {@inheritDoc}
      *
-     * @throws \LogicException  If a variable is referenced more than once
-     * @throws \DomainException If a variable name is numeric because PHP raises an error for such
+     * @throws LogicException  If a variable is referenced more than once
+     * @throws DomainException If a variable name is numeric because PHP raises an error for such
      *                          subpatterns in PCRE and thus would break matching, e.g. "(?<123>.+)".
      */
     public function compile(Route $route)
@@ -59,10 +62,10 @@ class RouteCompiler implements RouteCompilerInterface
             $tokens[] = array('variable', $match[0][0][0], $regexp, $var);
 
             if (is_numeric($var)) {
-                throw new \DomainException(sprintf('Variable name "%s" cannot be numeric in route pattern "%s". Please use a different name.', $var, $route->getPattern()));
+                throw new DomainException(sprintf('Variable name "%s" cannot be numeric in route pattern "%s". Please use a different name.', $var, $route->getPattern()));
             }
             if (in_array($var, $variables)) {
-                throw new \LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $route->getPattern(), $var));
+                throw new LogicException(sprintf('Route pattern "%s" cannot reference variable name "%s" more than once.', $route->getPattern(), $var));
             }
 
             $variables[] = $var;

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -15,6 +15,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
+use Symfony\Component\Routing\Exception\InvalidArgumentException;
 
 /**
  * The Router class is an example of the integration of all pieces of the
@@ -62,7 +63,7 @@ class Router implements RouterInterface
      *
      * @param array $options An array of options
      *
-     * @throws \InvalidArgumentException When unsupported option is provided
+     * @throws InvalidArgumentException When unsupported option is provided
      */
     public function setOptions(array $options)
     {
@@ -92,7 +93,7 @@ class Router implements RouterInterface
         }
 
         if ($invalid) {
-            throw new \InvalidArgumentException(sprintf('The Router does not support the following options: "%s".', implode('\', \'', $invalid)));
+            throw new InvalidArgumentException(sprintf('The Router does not support the following options: "%s".', implode('\', \'', $invalid)));
         }
     }
 
@@ -102,12 +103,12 @@ class Router implements RouterInterface
      * @param string $key   The key
      * @param mixed  $value The value
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function setOption($key, $value)
     {
         if (!array_key_exists($key, $this->options)) {
-            throw new \InvalidArgumentException(sprintf('The Router does not support the "%s" option.', $key));
+            throw new InvalidArgumentException(sprintf('The Router does not support the "%s" option.', $key));
         }
 
         $this->options[$key] = $value;
@@ -120,12 +121,12 @@ class Router implements RouterInterface
      *
      * @return mixed The value
      *
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function getOption($key)
     {
         if (!array_key_exists($key, $this->options)) {
-            throw new \InvalidArgumentException(sprintf('The Router does not support the "%s" option.', $key));
+            throw new InvalidArgumentException(sprintf('The Router does not support the "%s" option.', $key));
         }
 
         return $this->options[$key];

--- a/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/Annotation/RouteTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Annotation\Route;
 class RouteTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException \BadMethodCallException
+     * @expectedException Symfony\Component\Routing\Exception\BadMethodCallException
      */
     public function testInvalidRouteParameter()
     {

--- a/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/Dumper/PhpGeneratorDumperTest.php
@@ -76,7 +76,7 @@ class PhpGeneratorDumperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\RouteNotFoundException
      */
     public function testDumpWithoutRoutes()
     {

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
-use Symfony\Component\Routing\Loader\AnnotationClassLoader;
-
 class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 {
     protected $loader;
@@ -25,7 +23,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testLoadMissingClass()
     {
@@ -33,7 +31,7 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testLoadAbstractClass()
     {

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -65,7 +65,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFile($filePath)
@@ -75,7 +75,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      * @dataProvider getPathsToInvalidFiles
      */
     public function testLoadThrowsExceptionWithInvalidFileEvenWithoutSchemaValidation($filePath)
@@ -90,7 +90,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      * @expectedExceptionMessage Document types are not allowed.
      */
     public function testDocTypeIsNotAllowed()

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Config\Resource\FileResource;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
@@ -53,7 +52,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testLoadThrowsExceptionIfNotAnArray()
     {
@@ -62,7 +61,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testLoadThrowsExceptionIfArrayHasUnsupportedKeys()
     {
@@ -71,7 +70,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testLoadThrowsExceptionWhenIncomplete()
     {
@@ -105,7 +104,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testParseRouteThrowsExceptionWithMissingPattern()
     {

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Routing\RouteCollection;
 class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException \LogicException
+     * @expectedException Symfony\Component\Routing\Exception\LogicException
      */
     public function testDumpWhenSchemeIsUsedWithoutAProperDumper()
     {

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -28,7 +28,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testAddInvalidRoute()
     {
@@ -233,7 +233,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testCannotSelfJoinCollection()
     {
@@ -243,7 +243,7 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testCannotAddExistingCollectionToTree()
     {

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -132,7 +132,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \LogicException
+     * @expectedException Symfony\Component\Routing\Exception\LogicException
      */
     public function testRouteWithSameVariableTwice()
     {
@@ -143,7 +143,7 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getNumericVariableNames
-     * @expectedException \DomainException
+     * @expectedException Symfony\Component\Routing\Exception\DomainException
      */
     public function testRouteWithNumericVariableName($name)
     {

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -100,7 +100,7 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider getInvalidRequirements
-     * @expectedException \InvalidArgumentException
+     * @expectedException Symfony\Component\Routing\Exception\InvalidArgumentException
      */
     public function testSetInvalidRequirement($req)
     {


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Exceptions are now normalized inside the Routing Component and implement `Symfony\Component\Routing\Exception\ExceptionInterface`
