### PR TITLE
Implemented tagging support for translation.

### DIFF
--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -56,6 +56,10 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There is one apple', 'one: There is one apple|more: There is %count% apples', 1),
             array('There is %count% apples', 'one: There is one apple|more: There is %count% apples', 10),
 
+            array('There is %count% apples', 'one: There is one apple|more: There is %count% apples', 'more'),
+            array('There is one apple', 'one: There is one apple|more: There is %count% apples', 'one'),
+            array('There are some apples', 'one: There is one apple|some: There are some apples|more: There is %count% apples', 'some'),
+
             array('There is no apples', '{0} There is no apples|one: There is one apple|more: There is %count% apples', 0),
             array('There is one apple', '{0} There is no apples|one: There is one apple|more: There is %count% apples', 1),
             array('There is %count% apples', '{0} There is no apples|one: There is one apple|more: There is %count% apples', 10),

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -155,7 +155,7 @@ class Translator implements TranslatorInterface
             }
         }
 
-        return strtr($this->selector->choose($catalogue->get($id, $domain), (int) $number, $locale), $parameters);
+        return strtr($this->selector->choose($catalogue->get($id, $domain), $number, $locale), $parameters);
     }
 
     protected function loadCatalogue($locale)

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -38,7 +38,7 @@ interface TranslatorInterface
      * Translates the given choice message by choosing a translation according to a number.
      *
      * @param string  $id         The message id
-     * @param integer $number     The number to use to find the indice of the message
+     * @param mixed   $number     The number or tag to use to find the indice of the message
      * @param array   $parameters An array of parameters for the message
      * @param string  $domain     The domain for the message
      * @param string  $locale     The locale


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

Introduced tagging support for translation entries.
The idea behind this patch is to start support for gender specific translations without interfering with current support of Symfony.

Internals: Instead of only adding elements to translation choices without indexing the key, I added a new entry to these choices by considering the key. So, whenever I add a new translation, my transchoice now works not only with integers, but also strings.
Example:

`male: His ideas|female: Her ideas|couple: Their ideas`

Then I could simply do:

``` php
$gender = 'female';

$t = $this->get('translator')->transChoice(
    'male: His ideas|female: Her ideas|couple: Their ideas',
    $gender
);
```
