### PR TITLE
[HttpKernel] Added UTF8 encoding, decoding to MongoDBProfilerStorage

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -95,7 +95,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
         $record = array(
             '_id' => $profile->getToken(),
             'parent' => $profile->getParentToken(),
-            'data' => serialize($profile->getCollectors()),
+            'data' => base64_encode(serialize($profile->getCollectors())),
             'ip' => $profile->getIp(),
             'method' => $profile->getMethod(),
             'url' => $profile->getUrl(),
@@ -220,7 +220,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
         $profile->setMethod($data['method']);
         $profile->setUrl($data['url']);
         $profile->setTime($data['time']);
-        $profile->setCollectors(unserialize($data['data']));
+        $profile->setCollectors(unserialize(base64_decode($data['data'])));
 
         return $profile;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/MongoDbProfilerStorageTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/MongoDbProfilerStorageTest.php
@@ -13,12 +13,37 @@ namespace Symfony\Component\HttpKernel\Tests\Profiler;
 
 use Symfony\Component\HttpKernel\Profiler\MongoDbProfilerStorage;
 use Symfony\Component\HttpKernel\Profiler\Profile;
+use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class DummyMongoDbProfilerStorage extends MongoDbProfilerStorage
 {
     public function getMongo()
     {
         return parent::getMongo();
+    }
+}
+
+class MongoDbProfilerStorageTestDataCollector extends DataCollector
+{
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function collect(Request $request, Response $response, \Exception $exception = null)
+    {
+    }
+    
+    public function getName()
+    {
+        return 'test_data_collector';
     }
 }
 
@@ -62,6 +87,28 @@ class MongoDbProfilerStorageTest extends AbstractProfilerStorageTest
         self::$storage->purge();
     }
 
+    public function testUtf8()
+    {
+        $profile = new Profile('utf8_test_profile');
+
+        $data = 'HЁʃʃϿ, ϢorЃd!';
+        $nonUtf8Data = mb_convert_encoding($data, 'UCS-2');
+
+        $collector = new MongoDbProfilerStorageTestDataCollector();
+        $collector->setData($nonUtf8Data);
+
+        $profile->setCollectors(array($collector));
+
+        self::$storage->write($profile);
+
+        $readProfile = self::$storage->read('utf8_test_profile');
+        $collectors = $readProfile->getCollectors();
+
+        $this->assertCount(1, $collectors);
+        $this->assertArrayHasKey('test_data_collector', $collectors);
+        $this->assertEquals($nonUtf8Data, $collectors['test_data_collector']->getData(), 'Non-UTF8 data is properly encoded/decoded');
+    }
+
     /**
      * @return \Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface
      */
@@ -79,3 +126,4 @@ class MongoDbProfilerStorageTest extends AbstractProfilerStorageTest
         }
     }
 }
+


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

It didn't take long for us to hit a non-utf8 error using the new `MongoDBProfilerStorage`.  I'm pretty sure the culprit was the Switfmailer DataCollector serializing a message with a PDF attachment.

I thought this would be a good failsafe, although one could ask whether mail message attachments should be serialized at all...
