### PR TITLE
Fixed FlashBagInterface phpdoc, clarified upgrade doc

### DIFF
--- a/UPGRADE-2.1.md
+++ b/UPGRADE-2.1.md
@@ -1332,8 +1332,7 @@
 
 ### Session
 
-  * Flash messages now return an array based on their type. The old method is
-    still available but is now deprecated.
+  * Using `get` to retrieve flash messages now returns an array.
 
     ##### Retrieving the flash messages from a Twig template
 

--- a/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBagInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBagInterface.php
@@ -31,18 +31,18 @@ interface FlashBagInterface extends SessionBagInterface
     /**
      * Registers a message for a given type.
      *
-     * @param string $type
-     * @param string $message
+     * @param string       $type
+     * @param string|array $message
      */
     public function set($type, $message);
 
     /**
-     * Gets flash message for a given type.
+     * Gets flash messages for a given type.
      *
      * @param string $type    Message category type.
-     * @param array  $default Default value if $type doee not exist.
+     * @param array  $default Default value if $type does not exist.
      *
-     * @return string
+     * @return array
      */
     public function peek($type, array $default = array());
 
@@ -57,9 +57,9 @@ interface FlashBagInterface extends SessionBagInterface
      * Gets and clears flash from the stack.
      *
      * @param string $type
-     * @param array  $default Default value if $type doee not exist.
+     * @param array  $default Default value if $type does not exist.
      *
-     * @return string
+     * @return array
      */
     public function get($type, array $default = array());
 


### PR DESCRIPTION
The fact that multiple flash messages are now stored/retrieved per type was an additional BC break that I missed when I first went through the 2.1 update doc, and it didn't help that the phpdoc was outdated.

These changes just clarify things a little.
