### PR TITLE
use ->find instead of ->get in the help command to allow command aliases...

### DIFF
--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -70,7 +70,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->command) {
-            $this->command = $this->getApplication()->get($input->getArgument('command_name'));
+            $this->command = $this->getApplication()->find($input->getArgument('command_name'));
         }
 
         if ($input->getOption('xml')) {

--- a/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/HelpCommandTest.php
@@ -22,6 +22,14 @@ class HelpCommandTest extends \PHPUnit_Framework_TestCase
     {
         $command = new HelpCommand();
 
+        $application = new Application();
+        $command->setApplication($application);
+        $commandTester = new CommandTester($command);
+        $commandTester->execute(array('command_name' => 'li'));
+        $this->assertRegExp('/list \[--xml\] \[--raw\] \[namespace\]/', $commandTester->getDisplay(), '->execute() returns a text help for the given command alias');
+
+        $command = new HelpCommand();
+
         $commandTester = new CommandTester($command);
         $command->setCommand(new ListCommand());
         $commandTester->execute(array());


### PR DESCRIPTION
... to be used (e.g. "./app/console help do:sc:ge")
