### PR TITLE
[2.2] add possibility for bundles extensions to prepend the app configs

### DIFF
--- a/src/Symfony/Component/DependencyInjection/CHANGELOG.md
+++ b/src/Symfony/Component/DependencyInjection/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+ * added PrependExtensionInterface (to be able to allow extensions to prepend
+   application configuration settings for any Bundle)
+
 2.1.0
 -----
 

--- a/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/MergeExtensionConfigurationPass.php
@@ -29,6 +29,12 @@ class MergeExtensionConfigurationPass implements CompilerPassInterface
         $definitions = $container->getDefinitions();
         $aliases = $container->getAliases();
 
+        foreach ($container->getExtensions() as $extension) {
+            if ($extension instanceof PrependExtensionInterface) {
+                $extension->prepend($container);
+            }
+        }
+
         foreach ($container->getExtensions() as $name => $extension) {
             if (!$config = $container->getExtensionConfig($name)) {
                 // this extension was not called

--- a/src/Symfony/Component/DependencyInjection/Compiler/PrependExtensionInterface.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/PrependExtensionInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+interface PrependExtensionInterface
+{
+    /**
+     * Allow an extension to prepend the extension configurations.
+     *
+     * @param ContainerBuilder $container
+     */
+    public function prepend(ContainerBuilder $container);
+}

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -466,6 +466,21 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
+     * Prepends a config array to the configs of the given extension.
+     *
+     * @param string $name    The name of the extension
+     * @param array  $config  The config to set
+     */
+    public function prependExtensionConfig($name, array $config)
+    {
+        if (!isset($this->extensionConfigs[$name])) {
+            $this->extensionConfigs[$name] = array();
+        }
+
+        array_unshift($this->extensionConfigs[$name], $config);
+    }
+
+    /**
      * Compiles the container.
      *
      * This method passes the container to compiler

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -548,6 +548,28 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $container->compile();
         $container->setDefinition('a', new Definition());
     }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getExtensionConfig
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::prependExtensionConfig
+     */
+    public function testExtensionConfig()
+    {
+        $container = new ContainerBuilder();
+
+        $configs = $container->getExtensionConfig('foo');
+        $this->assertEmpty($configs);
+
+        $first = array('foo' => 'bar');
+        $container->prependExtensionConfig('foo', $first);
+        $configs = $container->getExtensionConfig('foo');
+        $this->assertEquals(array($first), $configs);
+
+        $second = array('ding' => 'dong');
+        $container->prependExtensionConfig('foo', $second);
+        $configs = $container->getExtensionConfig('foo');
+        $this->assertEquals(array($second, $first), $configs);
+    }
 }
 
 class FooClass {}

--- a/src/Symfony/Component/HttpKernel/.gitignore
+++ b/src/Symfony/Component/HttpKernel/.gitignore
@@ -1,4 +1,5 @@
 vendor/
 composer.lock
 phpunit.xml
-
+Tests/ProjectContainer.php
+Tests/classes.map


### PR DESCRIPTION
Bug fix: #4652
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

As can be seen in the patch the extensions that should prepend the configuration are enabled automatically if they implement `PrependExtensionInterface`.

Just as an example, here an extension, which checks if SonataAdminBundle is available and if not disables integration with it in several Bundles. It also sets some default settings for `document_class` and `default_document_manager_name`:

```
diff --git a/DependencyInjection/SymfonyCmfCoreExtension.php b/DependencyInjection/SymfonyCmfCoreExtension.php
index 9f92410..c0a8dbb 100644
--- a/DependencyInjection/SymfonyCmfCoreExtension.php
+++ b/DependencyInjection/SymfonyCmfCoreExtension.php
@@ -3,11 +3,12 @@
 namespace Symfony\Cmf\Bundle\CoreBundle\DependencyInjection;

 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\\DependencyInjection\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;

-class SymfonyCmfCoreExtension extends Extension
+class SymfonyCmfCoreExtension extends Extension implements PrependExtensionInterface
 {
     public function load(array $configs, ContainerBuilder $container)
     {
@@ -15,4 +16,45 @@ class SymfonyCmfCoreExtension extends Extension
         $loader->load('config.xml');
         $loader->load('services.xml');
     }
+
+    public function prepend(ContainerBuilder $container)
+    {
+        $bundles = $container->getParameter('kernel.bundles');
+        if (!isset($bundles['SonataDoctrinePHPCRAdminBundle'])) {
+            // disable SonataDoctrinePHPCRAdminBundle admin support in Bundles
+            $config = array('use_sonata_admin' => false);
+            foreach ($container->getExtensions() as $name => $extension) {
+                switch ($name) {
+                    case 'symfony_cmf_menu':
+                    case 'symfony_cmf_routing_extra':
+                    case 'symfony_cmf_simple_cms':
+                        $container->prependExtensionConfig($name, $config);
+                        break;
+                }
+            }
+        }
+
+        // process the configuration of SymfonyCmfCoreExtension
+        $configs = $container->getExtensionConfig($this->getAlias());
+        $config = $this->processConfiguration(new Configuration(), $configs);
+        // add the default configs to various Bundles
+        foreach ($container->getExtensions() as $name => $extension) {
+            switch ($name) {
+                case 'symfony_cmf_content':
+                case 'symfony_cmf_simple_cms':
+                    $container->prependExtensionConfig($name, $config);
+                    break;
+                }
+        }
+    }
 }
```
