### PR TITLE
Added missing return codes in commands

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -84,6 +84,8 @@ EOF
 
         if (!$matches) {
             $output->writeln('<fg=red>None of the routes matches</>');
+
+            return 1;
         }
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -26,6 +26,10 @@ use Symfony\Component\Yaml\Yaml;
  */
 class TranslationUpdateCommand extends ContainerAwareCommand
 {
+    const RETURN_CODE_MISSING_OPTIONS = 1;
+
+    const RETURN_CODE_UNSUPPORTED_FORMAT = 2;
+
     /**
      * Compiled catalogue of messages.
      * @var MessageCatalogue
@@ -82,7 +86,7 @@ EOF
         if ($input->getOption('force') !== true && $input->getOption('dump-messages') !== true) {
             $output->writeln('<info>You must choose one of --force or --dump-messages</info>');
 
-            return;
+            return self::RETURN_CODE_MISSING_OPTIONS;
         }
 
         // check format
@@ -92,7 +96,7 @@ EOF
             $output->writeln('<error>Wrong output format</error>');
             $output->writeln('Supported formats are '.implode(', ', $supportedFormats).'.');
 
-            return;
+            return self::RETURN_CODE_UNSUPPORTED_FORMAT;
         }
 
         // get bundle directory

--- a/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
+++ b/src/Symfony/Bundle/SecurityBundle/Command/InitAclCommand.php
@@ -62,7 +62,7 @@ EOF
         } catch (SchemaException $e) {
             $output->writeln("Aborting: " . $e->getMessage());
 
-            return;
+            return 1;
         }
 
         foreach ($schema->toSql($connection->getDatabasePlatform()) as $sql) {

--- a/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
+++ b/src/Symfony/Bundle/TwigBundle/Command/LintCommand.php
@@ -70,7 +70,7 @@ EOF
                 $template .= fread(STDIN, 1024);
             }
 
-            return $twig->parse($twig->tokenize($template));
+            return $this->validateTemplate($twig, $output, $template);
         }
 
         if (0 !== strpos($filename, '@') && !is_readable($filename)) {
@@ -87,26 +87,39 @@ EOF
             $files = Finder::create()->files()->in($dir)->name('*.twig');
         }
 
-        $error = false;
+        $errors = 0;
         foreach ($files as $file) {
-            try {
-                $twig->parse($twig->tokenize(file_get_contents($file), (string) $file));
-                $output->writeln(sprintf("<info>OK</info> in %s", $file));
-            } catch (\Twig_Error $e) {
-                $this->renderException($output, $file, $e);
-                $error = true;
-            }
+            $errors += $this->validateTemplate($twig, $output, file_get_contents($file), $file);
         }
 
-        return $error ? 1 : 0;
+        return $errors > 0 ? 1 : 0;
     }
 
-    protected function renderException(OutputInterface $output, $file, \Twig_Error $exception)
+    protected function validateTemplate(\Twig_Environment $twig, OutputInterface $output, $template, $file = null)
+    {
+        try {
+            $twig->parse($twig->tokenize($template, $file ? (string) $file : null));
+            $output->writeln('<info>OK</info>'.($file ? sprintf(' in %s', $file) : ''));
+        } catch (\Twig_Error $e) {
+            $this->renderException($output, $template, $e, $file);
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    protected function renderException(OutputInterface $output, $template, \Twig_Error $exception, $file = null)
     {
         $line =  $exception->getTemplateLine();
-        $lines = $this->getContext($file, $line);
+        $lines = $this->getContext($template, $line);
 
-        $output->writeln(sprintf("<error>KO</error> in %s (line %s)", $file, $line));
+        if ($file) {
+            $output->writeln(sprintf("<error>KO</error> in %s (line %s)", $file, $line));
+        } else {
+            $output->writeln(sprintf("<error>KO</error> (line %s)", $line));
+        }
+
         foreach ($lines as $no => $code) {
             $output->writeln(sprintf(
                 "%s %-6s %s",
@@ -120,10 +133,9 @@ EOF
         }
     }
 
-    protected function getContext($file, $line, $context = 3)
+    protected function getContext($template, $line, $context = 3)
     {
-        $fileContent = file_get_contents($file);
-        $lines = explode("\n", $fileContent);
+        $lines = explode("\n", $template);
 
         $position = max(0, $line - $context);
         $max = min(count($lines), $line - 1 + $context);


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

[Command::execute](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Console/Command/Command.php#L165) has to return 0 if everything went fine, or an error code
