### PR TITLE
[Process][Tests] Prove process fail

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -76,6 +76,17 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $p->getErrorOutput());
     }
 
+    public function testProcessOutput()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Does it work on windows ?');
+        }
+
+        $process = $this->getProcess("echo -n 1 ; echo -n 1");
+        $process->run();
+        $this->assertEquals('11', $process->getOutput());
+    }
+
     public function testCallbackIsExecutedForOutput()
     {
         $p = $this->getProcess(sprintf('php -r %s', escapeshellarg('echo \'foo\';')));

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -76,15 +76,27 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $p->getErrorOutput());
     }
 
-    public function testProcessOutput()
+    public function chainedCommandsOutputProvider()
+    {
+        return array(
+            array('11', ';', '1'),
+            array('22', '&&', '2'),
+        );
+    }
+
+    /**
+     *
+     * @dataProvider chainedCommandsOutputProvider
+     */
+    public function testChainedCommandsOutput($expected, $operator, $input)
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Does it work on windows ?');
         }
 
-        $process = $this->getProcess("echo -n 1 ; echo -n 1");
+        $process = $this->getProcess(sprintf('echo -n %s %s echo -n %s', $input, $operator, $input));
         $process->run();
-        $this->assertEquals('11', $process->getOutput());
+        $this->assertEquals($expected, $process->getOutput());
     }
 
     public function testCallbackIsExecutedForOutput()


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no
Fixes the following tickets: -
Todo: Fix that
License of the code: MIT

I am not sure this is an issue, but the following code does not work : 

``` php
$process = new Process("echo -n 1 ; echo -n 1");
$process->run();
var_dump('11' == $process->getOutput()); // false, 
var_dump($process->getOutput()) // 1
```

I don't know why.

tests are run on php 5.4.7 and ubuntu 11.04
