### PR TITLE
[RFC] [Form] Add Partial Bind Support

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -41,7 +41,7 @@ class FormType extends AbstractType
             ->setByReference($options['by_reference'])
             ->setVirtual($options['virtual'])
             ->setCompound($options['compound'])
-            ->setPartial($options['partial'])
+            ->setIgnoreMissing($options['ignore_missing'])
             ->setData(isset($options['data']) ? $options['data'] : null)
             ->setDataLocked(isset($options['data']))
             ->setDataMapper($options['compound'] ? new PropertyPathMapper() : null)
@@ -126,7 +126,7 @@ class FormType extends AbstractType
             'attr'                => $options['attr'],
             'label_attr'          => $options['label_attr'],
             'compound'            => $form->getConfig()->getCompound(),
-            'partial'             => $form->getConfig()->getPartial(),
+            'ignore_missing'      => $form->getConfig()->getIgnoreMissing(),
             'block_prefixes'      => $blockPrefixes,
             'unique_block_prefix' => $uniqueBlockPrefix,
             'translation_domain'  => $translationDomain,
@@ -218,7 +218,7 @@ class FormType extends AbstractType
             'label_attr'         => array(),
             'virtual'            => false,
             'compound'           => true,
-            'partial'            => false,
+            'ignore_missing'     => null,
             'translation_domain' => null,
         ));
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -41,6 +41,7 @@ class FormType extends AbstractType
             ->setByReference($options['by_reference'])
             ->setVirtual($options['virtual'])
             ->setCompound($options['compound'])
+            ->setPartial($options['partial'])
             ->setData(isset($options['data']) ? $options['data'] : null)
             ->setDataLocked(isset($options['data']))
             ->setDataMapper($options['compound'] ? new PropertyPathMapper() : null)
@@ -125,6 +126,7 @@ class FormType extends AbstractType
             'attr'                => $options['attr'],
             'label_attr'          => $options['label_attr'],
             'compound'            => $form->getConfig()->getCompound(),
+            'partial'             => $form->getConfig()->getPartial(),
             'block_prefixes'      => $blockPrefixes,
             'unique_block_prefix' => $uniqueBlockPrefix,
             'translation_domain'  => $translationDomain,
@@ -216,6 +218,7 @@ class FormType extends AbstractType
             'label_attr'         => array(),
             'virtual'            => false,
             'compound'           => true,
+            'partial'            => false,
             'translation_domain' => null,
         ));
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -509,6 +509,8 @@ class Form implements \IteratorAggregate, FormInterface
         // and radio buttons with empty values.
         if (is_scalar($submittedData)) {
             $submittedData = (string) $submittedData;
+        } elseif ($this->config->getPartial() && is_null($submittedData)) {
+            $submittedData = $this->getViewData();
         }
 
         // Initialize errors in the very beginning so that we don't lose any

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -518,7 +518,7 @@ class Form implements \IteratorAggregate, FormInterface
         // and radio buttons with empty values.
         if (is_scalar($submittedData)) {
             $submittedData = (string) $submittedData;
-        } elseif ($this->config->getPartial() && is_null($submittedData)) {
+        } elseif ($this->getIgnoreMissing() && null === $submittedData) {
             $submittedData = $this->getViewData();
         }
 

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -180,6 +180,15 @@ class Form implements \IteratorAggregate, FormInterface
         return $this->config->getName();
     }
 
+    public function getIgnoreMissing()
+    {
+        if ($this->parent && null === $this->config->getIgnoreMissing()) {
+            return $this->parent->getIgnoreMissing();
+        }
+
+        return $this->config->getIgnoreMissing();
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -67,6 +67,11 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     private $compound = false;
 
     /**
+     * @var Boolean
+     */
+    private $partial = false;
+
+    /**
      * @var ResolvedFormTypeInterface
      */
     private $type;
@@ -448,6 +453,14 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function getPartial()
+    {
+        return $this->partial;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getType()
     {
         return $this->type;
@@ -783,6 +796,20 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         }
 
         $this->compound = $compound;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPartial($partial)
+    {
+        if ($this->locked) {
+            throw new FormException('The config builder cannot be modified anymore.');
+        }
+
+        $this->partial = $partial;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -69,7 +69,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * @var Boolean
      */
-    private $ignoreMissing = false;
+    private $ignoreMissing = null;
 
     /**
      * @var ResolvedFormTypeInterface
@@ -809,7 +809,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
             throw new FormException('The config builder cannot be modified anymore.');
         }
 
-        $this->ignoreMissing = (Boolean) $ignoreMissing;
+        $this->ignoreMissing = $ignoreMissing;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -69,7 +69,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * @var Boolean
      */
-    private $partial = false;
+    private $ignoreMissing = false;
 
     /**
      * @var ResolvedFormTypeInterface
@@ -453,9 +453,9 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function getPartial()
+    public function getIgnoreMissing()
     {
-        return $this->partial;
+        return $this->ignoreMissing;
     }
 
     /**
@@ -803,13 +803,13 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function setPartial($partial)
+    public function setIgnoreMissing($ignoreMissing)
     {
         if ($this->locked) {
             throw new FormException('The config builder cannot be modified anymore.');
         }
 
-        $this->partial = $partial;
+        $this->ignoreMissing = (Boolean) $ignoreMissing;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -69,7 +69,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * @var Boolean
      */
-    private $ignoreMissing = null;
+    private $ignoreMissing;
 
     /**
      * @var ResolvedFormTypeInterface

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -213,13 +213,13 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     /**
      * Sets whether the form should support partial binding.
      *
-     * @param  Boolean $partial Whether the form should support partial binding.
+     * @param  Boolean $ignoreMissing Whether the form should support partial binding.
      *
      * @return self The configuration object.
      *
      * @see FormConfigInterface::getPartial()
      */
-    public function setPartial($partial);
+    public function setIgnoreMissing($ignoreMissing);
 
     /**
      * Set the types.

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -211,6 +211,17 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setCompound($compound);
 
     /**
+     * Sets whether the form should support partial binding.
+     *
+     * @param  Boolean $partial Whether the form should support partial binding.
+     *
+     * @return self The configuration object.
+     *
+     * @see FormConfigInterface::getPartial()
+     */
+    public function setPartial($partial);
+
+    /**
      * Set the types.
      *
      * @param ResolvedFormTypeInterface $type The type of the form.

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -77,6 +77,16 @@ interface FormConfigInterface
     public function getCompound();
 
     /**
+     * Returns whether the form explicitly supports missing children
+     *
+     * When enabled, missing child data uses pre-existing model data
+     * rather than defaulting to `null`.
+     *
+     * @return null|Boolean Whether the form explicitly supports missing children
+     */
+    public function getIgnoreMissing();
+
+    /**
      * Returns the form types used to construct the form.
      *
      * @return ResolvedFormTypeInterface The form's type.

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -89,6 +89,30 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertTrue($form->isBound());
     }
 
+    public function testPartialBindUsesViewDataIfNull()
+    {
+        $form = $this->getBuilder('name', new EventDispatcher())
+            ->setPartial(true)
+            ->addViewTransformer(new FixedDataTransformer(array(
+                ''      => '',
+                'norm'  => 'client',
+            )))
+            ->addModelTransformer(new FixedDataTransformer(array(
+                ''      => '',
+                'app'   => 'norm',
+            )))
+            ->getForm()
+        ;
+
+        $form->setData('app');
+
+        $form->bind(null);
+
+        $this->assertEquals('app',      $form->getData());
+        $this->assertEquals('norm',     $form->getNormData());
+        $this->assertEquals('client',   $form->getClientData());
+    }
+
     public function testNeverRequiredIfParentNotRequired()
     {
         $parent = $this->getBuilder()->setRequired(false)->getForm();

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -89,10 +89,10 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertTrue($form->isBound());
     }
 
-    public function testPartialBindUsesViewDataIfNull()
+    public function testBindUsesViewDataIfNullAndIgnoreMissing()
     {
         $form = $this->getBuilder('name', new EventDispatcher())
-            ->setPartial(true)
+            ->setIgnoreMissing(true)
             ->addViewTransformer(new FixedDataTransformer(array(
                 ''      => '',
                 'norm'  => 'client',

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -113,6 +113,39 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertEquals('client',   $form->getClientData());
     }
 
+    public function testIgnoreMissingUsesParentSettingByDefault()
+    {
+        $parent = $this->getBuilder()->setIgnoreMissing(true)->getForm();
+        $child = $this->getBuilder()->getForm();
+
+        $child->setParent($parent);
+
+        $this->assertTrue($child->getIgnoreMissing());
+    }
+
+    public function testIgnoreMissingDefaultsToNull()
+    {
+        $form = $this->getBuilder()->getForm();
+        $this->assertNull($form->getIgnoreMissing());
+    }
+
+    public function testIgnoreMissingUsesSetValue()
+    {
+        $parent = $this->getBuilder()->setIgnoreMissing(false)->getForm();
+        $child  = $this->getBuilder()->setIgnoreMissing(true)->getForm();
+
+        $child->setParent($parent);
+
+        $this->assertTrue($child->getIgnoreMissing());
+
+        $parent = $this->getBuilder()->setIgnoreMissing(true)->getForm();
+        $child  = $this->getBuilder()->setIgnoreMissing(false)->getForm();
+
+        $child->setParent($parent);
+
+        $this->assertFalse($child->getIgnoreMissing());
+    }
+
     public function testNeverRequiredIfParentNotRequired()
     {
         $parent = $this->getBuilder()->setRequired(false)->getForm();


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #1341
Todo: [list of todos pending]
License of the code: MIT
Documentation PR: Not yet

After much discussion in #1341, I've added the ability for `FormType` to support binding partial data via `ignore_missing` when client data is not set:
1. When `false`, the current behavior of binding `null` onto the form takes place
2. When `true`, the original model data (which is transformed into view data) is bound to the form (as if the user chose the existing value)
3. When `null` (or not explicitly set), the parent form's `ignore_missing` value is used, and then follows option 1 or 2.

I'm still considering a way to turn on `ignore_missing` when calling `$form->bind($request)` (and the request is `PATCH`), but this can be done when creating the form:

``` php
$builder->create('form', null, array('ignore_missing' => 'PATCH' === $request->getMethod());
```
