### PR TITLE
[Form] removed assertion that clashes with use of EntityChoiceList

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -391,16 +391,6 @@ class Form implements \IteratorAggregate, FormInterface
                     'that transforms ' . $actualType . ' to ' . $expectedType . '.'
                 );
             }
-
-            if (null !== $dataClass && !$viewData instanceof $dataClass) {
-                throw new FormException(
-                    'The form\'s view data is expected to be an instance of class ' .
-                    $dataClass . ', but is '. $actualType . '. You can avoid this error ' .
-                    'by setting the "data_class" option to null or by adding a view ' .
-                    'transformer that transforms ' . $actualType . ' to an instance of ' .
-                    $dataClass . '.'
-                );
-            }
         }
 
         $this->modelData = $modelData;


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Before the removed assertion, `$viewData` is assigned to `normToView($normData);` that can go through ChoiceToValueTransformer. This transformer returns a string no matter what, not an instance of the entity, so the assertion fails and the exception is thrown.

https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php#L38

This Type makes this assertion crash:

``` php
<?php

namespace Acme\DemoBundle\Form\Type;

use Symfony\Component\Form\AbstractType;
use Symfony\Component\Form\FormBuilderInterface;
use Symfony\Component\Form\FormEvents;
use Symfony\Component\Form\Event\DataEvent;
use Acme\DemoBundle\Entity\Product;

class ProductType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $factory = $builder->getFormFactory();
        $refreshCountry = function($form, $preset = null) use ($factory) {
            $form->add($factory->createNamed('country', 'entity', null, array(
                'class' => 'Acme\DemoBundle\Entity\Country',
                'data' => $preset,
            )));
        };
        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (DataEvent $event) use ($refreshCountry) {
            $form = $event->getForm();
            $data = $event->getData();
            if($data instanceof Product) {
                $refreshCountry($form, $data->getCountry());
            }
        });
    }

    public function getName()
    {
        return 'product';
    }

}
```

This code is only to reproduce the problem, it is useless as it is. An actual use case would be a chained selector city -> zone -> country
