### PR TITLE
[HttpFoundation] fixed wrong return type

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -229,8 +229,12 @@ class HeaderBag implements \IteratorAggregate, \Countable
      */
     public function getDate($key, \DateTime $default = null)
     {
-        if (null === $value = $this->get($key)) {
+        if (!$this->has($key) && $default instanceof \DateTime) {
             return $default;
+        }
+
+        if (null === $value = $this->get($key, $default)) {
+            return new \DateTime();
         }
 
         if (false === $date = \DateTime::createFromFormat(DATE_RFC2822, $value)) {

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -43,11 +43,27 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("foo", $keys[0]);
     }
 
-    public function testGetDate()
+    /**
+     * @dataProvider getHeaders
+     * @param $headers
+     */
+    public function testGetDate($headers)
     {
-        $bag = new HeaderBag(array('foo' => 'Tue, 4 Sep 2012 20:00:00 +0200'));
+        $bag = new HeaderBag($headers);
         $headerDate = $bag->getDate('foo');
         $this->assertInstanceOf('DateTime', $headerDate);
+    }
+
+    public function getHeaders()
+    {
+        return array(
+            array(
+                array()
+            ),
+            array(
+                array('foo' => 'Tue, 4 Sep 2012 20:00:00 +0200')
+            ),
+        );
     }
 
     /**


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: the one I added passes
License of the code: MIT

HeaderBag::getDate must return a DateTime. However if there is no 'Date'
in the headers it will return null, resulting in a bug in the
Response::getAge method.
