### PR TITLE
[2.1][Config] Fixed preserving keys in associative arrays

### DIFF
--- a/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
+++ b/src/Symfony/Component/Config/Definition/PrototypedArrayNode.php
@@ -242,11 +242,11 @@ class PrototypedArrayNode extends ArrayNode
 
         $value = $this->remapXml($value);
 
-        $isAssoc = array_keys($value) === range(0, count($value) -1);
+        $isAssoc = array_keys($value) !== range(0, count($value) -1);
         $normalized = array();
         foreach ($value as $k => $v) {
             if (null !== $this->keyAttribute && is_array($v)) {
-                if (!isset($v[$this->keyAttribute]) && is_int($k) && $isAssoc) {
+                if (!isset($v[$this->keyAttribute]) && is_int($k) && !$isAssoc) {
                     $msg = sprintf('The attribute "%s" must be set for path "%s".', $this->keyAttribute, $this->getPath());
                     $ex = new InvalidConfigurationException($msg);
                     $ex->setPath($this->getPath());
@@ -276,7 +276,7 @@ class PrototypedArrayNode extends ArrayNode
             }
 
             $this->prototype->setName($k);
-            if (null !== $this->keyAttribute) {
+            if (null !== $this->keyAttribute || $isAssoc) {
                 $normalized[$k] = $this->prototype->normalize($v);
             } else {
                 $normalized[] = $this->prototype->normalize($v);

--- a/src/Symfony/Component/Config/Tests/Definition/NormalizationTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/NormalizationTest.php
@@ -183,6 +183,25 @@ class NormalizerTest extends \PHPUnit_Framework_TestCase
         $this->assertNormalized($this->getNumericKeysTestTree(), $denormalized, array());
     }
 
+    public function testAssociativeArrayPreserveKeys()
+    {
+        $tb = new TreeBuilder();
+        $tree = $tb
+            ->root('root', 'array')
+                ->prototype('array')
+                    ->children()
+                        ->node('foo', 'scalar')->end()
+                    ->end()
+                ->end()
+            ->end()
+            ->buildTree()
+        ;
+
+        $data = array('first' => array('foo' => 'bar'));
+
+        $this->assertNormalized($tree, $data, $data);
+    }
+
     public static function assertNormalized(NodeInterface $tree, $denormalized, $normalized)
     {
         self::assertSame($normalized, $tree->normalize($denormalized));


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
