### PR TITLE
[Process][Tests] Prove process fail with chained commands

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -229,8 +229,6 @@ class Process
                 $descriptors = array_merge($descriptors, array(array('pipe', 'w')));
 
                 $this->commandline = '('.$this->commandline.') 3>/dev/null; code=$?; echo $code >&3; exit $code';
-            } else {
-                $this->commandline = 'exec ' . $this->commandline;
             }
         }
 

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -76,6 +76,17 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $p->getErrorOutput());
     }
 
+    public function testProcessOutput()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Does it work on windows ?');
+        }
+
+        $process = $this->getProcess("echo -n 1 ; echo -n 1");
+        $process->run();
+        $this->assertEquals('11', $process->getOutput());
+    }
+
     public function testCallbackIsExecutedForOutput()
     {
         $p = $this->getProcess(sprintf('php -r %s', escapeshellarg('echo \'foo\';')));

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -76,15 +76,27 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $p->getErrorOutput());
     }
 
-    public function testProcessOutput()
+    public function chainedCommandsOutputProvider()
+    {
+        return array(
+            array('11', ';', '1'),
+            array('22', '&&', '2'),
+        );
+    }
+
+    /**
+     *
+     * @dataProvider chainedCommandsOutputProvider
+     */
+    public function testChainedCommandsOutput($expected, $operator, $input)
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             $this->markTestSkipped('Does it work on windows ?');
         }
 
-        $process = $this->getProcess("echo -n 1 ; echo -n 1");
+        $process = $this->getProcess(sprintf('echo -n %s %s echo -n %s', $input, $operator, $input));
         $process->run();
-        $this->assertEquals('11', $process->getOutput());
+        $this->assertEquals($expected, $process->getOutput());
     }
 
     public function testCallbackIsExecutedForOutput()


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no
Fixes the following tickets: -
Todo: Fix that
License of the code: MIT

This PR is against 2.1 branch. Previous PR was #5575

This PR try to hiligh a regression in Process component.

``` php
$process = new Process("echo -n 1 && echo -n 1");
// or $process = new Process("echo -n 1 ; echo -n 1");
$process->run();
var_dump('11' == $process->getOutput()); // false, 
var_dump($process->getOutput()); // '1', 
```

This test failed because of PR #5543 ; see https://github.com/symfony/symfony/commit/7bafc69f38a3512eb15aad506959a4e7be162e52#L0R233
