### PR TITLE
fixed issue #5596 (Broken DOM with the profiler's toolbar set in position top)

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/EventListener/WebDebugToolbarListener.php
@@ -99,28 +99,22 @@ class WebDebugToolbarListener implements EventSubscriberInterface
     {
         if (function_exists('mb_stripos')) {
             $posrFunction   = 'mb_strripos';
-            $posFunction    = 'mb_stripos';
             $substrFunction = 'mb_substr';
         } else {
             $posrFunction   = 'strripos';
-            $posFunction    = 'stripos';
             $substrFunction = 'substr';
         }
 
         $content = $response->getContent();
+        $pos = $posrFunction($content, '</body>');
 
-        if ($this->position === 'bottom') {
-            $pos = $posrFunction($content, '</body>');
-        } else {
-            $pos = $posFunction($content, '<body');
-            if (false !== $pos) {
-                $pos = $posFunction($content, '>', $pos) + 1;
-            }
-        }
         if (false !== $pos) {
             $toolbar = "\n".str_replace("\n", '', $this->templating->render(
                 'WebProfilerBundle:Profiler:toolbar_js.html.twig',
-                array('token' => $response->headers->get('X-Debug-Token'))
+                array(
+                    'position' => $this->position,
+                    'token' => $response->headers->get('X-Debug-Token')
+                ))
             ))."\n";
             $content = $substrFunction($content, 0, $pos).$toolbar.$substrFunction($content, $pos);
             $response->setContent($content);

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar_js.html.twig
@@ -2,6 +2,14 @@
 {% include 'WebProfilerBundle:Profiler:base_js.html.twig' %}
 <script type="text/javascript">/*<![CDATA[*/
     (function () {
+        {% if 'top' == position %}
+            var sfwdt = document.getElementById('sfwdt{{ token }}');
+            document.body.insertBefore(
+                document.body.removeChild(sfwdt),
+                document.body.firstChild
+            );
+        {% endif %}
+
         Sfjs.load(
             'sfwdt{{ token }}',
             '{{ path("_wdt", { "token": token }) }}',


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5596
Todo: -
License of the code: MIT
Documentation PR: -

Whatever the toolbar position, the html code associated to it may be placed at the end of the page (and this will be better from a webperf point of view).
