### PR TITLE
[HttpFoundation] UploadedFile: Added ability to the original extension of the file uploaded

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -119,6 +119,23 @@ class UploadedFile extends File
     }
 
     /**
+     * Returns the original file extension
+     *
+     * It is extracted from the original file name that was uploaded.
+     * Then is should not be considered as a safe value.
+     *
+     * \SplFileInfo::getExtension() is not available before PHP 5.3.6
+     *
+     * @return string The extension
+     *
+     * @api
+     */
+    public function getClientOriginalExtension()
+    {
+        return pathinfo($this->originalName,PATHINFO_EXTENSION);
+    }
+
+    /**
      * Returns the file mime type.
      *
      * It is extracted from the request from which the file has been uploaded.

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -124,15 +124,11 @@ class UploadedFile extends File
      * It is extracted from the original file name that was uploaded.
      * Then is should not be considered as a safe value.
      *
-     * \SplFileInfo::getExtension() is not available before PHP 5.3.6
-     *
      * @return string The extension
-     *
-     * @api
      */
     public function getClientOriginalExtension()
     {
-        return pathinfo($this->originalName,PATHINFO_EXTENSION);
+        return pathinfo($this->originalName, PATHINFO_EXTENSION);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -89,6 +89,20 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('original.gif', $file->getClientOriginalName());
     }
 
+    public function testGetClientOriginalExtension()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null
+        );
+
+        $this->assertEquals('gif', $file->getClientOriginalExtension());
+    }
+
+
     /**
      * @expectedException Symfony\Component\HttpFoundation\File\Exception\FileException
      */


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
Fixes the following tickets: #5599
Todo: -

`$file->getExtension()` on uploaded files always will return blank as the temp file names do not have an extension. This adds `$file->getClientOriginalExtension()` which returns the extension based off the original file name. It also includes a test to check this function.
