### PR TITLE
Optimize autoload prefix in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Symfony": "src/",
+            "Symfony\\": "src/",
             "SessionHandlerInterface": "src/Symfony/Component/HttpFoundation/Resources/stubs"
         }
     },

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -27,7 +27,7 @@
         "doctrine/orm": ">=2.2.3,<2.4-dev"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Doctrine": "" }
+        "psr-0": { "Symfony\\Bridge\\Doctrine\\": "" }
     },
     "target-dir": "Symfony/Bridge/Doctrine",
     "minimum-stability": "dev",

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -21,7 +21,7 @@
         "monolog/monolog": "1.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Monolog": "" }
+        "psr-0": { "Symfony\\Bridge\\Monolog\\": "" }
     },
     "target-dir": "Symfony/Bridge/Monolog",
     "minimum-stability": "dev",

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -23,7 +23,7 @@
         "propel/propel1": "1.6.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Propel1": "" }
+        "psr-0": { "Symfony\\Bridge\\Propel1\\": "" }
     },
     "target-dir": "Symfony/Bridge/Propel1",
     "minimum-stability": "dev",

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -23,7 +23,7 @@
         "symfony/http-kernel": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Swiftmailer": "" }
+        "psr-0": { "Symfony\\Bridge\\Swiftmailer\\": "" }
     },
     "target-dir": "Symfony/Bridge/Swiftmailer",
     "minimum-stability": "dev",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -36,7 +36,7 @@
         "symfony/security": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bridge\\Twig": "" }
+        "psr-0": { "Symfony\\Bridge\\Twig\\": "" }
     },
     "target-dir": "Symfony/Bridge/Twig",
     "minimum-stability": "dev",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -37,7 +37,7 @@
         "symfony/validator": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\FrameworkBundle": "" }
+        "psr-0": { "Symfony\\Bundle\\FrameworkBundle\\": "" }
     },
     "target-dir": "Symfony/Bundle/FrameworkBundle",
     "minimum-stability": "dev",

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/security": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\SecurityBundle": "" }
+        "psr-0": { "Symfony\\Bundle\\SecurityBundle\\": "" }
     },
     "target-dir": "Symfony/Bundle/SecurityBundle",
     "minimum-stability": "dev",

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/twig-bridge": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\TwigBundle": "" }
+        "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }
     },
     "target-dir": "Symfony/Bundle/TwigBundle",
     "minimum-stability": "dev",

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/twig-bundle": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Bundle\\WebProfilerBundle": "" }
+        "psr-0": { "Symfony\\Bundle\\WebProfilerBundle\\": "" }
     },
     "target-dir": "Symfony/Bundle/WebProfilerBundle",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -27,7 +27,7 @@
         "symfony/process": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\BrowserKit": "" }
+        "psr-0": { "Symfony\\Component\\BrowserKit\\": "" }
     },
     "target-dir": "Symfony/Component/BrowserKit",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -23,7 +23,7 @@
         "symfony/finder": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\ClassLoader": "" }
+        "psr-0": { "Symfony\\Component\\ClassLoader\\": "" }
     },
     "target-dir": "Symfony/Component/ClassLoader",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Config": "" }
+        "psr-0": { "Symfony\\Component\\Config\\": "" }
     },
     "target-dir": "Symfony/Component/Config",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Console": "" }
+        "psr-0": { "Symfony\\Component\\Console\\": "" }
     },
     "target-dir": "Symfony/Component/Console",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\CssSelector": "" }
+        "psr-0": { "Symfony\\Component\\CssSelector\\": "" }
     },
     "target-dir": "Symfony/Component/CssSelector",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -27,7 +27,7 @@
         "symfony/config": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\DependencyInjection": "" }
+        "psr-0": { "Symfony\\Component\\DependencyInjection\\": "" }
     },
     "target-dir": "Symfony/Component/DependencyInjection",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -25,7 +25,7 @@
         "symfony/css-selector": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\DomCrawler": "" }
+        "psr-0": { "Symfony\\Component\\DomCrawler\\": "" }
     },
     "target-dir": "Symfony/Component/DomCrawler",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -26,7 +26,7 @@
         "symfony/http-kernel": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\EventDispatcher": "" }
+        "psr-0": { "Symfony\\Component\\EventDispatcher\\": "" }
     },
     "target-dir": "Symfony/Component/EventDispatcher",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Filesystem": "" }
+        "psr-0": { "Symfony\\Component\\Filesystem\\": "" }
     },
     "target-dir": "Symfony/Component/Filesystem",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Finder": "" }
+        "psr-0": { "Symfony\\Component\\Finder\\": "" }
     },
     "target-dir": "Symfony/Component/Finder",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -30,7 +30,7 @@
         "symfony/http-foundation": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Form": "" }
+        "psr-0": { "Symfony\\Component\\Form\\": "" }
     },
     "target-dir": "Symfony/Component/Form",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-0": {
-            "Symfony\\Component\\HttpFoundation": "",
+            "Symfony\\Component\\HttpFoundation\\": "",
             "SessionHandlerInterface": "Symfony/Component/HttpFoundation/Resources/stubs"
         }
     },

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -39,7 +39,7 @@
         "symfony/finder": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\HttpKernel": "" }
+        "psr-0": { "Symfony\\Component\\HttpKernel\\": "" }
     },
     "target-dir": "Symfony/Component/HttpKernel",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -22,7 +22,7 @@
         "ext-intl": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Locale": "" }
+        "psr-0": { "Symfony\\Component\\Locale\\": "" }
     },
     "target-dir": "Symfony/Component/Locale",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/OptionsResolver/composer.json
+++ b/src/Symfony/Component/OptionsResolver/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\OptionsResolver": "" }
+        "psr-0": { "Symfony\\Component\\OptionsResolver\\": "" }
     },
     "target-dir": "Symfony/Component/OptionsResolver",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Process": "" }
+        "psr-0": { "Symfony\\Component\\Process\\": "" }
     },
     "target-dir": "Symfony/Component/Process",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -30,7 +30,7 @@
         "doctrine/common": ">=2.2,<2.4-dev"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Routing": "" }
+        "psr-0": { "Symfony\\Component\\Routing\\": "" }
     },
     "target-dir": "Symfony/Component/Routing",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -37,7 +37,7 @@
         "doctrine/dbal": "to use the built-in ACL implementation"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Security": "" }
+        "psr-0": { "Symfony\\Component\\Security\\": "" }
     },
     "target-dir": "Symfony/Component/Security",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Serializer": "" }
+        "psr-0": { "Symfony\\Component\\Serializer\\": "" }
     },
     "target-dir": "Symfony/Component/Serializer",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Templating": "" }
+        "psr-0": { "Symfony\\Component\\Templating\\": "" }
     },
     "target-dir": "Symfony/Component/Templating",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Translation": "" }
+        "psr-0": { "Symfony\\Component\\Translation\\": "" }
     },
     "target-dir": "Symfony/Component/Translation",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -29,7 +29,7 @@
         "symfony/yaml": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Validator": "" }
+        "psr-0": { "Symfony\\Component\\Validator\\": "" }
     },
     "target-dir": "Symfony/Component/Validator",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Yaml": "" }
+        "psr-0": { "Symfony\\Component\\Yaml\\": "" }
     },
     "target-dir": "Symfony/Component/Yaml",
     "minimum-stability": "dev",


### PR DESCRIPTION
By having more specific autoload prefixes it is possible to reduce the
number of stat calls made. Also it prevents conflicts with similar
namespaces.

See ref: https://github.com/zendframework/zf2/commit/e58c6cdbf50dd06b71e76a413fb870c95ab22bf5

SessionHandlerInterface is left intentionally.
