### PR TITLE
[FrameworkBundle] Make secret not be required

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -62,7 +62,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->scalarNode('trust_proxy_headers')->defaultFalse()->end()
-                ->scalarNode('secret')->isRequired()->end()
+                ->scalarNode('secret')->end()
                 ->scalarNode('ide')->defaultNull()->end()
                 ->booleanNode('test')->end()
                 ->scalarNode('default_locale')->defaultValue('en')->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -59,7 +59,9 @@ class FrameworkExtension extends Extension
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);
 
-        $container->setParameter('kernel.secret', $config['secret']);
+        if (isset($config['secret'])) {
+            $container->setParameter('kernel.secret', $config['secret']);
+        }
 
         $container->setParameter('kernel.trust_proxy_headers', $config['trust_proxy_headers']);
 
@@ -155,6 +157,9 @@ class FrameworkExtension extends Extension
         if (isset($config['csrf_protection'])) {
             if (!isset($config['session'])) {
                 throw new \LogicException('CSRF protection needs that sessions are enabled.');
+            }
+            if (!isset($config['secret'])) {
+                throw new \LogicException('CSRF protection needs a secret to be set.');
             }
             $loader->load('form_csrf.xml');
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no (questionable)
Symfony2 tests pass: yes
License of the code: MIT
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Framework bundle currently requires that the `secret` key under `framework` be set. The end result is that `kernel.secret` is made available. This is, as far as I can tell, the only required configuration for Framework bundle.

The only thing that currently uses `kernel.secret` is the Form component and then only if CSRF protection is enabled.

In the spirit of making Framework more decoupled and not requiring things in the case you don't need them I would like to make framework secret optional.

I followed the pattern used by CSRF support for when Session is disabled to throw a `LogicException` stating that if CSRF support is enabled then the secret should be set.

For anyone who currently depends on `kernel.secret`, if someone ends up _not_ defining `kernel.secret` there will be a dependency error on kernel configuration as `kernel.secret` will not be made available. The biggest downside to this that I could see is that the error message may be slightly confusing; it will complain that there is a dependency on `kernel.secret` when that is generally set by way of adding the Framework secret to the configuration.

As this relates to Symfony Standard Edition, there should be no changes as there is a default secret set there already anyway.
