### PR TITLE
[DoctrineBridge] Require class option for DoctrineType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -135,7 +135,6 @@ abstract class DoctrineType extends AbstractType
 
         $resolver->setDefaults(array(
             'em'                => null,
-            'class'             => null,
             'property'          => null,
             'query_builder'     => null,
             'loader'            => $loader,
@@ -143,6 +142,8 @@ abstract class DoctrineType extends AbstractType
             'choice_list'       => $choiceList,
             'group_by'          => null,
         ));
+
+        $resolver->setRequired(array('class'));
 
         $resolver->setNormalizers(array(
             'em' => $emNormalizer,

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -110,6 +110,14 @@ class EntityTypeTest extends TypeTestCase
         // be managed!
     }
 
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\MissingOptionsException
+     */
+    public function testClassOptionIsRequired()
+    {
+        $this->factory->createNamed('name', 'entity');
+    }
+
     public function testSetDataToUninitializedEntityWithNonRequired()
     {
         $entity1 = new SingleIdentEntity(1, 'Foo');


### PR DESCRIPTION
This is a resubmission of #5289 against the 2.1 branch.

```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
```
