### PR TITLE
[2.0][http-foundation] Fix Response::getDate method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -226,7 +226,9 @@ class HeaderBag
      * @param string    $key     The parameter key
      * @param \DateTime $default The default value
      *
-     * @return \DateTime The filtered value
+     * @return null|\DateTime The filtered value
+     *
+     * @throws \RuntimeException When the HTTP header is not parseable
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -430,7 +430,7 @@ class Response
      */
     public function getDate()
     {
-        return $this->headers->getDate('Date');
+        return $this->headers->getDate('Date', new \DateTime());
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/ResponseTest.php
@@ -40,6 +40,10 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $now = $this->createDateTimeNow();
         $response->headers->set('Date', $now->format(DATE_RFC2822));
         $this->assertEquals(0, $now->diff($response->getDate())->format('%s'), '->getDate() returns the date when the header has been modified');
+
+        $response = new Response('', 200);
+        $response->headers->remove('Date');
+        $this->assertInstanceOf('\DateTime', $response->getDate());
     }
 
     public function testGetMaxAge()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Reference #5588, #5629
