### PR TITLE
fixed some classmap paths

### DIFF
--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -20,7 +20,7 @@
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\HttpFoundation\\": "" },
-        "classmap": [ "Resources/stubs" ]
+        "classmap": [ "Symfony/Component/HttpFoundation/Resources/stubs" ]
     },
     "target-dir": "Symfony/Component/HttpFoundation",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -23,7 +23,7 @@
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Locale\\": "" },
-        "classmap": [ "Resources/stubs" ]
+        "classmap": [ "Symfony/Component/Locale/Resources/stubs" ]
     },
     "target-dir": "Symfony/Component/Locale",
     "minimum-stability": "dev",


### PR DESCRIPTION
Since #5213, an error occurs when requiring the locale or http-foundation package with composer, because it doesn't automatically prepend the target-dir to the classmaps.

Cf. here for example : https://travis-ci.org/#!/doctrine/DoctrineMongoDBBundle/jobs/2608238

cc @jalliot
