### PR TITLE
[2.2][Console] Add possibility to add new input options to console application

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -220,7 +220,7 @@ class Application
     {
         return $this->helperSet;
     }
-    
+
     /**
      * Set an input definition set to be used with this application
      *

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -220,6 +220,18 @@ class Application
     {
         return $this->helperSet;
     }
+    
+    /**
+     * Set an input definition set to be used with this application
+     *
+     * @param InputDefinition $definition The input definition
+     *
+     * @api
+     */
+    public function setDefinition(InputDefinition $definition)
+    {
+        $this->definition = $definition;
+    }
 
     /**
      * Gets the InputDefinition related to this Application.

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -597,6 +597,30 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($inputDefinition->hasOption('custom'));
     }
+           
+    public function testSettingCustomInputDefinitionOverwritesDefaultValues()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        
+        $application->setDefinition(new InputDefinition(array(new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Set the custom input definition.'))));
+        
+        $inputDefinition = $application->getDefinition();
+
+        // check wether the default arguments and options are not returned any more
+        $this->assertFalse($inputDefinition->hasArgument('command'));
+
+        $this->assertFalse($inputDefinition->hasOption('help'));
+        $this->assertFalse($inputDefinition->hasOption('quiet'));
+        $this->assertFalse($inputDefinition->hasOption('verbose'));
+        $this->assertFalse($inputDefinition->hasOption('version'));
+        $this->assertFalse($inputDefinition->hasOption('ansi'));
+        $this->assertFalse($inputDefinition->hasOption('no-ansi'));
+        $this->assertFalse($inputDefinition->hasOption('no-interaction'));
+
+        $this->assertTrue($inputDefinition->hasOption('custom'));
+    }
 }
 
 class CustomApplication extends Application


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

At the moment it is not possible to overwrite the input arguments of a console application to not have the default ones. Adding is possible with: 

$cli->getDefinition()->addOption(new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Use custom option.'));

Also added some simple tests for adding a custom HelperSet.
