### PR TITLE
[2.1] Fix SessionHandlerInterface autoloading

### DIFF
--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -21,7 +21,7 @@
     "autoload": {
         "psr-0": {
             "Symfony\\Component\\HttpFoundation": "",
-            "SessionHandlerInterface": "Resources/stubs"
+            "SessionHandlerInterface": "Symfony/Component/HttpFoundation/Resources/stubs"
         }
     },
     "target-dir": "Symfony/Component/HttpFoundation",


### PR DESCRIPTION
The path for 2.1 is also incorrect. For master, this was fixed in 3b47088c582f8ac9f969967380a8c5d8e97b47b8. This patch adds the `target-dir` prefix to the autoloading base directory of the HttpFoundation stubs.

Note: Issue only affects 2.1, but it probably means `symfony/http-foundation` never worked on PHP 5.3.
