### PR TITLE
[Console] easy run command within command

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Tester\CommandTester;
@@ -31,6 +32,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
         require_once self::$fixturesPath.'/TestCommand.php';
+        require_once self::$fixturesPath.'/FooCommand.php';
     }
 
     public function testConstructor()
@@ -256,5 +258,21 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $tester = new CommandTester($command);
         $tester->execute(array('command' => $command->getName()));
         $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/command_asxml.txt', $command->asXml(), '->asXml() returns an XML representation of the command');
+    }
+
+    public function testRunAutoCommandNameOnInput()
+    {
+        $command = new \TestCommand();
+        $otherCommand = new \FooCommand();
+        $application = new Application();
+        $application->add($command);
+        $application->add($otherCommand);
+
+        $args = array($command->getName(), new ArrayInput(array()), new NullOutput());
+        $method = new \ReflectionMethod($otherCommand, 'runCommand');
+        $method->setAccessible(true);
+        $result = $method->invokeArgs($otherCommand, $args);
+
+        $this->assertSame(0, $result);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -32,7 +32,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     {
         self::$fixturesPath = __DIR__.'/../Fixtures/';
         require_once self::$fixturesPath.'/TestCommand.php';
-        require_once self::$fixturesPath.'/FooCommand.php';
+        require_once self::$fixturesPath.'/OtherCommand.php';
     }
 
     public function testConstructor()
@@ -263,7 +263,7 @@ class CommandTest extends \PHPUnit_Framework_TestCase
     public function testRunAutoCommandNameOnInput()
     {
         $command = new \TestCommand();
-        $otherCommand = new \FooCommand();
+        $otherCommand = new \OtherCommand();
         $application = new Application();
         $application->add($command);
         $application->add($otherCommand);

--- a/src/Symfony/Component/Console/Tests/Fixtures/OtherCommand.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/OtherCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class OtherCommand extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('namespace:other')
+            ->setAliases(array('other'))
+            ->setDescription('other description')
+            ->setHelp('help')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('execute called');
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $output->writeln('interact called');
+    }
+}


### PR DESCRIPTION
symfonylive hackingday PR for the console component

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: no
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: pending

@jmather helped me with the initial refactoring and workaround

We had to avoid the initial way of doing things because definition can only be modified at construction time

``` php
// automatically adds command key if not passed in the input
if (!$input->hasArgument('command')) {
    $input->setArgument('command', $this->getName());
}
```

so this approach was not suitable

but something had to be done to avoid:

``` php
$command = $this->getApplication()->find('doctrine:phpcr:fixtures:load');

$arguments = array(
    'command' => 'doctrine:phpcr:fixtures:load'
);

$input = new ArrayInput($arguments);

$returnCode = $command->run($input, $output);

return $returnCode;
```

to turn it into:

``` php
return $this->runCommand('doctrine:phpcr:fixtures', $input, $output);
```
