### PR TITLE
[Finder] [FrameworkBundle] Added Finder Factory

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -11,6 +11,7 @@
         <parameter key="cache_warmer.class">Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate</parameter>
         <parameter key="cache_clearer.class">Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer</parameter>
         <parameter key="file_locator.class">Symfony\Component\HttpKernel\Config\FileLocator</parameter>
+        <parameter key="finder_factory.class">Symfony\Component\Finder\FinderFactory</parameter>
     </parameters>
 
     <services>
@@ -51,5 +52,7 @@
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%/Resources</argument>
         </service>
+
+        <service id="finder_factory" class="%finder_factory.class%" />
     </services>
 </container>

--- a/src/Symfony/Component/Finder/FinderFactory.php
+++ b/src/Symfony/Component/Finder/FinderFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder;
+
+/**
+ * A simple implementation of FinderFactoryInterface.
+ *
+ * @author Beau Simensen <beau@dflydev.com>
+ */
+class FinderFactory implements FinderFactoryInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function createFinder()
+    {
+        return new Finder;
+    }
+}

--- a/src/Symfony/Component/Finder/FinderFactoryInterface.php
+++ b/src/Symfony/Component/Finder/FinderFactoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder;
+
+/**
+ * Interface for creating new instances of Finder
+ *
+ * @author Beau Simensen <beau@dflydev.com>
+ */
+interface FinderFactoryInterface
+{
+    /**
+     * Create Finder instance
+     *
+     * @return Finder
+     */
+    public function createFinder();
+}

--- a/src/Symfony/Component/Finder/Tests/FinderFactoryTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderFactoryTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests;
+
+use Symfony\Component\Finder\FinderFactory;
+
+/**
+ * Test Finder Factory
+ *
+ * @author Beau Simensen <beau@dflydev.com>
+ */
+class FinderFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test createFinder() method
+     */
+    public function testCreateFinder()
+    {
+        $finderFactory = new FinderFactory;
+
+        $this->assertInstanceOf('Symfony\Component\Finder\Finder', $finderFactory->createFinder());
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -231,7 +231,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder = new Finder();
         $iterator = $finder->files()->name('*.php')->depth('< 1')->in(array(self::$tmpDir, __DIR__))->getIterator();
 
-        $this->assertIterator(array(self::$tmpDir.DIRECTORY_SEPARATOR.'test.php', __DIR__.DIRECTORY_SEPARATOR.'FinderTest.php', __DIR__.DIRECTORY_SEPARATOR.'bootstrap.php', __DIR__.DIRECTORY_SEPARATOR.'GlobTest.php'), $iterator);
+        $this->assertIterator(array(self::$tmpDir.DIRECTORY_SEPARATOR.'test.php', __DIR__.DIRECTORY_SEPARATOR.'FinderFactoryTest.php', __DIR__.DIRECTORY_SEPARATOR.'FinderTest.php', __DIR__.DIRECTORY_SEPARATOR.'bootstrap.php', __DIR__.DIRECTORY_SEPARATOR.'GlobTest.php'), $iterator);
     }
 
     public function testGetIterator()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Added `FinderFactoryInterface` and default `FinderFactory` implementation. The idea being able to inject a factory to create Finder instances into services rather than calling `new Finder` in each service.

Added `finder_factory` service to Framework Bundle. This will allow for services to easily consume the default FinderFactory implementation.

Mocking Finder has proven to be extremely difficult if `new Finder` is called inside the class. By injecting a mocked Finder Factory we can have the opportunity to get mocked Finder instances inside our classes for the purpose of testing.

I've created implementations of Finder Factory at least twice now for two different projects and realized it was generic enough that it probably just belonged in the Finder component so I don't have to keep rewriting it and so other people could use it.

Example class:

```
<?php
namespace My;

use Symfony\Component\Finder\Finder;
use Symfony\Component\Finder\FinderFactory;
use Symfony\Component\Finder\FinderFactoryInterface;

class Service
{
    public function __construct(FinderFactoryInterface $finderFactory = null)
    {
        $this->finderFactory = $finderFactory ?: new FinderFactory;
    }
    public function findTmpFilesNew()
    {
        // Potential for mocked injected Finder Factory to return
        // a mocked Finder instance.
        $finder = $this->finderFactory()->create();

        return $finder->in(sys_get_temp_dir());
    }
    public function findTmpFilesOld()
    {
        // Difficult to Mock
        $finder = new Finder;

        return $finder->in(sys_get_temp_dir());
    }
}
```

Example service:

```
<service id="my_service" class="My\Service">
    <argument type="service" id="finder_factory">
</service>
```

This also opens the door for "prepared" Finder instances to anyone that wants to leverage the `FinderFactoryInterface` and massage the Finder before returning it.

I can split the PR into two commits or two PR for Framework and Finder if that would be better.
