### PR TITLE
[Routing] Added an optional event trigger for handleRouteRequirements

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
@@ -72,9 +72,9 @@ class UrlMatcher implements UrlMatcherInterface
     }
 
     /**
-     * @param \Symfony\Component\EventDispatcher\EventDispatcher $event_dispatcher
+     * @param EventDispatcherInterface $event_dispatcher
      */
-    public function setEventDispatcher(EventDispatcher $event_dispatcher)
+    public function setEventDispatcher(EventDispatcherInterface $event_dispatcher)
     {
         $this->dispatcher = $event_dispatcher;
     }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -17,7 +17,6 @@ use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * UrlMatcher matches URL based on a set of routes.

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -174,7 +174,7 @@ class UrlMatcher implements UrlMatcherInterface
         $scheme = $route->getRequirement('_scheme');
         $status = $scheme && $scheme !== $this->context->getScheme() ? self::REQUIREMENT_MISMATCH : self::REQUIREMENT_MATCH;
 
-        if (0 === $status) {
+        if (self::REQUIREMENT_MISMATCH === $status) {
             return array($status, null);
         }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -32,13 +32,12 @@ class UrlMatcher implements UrlMatcherInterface
     const REQUIREMENT_MISMATCH  = 1;
     const ROUTE_MATCH           = 2;
 
-    const EVENT_HANDLE_REQUIREMENTS = 'match.requirements';
+    const EVENT_HANDLE_REQUIREMENTS = 'routing.match.requirements';
 
     protected $context;
     protected $allow;
 
-    /** @var \Symfony\Component\EventDispatcher\EventDispatcher */
-    protected $event_dispatcher;
+    protected $dispatcher;
 
     private $routes;
 
@@ -77,7 +76,7 @@ class UrlMatcher implements UrlMatcherInterface
      */
     public function setEventDispatcher(EventDispatcher $event_dispatcher)
     {
-        $this->event_dispatcher = $event_dispatcher;
+        $this->dispatcher = $event_dispatcher;
     }
 
     /**
@@ -180,9 +179,9 @@ class UrlMatcher implements UrlMatcherInterface
             return array($status, null);
         }
 
-        if ($this->event_dispatcher) {
+        if ($this->dispatcher) {
             $event = new UrlMatcherEvent($route);
-            $this->event_dispatcher->dispatch(self::EVENT_HANDLE_REQUIREMENTS, $event);
+            $this->dispatcher->dispatch(self::EVENT_HANDLE_REQUIREMENTS, $event);
             $status = $event->getStatus();
         }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -16,6 +16,8 @@ use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Route;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * UrlMatcher matches URL based on a set of routes.
@@ -30,8 +32,13 @@ class UrlMatcher implements UrlMatcherInterface
     const REQUIREMENT_MISMATCH  = 1;
     const ROUTE_MATCH           = 2;
 
+    const EVENT_HANDLE_REQUIREMENTS = 'match.requirements';
+
     protected $context;
     protected $allow;
+
+    /** @var \Symfony\Component\EventDispatcher\EventDispatcher */
+    protected $event_dispatcher;
 
     private $routes;
 
@@ -63,6 +70,14 @@ class UrlMatcher implements UrlMatcherInterface
     public function getContext()
     {
         return $this->context;
+    }
+
+    /**
+     * @param \Symfony\Component\EventDispatcher\EventDispatcher $event_dispatcher
+     */
+    public function setEventDispatcher(EventDispatcher $event_dispatcher)
+    {
+        $this->event_dispatcher = $event_dispatcher;
     }
 
     /**
@@ -160,6 +175,16 @@ class UrlMatcher implements UrlMatcherInterface
         // check HTTP scheme requirement
         $scheme = $route->getRequirement('_scheme');
         $status = $scheme && $scheme !== $this->context->getScheme() ? self::REQUIREMENT_MISMATCH : self::REQUIREMENT_MATCH;
+
+        if (0 === $status) {
+            return array($status, null);
+        }
+
+        if ($this->event_dispatcher) {
+            $event = new UrlMatcherEvent($route);
+            $this->event_dispatcher->dispatch(self::EVENT_HANDLE_REQUIREMENTS, $event);
+            $status = $event->getStatus();
+        }
 
         return array($status, null);
     }

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
@@ -7,10 +7,8 @@ use Symfony\Component\Routing\Route;
 
 class UrlMatcherEvent extends Event
 {
-    /** @var \Symfony\Component\Routing\Route */
     private $route;
 
-    /** @var boolean */
     private $status;
 
     const REQUIREMENT_MISMATCH = 2;
@@ -40,17 +38,22 @@ class UrlMatcherEvent extends Event
      *
      * First listener to set to Mismatch wins
      *
-     * @param $result boolean
+     * @param $status boolean|null
      */
-    public function setStatus($result)
+    public function setStatus($status)
     {
-        $this->status = $result;
+        $this->status = $status;
 
         if ($this->status == self::REQUIREMENT_MISMATCH) {
             $this->stopPropagation();
         }
     }
 
+    /**
+     * Returns the set status
+     *
+     * @return boolean|null
+     */
     public function getStatus()
     {
         return $this->status;

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Symfony\Component\Routing\Matcher;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Routing\Route;
+
+class UrlMatcherEvent extends Event
+{
+    /** @var \Symfony\Component\Routing\Route */
+    private $route;
+
+    /** @var boolean */
+    private $status;
+
+    const REQUIREMENT_MISMATCH = 2;
+    const REQUIREMENT_MATCH = 1;
+
+    public function __construct(Route $route)
+    {
+        $this->route = $route;
+    }
+
+    /**
+     * Returns the route being matched
+     *
+     * @return \Symfony\Component\Routing\Route
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+
+    /**
+     * Set the result of the requirement match
+     *
+     * 0 - Mismatch
+     * 1 - Match
+     * null - No vote
+     *
+     * First listener to set to Mismatch wins
+     *
+     * @param $result boolean
+     */
+    public function setStatus($result)
+    {
+        $this->status = $result;
+
+        if ($this->status == self::REQUIREMENT_MISMATCH) {
+            $this->stopPropagation();
+        }
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
@@ -22,7 +22,7 @@ class UrlMatcherEvent extends Event
     /**
      * Returns the route being matched
      *
-     * @return \Symfony\Component\Routing\Route
+     * @return Route
      */
     public function getRoute()
     {

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherEvent.php
@@ -11,8 +11,8 @@ class UrlMatcherEvent extends Event
 
     private $status;
 
-    const REQUIREMENT_MISMATCH = 2;
-    const REQUIREMENT_MATCH = 1;
+    const REQUIREMENT_MISMATCH = 1;
+    const REQUIREMENT_MATCH = 0;
 
     public function __construct(Route $route)
     {
@@ -32,13 +32,13 @@ class UrlMatcherEvent extends Event
     /**
      * Set the result of the requirement match
      *
-     * 0 - Mismatch
-     * 1 - Match
+     * 0 - Match
+     * 1 - Mismatch
      * null - No vote
      *
      * First listener to set to Mismatch wins
      *
-     * @param $status boolean|null
+     * @param $status integer|null
      */
     public function setStatus($status)
     {
@@ -52,7 +52,7 @@ class UrlMatcherEvent extends Event
     /**
      * Returns the set status
      *
-     * @return boolean|null
+     * @return integer|null
      */
     public function getStatus()
     {

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -278,7 +278,6 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
 
         $callback = function($name, $event) {
             $event->setStatus(1);
-            $event->stopPropagation();
         };
 
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
@@ -303,7 +302,6 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $callback = function($name, $event) {
             if ($event->getRoute()->getRequirement('_bar') == 'hello') {
                 $event->setStatus(1);
-                $event->stopPropagation();
             }
             if ($event->getRoute()->getRequirement('_bar') == 'hiya') {
                 $event->setStatus(0);
@@ -336,7 +334,6 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $callback = function($name, $event) {
             if ($event->getRoute()->getRequirement('_bar') == 'hiya') {
                 $event->setStatus(1);
-                $event->stopPropagation();
             }
             if ($event->getRoute()->getRequirement('_bar') == 'hello') {
                 $event->setStatus(0);


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: -- as much as they did before -- tests added for feature.
Fixes the following tickets: none
Todo: Documentation
License of the code: MIT
Documentation PR: 

Ran into an issue where having a more flexible routing requirements implementation would be helpful, and wanted to see if there was any interest in this.

I added an optional event trigger to handleRouteRequirements to enable more flexible routing rules.

Initially the the use case is when implementing Accept header based routing, but I figured others may want to use that in addition to other custom routing rules, at which point, using the event dispatcher optionally made sense.

You can find my current use-case here: https://gist.github.com/3805361
