### PR TITLE
STDIN fix src/Symfony/Component/Console/Helper/DialogHelper.php

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -37,7 +37,7 @@ class DialogHelper extends Helper
     {
         $output->write($question);
 
-        $ret = fgets($this->inputStream ?: STDIN, 4096);
+        $ret = fgets($this->inputStream ?: fopen('php://stdin', 'r'), 4096);
         if (false === $ret) {
             throw new \RuntimeException('Aborted');
         }


### PR DESCRIPTION
siteground's php 5.4 doesn't seem to recognize STDIN.  Fix is found to be fopen('php://stdin', 'r') which should portable to all php installations.
