### PR TITLE
Patch method OptionsResover::validateOptionValues().

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -294,7 +294,7 @@ class OptionsResolver implements OptionsResolverInterface
     private function validateOptionValues(array $options)
     {
         foreach ($this->allowedValues as $option => $allowedValues) {
-            if (!in_array($options[$option], $allowedValues, true)) {
+            if (isset($options[$option]) && !in_array($options[$option], $allowedValues, true)) {
                 throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", but is expected to be one of "%s"', $option, $options[$option], implode('", "', $allowedValues)));
             }
         }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -258,6 +258,30 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         ), $this->resolver->resolve($options));
     }
 
+    public function testResolveSucceedsIfOptionalWithAllowedValuesNotSet()
+    {
+        $this->resolver->setRequired(array(
+            'one',
+        ));
+
+        $this->resolver->setOptional(array(
+            'two',
+        ));
+
+        $this->resolver->setAllowedValues(array(
+            'one' => array('1', 'one'),
+            'two' => array('2', 'two'),
+        ));
+
+        $options = array(
+            'one' => '1',
+        );
+
+        $this->assertEquals(array(
+            'one' => '1',
+        ), $this->resolver->resolve($options));
+    }
+
     /**
      * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */


### PR DESCRIPTION
This PR was submitted on the symfony/OptionsResolver read-only repository and moved automatically to the main Symfony repository (closes symfony/OptionsResolver#1).

When we define allowed values for an optional option and the corresponding option was not set. On resolve, OptionsResover::validateOptionValues() was throwing a notice.
