### PR TITLE
[TwigBundle] added support for Twig namespaced paths (Twig 1.10)

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+ * added automatic registration of namespaced paths for registered bundles
+ * added support for namespaced paths
+
 2.1.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -126,6 +126,29 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('auto_reload')->end()
                 ->scalarNode('optimizations')->end()
                 ->arrayNode('paths')
+                    ->beforeNormalization()
+                        ->always()
+                        ->then(function ($paths) {
+                            $normalized = array();
+                            foreach ($paths as $path => $namespace) {
+                                if (is_array($namespace)) {
+                                    // xml
+                                    $path = $namespace['value'];
+                                    $namespace = $namespace['namespace'];
+                                }
+
+                                // path within the default namespace
+                                if (ctype_digit((string) $path)) {
+                                    $path = $namespace;
+                                    $namespace = null;
+                                }
+
+                                $normalized[$path] = $namespace;
+                            }
+
+                            return $normalized;
+                        })
+                    ->end()
                     ->prototype('variable')->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -60,10 +60,31 @@ class TwigExtension extends Extension
         $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
         $container->getDefinition('twig.loader')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
 
-        if (!empty($config['paths'])) {
-            foreach ($config['paths'] as $path) {
-                $container->getDefinition('twig.loader')->addMethodCall('addPath', array($path));
+        $twigLoaderDefinition = $container->getDefinition('twig.loader');
+
+        // register user-configured paths
+        foreach ($config['paths'] as $path => $namespace) {
+            if (!$namespace) {
+                $twigLoaderDefinition->addMethodCall('addPath', array($path));
+            } else {
+                $twigLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }
+        }
+
+        // register bundles as Twig namespaces
+        foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
+            if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
+                $this->addTwigPath($twigLoaderDefinition, $dir, $bundle);
+            }
+
+            $reflection = new \ReflectionClass($class);
+            if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
+                $this->addTwigPath($twigLoaderDefinition, $dir, $bundle);
+            }
+        }
+
+        if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/views')) {
+            $twigLoaderDefinition->addMethodCall('addPath', array($dir));
         }
 
         if (!empty($config['globals'])) {
@@ -106,6 +127,15 @@ class TwigExtension extends Extension
             'Twig_Markup',
             'Twig_Template',
         ));
+    }
+
+    private function addTwigPath($twigLoaderDefinition, $dir, $bundle)
+    {
+        $name = $bundle;
+        if ('Bundle' === substr($name, -6)) {
+            $name = substr($name, 0, -6);
+        }
+        $twigLoaderDefinition->addMethodCall('addPath', array($dir, $name));
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -64,16 +64,19 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
         $file = null;
         $previous = null;
         try {
-            $template = $this->parser->parse($template);
+            $file = parent::findTemplate($template);
+        } catch (\Twig_Error_Loader $e) {
+            $previous = $e;
+
+            // for BC
             try {
-                $file = $this->locator->locate($template);
-            } catch (\InvalidArgumentException $e) {
-                $previous = $e;
-            }
-        } catch (\Exception $e) {
-            try {
-                $file = parent::findTemplate($template);
-            } catch (\Twig_Error_Loader $e) {
+                $template = $this->parser->parse($template);
+                try {
+                    $file = $this->locator->locate($template);
+                } catch (\InvalidArgumentException $e) {
+                    $previous = $e;
+                }
+            } catch (\Exception $e) {
                 $previous = $e;
             }
         }

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
@@ -11,7 +11,7 @@
         <xsd:sequence>
             <xsd:element name="form" type="form" minOccurs="0" maxOccurs="1" />
             <xsd:element name="global" type="global" minOccurs="0" maxOccurs="unbounded" />
-            <xsd:element name="path" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="path" type="path" minOccurs="0" maxOccurs="unbounded" />
         </xsd:sequence>
 
         <xsd:attribute name="auto-reload" type="xsd:string" />
@@ -28,6 +28,10 @@
         <xsd:choice minOccurs="1" maxOccurs="unbounded">
             <xsd:element name="resource" type="xsd:string" />
         </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:complexType name="path" mixed="true">
+        <xsd:attribute name="namespace" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="global" mixed="true">

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Resources/TwigBundle/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Resources/TwigBundle/views/layout.html.twig
@@ -1,0 +1,1 @@
+This is a layout

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Resources/views/layout.html.twig
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/Resources/views/layout.html.twig
@@ -1,0 +1,1 @@
+This is a layout

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -18,5 +18,10 @@ $container->loadFromExtension('twig', array(
      'charset'             => 'ISO-8859-1',
      'debug'               => true,
      'strict_variables'    => true,
-     'paths'               => array('path1', 'path2'),
+     'paths'               => array(
+         'path1',
+         'path2',
+         'namespaced_path1' => 'namespace',
+         'namespaced_path2' => 'namespace',
+      ),
 ));

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -14,5 +14,7 @@
         <twig:global key="pi">3.14</twig:global>
         <twig:path>path1</twig:path>
         <twig:path>path2</twig:path>
+        <twig:path namespace="namespace">namespaced_path1</twig:path>
+        <twig:path namespace="namespace">namespaced_path2</twig:path>
     </twig:config>
 </container>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -13,4 +13,8 @@ twig:
     charset:             ISO-8859-1
     debug:               true
     strict_variables:    true
-    paths:               [path1, path2]
+    paths:
+        path1: ''
+        path2: ''
+        namespaced_path1: namespace
+        namespaced_path2: namespace

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -16,59 +16,73 @@ use Symfony\Bundle\TwigBundle\Loader\FilesystemLoader;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Component\Templating\TemplateNameParserInterface;
-use InvalidArgumentException;
 
 class FilesystemLoaderTest extends TestCase
 {
-    /** @var FileLocatorInterface */
-    private $locator;
-    /** @var TemplateNameParserInterface */
-    private $parser;
-    /** @var FilesystemLoader */
-    private $loader;
-
-    protected function setUp()
+    public function testGetSource()
     {
-        parent::setUp();
-
-        $this->locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
-        $this->parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
-        $this->loader = new FilesystemLoader($this->locator, $this->parser);
-
-        $this->parser->expects($this->once())
-                ->method('parse')
-                ->with('name.format.engine')
-                ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
+        $parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
+        $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
+        $locator
+            ->expects($this->once())
+            ->method('locate')
+            ->will($this->returnValue(__DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig'))
         ;
+        $loader = new FilesystemLoader($locator, $parser);
+        $loader->addPath(__DIR__.'/../DependencyInjection/Fixtures/Resources/views', 'namespace');
+
+        // Twig-style
+        $this->assertEquals("This is a layout\n", $loader->getSource('@namespace/layout.html.twig'));
+
+        // Symfony-style
+        $this->assertEquals("This is a layout\n", $loader->getSource('TwigBundle::layout.html.twig'));
     }
 
-    protected function tearDown()
-    {
-        parent::tearDown();
-
-        $this->locator = null;
-        $this->parser = null;
-        $this->loader = null;
-    }
-
+    /**
+     * @expectedException Twig_Error_Loader
+     */
     public function testTwigErrorIfLocatorThrowsInvalid()
     {
-        $this->setExpectedException('Twig_Error_Loader');
-        $invalidException = new InvalidArgumentException('Unable to find template "NonExistent".');
-        $this->locator->expects($this->once())
-                      ->method('locate')
-                      ->will($this->throwException($invalidException));
+        $parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
+        $parser
+            ->expects($this->once())
+            ->method('parse')
+            ->with('name.format.engine')
+            ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
+        ;
 
-        $this->loader->getCacheKey('name.format.engine');
+        $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
+        $locator
+            ->expects($this->once())
+            ->method('locate')
+            ->will($this->throwException(new \InvalidArgumentException('Unable to find template "NonExistent".')))
+        ;
+
+        $loader = new FilesystemLoader($locator, $parser);
+        $loader->getCacheKey('name.format.engine');
     }
 
+    /**
+     * @expectedException Twig_Error_Loader
+     */
     public function testTwigErrorIfLocatorReturnsFalse()
     {
-        $this->setExpectedException('Twig_Error_Loader');
-        $this->locator->expects($this->once())
-                      ->method('locate')
-                      ->will($this->returnValue(false));
+        $parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
+        $parser
+            ->expects($this->once())
+            ->method('parse')
+            ->with('name.format.engine')
+            ->will($this->returnValue(new TemplateReference('', '', 'name', 'format', 'engine')))
+        ;
 
-        $this->loader->getCacheKey('name.format.engine');
+        $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
+        $locator
+            ->expects($this->once())
+            ->method('locate')
+            ->will($this->returnValue(false))
+        ;
+
+        $loader = new FilesystemLoader($locator, $parser);
+        $loader->getCacheKey('name.format.engine');
     }
 }


### PR DESCRIPTION
In a template, you can now use native Twig template names, instead of
the Symfony ones:

Before (still works):

```
{% extends "AcmeDemoBundle::layout.html.twig" %}
{% include "AcmeDemoBundle:Foo:bar.html.twig" %}
```

After:

```
{% extends "@AcmeDemo/layout.html.twig" %}
{% include "@AcmeDemo/Foo/bar.html.twig" %}
```

Using native template names is also faster.

The only drawback is that the new notation looks similar to the way we
locate resources in Symfony, which would be
`@AcmeDemoBundle/Resources/views/Foo/bar.html.twig`. We could have used
the same notation, but it is rather verbose (and by the way, using this
notation did not work anyway in templates).

TODO: update documentation
