### PR TITLE
[HttpFoundation] Preserve capitalization of response header names

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -259,7 +259,7 @@ class Response
         header(sprintf('HTTP/%s %s %s', $this->version, $this->statusCode, $this->statusText));
 
         // headers
-        foreach ($this->headers->all() as $name => $values) {
+        foreach ($this->headers->allPreserveCase() as $name => $values) {
             foreach ($values as $value) {
                 header($name.': '.$value, false);
             }

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -37,6 +37,11 @@ class ResponseHeaderBag extends HeaderBag
     protected $cookies              = array();
 
     /**
+     * @var array
+     */
+    protected $headerNames          = array();
+
+    /**
      * Constructor.
      *
      * @param array $headers An array of HTTP headers
@@ -48,7 +53,7 @@ class ResponseHeaderBag extends HeaderBag
         parent::__construct($headers);
 
         if (!isset($this->headers['cache-control'])) {
-            $this->set('cache-control', '');
+            $this->set('Cache-Control', '');
         }
     }
 
@@ -66,16 +71,28 @@ class ResponseHeaderBag extends HeaderBag
     }
 
     /**
+     * Returns the headers, with original capitalizations.
+     *
+     * @return array An array of headers
+     */
+    public function allPreserveCase()
+    {
+        return array_combine($this->headerNames, $this->headers);
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @api
      */
     public function replace(array $headers = array())
     {
+        $this->headerNames = array();
+
         parent::replace($headers);
 
         if (!isset($this->headers['cache-control'])) {
-            $this->set('cache-control', '');
+            $this->set('Cache-Control', '');
         }
     }
 
@@ -88,10 +105,14 @@ class ResponseHeaderBag extends HeaderBag
     {
         parent::set($key, $values, $replace);
 
+        $uniqueKey = strtr(strtolower($key), '_', '-');
+        $this->headerNames[$uniqueKey] = $key;
+
         // ensure the cache-control header has sensible defaults
-        if (in_array(strtr(strtolower($key), '_', '-'), array('cache-control', 'etag', 'last-modified', 'expires'))) {
+        if (in_array($uniqueKey, array('cache-control', 'etag', 'last-modified', 'expires'))) {
             $computed = $this->computeCacheControlValue();
             $this->headers['cache-control'] = array($computed);
+            $this->headerNames['cache-control'] = 'Cache-Control';
             $this->computedCacheControl = $this->parseCacheControl($computed);
         }
     }
@@ -105,7 +126,10 @@ class ResponseHeaderBag extends HeaderBag
     {
         parent::remove($key);
 
-        if ('cache-control' === strtr(strtolower($key), '_', '-')) {
+        $uniqueKey = strtr(strtolower($key), '_', '-');
+        unset($this->headerNames[$uniqueKey]);
+
+        if ('cache-control' === $uniqueKey) {
             $this->computedCacheControl = array();
         }
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -16,6 +16,51 @@ use Symfony\Component\HttpFoundation\Cookie;
 
 class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @covers Symfony\Component\HttpFoundation\ResponseHeaderBag::allPreserveCase
+     * @dataProvider provideAllPreserveCase
+     */
+    public function testAllPreserveCase($headers, $expected)
+    {
+        $bag = new ResponseHeaderBag($headers);
+
+        $this->assertEquals($expected, $bag->allPreserveCase(), '->allPreserveCase() gets all input keys in original case');
+    }
+
+    public function provideAllPreserveCase()
+    {
+        return array(
+            array(
+                array('fOo' => 'BAR'),
+                array('fOo' => array('BAR'), 'Cache-Control' => array('no-cache'))
+            ),
+            array(
+                array('ETag' => 'xyzzy'),
+                array('ETag' => array('xyzzy'), 'Cache-Control' => array('private, must-revalidate'))
+            ),
+            array(
+                array('Content-MD5' => 'Q2hlY2sgSW50ZWdyaXR5IQ=='),
+                array('Content-MD5' => array('Q2hlY2sgSW50ZWdyaXR5IQ=='), 'Cache-Control' => array('no-cache'))
+            ),
+            array(
+                array('P3P' => 'CP="CAO PSA OUR"'),
+                array('P3P' => array('CP="CAO PSA OUR"'), 'Cache-Control' => array('no-cache'))
+            ),
+            array(
+                array('WWW-Authenticate' => 'Basic realm="WallyWorld"'),
+                array('WWW-Authenticate' => array('Basic realm="WallyWorld"'), 'Cache-Control' => array('no-cache'))
+            ),
+            array(
+                array('X-UA-Compatible' => 'IE=edge,chrome=1'),
+                array('X-UA-Compatible' => array('IE=edge,chrome=1'), 'Cache-Control' => array('no-cache'))
+            ),
+            array(
+                array('X-XSS-Protection' => '1; mode=block'),
+                array('X-XSS-Protection' => array('1; mode=block'), 'Cache-Control' => array('no-cache'))
+            ),
+        );
+    }
+
     public function testCacheControlHeader()
     {
         $bag = new ResponseHeaderBag(array());


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/gigablah/symfony.png)](http://travis-ci.org/gigablah/symfony)
License of the code: MIT
Fixes the following tickets: -
Todo: -

`HeaderBag` normalizes header names when they are set. Therefore, custom header names (e.g. X-Sendfile, Vary) are output in lowercase. I've added an array to map header keys to their original capitalization in `ResponseHeaderBag`. Calling `allPreserveCase()` will now output the header array with capitalization preserved.

More of a cosmetic (and consistency) fix, since HTTP header names are case insensitive.
