### PR TITLE
[2.2][Console] Test default input defintion and default helper set

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -220,18 +220,6 @@ class Application
     {
         return $this->helperSet;
     }
-    
-    /**
-     * Set an input definition set to be used with this application
-     *
-     * @param InputDefinition $definition The input definition
-     *
-     * @api
-     */
-    public function setDefinition(InputDefinition $definition)
-    {
-        $this->definition = $definition;
-    }
 
     /**
      * Gets the InputDefinition related to this Application.

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -220,6 +220,18 @@ class Application
     {
         return $this->helperSet;
     }
+    
+    /**
+     * Set an input definition set to be used with this application
+     *
+     * @param InputDefinition $definition The input definition
+     *
+     * @api
+     */
+    public function setDefinition(InputDefinition $definition)
+    {
+        $this->definition = $definition;
+    }
 
     /**
      * Gets the InputDefinition related to this Application.

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -12,8 +12,11 @@
 namespace Symfony\Component\Console\Tests;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\Output;
@@ -505,5 +508,78 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             array(new InputOption('quiet', '', InputOption::VALUE_NONE)),
             array(new InputOption('query', 'q', InputOption::VALUE_NONE)),
         );
+    }
+    
+    public function testGetDefaultHelperSetReturnsDefaultValues()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        
+        $helperSet = $application->getHelperSet();
+        
+        $this->assertTrue($helperSet->has('formatter'));
+        $this->assertTrue($helperSet->has('dialog'));
+        $this->assertTrue($helperSet->has('progress'));
+    }
+    
+    public function testAddingSingleHelperSetOverwritesDefaultValues()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        
+        $application->setHelperSet(new HelperSet(array(new FormatterHelper())));
+        
+        $helperSet = $application->getHelperSet();
+        
+        $this->assertTrue($helperSet->has('formatter'));
+        
+        // no other default helper set should be returned
+        $this->assertFalse($helperSet->has('dialog'));
+        $this->assertFalse($helperSet->has('progress'));
+    }
+    
+    public function testGetDefaultInputDefinitionReturnsDefaultValues()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        
+        $inputDefinition = $application->getDefinition();
+
+        $this->assertTrue($inputDefinition->hasArgument('command'));
+        
+        $this->assertTrue($inputDefinition->hasOption('help'));
+        $this->assertTrue($inputDefinition->hasOption('quiet'));
+        $this->assertTrue($inputDefinition->hasOption('verbose'));
+        $this->assertTrue($inputDefinition->hasOption('version'));
+        $this->assertTrue($inputDefinition->hasOption('ansi'));
+        $this->assertTrue($inputDefinition->hasOption('no-ansi'));
+        $this->assertTrue($inputDefinition->hasOption('no-interaction'));
+    }
+    
+    public function testSettingCustomInputDefinitionOverwritesDefaultValues()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        
+        $application->setDefinition(new InputDefinition(array(new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Set the custom input definition.'))));
+        
+        $inputDefinition = $application->getDefinition();
+
+        // check wether the default arguments and options are not returned any more
+        $this->assertFalse($inputDefinition->hasArgument('command'));
+        
+        $this->assertFalse($inputDefinition->hasOption('help'));
+        $this->assertFalse($inputDefinition->hasOption('quiet'));
+        $this->assertFalse($inputDefinition->hasOption('verbose'));
+        $this->assertFalse($inputDefinition->hasOption('version'));
+        $this->assertFalse($inputDefinition->hasOption('ansi'));
+        $this->assertFalse($inputDefinition->hasOption('no-ansi'));
+        $this->assertFalse($inputDefinition->hasOption('no-interaction'));
+        
+        $this->assertTrue($inputDefinition->hasOption('custom'));
     }
 }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -540,6 +540,23 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($helperSet->has('progress'));
     }
     
+    public function testOverwritingDefaultHelperSetOverwritesDefaultValues()
+    {
+        $application = new CustomApplication();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+        
+        $application->setHelperSet(new HelperSet(array(new FormatterHelper())));
+        
+        $helperSet = $application->getHelperSet();
+        
+        $this->assertTrue($helperSet->has('formatter'));
+        
+        // no other default helper set should be returned
+        $this->assertFalse($helperSet->has('dialog'));
+        $this->assertFalse($helperSet->has('progress'));
+    }
+    
     public function testGetDefaultInputDefinitionReturnsDefaultValues()
     {
         $application = new Application();
@@ -559,13 +576,11 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($inputDefinition->hasOption('no-interaction'));
     }
     
-    public function testSettingCustomInputDefinitionOverwritesDefaultValues()
+    public function testOverwritingDefaultInputDefinitionOverwritesDefaultValues()
     {
-        $application = new Application();
+        $application = new CustomApplication();
         $application->setAutoExit(false);
         $application->setCatchExceptions(false);
-        
-        $application->setDefinition(new InputDefinition(array(new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Set the custom input definition.'))));
         
         $inputDefinition = $application->getDefinition();
 
@@ -581,5 +596,28 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($inputDefinition->hasOption('no-interaction'));
         
         $this->assertTrue($inputDefinition->hasOption('custom'));
+    }
+}
+
+class CustomApplication extends Application
+{
+    /**
+     * Overwrites the default input definition.
+     *
+     * @return InputDefinition An InputDefinition instance
+     */
+    protected function getDefaultInputDefinition()
+    {
+        return new InputDefinition(array(new InputOption('--custom', '-c', InputOption::VALUE_NONE, 'Set the custom input definition.')));
+    }
+    
+    /**
+     * Gets the default helper set with the helpers that should always be available.
+     *
+     * @return HelperSet A HelperSet instance
+     */
+    protected function getDefaultHelperSet()
+    {
+        return new HelperSet(array(new FormatterHelper()));
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

See: https://github.com/symfony/symfony/pull/5638
