### PR TITLE
[Console] Simplified find method

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -545,7 +545,10 @@ class Application
         // name
         $commands = array();
         foreach ($this->commands as $command) {
-            if ($this->extractNamespace($command->getName()) == $namespace) {
+            $extractedNamespace = $this->extractNamespace($command->getName());
+            if ($extractedNamespace === $namespace
+               || !empty($namespace) && 0 === strpos($extractedNamespace, $namespace)
+            ) {
                 $commands[] = $command->getName();
             }
         }
@@ -565,7 +568,10 @@ class Application
         $aliases = array();
         foreach ($this->commands as $command) {
             foreach ($command->getAliases() as $alias) {
-                if ($this->extractNamespace($alias) == $namespace) {
+                $extractedNamespace = $this->extractNamespace($alias);
+                if ($extractedNamespace === $namespace
+                   || !empty($namespace) && 0 === strpos($extractedNamespace, $namespace)
+                ) {
                     $aliases[] = $alias;
                 }
             }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -30,6 +30,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         require_once self::$fixturesPath.'/Foo1Command.php';
         require_once self::$fixturesPath.'/Foo2Command.php';
         require_once self::$fixturesPath.'/Foo3Command.php';
+        require_once self::$fixturesPath.'/Foo4Command.php';
     }
 
     protected function normalizeLineBreaks($text)
@@ -258,6 +259,19 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             $this->assertInstanceOf('\InvalidArgumentException', $e, '->find() throws an \InvalidArgumentException if command does not exist, with alternatives');
             $this->assertRegExp('/Did you mean one of these/', $e->getMessage(), '->find() throws an \InvalidArgumentException if command does not exist, with alternatives');
+        }
+
+        $application->add(new \Foo3Command());
+        $application->add(new \Foo4Command());
+
+        // Subnamespace + plural
+        try {
+            $a = $application->find('foo3:');
+            $this->fail('->find() should throw an \InvalidArgumentException if a command is ambiguous because of a subnamespace, with alternatives');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e);
+            $this->assertRegExp('/foo3:bar/', $e->getMessage());
+            $this->assertRegExp('/foo3:bar:toh/', $e->getMessage());
         }
     }
 

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo4Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo4Command.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+
+class Foo4Command extends Command
+{
+    protected function configure()
+    {
+        $this->setName('foo3:bar:toh');
+    }
+}


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5384

It simplifies the way command or command suggestions are found, also fixing issue #5384.

It's a WIP I had, my plan was to also remove the original methods findAlternatives, etc... but some other methods are relying on them, so I'm sending it as it instead of running into more refactoring.
