### PR TITLE
[Web Profiler Bundle] Added navigation to the Web Profiler panel content

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/profiler.css
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/public/css/profiler.css
@@ -510,3 +510,20 @@ td.main, td.menu {
 .collapsed-menu span.icon img {
     display: inline !important;
 }
+
+#panel_items_navigation.fixed {
+    position: fixed;
+    top: 0;
+    padding: 10px;
+    margin-right: 51px;
+    margin-left: -40px;
+
+    -moz-border-radius: 0 0 16px 16px;
+    -webkit-border-radius: 0 0 16px 16px;
+    border-radius: 0 0 16px 16px;
+
+    background-image: -moz-linear-gradient(top, #e4e4e4, #ffffff);
+    background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(#e4e4e4), to(#ffffff));
+    background-image: -o-linear-gradient(top, #e4e4e4, #ffffff);
+    background: linear-gradient(top, #e4e4e4, #ffffff);
+}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -28,6 +28,7 @@
                     {% endif %}
 
                     <div id="collector_content">
+                        <div id="panel_items_navigation"></div>
                         {% include 'WebProfilerBundle:Profiler:base_js.html.twig' %}
                         {% block panel '' %}
                     </div>
@@ -126,7 +127,48 @@
                     }
                 }
             }
+
+
+            // Add navigation items
+            var container = document.getElementById('panel_items_navigation'),
+                wrapper, myDiv, newElement, contents;
+
+            var elements = document.getElementById('collector_content').getElementsByTagName('H2');
+            if (elements.length < 2) {
+                return;
+            }
+
+            contents = '<span style="display: none;"><a href="#">Top</a></span> ';
+
+            for (elem = 0; elem < elements.length; elem++) {
+                // Prepare the value for the paragraph that will wrap the H2 items
+                value = elements[elem].innerHTML.toLowerCase().replace(/\s/g, '-');
+                elements[elem].id = value;
+                contents += '<span><a href="#'+ value +'">' + elements[elem].innerHTML + '</a></span> ';
+            }
+
+            container.innerHTML = contents;
+
+            newElement = document.createElement('BR');
+            container.parentNode.insertBefore(newElement, container.nextSibling);
+
+            // Add the scroll event listener
+            if (window.addEventListener){
+                window.addEventListener('scroll', handleScroll, false);
+            }else{
+                window.attachEvent('onscroll', handleScroll);
+            }
+
+            handleScroll();
+
         }, 25);
+
+        function handleScroll() {
+            var offset = window.pageYOffset ? window.pageYOffset : document.documentElement.scrollTop;
+
+            document.getElementById('panel_items_navigation').className = (offset > 240 ? 'fixed' : '');
+            document.getElementById('panel_items_navigation').firstChild.style.display = (offset > 240 ? 'inline' : 'none');
+        }
 
     //]]></script>
 {% endblock %}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR:  ~

This will add a simple navigation bar to the content of a Web Profiler panel.
You can view the demo by accessing the Web Profiler panel here: http://sf2demo.rodb.ro/app_dev.php/

Feedback is welcomed.
