### PR TITLE
[2.1][ClassLoader]UniversalClassLoader not working with AnnotationRe...

### DIFF
--- a/src/Symfony/Component/ClassLoader/Tests/UniversalClassLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/UniversalClassLoaderTest.php
@@ -23,7 +23,7 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new UniversalClassLoader();
         $loader->registerNamespace('Namespaced', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
         $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
-        $loader->loadClass($testClassName);
+        $this->assertTrue($loader->loadClass($testClassName));
         $this->assertTrue(class_exists($className), $message);
     }
 
@@ -92,7 +92,7 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->registerPrefix('Pearlike_', __DIR__.DIRECTORY_SEPARATOR.'Fixtures');
         $loader->registerNamespaceFallbacks(array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'));
         $loader->registerPrefixFallbacks(array(__DIR__.DIRECTORY_SEPARATOR.'Fixtures/fallback'));
-        $loader->loadClass($testClassName);
+        $this->assertTrue($loader->loadClass($testClassName));
         $this->assertTrue(class_exists($className), $message);
     }
 
@@ -128,7 +128,7 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new UniversalClassLoader();
         $loader->registerNamespaces($namespaces);
 
-        $loader->loadClass($className);
+        $this->assertTrue($loader->loadClass($className));
         $this->assertTrue(class_exists($className), $message);
     }
 
@@ -178,7 +178,7 @@ class UniversalClassLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new UniversalClassLoader();
         $loader->registerPrefixes($prefixes);
 
-        $loader->loadClass($className);
+        $this->assertTrue($loader->loadClass($className));
         $this->assertTrue(class_exists($className), $message);
     }
 

--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -242,11 +242,15 @@ class UniversalClassLoader
      * Loads the given class or interface.
      *
      * @param string $class The name of the class
+     * 
+     * @return Boolean|null True, if loaded
      */
     public function loadClass($class)
     {
         if ($file = $this->findFile($class)) {
             require $file;
+
+            return true;
         }
     }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~

The Doctrine\Common\Annotations\AnnotationRegistry::loadAnnotationClass examines the returning value of the loader and the load is successful only if the loader returns with "TRUE" value.
This is how method Symfony\Component\ClassLoader\ClassLoader::loadClass works, but it is not true for Symfony\Component\ClassLoader\UniversalClassLoader::loadClass.
