### PR TITLE
[2.1][DependencyInjection] Incomplete error handling in the container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -258,6 +258,11 @@ class Container implements IntrospectableContainerInterface
                 $service = $this->$method();
             } catch (\Exception $e) {
                 unset($this->loading[$id]);
+
+                if (isset($this->services[$id])) {
+                    unset($this->services[$id]);
+                }
+
                 throw $e;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -98,7 +98,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('service_container', 'foo', 'bar'), $sc->getServiceIds(), '->getServiceIds() returns all defined service ids');
 
         $sc = new ProjectServiceContainer();
-        $this->assertEquals(array('scoped', 'scoped_foo', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'service_container'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods');
+        $this->assertEquals(array('scoped', 'scoped_foo', 'bar', 'foo_bar', 'foo.baz', 'circular', 'throw_exception', 'throws_exception_on_service_configuration', 'service_container'), $sc->getServiceIds(), '->getServiceIds() returns defined service ids by getXXXService() methods');
     }
 
     /**
@@ -367,6 +367,25 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGetThrowsExceptionOnServiceConfiguration()
+    {
+        $c = new ProjectServiceContainer();
+
+        try {
+            $c->get('throws_exception_on_service_configuration');
+            $this->fail('The container can not contain invalid service!');
+        } catch (\Exception $e) {
+            $this->assertEquals('Something was terribly wrong while trying to configure the service!', $e->getMessage());
+        }
+
+        try {
+            $c->get('throws_exception_on_service_configuration');
+            $this->fail('The container can not contain invalid service!');
+        } catch (\Exception $e) {
+            $this->assertEquals('Something was terribly wrong while trying to configure the service!', $e->getMessage());
+        }
+    }
+
     public function getInvalidParentScopes()
     {
         return array(
@@ -446,5 +465,14 @@ class ProjectServiceContainer extends Container
     protected function getThrowExceptionService()
     {
         throw new \Exception('Something went terribly wrong!');
+    }
+
+    protected function getThrowsExceptionOnServiceConfigurationService()
+    {
+        $this->services['throws_exception_on_service_configuration'] = $instance = new \stdClass();
+
+        throw new \Exception('Something was terribly wrong while trying to configure the service!');
+
+        return $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -474,7 +474,5 @@ class ProjectServiceContainer extends Container
         $this->services['throws_exception_on_service_configuration'] = $instance = new \stdClass();
 
         throw new \Exception('Something was terribly wrong while trying to configure the service!');
-
-        return $instance;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -377,6 +377,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             $this->assertEquals('Something was terribly wrong while trying to configure the service!', $e->getMessage());
         }
+        $this->assertFalse($c->initialized('throws_exception_on_service_configuration'));
 
         try {
             $c->get('throws_exception_on_service_configuration');
@@ -384,6 +385,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             $this->assertEquals('Something was terribly wrong while trying to configure the service!', $e->getMessage());
         }
+        $this->assertFalse($c->initialized('throws_exception_on_service_configuration'));
     }
 
     public function getInvalidParentScopes()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~

The Container::get method, error handling has been handled incompletely because the created wrong service was not removed from the container.
