### PR TITLE
[DomCrawler] fixed Form to handle <button> when submitted

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/InputFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/InputFormField.php
@@ -30,8 +30,8 @@ class InputFormField extends FormField
      */
     protected function initialize()
     {
-        if ('input' != $this->node->nodeName) {
-            throw new \LogicException(sprintf('An InputFormField can only be created from an input tag (%s given).', $this->node->nodeName));
+        if ('input' != $this->node->nodeName && 'button' != $this->node->nodeName) {
+            throw new \LogicException(sprintf('An InputFormField can only be created from an input or button tag (%s given).', $this->node->nodeName));
         }
 
         if ('checkbox' == $this->node->getAttribute('type')) {

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -293,7 +293,7 @@ class Form extends Link implements \ArrayAccess
         $root->appendChild($button);
         $xpath = new \DOMXPath($document);
 
-        foreach ($xpath->query('descendant::input | descendant::textarea | descendant::select', $root) as $node) {
+        foreach ($xpath->query('descendant::input | descendant::button | descendant::textarea | descendant::select', $root) as $node) {
             if (!$node->hasAttribute('name')) {
                 continue;
             }

--- a/tests/Symfony/Tests/Component/DomCrawler/FormTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/FormTest.php
@@ -84,6 +84,11 @@ class FormTest extends \PHPUnit_Framework_TestCase
                 array('bar' => array('Symfony\\Component\\DomCrawler\\Field\\InputFormField', 'bar')),
             ),
             array(
+                'appends the submitted button value for Button element',
+                '<button type="submit" name="bar" value="bar">Bar</button>',
+                array('bar' => array('Symfony\\Component\\DomCrawler\\Field\\InputFormField', 'bar')),
+            ),
+            array(
                 'appends the submitted button value but not other submit buttons',
                 '<input type="submit" name="bar" value="bar" />
                  <input type="submit" name="foobar" value="foobar" />',
@@ -404,7 +409,8 @@ class FormTest extends \PHPUnit_Framework_TestCase
         $dom = new \DOMDocument();
         $dom->loadHTML('<html>'.$form.'</html>');
 
-        $nodes = $dom->getElementsByTagName('input');
+        $xPath = new \DOMXPath($dom);
+        $nodes = $xPath->query('//input | //button');
 
         if (null === $currentUri) {
             $currentUri = 'http://example.com/';


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Issue appears when submitting form with <button> form element.
Name-value of this button wasn`t passed to the request.
