### PR TITLE
[HttpFoundation] Fixed #5697 - Request::createFromGlobals

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -217,7 +217,7 @@ class Request
     {
         $request = new static($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER);
 
-        if (0 === strpos($request->server->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
+        if (0 === strpos($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
             && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE', 'PATCH'))
         ) {
             parse_str($request->getContent(), $data);
@@ -1043,7 +1043,7 @@ class Request
      */
     public function getContentType()
     {
-        return $this->getFormat($this->server->get('CONTENT_TYPE'));
+        return $this->getFormat($this->headers->get('CONTENT_TYPE'));
     }
 
     /**

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -95,13 +95,9 @@ class Route implements \Serializable
      */
     public function setPattern($pattern)
     {
-        $this->pattern = trim($pattern);
-
-        // a route must start with a slash
-        if ('' === $this->pattern || '/' !== $this->pattern[0]) {
-            $this->pattern = '/'.$this->pattern;
-        }
-
+        // A pattern must start with a slash and must not have multiple slashes at the beginning because the
+        // generated path for this route would be confused with a network path, e.g. '//domain.com/path'.
+        $this->pattern = '/' . ltrim(trim($pattern), '/');
         $this->compiled = null;
 
         return $this;

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -223,25 +223,25 @@ class RouteCollection implements \IteratorAggregate, \Countable
      */
     public function addPrefix($prefix, $defaults = array(), $requirements = array(), $options = array())
     {
-        // a prefix must not end with a slash
-        $prefix = rtrim($prefix, '/');
+        $prefix = trim(trim($prefix), '/');
 
         if ('' === $prefix && empty($defaults) && empty($requirements) && empty($options)) {
             return;
         }
 
-        // a prefix must start with a slash
-        if ('' !== $prefix && '/' !== $prefix[0]) {
-            $prefix = '/'.$prefix;
+        // a prefix must start with a single slash and must not end with a slash
+        if ('' !== $prefix) {
+            $this->prefix = '/' . $prefix . $this->prefix;
         }
-
-        $this->prefix = $prefix.$this->prefix;
 
         foreach ($this->routes as $route) {
             if ($route instanceof RouteCollection) {
-                $route->addPrefix($prefix, $defaults, $requirements, $options);
+                // we add the slashes so the prefix is not lost by trimming in the sub-collection
+                $route->addPrefix('/' . $prefix . '/', $defaults, $requirements, $options);
             } else {
-                $route->setPattern($prefix.$route->getPattern());
+                if ('' !== $prefix) {
+                    $route->setPattern('/' . $prefix . $route->getPattern());
+                }
                 $route->addDefaults($defaults);
                 $route->addRequirements($requirements);
                 $route->addOptions($options);

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -214,6 +214,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $routes = $this->getRoutes('test', new Route('/', array(), array('_scheme' => 'http')));
         $this->assertEquals('http://localhost/app.php/', $this->getGenerator($routes, array('scheme' => 'https'))->generate('test'));
     }
+    
+    public function testPathWithTwoStartingSlashes()
+    {
+        $routes = $this->getRoutes('test', new Route('//path-and-not-domain'));
+
+        // this must not generate '//path-and-not-domain' because that would be a network path
+        $this->assertSame('/path-and-not-domain', $this->getGenerator($routes, array('BaseUrl' => ''))->generate('test'));
+    }
 
     public function testNoTrailingSlashForMultipleOptionalParameters()
     {

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -140,14 +140,19 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
     {
         $collection = new RouteCollection();
         $collection->add('foo', $foo = new Route('/foo'));
-        $collection->add('bar', $bar = new Route('/bar'));
+        $collection2 = new RouteCollection();
+        $collection2->add('bar', $bar = new Route('/bar'));
+        $collection->addCollection($collection2);
+        $this->assertSame('', $collection->getPrefix(), '->getPrefix() is initialized with ""');
+        $collection->addPrefix(' / ');
+        $this->assertSame('', $collection->getPrefix(), '->addPrefix() trims the prefix and a single slash has no effect');
         $collection->addPrefix('/{admin}', array('admin' => 'admin'), array('admin' => '\d+'), array('foo' => 'bar'));
         $this->assertEquals('/{admin}/foo', $collection->get('foo')->getPattern(), '->addPrefix() adds a prefix to all routes');
         $this->assertEquals('/{admin}/bar', $collection->get('bar')->getPattern(), '->addPrefix() adds a prefix to all routes');
-        $this->assertEquals(array('admin' => 'admin'), $collection->get('foo')->getDefaults(), '->addPrefix() adds a prefix to all routes');
-        $this->assertEquals(array('admin' => 'admin'), $collection->get('bar')->getDefaults(), '->addPrefix() adds a prefix to all routes');
-        $this->assertEquals(array('admin' => '\d+'), $collection->get('foo')->getRequirements(), '->addPrefix() adds a prefix to all routes');
-        $this->assertEquals(array('admin' => '\d+'), $collection->get('bar')->getRequirements(), '->addPrefix() adds a prefix to all routes');
+        $this->assertEquals(array('admin' => 'admin'), $collection->get('foo')->getDefaults(), '->addPrefix() adds defaults to all routes');
+        $this->assertEquals(array('admin' => 'admin'), $collection->get('bar')->getDefaults(), '->addPrefix() adds defaults to all routes');
+        $this->assertEquals(array('admin' => '\d+'), $collection->get('foo')->getRequirements(), '->addPrefix() adds requirements to all routes');
+        $this->assertEquals(array('admin' => '\d+'), $collection->get('bar')->getRequirements(), '->addPrefix() adds requirements to all routes');
         $this->assertEquals(
             array('foo' => 'bar', 'compiler_class' => 'Symfony\\Component\\Routing\\RouteCompiler'),
             $collection->get('foo')->getOptions(), '->addPrefix() adds an option to all routes'
@@ -158,6 +163,10 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         );
         $collection->addPrefix('0');
         $this->assertEquals('/0/{admin}', $collection->getPrefix(), '->addPrefix() ensures a prefix must start with a slash and must not end with a slash');
+        $collection->addPrefix('/ /');
+        $this->assertSame('/ /0/{admin}', $collection->getPrefix(), '->addPrefix() can handle spaces if desired');
+        $this->assertSame('/ /0/{admin}/foo', $collection->get('foo')->getPattern(), 'the route pattern is in synch with the collection prefix');
+        $this->assertSame('/ /0/{admin}/bar', $collection->get('bar')->getPattern(), 'the route pattern in a sub-collection is in synch with the collection prefix');
     }
 
     public function testAddPrefixOverridesDefaultsAndRequirements()

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -34,6 +34,8 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route->setPattern('bar');
         $this->assertEquals('/bar', $route->getPattern(), '->setPattern() adds a / at the beginning of the pattern if needed');
         $this->assertEquals($route, $route->setPattern(''), '->setPattern() implements a fluent interface');
+        $route->setPattern('//path');
+        $this->assertEquals('/path', $route->getPattern(), '->setPattern() does not allow two slahes "//" at the beginning of the pattern as it would be confused with a network path when generating the path from the route');
     }
 
     public function testOptions()


### PR DESCRIPTION
Changed checking CONTENT_TYPE from server to headers variable

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5697
Todo: -
License of the code: MIT
