### PR TITLE
Returns HTTP 401 response on an XML HTTP request.

### DIFF
--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -56,6 +56,12 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
             return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
         }
 
+        if ($request->isXmlHttpRequest()) {
+            $http401Response = new Response('', 401);
+
+            return $http401Response;
+        }
+
         return $this->httpUtils->createRedirectResponse($request, $this->loginPath);
     }
 }


### PR DESCRIPTION
When the XML HTTP request is made (usually by JavaScript), instead of sending a HTTP 302 redirection to the login screen, respond with a HTTP 401 response.

Please note that this is to handle the case that any XML HTTP requests to an area requiring form authentication are sent when the session is invalid or not authenticated.

For example, with a Symfony app right out of the box, sending a GET to /demo/secured/hello via JavaScript should get a HTTP 401 response instead of a HTTP 302 response.
