### PR TITLE
Added missing breaks

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
@@ -33,9 +33,11 @@ class ServerParams
 
         switch (substr($iniMax, -1)) {
             case 'G':
-                $max *= 1024;
+                $max *= 1024 * 1024 * 1024;
+                break;
             case 'M':
-                $max *= 1024;
+                $max *= 1024 * 1024;
+                break;
             case 'K':
                 $max *= 1024;
         }

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -211,9 +211,11 @@ class UploadedFile extends File
 
         switch (strtolower(substr($max, -1))) {
             case 'g':
-                $max *= 1024;
+                $max *= 1024 * 1024 * 1024;
+                break;
             case 'm':
-                $max *= 1024;
+                $max *= 1024 * 1024;
+                break;
             case 'k':
                 $max *= 1024;
         }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -294,6 +294,9 @@ class Request
             case 'PUT':
             case 'DELETE':
                 $defaults['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+                $request = $parameters;
+                $query = array();
+                break;
             case 'PATCH':
                 $request = $parameters;
                 $query = array();


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~

This adds the missing `break` statements to various files.
