### PR TITLE
[Form][Tests] Make FormIntegrationTestCase abstract

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeTestCase.php
@@ -11,10 +11,11 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
-class DateTimeTestCase extends LocalizedTestCase
+abstract class DateTimeTestCase extends LocalizedTestCase
 {
     public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
     {
         self::assertEquals($expected->format('c'), $actual->format('c'));
     }
 }
+

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/LocalizedTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/LocalizedTestCase.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\DataTransformer;
 
-class LocalizedTestCase extends \PHPUnit_Framework_TestCase
+abstract class LocalizedTestCase extends \PHPUnit_Framework_TestCase
 {
     protected static $icuVersion = null;
 

--- a/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\Extension\Core\CoreExtension;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
+abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var \Symfony\Component\Form\FormFactoryInterface

--- a/src/Symfony/Component/Form/Tests/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormPerformanceTestCase.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Form\Tests;
  * @author robo
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class FormPerformanceTestCase extends FormIntegrationTestCase
+abstract class FormPerformanceTestCase extends FormIntegrationTestCase
 {
     /**
      * @var    integer


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no - but failing tests are unrelated (not in the Form component)
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Depending on PHPUnit configuration extending this class in a test makes PHPUnit fail throwing a warning: `No tests found in class "Symfony\Component\Form\Tests\FormIntegrationTestCase"`. 

This class should not be run as a test and thus it can be safely converted to abstract. There's also an  incoherence between other TestCases, some of them being abstract and others concrete (eg. compare with _TypeTestCase_ inheriting from _FormIntegrationTestCase_). Shouldn't all the TestCases be marked as abstract?
