### PR TITLE
[Form] Removed unused method ChoiceView::isSelected()

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -52,20 +52,4 @@ class ChoiceView
         $this->value = $value;
         $this->label = $label;
     }
-
-    /**
-     * Returns whether this choice is selected for the given value.
-     *
-     * @param string|array $value The selected choice value.
-     *
-     * @return Boolean Whether the choice is selected.
-     */
-    public function isSelected($value)
-    {
-        if (is_array($value)) {
-            return false !== array_search($this->value, $value, true);
-        }
-
-        return $this->value === $value;
-    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5722
Todo: -
License of the code: MIT
Documentation PR: -
