### PR TITLE
[Routing] Simplified php matcher dumper (and optimized generated matcher)

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperCollection.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Dumper;
+
+/**
+ * Collection of routes.
+ *
+ * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ */
+class DumperCollection implements \IteratorAggregate
+{
+    private $parent;
+    private $children = array();
+
+    /**
+     * Returns the children routes and collections.
+     *
+     * @return array Array of DumperCollection|DumperRoute
+     */
+    public function all()
+    {
+        return $this->children;
+    }
+
+    /**
+     * Adds a route or collection
+     *
+     * @param DumperRoute|DumperCollection The route or collection
+     */
+    public function add($child)
+    {
+        if ($child instanceof DumperCollection) {
+            $child->setParent($this);
+        }
+        $this->children[] = $child;
+    }
+
+    /**
+     * Sets children
+     *
+     * @param array $children The children
+     */
+    public function setAll(array $children)
+    {
+        foreach ($children as $child) {
+            if ($child instanceof DumperCollection) {
+                $child->setParent($this);
+            }
+        }
+        $this->children = $children;
+    }
+
+    /**
+     * Returns an iterator over the children.
+     *
+     * @return \Iterator The iterator
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->children);
+    }
+
+    /**
+     * Returns the root of the collection.
+     *
+     * @return DumperCollection The root collection
+     */
+    public function getRoot()
+    {
+        return (null !== $this->parent) ? $this->parent->getRoot() : $this;
+    }
+
+    /**
+     * Returns the parent collection.
+     *
+     * @return DumperCollection|null The parent collection or null if the collection has no parent
+     */
+    protected function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Sets the parent collection.
+     *
+     * @param DumperCollection $parent The parent collection
+     */
+    protected function setParent(DumperCollection $parent)
+    {
+        $this->parent = $parent;
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperPrefixCollection.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Dumper;
+
+/**
+ * Prefix tree of routes preserving routes order.
+ *
+ * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ */
+class DumperPrefixCollection extends DumperCollection
+{
+    private $prefix = '';
+
+    /**
+     * Returns the prefix.
+     *
+     * @return string The prefix
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * Sets the prefix.
+     *
+     * @param string $prefix The prefix
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * Adds a route in the tree.
+     *
+     * @param DumperRoute $route The route
+     *
+     * @return DumperPrefixCollection The node the route was added to
+     */
+    public function addPrefixRoute(DumperRoute $route)
+    {
+        $prefix = $route->getRoute()->compile()->getStaticPrefix();
+
+        // Same prefix, add to current leave
+        if ($this->prefix === $prefix) {
+            $this->add($route);
+
+            return $this;
+        }
+
+        // Prefix starts with route's prefix
+        if ('' === $this->prefix || 0 === strpos($prefix, $this->prefix)) {
+            $collection = new DumperPrefixCollection();
+            $collection->setPrefix(substr($prefix, 0, strlen($this->prefix)+1));
+            $this->add($collection);
+
+            return $collection->addPrefixRoute($route);
+        }
+
+        // No match, fallback to parent (recursively)
+
+        if (null === $parent = $this->getParent()) {
+            throw new \LogicException("The collection root must not have a prefix");
+        }
+
+        return $parent->addPrefixRoute($route);
+    }
+
+    /**
+     * Merges nodes whose prefix ends with a slash
+     *
+     * Children of a node whose prefix ends with a slash are moved to the parent node
+     */
+    public function mergeSlashNodes()
+    {
+        $children = array();
+
+        foreach ($this as $child) {
+            if ($child instanceof self) {
+                $child->mergeSlashNodes();
+                if ('/' === substr($child->prefix, -1)) {
+                    $children = array_merge($children, $child->all());
+                } else {
+                    $children[] = $child;
+                }
+            } else {
+                $children[] = $child;
+            }
+        }
+
+        $this->setAll($children);
+    }
+}

--- a/src/Symfony/Component/Routing/Matcher/Dumper/DumperRoute.php
+++ b/src/Symfony/Component/Routing/Matcher/Dumper/DumperRoute.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher\Dumper;
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Container for a Route.
+ *
+ * @author Arnaud Le Blanc <arnaud.lb@gmail.com>
+ */
+class DumperRoute
+{
+    private $name;
+    private $route;
+
+    /**
+     * Constructor.
+     *
+     * @param string $name  The route name
+     * @param Route  $route The route
+     */
+    public function __construct($name, Route $route)
+    {
+        $this->name = $name;
+        $this->route = $route;
+    }
+
+    /**
+     * Returns the route name.
+     *
+     * @return string The route name
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Returns the route.
+     *
+     * @return Route The route
+     */
+    public function getRoute()
+    {
+        return $this->route;
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher1.php
@@ -30,79 +30,88 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return array_merge($this->mergeDefaults($matches, array (  'def' => 'test',)), array('_route' => 'foo'));
         }
 
-        // bar
-        if (0 === strpos($pathinfo, '/bar') && preg_match('#^/bar/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
-                $allow = array_merge($allow, array('GET', 'HEAD'));
-                goto not_bar;
+        if (0 === strpos($pathinfo, '/bar')) {
+            // bar
+            if (preg_match('#^/bar/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                    goto not_bar;
+                }
+
+                $matches['_route'] = 'bar';
+
+                return $matches;
+            }
+            not_bar:
+
+            // barhead
+            if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                    goto not_barhead;
+                }
+
+                $matches['_route'] = 'barhead';
+
+                return $matches;
+            }
+            not_barhead:
+
+        }
+
+        if (0 === strpos($pathinfo, '/test')) {
+            if (0 === strpos($pathinfo, '/test/baz')) {
+                // baz
+                if ($pathinfo === '/test/baz') {
+                    return array('_route' => 'baz');
+                }
+
+                // baz2
+                if ($pathinfo === '/test/baz.html') {
+                    return array('_route' => 'baz2');
+                }
+
+                // baz3
+                if ($pathinfo === '/test/baz3/') {
+                    return array('_route' => 'baz3');
+                }
+
             }
 
-            $matches['_route'] = 'bar';
+            // baz4
+            if (preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+                $matches['_route'] = 'baz4';
 
-            return $matches;
-        }
-        not_bar:
-
-        // barhead
-        if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
-                $allow = array_merge($allow, array('GET', 'HEAD'));
-                goto not_barhead;
+                return $matches;
             }
 
-            $matches['_route'] = 'barhead';
+            // baz5
+            if (preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+                if ($this->context->getMethod() != 'POST') {
+                    $allow[] = 'POST';
+                    goto not_baz5;
+                }
 
-            return $matches;
-        }
-        not_barhead:
+                $matches['_route'] = 'baz5';
 
-        // baz
-        if ($pathinfo === '/test/baz') {
-            return array('_route' => 'baz');
-        }
-
-        // baz2
-        if ($pathinfo === '/test/baz.html') {
-            return array('_route' => 'baz2');
-        }
-
-        // baz3
-        if ($pathinfo === '/test/baz3/') {
-            return array('_route' => 'baz3');
-        }
-
-        // baz4
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-            $matches['_route'] = 'baz4';
-
-            return $matches;
-        }
-
-        // baz5
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-            if ($this->context->getMethod() != 'POST') {
-                $allow[] = 'POST';
-                goto not_baz5;
+                return $matches;
             }
+            not_baz5:
 
-            $matches['_route'] = 'baz5';
+            // baz.baz6
+            if (preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+                if ($this->context->getMethod() != 'PUT') {
+                    $allow[] = 'PUT';
+                    goto not_bazbaz6;
+                }
 
-            return $matches;
-        }
-        not_baz5:
+                $matches['_route'] = 'baz.baz6';
 
-        // baz.baz6
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-            if ($this->context->getMethod() != 'PUT') {
-                $allow[] = 'PUT';
-                goto not_bazbaz6;
+                return $matches;
             }
+            not_bazbaz6:
 
-            $matches['_route'] = 'baz.baz6';
-
-            return $matches;
         }
-        not_bazbaz6:
 
         // foofoo
         if ($pathinfo === '/foofoo') {
@@ -197,19 +206,22 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
             return $matches;
         }
 
-        // ababa
-        if ($pathinfo === '/ababa') {
-            return array('_route' => 'ababa');
-        }
-
-        // foo4
-        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            $matches['_route'] = 'foo4';
-
-            return $matches;
-        }
-
         if (0 === strpos($pathinfo, '/a')) {
+            if (0 === strpos($pathinfo, '/aba')) {
+                // ababa
+                if ($pathinfo === '/ababa') {
+                    return array('_route' => 'ababa');
+                }
+
+                // foo4
+                if (preg_match('#^/aba/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                    $matches['_route'] = 'foo4';
+
+                    return $matches;
+                }
+
+            }
+
             // a
             if ($pathinfo === '/a/a...') {
                 return array('_route' => 'a');

--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/url_matcher2.php
@@ -30,87 +30,96 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             return array_merge($this->mergeDefaults($matches, array (  'def' => 'test',)), array('_route' => 'foo'));
         }
 
-        // bar
-        if (0 === strpos($pathinfo, '/bar') && preg_match('#^/bar/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
-                $allow = array_merge($allow, array('GET', 'HEAD'));
-                goto not_bar;
+        if (0 === strpos($pathinfo, '/bar')) {
+            // bar
+            if (preg_match('#^/bar/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                    goto not_bar;
+                }
+
+                $matches['_route'] = 'bar';
+
+                return $matches;
+            }
+            not_bar:
+
+            // barhead
+            if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
+                    $allow = array_merge($allow, array('GET', 'HEAD'));
+                    goto not_barhead;
+                }
+
+                $matches['_route'] = 'barhead';
+
+                return $matches;
+            }
+            not_barhead:
+
+        }
+
+        if (0 === strpos($pathinfo, '/test')) {
+            if (0 === strpos($pathinfo, '/test/baz')) {
+                // baz
+                if ($pathinfo === '/test/baz') {
+                    return array('_route' => 'baz');
+                }
+
+                // baz2
+                if ($pathinfo === '/test/baz.html') {
+                    return array('_route' => 'baz2');
+                }
+
+                // baz3
+                if (rtrim($pathinfo, '/') === '/test/baz3') {
+                    if (substr($pathinfo, -1) !== '/') {
+                        return $this->redirect($pathinfo.'/', 'baz3');
+                    }
+
+                    return array('_route' => 'baz3');
+                }
+
             }
 
-            $matches['_route'] = 'bar';
+            // baz4
+            if (preg_match('#^/test/(?<foo>[^/]++)/?$#s', $pathinfo, $matches)) {
+                if (substr($pathinfo, -1) !== '/') {
+                    return $this->redirect($pathinfo.'/', 'baz4');
+                }
 
-            return $matches;
-        }
-        not_bar:
+                $matches['_route'] = 'baz4';
 
-        // barhead
-        if (0 === strpos($pathinfo, '/barhead') && preg_match('#^/barhead/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            if (!in_array($this->context->getMethod(), array('GET', 'HEAD'))) {
-                $allow = array_merge($allow, array('GET', 'HEAD'));
-                goto not_barhead;
+                return $matches;
             }
 
-            $matches['_route'] = 'barhead';
+            // baz5
+            if (preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+                if ($this->context->getMethod() != 'POST') {
+                    $allow[] = 'POST';
+                    goto not_baz5;
+                }
 
-            return $matches;
-        }
-        not_barhead:
+                $matches['_route'] = 'baz5';
 
-        // baz
-        if ($pathinfo === '/test/baz') {
-            return array('_route' => 'baz');
-        }
-
-        // baz2
-        if ($pathinfo === '/test/baz.html') {
-            return array('_route' => 'baz2');
-        }
-
-        // baz3
-        if (rtrim($pathinfo, '/') === '/test/baz3') {
-            if (substr($pathinfo, -1) !== '/') {
-                return $this->redirect($pathinfo.'/', 'baz3');
+                return $matches;
             }
+            not_baz5:
 
-            return array('_route' => 'baz3');
-        }
+            // baz.baz6
+            if (preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
+                if ($this->context->getMethod() != 'PUT') {
+                    $allow[] = 'PUT';
+                    goto not_bazbaz6;
+                }
 
-        // baz4
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]++)/?$#s', $pathinfo, $matches)) {
-            if (substr($pathinfo, -1) !== '/') {
-                return $this->redirect($pathinfo.'/', 'baz4');
+                $matches['_route'] = 'baz.baz6';
+
+                return $matches;
             }
+            not_bazbaz6:
 
-            $matches['_route'] = 'baz4';
-
-            return $matches;
         }
-
-        // baz5
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-            if ($this->context->getMethod() != 'POST') {
-                $allow[] = 'POST';
-                goto not_baz5;
-            }
-
-            $matches['_route'] = 'baz5';
-
-            return $matches;
-        }
-        not_baz5:
-
-        // baz.baz6
-        if (0 === strpos($pathinfo, '/test') && preg_match('#^/test/(?<foo>[^/]++)/$#s', $pathinfo, $matches)) {
-            if ($this->context->getMethod() != 'PUT') {
-                $allow[] = 'PUT';
-                goto not_bazbaz6;
-            }
-
-            $matches['_route'] = 'baz.baz6';
-
-            return $matches;
-        }
-        not_bazbaz6:
 
         // foofoo
         if ($pathinfo === '/foofoo') {
@@ -209,19 +218,22 @@ class ProjectUrlMatcher extends Symfony\Component\Routing\Tests\Fixtures\Redirec
             return $matches;
         }
 
-        // ababa
-        if ($pathinfo === '/ababa') {
-            return array('_route' => 'ababa');
-        }
-
-        // foo4
-        if (0 === strpos($pathinfo, '/aba') && preg_match('#^/aba/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
-            $matches['_route'] = 'foo4';
-
-            return $matches;
-        }
-
         if (0 === strpos($pathinfo, '/a')) {
+            if (0 === strpos($pathinfo, '/aba')) {
+                // ababa
+                if ($pathinfo === '/ababa') {
+                    return array('_route' => 'ababa');
+                }
+
+                // foo4
+                if (preg_match('#^/aba/(?<foo>[^/]++)$#s', $pathinfo, $matches)) {
+                    $matches['_route'] = 'foo4';
+
+                    return $matches;
+                }
+
+            }
+
             // a
             if ($pathinfo === '/a/a...') {
                 return array('_route' => 'a');

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/DumperPrefixCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/DumperPrefixCollectionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Symfony\Component\Routing\Tests\Matcher\Dumper;
+
+use Symfony\Component\Routing\Route;
+use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\Routing\Matcher\Dumper\DumperPrefixCollection;
+use Symfony\Component\Routing\Matcher\Dumper\DumperRoute;
+use Symfony\Component\Routing\Matcher\Dumper\DumperCollection;
+
+class DumperPrefixCollectionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testAddPrefixRoute()
+    {
+        $coll = new DumperPrefixCollection;
+        $coll->setPrefix('');
+
+        $route = new DumperRoute('bar', new Route('/foo/bar'));
+        $coll = $coll->addPrefixRoute($route);
+
+        $route = new DumperRoute('bar2', new Route('/foo/bar'));
+        $coll = $coll->addPrefixRoute($route);
+
+        $route = new DumperRoute('qux', new Route('/foo/qux'));
+        $coll = $coll->addPrefixRoute($route);
+
+        $route = new DumperRoute('bar3', new Route('/foo/bar'));
+        $coll = $coll->addPrefixRoute($route);
+
+        $route = new DumperRoute('bar4', new Route(''));
+        $result = $coll->addPrefixRoute($route);
+
+        $expect = <<<'EOF'
+            |-coll /
+            | |-coll /f
+            | | |-coll /fo
+            | | | |-coll /foo
+            | | | | |-coll /foo/
+            | | | | | |-coll /foo/b
+            | | | | | | |-coll /foo/ba
+            | | | | | | | |-coll /foo/bar
+            | | | | | | | | |-route bar /foo/bar
+            | | | | | | | | |-route bar2 /foo/bar
+            | | | | | |-coll /foo/q
+            | | | | | | |-coll /foo/qu
+            | | | | | | | |-coll /foo/qux
+            | | | | | | | | |-route qux /foo/qux
+            | | | | | |-coll /foo/b
+            | | | | | | |-coll /foo/ba
+            | | | | | | | |-coll /foo/bar
+            | | | | | | | | |-route bar3 /foo/bar
+            | |-route bar4 /
+
+EOF;
+
+        $this->assertSame($expect, $this->collectionToString($result->getRoot(), '            '));
+    }
+
+    public function testMergeSlashNodes()
+    {
+        $coll = new DumperPrefixCollection;
+        $coll->setPrefix('');
+
+        $route = new DumperRoute('bar', new Route('/foo/bar'));
+        $coll = $coll->addPrefixRoute($route);
+
+        $route = new DumperRoute('bar2', new Route('/foo/bar'));
+        $coll = $coll->addPrefixRoute($route);
+
+        $route = new DumperRoute('qux', new Route('/foo/qux'));
+        $coll = $coll->addPrefixRoute($route);
+
+        $route = new DumperRoute('bar3', new Route('/foo/bar'));
+        $result = $coll->addPrefixRoute($route);
+
+        $result->getRoot()->mergeSlashNodes();
+
+        $expect = <<<'EOF'
+            |-coll /f
+            | |-coll /fo
+            | | |-coll /foo
+            | | | |-coll /foo/b
+            | | | | |-coll /foo/ba
+            | | | | | |-coll /foo/bar
+            | | | | | | |-route bar /foo/bar
+            | | | | | | |-route bar2 /foo/bar
+            | | | |-coll /foo/q
+            | | | | |-coll /foo/qu
+            | | | | | |-coll /foo/qux
+            | | | | | | |-route qux /foo/qux
+            | | | |-coll /foo/b
+            | | | | |-coll /foo/ba
+            | | | | | |-coll /foo/bar
+            | | | | | | |-route bar3 /foo/bar
+
+EOF;
+
+        $this->assertSame($expect, $this->collectionToString($result->getRoot(), '            '));
+    }
+
+    private function collectionToString(DumperCollection $collection, $prefix)
+    {
+        $string = '';
+        foreach ($collection as $route) {
+            if ($route instanceof DumperCollection) {
+                $string .= sprintf("%s|-coll %s\n", $prefix, $route->getPrefix());
+                $string .= $this->collectionToString($route, $prefix.'| ');
+            } else {
+                $string .= sprintf("%s|-route %s %s\n", $prefix, $route->getName(), $route->getRoute()->getPattern());
+            }
+        }
+
+        return $string;
+    }
+}
+


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Related: #3378
Backwards compatibility break: no
Symfony2 tests pass: yes

This simplifies the php matcher dumper by allowing the dumper to re-organize routes in the dumper's own structure.

As a result, dumping is made a little simpler. This is also helps much for my hostname-based routes PR #3378.

Reorganizing routes also allows to find more optimization opportunities:

Currently the dumper wraps some collections of routes in a `if (0 === strpos($pathinfo, '/someprefix')` if the collection has user-defined prefix, and if it contains more than one direct child Route. This can miss many optimization opportunities.

The PR changes this by building a prefix tree of routes based on the static prefix extracted from routes' patterns. Then every leave having a prefix and more than one child (route or collection) will be wrapped in a `if` statement.

Example:

```
// No explicit prefix is specified
@Route("/cafe")
@Route("/cacao")
@Route("/coca")
```

is compiled like this:

```
if (url starts with /c) {
    if (url starts with /ca) {
        // test route "/cafe"
        // test route "/cacao"
    }
    // test route "/coca"
}
```

Some tests have many white space changes, much more easier to review [here](https://github.com/symfony/symfony/pull/5734/files?w=1)
