### PR TITLE
[Console] [ProgressHelper] better percentage precision

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -304,7 +304,7 @@ class ProgressHelper extends Helper
         $vars    = array();
         $percent = 0;
         if ($this->max > 0) {
-            $percent = (double) round($this->current / $this->max, 1);
+            $percent = (double) round($this->current / $this->max, 2);
         }
 
         if (isset($this->formatVars['bar'])) {

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
@@ -63,6 +63,18 @@ class ProgressHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->generateOutput('  1/10 [_/        ]  10%'), stream_get_contents($output->getStream()));
     }
 
+    public function testPercent()
+    {
+        $progress = new ProgressHelper();
+        $progress->start($output = $this->getOutputStream(), 50);
+        $progress->display();
+        $progress->advance();
+        $progress->advance();
+
+        rewind($output->getStream());
+        $this->assertEquals($this->generateOutput('  0/50 [>---------------------------]   0%').$this->generateOutput('  1/50 [>---------------------------]   2%').$this->generateOutput('  2/50 [=>--------------------------]   4%'), stream_get_contents($output->getStream()));
+    }
+
     protected function getOutputStream()
     {
         return new StreamOutput(fopen('php://memory', 'r+', false));


### PR DESCRIPTION
With this code : 

``` php
$progress = new ProgressHelper();
$progress->start($output, 50);
$progress->display();
$progress->advance();
$progress->advance();
$progress->advance();
$progress->advance();
$progress->advance();
$progress->advance();
```

The output was : 

```
  0/50 [>---------------------------]   0% // float(0)
  1/50 [>---------------------------]   0% // float(0)
  2/50 [>---------------------------]   0% // float(0)
  3/50 [==>-------------------------]  10% // float(0.1)
  4/50 [==>-------------------------]  10% // float(0.1)
  5/50 [==>-------------------------]  10% // float(0.1)
  6/50 [==>-------------------------]  10% // float(0.1)
```

With this PR :

```
  0/50 [>---------------------------]   0% // float(0)
  1/50 [>---------------------------]   2% // float(0.02)
  2/50 [=>--------------------------]   4% // float(0.04)
  3/50 [=>--------------------------]   6% // float(0.06)
  4/50 [==>-------------------------]   8% // float(0.08)
  5/50 [==>-------------------------]  10% // float(0.1)
  6/50 [===>------------------------]  12% // float(0.12)
```

Tests are included.
