### PR TITLE
[TwigBundle] Moved the registration of the app global to the environment

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+ * The `app` global variable is now injected even when using the twig service directly.
+
 2.1.0
 -----
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -26,6 +26,10 @@
         <service id="twig" class="%twig.class%">
             <argument type="service" id="twig.loader" />
             <argument>%twig.options%</argument>
+            <call method="addGlobal">
+                <argument>app</argument>
+                <argument type="service" id="templating.globals" />
+            </call>
         </service>
 
         <service id="twig.cache_warmer" class="%twig.cache_warmer.class%" public="false">
@@ -43,7 +47,6 @@
             <argument type="service" id="twig" />
             <argument type="service" id="templating.name_parser" />
             <argument type="service" id="templating.locator" />
-            <argument type="service" id="templating.globals" />
         </service>
 
         <service id="twig.extension.trans" class="%twig.extension.trans.class%" public="false">

--- a/src/Symfony/Bundle/TwigBundle/TwigEngine.php
+++ b/src/Symfony/Bundle/TwigBundle/TwigEngine.php
@@ -13,7 +13,6 @@ namespace Symfony\Bundle\TwigBundle;
 
 use Symfony\Bridge\Twig\TwigEngine as BaseEngine;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
 use Symfony\Bundle\FrameworkBundle\Templating\TemplateReference;
 use Symfony\Component\Templating\TemplateNameParserInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,17 +33,12 @@ class TwigEngine extends BaseEngine implements EngineInterface
      * @param \Twig_Environment           $environment A \Twig_Environment instance
      * @param TemplateNameParserInterface $parser      A TemplateNameParserInterface instance
      * @param FileLocatorInterface        $locator     A FileLocatorInterface instance
-     * @param GlobalVariables|null        $globals     A GlobalVariables instance or null
      */
-    public function __construct(\Twig_Environment $environment, TemplateNameParserInterface $parser, FileLocatorInterface $locator, GlobalVariables $globals = null)
+    public function __construct(\Twig_Environment $environment, TemplateNameParserInterface $parser, FileLocatorInterface $locator)
     {
         parent::__construct($environment, $parser);
 
         $this->locator = $locator;
-
-        if (null !== $globals) {
-            $environment->addGlobal('app', $globals);
-        }
     }
 
     public function setDefaultEscapingStrategy($strategy)

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -75,8 +75,6 @@ class ProfilerController
             'request'   => $request,
             'templates' => $this->getTemplateManager()->getTemplates($profile),
             'is_ajax'   => $request->isXmlHttpRequest(),
-            // for BC compatibility
-            'app'       => array('request' => $request),
         )));
     }
 
@@ -126,7 +124,7 @@ class ProfilerController
         $file = $request->files->get('file');
 
         if (empty($file) || !$file->isValid()) {
-            return new RedirectResponse($router->generate('_profiler_info', array('about' => 'upload_error')));
+            return new RedirectResponse($this->generator->generate('_profiler_info', array('about' => 'upload_error')));
         }
 
         if (!$profile = $this->profiler->import(file_get_contents($file->getPathname()))) {


### PR DESCRIPTION
This makes the app global variable available also when accessing the Twig
environment directly instead of using the TwigEngine.
