### PR TITLE
Made the router lazy when setting the context

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -15,6 +15,8 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\ConfigCache;
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 
 /**
  * The Router class is an example of the integration of all pieces of the
@@ -150,8 +152,12 @@ class Router implements RouterInterface
     {
         $this->context = $context;
 
-        $this->getMatcher()->setContext($context);
-        $this->getGenerator()->setContext($context);
+        if (null !== $this->matcher) {
+            $this->getMatcher()->setContext($context);
+        }
+        if (null !== $this->generator) {
+            $this->getGenerator()->setContext($context);
+        }
     }
 
     /**


### PR DESCRIPTION
Initializing the matcher and the generator to set the context does not make
sense as it is set anyway when building them. This avoids initializing
them in the RouterListener if you never actually use them (for instance
because you use the apache matcher).

@fabpot should it be considered as a bugfix (and so done in older branches) or a new feature ?
