### PR TITLE
[Locale] fixed fallback locale

### DIFF
--- a/src/Symfony/Component/Locale/Locale.php
+++ b/src/Symfony/Component/Locale/Locale.php
@@ -285,12 +285,8 @@ class Locale extends \Locale
      */
     protected static function getFallbackLocale($locale)
     {
-        if ($locale === self::getDefault()) {
-            return null;
-        }
-
         if (false === $pos = strrpos($locale, '_')) {
-            return self::getDefault();
+            return null;
         }
 
         return substr($locale, 0, $pos);

--- a/src/Symfony/Component/Locale/Tests/LocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/LocaleTest.php
@@ -19,6 +19,9 @@ class LocaleTest extends LocaleTestCase
     public function testGetDisplayCountriesReturnsFullListForSubLocale()
     {
         $this->skipIfIntlExtensionIsNotLoaded();
+
+        Locale::setDefault('de_CH');
+
         $countriesDe = Locale::getDisplayCountries('de');
         $countriesDeCh = Locale::getDisplayCountries('de_CH');
 
@@ -30,6 +33,9 @@ class LocaleTest extends LocaleTestCase
     public function testGetDisplayLanguagesReturnsFullListForSubLocale()
     {
         $this->skipIfIntlExtensionIsNotLoaded();
+
+        Locale::setDefault('de_CH');
+
         $languagesDe = Locale::getDisplayLanguages('de');
         $languagesDeCh = Locale::getDisplayLanguages('de_CH');
 
@@ -41,6 +47,9 @@ class LocaleTest extends LocaleTestCase
     public function testGetDisplayLocalesReturnsFullListForSubLocale()
     {
         $this->skipIfIntlExtensionIsNotLoaded();
+
+        Locale::setDefault('de_CH');
+
         $localesDe = Locale::getDisplayLocales('de');
         $localesDeCh = Locale::getDisplayLocales('de_CH');
 


### PR DESCRIPTION
The `getFallbackLocale()` method in `Symfony\Component\Locale\Locale` did not return a fallback locale if the current locale (`Locale::getDefault()`) was a 5-char locale like de_CH.

`LocaleTest` failed when the locale was set to de_CH before running (see changes in LocaleTest).

(second attempt after messing up PR#5641)
