### PR TITLE
[ClassLoader] fixed bracketed/unbracketed namespaces mix

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -126,6 +126,8 @@ class ClassCollectionLoader
     public static function fixNamespaceDeclarations($source)
     {
         if (!function_exists('token_get_all')) {
+            $source = preg_replace('/namespace\s(.*);/', "\nnamespace $1\n{\n", $source)."\n}\n";
+
             return $source;
         }
 


### PR DESCRIPTION
fixes symfony/symfony-standard#430

This error occurs when loading classes in some namespace with classes in the global namespace and php is compiled without the tokenizer.

This adds brackets around namespace classes in this case.

Tests don't pass when the tokenizer is disabled, because of small diffs (extra \n in some palces), not sure if it's a big deal, anyway they were already failing with this php config.
