### PR TITLE
Add phpunit/phpunit requirement in dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ before_script:
     - COMPOSER_ROOT_VERSION=dev-master composer --dev install
     - php src/Symfony/Component/Locale/Resources/data/build-data.php
     - export USE_INTL_ICU_DATA_VERSION=1
+    
+script: ./vendor/bin/phpunit

--- a/autoload.php.dist
+++ b/autoload.php.dist
@@ -1,6 +1,6 @@
 <?php
 
-$loader = require_once __DIR__.'/vendor/autoload.php';
+$loader = require __DIR__.'/vendor/autoload.php';
 
 use Doctrine\Common\Annotations\AnnotationRegistry;
 

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         "doctrine/orm": ">=2.2.3,<2.4-dev",
         "doctrine/data-fixtures": "1.0.*",
         "propel/propel1": "dev-master",
-        "monolog/monolog": "dev-master"
+        "monolog/monolog": "dev-master",
+        "phpunit/phpunit": "3.7.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\": "src/" },


### PR DESCRIPTION
This change avoid using pear for test and simplify test process (specially on windows) for a new install by using vendor/bin/phpunit command
