### PR TITLE
[Console] Add askForList in dialog helper

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -79,7 +79,7 @@ class DialogHelper extends Helper
      *
      * @param OutputInterface $output    An Output instance
      * @param string|array    $question  The question to ask
-     * @param callback        $validator A PHP callback
+     * @param callable        $validator A PHP callback
      *
      * @return array
      */
@@ -108,6 +108,8 @@ class DialogHelper extends Helper
                 } catch (\Exception $error) {
                     $output->writeln($formatter->formatBlock($error->getMessage(), 'error'));
                 }
+            } else {
+                $list[] = $value;
             }
         }
 
@@ -123,7 +125,7 @@ class DialogHelper extends Helper
      *
      * @param OutputInterface $output    An Output instance
      * @param string|array    $question  The question to ask
-     * @param callback        $validator A PHP callback
+     * @param callable        $validator A PHP callback
      * @param integer         $attempts  Max number of times to ask before giving up (false by default, which means infinite)
      * @param string          $default   The default answer if none is given by the user
      *

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -72,6 +72,49 @@ class DialogHelper extends Helper
     }
 
     /**
+     * Asks for a list of values interactively
+     *
+     * Optionally filter callback can be provided to filter out values
+     * and/or throw exception, if they don't pass validation
+     *
+     * @param OutputInterface $output    An Output instance
+     * @param string|array    $question  The question to ask
+     * @param callback        $validator A PHP callback
+     *
+     * @return array
+     */
+    public function askForList(OutputInterface $output, $question, $filter = null)
+    {
+        if (!empty($filter)) {
+            if(!is_callable($filter)) {
+                throw new \InvalidArgumentException('Filter should be callable');
+            }
+
+            $formatter = $this->getHelperSet()->get('formatter');
+        }
+
+        $output->writeln($question);
+
+        $list = array();
+        while (true) {
+            $value = $this->ask($output, '> ');
+            if (empty($value)) {
+                break;
+            }
+
+            if(!empty($filter)) {
+                try {
+                    $list[] = call_user_func($filter, $value);
+                } catch (\Exception $error) {
+                    $output->writeln($formatter->formatBlock($error->getMessage(), 'error'));
+                }
+            }
+        }
+
+        return $list;
+    }
+
+    /**
      * Asks for a value and validates the response.
      *
      * The validator receives the data to validate. It must return the

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -18,6 +18,27 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class DialogHelperTest extends \PHPUnit_Framework_TestCase
 {
+    public function testAskForList()
+    {
+        $dialog = new DialogHelper();
+        $dialog->setInputStream($this->getInputStream("1\n2\n3\n\n"));
+
+        $list = $dialog->askForList($this->getOutputStream(), 'Give me a list');
+        $this->assertEquals(array(1,2,3), $list);
+
+        $helperSet = new HelperSet(array(new FormatterHelper()));
+        $dialog->setHelperSet($helperSet);
+
+        $dialog->setInputStream($this->getInputStream("1\nbanana\n3\n\n"));
+        $list = $dialog->askForList($this->getOutputStream(), 'Give me a list of numbers', function($v) {
+            if(!is_numeric($v)) {
+                throw new \InvalidArgumentException("'$v' is not a number!");
+            }
+            return $v;
+        });
+        $this->assertEquals(array(1,3), $list);
+    }
+
     public function testAsk()
     {
         $dialog = new DialogHelper();


### PR DESCRIPTION
There are some cases, when CLI application wants to get a list of values from a user interactively. So this functionality could be helpful for that.

```
$list = $this->getHelper('dialog')->askForList($output, 'Give me a list of numbers', function($i) {
    if(!is_numeric($i)) {
        throw new \InvalidArgumentException('Value is not number');
    }

    return $i;
});
var_dump($list);
```

In order to get list from user simple call to askForList is required. Optional filter could be provided to validate and filter received value. Example flow would look like the following:

```
$ app/console pugooroo:ask-for-list
Give me a list of numbers
> 1
> 2
> fsf
 Value is not number
>  4
> 
array(3) {
  [0] =>
  string(1) "1"
  [1] =>
  string(1) "2"
  [2] =>
  string(1) "4"
}
```

Still needs comments, as this method has similarities with askAndValidate, which has validation behaviour semantically different to Validator component, so i've decided not to re-use it and name a filter concept. If receive approval - will add unit tests and further documentation.
