### PR TITLE
[HttpFoundation] Fixed IPv6 Check in RequestMatcher

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RequestMatcher.php
+++ b/src/Symfony/Component/HttpFoundation/RequestMatcher.php
@@ -198,7 +198,7 @@ class RequestMatcher implements RequestMatcherInterface
      */
     protected function checkIp6($requestIp, $ip)
     {
-        if (!defined('AF_INET6')) {
+        if (!((extension_loaded('sockets') && defined('AF_INET6')) || @inet_pton('::1'))) {
             throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
         }
 


### PR DESCRIPTION
RequestMatcher checks IPv6 support with

``` php
if (!defined('AF_INET6')) {
    throw new \RuntimeException('Unable to check Ipv6. Check that PHP was not compiled with option "disable-ipv6".');
}
```

wich depends on sockets extension.

This PR adds a fallback by checking return value of silented call to `inet_pton` if extension is not available (code from https://github.com/dsp/v6tools/blob/master/src/v6tools/Runtime.php).
