### PR TITLE
[Form] Fixed setting the "data" option to an object in "choice" and "entity" type

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -198,6 +198,10 @@ class ChoiceType extends AbstractType
             'empty_value'       => $emptyValue,
             'error_bubbling'    => false,
             'compound'          => $compound,
+            // The view data is always a string, even if the "data" option
+            // is manually set to an object.
+            // See https://github.com/symfony/symfony/pull/5582
+            'data_class'        => null,
         ));
 
         $resolver->setNormalizers(array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -745,4 +745,22 @@ class ChoiceTypeTest extends TypeTestCase
             'choices' => array(),
         ));
     }
+
+    public function testInitializeWithDefaultObjectChoice()
+    {
+        $obj1 = (object) array('value' => 'a', 'label' => 'A');
+        $obj2 = (object) array('value' => 'b', 'label' => 'B');
+        $obj3 = (object) array('value' => 'c', 'label' => 'C');
+        $obj4 = (object) array('value' => 'd', 'label' => 'D');
+
+        $form = $this->factory->create('choice', null, array(
+            'choice_list' => new ObjectChoiceList(array($obj1, $obj2, $obj3, $obj4), 'label', array(), null, 'value'),
+            // Used to break because "data_class" was inferred, which needs to
+            // remain null in every case (because it refers to the view format)
+            'data' => $obj3,
+        ));
+
+        // Trigger data initialization
+        $form->getViewData();
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5582
Todo: -
License of the code: MIT
Documentation PR: -
