### PR TITLE
[Form] Fixed creation of multiple money fields with different currencies

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/MoneyType.php
@@ -86,12 +86,14 @@ class MoneyType extends AbstractType
             return '{{ widget }}';
         }
 
-        if (!isset(self::$patterns[\Locale::getDefault()])) {
-            self::$patterns[\Locale::getDefault()] = array();
+        $locale = \Locale::getDefault();
+
+        if (!isset(self::$patterns[$locale])) {
+            self::$patterns[$locale] = array();
         }
 
-        if (!isset(self::$patterns[\Locale::getDefault()][$currency])) {
-            $format = new \NumberFormatter(\Locale::getDefault(), \NumberFormatter::CURRENCY);
+        if (!isset(self::$patterns[$locale][$currency])) {
+            $format = new \NumberFormatter($locale, \NumberFormatter::CURRENCY);
             $pattern = $format->formatCurrency('123', $currency);
 
             // the spacings between currency symbol and number are ignored, because
@@ -103,14 +105,14 @@ class MoneyType extends AbstractType
             preg_match('/^([^\s\xc2\xa0]*)[\s\xc2\xa0]*123(?:[,.]0+)?[\s\xc2\xa0]*([^\s\xc2\xa0]*)$/u', $pattern, $matches);
 
             if (!empty($matches[1])) {
-                self::$patterns[\Locale::getDefault()] = $matches[1].' {{ widget }}';
+                self::$patterns[$locale][$currency] = $matches[1].' {{ widget }}';
             } elseif (!empty($matches[2])) {
-                self::$patterns[\Locale::getDefault()] = '{{ widget }} '.$matches[2];
+                self::$patterns[$locale][$currency] = '{{ widget }} '.$matches[2];
             } else {
-                self::$patterns[\Locale::getDefault()] = '{{ widget }}';
+                self::$patterns[$locale][$currency] = '{{ widget }}';
             }
         }
 
-        return self::$patterns[\Locale::getDefault()];
+        return self::$patterns[$locale][$currency];
     }
 }

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/Type/MoneyTypeTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/Type/MoneyTypeTest.php
@@ -33,4 +33,18 @@ class MoneyTypeTest extends LocalizedTestCase
         $view = $form->createView();
         $this->assertTrue((Boolean) strstr($view->get('money_pattern'), '¥'));
     }
+
+    // https://github.com/symfony/symfony/issues/5458
+    public function testPassDifferentPatternsForDifferentCurrencies()
+    {
+        \Locale::setDefault('de_DE');
+
+        $form1 = $this->factory->create('money', null, array('currency' => 'GBP'));
+        $form2 = $this->factory->create('money', null, array('currency' => 'EUR'));
+        $view1 = $form1->createView();
+        $view2 = $form2->createView();
+
+        $this->assertSame('{{ widget }} £', $view1->get('money_pattern'));
+        $this->assertSame('{{ widget }} €', $view2->get('money_pattern'));
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5458
Todo: -
License of the code: MIT
Documentation PR: -
