### PR TITLE
[Form] Fixed error message in PropertyPath to not advice to use a non-existing feature

### DIFF
--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
@@ -299,8 +299,10 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
         $expectedMessage = sprintf(
             'Neither element "axes" nor method "setAxes()" exists in class '
                 .'"%s", nor could adders and removers be found based on the '
-                .'guessed singulars: %s (provide a singular by suffixing the '
-                .'property path with "|{singular}" to override the guesser)',
+                .'guessed singulars: %s'
+//                . '(provide a singular by suffixing the '
+//                .'property path with "|{singular}" to override the guesser)'
+                ,
             get_class($car),
             implode(', ', (array) $singulars = FormUtil::singularify('Axes'))
         );
@@ -324,9 +326,10 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
         $propertyPath = new PropertyPath('axes');
         $expectedMessage = sprintf(
             'Property "axes" is not public in class "%s", nor could adders and '
-                .'removers be found based on the guessed singulars: %s '
-                .'(provide a singular by suffixing the property path with '
-                .'"|{singular}" to override the guesser). Maybe you should '
+                .'removers be found based on the guessed singulars: %s'
+//                .' (provide a singular by suffixing the property path with '
+//                .'"|{singular}" to override the guesser)'
+                . '. Maybe you should '
                 .'create the method "setAxes()"?',
             get_class($car),
             implode(', ', (array) $singulars = FormUtil::singularify('Axes'))

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -521,7 +521,8 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 } else {
                     $adderRemoverError = ', nor could adders and removers be found based on the ';
                     if (null === $singular) {
-                        $adderRemoverError .= 'guessed singulars: '.implode(', ', $singulars).' (provide a singular by suffixing the property path with "|{singular}" to override the guesser)';
+                        // $adderRemoverError .= 'guessed singulars: '.implode(', ', $singulars).' (provide a singular by suffixing the property path with "|{singular}" to override the guesser)';
+                        $adderRemoverError .= 'guessed singulars: '.implode(', ', $singulars);
                     } else {
                         $adderRemoverError .= 'passed singular: '.$singular;
                     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5388
Todo: -
License of the code: MIT
Documentation PR: -
