### PR TITLE
[ConfigDumpReference] avoid notice for variable nodes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -213,6 +213,12 @@ EOF
                     $default = 'false';
                 } elseif (null === $default) {
                     $default = '~';
+                } elseif (is_array($default)) {
+                    if ($node->hasDefaultValue() && count($defaultArray = $node->getDefaultValue())) {
+                        $default = '';
+                    } elseif (!is_array($example)) {
+                        $default = '[]';
+                    }
                 }
             }
         }


### PR DESCRIPTION
When a variable node has an array as default value, a notice occurs later on because of an "array to string conversion", which is turned to an exception in debug mode (mandatory in order to run this command).
