### PR TITLE
[Config/ReferenceDumper] avoid notice for variable nodes

### DIFF
--- a/src/Symfony/Component/Config/Definition/ReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/ReferenceDumper.php
@@ -91,6 +91,12 @@ class ReferenceDumper
                     $default = 'false';
                 } elseif (null === $default) {
                     $default = '~';
+                } elseif (is_array($default)) {
+                    if ($node->hasDefaultValue() && count($defaultArray = $node->getDefaultValue())) {
+                        $default = '';
+                    } elseif (!is_array($example)) {
+                        $default = '[]';
+                    }
                 }
             }
         }


### PR DESCRIPTION
Not sure if you usually handle this manually when merging branches, but there has been some refactoring in master which makes #5783 not automatically mergeable. This is the same patch against master.
