### PR TITLE
Allow container extensions to reach imports, parameters and services sections

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -319,10 +319,6 @@ class YamlFileLoader extends FileLoader
     private function loadFromExtensions($content)
     {
         foreach ($content as $namespace => $values) {
-            if (in_array($namespace, array('imports', 'parameters', 'services'))) {
-                continue;
-            }
-
             if (!is_array($values)) {
                 $values = array();
             }


### PR DESCRIPTION
I would like to write an extension to enhance the capability of "services" section, but current YamlFileLoader does not explicitly allow me to do that.

If a developer writes extension method `getAlias` as `return "services"`, he definitely wants to use this extension for "services" section and knows what he's doing. Why disallow that?
