### PR TITLE
[Console] Read input in raw mode to avoid processing escape sequences

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -128,7 +128,7 @@ class DialogHelper extends Helper
 
         if (false !== $shell = $this->getShell()) {
             $output->write($question);
-            $readCmd = $shell === 'csh' ? 'set mypassword = $<' : 'read mypassword';
+            $readCmd = $shell === 'csh' ? 'set mypassword = $<' : 'read -r mypassword';
             $command = sprintf("/usr/bin/env %s -c 'stty -echo; %s; stty echo; echo \$mypassword'", $shell, $readCmd);
             $value = rtrim(shell_exec($command));
             $output->writeln('');


### PR DESCRIPTION
As outlined in composer/composer#1238:

> Use read -r rather than the current read shell builtin to take a password from the user on the CLI, the -r is the raw option which means backslashes () aren't interpreted as escape characters, so \ is a literal \, otherwise they are nommed or double slashes become single ones etc.
