### PR TITLE
[Console] Switch to Application::find() method for ease

### DIFF
--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -70,7 +70,7 @@ EOF
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         if (null === $this->command) {
-            $this->command = $this->getApplication()->get($input->getArgument('command_name'));
+            $this->command = $this->getApplication()->find($input->getArgument('command_name'));
         }
 
         if ($input->getOption('xml')) {


### PR DESCRIPTION
Why we need to write the full command name when using the app/console help? 
Here I simply switch to find(), to be able to use a shortcut.
