### PR TITLE
Update src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoS...

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -22,12 +22,12 @@ class PdoSessionHandler implements \SessionHandlerInterface
     /**
      * @var \PDO PDO instance.
      */
-    private $pdo;
+    protected $pdo;
 
     /**
      * @var array Database options.
      */
-    private $dbOptions;
+    protected $dbOptions;
 
     /**
      * Constructor.


### PR DESCRIPTION
...essionHandler.php

Changed private to protected on the pdo and dbOptions class.  Private
properties makes this class very difficult to subclass.  When attempting to modify
some query syntax for an oracle installation, the ability to access dbOptions and 
the pdo reference is essential, yet inaccessible to the subclass.
