### PR TITLE
[Security] Tweak UsernamePasswordFormAuthenticationListener

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -55,7 +55,7 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
      */
     protected function requiresAuthentication(Request $request)
     {
-        if ($this->options['post_only'] && !$request->isMethod('post')) {
+        if ($this->options['post_only'] && !$request->isMethod('POST')) {
             return false;
         }
 
@@ -67,14 +67,6 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
      */
     protected function attemptAuthentication(Request $request)
     {
-        if ($this->options['post_only'] && !$request->isMethod('post')) {
-            if (null !== $this->logger) {
-                $this->logger->debug(sprintf('Authentication method not supported: %s.', $request->getMethod()));
-            }
-
-            return null;
-        }
-
         if (null !== $this->csrfProvider) {
             $csrfToken = $request->get($this->options['csrf_parameter'], null, true);
 
@@ -83,8 +75,13 @@ class UsernamePasswordFormAuthenticationListener extends AbstractAuthenticationL
             }
         }
 
-        $username = trim($request->get($this->options['username_parameter'], null, true));
-        $password = $request->get($this->options['password_parameter'], null, true);
+        if ($this->options['post_only']) {
+            $username = trim($request->request->get($this->options['username_parameter'], null, true));
+            $password = $request->request->get($this->options['password_parameter'], null, true);
+        } else {
+            $username = trim($request->get($this->options['username_parameter'], null, true));
+            $password = $request->get($this->options['password_parameter'], null, true);
+        }
 
         $request->getSession()->set(SecurityContextInterface::LAST_USERNAME, $username);
 


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: [![Build Status](https://secure.travis-ci.org/acasademont/symfony.png)](http://travis-ci.org/acasademont/symfony)
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Improvements:
- Do not check twice for the `only_post` condition. The condition in the `attemptAuthentication` method is useless as this method will never be called if the previous `requiresAuthentication` call returns false.
- If the expected request is `only_post`, check only the POST variables for the username and password parameters. Otherwise, query params and attributes are checked before.
- Use POST instead of post for correctness
