### PR TITLE
[Form] A form with an entity field is never empty

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -684,7 +684,7 @@ class Form implements \IteratorAggregate, FormInterface
             }
         }
 
-        return FormUtil::isEmpty($this->modelData) || array() === $this->modelData;
+        return FormUtil::isEmpty($this->modelData) || 0 === count($this->modelData);
     }
 
     /**

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -684,7 +684,11 @@ class Form implements \IteratorAggregate, FormInterface
             }
         }
 
-        return FormUtil::isEmpty($this->modelData) || 0 === count($this->modelData);
+        return FormUtil::isEmpty($this->modelData) ||
+               array() === $this->modelData ||
+               ($this->modelData instanceof \Serializable &&
+               $this->modelData instanceof \ArrayAccess &&
+               0 === iterator_count($this->modelData));
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -21,7 +21,6 @@ use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;
 use Symfony\Component\Form\Tests\Fixtures\FixedFilterListener;
-use Doctrine\Common\Collections\ArrayCollection;
 
 class SimpleFormTest extends AbstractFormTest
 {
@@ -173,9 +172,9 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertTrue($this->form->isEmpty());
     }
 
-    public function testEmptyIfEmptyArrayCollection()
+    public function testEmptyIfEmptyCountable()
     {
-        $this->form->setData(new ArrayCollection());
+        $this->form->setData(new \ArrayObject());
 
         $this->assertTrue($this->form->isEmpty());
     }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -16,12 +16,12 @@ use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Form\FormConfigBuilder;
-use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;
 use Symfony\Component\Form\Tests\Fixtures\FixedFilterListener;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class SimpleFormTest extends AbstractFormTest
 {
@@ -169,6 +169,13 @@ class SimpleFormTest extends AbstractFormTest
     public function testEmptyIfEmptyArray()
     {
         $this->form->setData(array());
+
+        $this->assertTrue($this->form->isEmpty());
+    }
+
+    public function testEmptyIfEmptyArrayCollection()
+    {
+        $this->form->setData(new ArrayCollection());
 
         $this->assertTrue($this->form->isEmpty());
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5826
License of the code: MIT
