### PR TITLE
[Locale] Implement the lenient isser in the StubIntlFormatter

### DIFF
--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -319,7 +319,7 @@ class StubIntlDateFormatter
     /**
      * Returns whether the formatter is lenient
      *
-     * @return string   The timezone identifier used by the formatter
+     * @return Boolean
      *
      * @see    http://www.php.net/manual/en/intldateformatter.islenient.php
      *
@@ -327,7 +327,7 @@ class StubIntlDateFormatter
      */
     public function isLenient()
     {
-        throw new MethodNotImplementedException(__METHOD__);
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
@@ -629,13 +629,10 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->assertEquals(StubIntlDateFormatter::FULL, $formatter->getTimeType());
     }
 
-    /**
-     * @expectedException Symfony\Component\Locale\Exception\MethodNotImplementedException
-     */
     public function testIsLenient()
     {
         $formatter = $this->createStubFormatter();
-        $formatter->isLenient();
+        $this->assertFalse($formatter->isLenient());
     }
 
     /**


### PR DESCRIPTION
When hardcoding other settings in the stub (the calendar, the locale...), the corresponding getters are implemented using the hardcoded value. This does the same for `isLenient` to be consistent.
