### PR TITLE
[Form] Fixed cannot unset string offsets in CsrfValidationListener

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -68,7 +68,9 @@ class CsrfValidationListener implements EventSubscriberInterface
                 $form->addError(new FormError('The CSRF token is invalid. Please try to resubmit the form.'));
             }
 
-            unset($data[$this->fieldName]);
+            if (is_array($data)) {
+                unset($data[$this->fieldName]);
+            }
         }
 
         $event->setData($data);

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -71,5 +71,8 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
 
         $validation = new CsrfValidationListener('csrf', $this->csrfProvider, 'unknown');
         $validation->preBind($event);
+
+        // Validate accordingly
+        $this->assertSame($data, $event->getData());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Csrf\EventListener;
+
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener;
+
+class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $dispatcher;
+    protected $factory;
+    protected $csrfProvider;
+
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
+            $this->markTestSkipped('The "EventDispatcher" component is not available');
+        }
+
+        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');
+        $this->csrfProvider = $this->getMock('Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface');
+        $this->form = $this->getBuilder('post')
+            ->setDataMapper($this->getDataMapper())
+            ->getForm();
+    }
+
+    protected function tearDown()
+    {
+        $this->dispatcher = null;
+        $this->factory = null;
+        $this->csrfProvider = null;
+        $this->form = null;
+    }
+
+    protected function getBuilder($name = 'name')
+    {
+        return new FormBuilder($name, null, $this->dispatcher, $this->factory, array('compound' => true));
+    }
+
+    protected function getForm($name = 'name')
+    {
+        return $this->getBuilder($name)->getForm();
+    }
+
+    protected function getDataMapper()
+    {
+        return $this->getMock('Symfony\Component\Form\DataMapperInterface');
+    }
+
+    protected function getMockForm()
+    {
+        return $this->getMock('Symfony\Component\Form\Tests\FormInterface');
+    }
+
+    public function testStringFormData()
+    {
+        $data = "XP4HUzmHPi";
+        $event = new FormEvent($this->form, $data);
+
+        $validation = new CsrfValidationListener('csrf', $this->csrfProvider, 'unknown');
+        $validation->preBind($event);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -63,6 +63,7 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
         return $this->getMock('Symfony\Component\Form\Tests\FormInterface');
     }
 
+    // https://github.com/symfony/symfony/pull/5838
     public function testStringFormData()
     {
         $data = "XP4HUzmHPi";


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

A php fatal error is happening when someone rewrite the entire form data for an object with a single input. 

```
Fatal error: Cannot unset string offsets in vendor/symfony/symfony/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php on line 72
```

Example: 

``` html
<form action="/app_dev.php/post/create" method="post" >
    <div id="posttype">
        <div>
            <label for="posttype_name" class="required">Name</label>
            <input type="text" id="posttype_name" name="posttype[name]" required="required" maxlength="255" />
        </div>
        <div>
            <label for="posttype_text" class="required">Text</label>
            <textarea id="posttype_text" name="posttype[text]" required="required"></textarea>
        </div>
        <input type="hidden" id="posttype__token" name="posttype[_token]" value="83a1617c694fbdea43c2527f1a55c7419ce82a42" /></div>
        <p>
            <button type="submit">Create</button>
        </p>
</form>
```

If someone alters the html to add a simple input at the bottom of the form like this one:

``` html
<input type="text" id="posttype" name="posttype" value="test123" />
```

The result will be a php fatal error.
