### PR TITLE
[Form] Use Norm Data instead of App Data

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeCollectionListener.php
@@ -33,7 +33,7 @@ class MergeCollectionListener implements EventSubscriberInterface
 
     public function onBindNormData(FilterDataEvent $event)
     {
-        $collection = $event->getForm()->getData();
+        $collection = $event->getForm()->getNormData();
         $data = $event->getData();
 
         if (!$collection) {


### PR DESCRIPTION
This listener is triggered when normalized data are binded.

We have to use $event->getForm()->getNormData() instead of $event->getForm()->getData().

I have made a new FormType having 'entity' as parent and having a NormTransformer. I encountered a problem in MergeCollectionListener when the request is binded.

My commit fix it.
