### PR TITLE
[Form] Add Translator Validator 

### DIFF
--- a/src/Symfony/Component/Validator/Tests/Translation/TranslatorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Translation/TranslatorValidatorTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Symfony\Component\Validator\Tests\Translation;
+
+use Symfony\Component\Validator\Translation\TranslatorValidator;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use stdClass;
+
+class TranslatorValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    private $parentValidator;
+    private $translatorValidator;
+    private $translator;
+
+    public function setUp()
+    {
+        $this->parentValidator     = $this->getMock('Symfony\Component\Validator\ValidatorInterface');
+        $this->translator          = $this->getMock('Symfony\Component\Translation\TranslatorInterface');
+        $this->translatorValidator = new TranslatorValidator($this->parentValidator, $this->translator);
+    }
+
+    public function createCvlFixture()
+    {
+        $cvl = new ConstraintViolationList();
+        $cvl->add(new ConstraintViolation('message', array(), null, 'path', 1234));
+
+        return $cvl;
+    }
+
+    public function testValidate()
+    {
+        $object = new stdClass;
+        $cvl = $this->createCvlFixture();
+
+        $this->mockTranslatorTrans();
+        $this->parentValidator->expects($this->once())
+                              ->method('validate')
+                              ->with($this->equalTo($object), $this->equalTo(array('GROUP')))
+                              ->will($this->returnValue($cvl));
+
+        $translatedCvl = $this->translatorValidator->validate($object, array('GROUP'));
+
+        $this->assertConstraintsTranslated($translatedCvl, $cvl);
+    }
+
+    public function testValidateProperty()
+    {
+        $object = new stdClass;
+        $cvl = $this->createCvlFixture();
+
+        $this->mockTranslatorTrans();
+        $this->parentValidator->expects($this->once())
+                              ->method('validateProperty')
+                              ->with($this->equalTo($object), $this->equalTo('prop'), $this->equalTo(array('GROUP')))
+                              ->will($this->returnValue($cvl));
+
+        $translatedCvl = $this->translatorValidator->validateProperty($object, 'prop', array('GROUP'));
+
+        $this->assertConstraintsTranslated($translatedCvl, $cvl);
+    }
+ 
+    public function testValidatePropertyValue()
+    {
+        $object = new stdClass;
+        $cvl = $this->createCvlFixture();
+
+        $this->mockTranslatorTrans();
+        $this->parentValidator->expects($this->once())
+                              ->method('validatePropertyValue')
+                              ->with($this->equalTo($object), $this->equalTo('prop'), $this->equalTo('val'), $this->equalTo(array('GROUP')))
+                              ->will($this->returnValue($cvl));
+
+        $translatedCvl = $this->translatorValidator->validatePropertyValue($object, 'prop', 'val', array('GROUP'));
+
+        $this->assertConstraintsTranslated($translatedCvl, $cvl);
+    }
+
+    public function testValidateValue()
+    {
+        $object = new stdClass;
+        $cvl = $this->createCvlFixture();
+
+        $constraint = $this->getMock('Symfony\Component\Validator\Constraint');
+
+        $this->mockTranslatorTrans();
+        $this->parentValidator->expects($this->once())
+            ->method('validateValue')
+            ->with($this->equalTo('val'), $this->equalTo($constraint), $this->equalTo(array('GROUP')))
+            ->will($this->returnValue($cvl));
+
+        $translatedCvl = $this->translatorValidator->validateValue('val', $constraint, array('GROUP'));
+
+        $this->assertConstraintsTranslated($translatedCvl, $cvl);
+    }
+
+    public function testGetMetadataFactory()
+    {
+        $this->parentValidator->expects($this->once())->method('getMetadataFactory');
+
+        $this->translatorValidator->getMetadataFactory();
+    }
+
+    public function assertConstraintsTranslated($translatedCvl, $originalCvl)
+    {
+        $this->assertNotSame($translatedCvl, $originalCvl);
+        $this->assertEquals(1, count($translatedCvl));
+
+        $violation = $translatedCvl->get(0);
+
+        $this->assertEquals('translated message', $violation->getMessageTemplate());
+        $this->assertEquals('translated message', $violation->getMessage());
+        $this->assertnull($violation->getRoot());
+        $this->assertEquals('path', $violation->getPropertyPath());
+        $this->assertEquals(1234, $violation->getInvalidValue());
+    }
+
+    public function mockTranslatorTrans()
+    {
+        $this->translator->expects($this->once())
+                         ->method('trans')
+                         ->with($this->equalTo('message'), $this->equalTo(array()), $this->equalTo('validators'))
+                         ->will($this->returnValue('translated message'));
+    }
+}
+

--- a/src/Symfony/Component/Validator/Tests/Translation/TranslatorValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Translation/TranslatorValidatorTest.php
@@ -44,6 +44,27 @@ class TranslatorValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertConstraintsTranslated($translatedCvl, $cvl);
     }
 
+    public function testValidateTransChoice()
+    {
+        $cvl = new ConstraintViolationList();
+        $cvl->add(new ConstraintViolation('message', array(), null, 'path', 1234, 2));
+        $object = new stdClass;
+
+        $this->translator->expects($this->once())
+                         ->method('transChoice')
+                         ->with($this->equalTo('message'), $this->equalTo(2), $this->equalTo(array()), $this->equalTo('validators'))
+                         ->will($this->returnValue('translated message'));
+
+        $this->parentValidator->expects($this->once())
+                              ->method('validate')
+                              ->with($this->equalTo($object), $this->equalTo(array('GROUP')))
+                              ->will($this->returnValue($cvl));
+
+        $translatedCvl = $this->translatorValidator->validate($object, array('GROUP'));
+
+        $this->assertConstraintsTranslated($translatedCvl, $cvl);
+    }
+
     public function testValidateProperty()
     {
         $object = new stdClass;

--- a/src/Symfony/Component/Validator/Translation/TranslatorValidator.php
+++ b/src/Symfony/Component/Validator/Translation/TranslatorValidator.php
@@ -93,12 +93,21 @@ class TranslatorValidator implements ValidatorInterface
         $translatedConstraintViolations = new ConstraintViolationList();
 
         foreach ($constraintViolationList as $violation) {
+            $template = $violation->getMessageTemplate();
+            $params = $violation->getMessageParameters();
+
+            $translatedMessage = $violation->getMessagePluralization() === null
+                ? $this->translator->trans($template, $params, 'validators')
+                : $this->translator->transChoice($template, $violation->getMessagePluralization(), $params, 'validators');
+
             $translatedConstraintViolations->add(new ConstraintViolation(
-                $this->translator->trans($violation->getMessageTemplate(), $violation->getMessageParameters(), 'validators'),
+                $translatedMessage,
                 $violation->getMessageParameters(),
                 $violation->getRoot(),
                 $violation->getPropertyPath(),
-                $violation->getInvalidValue()
+                $violation->getInvalidValue(),
+                $violation->getMessagePluralization(),
+                $violation->getCode()
             ));
         }
 

--- a/src/Symfony/Component/Validator/Translation/TranslatorValidator.php
+++ b/src/Symfony/Component/Validator/Translation/TranslatorValidator.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Translation;
+
+use Symfony\Component\Validator\ValidatorInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Translation\TranslatorInterface;
+
+/**
+ * Translate constraint violations for a given validator.
+ *
+ * This service can be used, if the validation framework is not used in
+ * conjunction with the form framework to display translated error messages.
+ * This is the case whenever you use validations without the form framework.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
+class TranslatorValidator implements ValidatorInterface
+{
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+      * @var TranslatorInterface
+      */
+    private $translator;
+
+    public function __construct(ValidatorInterface $validator, TranslatorInterface $translator = null)
+    {
+        $this->validator  = $validator;
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($object, $groups = null)
+    {
+        return $this->translate($this->validator->validate($object, $groups));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validateProperty($object, $property, $groups = null)
+    {
+        return $this->translate($this->validator->validateProperty($object, $property, $groups));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePropertyValue($class, $property, $value, $groups = null)
+    {
+        return $this->translate($this->validator->validatePropertyValue($class, $property, $value, $groups));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validateValue($value, Constraint $constraint, $groups = null)
+    {
+        return $this->translate($this->validator->validateValue($value, $constraint, $groups));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMetadataFactory()
+    {
+        return $this->validator->getMetadataFactory();
+    }
+
+    private function translate(ConstraintViolationList $constraintViolationList)
+    {
+        if ( ! $this->translator) {
+            return $constraintViolationList;
+        }
+
+        $translatedConstraintViolations = new ConstraintViolationList();
+
+        foreach ($constraintViolationList as $violation) {
+            $translatedConstraintViolations->add(new ConstraintViolation(
+                $this->translator->trans($violation->getMessageTemplate(), $violation->getMessageParameters(), 'validators'),
+                $violation->getMessageParameters(),
+                $violation->getRoot(),
+                $violation->getPropertyPath(),
+                $violation->getInvalidValue()
+            ));
+        }
+
+        return $translatedConstraintViolations;
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This PR adds a translator validator that allows to translate error messages easily when you don't use the validator in context of the form framework (for example SOAP, REST APIs, console commands, ...)
