### PR TITLE
Proposal: use Type[] in PHPDoc block

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -70,13 +70,13 @@ class Form implements \IteratorAggregate, FormInterface
 
     /**
      * The children of this form
-     * @var array An array of FormInterface instances
+     * @var FormInterface[] An array of FormInterface instances
      */
     private $children = array();
 
     /**
      * The errors of this form
-     * @var array An array of FormError instances
+     * @var FormError[] An array of FormError instances
      */
     private $errors = array();
 
@@ -203,7 +203,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns the types used by this form.
      *
-     * @return array An array of FormTypeInterface
+     * @return FormTypeInterface[] An array of FormTypeInterface
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link getConfig()} and {@link FormConfigInterface::getType()} instead.
@@ -776,7 +776,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns the DataTransformers.
      *
-     * @return array An array of DataTransformerInterface
+     * @return DataTransformerInterface[] An array of DataTransformerInterface
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link getConfig()} and {@link FormConfigInterface::getViewTransformers()} instead.

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -84,14 +84,14 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns all children in this group.
      *
-     * @return array An array of FormInterface instances
+     * @return FormInterface[] An array of FormInterface instances
      */
     public function all();
 
     /**
      * Returns all errors.
      *
-     * @return array An array of FormError instances that occurred during binding
+     * @return FormError[] An array of FormError instances that occurred during binding
      */
     public function getErrors();
 


### PR DESCRIPTION
This PR must not be merged. It's a proposal.

To improve support of the eclipse PDT pluggin (for autocompletion), I propose to change the array notation in PHPDoc blocks to match the phpDocumentor notation for "array of type".

See http://www.phpdoc.org/docs/latest/for-users/types.html?highlight=array

See https://github.com/eclipse/pdt/pull/6

For the moment I just modified this file to show the proposal. If it's accepted, we must to change all the PHPDoc in only one PR. It could be done easily with a find and replace.

What do you think about this?
