### PR TITLE
[Process] Add ability to reset arguments on ProcessBuilder

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.2.0
 -----
 
+ * added ProcessBuilder::setArguments() to reset the arguments on a builder
  * added a way to retrieve the standard and error output incrementally
  * added Process:restart()
 

--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -56,6 +56,18 @@ class ProcessBuilder
         return $this;
     }
 
+    /**
+     * @param array $arguments
+     *
+     * @return ProcessBuilder
+     */
+    public function setArguments(array $arguments)
+    {
+        $this->arguments = $arguments;
+
+        return $this;
+    }
+
     public function setWorkingDirectory($cwd)
     {
         $this->cwd = $cwd;

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -105,4 +105,14 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertNull($p->getValue($pb));
     }
+
+    public function testShouldSetArguments()
+    {
+        $pb = new ProcessBuilder(array('initial'));
+        $pb->setArguments(array('second'));
+
+        $proc = $pb->getProcess();
+
+        $this->assertContains("second", $proc->getCommandLine());
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This PR adds the ability to "reset" the arguments set on a `ProcessBuilder`. This allows the builder to be re-used without having to set things like custom environment variables, current working directory etc again.
