### PR TITLE
Added failure_path_parameter to mirror target_path_parameter

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -455,4 +455,3 @@ Symfony2 is the result of the work of many people who made the code better
  - Nicolas de Marqué Fromentin (nicodmf)
  - Florent Cailhol (ooflorent)
  - Pierre (ptheg)
- - Leevi Graham (leevigraham)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -455,3 +455,4 @@ Symfony2 is the result of the work of many people who made the code better
  - Nicolas de Marqué Fromentin (nicodmf)
  - Florent Cailhol (ooflorent)
  - Pierre (ptheg)
+ - Leevi Graham (leevigraham)

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/AbstractFactory.php
@@ -43,6 +43,7 @@ abstract class AbstractFactory implements SecurityFactoryInterface
         'failure_path'                   => null,
         'failure_forward'                => false,
         'login_path'                     => '/login',
+        'failure_path_parameter'         => '_failure_path',
     );
 
     public function create(ContainerBuilder $container, $id, $config, $userProviderId, $defaultEntryPointId)

--- a/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/Functional/app/CsrfFormLogin/config.yml
@@ -33,6 +33,7 @@ security:
                 check_path: /login_check
                 default_target_path: /profile
                 target_path_parameter: "user_login[_target_path]"
+                failure_path_parameter: "user_login[_failure_path]"
                 username_parameter: "user_login[username]"
                 password_parameter: "user_login[password]"
                 csrf_parameter: "user_login[_token]"

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -50,9 +50,10 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
         $this->logger     = $logger;
 
         $this->options = array_merge(array(
-            'failure_path'    => null,
-            'failure_forward' => false,
-            'login_path'      => '/login',
+            'failure_path'           => null,
+            'failure_forward'        => false,
+            'login_path'             => '/login',
+            'failure_path_parameter' => '_failure_path'
         ), $options);
     }
 
@@ -61,6 +62,10 @@ class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandle
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
     {
+        if ($failureUrl = $request->get($this->options['failure_path_parameter'], null, true)) {
+             $this->options['failure_path'] = $failureUrl;
+         }
+
         if (null === $this->options['failure_path']) {
             $this->options['failure_path'] = $this->options['login_path'];
         }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Enable login failure redirect path can be assigned in a form field just like target path.
