### PR TITLE
Display traces for fatal errors

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Debug;
 
+use Symfony\Component\HttpKernel\Exception\FatalErrorException;
+
 /**
  * ErrorHandler.
  *
@@ -28,9 +30,15 @@ class ErrorHandler
         E_RECOVERABLE_ERROR => 'Catchable Fatal Error',
         E_DEPRECATED        => 'Deprecated',
         E_USER_DEPRECATED   => 'User Deprecated',
+        E_ERROR             => 'Error',
+        E_CORE_ERROR        => 'Core Error',
+        E_COMPILE_ERROR     => 'Compile Error',
+        E_PARSE             => 'Parse',
     );
 
     private $level;
+
+    private $reservedMemory;
 
     /**
      * Register the error handler.
@@ -45,6 +53,8 @@ class ErrorHandler
         $handler->setLevel($level);
 
         set_error_handler(array($handler, 'handle'));
+        register_shutdown_function(array($handler, 'handleFatal'));
+        $handler->reservedMemory = str_repeat('x', 10240);
 
         return $handler;
     }
@@ -68,5 +78,29 @@ class ErrorHandler
         }
 
         return false;
+    }
+
+    public function handleFatal()
+    {
+        if (null === $error = error_get_last()) {
+            return;
+        }
+
+        unset($this->reservedMemory);
+        $type = $error['type'];
+        if (0 === $this->level || !in_array($type, array(E_ERROR, E_CORE_ERROR, E_COMPILE_ERROR, E_PARSE))) {
+            return;
+        }
+
+        // get current exception handler
+        $exceptionHandler = set_exception_handler(function() {});
+        restore_exception_handler();
+
+        if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandler) {
+            $level = isset($this->levels[$type]) ? $this->levels[$type] : $type;
+            $message = sprintf('%s: %s in %s line %d', $level, $error['message'], $error['file'], $error['line']);
+            $exception = new FatalErrorException($message, 0, $type, $error['file'], $error['line']);
+            $exceptionHandler[0]->handle($exception);
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ExceptionHandler.php
@@ -209,6 +209,9 @@ EOF
                 border-radius: 10px;
                 border: 1px solid #ccc;
             }
+            .xdebug-error {
+                display: none;
+            }
         </style>
     </head>
     <body>

--- a/src/Symfony/Component/HttpKernel/Exception/FatalErrorException.php
+++ b/src/Symfony/Component/HttpKernel/Exception/FatalErrorException.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Exception;
+
+/**
+ * Fatal Error Exception.
+ *
+ * @author Konstanton Myakshin <koc-dp@yandex.ru>
+ */
+class FatalErrorException extends \ErrorException
+{
+
+}

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerTest.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\HttpKernel\Tests\Debug;
 
 use Symfony\Component\HttpKernel\Debug\ErrorHandler;
-use Symfony\Component\HttpKernel\Debug\ErrorException;
 
 /**
  * ErrorHandlerTest
@@ -48,10 +47,10 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
         $handler = ErrorHandler::register(3);
         try {
-            $handler->handle(1, 'foo', 'foo.php', 12, 'foo');
+            $handler->handle(111, 'foo', 'foo.php', 12, 'foo');
         } catch (\ErrorException $e) {
-            $this->assertSame('1: foo in foo.php line 12', $e->getMessage());
-            $this->assertSame(1, $e->getSeverity());
+            $this->assertSame('111: foo in foo.php line 12', $e->getMessage());
+            $this->assertSame(111, $e->getSeverity());
             $this->assertSame('foo.php', $e->getFile());
             $this->assertSame(12, $e->getLine());
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Exception/FlattenExceptionTest.php
@@ -90,14 +90,14 @@ class FlattenExceptionTest extends \PHPUnit_Framework_TestCase
     public function testToArray(\Exception $exception, $statusCode)
     {
         $flattened = FlattenException::create($exception);
-        $flattened->setTrace(array(),'foo.php',123);
+        $flattened->setTrace(array(), 'foo.php', 123);
 
         $this->assertEquals(array(
             array(
                 'message'=> 'test',
                 'class'=>'Exception',
                 'trace'=>array(array(
-                    'namespace'   => '', 'short_class' => '', 'class' => '','type' => '','function' => '', 'file' => 'foo.php','line' => 123,
+                    'namespace'   => '', 'short_class' => '', 'class' => '','type' => '','function' => '', 'file' => 'foo.php', 'line' => 123,
                     'args'        => array()
                 )),
             )


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: looks like yes
Fixes the following tickets: #2042 (partly)
License of the code: MIT

Output looks like on screen http://easycaptures.com/fs/uploaded/737/1191436899.png . I've added one line to css to prevent displaying standard xdebug trace http://easycaptures.com/fs/uploaded/737/5939488074.png
