### PR TITLE
[HttpFoundation] Return value of BinaryFileResponse::getContent() and StreamedResponse::getContent()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -242,11 +242,11 @@ class BinaryFileResponse extends Response
     /**
      * {@inheritdoc}
      *
-     * @return false
+     * @return null
      */
     public function getContent()
     {
-        return false;
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/StreamedResponse.php
+++ b/src/Symfony/Component/HttpFoundation/StreamedResponse.php
@@ -120,10 +120,10 @@ class StreamedResponse extends Response
     /**
      * {@inheritdoc}
      *
-     * @return false
+     * @return null
      */
     public function getContent()
     {
-        return false;
+        return null;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -44,7 +44,7 @@ class BinaryFileResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetContent()
     {
         $response = new BinaryFileResponse('README.md');
-        $this->assertFalse($response->getContent());
+        $this->assertNull($response->getContent());
     }
 
     public function testRequests()

--- a/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/StreamedResponseTest.php
@@ -101,7 +101,7 @@ class StreamedResponseTest extends \PHPUnit_Framework_TestCase
     public function testGetContent()
     {
         $response = new StreamedResponse(function () { echo 'foo'; });
-        $this->assertFalse($response->getContent());
+        $this->assertNull($response->getContent());
     }
 
     public function testCreate()


### PR DESCRIPTION
While reviewing #4546 @stof found an inconsistency:

``` php
    public function setContent($content)
    {   
        if (null !== $content) { // <--- Here we only allow only null
            throw new \LogicException('The content cannot be set on a StreamedResponse instance.');
        }   
    } 
```

``` php
    public function getContent()
    {   
        return false; // <-- Here we return false
    } 
```

That means for example, that `$streamedResponse->setContent($streamedResponse->getContent())` will throw an exception.

Should we (or can we even, without breaking backwards compability) change the return value of StreamedResponse::getContent() and BinaryFileResponse::getContent() to `null`?

Edit: For BinaryFileResponse we could also consider returning the real content. That might however be a huge string. For StreamedResponse we have no guarantees that we can do that and get the same result when we do it again.
