### PR TITLE
[FrameworkBundle] new method to create shorthand name from full Controller name

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerNameParser.php
@@ -67,6 +67,28 @@ class ControllerNameParser
         return $class.'::'.$action.'Action';
     }
 
+    public function build($controller) {
+        if (2 != count($parts = explode('::', $controller))) {
+            throw new \InvalidArgumentException(sprintf('The "%s" controller is not a valid aController::cAction controller string.', $controller));
+        }
+
+        list ($className, $action) = $parts;
+        if (5 !== strripos($action, 'Action')) {
+            throw new \InvalidArgumentException(sprintf('The "%s" controller is not a valid aController::cAction controller string.', $controller));
+        }
+        $action = substr($action, 0, strlen($action) - 6);
+
+        foreach ($this->kernel->getBundles() as $bundles) {
+            foreach($bundles as $bundle) {
+                if (preg_match('/^'.preg_quote($bundle->getNamespace()).'\\\\Controller\\\\(.*)Controller/', $className, $m)) {
+                    return sprintf('%s:%s:%s', $bundle->getName(), $m[1], $action);
+                }
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('The "%s" controller is not a valid aController::cAction controller string.', $controller));
+    }
+
     private function handleControllerNotFoundException($bundle, $controller, array $logs)
     {
         // just one log, return it as the exception

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/ControllerNameParserTest.php
@@ -55,6 +55,31 @@ class ControllerNameParserTest extends TestCase
         }
     }
 
+    public function testBuild()
+    {
+        $parser = $this->createParser();
+
+        $this->assertEquals('FooBundle:Default:index', $parser->build('TestBundle\FooBundle\Controller\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
+        $this->assertEquals('FooBundle:Sub\Default:index', $parser->build('TestBundle\FooBundle\Controller\Sub\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
+        $this->assertEquals('FabpotFooBundle:Default:index', $parser->build('TestBundle\Fabpot\FooBundle\Controller\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
+        $this->assertEquals('SensioCmsFooBundle:Default:index', $parser->build('TestBundle\Sensio\Cms\FooBundle\Controller\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
+        $this->assertEquals('FooBundle:Test\\Default:index', $parser->build('TestBundle\FooBundle\Controller\Test\DefaultController::indexAction'), '->parse() converts a class::method string to a short a:b:c notation string');
+
+        try {
+            $parser->build('TestBundle\FooBundle\Controller\DefaultController::index');
+            $this->fail('->parse() throws an \InvalidArgumentException if the controller is not an aController::cAction string');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws an \InvalidArgumentException if the controller is not an aController::cAction string');
+        }
+
+        try {
+            $parser->build('TestBundle\FooBundle\Controller\Default::indexAction');
+            $this->fail('->parse() throws an \InvalidArgumentException if the controller is not an aController::cAction string');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->parse() throws an \InvalidArgumentException if the controller is not an aController::cAction string');
+        }
+    }
+
     /**
      * @dataProvider getMissingControllersTest
      */
@@ -94,6 +119,11 @@ class ControllerNameParserTest extends TestCase
             ->will($this->returnCallback(function ($bundle) use ($bundles) {
                 return $bundles[$bundle];
             }))
+        ;
+        $kernel
+            ->expects($this->any())
+            ->method('getBundles')
+            ->will($this->returnValue($bundles))
         ;
 
         return new ControllerNameParser($kernel);


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: n/a
Todo: see if there's a more elegant way of finding the controller
License of the code: MIT
Documentation PR: n/a

The code now loops over all existing bundles and uses a regexp to see if it's the one we're looking for. Perhaps someone knows of a more efficient way to do this, but I wasn't able to find it.
