### PR TITLE
Fix digest authentication

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -141,7 +141,7 @@ class DigestData
     public function __construct($header)
     {
         $this->header = $header;
-        preg_match_all('/(\w+)=("([^"]+)"|([^\s,$]+))/', $header, $matches, PREG_SET_ORDER);
+        preg_match_all('/(\w+)=("((?:[^"\\\\]|\\\\.)+)"|([^\s,$]+))/', $header, $matches, PREG_SET_ORDER);
         $this->elements = array();
         foreach ($matches as $match) {
             if (isset($match[1]) && isset($match[3])) {

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -157,7 +157,7 @@ class DigestData
 
     public function getUsername()
     {
-        return $this->elements['username'];
+        return strtr($this->elements['username'], array("\\\"" => "\"", "\\\\" => "\\"));
     }
 
     public function validateAndDecode($entryPointKey, $expectedRealm)

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -141,11 +141,12 @@ class DigestData
     public function __construct($header)
     {
         $this->header = $header;
-        $parts = preg_split('/, /', $header);
+        preg_match_all('/(\w+)=("([^"]+)"|([^\s,$]+))/', $header, $matches, PREG_SET_ORDER);
         $this->elements = array();
-        foreach ($parts as $part) {
-            list($key, $value) = explode('=', $part);
-            $this->elements[$key] = '"' === $value[0] ? substr($value, 1, -1) : $value;
+        foreach ($matches as $match) {
+            if (isset($match[1]) && isset($match[3])) {
+                $this->elements[$match[1]] = isset($match[4]) ? $match[4] : $match[3];
+            }
         }
     }
 
@@ -188,7 +189,7 @@ class DigestData
         $this->nonceExpiryTime = $nonceTokens[0];
 
         if (md5($this->nonceExpiryTime.':'.$entryPointKey) !== $nonceTokens[1]) {
-            new BadCredentialsException(sprintf('Nonce token compromised "%s".', $nonceAsPlainText));
+            throw new BadCredentialsException(sprintf('Nonce token compromised "%s".', $nonceAsPlainText));
         }
     }
 

--- a/tests/Symfony/Tests/Component/Security/Http/Firewall/DigestDataTest.php
+++ b/tests/Symfony/Tests/Component/Security/Http/Firewall/DigestDataTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Tests\Http\Firewall;
+
+use Symfony\Component\Security\Http\Firewall\DigestData;
+
+class DigestDataTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        class_exists('Symfony\Component\Security\Http\Firewall\DigestAuthenticationListener', true);
+    }
+
+    public function testGetResponse()
+    {
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('b52938fc9e6d7c01be7702ece9031b42', $digestAuth->getResponse());
+    }
+
+    public function testGetUsername()
+    {
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('user', $digestAuth->getUsername());
+    }
+
+    public function testValidateAndDecode()
+    {
+        $time = microtime(true);
+        $key = 'ThisIsAKey';
+        $nonce = base64_encode($time . ':' . md5($time . ':' . $key));
+
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", nonce="' . $nonce . '", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        try {
+            $digestAuth->validateAndDecode($key, 'Welcome, robot!');
+        } catch (\Exception $e) {
+            $this->fail(sprintf('testValidateAndDecode fail with message: %s', $e->getMessage()));
+        }
+    }
+
+    public function testCalculateServerDigest()
+    {
+        $username = 'user';
+        $realm = 'Welcome, robot!';
+        $password = 'pass,word=password';
+        $time = microtime(true);
+        $key = 'ThisIsAKey';
+        $nonce = base64_encode($time . ':' . md5($time . ':' . $key));
+        $nc = '00000001';
+        $cnonce = 'MDIwODkz';
+        $qop = 'auth';
+        $method = 'GET';
+        $uri = '/path/info?p1=5&p2=5';
+
+        $response = md5(
+            md5($username . ':' . $realm . ':' . $password) .
+            ':' . $nonce . ':' . $nc . ':' . $cnonce . ':' . $qop . ':' . md5($method . ':' . $uri)
+        );
+
+        $digest = sprintf('username="%s", realm="%s", nonce="%s", uri="%s", cnonce="%s", nc="%s", qop="%s", response="%s"',
+            $username, $realm, $nonce, $uri, $cnonce, $nc, $qop, $response
+        );
+
+        $digestAuth = new DigestData($digest);
+
+        $this->assertEquals($digestAuth->getResponse(), $digestAuth->calculateServerDigest($password, $method));
+    }
+
+    public function testIsNonceExpired()
+    {
+        $time = microtime(true) + 10;
+        $key = 'ThisIsAKey';
+        $nonce = base64_encode($time . ':' . md5($time . ':' . $key));
+
+        $digestAuth = new DigestData(
+            'username="user", realm="Welcome, robot!", nonce="' . $nonce . '", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $digestAuth->validateAndDecode($key, 'Welcome, robot!');
+
+        $this->assertFalse($digestAuth->isNonceExpired());
+    }
+}

--- a/tests/Symfony/Tests/Component/Security/Http/Firewall/DigestDataTest.php
+++ b/tests/Symfony/Tests/Component/Security/Http/Firewall/DigestDataTest.php
@@ -51,6 +51,42 @@ class DigestDataTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('\"user\"', $digestAuth->getUsername());
     }
 
+    public function testGetUsernameWithQuoteAndEscape()
+    {
+        $digestAuth = new DigestData(
+            'username="\"u\\\\\"ser\"", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('\"u\\\\\"ser\"', $digestAuth->getUsername());
+    }
+
+    public function testGetUsernameWithSingleQuote()
+    {
+        $digestAuth = new DigestData(
+            'username="\"u\'ser\"", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('\"u\'ser\"', $digestAuth->getUsername());
+    }
+
+    public function testGetUsernameWithEscape()
+    {
+        $digestAuth = new DigestData(
+            'username="\"u\\ser\"", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('\"u\\ser\"', $digestAuth->getUsername());
+    }
+
     public function testValidateAndDecode()
     {
         $time = microtime(true);
@@ -78,6 +114,17 @@ class DigestDataTest extends \PHPUnit_Framework_TestCase
     public function testCalculateServerDigestWithQuote()
     {
         $this->calculateServerDigest('\"user\"', 'Welcome, \"robot\"!', 'pass,word=password', 'ThisIsAKey', '00000001', 'MDIwODkz', 'auth', 'GET', '/path/info?p1=5&p2=5');
+    }
+
+    public function testCalculateServerDigestWithQuoteAndEscape()
+    {
+        $this->calculateServerDigest('\"u\\\\\"ser\"', 'Welcome, \"robot\"!', 'pass,word=password', 'ThisIsAKey', '00000001', 'MDIwODkz', 'auth', 'GET', '/path/info?p1=5&p2=5');
+    }
+
+    public function testCalculateServerDigestEscape()
+    {
+        $this->calculateServerDigest('\"u\\ser\"', 'Welcome, \"robot\"!', 'pass,word=password', 'ThisIsAKey', '00000001', 'MDIwODkz', 'auth', 'GET', '/path/info?p1=5&p2=5');
+        $this->calculateServerDigest('\"u\\ser\\\\\"', 'Welcome, \"robot\"!', 'pass,word=password', 'ThisIsAKey', '00000001', 'MDIwODkz', 'auth', 'GET', '/path/info?p1=5&p2=5');
     }
 
     public function testIsNonceExpired()

--- a/tests/Symfony/Tests/Component/Security/Http/Firewall/DigestDataTest.php
+++ b/tests/Symfony/Tests/Component/Security/Http/Firewall/DigestDataTest.php
@@ -48,7 +48,7 @@ class DigestDataTest extends \PHPUnit_Framework_TestCase
             'response="b52938fc9e6d7c01be7702ece9031b42"'
         );
 
-        $this->assertEquals('\"user\"', $digestAuth->getUsername());
+        $this->assertEquals('"user"', $digestAuth->getUsername());
     }
 
     public function testGetUsernameWithQuoteAndEscape()
@@ -60,7 +60,7 @@ class DigestDataTest extends \PHPUnit_Framework_TestCase
             'response="b52938fc9e6d7c01be7702ece9031b42"'
         );
 
-        $this->assertEquals('\"u\\\\\"ser\"', $digestAuth->getUsername());
+        $this->assertEquals('"u\\"ser"', $digestAuth->getUsername());
     }
 
     public function testGetUsernameWithSingleQuote()
@@ -72,7 +72,19 @@ class DigestDataTest extends \PHPUnit_Framework_TestCase
             'response="b52938fc9e6d7c01be7702ece9031b42"'
         );
 
-        $this->assertEquals('\"u\'ser\"', $digestAuth->getUsername());
+        $this->assertEquals('"u\'ser"', $digestAuth->getUsername());
+    }
+
+    public function testGetUsernameWithSingleQuoteAndEscape()
+    {
+        $digestAuth = new DigestData(
+            'username="\"u\\\'ser\"", realm="Welcome, robot!", ' .
+            'nonce="MTM0NzMyMTgyMy42NzkzOmRlZjM4NmIzOGNjMjE0OWJiNDU0MDAxNzJmYmM1MmZl", ' .
+            'uri="/path/info?p1=5&p2=5", cnonce="MDIwODkz", nc=00000001, qop="auth", ' .
+            'response="b52938fc9e6d7c01be7702ece9031b42"'
+        );
+
+        $this->assertEquals('"u\\\'ser"', $digestAuth->getUsername());
     }
 
     public function testGetUsernameWithEscape()
@@ -84,7 +96,7 @@ class DigestDataTest extends \PHPUnit_Framework_TestCase
             'response="b52938fc9e6d7c01be7702ece9031b42"'
         );
 
-        $this->assertEquals('\"u\\ser\"', $digestAuth->getUsername());
+        $this->assertEquals('"u\\ser"', $digestAuth->getUsername());
     }
 
     public function testValidateAndDecode()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: -
License of the code: MIT
Documentation PR: -
Replaces: #5485

This adds the missing fixes.

My only concerns is the `\"` removing.
`\"` is only needed for the HTTP transport, but keeping them would require to also store the username with the escapes as well.
