### PR TITLE
Exception when using File move() across local partition & NFS share

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -117,11 +117,12 @@ class File extends \SplFileInfo
 
         $target = $directory.DIRECTORY_SEPARATOR.(null === $name ? $this->getBasename() : basename($name));
 
-        if (!@rename($this->getPathname(), $target)) {
+        if (!@copy($this->getPathname(), $target)) {
             $error = error_get_last();
             throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
         }
 
+        @unlink($this->getPathname());
         @chmod($target, 0666 & ~umask());
 
         return new File($target);


### PR DESCRIPTION
Hello,

We've faced an issue using move() function to move a local file to a locally mounted network share. The root cause seems to be PHP's rename() function failing in this use case.

This patch is, by design, less atomic than your current function as it performs the move in 2 steps ( copy() then unlink() ) but allow usage of this function in all types of infrastructures.

Bests
