### PR TITLE
Make non-instantiable utils classes consistent with each other

### DIFF
--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Util;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class FormUtil
+class FormUtil
 {
     /**
      * Map english plural to singular suffixes
@@ -201,4 +201,9 @@ abstract class FormUtil
         // not considered to be empty, ever.
         return null === $data || '' === $data;
     }
+
+    /**
+     * This class should not be instantiated
+     */
+    private function __construct() {}
 }

--- a/src/Symfony/Component/Form/Util/FormUtil.php
+++ b/src/Symfony/Component/Form/Util/FormUtil.php
@@ -98,6 +98,11 @@ class FormUtil
     );
 
     /**
+     * This class should not be instantiated
+     */
+    private function __construct() {}
+
+    /**
      * Returns the singular form of a word
      *
      * If the method can't determine the form with certainty, an array of the
@@ -201,9 +206,4 @@ class FormUtil
         // not considered to be empty, ever.
         return null === $data || '' === $data;
     }
-
-    /**
-     * This class should not be instantiated
-     */
-    private function __construct() {}
 }

--- a/src/Symfony/Component/Security/Core/Util/ClassUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/ClassUtils.php
@@ -52,4 +52,9 @@ class ClassUtils
 
         return substr($class, $pos + self::MARKER_LENGTH + 2);
     }
+
+    /**
+     * This class should not be instantiated
+     */
+    private function __construct() {}
 }

--- a/src/Symfony/Component/Security/Core/Util/ClassUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/ClassUtils.php
@@ -37,6 +37,11 @@ class ClassUtils
     const MARKER_LENGTH = 6;
 
     /**
+     * This class should not be instantiated
+     */
+    private function __construct() {}
+
+    /**
      * Gets the real class name of a class name that could be a proxy.
      *
      * @param string|object
@@ -52,9 +57,4 @@ class ClassUtils
 
         return substr($class, $pos + self::MARKER_LENGTH + 2);
     }
-
-    /**
-     * This class should not be instantiated
-     */
-    private function __construct() {}
 }

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -19,6 +19,11 @@ namespace Symfony\Component\Security\Core\Util;
 class StringUtils
 {
     /**
+     * This class should not be instantiated
+     */
+    private function __construct() {}
+
+    /**
      * Compares two strings.
      *
      * This method implements a constant-time algorithm to compare strings.
@@ -41,9 +46,4 @@ class StringUtils
 
         return 0 === $result;
     }
-
-    /**
-     * This class should not be instantiated
-     */
-    private function __construct() {}
 }

--- a/src/Symfony/Component/Security/Core/Util/StringUtils.php
+++ b/src/Symfony/Component/Security/Core/Util/StringUtils.php
@@ -16,12 +16,8 @@ namespace Symfony\Component\Security\Core\Util;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-final class StringUtils
+class StringUtils
 {
-    final private function __construct()
-    {
-    }
-
     /**
      * Compares two strings.
      *
@@ -45,4 +41,9 @@ final class StringUtils
 
         return 0 === $result;
     }
+
+    /**
+     * This class should not be instantiated
+     */
+    private function __construct() {}
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

As per discussion in #5875 turned out that we don't have a consistent way to define non-instantiatable classes.

I don't like `final` as it removes flexibility with no visible gain.
I don't like `abstract` since it's not specifically clear what is meant by that. Is this class not complete? Should it be extended? 
