### PR TITLE
Ensure the header names match the header values

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -77,7 +77,11 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function allPreserveCase()
     {
-        return array_combine($this->headerNames, $this->headers);
+    	$headerNames = $this->headerNames;
+		$headers = $this->headers;
+		ksort($headerNames);
+		ksort($headers);
+        return array_combine($headerNames, $headers);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -77,10 +77,10 @@ class ResponseHeaderBag extends HeaderBag
      */
     public function allPreserveCase()
     {
-    	$headerNames = $this->headerNames;
-		$headers = $this->headers;
-		ksort($headerNames);
-		ksort($headers);
+        $headerNames = $this->headerNames;
+        $headers = $this->headers;
+        ksort($headerNames);
+        ksort($headers);
         return array_combine($headerNames, $headers);
     }
 


### PR DESCRIPTION
In Silex, when an existing header is replaced in $app->after() callback, the order of header names and values become not corresponding to each other, which in turn causes the response headers to get messed up.

Ordering the header names and values according to their keys before combining and returning them can ensure the order of header names and that of values match each other correctly.
