### PR TITLE
[HttpKernel] Added ability to set controller result in the kernel.view event

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForControllerResultEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForControllerResultEvent.php
@@ -61,6 +61,6 @@ class GetResponseForControllerResultEvent extends GetResponseEvent
      */
     public function setControllerResult(array $controllerResult)
     {
-        $this->controllerResult = controllerResult;
+        $this->controllerResult = $controllerResult;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForControllerResultEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForControllerResultEvent.php
@@ -51,4 +51,16 @@ class GetResponseForControllerResultEvent extends GetResponseEvent
     {
         return $this->controllerResult;
     }
+    
+    /**
+     * Assign the return value of the controller
+     *
+     * @param array The controller return value
+     *
+     * @api
+     */
+    public function setControllerResult(array $controllerResult)
+    {
+        $this->controllerResult = controllerResult;
+    }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerResponseInjectorListener.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerResponseInjectorListener.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+
+class ControllerResponseInjectorListener
+{
+    protected $newParameters = array();
+    
+    public function __construct(array $newParameters)
+    {
+        $this->newParameters = $newParameters;
+    }
+    
+    public function onKernelView(GetResponseForControllerResultEvent $event)
+    {
+        $controllerResult = $event->getControllerResult();
+        
+        $event->setControllerResult(array_merge($controllerResult, $this->newParameters));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerResponseTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerResponseTest.php
@@ -50,11 +50,11 @@ class ControllerResponseTest extends \PHPUnit_Framework_TestCase
     public function testControllerResponseIsChainable()
     {
         
-        $controllerResponse = ['foo' => 'foo'];
+        $controllerResponse = array('foo' => 'foo');
         
         $event = new GetResponseForControllerResultEvent($this->kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, $controllerResponse);
         $this->dispatcher->dispatch(KernelEvents::VIEW, $event);
         
-        $this->assertEquals(['foo' => 'foo', 'bar' => 'bar'], $event->getControllerResult());
+        $this->assertEquals(array('foo' => 'foo', 'bar' => 'bar'), $event->getControllerResult());
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerResponseTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ControllerResponseTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use Symfony\Component\HttpKernel\EventListener\ResponseListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class ControllerResponseTest extends \PHPUnit_Framework_TestCase
+{
+    private $dispatcher;
+    
+    private $kernel;
+    
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
+            $this->markTestSkipped('The "EventDispatcher" component is not available');
+        }
+        
+        $this->dispatcher = new EventDispatcher();
+        $listener = new ControllerResponseInjectorListener(array(
+            'bar' => 'bar',
+        ));
+        $this->dispatcher->addListener(KernelEvents::VIEW, array($listener, 'onKernelView'));
+        
+        $this->kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        
+    }
+    
+    protected function tearDown()
+    {
+        $this->dispatcher = null;
+        $this->kernel = null;
+    }
+    
+    public function testControllerResponseIsChainable()
+    {
+        
+        $controllerResponse = ['foo' => 'foo'];
+        
+        $event = new GetResponseForControllerResultEvent($this->kernel, new Request(), HttpKernelInterface::MASTER_REQUEST, $controllerResponse);
+        $this->dispatcher->dispatch(KernelEvents::VIEW, $event);
+        
+        $this->assertEquals(['foo' => 'foo', 'bar' => 'bar'], $event->getControllerResult());
+    }
+}


### PR DESCRIPTION
Added the method `GetResponseForControllerResultEvent:setControllerResult(array $controllerResult)` to allow kernel.view events to inject data into the result.
