### PR TITLE
CS Fixes - Replaced "array of type" by "Type[]" in PHPDoc block

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -127,7 +127,7 @@ class CookieJar
     /**
      * Returns not yet expired cookies.
      *
-     * @return array An array of cookies
+     * @return Cookies[] An array of cookies
      */
     public function all()
     {

--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -127,7 +127,7 @@ class CookieJar
     /**
      * Returns not yet expired cookies.
      *
-     * @return Cookies[] An array of cookies
+     * @return Cookie[] An array of cookies
      */
     public function all()
     {

--- a/src/Symfony/Component/BrowserKit/Request.php
+++ b/src/Symfony/Component/BrowserKit/Request.php
@@ -32,7 +32,7 @@ class Request
      * Constructor.
      *
      * @param string $uri        The request URI
-     * @param array  $method     The HTTP method request
+     * @param string $method     The HTTP method request
      * @param array  $parameters The request parameters
      * @param array  $files      An array of uploaded files
      * @param array  $cookies    An array of cookies

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -210,7 +210,7 @@ class ClassCollectionLoader
      *
      * @param array $classes
      *
-     * @return array An array of sorted \ReflectionClass instances (dependencies added if needed)
+     * @return ReflectionClass[] An array of sorted \ReflectionClass instances (dependencies added if needed)
      *
      * @throws \InvalidArgumentException When a class can't be loaded
      */

--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -210,7 +210,7 @@ class ClassCollectionLoader
      *
      * @param array $classes
      *
-     * @return ReflectionClass[] An array of sorted \ReflectionClass instances (dependencies added if needed)
+     * @return \ReflectionClass[] An array of sorted \ReflectionClass instances (dependencies added if needed)
      *
      * @throws \InvalidArgumentException When a class can't be loaded
      */

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -83,8 +83,8 @@ class ConfigCache
     /**
      * Writes cache.
      *
-     * @param string $content  The content to write in the cache
-     * @param array  $metadata An array of ResourceInterface instances
+     * @param string              $content  The content to write in the cache
+     * @param ResourceInterface[] $metadata An array of ResourceInterface instances
      *
      * @throws \RuntimeException When cache file can't be wrote
      */

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Config;
 
+use Symfony\Component\Config\Resource\ResourceInterface;
+
 /**
  * ConfigCache manages PHP cache files.
  *

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -158,7 +158,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Sets the closures used for normalization.
      *
-     * @param array $closures An array of Closures used for normalization
+     * @param \Closure[] $closures An array of Closures used for normalization
      */
     public function setNormalizationClosures(array $closures)
     {
@@ -168,7 +168,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Sets the closures used for final validation.
      *
-     * @param array $closures An array of Closures used for final validation
+     * @param \Closure[] $closures An array of Closures used for final validation
      */
     public function setFinalValidationClosures(array $closures)
     {

--- a/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
+++ b/src/Symfony/Component/Config/Definition/Builder/ExprBuilder.php
@@ -210,7 +210,7 @@ class ExprBuilder
     /**
      * Builds the expressions.
      *
-     * @param array $expressions An array of ExprBuilder instances to build
+     * @param ExprBuilder[] $expressions An array of ExprBuilder instances to build
      *
      * @return array
      */

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -619,7 +619,7 @@ class Application
      *
      * @param string $namespace A namespace name
      *
-     * @return array An array of Command instances
+     * @return Command[] An array of Command instances
      *
      * @api
      */
@@ -933,7 +933,7 @@ class Application
     /**
      * Gets the default commands that should always be available.
      *
-     * @return array An array of default Command instances
+     * @return Command[] An array of default Command instances
      */
     protected function getDefaultCommands()
     {

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -44,8 +44,8 @@ class OutputFormatter implements OutputFormatterInterface
     /**
      * Initializes console output formatter.
      *
-     * @param Boolean $decorated Whether this formatter should actually decorate strings
-     * @param array   $styles    Array of "name => FormatterStyle" instances
+     * @param Boolean          $decorated Whether this formatter should actually decorate strings
+     * @param FormatterStyle[] $styles    Array of "name => FormatterStyle" instances
      *
      * @api
      */

--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -72,7 +72,7 @@ class InputDefinition
     /**
      * Sets the InputArgument objects.
      *
-     * @param array $arguments An array of InputArgument objects
+     * @param InputArgument[] $arguments An array of InputArgument objects
      *
      * @api
      */
@@ -178,7 +178,7 @@ class InputDefinition
     /**
      * Gets the array of InputArgument objects.
      *
-     * @return array An array of InputArgument objects
+     * @return InputArgument[] An array of InputArgument objects
      *
      * @api
      */
@@ -225,7 +225,7 @@ class InputDefinition
     /**
      * Sets the InputOption objects.
      *
-     * @param array $options An array of InputOption objects
+     * @param InputOption[] $options An array of InputOption objects
      *
      * @api
      */
@@ -310,7 +310,7 @@ class InputDefinition
     /**
      * Gets the array of InputOption objects.
      *
-     * @return array An array of InputOption objects
+     * @return InputOption[] An array of InputOption objects
      *
      * @api
      */

--- a/src/Symfony/Component/CssSelector/Node/OrNode.php
+++ b/src/Symfony/Component/CssSelector/Node/OrNode.php
@@ -23,12 +23,15 @@ use Symfony\Component\CssSelector\XPathExprOr;
  */
 class OrNode implements NodeInterface
 {
+    /**
+     * @var NodeInterface[]
+     */
     protected $items;
 
     /**
      * Constructor.
      *
-     * @param array $items An array of NodeInterface objects
+     * @param NodeInterface[] $items An array of NodeInterface objects
      */
     public function __construct($items)
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -49,7 +49,7 @@ class CheckCircularReferencesPass implements CompilerPassInterface
     /**
      * Checks for circular references.
      *
-     * @param array $edges An array of Nodes
+     * @param ServiceReferenceGraphEdge[] $edges An array of Edges
      *
      * @throws ServiceCircularReferenceException When a circular reference is found.
      */

--- a/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
@@ -24,7 +24,7 @@ class RepeatedPass implements CompilerPassInterface
     /**
      * @var Boolean
      */
-    private $repeat;
+    private $repeat = false;
     
     /**
      * @var RepeatablePassInterface[]

--- a/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
@@ -21,13 +21,20 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  */
 class RepeatedPass implements CompilerPassInterface
 {
+    /**
+     * @var Boolean
+     */
     private $repeat;
+    
+    /**
+     * @var RepeatablePassInterface[]
+     */
     private $passes;
 
     /**
      * Constructor.
      *
-     * @param array $passes An array of RepeatablePassInterface objects
+     * @param RepeatablePassInterface[] $passes An array of RepeatablePassInterface objects
      *
      * @throws InvalidArgumentException when the passes don't implement RepeatablePassInterface
      */
@@ -72,7 +79,7 @@ class RepeatedPass implements CompilerPassInterface
     /**
      * Returns the passes
      *
-     * @return array An array of RepeatablePassInterface objects
+     * @return RepeatablePassInterface[] An array of RepeatablePassInterface objects
      */
     public function getPasses()
     {

--- a/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/RepeatedPass.php
@@ -25,7 +25,7 @@ class RepeatedPass implements CompilerPassInterface
      * @var Boolean
      */
     private $repeat = false;
-    
+
     /**
      * @var RepeatablePassInterface[]
      */

--- a/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ServiceReferenceGraph.php
@@ -23,6 +23,9 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
  */
 class ServiceReferenceGraph
 {
+    /**
+     * @var ServiceReferenceGraphNode[]
+     */
     private $nodes;
 
     /**
@@ -66,7 +69,7 @@ class ServiceReferenceGraph
     /**
      * Returns all nodes.
      *
-     * @return array An array of all ServiceReferenceGraphNode objects
+     * @return ServiceReferenceGraphNode[] An array of all ServiceReferenceGraphNode objects
      */
     public function getNodes()
     {

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -61,7 +61,11 @@ use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
  */
 class Container implements IntrospectableContainerInterface
 {
+    /**
+     * @var ParameterBagInterface
+     */
     protected $parameterBag;
+    
     protected $services;
     protected $scopes;
     protected $scopeChildren;

--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -65,7 +65,7 @@ class Container implements IntrospectableContainerInterface
      * @var ParameterBagInterface
      */
     protected $parameterBag;
-    
+
     protected $services;
     protected $scopes;
     protected $scopeChildren;

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -517,7 +517,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Sets the service aliases.
      *
-     * @param array $aliases An array of service definitions
+     * @param array $aliases An array of aliases
      *
      * @api
      */
@@ -652,7 +652,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Sets the service definitions.
      *
-     * @param array $definitions An array of service definitions
+     * @param Definition[] $definitions An array of service definitions
      *
      * @api
      */

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -31,12 +31,36 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  */
 class ContainerBuilder extends Container implements TaggedContainerInterface
 {
-    private $extensions       = array();
-    private $extensionsByNs   = array();
-    private $definitions      = array();
-    private $aliases          = array();
-    private $resources        = array();
+    /**
+     * @var ExtensionInterface[]
+     */
+    private $extensions = array();
+    
+    /**
+     * @var ExtensionInterface[]
+     */
+    private $extensionsByNs = array();
+    
+    /**
+     * @var Definition[]
+     */
+    private $definitions = array();
+    
+    /**
+     * @var Alias[]
+     */
+    private $aliases = array();
+    
+    /**
+     * @var ResourceInterface[]
+     */
+    private $resources = array();
+    
     private $extensionConfigs = array();
+    
+    /**
+     * @var Compiler
+     */
     private $compiler;
 
     /**
@@ -82,7 +106,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     /**
      * Returns all registered extensions.
      *
-     * @return array An array of ExtensionInterface
+     * @return ExtensionInterface[] An array of ExtensionInterface
      *
      * @api
      */
@@ -133,6 +157,15 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         return $this;
     }
 
+    /**
+     * Sets the resources for this configuration.
+     * 
+     * @param ResourceInterface[] $resources An array of resources
+     * 
+     * @return ContainerBuilder The current instance
+     * 
+     * @api
+     */
     public function setResources(array $resources)
     {
         $this->resources = $resources;

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -35,29 +35,29 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
      * @var ExtensionInterface[]
      */
     private $extensions = array();
-    
+
     /**
      * @var ExtensionInterface[]
      */
     private $extensionsByNs = array();
-    
+
     /**
      * @var Definition[]
      */
     private $definitions = array();
-    
+
     /**
      * @var Alias[]
      */
     private $aliases = array();
-    
+
     /**
      * @var ResourceInterface[]
      */
     private $resources = array();
-    
+
     private $extensionConfigs = array();
-    
+
     /**
      * @var Compiler
      */

--- a/src/Symfony/Component/DependencyInjection/Definition.php
+++ b/src/Symfony/Component/DependencyInjection/Definition.php
@@ -373,7 +373,7 @@ class Definition
     /**
      * Gets the methods to call after service initialization.
      *
-     * @return  array An array of method calls
+     * @return array An array of method calls
      *
      * @api
      */

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -213,7 +213,7 @@ class Crawler extends \SplObjectStorage
     /**
      * Adds an array of \DOMNode instances to the list of nodes.
      *
-     * @param array $nodes An array of \DOMNode instances
+     * @param \DOMNode[] $nodes An array of \DOMNode instances
      *
      * @api
      */
@@ -592,7 +592,7 @@ class Crawler extends \SplObjectStorage
      *
      * @param string $method The method for the link (get by default)
      *
-     * @return Link   A Link instance
+     * @return Link A Link instance
      *
      * @throws \InvalidArgumentException If the current node list is empty
      *
@@ -612,7 +612,7 @@ class Crawler extends \SplObjectStorage
     /**
      * Returns an array of Link objects for the nodes in the list.
      *
-     * @return array An array of Link instances
+     * @return Link[] An array of Link instances
      *
      * @api
      */
@@ -632,7 +632,7 @@ class Crawler extends \SplObjectStorage
      * @param array  $values An array of values for the form fields
      * @param string $method The method for the form
      *
-     * @return Form   A Form instance
+     * @return Form A Form instance
      *
      * @throws \InvalidArgumentException If the current node list is empty
      *

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -330,7 +330,7 @@ class Form extends Link implements \ArrayAccess
     }
 
     /**
-     * Sets current \DOMNode instance
+     * Sets current \DOMNode instance.
      *
      * @param \DOMNode $node A \DOMNode instance
      *

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -329,6 +329,13 @@ class Form extends Link implements \ArrayAccess
         $this->fields->remove($name);
     }
 
+    /**
+     * Sets current \DOMNode instance
+     *
+     * @param \DOMNode $node A \DOMNode instance
+     *
+     * @throws \LogicException If given node is not a button or input or does not have a form ancestor
+     */
     protected function setNode(\DOMNode $node)
     {
         $this->button = $node;

--- a/src/Symfony/Component/DomCrawler/Form.php
+++ b/src/Symfony/Component/DomCrawler/Form.php
@@ -26,6 +26,7 @@ class Form extends Link implements \ArrayAccess
      * @var \DOMNode
      */
     private $button;
+
     /**
      * @var Field\FormField[]
      */
@@ -271,7 +272,7 @@ class Form extends Link implements \ArrayAccess
     /**
      * Gets all fields.
      *
-     * @return array An array of fields
+     * @return FormField[] An array of fields
      *
      * @api
      */

--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -130,7 +130,7 @@ class Link
     }
 
     /**
-     * Returns raw uri data
+     * Returns raw uri data.
      *
      * @return string
      */
@@ -140,7 +140,7 @@ class Link
     }
 
     /**
-     * Sets current \DOMNode instance
+     * Sets current \DOMNode instance.
      *
      * @param \DOMNode $node A \DOMNode instance
      *

--- a/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DateRangeFilterIterator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Finder\Iterator;
 
+use Symfony\Component\Finder\Comparator\DateComparator;
+
 /**
  * DateRangeFilterIterator filters out files that are not in the given date range (last modified dates).
  *
@@ -23,8 +25,8 @@ class DateRangeFilterIterator extends FilterIterator
     /**
      * Constructor.
      *
-     * @param \Iterator $iterator    The Iterator to filter
-     * @param array     $comparators An array of \DateCompare instances
+     * @param \Iterator        $iterator    The Iterator to filter
+     * @param DateComparator[] $comparators An array of DateComparator instances
      */
     public function __construct(\Iterator $iterator, array $comparators)
     {

--- a/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Finder\Iterator;
 
+use Symfony\Component\Finder\Comparator\NumberComparator;
+
 /**
  * SizeRangeFilterIterator filters out files that are not in the given size range.
  *
@@ -23,8 +25,8 @@ class SizeRangeFilterIterator extends FilterIterator
     /**
      * Constructor.
      *
-     * @param \Iterator $iterator    The Iterator to filter
-     * @param array     $comparators An array of \NumberComparator instances
+     * @param \Iterator          $iterator    The Iterator to filter
+     * @param NumberComparator[] $comparators An array of NumberComparator instances
      */
     public function __construct(\Iterator $iterator, array $comparators)
     {

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -21,13 +21,13 @@ abstract class AbstractExtension implements FormExtensionInterface
 {
     /**
      * The types provided by this extension
-     * @var array An array of FormTypeInterface
+     * @var FormTypeInterface[] An array of FormTypeInterface
      */
     private $types;
 
     /**
      * The type extensions provided by this extension
-     * @var array An array of FormTypeExtensionInterface
+     * @var FormTypeExtensionInterface[] An array of FormTypeExtensionInterface
      */
     private $typeExtensions;
 
@@ -112,7 +112,7 @@ abstract class AbstractExtension implements FormExtensionInterface
     /**
      * Registers the types.
      *
-     * @return array An array of FormTypeInterface instances
+     * @return FormTypeInterface[] An array of FormTypeInterface instances
      */
     protected function loadTypes()
     {
@@ -122,7 +122,7 @@ abstract class AbstractExtension implements FormExtensionInterface
     /**
      * Registers the type extensions.
      *
-     * @return array An array of FormTypeExtensionInterface instances
+     * @return FormTypeExtensionInterface[] An array of FormTypeExtensionInterface instances
      */
     protected function loadTypeExtensions()
     {

--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -96,7 +96,7 @@ abstract class AbstractType implements FormTypeInterface
     /**
      * Sets the extensions for this type.
      *
-     * @param array $extensions An array of FormTypeExtensionInterface
+     * @param FormTypeExtensionInterface[] $extensions An array of FormTypeExtensionInterface
      *
      * @throws Exception\UnexpectedTypeException if any extension does not implement FormTypeExtensionInterface
      *
@@ -110,7 +110,7 @@ abstract class AbstractType implements FormTypeInterface
     /**
      * Returns the extensions associated with this type.
      *
-     * @return array An array of FormTypeExtensionInterface
+     * @return FormTypeExtensionInterface[] An array of FormTypeExtensionInterface
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link ResolvedFormTypeInterface::getTypeExtensions()} instead.

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -70,13 +70,13 @@ class Form implements \IteratorAggregate, FormInterface
 
     /**
      * The children of this form
-     * @var array An array of FormInterface instances
+     * @var FormInterface[] An array of FormInterface instances
      */
     private $children = array();
 
     /**
      * The errors of this form
-     * @var array An array of FormError instances
+     * @var FormError[] An array of FormError instances
      */
     private $errors = array();
 
@@ -203,7 +203,7 @@ class Form implements \IteratorAggregate, FormInterface
     /**
      * Returns the types used by this form.
      *
-     * @return array An array of FormTypeInterface
+     * @return FormTypeInterface[] An array of FormTypeInterface
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link getConfig()} and {@link FormConfigInterface::getType()} instead.
@@ -761,9 +761,9 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
-     * Returns the DataTransformers.
+     * Returns the model transformers of the form.
      *
-     * @return array An array of DataTransformerInterface
+     * @return DataTransformerInterface[] An array of DataTransformerInterface
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link getConfig()} and {@link FormConfigInterface::getModelTransformers()} instead.
@@ -774,9 +774,9 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
-     * Returns the DataTransformers.
+     * Returns the view transformers of the form.
      *
-     * @return array An array of DataTransformerInterface
+     * @return DataTransformerInterface[] An array of DataTransformerInterface
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link getConfig()} and {@link FormConfigInterface::getViewTransformers()} instead.

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -288,7 +288,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     /**
      * Returns the types used by this builder.
      *
-     * @return array An array of FormTypeInterface
+     * @return FormTypeInterface[] An array of FormTypeInterface
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link FormConfigInterface::getType()} instead.

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -86,14 +86,14 @@ interface FormConfigInterface
     /**
      * Returns the view transformers of the form.
      *
-     * @return array An array of {@link DataTransformerInterface} instances.
+     * @return DataTransformerInterface[] An array of {@link DataTransformerInterface} instances.
      */
     public function getViewTransformers();
 
     /**
      * Returns the model transformers of the form.
      *
-     * @return array An array of {@link DataTransformerInterface} instances.
+     * @return DataTransformerInterface[] An array of {@link DataTransformerInterface} instances.
      */
     public function getModelTransformers();
 

--- a/src/Symfony/Component/Form/FormExtensionInterface.php
+++ b/src/Symfony/Component/Form/FormExtensionInterface.php
@@ -41,7 +41,7 @@ interface FormExtensionInterface
      *
      * @param string $name The name of the type
      *
-     * @return array An array of extensions as FormTypeExtensionInterface instances
+     * @return FormTypeExtensionInterface[] An array of extensions as FormTypeExtensionInterface instances
      */
     public function getTypeExtensions($name);
 

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -84,14 +84,14 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns all children in this group.
      *
-     * @return array An array of FormInterface instances
+     * @return FormInterface[] An array of FormInterface instances
      */
     public function all();
 
     /**
      * Returns all errors.
      *
-     * @return array An array of FormError instances that occurred during binding
+     * @return FormError[] An array of FormError instances that occurred during binding
      */
     public function getErrors();
 

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -23,7 +23,8 @@ class FormRegistry implements FormRegistryInterface
 {
     /**
      * Extensions
-     * @var array An array of FormExtensionInterface
+     *
+     * @var FormExtensionInterface[] An array of FormExtensionInterface
      */
     private $extensions = array();
 
@@ -45,7 +46,7 @@ class FormRegistry implements FormRegistryInterface
     /**
      * Constructor.
      *
-     * @param array                            $extensions          An array of FormExtensionInterface
+     * @param FormExtensionInterface[]         $extensions          An array of FormExtensionInterface
      * @param ResolvedFormTypeFactoryInterface $resolvedTypeFactory The factory for resolved form types.
      *
      * @throws UnexpectedTypeException if any extension does not implement FormExtensionInterface

--- a/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
+++ b/src/Symfony/Component/Form/ResolvedFormTypeInterface.php
@@ -42,7 +42,7 @@ interface ResolvedFormTypeInterface
     /**
      * Returns the extensions of the wrapped form type.
      *
-     * @return array An array of {@link FormTypeExtensionInterface} instances.
+     * @return FormTypeExtensionInterface[] An array of {@link FormTypeExtensionInterface} instances.
      */
     public function getTypeExtensions();
 

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -27,17 +27,17 @@ class NativeSessionStorage implements SessionStorageInterface
     /**
      * Array of SessionBagInterface
      *
-     * @var array
+     * @var SessionBagInterface[]
      */
     protected $bags;
 
     /**
-     * @var boolean
+     * @var Boolean
      */
     protected $started = false;
 
     /**
-     * @var boolean
+     * @var Boolean
      */
     protected $closed = false;
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -46,7 +46,11 @@ use Symfony\Component\ClassLoader\DebugClassLoader;
  */
 abstract class Kernel implements KernelInterface, TerminableInterface
 {
+    /**
+     * @var BundleInterface[]
+     */
     protected $bundles;
+    
     protected $bundleMap;
     protected $container;
     protected $rootDir;
@@ -157,9 +161,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Shutdowns the kernel.
-     *
-     * This method is mainly useful when doing functional testing.
+     * {@inheritdoc}
      *
      * @api
      */
@@ -204,10 +206,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the registered bundle instances.
-     *
-     * @return array An array of registered bundle instances
-     *
+     * {@inheritdoc}
+     * 
      * @api
      */
     public function getBundles()
@@ -216,11 +216,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Checks if a given class name belongs to an active bundle.
-     *
-     * @param string $class A class name
-     *
-     * @return Boolean true if the class belongs to an active bundle, false otherwise
+     * {@inheritdoc}
      *
      * @api
      */
@@ -236,14 +232,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Returns a bundle and optionally its descendants by its name.
-     *
-     * @param string  $name  Bundle name
-     * @param Boolean $first Whether to return the first bundle only or together with its descendants
-     *
-     * @return BundleInterface|Array A BundleInterface instance or an array of BundleInterface instances if $first is false
-     *
-     * @throws \InvalidArgumentException when the bundle is not enabled
+     * {@inheritdoc}
      *
      * @api
      */
@@ -346,9 +335,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the name of the kernel
-     *
-     * @return string The kernel name
+     * {@inheritdoc}
      *
      * @api
      */
@@ -362,9 +349,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the environment.
-     *
-     * @return string The current environment
+     * {@inheritdoc}
      *
      * @api
      */
@@ -374,9 +359,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Checks if debug mode is enabled.
-     *
-     * @return Boolean true if debug mode is enabled, false otherwise
+     * {@inheritdoc}
      *
      * @api
      */
@@ -386,9 +369,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the application root dir.
-     *
-     * @return string The application root dir
+     * {@inheritdoc}
      *
      * @api
      */
@@ -403,9 +384,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the current container.
-     *
-     * @return ContainerInterface A ContainerInterface instance
+     * {@inheritdoc}
      *
      * @api
      */
@@ -436,9 +415,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the request start time (not available if debug is disabled).
-     *
-     * @return integer The request start timestamp
+     * {@inheritdoc}
      *
      * @api
      */
@@ -448,9 +425,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the cache directory.
-     *
-     * @return string The cache directory
+     * {@inheritdoc}
      *
      * @api
      */
@@ -460,9 +435,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the log directory.
-     *
-     * @return string The log directory
+     * {@inheritdoc}
      *
      * @api
      */
@@ -472,9 +445,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     }
 
     /**
-     * Gets the charset of the application.
-     *
-     * @return string The charset
+     * {@inheritdoc}
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -50,7 +50,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      * @var BundleInterface[]
      */
     protected $bundles;
-    
+
     protected $bundleMap;
     protected $container;
     protected $rootDir;

--- a/src/Symfony/Component/HttpKernel/KernelInterface.php
+++ b/src/Symfony/Component/HttpKernel/KernelInterface.php
@@ -30,7 +30,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Returns an array of bundles to registers.
      *
-     * @return array An array of bundle instances.
+     * @return BundleInterface[] An array of bundle instances.
      *
      * @api
      */
@@ -64,7 +64,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
     /**
      * Gets the registered bundle instances.
      *
-     * @return array An array of registered bundle instances
+     * @return BundleInterface[] An array of registered bundle instances
      *
      * @api
      */
@@ -87,7 +87,7 @@ interface KernelInterface extends HttpKernelInterface, \Serializable
      * @param string  $name  Bundle name
      * @param Boolean $first Whether to return the first bundle only or together with its descendants
      *
-     * @return BundleInterface|Array A BundleInterface instance or an array of BundleInterface instances if $first is false
+     * @return BundleInterface|BundleInterface[] A BundleInterface instance or an array of BundleInterface instances if $first is false
      *
      * @throws \InvalidArgumentException when the bundle is not enabled
      *

--- a/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/MongoDbProfilerStorage.php
@@ -32,14 +32,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     }
 
     /**
-     * Finds profiler tokens for the given criteria.
-     *
-     * @param string $ip     The IP
-     * @param string $url    The URL
-     * @param string $limit  The maximum number of tokens to return
-     * @param string $method The request method
-     *
-     * @return array An array of tokens
+     * {@inheritdoc}
      */
     public function find($ip, $url, $limit, $method)
     {
@@ -54,7 +47,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     }
 
     /**
-     * Purges all data from the database.
+     * {@inheritdoc}
      */
     public function purge()
     {
@@ -62,13 +55,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     }
 
     /**
-     * Reads data associated with the given token.
-     *
-     * The method returns false if the token does not exists in the storage.
-     *
-     * @param string $token A token
-     *
-     * @return Profile The profile associated with token
+     * {@inheritdoc}
      */
     public function read($token)
     {
@@ -82,11 +69,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
     }
 
     /**
-     * Saves a Profile.
-     *
-     * @param Profile $profile A Profile instance
-     *
-     * @return Boolean Write operation successful
+     * {@inheritdoc}
      */
     public function write(Profile $profile)
     {
@@ -128,6 +111,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
 
     /**
      * @param array $data
+     * 
      * @return Profile
      */
     protected function createProfileFromData(array $data)
@@ -148,7 +132,8 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
 
     /**
      * @param string $token
-     * @return array
+     * 
+     * @return Profile[] An array of Profile instances
      */
     protected function readChildren($token)
     {
@@ -171,6 +156,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
      * @param string $ip
      * @param string $url
      * @param string $method
+     * 
      * @return array
      */
     private function buildQuery($ip, $url, $method)
@@ -194,6 +180,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
 
     /**
      * @param array $data
+     * 
      * @return array
      */
     private function getData(array $data)
@@ -211,6 +198,7 @@ class MongoDbProfilerStorage implements ProfilerStorageInterface
 
     /**
      * @param array $data
+     * 
      * @return Profile
      */
     private function getProfile(array $data)

--- a/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/PdoProfilerStorage.php
@@ -216,7 +216,7 @@ abstract class PdoProfilerStorage implements ProfilerStorageInterface
      * @param string $token  The parent token
      * @param string $parent The parent instance
      *
-     * @return array An array of Profile instance
+     * @return Profile[] An array of Profile instance
      */
     protected function readChildren($token, $parent)
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -21,13 +21,26 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 class Profile
 {
     private $token;
-    private $collectors;
+    
+    /**
+     * @var DataCollectorInterface[]
+     */
+    private $collectors = array();
+    
     private $ip;
     private $method;
     private $url;
     private $time;
+    
+    /**
+     * @var Profile
+     */
     private $parent;
-    private $children;
+    
+    /**
+     * @var Profile[]
+     */
+    private $children = array();
 
     /**
      * Constructor.
@@ -37,8 +50,6 @@ class Profile
     public function __construct($token)
     {
         $this->token = $token;
-        $this->collectors = array();
-        $this->children = array();
     }
 
     /**
@@ -101,6 +112,11 @@ class Profile
         return $this->ip;
     }
 
+    /**
+     * Sets the IP.
+     * 
+     * @param string $ip
+     */
     public function setIp($ip)
     {
         $this->ip = $ip;
@@ -154,13 +170,18 @@ class Profile
     /**
      * Finds children profilers.
      *
-     * @return array An array of Profile
+     * @return Profile[] An array of Profile
      */
     public function getChildren()
     {
         return $this->children;
     }
 
+    /**
+     * Sets children profiler.
+     * 
+     * @param Profile[] $children An array of Profile
+     */
     public function setChildren(array $children)
     {
         $this->children = array();
@@ -180,6 +201,15 @@ class Profile
         $child->setParent($this);
     }
 
+    /**
+     * Gets a Collector by name.
+     *
+     * @param string $name A collector name
+     *
+     * @return DataCollectorInterface A DataCollectorInterface instance
+     *
+     * @throws \InvalidArgumentException if the collector does not exist
+     */
     public function getCollector($name)
     {
         if (!isset($this->collectors[$name])) {
@@ -189,11 +219,21 @@ class Profile
         return $this->collectors[$name];
     }
 
+    /**
+     * Gets the Collectors associated with this profile.
+     * 
+     * @return DataCollectorInterface[]
+     */
     public function getCollectors()
     {
         return $this->collectors;
     }
 
+    /**
+     * Sets the Collectors associated with this profile.
+     * 
+     * @param DataCollectorInterface[] $collectors
+     */
     public function setCollectors(array $collectors)
     {
         $this->collectors = array();
@@ -202,11 +242,23 @@ class Profile
         }
     }
 
+    /**
+     * Adds a Collector.
+     *
+     * @param DataCollectorInterface $collector A DataCollectorInterface instance
+     */
     public function addCollector(DataCollectorInterface $collector)
     {
         $this->collectors[$collector->getName()] = $collector;
     }
 
+    /**
+     * Returns true if a Collector for the given name exists.
+     *
+     * @param string $name A collector name
+     *
+     * @return Boolean
+     */
     public function hasCollector($name)
     {
         return isset($this->collectors[$name]);

--- a/src/Symfony/Component/HttpKernel/Profiler/Profile.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profile.php
@@ -21,22 +21,22 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
 class Profile
 {
     private $token;
-    
+
     /**
      * @var DataCollectorInterface[]
      */
     private $collectors = array();
-    
+
     private $ip;
     private $method;
     private $url;
     private $time;
-    
+
     /**
      * @var Profile
      */
     private $parent;
-    
+
     /**
      * @var Profile[]
      */

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -24,10 +24,25 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
  */
 class Profiler
 {
+    /**
+     * @var ProfilerStorageInterface
+     */
     private $storage;
-    private $collectors;
+    
+    /**
+     * @var DataCollectorInterface[]
+     */
+    private $collectors = array();
+    
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
-    private $enabled;
+    
+    /**
+     * @var Boolean
+     */
+    private $enabled = true;
 
     /**
      * Constructor.
@@ -39,8 +54,6 @@ class Profiler
     {
         $this->storage = $storage;
         $this->logger = $logger;
-        $this->collectors = array();
-        $this->enabled = true;
     }
 
     /**
@@ -204,7 +217,7 @@ class Profiler
     /**
      * Sets the Collectors associated with this profiler.
      *
-     * @param array $collectors An array of collectors
+     * @param DataCollectorInterface[] $collectors An array of collectors
      */
     public function set(array $collectors = array())
     {

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -28,17 +28,17 @@ class Profiler
      * @var ProfilerStorageInterface
      */
     private $storage;
-    
+
     /**
      * @var DataCollectorInterface[]
      */
     private $collectors = array();
-    
+
     /**
      * @var LoggerInterface
      */
     private $logger;
-    
+
     /**
      * @var Boolean
      */

--- a/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
@@ -27,7 +27,11 @@ class FullTransformer
     private $notImplementedChars = 'GYuwWFgecSAZvVW';
     private $regExp;
 
+    /**
+     * @var Transformer[]
+     */
     private $transformers;
+    
     private $pattern;
     private $timezone;
 
@@ -69,7 +73,7 @@ class FullTransformer
     /**
      * Return the array of Transformer objects
      *
-     * @return  array  Associative array of Transformer objects (format char => Transformer)
+     * @return Transformer[] Associative array of Transformer objects (format char => Transformer)
      */
     public function getTransformers()
     {

--- a/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
+++ b/src/Symfony/Component/Locale/Stub/DateFormat/FullTransformer.php
@@ -31,7 +31,7 @@ class FullTransformer
      * @var Transformer[]
      */
     private $transformers;
-    
+
     private $pattern;
     private $timezone;
 

--- a/src/Symfony/Component/Security/Acl/Domain/AclCollectionCache.php
+++ b/src/Symfony/Component/Security/Acl/Domain/AclCollectionCache.php
@@ -44,8 +44,8 @@ class AclCollectionCache
      * Batch loads ACLs for an entire collection; thus, it reduces the number
      * of required queries considerably.
      *
-     * @param mixed $collection anything that can be passed to foreach()
-     * @param array $tokens     an array of TokenInterface implementations
+     * @param mixed            $collection anything that can be passed to foreach()
+     * @param TokenInterface[] $tokens     an array of TokenInterface implementations
      */
     public function cache($collection, array $tokens = array())
     {

--- a/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
+++ b/src/Symfony/Component/Security/Acl/Domain/PermissionGrantingStrategy.php
@@ -16,6 +16,7 @@ use Symfony\Component\Security\Acl\Model\AclInterface;
 use Symfony\Component\Security\Acl\Model\AuditLoggerInterface;
 use Symfony\Component\Security\Acl\Model\EntryInterface;
 use Symfony\Component\Security\Acl\Model\PermissionGrantingStrategyInterface;
+use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
 
 /**
  * The permission granting strategy to apply to the access control list.
@@ -125,11 +126,12 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      * is true. Otherwise, we will either throw an NoAceFoundException, or deny
      * access finally.
      *
-     * @param AclInterface $acl
-     * @param array        $aces               An array of ACE to check against
-     * @param array        $masks              An array of permission masks
-     * @param array        $sids               An array of SecurityIdentityInterface implementations
-     * @param Boolean      $administrativeMode True turns off audit logging
+     * @param AclInterface                $acl
+     * @param EntryInterface[]            $aces               An array of ACE to check against
+     * @param array                       $masks              An array of permission masks
+     * @param SecurityIdentityInterface[] $sids               An array of SecurityIdentityInterface implementations
+     * @param Boolean                     $administrativeMode True turns off audit logging
+     *
      * @return Boolean true, or false; either granting, or denying access respectively.
      */
     private function hasSufficientPermissions(AclInterface $acl, array $aces, array $masks, array $sids, $administrativeMode)
@@ -188,7 +190,10 @@ class PermissionGrantingStrategy implements PermissionGrantingStrategyInterface
      *
      * @param integer        $requiredMask
      * @param EntryInterface $ace
+     *
      * @return Boolean
+     *
+     * @throws \RuntimeException if the ACE strategy is not supported
      */
     private function isAceApplicable($requiredMask, EntryInterface $ace)
     {

--- a/src/Symfony/Component/Security/Acl/Model/AclProviderInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/AclProviderInterface.php
@@ -23,6 +23,7 @@ interface AclProviderInterface
      *
      * @param ObjectIdentityInterface $parentOid
      * @param Boolean                 $directChildrenOnly
+     *
      * @return array returns an array of child 'ObjectIdentity's
      */
     public function findChildren(ObjectIdentityInterface $parentOid, $directChildrenOnly = false);
@@ -30,20 +31,24 @@ interface AclProviderInterface
     /**
      * Returns the ACL that belongs to the given object identity
      *
-     * @throws AclNotFoundException when there is no ACL
-     * @param ObjectIdentityInterface $oid
-     * @param array                   $sids
+     * @param ObjectIdentityInterface     $oid
+     * @param SecurityIdentityInterface[] $sids
+     *
      * @return AclInterface
+     *
+     * @throws AclNotFoundException when there is no ACL
      */
     public function findAcl(ObjectIdentityInterface $oid, array $sids = array());
 
     /**
      * Returns the ACLs that belong to the given object identities
      *
-     * @throws AclNotFoundException when we cannot find an ACL for all identities
-     * @param array $oids an array of ObjectIdentityInterface implementations
-     * @param array $sids an array of SecurityIdentityInterface implementations
+     * @param ObjectIdentityInterface[]   $oids an array of ObjectIdentityInterface implementations
+     * @param SecurityIdentityInterface[] $sids an array of SecurityIdentityInterface implementations
+     *
      * @return \SplObjectStorage mapping the passed object identities to ACLs
+     *
+     * @throws AclNotFoundException when we cannot find an ACL for all identities
      */
     public function findAcls(array $oids, array $sids = array());
 }

--- a/src/Symfony/Component/Security/Acl/Model/SecurityIdentityRetrievalStrategyInterface.php
+++ b/src/Symfony/Component/Security/Acl/Model/SecurityIdentityRetrievalStrategyInterface.php
@@ -28,7 +28,8 @@ interface SecurityIdentityRetrievalStrategyInterface
      * least specific.
      *
      * @param TokenInterface $token
-     * @return array of SecurityIdentityInterface implementations
+     *
+     * @return SecurityIdentityInterface[] An array of SecurityIdentityInterface implementations
      */
     public function getSecurityIdentities(TokenInterface $token);
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AbstractToken.php
@@ -33,7 +33,7 @@ abstract class AbstractToken implements TokenInterface
     /**
      * Constructor.
      *
-     * @param Role[] $roles An array of roles
+     * @param RoleInterface[] $roles An array of roles
      */
     public function __construct(array $roles = array())
     {

--- a/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/AnonymousToken.php
@@ -24,9 +24,9 @@ class AnonymousToken extends AbstractToken
     /**
      * Constructor.
      *
-     * @param string $key   The key shared with the authentication provider
-     * @param string $user  The user
-     * @param Role[] $roles An array of roles
+     * @param string          $key   The key shared with the authentication provider
+     * @param string          $user  The user
+     * @param RoleInterface[] $roles An array of roles
      */
     public function __construct($key, $user, array $roles = array())
     {
@@ -66,9 +66,9 @@ class AnonymousToken extends AbstractToken
     /**
      * {@inheritDoc}
      */
-    public function unserialize($str)
+    public function unserialize($serialized)
     {
-        list($this->key, $parentStr) = unserialize($str);
+        list($this->key, $parentStr) = unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/TokenInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Security\Core\Authentication\Token;
 
+use Symfony\Component\Security\Core\Role\RoleInterface;
+
 /**
  * TokenInterface is the interface for the user authentication information.
  *
@@ -31,7 +33,7 @@ interface TokenInterface extends \Serializable
     /**
      * Returns the user roles.
      *
-     * @return Role[] An array of Role instances.
+     * @return RoleInterface[] An array of RoleInterface instances.
      */
     public function getRoles();
 

--- a/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Token/UsernamePasswordToken.php
@@ -24,10 +24,10 @@ class UsernamePasswordToken extends AbstractToken
     /**
      * Constructor.
      *
-     * @param string $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method.
-     * @param string $credentials This usually is the password of the user
-     * @param string $providerKey The provider key
-     * @param array  $roles       An array of roles
+     * @param string          $user        The username (like a nickname, email address, etc.), or a UserInterface instance or an object implementing a __toString method.
+     * @param string          $credentials This usually is the password of the user
+     * @param string          $providerKey The provider key
+     * @param RoleInterface[] $roles       An array of roles
      *
      * @throws \InvalidArgumentException
      */
@@ -78,14 +78,20 @@ class UsernamePasswordToken extends AbstractToken
         $this->credentials = null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function serialize()
     {
         return serialize(array($this->credentials, $this->providerKey, parent::serialize()));
     }
 
-    public function unserialize($str)
+    /**
+     * {@inheritdoc}
+     */
+    public function unserialize($serialized)
     {
-        list($this->credentials, $this->providerKey, $parentStr) = unserialize($str);
+        list($this->credentials, $this->providerKey, $parentStr) = unserialize($serialized);
         parent::unserialize($parentStr);
     }
 }

--- a/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
+++ b/src/Symfony/Component/Security/Core/Role/RoleHierarchyInterface.php
@@ -24,9 +24,9 @@ interface RoleHierarchyInterface
      * Reachable roles are the roles directly assigned but also all roles that
      * are transitively reachable from them in the role hierarchy.
      *
-     * @param array $roles An array of directly assigned roles
+     * @param RoleInterface[] $roles An array of directly assigned roles
      *
-     * @return array An array of all reachable roles
+     * @return RoleInterface[] An array of all reachable roles
      */
     public function getReachableRoles(array $roles);
 }

--- a/src/Symfony/Component/Templating/DelegatingEngine.php
+++ b/src/Symfony/Component/Templating/DelegatingEngine.php
@@ -20,12 +20,15 @@ namespace Symfony\Component\Templating;
  */
 class DelegatingEngine implements EngineInterface, StreamingEngineInterface
 {
+    /**
+     * @var EngineInterface[]
+     */
     protected $engines;
 
     /**
      * Constructor.
      *
-     * @param array $engines An array of EngineInterface instances to add
+     * @param EngineInterface[] $engines An array of EngineInterface instances to add
      *
      * @api
      */
@@ -38,15 +41,7 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
     }
 
     /**
-     * Renders a template.
-     *
-     * @param mixed $name       A template name or a TemplateReferenceInterface instance
-     * @param array $parameters An array of parameters to pass to the template
-     *
-     * @return string The evaluated template as a string
-     *
-     * @throws \InvalidArgumentException if the template does not exist
-     * @throws \RuntimeException         if the template cannot be rendered
+     * {@inheritdoc}
      *
      * @api
      */
@@ -56,12 +51,7 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
     }
 
     /**
-     * Streams a template.
-     *
-     * @param mixed $name       A template name or a TemplateReferenceInterface instance
-     * @param array $parameters An array of parameters to pass to the template
-     *
-     * @throws \RuntimeException if the template cannot be rendered
+     * {@inheritdoc}
      *
      * @api
      */
@@ -76,11 +66,7 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
     }
 
     /**
-     * Returns true if the template exists.
-     *
-     * @param mixed $name A template name or a TemplateReferenceInterface instance
-     *
-     * @return Boolean true if the template exists, false otherwise
+     * {@inheritdoc}
      *
      * @api
      */
@@ -102,11 +88,7 @@ class DelegatingEngine implements EngineInterface, StreamingEngineInterface
     }
 
     /**
-     * Returns true if this class is able to render the given template.
-     *
-     * @param mixed $name A template name or a TemplateReferenceInterface instance
-     *
-     * @return Boolean true if this class supports the given template, false otherwise
+     * {@inheritdoc}
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
+++ b/src/Symfony/Component/Templating/Loader/FilesystemLoader.php
@@ -89,6 +89,8 @@ class FilesystemLoader extends Loader
      *
      * @param TemplateReferenceInterface $template A template
      * @param integer                    $time     The last modification time of the cached template (timestamp)
+     * 
+     * @return Boolean true if the template is still fresh, false otherwise
      *
      * @api
      */
@@ -106,7 +108,7 @@ class FilesystemLoader extends Loader
      *
      * @param string $file A path
      *
-     * @return true if the path exists and is absolute, false otherwise
+     * @return Boolean true if the path exists and is absolute, false otherwise
      */
     protected static function isAbsolutePath($file)
     {

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -47,7 +47,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      *
      * @param TemplateNameParserInterface $parser  A TemplateNameParserInterface instance
      * @param LoaderInterface             $loader  A loader instance
-     * @param array                       $helpers An array of helper instances
+     * @param HelperInterface[]           $helpers An array of helper instances
      */
     public function __construct(TemplateNameParserInterface $parser, LoaderInterface $loader, array $helpers = array())
     {
@@ -235,7 +235,9 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     }
 
     /**
-     * @param Helper[] $helpers An array of helper
+     * Adds some helpers.
+     * 
+     * @param HelperInterface[] $helpers An array of helper
      *
      * @api
      */
@@ -249,7 +251,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     /**
      * Sets the helpers.
      *
-     * @param Helper[] $helpers An array of helper
+     * @param HelperInterface[] $helpers An array of helper
      *
      * @api
      */

--- a/src/Symfony/Component/Templating/StreamingEngineInterface.php
+++ b/src/Symfony/Component/Templating/StreamingEngineInterface.php
@@ -27,6 +27,7 @@ interface StreamingEngineInterface
      * @param array $parameters An array of parameters to pass to the template
      *
      * @throws \RuntimeException if the template cannot be rendered
+     * @throws \LogicException   if the template cannot be streamed
      */
     public function stream($name, array $parameters = array());
 }

--- a/src/Symfony/Component/Translation/Extractor/ChainExtractor.php
+++ b/src/Symfony/Component/Translation/Extractor/ChainExtractor.php
@@ -23,7 +23,7 @@ class ChainExtractor implements ExtractorInterface
     /**
      * The extractors.
      *
-     * @var array
+     * @var ExtractorInterface[]
      */
     private $extractors = array();
 

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -22,11 +22,34 @@ use Symfony\Component\Translation\Loader\LoaderInterface;
  */
 class Translator implements TranslatorInterface
 {
-    protected $catalogues;
+    /**
+     * @var MessageCatalogueInterface[]
+     */
+    protected $catalogues = array();
+    
+    /**
+     * @var string
+     */
     protected $locale;
-    private $fallbackLocales;
-    private $loaders;
-    private $resources;
+    
+    /**
+     * @var array
+     */
+    private $fallbackLocales = array();
+    
+    /**
+     * @var LoaderInterface[]
+     */
+    private $loaders = array();
+    
+    /**
+     * @var array
+     */
+    private $resources = array();
+    
+    /**
+     * @var MessageSelector
+     */
     private $selector;
 
     /**
@@ -41,10 +64,6 @@ class Translator implements TranslatorInterface
     {
         $this->locale = $locale;
         $this->selector = null === $selector ? new MessageSelector() : $selector;
-        $this->loaders = array();
-        $this->resources = array();
-        $this->catalogues = array();
-        $this->fallbackLocales = array();
     }
 
     /**

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -26,27 +26,27 @@ class Translator implements TranslatorInterface
      * @var MessageCatalogueInterface[]
      */
     protected $catalogues = array();
-    
+
     /**
      * @var string
      */
     protected $locale;
-    
+
     /**
      * @var array
      */
     private $fallbackLocales = array();
-    
+
     /**
      * @var LoaderInterface[]
      */
     private $loaders = array();
-    
+
     /**
      * @var array
      */
     private $resources = array();
-    
+
     /**
      * @var MessageSelector
      */

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -23,13 +23,44 @@ use Symfony\Component\Validator\Exception\GroupDefinitionException;
  */
 class ClassMetadata extends ElementMetadata
 {
+    /**
+     * @var string
+     */
     public $name;
+
+    /**
+     * @var string
+     */
     public $defaultGroup;
+
+    /**
+     * @var MemberMetadata[]
+     */
     public $members = array();
+
+    /**
+     * @var PropertyMetadata[]
+     */
     public $properties = array();
+
+    /**
+     * @var GetterMetadata[]
+     */
     public $getters = array();
+
+    /**
+     * @var array
+     */
     public $groupSequence = array();
+
+    /**
+     * @var Boolean
+     */
     public $groupSequenceProvider = false;
+
+    /**
+     * @var \ReflectionClass
+     */
     private $reflClass;
 
     /**
@@ -119,7 +150,7 @@ class ClassMetadata extends ElementMetadata
      * @param string     $property   The name of the property
      * @param Constraint $constraint The constraint
      *
-     * @return ClassMetadata           This object
+     * @return ClassMetadata This object
      */
     public function addPropertyConstraint($property, Constraint $constraint)
     {
@@ -197,7 +228,7 @@ class ClassMetadata extends ElementMetadata
     }
 
     /**
-     * Adds a member metadata
+     * Adds a member metadata.
      *
      * @param MemberMetadata $metadata
      */
@@ -221,11 +252,11 @@ class ClassMetadata extends ElementMetadata
     }
 
     /**
-     * Returns all metadatas of members describing the given property
+     * Returns all metadatas of members describing the given property.
      *
      * @param string $property The name of the property
      *
-     * @return array An array of MemberMetadata
+     * @return MemberMetadata[] An array of MemberMetadata
      */
     public function getMemberMetadatas($property)
     {
@@ -289,7 +320,7 @@ class ClassMetadata extends ElementMetadata
     /**
      * Returns a ReflectionClass instance for this class.
      *
-     * @return ReflectionClass
+     * @return \ReflectionClass
      */
     public function getReflectionClass()
     {
@@ -301,9 +332,9 @@ class ClassMetadata extends ElementMetadata
     }
 
     /**
-     * Sets whether a group sequence provider should be used
+     * Sets whether a group sequence provider should be used.
      *
-     * @param boolean $active
+     * @param Boolean $active
      */
     public function setGroupSequenceProvider($active)
     {
@@ -321,7 +352,7 @@ class ClassMetadata extends ElementMetadata
     /**
      * Returns whether the class is a group sequence provider.
      *
-     * @return boolean
+     * @return Boolean
      */
     public function isGroupSequenceProvider()
     {

--- a/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ElementMetadata.php
@@ -15,7 +15,14 @@ use Symfony\Component\Validator\Constraint;
 
 abstract class ElementMetadata
 {
+    /**
+     * @var Constraint[]
+     */
     public $constraints = array();
+
+    /**
+     * @var array
+     */
     public $constraintsByGroup = array();
 
     /**
@@ -65,7 +72,7 @@ abstract class ElementMetadata
     /**
      * Returns all constraints of this element.
      *
-     * @return array  An array of Constraint instances
+     * @return Constraint[] An array of Constraint instances
      */
     public function getConstraints()
     {

--- a/src/Symfony/Component/Validator/Mapping/Loader/FilesLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/FilesLoader.php
@@ -38,7 +38,7 @@ abstract class FilesLoader extends LoaderChain
      *
      * @param array $paths Array of file paths
      *
-     * @return array Array of metadata loaders
+     * @return LoaderInterface[] Array of metadata loaders
      */
     protected function getFileLoaders($paths)
     {

--- a/src/Symfony/Component/Validator/Mapping/Loader/LoaderChain.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/LoaderChain.php
@@ -31,7 +31,7 @@ class LoaderChain implements LoaderInterface
     /**
      * Accepts a list of LoaderInterface instances
      *
-     * @param array $loaders An array of LoaderInterface instances
+     * @param LoaderInterface[] $loaders An array of LoaderInterface instances
      *
      * @throws MappingException If any of the loaders does not implement LoaderInterface
      */

--- a/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/XmlFileLoader.php
@@ -18,7 +18,8 @@ class XmlFileLoader extends FileLoader
 {
     /**
      * An array of SimpleXMLElement instances.
-     * @val array
+     *
+     * @var \SimpleXMLElement[]
      */
     protected $classes = null;
 

--- a/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/YamlFileLoader.php
@@ -18,7 +18,8 @@ class YamlFileLoader extends FileLoader
 {
     /**
      * An array of YAML class descriptions
-     * @val array
+     *
+     * @var array
      */
     protected $classes = null;
 


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no (but tests doesn't pass on master too). See Travis.
License of the code: MIT
Documentation PR: Not Applicable
Status: Finished

To improve support of the eclipse PDT pluggin (for autocompletion), I propose to change the array notation in PHPDoc blocks to match the phpDocumentor notation for "array of type".

Modifications are made for the following components:
- BrowserKit
- ClassLoader
- Config
- Console
- CssSelector
- DependencyInjection
- DomCrawler
- EventDispatcher (no changes)
- Filesystem (no changes)
- Finder
- Form
- HttpFoundation
- HttpKernel
- Locale
- OptionResolver (no changes)
- Process (no changes)
- Routing (no changes)
- Serializer (no changes)
- Templating
- Translation
- Validator
- Yaml (no changes)
- Security
- Stopwatch (no changes)

See Proposal https://github.com/symfony/symfony/pull/5852
