### PR TITLE
[2.2][Routing] Added support for default attributes with default values of method params

### DIFF
--- a/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
+++ b/src/Symfony/Component/Routing/Loader/AnnotationClassLoader.php
@@ -149,6 +149,11 @@ abstract class AnnotationClassLoader implements LoaderInterface
         }
 
         $defaults = array_merge($globals['defaults'], $annot->getDefaults());
+        foreach ($method->getParameters() as $param) {
+            if ($param->isOptional()) {
+                $defaults[$param->getName()] = $param->getDefaultValue();
+            }
+        }
         $requirements = array_merge($globals['requirements'], $annot->getRequirements());
         $options = array_merge($globals['options'], $annot->getOptions());
 

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/BarClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/BarClass.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
 
 class BarClass
 {
-    public function routeAction()
+    public function routeAction($arg1, $arg2 = 'defaultValue2', $arg3 = 'defaultValue3')
     {
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/BarClass.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/AnnotatedClasses/BarClass.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses;
+
+class BarClass
+{
+    public function routeAction()
+    {
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -21,7 +21,8 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     {
         parent::setUp();
 
-        $this->loader = $this->getClassLoader($this->getReader());
+        $this->reader = $this->getReader();
+        $this->loader = $this->getClassLoader($this->reader);
     }
 
     /**
@@ -69,6 +70,45 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     {
         $this->assertTrue($this->loader->supports('class', 'annotation'), '->supports() checks the resource type if specified');
         $this->assertFalse($this->loader->supports('class', 'foo'), '->supports() checks the resource type if specified');
+    }
+
+    public function getLoadTests()
+    {
+        return array(
+            array(array('name'=>'route1')),
+        );
+    }
+
+    /**
+     * @dataProvider getLoadTests
+     */
+    public function testLoad($routeDatas)
+    {
+        $routeDatas = array_replace(array(
+            'name'         => 'route',
+            'pattern'      => '/',
+            'requirements' => array(),
+            'options'      => array(),
+            'defaults'     => array(),
+        ), $routeDatas);
+
+        $this->reader
+            ->expects($this->once())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array($this->getAnnotedRoute($routeDatas))))
+        ;
+        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass');
+        $route = $routeCollection->get($routeDatas['name']);
+
+        $this->assertSame($routeDatas['pattern'], $route->getPattern(), '->load preserves pattern annotation');
+        $this->assertSame($routeDatas['requirements'],$route->getRequirements(), '->load preserves requirements annotation');
+        $this->assertCount(0, array_intersect($route->getOptions(), $routeDatas['options']), '->load preserves options annotation');
+        $this->assertSame($routeDatas['defaults'], $route->getDefaults(), '->load preserves defaults annotation');
+    }
+
+    private function getAnnotedRoute($datas)
+    {
+        return new \Symfony\Component\Routing\Annotation\Route($datas);
     }
 
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -75,14 +75,23 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     public function getLoadTests()
     {
         return array(
-            array(array('name'=>'route1')),
+            array(
+                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
+                array('name'=>'route1'),
+                array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3')
+            ),
+            array(
+                'Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass',
+                array('name'=>'route1', 'defaults' => array('arg2' => 'foo')),
+                array('arg2' => 'defaultValue2', 'arg3' =>'defaultValue3')
+            ),
         );
     }
 
     /**
      * @dataProvider getLoadTests
      */
-    public function testLoad($routeDatas)
+    public function testLoad($className, $routeDatas = array(), $methodArgs = array())
     {
         $routeDatas = array_replace(array(
             'name'         => 'route',
@@ -97,13 +106,13 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
             ->method('getMethodAnnotations')
             ->will($this->returnValue(array($this->getAnnotedRoute($routeDatas))))
         ;
-        $routeCollection = $this->loader->load('Symfony\Component\Routing\Tests\Fixtures\AnnotatedClasses\BarClass');
+        $routeCollection = $this->loader->load($className);
         $route = $routeCollection->get($routeDatas['name']);
 
         $this->assertSame($routeDatas['pattern'], $route->getPattern(), '->load preserves pattern annotation');
         $this->assertSame($routeDatas['requirements'],$route->getRequirements(), '->load preserves requirements annotation');
         $this->assertCount(0, array_intersect($route->getOptions(), $routeDatas['options']), '->load preserves options annotation');
-        $this->assertSame($routeDatas['defaults'], $route->getDefaults(), '->load preserves defaults annotation');
+        $this->assertSame(array_replace($routeDatas['defaults'], $methodArgs), $route->getDefaults(), '->load preserves defaults annotation');
     }
 
     private function getAnnotedRoute($datas)

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -29,7 +29,13 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
 
     public function testLoad()
     {
-        $this->reader->expects($this->once())->method('getClassAnnotation');
+        $this->reader->expects($this->exactly(2))->method('getClassAnnotation');
+
+        $this->reader
+            ->expects($this->any())
+            ->method('getMethodAnnotations')
+            ->will($this->returnValue(array()))
+        ;
 
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes

With this patch, you can configure your default values likes this:

``` php
/**
 * @Route("/hi/{name}", name="hi")
 */
public function hiAction($name = "Bob")
{
    return new Response($name);
}
```
