### PR TITLE
[Console] shows correct class name InputOption in error message

### DIFF
--- a/src/Symfony/Component/Console/Input/InputOption.php
+++ b/src/Symfony/Component/Console/Input/InputOption.php
@@ -148,7 +148,7 @@ class InputOption
     public function setDefault($default = null)
     {
         if (self::VALUE_NONE === (self::VALUE_NONE & $this->mode) && null !== $default) {
-            throw new \LogicException('Cannot set a default value when using Option::VALUE_NONE mode.');
+            throw new \LogicException('Cannot set a default value when using InputOption::VALUE_NONE mode.');
         }
 
         if ($this->isArray()) {

--- a/tests/Symfony/Tests/Component/Console/Input/InputOptionTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputOptionTest.php
@@ -121,7 +121,7 @@ class InputOptionTest extends \PHPUnit_Framework_TestCase
             $this->fail('->setDefault() throws an Exception if you give a default value for a VALUE_NONE option');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\Exception', $e, '->setDefault() throws an Exception if you give a default value for a VALUE_NONE option');
-            $this->assertEquals('Cannot set a default value when using Option::VALUE_NONE mode.', $e->getMessage());
+            $this->assertEquals('Cannot set a default value when using InputOption::VALUE_NONE mode.', $e->getMessage());
         }
 
         $option = new InputOption('foo', 'f', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
