### PR TITLE
[Console] Fix #5897 - Console component require Shell component

### DIFF
--- a/src/Symfony/Component/Console/Shell.php
+++ b/src/Symfony/Component/Console/Shell.php
@@ -203,5 +203,9 @@ EOF;
     public function setProcessIsolation($processIsolation)
     {
         $this->processIsolation = (Boolean) $processIsolation;
+
+        if ($this->processIsolation && !class_exists('Symfony\\Component\\Process\\Process')) {
+            throw new \RuntimeException('Unable to isolate processes as the Symfony Process Component is not installed.');
+        }
     }
 }


### PR DESCRIPTION
When setting the process isolation of a shell to true:
`setProcessIsolation(true)` throw a `\RuntimeException` if the Process component isn't available.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5897
Todo: -
License of the code: MIT
Documentation PR: -
