### PR TITLE
allowed security to be disabled through config

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/MainConfiguration.php
@@ -56,6 +56,7 @@ class MainConfiguration implements ConfigurationInterface
         $rootNode = $tb->root('security');
 
         $rootNode
+            ->canBeDisabled()
             ->children()
                 ->scalarNode('access_denied_url')->defaultNull()->example('/foo/error403')->end()
                 ->scalarNode('session_fixation_strategy')->cannotBeEmpty()->info('strategy can be: none, migrate, invalidate')->defaultValue('migrate')->end()
@@ -185,8 +186,6 @@ class MainConfiguration implements ConfigurationInterface
             ->fixXmlConfig('firewall')
             ->children()
                 ->arrayNode('firewalls')
-                    ->isRequired()
-                    ->requiresAtLeastOneElement()
                     ->disallowNewKeysInSubsequentConfigs()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
@@ -313,8 +312,6 @@ class MainConfiguration implements ConfigurationInterface
                         'entity' => array('entity' => array('class' => 'SecurityBundle:User', 'property' => 'username'))
                     ))
                     ->disallowNewKeysInSubsequentConfigs()
-                    ->isRequired()
-                    ->requiresAtLeastOneElement()
                     ->useAttributeAsKey('name')
                     ->prototype('array')
         ;

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -53,6 +53,10 @@ class SecurityExtension extends Extension
 
         $config = $this->processConfiguration($mainConfig, $configs);
 
+        if (!$config['enabled']) {
+            return;
+        }
+
         // load services
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('security.xml');


### PR DESCRIPTION
Cf. symfony/symfony-standard#434 , this allows security to be disabled as suggested by @dlsniper, I guess it is enough, all compiler passes will also return because of some missing definitions.

It would help for the command removing the demo related stuff from the standard edition (symfony/symfony-standard#412).
