### PR TITLE
Allow Custom Roles to implement the RoleInterface

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * A SecurityIdentity implementation for roles
@@ -30,7 +30,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function __construct($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
 


### PR DESCRIPTION
Allow Custom roles to implement the RoleInterface rather than concreate class.
Otherwise, in the constructor, if a custom role (that implements the interface only)
is provided, the if statement is never entered. 
And then the comparison in equals method fails too.

Spent an honour debugging why my class level roles based permissions 
weren't working.
