### PR TITLE
Interchangeable ConfigCache

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -6,6 +6,7 @@
 
     <parameters>
         <parameter key="router.class">Symfony\Bundle\FrameworkBundle\Routing\Router</parameter>
+        <parameter key="routing.config_cache_factory.class">Symfony\Component\Config\ConfigCacheFactory</parameter>
         <parameter key="router.request_context.class">Symfony\Component\Routing\RequestContext</parameter>
         <parameter key="routing.loader.class">Symfony\Bundle\FrameworkBundle\Routing\DelegatingLoader</parameter>
         <parameter key="routing.resolver.class">Symfony\Component\Config\Loader\LoaderResolver</parameter>
@@ -44,6 +45,10 @@
             <argument type="service" id="file_locator" />
         </service>
 
+        <service id="routing.config_cache_factory" class="%routing.config_cache_factory.class%" public="false">
+            <argument>%kernel.debug%</argument>
+        </service>
+
         <service id="routing.loader" class="%routing.loader.class%">
             <tag name="monolog.logger" channel="router" />
             <argument type="service" id="controller_name_converter" />
@@ -69,6 +74,9 @@
             </argument>
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
+            <call method="setConfigCacheFactory">
+                <argument type="service" id="routing.config_cache_factory" />
+            </call>
         </service>
 
         <service id="router" alias="router.default" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -31,6 +31,7 @@
         <parameter key="translation.loader.class">Symfony\Bundle\FrameworkBundle\Translation\TranslationLoader</parameter>
         <parameter key="translation.extractor.class">Symfony\Component\Translation\Extractor\ChainExtractor</parameter>
         <parameter key="translation.writer.class">Symfony\Component\Translation\Writer\TranslationWriter</parameter>
+        <parameter key="translator.config_cache_factory.class">Symfony\Component\Config\ConfigCacheFactory</parameter>
     </parameters>
 
     <services>
@@ -42,6 +43,13 @@
                 <argument key="cache_dir">%kernel.cache_dir%/translations</argument>
                 <argument key="debug">%kernel.debug%</argument>
             </argument>
+            <call method="setConfigCacheFactory">
+                <argument type="service" id="translator.config_cache_factory" />
+            </call>
+        </service>
+
+        <service id="translator.config_cache_factory" class="%translator.config_cache_factory.class%" public="false">
+            <argument>%kernel.debug%</argument>
         </service>
 
         <service id="translator" class="%translator.identity.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Translation;
 use Symfony\Component\Translation\Translator as BaseTranslator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Config\ConfigCacheFactoryInterface;
 
 /**
  * Translator.
@@ -26,6 +26,7 @@ class Translator extends BaseTranslator
     protected $container;
     protected $options;
     protected $loaderIds;
+    protected $configCacheFactory;
 
     /**
      * Constructor.
@@ -61,6 +62,30 @@ class Translator extends BaseTranslator
     }
 
     /**
+     * Sets the configCacheFactory
+     *
+     * @param ConfigCacheFactoryInterface $configCacheFactory
+     */
+    public function setConfigCacheFactory(ConfigCacheFactoryInterface $configCacheFactory)
+    {
+        $this->configCacheFactory = $configCacheFactory;
+    }
+
+    /**
+     * Returns the configCacheFactory set by setConfigCacheFactory or a BC default implementation
+     *
+     * @return ConfigCacheFactoryInterface $configCacheFactory
+     */
+    private function getConfigCacheFactory()
+    {
+        if (!$this->configCacheFactory) {
+            $this->configCacheFactory = new \Symfony\Component\Config\ConfigCacheFactory($this->options['debug']);
+        }
+
+        return $this->configCacheFactory;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getLocale()
@@ -87,7 +112,7 @@ class Translator extends BaseTranslator
             return parent::loadCatalogue($locale);
         }
 
-        $cache = new ConfigCache($this->options['cache_dir'].'/catalogue.'.$locale.'.php', $this->options['debug']);
+        $cache = $this->getConfigCacheFactory()->create($this->options['cache_dir'].'/catalogue.'.$locale.'.php');
         if (!$cache->isFresh()) {
             $this->initialize();
 

--- a/src/Symfony/Component/Config/ConfigCache.php
+++ b/src/Symfony/Component/Config/ConfigCache.php
@@ -19,7 +19,7 @@ namespace Symfony\Component\Config;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ConfigCache
+class ConfigCache implements ConfigCacheInterface
 {
     private $debug;
     private $file;

--- a/src/Symfony/Component/Config/ConfigCacheFactory.php
+++ b/src/Symfony/Component/Config/ConfigCacheFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config;
+
+/**
+ * Default implementation of ConfigCacheFactoryInterface
+ *
+ * @author Benjamin Klotz <bk@webfactory.de>
+ */
+class ConfigCacheFactory implements ConfigCacheFactoryInterface
+{
+
+    protected $debug;
+
+    /**
+     * Constructor.
+     *
+     * @param bool $debug Whether to enable debugging or not
+     */
+    public function __construct($debug)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function create($file)
+    {
+        return new ConfigCache($file, $this->debug);
+    }
+
+}

--- a/src/Symfony/Component/Config/ConfigCacheFactoryInterface.php
+++ b/src/Symfony/Component/Config/ConfigCacheFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config;
+
+/**
+ * Interface for ConfigCacheFactory
+ *
+ * @author Benjamin Klotz <bk@webfactory.de>
+ */
+interface ConfigCacheFactoryInterface
+{
+
+    /**
+     * Factory Method
+     *
+     * @param string $file The absolute cache path
+     * 
+     * @return ConfigCacheInterface $configCache 
+     */
+    public function create($file);
+
+}

--- a/src/Symfony/Component/Config/ConfigCacheInterface.php
+++ b/src/Symfony/Component/Config/ConfigCacheInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config;
+
+/**
+ * Interface for ConfigCache
+ *
+ * @author Benjamin Klotz <bk@webfactory.de>
+ */
+interface ConfigCacheInterface
+{
+
+    /**
+     * Gets the cache file path.
+     *
+     * @return string The cache file path
+     */
+    public function __toString();
+
+    /**
+     * Checks if the cache is still fresh.
+     *
+     * @return Boolean true if the cache is fresh, false otherwise
+     */
+    public function isFresh();
+
+    /**
+     * Writes cache.
+     *
+     * @param string $content  The content to write in the cache
+     * @param array  $metadata An array of ResourceInterface instances
+     *
+     * @throws \RuntimeException When cache file can't be wrote
+     */
+    public function write($content, array $metadata = null);
+
+}


### PR DESCRIPTION
We would like to use a custom implementation of ConfigCache to employ a modified caching strategy.  Basically, it is about special kinds of resources that might change on runtime also during production (will post more details if anyone is interested).

Currently the ConfigCache implementation is not exchangeable, which this what this PR addresses. I have tried to keep BC as far as possible. If that is not a hard requirement, I could also come up with different implementations.

Alternatively, a factory method for the ConfigCache in client classes could do.

Additionally, the kernel uses ConfigCache for the service container itself. We did not touch that part because there is probably no useful way to configure or inject alternative implementations before the container itself is available.
