### PR TITLE
[Console] Show correct class name InputArgument in error message

### DIFF
--- a/src/Symfony/Component/Console/Input/InputArgument.php
+++ b/src/Symfony/Component/Console/Input/InputArgument.php
@@ -96,7 +96,7 @@ class InputArgument
     public function setDefault($default = null)
     {
         if (self::REQUIRED === $this->mode && null !== $default) {
-            throw new \LogicException('Cannot set a default value except for Parameter::OPTIONAL mode.');
+            throw new \LogicException('Cannot set a default value except for InputArgument::OPTIONAL mode.');
         }
 
         if ($this->isArray()) {

--- a/tests/Symfony/Tests/Component/Console/Input/InputArgumentTest.php
+++ b/tests/Symfony/Tests/Component/Console/Input/InputArgumentTest.php
@@ -82,7 +82,7 @@ class InputArgumentTest extends \PHPUnit_Framework_TestCase
             $this->fail('->setDefault() throws an Exception if you give a default value for a required argument');
         } catch (\Exception $e) {
             $this->assertInstanceOf('\Exception', $e, '->parse() throws an \InvalidArgumentException exception if an invalid option is passed');
-            $this->assertEquals('Cannot set a default value except for Parameter::OPTIONAL mode.', $e->getMessage());
+            $this->assertEquals('Cannot set a default value except for InputArgument::OPTIONAL mode.', $e->getMessage());
         }
 
         try {


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
