### PR TITLE
[HttpFoundation] Revise MongoDB session storage

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/MongoDbSessionHandler.php
@@ -50,9 +50,9 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
         $this->mongo = $mongo;
 
         $this->options = array_merge(array(
-            'id_field'   => 'sess_id',
-            'data_field' => 'sess_data',
-            'time_field' => 'sess_time',
+            'id_field'   => '_id',
+            'data_field' => 'data',
+            'time_field' => 'time',
         ), $options);
     }
 
@@ -77,10 +77,9 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function destroy($sessionId)
     {
-        $this->getCollection()->remove(
-            array($this->options['id_field'] => $sessionId),
-            array('justOne' => true)
-        );
+        $this->getCollection()->remove(array(
+            $this->options['id_field'] => $sessionId
+        ));
 
         return true;
     }
@@ -90,11 +89,21 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function gc($lifetime)
     {
-        $time = new \MongoTimestamp(time() - $lifetime);
+        /* Note: MongoDB 2.2+ supports TTL collections, which may be used in
+         * place of this method by indexing the "time_field" field with an
+         * "expireAfterSeconds" option. Regardless of whether TTL collections
+         * are used, consider indexing this field to make the remove query more
+         * efficient.
+         *
+         * See: http://docs.mongodb.org/manual/tutorial/expire-data/
+         */
+        $time = new \MongoDate(time() - $lifetime);
 
         $this->getCollection()->remove(array(
             $this->options['time_field'] => array('$lt' => $time),
         ));
+
+        return true;
     }
 
     /**
@@ -102,16 +111,13 @@ class MongoDbSessionHandler implements \SessionHandlerInterface
      */
     public function write($sessionId, $data)
     {
-        $data = array(
-            $this->options['id_field']   => $sessionId,
-            $this->options['data_field'] => new \MongoBinData($data, \MongoBinData::BYTE_ARRAY),
-            $this->options['time_field'] => new \MongoTimestamp()
-        );
-
         $this->getCollection()->update(
             array($this->options['id_field'] => $sessionId),
-            array('$set' => $data),
-            array('upsert' => true)
+            array('$set' => array(
+                $this->options['data_field'] => new \MongoBinData($data, \MongoBinData::BYTE_ARRAY),
+                $this->options['time_field'] => new \MongoDate(),
+            )),
+            array('upsert' => true, 'multiple' => false)
         );
 
         return true;


### PR DESCRIPTION
```
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
```

I decided to take a look at the MongoDB session driver after reading @pgodel's [blog post](http://blog.servergrove.com/2012/11/05/storing-sessions-in-mongodb-with-symfony2/) today. This PR contains some fixes to make this session handler integrate better with MongoDB, as well as make it more in line with the work I did in zendframework/zf2#2031:
- Default to _id for storing session ID (BC break)
- Use MongoDate instead of MongoTimestamp (BC break)
- Rename default field names ("sess_" is redundant)
- "justOne" is redundant for session removal
- Assert true return values in method tests
- Add note about TTL collections for gc()
- Don't set identifier in upsert (invalid behavior)

In my opinion, the BC breaks are reasonable. `_id` is the logical field to store the session ID, as I'd expect many users may not even think to index the `sess_id` field to avoid inefficient queries otherwise. Also, MongoTimestamp should never have been used in the existing manner. Per the [documentation](http://php.net/manual/en/class.mongotimestamp.php):

> This class is not for measuring time, creating a timestamp on a document or automatically adding or updating a timestamp on a document. Unless you are writing something that interacts with the sharding internals, stop, go directly to MongoDate, do not pass go, do not collect 200 dollars. This is not the class you are looking for.

On a side note, I'm not sure why `sess_` prefixes exist for the PDO driver. It seems redundant in either case (the table/collection would logically have "session" in the name).

The fix to the update statement actually addresses a bug were `_id` to appear in the `$set` query.

I'm not sure how to document the BC breaks or changes, as the 2.1 branch's readme files look a lot sparser than those for 2.0. Let me know if there's something else to be done, though.
