### PR TITLE
[FrameworkBundle] Router skip defaults resolution for arrays

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -114,7 +114,7 @@ class Router extends BaseRouter implements WarmableInterface
     {
         $container = $this->container;
 
-        if (null === $value || false === $value || true === $value || is_object($value)) {
+        if (null === $value || false === $value || true === $value || is_object($value) || is_array($value)) {
             return $value;
         }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -163,7 +163,7 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
 
     public function getNonStringValues()
     {
-        return array(array(null), array(false), array(true), array(new \stdClass()), array(array('foo', 'bar')));
+        return array(array(null), array(false), array(true), array(new \stdClass()), array(array('foo', 'bar')), array(array(array())));
     }
 
     private function getServiceContainer(RouteCollection $routes)


### PR DESCRIPTION
The router should not resolve complex defaults/options parameters but it is not the case for arrays. So this small PR simply adds a check for arrays to prevent array-to-string fatal errors with deep array defaults.

```
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: ~
License of the code: MIT
Documentation PR: ~
```
