### PR TITLE
Fix export-ignore on Windows

### DIFF
--- a/src/Symfony/Bridge/Doctrine/.gitattributes
+++ b/src/Symfony/Bridge/Doctrine/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Monolog/.gitattributes
+++ b/src/Symfony/Bridge/Monolog/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Propel1/.gitattributes
+++ b/src/Symfony/Bridge/Propel1/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Swiftmailer/.gitattributes
+++ b/src/Symfony/Bridge/Swiftmailer/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Twig/.gitattributes
+++ b/src/Symfony/Bridge/Twig/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/FrameworkBundle/.gitattributes
+++ b/src/Symfony/Bundle/FrameworkBundle/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/SecurityBundle/.gitattributes
+++ b/src/Symfony/Bundle/SecurityBundle/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/TwigBundle/.gitattributes
+++ b/src/Symfony/Bundle/TwigBundle/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/BrowserKit/.gitattributes
+++ b/src/Symfony/Component/BrowserKit/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/ClassLoader/.gitattributes
+++ b/src/Symfony/Component/ClassLoader/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Config/.gitattributes
+++ b/src/Symfony/Component/Config/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Console/.gitattributes
+++ b/src/Symfony/Component/Console/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/CssSelector/.gitattributes
+++ b/src/Symfony/Component/CssSelector/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/DependencyInjection/.gitattributes
+++ b/src/Symfony/Component/DependencyInjection/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/DomCrawler/.gitattributes
+++ b/src/Symfony/Component/DomCrawler/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/EventDispatcher/.gitattributes
+++ b/src/Symfony/Component/EventDispatcher/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Filesystem/.gitattributes
+++ b/src/Symfony/Component/Filesystem/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Finder/.gitattributes
+++ b/src/Symfony/Component/Finder/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Form/.gitattributes
+++ b/src/Symfony/Component/Form/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/HttpKernel/.gitattributes
+++ b/src/Symfony/Component/HttpKernel/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Locale/.gitattributes
+++ b/src/Symfony/Component/Locale/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/OptionsResolver/.gitattributes
+++ b/src/Symfony/Component/OptionsResolver/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Process/.gitattributes
+++ b/src/Symfony/Component/Process/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Routing/.gitattributes
+++ b/src/Symfony/Component/Routing/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Security/.gitattributes
+++ b/src/Symfony/Component/Security/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Serializer/.gitattributes
+++ b/src/Symfony/Component/Serializer/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Templating/.gitattributes
+++ b/src/Symfony/Component/Templating/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Translation/.gitattributes
+++ b/src/Symfony/Component/Translation/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Validator/.gitattributes
+++ b/src/Symfony/Component/Validator/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Yaml/.gitattributes
+++ b/src/Symfony/Component/Yaml/.gitattributes
@@ -1,2 +1,2 @@
-Tests/ export-ignore
+/Tests export-ignore
 phpunit.xml.dist export-ignore


### PR DESCRIPTION
Rules:

```
Tests/ export-ignore
```

don't work on Windows. My proposition is:

```
/Tests export-ignore
```
