### PR TITLE
[ClassLoader] Make ApcClassLoader properly decorate ClassLoader.

### DIFF
--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -42,28 +42,35 @@ namespace Symfony\Component\ClassLoader;
 class ApcClassLoader
 {
     private $prefix;
-    private $classFinder;
+
+    /**
+     * The class loader object being decorated.
+     *
+     * @var \Symfony\Component\ClassLoader\ClassLoader
+     *   A class loader object that implements the findFile() method.
+     */
+    protected $decorated;
 
     /**
      * Constructor.
      *
-     * @param string $prefix      A prefix to create a namespace in APC
-     * @param object $classFinder An object that implements findFile() method.
+     * @param string $prefix      The APC namespace prefix to use.
+     * @param object $decorated   A class loader object that implements the findFile() method.
      *
      * @api
      */
-    public function __construct($prefix, $classFinder)
+    public function __construct($prefix, $decorated)
     {
         if (!extension_loaded('apc')) {
             throw new \RuntimeException('Unable to use ApcClassLoader as APC is not enabled.');
         }
 
-        if (!method_exists($classFinder, 'findFile')) {
+        if (!method_exists($decorated, 'findFile')) {
             throw new \InvalidArgumentException('The class finder must implement a "findFile" method.');
         }
 
         $this->prefix = $prefix;
-        $this->classFinder = $classFinder;
+        $this->decorated = $decorated;
     }
 
     /**
@@ -110,9 +117,18 @@ class ApcClassLoader
     public function findFile($class)
     {
         if (false === $file = apc_fetch($this->prefix.$class)) {
-            apc_store($this->prefix.$class, $file = $this->classFinder->findFile($class));
+            apc_store($this->prefix.$class, $file = $this->decorated->findFile($class));
         }
 
         return $file;
     }
+
+    /**
+     * Passes through all unknown calls onto the decorated object.
+     */
+    public function __call($method, $args)
+    {
+        return call_user_func_array(array($this->decorated, $method), $args);
+    }
+
 }


### PR DESCRIPTION
ApcClassLoader only implements the findFile() and loadClass() methods, but none of the other methods.  That's an implementation detail, which isn't particularly trivial.

I can't see a reason for why ApcClassLoader cannot simply decorate ClassLoader in a proper way, passing forward all unknown method calls to ClassLoader.
