### PR TITLE
Make YamlFileLoader and XmlFileLoader file loading extensible

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -204,7 +204,7 @@ class XmlFileLoader extends FileLoader
      *
      * @throws \InvalidArgumentException When loading of XML file returns error
      */
-    private function parseFile($file)
+    protected function parseFile($file)
     {
         $internalErrors = libxml_use_internal_errors(true);
         $disableEntities = libxml_disable_entity_loader(true);

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -233,7 +233,7 @@ class YamlFileLoader extends FileLoader
      *
      * @return array The file content
      */
-    private function loadFile($file)
+    protected function loadFile($file)
     {
         return $this->validate(Yaml::parse($file), $file);
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
Documentation PR: not needed

For phpBB we want to use a non-dumped container in the dev env to prevent having to clear the cache all the time. We're creating the container twice because we need some information at compile time which must be fetched from the container. The process is as follows:

Create temp container, get list of installed extensions (think bundles), create a compiler pass with the extensions list, create a new container with that compiler pass, compile it, dump it.

The problem is that we need to load and parse the YAML twice which is really slow. Caching it in the YamlFileLoader should save 50-100ms per page load.

By changing visibility to protected it becomes possible to extend the loader and cache file contents. 
