### PR TITLE
[FrameworkBundle] switch to parameter for base url

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -10,13 +10,6 @@
    `MongoDate` instead of `MongoTimestamp`, which also makes it possible to use
    TTL collections in MongoDB 2.2+ instead of relying on the `gc()` method.
 
-### Routing
-
-  * A new parameter has been added to the DIC: `router.request_context.base_url`
-    You can customize it for your functional tests or for generating urls with
-    the right base url when your are in the cli context.
-
-
 #### Deprecations
 
  * The `Request::splitHttpAcceptHeader()` is deprecated and will be removed in 2.3.

--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -10,6 +10,13 @@
    `MongoDate` instead of `MongoTimestamp`, which also makes it possible to use
    TTL collections in MongoDB 2.2+ instead of relying on the `gc()` method.
 
+### Routing
+
+  * A new parameter has been added to the DIC: `router.request_context.base_url`
+    You can customize it for your functional tests or for generating urls with
+    the right base url when your are in the cli context.
+
+
 #### Deprecations
 
  * The `Request::splitHttpAcceptHeader()` is deprecated and will be removed in 2.3.

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
  * replaced Symfony\Bundle\FrameworkBundle\Controller\TraceableControllerResolver by Symfony\Component\HttpKernel\Controller\TraceableControllerResolver
  * replaced Symfony\Component\HttpKernel\Debug\ContainerAwareTraceableEventDispatcher by Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher
  * added Client::enableProfiler()
+ * A new parameter has been added to the DIC: `router.request_context.base_url`
+   You can customize it for your functional tests or for generating urls with
+   the right base url when your are in the cli context.
 
 2.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -24,6 +24,7 @@
         <parameter key="router_listener.class">Symfony\Component\HttpKernel\EventListener\RouterListener</parameter>
         <parameter key="router.request_context.host">localhost</parameter>
         <parameter key="router.request_context.scheme">http</parameter>
+        <parameter key="router.request_context.base_url"></parameter>
     </parameters>
 
     <services>
@@ -74,7 +75,7 @@
         <service id="router" alias="router.default" />
 
         <service id="router.request_context" class="%router.request_context.class%" public="false">
-            <argument></argument>
+            <argument>%router.request_context.base_url%</argument>
             <argument>GET</argument>
             <argument>%router.request_context.host%</argument>
             <argument>%router.request_context.scheme%</argument>


### PR DESCRIPTION
This will make it configurable the same way we have it for host and scheme done for 2.1 in d30943c2e86713b32b12cd6e2e2801dac845aee9

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: (no new test breakage)
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: (none yet. if this is merged, i will happily PR against doc if somebody can point me to the right place)
