### PR TITLE
[FrameworkBundle] Added support for default templates per render tag

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * A new parameter has been added to the DIC: `router.request_context.base_url`
    You can customize it for your functional tests or for generating urls with
    the right base url when your are in the cli context.
+ * Added support for default templates per render tag
 
 2.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -105,6 +105,7 @@ class HttpKernel extends BaseHttpKernel
             'alt'           => array(),
             'standalone'    => false,
             'comment'       => '',
+            'default'		=> null,
         ), $options);
 
         if (!is_array($options['alt'])) {
@@ -130,8 +131,16 @@ class HttpKernel extends BaseHttpKernel
             $uri = $this->generateInternalUri($controller, $options['attributes'], $options['query'], false);
             $defaultContent = null;
 
-            if ($template = $this->container->getParameter('templating.hinclude.default_template')) {
-                $defaultContent = $this->container->get('templating')->render($template);
+            $templating = $this->container->get('templating');
+
+            if ($options['default']) {
+                if ($templating->exists($options['default'])) {
+                    $defaultContent = $templating->render($options['default']);
+                } else {
+                    $defaultContent = $options['default'];
+                }
+            } elseif ($template = $this->container->getParameter('templating.hinclude.default_template')) {
+                $defaultContent = $templating->render($template);
             }
 
             return $this->renderHIncludeTag($uri, $defaultContent);
@@ -226,7 +235,7 @@ class HttpKernel extends BaseHttpKernel
     /**
      * Renders an HInclude tag.
      *
-     * @param string $uri A URI
+     * @param string $uri            A URI
      * @param string $defaultContent Default content
      */
     public function renderHIncludeTag($uri, $defaultContent = null)


### PR DESCRIPTION
This commit allows you to specify default templates per render tag when using hinclude.

E.G:
The following will use the specific default template for the render:
`{% render "AcmeDemoBundle:Controller:action" with {}, {"standalone" : "js", "default" : "AcmeDemoBundle:Default:content.html.twig"} %}`

or if you don't want to use a template for the default content but just a string, you can do the following
`{% render "AcmeDemoBundle:Controller:action" with {}, {"standalone" : "js", "default" : "Loading..."} %}`

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Fixes the following tickets: #3356
Todo: -
Documentation
