### PR TITLE
[Routing] removed irrelevant string cast in Route

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -143,7 +143,7 @@ class Route implements \Serializable
     public function addOptions(array $options)
     {
         foreach ($options as $name => $option) {
-            $this->options[(string) $name] = $option;
+            $this->options[$name] = $option;
         }
         $this->compiled = null;
 
@@ -220,7 +220,7 @@ class Route implements \Serializable
     public function addDefaults(array $defaults)
     {
         foreach ($defaults as $name => $default) {
-            $this->defaults[(string) $name] = $default;
+            $this->defaults[$name] = $default;
         }
         $this->compiled = null;
 
@@ -263,7 +263,7 @@ class Route implements \Serializable
      */
     public function setDefault($name, $default)
     {
-        $this->defaults[(string) $name] = $default;
+        $this->defaults[$name] = $default;
         $this->compiled = null;
 
         return $this;


### PR DESCRIPTION
Even if the passed key is an integer, casting to string won't make any difference in array keys (it remains an int key).
