### PR TITLE
[HttpFoundation] Fix AcceptHeader

### DIFF
--- a/src/Symfony/Component/HttpFoundation/AcceptHeader.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeader.php
@@ -146,7 +146,7 @@ class AcceptHeader
     {
         $this->sort();
 
-        return !empty($this->items) ? current($this->items) : null;
+        return !empty($this->items) ? $this->items[0] : null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderItemTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderItemTest.php
@@ -25,6 +25,28 @@ class AcceptHeaderItemTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($attributes, $item->getAttributes());
     }
 
+    public function provideFromStringData()
+    {
+        return array(
+            array(
+                'text/html',
+                'text/html', array()
+            ),
+            array(
+                '"this;should,not=matter"',
+                'this;should,not=matter', array()
+            ),
+            array(
+                "text/plain; charset=utf-8;param=\"this;should,not=matter\";\tfootnotes=true",
+                'text/plain', array('charset' => 'utf-8', 'param' => 'this;should,not=matter', 'footnotes' => 'true')
+            ),
+            array(
+                '"this;should,not=matter";charset=utf-8',
+                'this;should,not=matter', array('charset' => 'utf-8')
+            ),
+        );
+    }
+
     /**
      * @dataProvider provideToStringData
      */
@@ -32,6 +54,20 @@ class AcceptHeaderItemTest extends \PHPUnit_Framework_TestCase
     {
         $item = new AcceptHeaderItem($value, $attributes);
         $this->assertEquals($string, (string) $item);
+    }
+
+    public function provideToStringData()
+    {
+        return array(
+            array(
+                'text/html', array(),
+                'text/html'
+            ),
+            array(
+                'text/plain', array('charset' => 'utf-8', 'param' => 'this;should,not=matter', 'footnotes' => 'true'),
+                'text/plain;charset=utf-8;param="this;should,not=matter";footnotes=true'
+            ),
+        );
     }
 
     public function testValue()
@@ -72,41 +108,5 @@ class AcceptHeaderItemTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($item->hasAttribute('test'));
         $this->assertEquals('value', $item->getAttribute('test'));
         $this->assertEquals('value', $item->getAttribute('test', 'default'));
-    }
-
-    public function provideFromStringData()
-    {
-        return array(
-            array(
-                'text/html',
-                'text/html', array()
-            ),
-            array(
-                '"this;should,not=matter"',
-                'this;should,not=matter', array()
-            ),
-            array(
-                "text/plain; charset=utf-8;param=\"this;should,not=matter\";\tfootnotes=true",
-                'text/plain', array('charset' => 'utf-8', 'param' => 'this;should,not=matter', 'footnotes' => 'true')
-            ),
-            array(
-                '"this;should,not=matter";charset=utf-8',
-                'this;should,not=matter', array('charset' => 'utf-8')
-            ),
-        );
-    }
-
-    public function provideToStringData()
-    {
-        return array(
-            array(
-                'text/html', array(),
-                'text/html'
-            ),
-            array(
-                'text/plain', array('charset' => 'utf-8', 'param' => 'this;should,not=matter', 'footnotes' => 'true'),
-                'text/plain;charset=utf-8;param="this;should,not=matter";footnotes=true'
-            ),
-        );
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderTest.php
@@ -16,6 +16,12 @@ use Symfony\Component\HttpFoundation\AcceptHeaderItem;
 
 class AcceptHeaderTest extends \PHPUnit_Framework_TestCase
 {
+    public function testFirst()
+    {
+        $header = AcceptHeader::fromString('text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
+        $this->assertSame('text/html', $header->first()->getValue());
+    }
+
     /**
      * @dataProvider provideFromStringData
      */
@@ -30,33 +36,6 @@ class AcceptHeaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($items, $parsed);
     }
 
-    /**
-     * @dataProvider provideToStringData
-     */
-    public function testToString(array $items, $string)
-    {
-        $header = new AcceptHeader($items);
-        $this->assertEquals($string, (string) $header);
-    }
-
-    /**
-     * @dataProvider provideFilterData
-     */
-    public function testFilter($string, $filter, array $values)
-    {
-        $header = AcceptHeader::fromString($string)->filter($filter);
-        $this->assertEquals($values, array_keys($header->all()));
-    }
-
-    /**
-     * @dataProvider provideSortingData
-     */
-    public function testSorting($string, array $values)
-    {
-        $header = AcceptHeader::fromString($string);
-        $this->assertEquals($values, array_keys($header->all()));
-    }
-
     public function provideFromStringData()
     {
         return array(
@@ -68,20 +47,13 @@ class AcceptHeaderTest extends \PHPUnit_Framework_TestCase
         );
     }
 
-    public function provideFilterData()
+    /**
+     * @dataProvider provideToStringData
+     */
+    public function testToString(array $items, $string)
     {
-        return array(
-            array('fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4', '/fr.*/', array('fr-FR', 'fr')),
-        );
-    }
-
-    public function provideSortingData()
-    {
-        return array(
-            'quality has priority' => array('*;q=0.3,ISO-8859-1,utf-8;q=0.7',  array('ISO-8859-1', 'utf-8', '*')),
-            'order matters when q is equal' => array('*;q=0.3,ISO-8859-1;q=0.7,utf-8;q=0.7',  array('ISO-8859-1', 'utf-8', '*')),
-            'order matters when q is equal2' => array('*;q=0.3,utf-8;q=0.7,ISO-8859-1;q=0.7',  array('utf-8', 'ISO-8859-1', '*')),
-        );
+        $header = new AcceptHeader($items);
+        $this->assertEquals($string, (string) $header);
     }
 
     public function provideToStringData()
@@ -91,6 +63,40 @@ class AcceptHeaderTest extends \PHPUnit_Framework_TestCase
             array(array(new AcceptHeaderItem('gzip')), 'gzip'),
             array(array(new AcceptHeaderItem('gzip'), new AcceptHeaderItem('deflate'), new AcceptHeaderItem('sdch')), 'gzip,deflate,sdch'),
             array(array(new AcceptHeaderItem('this;should,not=matter')), 'this;should,not=matter'),
+        );
+    }
+
+    /**
+     * @dataProvider provideFilterData
+     */
+    public function testFilter($string, $filter, array $values)
+    {
+        $header = AcceptHeader::fromString($string)->filter($filter);
+        $this->assertEquals($values, array_keys($header->all()));
+    }
+
+    public function provideFilterData()
+    {
+        return array(
+            array('fr-FR,fr;q=0.8,en-US;q=0.6,en;q=0.4', '/fr.*/', array('fr-FR', 'fr')),
+        );
+    }
+
+    /**
+     * @dataProvider provideSortingData
+     */
+    public function testSorting($string, array $values)
+    {
+        $header = AcceptHeader::fromString($string);
+        $this->assertEquals($values, array_keys($header->all()));
+    }
+
+    public function provideSortingData()
+    {
+        return array(
+            'quality has priority' => array('*;q=0.3,ISO-8859-1,utf-8;q=0.7',  array('ISO-8859-1', 'utf-8', '*')),
+            'order matters when q is equal' => array('*;q=0.3,ISO-8859-1;q=0.7,utf-8;q=0.7',  array('ISO-8859-1', 'utf-8', '*')),
+            'order matters when q is equal2' => array('*;q=0.3,utf-8;q=0.7,ISO-8859-1;q=0.7',  array('utf-8', 'ISO-8859-1', '*')),
         );
     }
 }


### PR DESCRIPTION
The important lines are:

``` php
<?php
-        return !empty($this->items) ? current($this->items) : null;
+        return !empty($this->items) ? $this->items[0] : null;
```

(and the corresponding test).

The commit has some code re-org to make reading tests easier (providers defined close the the corresponding test). This might be personal preferences only, let me know if it should be reverted.
