### PR TITLE
revert #6002 

### DIFF
--- a/src/Symfony/Component/HttpFoundation/AcceptHeader.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeader.php
@@ -146,7 +146,7 @@ class AcceptHeader
     {
         $this->sort();
 
-        return !empty($this->items) ? $this->items[0] : null;
+        return !empty($this->items) ? current($this->items) : null;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderTest.php
@@ -20,6 +20,9 @@ class AcceptHeaderTest extends \PHPUnit_Framework_TestCase
     {
         $header = AcceptHeader::fromString('text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
         $this->assertSame('text/html', $header->first()->getValue());
+
+        $header = new AcceptHeader($header->all());
+        $this->assertSame('text/html', $header->first()->getValue());
     }
 
     /**


### PR DESCRIPTION
@vicb: There is reason why the author used current() because the index is not necessarily zero-indexed.
