### PR TITLE
[Form] Update password trimming to false by default

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -31,3 +31,7 @@
    $accepts = AcceptHeader::fromString($request->headers->get('Accept'))->all();
 
    ```
+
+### Form
+
+  * The PasswordType is now not trimmed by default.

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -35,6 +35,7 @@ class PasswordType extends AbstractType
     {
         $resolver->setDefaults(array(
             'always_empty' => true,
+            'trim'         => false,
         ));
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -39,4 +39,13 @@ class PasswordTypeTest extends TypeTestCase
 
         $this->assertSame('pAs5w0rd', $view->vars['value']);
     }
+
+    public function testNotTrimmed()
+    {
+        $form = $this->factory->create('password', null);
+        $form->bind(' pAs5w0rd ');
+        $data = $form->getData();
+
+        $this->assertSame(' pAs5w0rd ', $data);
+    }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: -
License of the code: MIT
Documentation PR: ~

Hey!

Today, I realize that the password type is by default trimmed. IMHO, this is not the expected behavior. By default, the password type should not trim the input value.

Regards
