### PR TITLE
[Filesystem] [mirror] added "delete" option

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -421,4 +421,3 @@ class Filesystem
         return $files;
     }
 }
-

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -348,12 +348,12 @@ class Filesystem
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir)) {
             if (isset($options['delete']) and $options['delete']) {
-                $l_iterator = $iterator;
-                if (null === $l_iterator) {
+                $deleteIterator = $iterator;
+                if (null === $deleteIterator) {
                     $flags = \FilesystemIterator::SKIP_DOTS;
-                    $l_iterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST );
+                    $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST );
                 }
-                foreach ($l_iterator as $file) {
+                foreach ($deleteIterator as $file) {
                     $origin = str_replace($targetDir, $originDir, $file->getPathname());
                     if (!$this->exists($origin)) {
                         $this->remove($file);

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -336,7 +336,7 @@ class Filesystem
      *                               Valid options are:
      *                                 - $options['override'] Whether to override an existing file on copy or not (see copy())
      *                                 - $options['copy_on_windows'] Whether to copy files instead of links on Windows (see symlink())
-     *                                 - $options['delete'] Default FALSE Whether to delete files that are not in the source directory
+     *                                 - $options['delete'] Default false Whether to delete files that are not in the source directory
      *
      * @throws IOException When file type is unknown
      */
@@ -347,11 +347,11 @@ class Filesystem
 
         // Iterate in destination folder to remove obsolete entries
         if ($this->exists($targetDir)) {
-            if (isset($options['delete']) and $options['delete']) {
+            if (isset($options['delete']) && $options['delete']) {
                 $deleteIterator = $iterator;
                 if (null === $deleteIterator) {
                     $flags = \FilesystemIterator::SKIP_DOTS;
-                    $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST );
+                    $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
                 }
                 foreach ($deleteIterator as $file) {
                     $origin = str_replace($targetDir, $originDir, $file->getPathname());

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -346,18 +346,16 @@ class Filesystem
         $originDir = rtrim($originDir, '/\\');
 
         // Iterate in destination folder to remove obsolete entries
-        if ($this->exists($targetDir)) {
-            if (isset($options['delete']) && $options['delete']) {
-                $deleteIterator = $iterator;
-                if (null === $deleteIterator) {
-                    $flags = \FilesystemIterator::SKIP_DOTS;
-                    $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
-                }
-                foreach ($deleteIterator as $file) {
-                    $origin = str_replace($targetDir, $originDir, $file->getPathname());
-                    if (!$this->exists($origin)) {
-                        $this->remove($file);
-                    }
+        if ($this->exists($targetDir) && isset($options['delete']) && $options['delete']) {
+            $deleteIterator = $iterator;
+            if (null === $deleteIterator) {
+                $flags = \FilesystemIterator::SKIP_DOTS;
+                $deleteIterator = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($targetDir, $flags), \RecursiveIteratorIterator::CHILD_FIRST);
+            }
+            foreach ($deleteIterator as $file) {
+                $origin = str_replace($targetDir, $originDir, $file->getPathname());
+                if (!$this->exists($origin)) {
+                    $this->remove($file);
                 }
             }
         }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -421,3 +421,4 @@ class Filesystem
         return $files;
     }
 }
+

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -798,6 +798,25 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(is_dir($targetPath.'directory'));
         $this->assertFileEquals($file1, $targetPath.'directory'.DIRECTORY_SEPARATOR.'file1');
         $this->assertFileEquals($file2, $targetPath.'file2');
+
+        $this->filesystem->remove($file1);
+
+        $this->filesystem->mirror($sourcePath, $targetPath, null, array("delete" => FALSE));
+        $this->assertTrue($this->filesystem->exists($targetPath.'directory'.DIRECTORY_SEPARATOR.'file1'));
+
+        $this->filesystem->mirror($sourcePath, $targetPath, null, array("delete" => TRUE));
+        $this->assertFalse($this->filesystem->exists($targetPath.'directory'.DIRECTORY_SEPARATOR.'file1'));
+
+        file_put_contents($file1, 'FILE1');
+
+        $this->filesystem->mirror($sourcePath, $targetPath, null, array("delete" => TRUE));
+        $this->assertTrue($this->filesystem->exists($targetPath.'directory'.DIRECTORY_SEPARATOR.'file1'));
+
+        $this->filesystem->remove($directory);
+        $this->filesystem->mirror($sourcePath, $targetPath, null, array("delete" => TRUE));
+        $this->assertFalse($this->filesystem->exists($targetPath.'directory'));
+        $this->assertFalse($this->filesystem->exists($targetPath.'directory'.DIRECTORY_SEPARATOR.'file1'));
+
     }
 
     public function testMirrorCopiesLinks()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: -
License of the code: MIT
Documentation PR: symfony/symfony-docs#123

I added a "delete" option to the mirror function. If set to true, then
files present in target dir and not in origin dir will be removed.

Added also unit test for these feature.
