### PR TITLE
Added HttpCache\Store::generateContentDigest() + changed $root visibility

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class Store implements StoreInterface
 {
-    private $root;
+    protected $root;
     private $keyCache;
     private $locks;
 
@@ -164,7 +164,7 @@ class Store implements StoreInterface
 
         // write the response body to the entity store if this is the original response
         if (!$response->headers->has('X-Content-Digest')) {
-            $digest = 'en'.sha1($response->getContent());
+            $digest = $this->generateContentDigest($response);
 
             if (false === $this->save($digest, $response->getContent())) {
                 throw new \RuntimeException('Unable to store the entity.');
@@ -200,6 +200,18 @@ class Store implements StoreInterface
         }
 
         return $key;
+    }
+
+    /**
+     * Returns content digest for $response.
+     *
+     * @param Response $response
+     *
+     * @return string
+     */
+    protected function generateContentDigest(Response $response)
+    {
+        return 'en'.sha1($response->getContent());
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
## Description

This PR adds 2 small changes in base `HttpCache\Store`:
1. Adds `generateContentDigest()` protected method, allowing to easily override the default behavior for special cases.
2. Change `$root` visibility to _protected_ to let descendant access it.

This allows special implementations of HttpCache when storing specific cache files in a different place is needed. 
## Example

An example of implementation can be found [in eZ Publish 5 source code](https://github.com/ezsystems/ezp-next/blob/master/eZ/Publish/Core/MVC/Symfony/Cache/Http/LocationAwareStore.php). In this example, eZ Publish content cache entities are stored under a different folder than regular cache entities in order to ease cache purge based on a content location.
## Testing

No unit tests were added since the behavior didn't change and the new method is protected.

PS : It would be nice to have this in 2.1 branch as well :smiley:
