### PR TITLE
[SecurityBundle] Convert Http method to uppercase in the config

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -177,7 +177,7 @@ class SecurityExtension extends Extension
                 $container,
                 $access['path'],
                 $access['host'],
-                count($access['methods']) === 0 ? null : $access['methods'],
+                $access['methods'],
                 $access['ip']
             );
 
@@ -536,13 +536,17 @@ class SecurityExtension extends Extension
         return $switchUserListenerId;
     }
 
-    private function createRequestMatcher($container, $path = null, $host = null, $methods = null, $ip = null, array $attributes = array())
+    private function createRequestMatcher($container, $path = null, $host = null, $methods = array(), $ip = null, array $attributes = array())
     {
         $serialized = serialize(array($path, $host, $methods, $ip, $attributes));
         $id = 'security.request_matcher.'.md5($serialized).sha1($serialized);
 
         if (isset($this->requestMatchers[$id])) {
             return $this->requestMatchers[$id];
+        }
+
+        if ($methods) {
+            $methods = array_map('strtoupper', (array) $methods);
         }
 
         // only add arguments that are necessary

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/php/container1.php
@@ -58,7 +58,7 @@ $container->loadFromExtension('security', array(
     ),
 
     'access_control' => array(
-        array('path' => '/blog/524', 'role' => 'ROLE_USER', 'requires_channel' => 'https'),
+        array('path' => '/blog/524', 'role' => 'ROLE_USER', 'requires_channel' => 'https', 'methods' => array('get', 'POST')),
         array('path' => '/blog/.*', 'role' => 'IS_AUTHENTICATED_ANONYMOUSLY'),
     ),
 

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/xml/container1.xml
@@ -53,7 +53,7 @@
         <role id="ROLE_SUPER_ADMIN">ROLE_USER,ROLE_ADMIN,ROLE_ALLOWED_TO_SWITCH</role>
         <role id="ROLE_REMOTE">ROLE_USER,ROLE_ADMIN</role>
 
-        <rule path="/blog/524" role="ROLE_USER" requires-channel="https" />
+        <rule path="/blog/524" role="ROLE_USER" requires-channel="https" methods="get,POST" />
         <rule role='IS_AUTHENTICATED_ANONYMOUSLY' path="/blog/.*" />
     </config>
 </srv:container>

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/Fixtures/yml/container1.yml
@@ -49,7 +49,7 @@ security:
         ROLE_REMOTE:      ROLE_USER,ROLE_ADMIN
 
     access_control:
-        - { path: /blog/524, role: ROLE_USER, requires_channel: https }
+        - { path: /blog/524, role: ROLE_USER, requires_channel: https, methods: [get, POST]}
         -
             path: /blog/.*
             role: IS_AUTHENTICATED_ANONYMOUSLY

--- a/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
+++ b/src/Symfony/Bundle/SecurityBundle/Tests/DependencyInjection/SecurityExtensionTest.php
@@ -104,6 +104,7 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
         $matcherIds = array();
         foreach ($rules as $rule) {
             list($matcherId, $roles, $channel) = $rule;
+            $requestMatcher = $container->getDefinition($matcherId);
 
             $this->assertFalse(isset($matcherIds[$matcherId]));
             $matcherIds[$matcherId] = true;
@@ -112,9 +113,17 @@ abstract class SecurityExtensionTest extends \PHPUnit_Framework_TestCase
             if (1 === $i) {
                 $this->assertEquals(array('ROLE_USER'), $roles);
                 $this->assertEquals('https', $channel);
+                $this->assertEquals(
+                    array('/blog/524', null, array('GET', 'POST')),
+                    $requestMatcher->getArguments()
+                );
             } elseif (2 === $i) {
                 $this->assertEquals(array('IS_AUTHENTICATED_ANONYMOUSLY'), $roles);
                 $this->assertNull($channel);
+                $this->assertEquals(
+                    array('/blog/.*'),
+                    $requestMatcher->getArguments()
+                );
             }
         }
     }


### PR DESCRIPTION
This is not striclty required as method names would be converted to uppercase by the matcher after #5988.

However I think it is better to always use uppercase for http method names.

The config UT has also been improved as part of this PR.

This is good to propagate to 2.1 & 2.2 also.
