### PR TITLE
[OptionsResolver] Add the ability to set up mutually exclusive options.

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -314,7 +314,6 @@ class OptionsResolver implements OptionsResolverInterface
 
         if (count($intersection) > 1) {
             ksort($this->mutuallyExclusive);
-            ksort($intersection);
 
             throw new InvalidOptionsException(sprintf(
                 'The options "%s" are mutually exclusive and  cannot be used at the same time. You must declare only one of them.',

--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -316,7 +316,7 @@ class OptionsResolver implements OptionsResolverInterface
             ksort($this->mutuallyExclusive);
 
             throw new InvalidOptionsException(sprintf(
-                'The options "%s" are mutually exclusive and  cannot be used at the same time. You must declare only one of them.',
+                'The options "%s" are mutually exclusive and cannot be used at the same time. You must declare only one of them.',
                 implode('", "', array_keys($this->mutuallyExclusive))
             ));
         }

--- a/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolverInterface.php
@@ -147,6 +147,23 @@ interface OptionsResolverInterface
      */
     public function addAllowedTypes(array $allowedTypes);
 
+     /**
+     * Sets mutually exclusive options.
+     *
+     * This is usefull when you want to define options which cannot coexist
+     * between them. If at least two of this options are defined, an Exception
+     * will be thrown.
+     *
+     * @param array $mutuallyExclusive A list of options names.
+     *
+     * @return OptionsResolverInterface The resolver instance.
+     *
+     * @throws Exception\InvalidOptionsException If are defined more than two
+     *                                           options which are listed as
+     *                                           mutually exclusive.
+     */
+    public function setMutuallyExclusive(array $mutuallyExclusive);
+
     /**
      * Sets normalizers that are applied on resolved options.
      *

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -678,4 +678,34 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
             'three' => '3',
         ), $clone->resolve());
     }
+
+    public function testResolveSucceedsIfNotContainMutuallyExclusiveOptions()
+    {
+        $this->resolver->setDefaults(array(
+            'one' => '1',
+            'two' => '2',
+        ));
+        $this->resolver->setMutuallyExclusive(array('one', 'two'));
+
+        $this->assertEquals(array(
+            'one' => '10',
+            'two' => '2'
+        ), $this->resolver->resolve(array('one' => '10')));
+    }
+
+    /**
+     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testResolveFailsIfContainMutuallyExclusiveOptions()
+    {
+        $options = array(
+            'one' => '1',
+            'two' => '2',
+        );
+
+        $this->resolver->setDefaults($options);
+        $this->resolver->setMutuallyExclusive(array('one', 'two'));
+
+        $this->resolver->resolve($options);
+    }
 }


### PR DESCRIPTION
Bug fix: NO
Feature addition: YES
Backwards compatibility break: NO
Symfony2 tests pass: YES
Usefull for the following ticket:  #5827
License of the code: MIT

There are times where you want to define options which cannot coexist between them because any of them invalidated the others. This commit solve that issue by setting a list of options which cannot be defined at the same time.
#5827 propose to use a couple of options in the Form component (before/after). Both of this options cannot be used together, because they invalidated each other, so, they are mutually exclusive.

Usage is quite simple:

``` php
$resolver->setMutuallyExclusive(array('before', 'after'));
```
