### PR TITLE
[2.0][HttpFoundation] Improved Cache-Control header when no-cache is sent

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -143,6 +143,14 @@ class Response
         if ($this->headers->has('Transfer-Encoding')) {
             $this->headers->remove('Content-Length');
         }
+
+
+        // Check if we need to send extra expire info headers
+        if ('1.0' == $this->getProtocolVersion() && 'no-cache' == $this->headers->get('Cache-Control')) {
+            $this->headers->set('pragma', 'no-cache');
+            $this->headers->set('expires', -1);
+        }
+
     }
 
     /**
@@ -525,8 +533,14 @@ class Response
             return $age;
         }
 
-        if (null !== $this->getExpires()) {
-            return $this->getExpires()->format('U') - $this->getDate()->format('U');
+        $expiry = $this->getExpires();
+
+        if (!$expiry instanceof \DateTime && (-1 == $expiry || 0 === $expiry)) {
+            return $expiry;
+        }
+
+        if (null !== $expiry) {
+            return $expiry->format('U') - $this->getDate()->format('U');
         }
 
         return null;


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: not sure, should be
Fixes the following tickets: #4681
Todo: check if this actually works
License of the code: MIT
Documentation PR: ~

@pulzarraider or @sstok does this work for you guys? I'm not sure how to test it nor do I have IE as I'm on Ubuntu.

Thanks!
