### PR TITLE
[2.0][Router] Improved ApacheMatcher performance

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -17,6 +17,7 @@
         <parameter key="router.options.matcher_class">Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher</parameter>
         <parameter key="router.options.matcher_base_class">Symfony\Bundle\FrameworkBundle\Routing\RedirectableUrlMatcher</parameter>
         <parameter key="router.options.matcher_dumper_class">Symfony\Component\Routing\Matcher\Dumper\PhpMatcherDumper</parameter>
+        <parameter key="router.options.matcher.needs_collection">true</parameter>
         <parameter key="router.cache_warmer.class">Symfony\Bundle\FrameworkBundle\CacheWarmer\RouterCacheWarmer</parameter>
         <parameter key="router.options.matcher.cache_class">%kernel.name%%kernel.environment%UrlMatcher</parameter>
         <parameter key="router.options.generator.cache_class">%kernel.name%%kernel.environment%UrlGenerator</parameter>
@@ -61,6 +62,7 @@
                 <argument key="matcher_base_class">%router.options.matcher_base_class%</argument>
                 <argument key="matcher_dumper_class">%router.options.matcher_dumper_class%</argument>
                 <argument key="matcher_cache_class">%router.options.matcher.cache_class%</argument>
+                <argument key="matcher_needs_collection">%router.options.matcher.needs_collection%</argument>
             </argument>
         </service>
         <service id="router" alias="router.default" />

--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Routing\Matcher;
 
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 
 /**
@@ -20,6 +21,17 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  */
 class ApacheUrlMatcher extends UrlMatcher
 {
+
+    public function __construct($routes, RequestContext $context)
+    {
+        $this->routes = $routes;
+        $this->context = $context;
+
+        if (null !== $routes) {
+            parent::__construct($routes, $context);
+        }
+    }
+
     /**
      * Tries to match a URL based on Apache mod_rewrite matching.
      *
@@ -67,10 +79,23 @@ class ApacheUrlMatcher extends UrlMatcher
 
         if ($match) {
             return $this->mergeDefaults($parameters, $defaults);
-        } elseif (0 < count($allow)) {
+        } elseif (!empty($allow)) {
             throw new MethodNotAllowedException($allow);
-        } else {
-            return parent::match($pathinfo);
         }
+    }
+
+    /**
+     * Tries to match a URL with a set of routes using the fallback strategy.
+     *
+     * @param string $pathinfo The path info to be parsed
+     *
+     * @return array An array of parameters
+     *
+     * @throws ResourceNotFoundException If the resource could not be found
+     * @throws MethodNotAllowedException If the resource was found but the request method is not allowed
+     */
+    public function parentMatch($pathinfo)
+    {
+        return parent::match($pathinfo);
     }
 }

--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -21,6 +21,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  */
 class ApacheUrlMatcher extends UrlMatcher
 {
+
     public function __construct($routes, RequestContext $context)
     {
         $this->routes = $routes;

--- a/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/ApacheUrlMatcher.php
@@ -21,7 +21,6 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  */
 class ApacheUrlMatcher extends UrlMatcher
 {
-
     public function __construct($routes, RequestContext $context)
     {
         $this->routes = $routes;

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -30,6 +30,8 @@ class UrlMatcher implements UrlMatcherInterface
 
     private $routes;
 
+    private $hasDefaultRoutesSet = false;
+
     /**
      * Constructor.
      *
@@ -42,6 +44,10 @@ class UrlMatcher implements UrlMatcherInterface
     {
         $this->routes = $routes;
         $this->context = $context;
+
+        if (null !== $routes) {
+            $this->hasDefaultRoutesSet = true;
+        }
     }
 
     /**
@@ -89,6 +95,32 @@ class UrlMatcher implements UrlMatcherInterface
         throw 0 < count($this->allow)
             ? new MethodNotAllowedException(array_unique(array_map('strtoupper', $this->allow)))
             : new ResourceNotFoundException();
+    }
+
+    /**
+     * Check if the extra defaults have been set
+     *
+     * @return Boolean
+     */
+    public function hasDefaultRoutesSet()
+    {
+        return $this->hasDefaultRoutesSet;
+    }
+
+    /**
+     * Set the default routes
+     *
+     * @param RouteCollection $routes
+     *
+     * @return UrlMatcher
+     */
+    public function setDefaultRoutes(RouteCollection $routes)
+    {
+        $this->routes = $routes;
+
+        $this->hasDefaultRoutesSet = true;
+
+        return $this;
     }
 
     protected function matchCollection($pathinfo, RouteCollection $routes)

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -30,7 +30,7 @@ class UrlMatcher implements UrlMatcherInterface
 
     private $routes;
 
-    private $hasDefaultRoutesSet = false;
+    private $hasDefaultRouteSet = false;
 
     /**
      * Constructor.
@@ -46,7 +46,7 @@ class UrlMatcher implements UrlMatcherInterface
         $this->context = $context;
 
         if (null !== $routes) {
-            $this->hasDefaultRoutesSet = true;
+            $this->hasDefaultRouteSet = true;
         }
     }
 
@@ -98,17 +98,17 @@ class UrlMatcher implements UrlMatcherInterface
     }
 
     /**
-     * Check if the extra defaults have been set
+     * Checks if the defaults have been set.
      *
      * @return Boolean
      */
-    public function hasDefaultRoutesSet()
+    public function hasDefaultRouteSet()
     {
-        return $this->hasDefaultRoutesSet;
+        return $this->hasDefaultRouteSet;
     }
 
     /**
-     * Set the default routes
+     * Sets the default routes.
      *
      * @param RouteCollection $routes
      *
@@ -118,7 +118,7 @@ class UrlMatcher implements UrlMatcherInterface
     {
         $this->routes = $routes;
 
-        $this->hasDefaultRoutesSet = true;
+        $this->hasDefaultRouteSet = true;
 
         return $this;
     }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -228,9 +228,9 @@ class Router implements RouterInterface
         if (null === $this->options['cache_dir'] || null === $this->options['matcher_cache_class']) {
             if ($this->options['matcher_needs_collection']) {
                 return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context, $this->defaults);
-            } else {
-                return $this->matcher = new $this->options['matcher_class'](null, $this->context, $this->defaults);
             }
+
+            return $this->matcher = new $this->options['matcher_class'](null, $this->context, $this->defaults);
         }
 
         $class = $this->options['matcher_cache_class'];

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -76,6 +76,7 @@ class Router implements RouterInterface
             'matcher_dumper_class'   => 'Symfony\\Component\\Routing\\Matcher\\Dumper\\PhpMatcherDumper',
             'matcher_cache_class'    => 'ProjectUrlMatcher',
             'resource_type'          => null,
+            'matcher_needs_collection' => true,
         );
 
         // check option names and live merge, if errors are encountered Exception will be thrown
@@ -192,7 +193,25 @@ class Router implements RouterInterface
      */
     public function match($url)
     {
-        return $this->getMatcher()->match($url);
+        $matcher = $this->getMatcher();
+
+        if ($this->options['matcher_needs_collection']) {
+            return $matcher->match($url);
+        }
+
+        try {
+            return $matcher->match($url);
+        } catch (\Exception $e) {
+            if (!method_exists($matcher, 'parentMatch')) {
+                throw $e;
+            }
+
+            if (!$matcher->hasDefaultRoutesSet()) {
+                $matcher->setDefaultRoutes($this->getRouteCollection());
+            }
+
+            return $matcher->parentMatch($url);
+        }
     }
 
     /**
@@ -207,7 +226,11 @@ class Router implements RouterInterface
         }
 
         if (null === $this->options['cache_dir'] || null === $this->options['matcher_cache_class']) {
-            return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context, $this->defaults);
+            if ($this->options['matcher_needs_collection']) {
+                return $this->matcher = new $this->options['matcher_class']($this->getRouteCollection(), $this->context, $this->defaults);
+            } else {
+                return $this->matcher = new $this->options['matcher_class'](null, $this->context, $this->defaults);
+            }
         }
 
         $class = $this->options['matcher_cache_class'];

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -206,8 +206,8 @@ class Router implements RouterInterface
                 throw $e;
             }
 
-            if (!$matcher->hasDefaultRoutesSet()) {
-                $matcher->setDefaultRoutes($this->getRouteCollection());
+            if (!$matcher->hasDefaultRouteSet()) {
+                $matcher->setDefaultRoute($this->getRouteCollection());
             }
 
             return $matcher->parentMatch($url);


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes - by currently removing the fallback matching
Symfony2 tests pass: yes
Fixes the following tickets: #5538
Todo: make the documentation PR if the patch works for 2.0 branch
License of the code: MIT
Documentation PR: ~

Hi, by adding the following option in `config_prod.yml` `router.options.matcher.needs_collection: true` this patch should start working again (the rest of the config params still apply)
As I don't have any project on 2.0 I couldn't test this properly but I'll try downloading 2.0.X and check it there soon.
