### PR TITLE
WIP [Routing] add scheme and method route definition option

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -116,9 +116,12 @@ class XmlFileLoader extends FileLoader
             throw new \InvalidArgumentException(sprintf('The <route> element in file "%s" must have an "id" and a "pattern" attribute.', $path));
         }
 
+        $schemes = array_filter(explode(' ', $node->getAttribute('schemes')));
+        $methods = array_filter(explode(' ', $node->getAttribute('methods')));
+
         list($defaults, $requirements, $options) = $this->parseConfigs($node, $path);
 
-        $route = new Route($node->getAttribute('pattern'), $defaults, $requirements, $options, $node->getAttribute('hostname-pattern'));
+        $route = new Route($node->getAttribute('pattern'), $defaults, $requirements, $options, $node->getAttribute('hostname-pattern'), $schemes, $methods);
         $collection->add($id, $route);
     }
 
@@ -141,6 +144,8 @@ class XmlFileLoader extends FileLoader
         $type = $node->getAttribute('type');
         $prefix = $node->getAttribute('prefix');
         $hostnamePattern = $node->hasAttribute('hostname-pattern') ? $node->getAttribute('hostname-pattern') : null;
+        $schemes = $node->hasAttribute('schemes') ? array_filter(explode(' ', $node->getAttribute('schemes'))) : null;
+        $methods = $node->hasAttribute('methods') ? array_filter(explode(' ', $node->getAttribute('methods'))) : null;
 
         list($defaults, $requirements, $options) = $this->parseConfigs($node, $path);
 
@@ -151,6 +156,12 @@ class XmlFileLoader extends FileLoader
         $subCollection->addPrefix($prefix);
         if (null !== $hostnamePattern) {
             $subCollection->setHostnamePattern($hostnamePattern);
+        }
+        if (null !== $schemes) {
+            $subCollection->setSchemes($schemes);
+        }
+        if (null !== $methods) {
+            $subCollection->setMethods($methods);
         }
         $subCollection->addDefaults($defaults);
         $subCollection->addRequirements($requirements);

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -28,7 +28,7 @@ use Symfony\Component\Config\Loader\FileLoader;
 class YamlFileLoader extends FileLoader
 {
     private static $availableKeys = array(
-        'resource', 'type', 'prefix', 'pattern', 'hostname_pattern', 'defaults', 'requirements', 'options',
+        'resource', 'type', 'prefix', 'pattern', 'hostname_pattern', 'schemes', 'methods', 'defaults', 'requirements', 'options',
     );
 
     /**
@@ -98,9 +98,11 @@ class YamlFileLoader extends FileLoader
         $defaults = isset($config['defaults']) ? $config['defaults'] : array();
         $requirements = isset($config['requirements']) ? $config['requirements'] : array();
         $options = isset($config['options']) ? $config['options'] : array();
-        $hostnamePattern = isset($config['hostname_pattern']) ? $config['hostname_pattern'] : null;
+        $hostnamePattern = isset($config['hostname_pattern']) ? $config['hostname_pattern'] : '';
+        $schemes = isset($config['schemes']) ? $config['schemes'] : array();
+        $methods = isset($config['methods']) ? $config['methods'] : array();
 
-        $route = new Route($config['pattern'], $defaults, $requirements, $options, $hostnamePattern);
+        $route = new Route($config['pattern'], $defaults, $requirements, $options, $hostnamePattern, $schemes, $methods);
 
         $collection->add($name, $route);
     }
@@ -121,6 +123,8 @@ class YamlFileLoader extends FileLoader
         $requirements = isset($config['requirements']) ? $config['requirements'] : array();
         $options = isset($config['options']) ? $config['options'] : array();
         $hostnamePattern = isset($config['hostname_pattern']) ? $config['hostname_pattern'] : null;
+        $schemes = isset($config['schemes']) ? $config['schemes'] : null;
+        $methods = isset($config['methods']) ? $config['methods'] : null;
 
         $this->setCurrentDir(dirname($path));
 
@@ -129,6 +133,12 @@ class YamlFileLoader extends FileLoader
         $subCollection->addPrefix($prefix);
         if (null !== $hostnamePattern) {
             $subCollection->setHostnamePattern($hostnamePattern);
+        }
+        if (null !== $schemes) {
+            $subCollection->setSchemes($schemes);
+        }
+        if (null !== $methods) {
+            $subCollection->setMethods($methods);
         }
         $subCollection->addDefaults($defaults);
         $subCollection->addRequirements($requirements);

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -17,6 +17,16 @@
 
   <xsd:element name="routes" type="routes" />
 
+  <xsd:simpleType name="word">
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="([a-zA-Z]){3,}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="stringlist">
+    <xsd:list itemType="word"/>
+  </xsd:simpleType>
+
   <xsd:complexType name="routes">
     <xsd:choice minOccurs="0" maxOccurs="unbounded">
       <xsd:element name="import" type="import" />
@@ -38,6 +48,8 @@
     <xsd:attribute name="id" type="xsd:string" use="required" />
     <xsd:attribute name="pattern" type="xsd:string" use="required" />
     <xsd:attribute name="hostname-pattern" type="xsd:string" />
+    <xsd:attribute name="schemes" type="stringlist" />
+    <xsd:attribute name="methods" type="stringlist" />
   </xsd:complexType>
 
   <xsd:complexType name="import">
@@ -47,6 +59,8 @@
     <xsd:attribute name="type" type="xsd:string" />
     <xsd:attribute name="prefix" type="xsd:string" />
     <xsd:attribute name="hostname-pattern" type="xsd:string" />
+    <xsd:attribute name="schemes" type="stringlist" />
+    <xsd:attribute name="methods" type="stringlist" />
   </xsd:complexType>
 
   <xsd:complexType name="element">

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -319,6 +319,30 @@ class RouteCollection implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Sets the schemes (e.g. 'https') all child routes are restricted to.
+     *
+     * @param string|array $schemes The scheme or an array of schemes
+     */
+    public function setSchemes($schemes)
+    {
+        foreach ($this->routes as $route) {
+            $route->setSchemes($schemes);
+        }
+    }
+
+    /**
+     * Sets the HTTP methods (e.g. 'POST') all child routes are restricted to.
+     *
+     * @param string|array $methods The method or an array of methods
+     */
+    public function setMethods($methods)
+    {
+        foreach ($this->routes as $route) {
+            $route->setMethods($methods);
+        }
+    }
+
+    /**
      * Returns an array of resources loaded to build this collection.
      *
      * @return ResourceInterface[] An array of resources

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -23,6 +23,14 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => '\d+'), $route->getRequirements(), '__construct() takes requirements as its third argument');
         $this->assertEquals('bar', $route->getOption('foo'), '__construct() takes options as its fourth argument');
         $this->assertEquals('{locale}.example.com', $route->getHostnamePattern(), '__construct() takes a hostname pattern as its fifth argument');
+
+        $route = new Route('/', array(), array(), array(), '', array('Https'), array('POST', 'put'));
+        $this->assertEquals(array('https'), $route->getSchemes(), '__construct() takes schemes as its sixth argument and lowercases it');
+        $this->assertEquals(array('POST', 'PUT'), $route->getMethods(), '__construct() takes methods as its seventh argument and uppercases it');
+
+        $route = new Route('/', array(), array(), array(), '', 'Https', 'Post');
+        $this->assertEquals(array('https'), $route->getSchemes(), '__construct() takes a single scheme as its sixth argument');
+        $this->assertEquals(array('POST'), $route->getMethods(), '__construct() takes a single method as its seventh argument');
     }
 
     public function testPattern()
@@ -127,6 +135,50 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $route = new Route('/');
         $route->setHostnamePattern('{locale}.example.net');
         $this->assertEquals('{locale}.example.net', $route->getHostnamePattern(), '->setHostnamePattern() sets the hostname pattern');
+    }
+
+    public function testScheme()
+    {
+        $route = new Route('/');
+        $this->assertEquals(array(), $route->getSchemes(), 'schemes is initialized with array()');
+        $route->setSchemes('hTTp');
+        $this->assertEquals(array('http'), $route->getSchemes(), '->setSchemes() accepts a single scheme string and lowercases it');
+        $route->setSchemes(array('HttpS', 'hTTp'));
+        $this->assertEquals(array('https', 'http'), $route->getSchemes(), '->setSchemes() accepts an array of schemes and lowercases them');
+    }
+
+    public function testSchemeIsBC()
+    {
+        $route = new Route('/');
+        $route->setRequirement('_scheme', 'http|https');
+        $this->assertEquals('http|https', $route->getRequirement('_scheme'));
+        $this->assertEquals(array('http', 'https'), $route->getSchemes());
+        $route->setSchemes(array('hTTp'));
+        $this->assertEquals('http', $route->getRequirement('_scheme'));
+        $route->setSchemes(array());
+        $this->assertNull($route->getRequirement('_scheme'));
+    }
+
+    public function testMethod()
+    {
+        $route = new Route('/');
+        $this->assertEquals(array(), $route->getMethods(), 'methods is initialized with array()');
+        $route->setMethods('gEt');
+        $this->assertEquals(array('GET'), $route->getMethods(), '->setMethods() accepts a single method string and uppercases it');
+        $route->setMethods(array('gEt', 'PosT'));
+        $this->assertEquals(array('GET', 'POST'), $route->getMethods(), '->setMethods() accepts an array of methods and uppercases them');
+    }
+
+    public function testMethodIsBC()
+    {
+        $route = new Route('/');
+        $route->setRequirement('_method', 'GET|POST');
+        $this->assertEquals('GET|POST', $route->getRequirement('_method'));
+        $this->assertEquals(array('GET', 'POST'), $route->getMethods());
+        $route->setMethods(array('gEt'));
+        $this->assertEquals('GET', $route->getRequirement('_method'));
+        $route->setMethods(array());
+        $this->assertNull($route->getRequirement('_method'));
     }
 
     public function testCompile()


### PR DESCRIPTION
fixes #5990
BC break: no
Deprecations: specifying `_scheme` and `_method` in the requirements section has been deprecated. you should use the dedicated `schemes` and `methods` config options instead. for BC both possibilities are synchronized.
Before

``` yaml
article_edit:
    pattern: /article/{id}}
    requirements: { '_method': 'POST|PUT', '_scheme': 'https', 'id': '\d+' }
```

After

``` yaml
article_edit:
    pattern: /article/{id}}
    methods: [POST, PUT]
    schemes: https
    requirements: { 'id': '\d+' }
```

Before

``` xml
<route id="article_edit" pattern="/article/{id}}">
    <requirement key="_method">POST|PUT</requirement>
    <requirement key="_scheme">https</requirement>
    <requirement key="id">\d+</requirement>
</route>
```

After

``` xml
<route id="article_edit" pattern="/article/{id}}" methods="POST PUT" schemes="https">
    <requirement key="id">\d+</requirement>
</route>
```

WIP
