### PR TITLE
[2.1] Fixed some wrong assignments in foreach loops

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -762,7 +762,7 @@ class Application
     /**
      * Renders a caught exception.
      *
-     * @param Exception       $e      An exception instance
+     * @param \Exception      $e      An exception instance
      * @param OutputInterface $output An OutputInterface instance
      */
     public function renderException($e, $output)
@@ -784,10 +784,12 @@ class Application
             $len = $strlen($title);
             $width = $this->getTerminalWidth() ? $this->getTerminalWidth() - 1 : PHP_INT_MAX;
             $lines = array();
-            foreach (preg_split("{\r?\n}", $e->getMessage()) as $line) {
-                foreach (str_split($line, $width - 4) as $line) {
-                    $lines[] = sprintf('  %s  ', $line);
-                    $len = max($strlen($line) + 4, $len);
+            $splitLines = preg_split("{\r?\n}", $e->getMessage());
+            foreach ($splitLines as $line) {
+                $line = str_split($line, $width - 4);
+                foreach ($line as $splitLine) {
+                    $lines[] = sprintf('  %s  ', $splitLine);
+                    $len = max($strlen($splitLine) + 4, $len);
                 }
             }
 

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -538,8 +538,8 @@ abstract class Kernel implements KernelInterface, TerminableInterface
                 $hierarchy[] = $name;
             }
 
-            foreach ($hierarchy as $bundle) {
-                $this->bundleMap[$bundle] = $bundleMap;
+            foreach ($hierarchy as $inheritedBundle) {
+                $this->bundleMap[$inheritedBundle] = $bundleMap;
                 array_pop($bundleMap);
             }
         }

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -61,8 +61,8 @@ class YamlFileLoader extends FileLoader
             throw new \InvalidArgumentException(sprintf('The file "%s" must contain a YAML array.', $file));
         }
 
-        foreach ($config as $name => $config) {
-            $config = $this->normalizeRouteConfig($config);
+        foreach ($config as $name => $cfg) {
+            $config = $this->normalizeRouteConfig($cfg);
 
             if (isset($config['resource'])) {
                 $type = isset($config['type']) ? $config['type'] : null;

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -270,32 +270,32 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         $append = true;
 
         if (is_array($data) || $data instanceof \Traversable) {
-            foreach ($data as $key => $data) {
+            foreach ($data as $key => $dataValue) {
                 //Ah this is the magic @ attribute types.
-                if (0 === strpos($key, "@") && is_scalar($data) && $this->isElementNameValid($attributeName = substr($key, 1))) {
-                    $parentNode->setAttribute($attributeName, $data);
+                if (0 === strpos($key, "@") && is_scalar($dataValue) && $this->isElementNameValid($attributeName = substr($key, 1))) {
+                    $parentNode->setAttribute($attributeName, $dataValue);
                 } elseif ($key === '#') {
-                    $append = $this->selectNodeType($parentNode, $data);
-                } elseif (is_array($data) && false === is_numeric($key)) {
+                    $append = $this->selectNodeType($parentNode, $dataValue);
+                } elseif (is_array($dataValue) && false === is_numeric($key)) {
                     /**
                      * Is this array fully numeric keys?
                      */
-                    if (ctype_digit(implode('', array_keys($data)))) {
+                    if (ctype_digit(implode('', array_keys($dataValue)))) {
                         /**
                          * Create nodes to append to $parentNode based on the $key of this array
                          * Produces <xml><item>0</item><item>1</item></xml>
                          * From array("item" => array(0,1));
                          */
-                        foreach ($data as $subData) {
+                        foreach ($dataValue as $subData) {
                             $append = $this->appendNode($parentNode, $subData, $key);
                         }
                     } else {
-                        $append = $this->appendNode($parentNode, $data, $key);
+                        $append = $this->appendNode($parentNode, $dataValue, $key);
                     }
                 } elseif (is_numeric($key) || !$this->isElementNameValid($key)) {
-                    $append = $this->appendNode($parentNode, $data, "item", $key);
+                    $append = $this->appendNode($parentNode, $dataValue, "item", $key);
                 } else {
-                    $append = $this->appendNode($parentNode, $data, $key);
+                    $append = $this->appendNode($parentNode, $dataValue, $key);
                 }
             }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no, hope not
Symfony2 tests pass: yes
Fixes the following tickets: ~
Todo: -
License of the code: MIT
Documentation PR: ~

This should fix some unexpected behavior from the assignments done in foreach.
I'm not sure if it's a BC break or not as there might be some code that relies unawarely on the fixed behavior.
