### PR TITLE
Delete cookies from the TokenProvider that is no longer in use

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -172,6 +172,9 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
      */
     final public function loginSuccess(Request $request, Response $response, TokenInterface $token)
     {
+        // Make sure any old remember-me cookies are cancelled
+        $this->cancelCookie($request);
+
         if (!$token->getUser() instanceof UserInterface) {
             if (null !== $this->logger) {
                 $this->logger->debug('Remember-me ignores token since it does not contain a UserInterface implementation.');

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/AbstractRememberMeServicesTest.php
@@ -39,7 +39,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoLoginReturnsNullWhenNoCookie()
     {
-        $service = $this->getService(null, array('name' => 'foo'));
+        $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null));
 
         $this->assertNull($service->autoLogin(new Request()));
     }
@@ -49,7 +49,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
      */
     public function testAutoLoginThrowsExceptionWhenImplementationDoesNotReturnUserInterface()
     {
-        $service = $this->getService(null, array('name' => 'foo'));
+        $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null));
         $request = new Request;
         $request->cookies->set('foo', 'foo');
 
@@ -64,7 +64,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
     public function testAutoLogin()
     {
-        $service = $this->getService(null, array('name' => 'foo'));
+        $service = $this->getService(null, array('name' => 'foo', 'path' => null, 'domain' => null));
         $request = new Request();
         $request->cookies->set('foo', 'foo');
 
@@ -112,7 +112,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
     public function testLoginSuccessIsNotProcessedWhenTokenDoesNotContainUserInterfaceImplementation()
     {
-        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true));
+        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null));
         $request = new Request;
         $response = new Response;
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
@@ -135,7 +135,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
     public function testLoginSuccessIsNotProcessedWhenRememberMeIsNotRequested()
     {
-        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo'));
+        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo', 'path' => null, 'domain' => null));
         $request = new Request;
         $response = new Response;
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
@@ -159,7 +159,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
     public function testLoginSuccessWhenRememberMeAlwaysIsTrue()
     {
-        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true));
+        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null));
         $request = new Request;
         $response = new Response;
         $account = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
@@ -184,7 +184,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoginSuccessWhenRememberMeParameterWithPathIsPositive($value)
     {
-        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo[bar]'));
+        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo[bar]', 'path' => null, 'domain' => null));
 
         $request = new Request;
         $request->request->set('foo', array('bar' => $value));
@@ -211,7 +211,7 @@ class AbstractRememberMeServicesTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoginSuccessWhenRememberMeParameterIsPositive($value)
     {
-        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo'));
+        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => false, 'remember_me_parameter' => 'foo', 'path' => null, 'domain' => null));
 
         $request = new Request;
         $request->request->set('foo', $value);

--- a/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/RememberMe/TokenBasedRememberMeServicesTest.php
@@ -179,7 +179,7 @@ class TokenBasedRememberMeServicesTest extends \PHPUnit_Framework_TestCase
 
     public function testLoginSuccessIgnoresTokensWhichDoNotContainAnUserInterfaceImplementation()
     {
-        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true));
+        $service = $this->getService(null, array('name' => 'foo', 'always_remember_me' => true, 'path' => null, 'domain' => null));
         $request = new Request;
         $response = new Response;
         $token = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Todo: -
License of the code: MIT

When the user logs in, or login fails for some reason, the old "remember me" cookie should be deleted from the TokenProvider if you are using the PersistentTokenBasedRememberMeServices.

As the code is now, the token is only deleted on logout.
