### PR TITLE
Added a DoctrineTokenProvider in Security/Core/Authentication/RememberMe

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/DoctrineTokenProvider.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Security\RememberMe;
+
+use Symfony\Component\Security\Core\Authentication\RememberMe\TokenProviderInterface;
+use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentTokenInterface;
+use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
+use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type as DoctrineType;
+use PDO, DateTime;
+
+/**
+ * This class provides storage for the tokens that is set in "remember me"
+ * cookies. This way no password secrets will be stored in the cookies on
+ * the client machine, and thus the security is improved.
+ *
+ * This depends only on doctrine in order to get a database connection
+ * and to do the conversion of the datetime column.
+ *
+ * In order to use this class, you need the following table in your database:
+ * CREATE TABLE `rememberme_token` (
+ *  `series`   char(88)     UNIQUE PRIMARY KEY NOT NULL,
+ *  `value`    char(88)     NOT NULL,
+ *  `lastUsed` datetime     NOT NULL,
+ *  `class`    varchar(100) NOT NULL,
+ *  `username` varchar(200) NOT NULL
+ * );
+ */
+class DoctrineTokenProvider implements TokenProviderInterface
+{
+    /**
+     * Doctrine DBAL database connection
+     * F.ex. service id: doctrine.dbal.default_connection
+     *
+     * @var \Doctrine\DBAL\Connection
+     */
+    private $conn;
+
+    /**
+     * new DoctrineTokenProvider for the RemembeMe authentication service
+     *
+     * @param \Doctrine\DBAL\Connection $conn
+     */
+    public function __construct(Connection $conn)
+    {
+        $this->conn = $conn;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function loadTokenBySeries($series)
+    {
+        $sql = 'SELECT class, username, value, lastUsed'
+            . ' FROM rememberme_token WHERE series=:series';
+        $paramValues = array('series' => $series);
+        $paramTypes  = array('series' => PDO::PARAM_STR);
+        $stmt = $this->conn->executeQuery($sql, $paramValues, $paramTypes);
+        $row =  $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row) {
+            return new PersistentToken($row['class'],
+                                       $row['username'],
+                                       $series,
+                                       $row['value'],
+                                       new DateTime($row['lastUsed'])
+                                       );
+        }
+
+        throw new TokenNotFoundException('No token found.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteTokenBySeries($series)
+    {
+        $sql = 'DELETE FROM rememberme_token WHERE series=:series';
+        $paramValues = array('series' => $series);
+        $paramTypes  = array('series' => PDO::PARAM_STR);
+        $this->conn->executeUpdate($sql, $paramValues, $paramTypes);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updateToken($series, $tokenValue, DateTime $lastUsed)
+    {
+        $sql = 'UPDATE rememberme_token SET value=:value, lastUsed=:lastUsed'
+            . ' WHERE series=:series';
+        $paramValues = array('value'    => $tokenValue,
+                             'lastUsed' => $lastUsed,
+                             'series'   => $series);
+        $paramTypes =  array('value'    => PDO::PARAM_STR,
+                             'lastUsed' => DoctrineType::DATETIME,
+                             'series'   => PDO::PARAM_STR);
+        $updated = $this->conn->executeUpdate($sql, $paramValues, $paramTypes);
+        if ($updated < 1) {
+            throw new TokenNotFoundException('No token found.');
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createNewToken(PersistentTokenInterface $token)
+    {
+        $sql = 'INSERT INTO rememberme_token'
+            .        ' (class, username, series, value, lastUsed)'
+            . ' VALUES (:class, :username, :series, :value, :lastUsed)';
+        $paramValues = array('class'    => $token->getClass(),
+                             'username' => $token->getUsername(),
+                             'series'   => $token->getSeries(),
+                             'value'    => $token->getTokenValue(),
+                             'lastUsed' => $token->getLastUsed());
+        $paramTypes  = array('class'    => PDO::PARAM_STR,
+                             'username' => PDO::PARAM_STR,
+                             'series'   => PDO::PARAM_STR,
+                             'value'    => PDO::PARAM_STR,
+                             'lastUsed' => DoctrineType::DATETIME);
+        $this->conn->executeUpdate($sql, $paramValues, $paramTypes);
+    }
+}

--- a/src/Symfony/Bridge/Doctrine/Security/RememberMe/SchemaForDoctrineTokenProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/RememberMe/SchemaForDoctrineTokenProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Symfony\Bridge\Doctrine\Security\RememberMe;
+
+use Doctrine\DBAL\Schema\Schema;
+
+$schema = new Schema();
+$rememberTable = $schema->createTable('rememberme_token');
+$rememberTable->addColumn('series', "string", array('Length' => 88,
+                                                    'Notnull' => true));
+$rememberTable->addColumn('value', "string", array('Length' => 88,
+                                                   'Notnull' => true));
+
+$rememberTable->addColumn('lastUsed', 'datetime', array('Notnull' => true));
+
+$rememberTable->addColumn('class', 'string', array('Length' => 100,
+                                                   'Notnull' => true));
+$rememberTable->addColumn('username', 'string', array('Length' => 200,
+                                                      'Notnull' => true));
+
+$rememberTable->setPrimaryKey(array('series'));
+$rememberTable->addUniqueIndex(array('series'));
+
+
+$queries = $schema->toSql($myPlatform); // get queries to create this schema.

--- a/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
+++ b/src/Symfony/Component/Security/Core/Authentication/RememberMe/TokenProviderInterface.php
@@ -21,11 +21,11 @@ interface TokenProviderInterface
     /**
      * Loads the active token for the given series.
      *
-     * @throws TokenNotFoundException if the token is not found
-     *
      * @param string $series
      *
      * @return PersistentTokenInterface
+     *
+     * @throws TokenNotFoundException if the token is not found
      */
     public function loadTokenBySeries($series);
 
@@ -42,6 +42,7 @@ interface TokenProviderInterface
      * @param string    $series
      * @param string    $tokenValue
      * @param \DateTime $lastUsed
+     * @throws TokenNotFoundException if the token is not found
      */
     public function updateToken($series, $tokenValue, \DateTime $lastUsed);
 


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Todo: Add tests and documentation
License of the code: MIT

In the directory Symfony/Component/Security/Core/Authentication/RememberMe there is only one TokenProvider that can be used, and that is the InMemoryTokenProvider.
I think it should be an example DoctrineTokenProvider there as well, that gives an example of how to store the tokens in the database.
