### PR TITLE
[Routing] initialize the Route properties

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -23,12 +23,12 @@ class Route implements \Serializable
     /**
      * @var string
      */
-    private $pattern;
+    private $pattern = '/';
 
     /**
      * @var string
      */
-    private $hostnamePattern;
+    private $hostnamePattern = '';
 
    /**
      * @var array


### PR DESCRIPTION
They should normally be initialized anyway in the constructor. But when extending the Route (like in CMF) and using an ORM/ODM to persist them in the DB, the constructor is not called. Then a new property that is not saved like hostnamePattern stays null which in turn makes the RouteCompiler fails as it expects '' instead of null.
