### PR TITLE
[Process][Tests] fixed chainedCommandsOutput tests

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -79,8 +79,8 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
     public function chainedCommandsOutputProvider()
     {
         return array(
-            array('11', ';', '1'),
-            array('22', '&&', '2'),
+            array("1\n1\n", ';', '1'),
+            array("2\n2\n", '&&', '2'),
         );
     }
 
@@ -94,7 +94,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Does it work on windows ?');
         }
 
-        $process = $this->getProcess(sprintf('echo -n %s %s echo -n %s', $input, $operator, $input));
+        $process = $this->getProcess(sprintf('echo %s %s echo %s', $input, $operator, $input));
         $process->run();
         $this->assertEquals($expected, $process->getOutput());
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes (previously no)
Fixes the following tickets: -
Todo: -
License of the code: MIT

Currently, if you run the Process Component tests on an OS where echo does not support the -n option (like MacOS X), they will fail.

This PR fix that by using only a simple echo which is universal.
