### PR TITLE
Xliff with other node than source or target are ignored

### DIFF
--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -39,7 +39,7 @@ class XliffFileLoader implements LoaderInterface
 
         $catalogue = new MessageCatalogue($locale);
         foreach ($xml->xpath('//xliff:trans-unit') as $translation) {
-            if (2 !== count($translation)) {
+            if (!isset($translation->source) || !isset($translation->target)) {
                 continue;
             }
             $catalogue->set((string) $translation->source, (string) $translation->target, $domain);

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -38,7 +38,7 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new XliffFileLoader();
         $catalogue = $loader->load(__DIR__.'/../fixtures/resources.xlf', 'en', 'domain1');
 
-        $this->assertEquals(array('foo' => 'bar', 'key' => ''), $catalogue->all('domain1'));
+        $this->assertEquals(array('foo' => 'bar', 'key' => '', 'test' => 'with'), $catalogue->all('domain1'));
         $this->assertFalse($catalogue->has('extra', 'domain1'));
     }
 

--- a/src/Symfony/Component/Translation/Tests/fixtures/resources.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/resources.xlf
@@ -13,6 +13,11 @@
         <source>key</source>
         <target></target>
       </trans-unit>
+      <trans-unit id="4">
+        <source>test</source>
+        <target>with</target>
+        <note>note</note>
+      </trans-unit>
     </body>
   </file>
 </xliff>


### PR DESCRIPTION
Referring to the xliff XSD, the format can allow other nodes like <note>. Check only count is dangerous if others nodes are present, and we aren't sure that nodes are the two we wan't (source and target)

And the real problem if that if there is other node in translation, the translation is silently ignored.
