### PR TITLE
[FrameworkBundle] Added caching to TemplateController

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -49,12 +49,17 @@ class TemplateController extends ContainerAware
     {
         /** @var $response \Symfony\Component\HttpFoundation\Response */
         $response = $this->container->get('templating')->renderResponse($template);
-        $response->setMaxAge($maxAge ? : self::MAX_AGE);
-        $response->setSharedMaxAge($sharedAge ? : self::SHARED_AGE);
+        if ($maxAge) {
+            $response->setMaxAge($maxAge);
+        }
+        if ($sharedAge) {
+            $response->setSharedMaxAge($sharedAge ? : self::SHARED_AGE);
+        }
+
         if ($private) {
             $response->setPrivate();
-        } else {
-            $response->setPublic();
+        } else if ($private === false  || (is_null($private) && ($maxAge || $sharedAge))) {
+            $response->setPublic($private);
         }
         return $response;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -22,14 +22,40 @@ use Symfony\Component\HttpFoundation\Response;
 class TemplateController extends ContainerAware
 {
     /**
+     * Default max age time in seconds for client (browser) caching
+     *
+     * @var int
+     */
+    const MAX_AGE = 86400;
+
+    /**
+     * Default max age time in seconds for shared (proxy) caching
+     *
+     * @var int
+     */
+    const SHARED_AGE = 86400;
+
+    /**
      * Renders a template.
      *
      * @param string $template The template name
+     * @param int|null $maxAge Max age for client caching
+     * @param int|null $sharedAge Max age for shared (proxy) caching
+     * @param bool|null $private Whether or not caching should apply for client caches only
      *
      * @return Response A Response instance
      */
-    public function templateAction($template)
+    public function templateAction($template, $maxAge = null, $sharedAge = null, $private = null)
     {
-        return $this->container->get('templating')->renderResponse($template);
+        /** @var $response \Symfony\Component\HttpFoundation\Response */
+        $response = $this->container->get('templating')->renderResponse($template);
+        $response->setMaxAge($maxAge ? : self::MAX_AGE);
+        $response->setSharedMaxAge($sharedAge ? : self::SHARED_AGE);
+        if ($private) {
+            $response->setPrivate();
+        } else {
+            $response->setPublic();
+        }
+        return $response;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -22,20 +22,6 @@ use Symfony\Component\HttpFoundation\Response;
 class TemplateController extends ContainerAware
 {
     /**
-     * Default max age time in seconds for client (browser) caching
-     *
-     * @var int
-     */
-    const MAX_AGE = 86400;
-
-    /**
-     * Default max age time in seconds for shared (proxy) caching
-     *
-     * @var int
-     */
-    const SHARED_AGE = 86400;
-
-    /**
      * Renders a template.
      *
      * @param string $template The template name
@@ -53,7 +39,7 @@ class TemplateController extends ContainerAware
             $response->setMaxAge($maxAge);
         }
         if ($sharedAge) {
-            $response->setSharedMaxAge($sharedAge ? : self::SHARED_AGE);
+            $response->setSharedMaxAge($sharedAge);
         }
 
         if ($private) {

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/TemplateController.php
@@ -27,7 +27,7 @@ class TemplateController extends ContainerAware
      * @param string $template The template name
      * @param int|null $maxAge Max age for client caching
      * @param int|null $sharedAge Max age for shared (proxy) caching
-     * @param bool|null $private Whether or not caching should apply for client caches only
+     * @param Boolean|null $private Whether or not caching should apply for client caches only
      *
      * @return Response A Response instance
      */


### PR DESCRIPTION
Because the main purpose for the `TemplateController` seems to be to render static pages like "disclaimer" and such, it seems useful to allow caching.

```
imprint:
    pattern: /imprint
    defaults:
        _controller: SymfonyFrameworkBundle:Template:template
        template: "::pages/imprint.html.twig"
        maxAge: 86400
```
