### PR TITLE
Implemented possibility to skip key normalization in config processing

### DIFF
--- a/src/Symfony/Component/Config/Definition/Processor.php
+++ b/src/Symfony/Component/Config/Definition/Processor.php
@@ -23,12 +23,15 @@ class Processor
      *
      * @param NodeInterface $configTree The node tree describing the configuration
      * @param array         $configs    An array of configuration items to process
+     * @param bool          $normalizeKeys Flag indicating if config key normalization is needed. True by default.
      *
      * @return array The processed configuration
      */
-    public function process(NodeInterface $configTree, array $configs)
+    public function process(NodeInterface $configTree, array $configs, $normalizeKeys = true)
     {
-        $configs = self::normalizeKeys($configs);
+        if ($normalizeKeys) {
+            $configs = self::normalizeKeys($configs);
+        }
 
         $currentConfig = array();
         foreach ($configs as $config) {
@@ -44,12 +47,13 @@ class Processor
      *
      * @param ConfigurationInterface $configuration The configuration class
      * @param array                  $configs       An array of configuration items to process
+     * @param bool                   $normalizeKeys Flag indicating if config key normalization is needed. True by default.
      *
      * @return array The processed configuration
      */
-    public function processConfiguration(ConfigurationInterface $configuration, array $configs)
+    public function processConfiguration(ConfigurationInterface $configuration, array $configs, $normalizeKeys = true)
     {
-        return $this->process($configuration->getConfigTreeBuilder()->buildTree(), $configs);
+        return $this->process($configuration->getConfigTreeBuilder()->buildTree(), $configs, $normalizeKeys);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/Extension.php
@@ -96,11 +96,11 @@ abstract class Extension implements ExtensionInterface, ConfigurationExtensionIn
         return Container::underscore($classBaseName);
     }
 
-    final protected function processConfiguration(ConfigurationInterface $configuration, array $configs)
+    final protected function processConfiguration(ConfigurationInterface $configuration, array $configs, $normalizeKeys = true)
     {
         $processor = new Processor();
 
-        return $processor->processConfiguration($configuration, $configs);
+        return $processor->processConfiguration($configuration, $configs, $normalizeKeys);
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
## Description

This PR implements the possibility to deactivate explicitly config keys normalization as it's sometimes annoying and unexpected to have `-` transformed in `_`. The default behavior is kept and deactivation is possible at the DI extension level (not possible to do it at the node level since the config processor does key normalization globally).
