### PR TITLE
Handling UsernameNotFoundException when trying to check user

### DIFF
--- a/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
+++ b/src/Symfony/Component/Security/Core/Authentication/Provider/UserAuthenticationProvider.php
@@ -81,7 +81,7 @@ abstract class UserAuthenticationProvider implements AuthenticationProviderInter
             $this->userChecker->checkPreAuth($user);
             $this->checkAuthentication($user, $token);
             $this->userChecker->checkPostAuth($user);
-        } catch (BadCredentialsException $e) {
+        } catch (UsernameNotFoundException $e) {
             if ($this->hideUserNotFoundExceptions) {
                 throw new BadCredentialsException('Bad credentials', 0, $e);
             }


### PR DESCRIPTION
UserChecker checkPreAuth, checkAuthentication and checkPostAuth methods can throw a UsernameNotFoundException instead of a generic BadCredentialsException.

Currently catching a BadCredentialsException to throw another BadCredentialsException.

Seems to have to catch a UsernameNotFoundException instead and then depending on the security parameter throw a BadCredentialsException.
