### PR TITLE
[WiP] Split urlmatcher for easier overriding

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -157,7 +157,7 @@ class UrlMatcher implements UrlMatcherInterface
                 continue;
             }
 
-            return $this->getAttributes($route, array_replace($matches, $hostnameMatches));
+            return $this->getAttributes($route, $name, array_replace($matches, $hostnameMatches));
         }
     }
 

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -157,24 +157,23 @@ class UrlMatcher implements UrlMatcherInterface
                 continue;
             }
 
-            return $this->getAttributes($route, $matches, $hostnameMatches);
+            return $this->getAttributes($route, array_replace($matches, $hostnameMatches));
         }
     }
 
     /**
      * Returns an array of values to use as request attributes
      *
-     * @param Route $route The route we are matching against
-     * @param array        (optional) A variable number of array arguments to be merged into parameters
+     * @param Route $route      The route we are matching against
+     * @param string $name      The name of the route
+     * @param array $attributes An array of attributes from the matcher
      *
      * @return array An array of parameters
      */
-    protected function getAttributes(Route $route)
+    protected function getAttributes(Route $route, $name, array $attributes)
     {
-        $args = func_get_args();
-        array_shift($args);
-        $args[] = array('_route' => $name);
-        return $this->mergeDefaults(call_user_func_array('array_replace', $args), $route->getDefaults());
+        $attributes['_route'] = $name;
+        return $this->mergeDefaults($attributes, $route->getDefaults());
     }
 
     /**

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -43,7 +43,7 @@ class UrlMatcher implements UrlMatcherInterface
     /**
      * @var RouteCollection
      */
-    private $routes;
+    protected $routes;
 
     /**
      * Constructor.

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcher.php
@@ -157,8 +157,24 @@ class UrlMatcher implements UrlMatcherInterface
                 continue;
             }
 
-            return $this->mergeDefaults(array_replace($matches, $hostnameMatches, array('_route' => $name)), $route->getDefaults());
+            return $this->getAttributes($route, $matches, $hostnameMatches);
         }
+    }
+
+    /**
+     * Returns an array of values to use as request attributes
+     *
+     * @param Route $route The route we are matching against
+     * @param array        (optional) A variable number of array arguments to be merged into parameters
+     *
+     * @return array An array of parameters
+     */
+    protected function getAttributes(Route $route)
+    {
+        $args = func_get_args();
+        array_shift($args);
+        $args[] = array('_route' => $name);
+        return $this->mergeDefaults(call_user_func_array('array_replace', $args), $route->getDefaults());
     }
 
     /**


### PR DESCRIPTION
Based on discussion in https://github.com/symfony-cmf/Routing/pull/30, this PR splits the matchCollection() method of UrlMatcher into two methods.  The reason is to allow Symfony CMF and Drupal to override just one of them, while leaving the actual meat of the class intact.

Additionally, it switches $routes from private to protected for the same reason: It makes it possible for us to extend the class cleanly.

Marking as WIP in case further discussion in CMF suggests other/different changes, but review and a conceptual go/no-go would be appreciated now.
