### PR TITLE
Issue #5288 fix 

### DIFF
--- a/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubNumberFormatterTest.php
@@ -210,7 +210,7 @@ class StubNumberFormatterTest extends LocaleTestCase
 
     public function formatCurrencyWithCurrencyStyleBrazilianRealRoundingProvider()
     {
-        $brl = $this->isIntlExtensionLoaded() && $this->isSameAsIcuVersion('4.8') ? 'BR' : 'R';
+        $brl = $this->isIntlExtensionLoaded() && $this->isGreaterOrEqualThanIcuVersion('4.8') ? 'BR' : 'R';
 
         return array(
             array(100, 'BRL', $brl, '%s$100.00'),

--- a/src/Symfony/Component/Locale/Tests/TestCase.php
+++ b/src/Symfony/Component/Locale/Tests/TestCase.php
@@ -89,7 +89,16 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function normalizeIcuVersion($version)
     {
-        return ((float) $version) * 100;
+        $versionIds = explode(".", $version);
+
+        $multi = 1000;
+        $intVersion = 0;
+        foreach ($versionIds as $id) {
+          $intVersion += $id * $multi;
+          $multi = $multi/10;
+        }
+
+        return (int) $intVersion;
     }
 
     protected function getIntlExtensionIcuVersion()


### PR DESCRIPTION
I only have the test failing on 

php -v 
5.4.6-1ubuntu1

ICU version 4.8.1.1

Test results

1) Symfony\Component\Locale\Tests\Stub\StubLocaleTest::testGetCurrenciesData
    Failed asserting that two strings are equal.
    --- Expected
    +++ Actual
    @@ @@
    -'BR$'
    +'R$'

It looks like the check $this->isSameAsIcuVersion('4.8') on line is to strict.
It was added here https://github.com/symfony/symfony/commit/90d6dc37 but I don't how to test the fix on icu version 4.8.0.x

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5288 
Todo: Check older version of the ICU lib are still working. Because I could not test that.
