### PR TITLE
[WIP][Form] Implement field order

### DIFF
--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\Exception\FormException;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\Exception\InvalidConfigurationException;
 
 /**
  * A builder for {@link Button} instances.
@@ -51,6 +52,11 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      * @var array
      */
     private $options;
+
+    /**
+     * @var null|string|array
+     */
+    private $position;
 
     /**
      * Creates a new button builder.
@@ -446,7 +452,7 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      * This method should not be invoked.
      *
      * @param FormFactoryInterface $formFactory
-     * 
+     *
      * @return void
      *
      * @throws \BadMethodCallException
@@ -454,6 +460,20 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     public function setFormFactory(FormFactoryInterface $formFactory)
     {
         throw new \BadMethodCallException('Buttons do not support form factories.');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPosition($position)
+    {
+        if (is_string($position) && ($position !== 'first') && ($position !== 'last')) {
+            throw new InvalidConfigurationException('If you use position as string, you can only use "first" & "last".');
+        } elseif (is_array($position) && !isset($position['before']) && !isset($position['after'])) {
+            throw new InvalidConfigurationException('If you use position as array, you must at least define the "before" or "after" option.');
+        }
+
+        $this->position = $position;
     }
 
     /**
@@ -726,6 +746,14 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     public function getOption($name, $default = null)
     {
         return array_key_exists($name, $this->options) ? $this->options[$name] : $default;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPosition()
+    {
+        return $this->position;
     }
 
     /**

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -53,6 +53,7 @@ class FormType extends BaseType
             ->setData(isset($options['data']) ? $options['data'] : null)
             ->setDataLocked(isset($options['data']))
             ->setDataMapper($options['compound'] ? new PropertyPathMapper($this->propertyAccessor) : null)
+            ->setPosition($options['position'])
         ;
 
         if ($options['trim']) {
@@ -167,10 +168,12 @@ class FormType extends BaseType
             'label_attr'         => array(),
             'virtual'            => false,
             'compound'           => true,
+            'position'           => null,
         ));
 
         $resolver->setAllowedTypes(array(
             'label_attr' => 'array',
+            'position'   => array('null', 'string', 'array'),
         ));
     }
 

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Exception\BadMethodCallException;
-use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
@@ -131,6 +130,11 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      * @var Boolean
      */
     private $dataLocked;
+
+    /**
+     * @var null|string|array
+     */
+    private $position;
 
     /**
      * @var FormFactoryInterface
@@ -430,6 +434,14 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getFormFactory()
     {
         return $this->formFactory;
@@ -683,6 +695,20 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         }
 
         $this->formFactory = $formFactory;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPosition($position)
+    {
+        if ($this->locked) {
+            throw new FormException('The config builder cannot be modified anymore.');
+        }
+
+        $this->position = $position;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form;
 
 use Symfony\Component\Form\Exception\BadMethodCallException;
+use Symfony\Component\Form\Exception\InvalidConfigurationException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\PropertyAccess\PropertyPathInterface;
@@ -706,6 +707,12 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     {
         if ($this->locked) {
             throw new FormException('The config builder cannot be modified anymore.');
+        }
+
+        if (is_string($position) && ($position !== 'first') && ($position !== 'last')) {
+            throw new InvalidConfigurationException('If you use position as string, you can only use "first" & "last".');
+        } elseif (is_array($position) && !isset($position['before']) && !isset($position['after'])) {
+            throw new InvalidConfigurationException('If you use position as array, you must at least define the "before" or "after" option.');
         }
 
         $this->position = $position;

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -265,6 +265,8 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      *
      * @param null|string|array $position The form position.
      *
+     * @throws InvalidConfigurationException If the position is not valid.
+     *
      * @return self The configuration object.
      */
     public function setPosition($position);

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -241,21 +241,27 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      * Sets the form position.
      *
      *  * The position can be `null` to reflect the original forms order.
-     *  * The position can be `first` to place this form at the very first position
-     *    (if many forms are defined as first, the original order between these
-     *    forms are maintained).
-     *  * The position can be `last` to place this form at the very last position
-     *    (if many forms are defined as last, the original order between these
-     *    forms are maintained).
-     *  * The position can be `array('before' => 'form_name')` to place this form before
-     *    the `form_name` form. (if many forms defines the same before form, the original
-     *    order between these forms are maintained).
-     *  * The position can be `array('after' => 'form_name')` to place this form after
-     *    the `form_name` form. (if many forms defines the same before form, the original
-     *    order between these forms are maintained).
      *
-     * You can combine the `after` & `before` options together or with `first` and/or `last`
-     * to archieve more complex use cases.
+     *  * The position can be `first` to place this form at the first position.
+     *    If many forms are defined as `first`, the original order between these forms is maintained.
+     *    Warning, `first` does not mean "very first" if there are many forms which are defined as `first`
+     *    or if you set up an other form `before` this form.
+     *
+     *  * The position can be `last` to place this form at the last position.
+     *    If many forms are defined as `last`, the original order between these forms is maintained.
+     *    Warning, `last` does not mean "very last" if there are many forms which are defined as `last`
+     *    or if you set up an other form `after` this form.
+     *
+     *  * The position can be `array('before' => 'form_name')` to place this form before the `form_name` form.
+     *    If many forms defines the same `before` form, the original order between these forms is maintained.
+     *    Warning, `before` does not mean "just before" if there are many forms which defined the same `before` form.
+     *
+     *  * The position can be `array('after' => 'form_name')` to place this form after the `form_name` form.
+     *    If many forms defines the same after form, the original order between these forms is maintained.
+     *    Warning, `after` does not mean "just after" if there are many forms which defined the same `after` form.
+     *
+     * You can combine the `after` & `before` options together or with `first` and/or `last` to achieve
+     * more complex use cases.
      *
      * @param null|string|array $position The form position.
      *

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -238,6 +238,32 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setFormFactory(FormFactoryInterface $formFactory);
 
     /**
+     * Sets the form position.
+     *
+     *  * The position can be `null` to reflect the original forms order.
+     *  * The position can be `first` to place this form at the very first position
+     *    (if many forms are defined as first, the original order between these
+     *    forms are maintained).
+     *  * The position can be `last` to place this form at the very last position
+     *    (if many forms are defined as last, the original order between these
+     *    forms are maintained).
+     *  * The position can be `array('before' => 'form_name')` to place this form before
+     *    the `form_name` form. (if many forms defines the same before form, the original
+     *    order between these forms are maintained).
+     *  * The position can be `array('after' => 'form_name')` to place this form after
+     *    the `form_name` form. (if many forms defines the same before form, the original
+     *    order between these forms are maintained).
+     *
+     * You can combine the `after` & `before` options together or with `first` and/or `last`
+     * to archieve more complex use cases.
+     *
+     * @param null|string|array $position The form position.
+     *
+     * @return self The configuration object.
+     */
+    public function setPosition($position);
+
+    /**
      * Builds and returns the form configuration.
      *
      * @return FormConfigInterface

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -215,4 +215,13 @@ interface FormConfigInterface
      * @return mixed The option value.
      */
     public function getOption($name, $default = null);
+
+    /**
+     * Gets the form position.
+     *
+     * @see FormConfigBuilderInterface::setPosition
+     *
+     * @return null|string|array The before form name.
+     */
+    public function getPosition();
 }

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -304,10 +304,6 @@ class ResolvedFormType implements ResolvedFormTypeInterface
             $position = $child->getConfig()->getPosition();
 
             if (is_string($position)) {
-                if (($position !== 'first') && ($position !== 'last')) {
-                    throw new InvalidConfigurationException('If you use position as string, you can only use "first" & "last".');
-                }
-
                 if ($position === 'first') {
                     if (isset($differredBefores[$child->getName()])) {
                         foreach ($differredBefores[$child->getName()] as $differredBefore) {
@@ -348,10 +344,6 @@ class ResolvedFormType implements ResolvedFormTypeInterface
 
                 continue;
             } elseif (is_array($position)) {
-                if (!isset($position['before']) && !isset($position['after'])) {
-                    throw new InvalidConfigurationException('If you use position as array, you must at least define the "before" or "after" option.');
-                }
-
                 if (isset($position['before'])) {
                     $cachedPositions[$child->getName()]['before'] = $position['before'];
 
@@ -484,9 +476,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
                 ));
             }
 
-            if ($positions[$item]['before'] !== null) {
-                $this->detectCircularBeforeAndAfterReferences($positions, $positions[$item]['before'], $name);
-            }
+            $this->detectCircularBeforeAndAfterReferences($positions, $positions[$item]['before'], $name);
         }
     }
 }

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -293,8 +293,8 @@ class ResolvedFormType implements ResolvedFormTypeInterface
 
         $weights = array();
         $afterGapWeights = array();
-        $firstFormWeigth = 0;
-        $lastFormWeigth = 0;
+        $firstFormWeight = 0;
+        $lastFormWeight = 0;
 
         $differredBefores = array();
         $differredAfters = array();
@@ -311,28 +311,28 @@ class ResolvedFormType implements ResolvedFormTypeInterface
                 if ($position === 'first') {
                     if (isset($differredBefores[$child->getName()])) {
                         foreach ($differredBefores[$child->getName()] as $differredBefore) {
-                            $weights = $this->incrementWeights($weights, $firstFormWeigth);
-                            $weights[$differredBefore] = $firstFormWeigth++;
-                            $lastFormWeigth++;
+                            $weights = $this->incrementWeights($weights, $firstFormWeight);
+                            $weights[$differredBefore] = $firstFormWeight++;
+                            $lastFormWeight++;
                         }
                     }
 
-                    $weights = $this->incrementWeights($weights, $firstFormWeigth);
-                    $weights[$child->getName()] = $firstFormWeigth++;
-                    $lastFormWeigth++;
+                    $weights = $this->incrementWeights($weights, $firstFormWeight);
+                    $weights[$child->getName()] = $firstFormWeight++;
+                    $lastFormWeight++;
 
                     if (isset($differredAfters[$child->getName()])) {
                         foreach ($differredAfters[$child->getName()] as $differredAfter) {
-                            $weights = $this->incrementWeights($weights, $firstFormWeigth);
-                            $weights[$differredAfter] = $firstFormWeigth++;
-                            $lastFormWeigth++;
+                            $weights = $this->incrementWeights($weights, $firstFormWeight);
+                            $weights[$differredAfter] = $firstFormWeight++;
+                            $lastFormWeight++;
                         }
                     }
                 } else {
                     if (isset($differredBefores[$child->getName()])) {
                         foreach ($differredBefores[$child->getName()] as $differredBefore) {
                             $weights[$differredBefore] = empty($weights) ? 0 : max($weights) + 1;
-                            $lastFormWeigth++;
+                            $lastFormWeight++;
                         }
                     }
 
@@ -341,7 +341,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
                     if (isset($differredAfters[$child->getName()])) {
                         foreach ($differredAfters[$child->getName()] as $differredAfter) {
                             $weights[$differredAfter] = empty($weights) ? 0 : max($weights) + 1;
-                            $lastFormWeigth++;
+                            $lastFormWeight++;
                         }
                     }
                 }
@@ -380,7 +380,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
                         $beforeOrder = $weights[$before];
                         $weights = $this->incrementWeights($weights, $weights[$before]);
                         $weights[$child->getName()] = $beforeOrder;
-                        $lastFormWeigth++;
+                        $lastFormWeight++;
                     } else {
                         if (isset($differredBefores[$before])) {
                             $differredBefores[$before][] = $child->getName();
@@ -402,7 +402,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
                         $newOrder = $weights[$after] + $afterGapWeights[$after] + 1;
                         $weights = $this->incrementWeights($weights, $newOrder);
                         $weights[$child->getName()] = $newOrder;
-                        $lastFormWeigth++;
+                        $lastFormWeight++;
 
                         $afterGapWeights[$after]++;
                     } else {
@@ -419,18 +419,18 @@ class ResolvedFormType implements ResolvedFormTypeInterface
 
             if (isset($differredBefores[$child->getName()])) {
                 foreach ($differredBefores[$child->getName()] as $differredBefore) {
-                    $weights = $this->incrementWeights($weights, $lastFormWeigth);
-                    $weights[$differredBefore] = $lastFormWeigth++;
+                    $weights = $this->incrementWeights($weights, $lastFormWeight);
+                    $weights[$differredBefore] = $lastFormWeight++;
                 }
             }
 
-            $weights = $this->incrementWeights($weights, $lastFormWeigth);
-            $weights[$child->getName()] = $lastFormWeigth++;
+            $weights = $this->incrementWeights($weights, $lastFormWeight);
+            $weights[$child->getName()] = $lastFormWeight++;
 
             if (isset($differredAfters[$child->getName()])) {
                 foreach ($differredAfters[$child->getName()] as $differredAfter) {
-                    $weights = $this->incrementWeights($weights, $lastFormWeigth);
-                    $weights[$differredAfter] = $lastFormWeigth++;
+                    $weights = $this->incrementWeights($weights, $lastFormWeight);
+                    $weights[$differredAfter] = $lastFormWeight++;
                 }
             }
         }
@@ -443,7 +443,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
     /**
      * Increments all fields weights greater than start.
      *
-     * @param array   $weights The form weigths.
+     * @param array   $weights The form weights.
      * @param integer $start   The start.
      *
      * @return array The form weights incremented.
@@ -451,9 +451,9 @@ class ResolvedFormType implements ResolvedFormTypeInterface
     private function incrementWeights(array $weights, $start)
     {
         if (!empty($weights) && (max($weights) >= $start)) {
-            foreach ($weights as &$weigth) {
-                if ($weigth >= $start) {
-                    $weigth++;
+            foreach ($weights as &$weight) {
+                if ($weight >= $start) {
+                    $weight++;
                 }
             }
         }

--- a/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/ResolvedFormTypeTest.php
@@ -14,7 +14,6 @@ namespace Symfony\Component\Form\Tests;
 use Symfony\Component\Form\ResolvedFormType;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Form;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -139,7 +138,7 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($resolvedType, $builder->getType());
     }
 
-    public function testCreateView()
+    public function testCreateViewWithoutOrder()
     {
         $parentType = $this->getMockFormType();
         $type = $this->getMockFormType();
@@ -241,6 +240,860 @@ class ResolvedFormTypeTest extends \PHPUnit_Framework_TestCase
         $view = $resolvedType->createView($form, $parentView);
 
         $this->assertSame($parentView, $view->parent);
+    }
+
+    public function testCreateViewOrderWithSimpleBeforePlacedAfterTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('before' => 'bar')))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bar']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['bat']);
+    }
+
+    public function testCreateViewOrderWithSimpleBeforePlacedBeforeTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition(array('before' => 'bat')))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bar']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['bat']);
+    }
+
+    public function testCreateViewOrderWithMultipleBeforePlacedAfterTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('before' => 'bar')))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType)->setPosition(array('before' => 'bar')))
+            ->add($this->getBuilder('ban')->setType($field5ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bat']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['bar']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['ban']);
+    }
+
+    public function testCreateViewOrderWithMultipleBeforePlacedBeforeTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition(array('before' => 'ban')))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('before' => 'ban')))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType))
+            ->add($this->getBuilder('ban')->setType($field5ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['bat']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bar']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['baz']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['ban']);
+    }
+
+    public function testCreateViewOrderWithSimpleAfterPlacedBeforeTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition(array('after' => 'baz')))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bar']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['bat']);
+    }
+
+    public function testCreateViewOrderWithSimpleAfterPlacedAfterTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('after' => 'foo')))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bar']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['bat']);
+    }
+
+    public function testCreateViewOrderWithMultipleAfterPlacedBeforeTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition(array('after' => 'bat')))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('after' => 'bat')))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType))
+            ->add($this->getBuilder('ban')->setType($field5ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['bat']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bar']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['baz']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['ban']);
+    }
+
+    public function testCreateViewOrderWithMultipleAfterPlacedAfterTheReferencedForm()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('after' => 'foo')))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType)->setPosition(array('after' => 'foo')))
+            ->add($this->getBuilder('ban')->setType($field5ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['foo']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bat']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['bar']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['ban']);
+    }
+
+    public function testCreateViewWithMultipleBeforeAndAfter()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+        $field6Type = $this->getMockFormType();
+        $field7Type = $this->getMockFormType();
+        $field8Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+        $field6ResolvedType = new ResolvedFormType($field6Type);
+        $field7ResolvedType = new ResolvedFormType($field7Type);
+        $field8ResolvedType = new ResolvedFormType($field8Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('start')->setType($field1ResolvedType))
+            ->add($this->getBuilder('foo')->setType($field2ResolvedType)->setPosition(array('after' => 'baz')))
+            ->add($this->getBuilder('bar')->setType($field3ResolvedType)->setPosition(array('before' => 'bat')))
+            ->add($this->getBuilder('baz')->setType($field4ResolvedType))
+            ->add($this->getBuilder('bat')->setType($field5ResolvedType))
+            ->add($this->getBuilder('ban')->setType($field6ResolvedType)->setPosition(array('after' => 'foo')))
+            ->add($this->getBuilder('baw')->setType($field7ResolvedType)->setPosition(array('before' => 'bar')))
+            ->add($this->getBuilder('end')->setType($field8ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['start']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['foo']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['ban']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['baw']);
+
+        $this->assertArrayHasKey(5, $children);
+        $this->assertSame($children[5], $view->children['bar']);
+
+        $this->assertArrayHasKey(6, $children);
+        $this->assertSame($children[6], $view->children['bat']);
+
+        $this->assertArrayHasKey(7, $children);
+        $this->assertSame($children[7], $view->children['end']);
+    }
+
+    public function testCreateViewOrderWithSimpleFirst()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition('first'))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['bar']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['foo']);
+    }
+
+    public function testCreateViewOrderWithMultipleFirst()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition('first'))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition('first'))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['bar']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['baz']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['foo']);
+    }
+
+    public function testCreateViewOrderWithSimpleLast()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType)->setPosition('last'))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['bar']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['foo']);
+    }
+
+    public function testCreateViewOrderWithMultipleLast()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType)->setPosition('last'))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition('last'))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['baz']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['foo']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bar']);
+    }
+
+    public function testCreateViewOrderWithSimpleFirstAndLast()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition('last'))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType)->setPosition('first'))
+            ->add($this->getBuilder('ban')->setType($field5ResolvedType))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['bat']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['foo']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['baz']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['ban']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['bar']);
+    }
+
+    public function testCreateViewOrderWithMultipleFirstAndLast()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType)->setPosition('last'))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition('last'))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType))
+            ->add($this->getBuilder('bat')->setType($field4ResolvedType)->setPosition('first'))
+            ->add($this->getBuilder('ban')->setType($field5ResolvedType)->setPosition('first'))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['bat']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['ban']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['baz']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['foo']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['bar']);
+    }
+
+    public function testCreateViewWithMultipleFirstAndLastAndBeforeAndAfter()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+        $field4Type = $this->getMockFormType();
+        $field5Type = $this->getMockFormType();
+        $field6Type = $this->getMockFormType();
+        $field7Type = $this->getMockFormType();
+        $field8Type = $this->getMockFormType();
+        $field9Type = $this->getMockFormType();
+        $field10Type = $this->getMockFormType();
+        $field11Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+        $field4ResolvedType = new ResolvedFormType($field4Type);
+        $field5ResolvedType = new ResolvedFormType($field5Type);
+        $field6ResolvedType = new ResolvedFormType($field6Type);
+        $field7ResolvedType = new ResolvedFormType($field7Type);
+        $field8ResolvedType = new ResolvedFormType($field8Type);
+        $field9ResolvedType = new ResolvedFormType($field9Type);
+        $field10ResolvedType = new ResolvedFormType($field10Type);
+        $field11ResolvedType = new ResolvedFormType($field11Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('bri')->setType($field1ResolvedType)->setPosition(array('after' => 'bro')))
+            ->add($this->getBuilder('foo')->setType($field2ResolvedType)->setPosition(array('after' => 'baz')))
+            ->add($this->getBuilder('bar')->setType($field3ResolvedType)->setPosition(array('before' => 'bat')))
+            ->add($this->getBuilder('baz')->setType($field4ResolvedType))
+            ->add($this->getBuilder('pop')->setType($field5ResolvedType)->setPosition(array('before' => 'bro')))
+            ->add($this->getBuilder('psy')->setType($field7ResolvedType)->setPosition(array('after' => 'bat')))
+            ->add($this->getBuilder('bat')->setType($field6ResolvedType)->setPosition('first'))
+            ->add($this->getBuilder('ban')->setType($field8ResolvedType)->setPosition(array('after' => 'foo')))
+            ->add($this->getBuilder('raz')->setType($field9ResolvedType)->setPosition('first'))
+            ->add($this->getBuilder('baw')->setType($field10ResolvedType)->setPosition(array('before' => 'bar')))
+            ->add($this->getBuilder('bro')->setType($field11ResolvedType)->setPosition('last'))
+            ->getForm();
+
+        $parentView = new FormView();
+        $view = $resolvedType->createView($form, $parentView);
+
+        $children = array_values($view->children);
+
+        $this->assertArrayHasKey(0, $children);
+        $this->assertSame($children[0], $view->children['baw']);
+
+        $this->assertArrayHasKey(1, $children);
+        $this->assertSame($children[1], $view->children['bar']);
+
+        $this->assertArrayHasKey(2, $children);
+        $this->assertSame($children[2], $view->children['bat']);
+
+        $this->assertArrayHasKey(3, $children);
+        $this->assertSame($children[3], $view->children['psy']);
+
+        $this->assertArrayHasKey(4, $children);
+        $this->assertSame($children[4], $view->children['raz']);
+
+        $this->assertArrayHasKey(5, $children);
+        $this->assertSame($children[5], $view->children['baz']);
+
+        $this->assertArrayHasKey(6, $children);
+        $this->assertSame($children[6], $view->children['foo']);
+
+        $this->assertArrayHasKey(7, $children);
+        $this->assertSame($children[7], $view->children['ban']);
+
+        $this->assertArrayHasKey(8, $children);
+        $this->assertSame($children[8], $view->children['pop']);
+
+        $this->assertArrayHasKey(9, $children);
+        $this->assertSame($children[9], $view->children['bro']);
+
+        $this->assertArrayHasKey(10, $children);
+        $this->assertSame($children[10], $view->children['bri']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidConfigurationException
+     */
+    public function testCreateViewWithInvalidStringPosition()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $fieldType = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($fieldType);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType)->setPosition('foo'))
+            ->getForm();
+
+        $parentView = new FormView();
+        $resolvedType->createView($form, $parentView);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidConfigurationException
+     */
+    public function testCreateViewWithInvalidBeforeOrder()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType)->setPosition(array('before' => 'bar')))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition(array('before' => 'baz')))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('before' => 'foo')))
+            ->getForm();
+
+        $parentView = new FormView();
+        $resolvedType->createView($form, $parentView);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidConfigurationException
+     */
+    public function testCreateViewWithInvalidAfterOrder()
+    {
+        $parentType = $this->getMockFormType();
+        $type = $this->getMockFormType();
+        $field1Type = $this->getMockFormType();
+        $field2Type = $this->getMockFormType();
+        $field3Type = $this->getMockFormType();
+
+        $parentResolvedType = new ResolvedFormType($parentType);
+        $resolvedType = new ResolvedFormType($type, array(), $parentResolvedType);
+        $field1ResolvedType = new ResolvedFormType($field1Type);
+        $field2ResolvedType = new ResolvedFormType($field2Type);
+        $field3ResolvedType = new ResolvedFormType($field3Type);
+
+        $form = $this->getBuilder('name')
+            ->setCompound(true)
+            ->setDataMapper($this->dataMapper)
+            ->setType($resolvedType)
+            ->add($this->getBuilder('foo')->setType($field1ResolvedType)->setPosition(array('after' => 'bar')))
+            ->add($this->getBuilder('bar')->setType($field2ResolvedType)->setPosition(array('after' => 'baz')))
+            ->add($this->getBuilder('baz')->setType($field3ResolvedType)->setPosition(array('after' => 'foo')))
+            ->getForm();
+
+        $parentView = new FormView();
+        $resolvedType->createView($form, $parentView);
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5827 #4254 #3452
Todo: -
License of the code: MIT
Documentation PR: ~

This PR adds the ability to set fields order via two new options: `before` & `after`.

These options represent respectively the field name just before the field & the field name just after the field. 

If none of the two options is given, the current behavior is maintained (fields order is determined by the way you added your fields on your builder). If you partially order your fields, the default behavior will be overridden by your explicit order.
