### PR TITLE
[Validator] Fix typos in validators.ru.xlf

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf
@@ -64,7 +64,7 @@
             </trans-unit>
             <trans-unit id="16">
                 <source>The file is too large ({{ size }} {{ suffix }}). Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Файл слишком большой ({{ size }} {{ suffix }}). Максимальный допустимый размер {{ limit }} {{ suffix }}.</target>
+                <target>Файл слишком большой ({{ size }} {{ suffix }}). Максимально допустимый размер {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>The mime type of the file is invalid ({{ type }}). Allowed mime types are {{ types }}.</source>
@@ -116,7 +116,7 @@
             </trans-unit>
             <trans-unit id="32">
                 <source>The file is too large. Allowed maximum size is {{ limit }} {{ suffix }}.</source>
-                <target>Файл слишком большой. Максимальный допустимый размер файла {{ limit }} {{ suffix }}.</target>
+                <target>Файл слишком большой. Максимально допустимый размер {{ limit }} {{ suffix }}.</target>
             </trans-unit>
             <trans-unit id="33">
                 <source>The file is too large.</source>


### PR DESCRIPTION
This PR fixes PR #6106 as it still [contains some issues](https://github.com/symfony/symfony/pull/6106#discussion_r2215735).  I also removed the word "файла" ([L119](https://github.com/rybakit/symfony/blob/31c32c551fc2a4a9d5140c5ac554fa65874f3321/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf#L119)), as it is not necessary and there is no such addition in the other messages (e.g. [L167](https://github.com/symfony/symfony/blob/2.1/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf#L167), [L171](https://github.com/symfony/symfony/blob/2.1/src/Symfony/Component/Validator/Resources/translations/validators.ru.xlf#L171), ...).
