### PR TITLE
[Validator] Ease overriding the ValidationVisitor and ConstraintViolation classes.

### DIFF
--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -24,7 +24,7 @@ class ExecutionContext implements ExecutionContextInterface
     /**
      * @var GlobalExecutionContextInterface
      */
-    private $globalContext;
+    protected $globalContext;
 
     /**
      * @var MetadataInterface

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -25,17 +25,17 @@ class Validator implements ValidatorInterface
     /**
      * @var MetadataFactoryInterface
      */
-    private $metadataFactory;
+    protected $metadataFactory;
 
     /**
      * @var ConstraintValidatorFactoryInterface
      */
-    private $validatorFactory;
+    protected $validatorFactory;
 
     /**
      * @var array
      */
-    private $objectInitializers;
+    protected $objectInitializers;
 
     public function __construct(
         MetadataFactoryInterface $metadataFactory,
@@ -174,7 +174,7 @@ class Validator implements ValidatorInterface
      *
      * @return ValidationVisitor
      */
-    private function createVisitor($root)
+    protected function createVisitor($root)
     {
         return new ValidationVisitor($root, $this->metadataFactory, $this->validatorFactory, $this->objectInitializers);
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Making this few variables protected would ease using a custom ConstraintVioloation class a lot. We need to do so to plug our translation system into the violation class' getMessage() method.

Relevant Drupal issues: http://drupal.org/node/1849564, http://drupal.org/node/1845546
