### PR TITLE
[DI] Fix 'undefined index' error, when entering scope recursively

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -338,8 +338,10 @@ class Container implements IntrospectableContainerInterface
             unset($this->scopedServices[$name]);
 
             foreach ($this->scopeChildren[$name] as $child) {
-                $services[$child] = $this->scopedServices[$child];
-                unset($this->scopedServices[$child]);
+                if (isset($this->scopedServices[$child])) {
+                    $services[$child] = $this->scopedServices[$child];
+                    unset($this->scopedServices[$child]);
+                }
             }
 
             // update global map

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -261,6 +261,38 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->has('a'));
     }
 
+    public function testEnterScopeRecursivelyWithInactiveChildScopes()
+    {
+        $container = new Container();
+        $container->addScope(new Scope('foo'));
+        $container->addScope(new Scope('bar', 'foo'));
+
+        $this->assertFalse($container->isScopeActive('foo'));
+
+        $container->enterScope('foo');
+
+        $this->assertTrue($container->isScopeActive('foo'));
+        $this->assertFalse($container->isScopeActive('bar'));
+        $this->assertFalse($container->has('a'));
+
+        $a = new \stdClass();
+        $container->set('a', $a, 'foo');
+
+        $services = $this->getField($container, 'scopedServices');
+        $this->assertTrue(isset($services['foo']['a']));
+        $this->assertSame($a, $services['foo']['a']);
+
+        $this->assertTrue($container->has('a'));
+        $container->enterScope('foo');
+
+        $services = $this->getField($container, 'scopedServices');
+        $this->assertFalse(isset($services['a']));
+
+        $this->assertTrue($container->isScopeActive('foo'));
+        $this->assertFalse($container->isScopeActive('bar'));
+        $this->assertFalse($container->has('a'));
+    }
+
     public function testLeaveScopeNotActive()
     {
         $container = new Container();


### PR DESCRIPTION
Imagine two scopes:

``` php
$container = new Container();
$container->addScope(new Scope('foo'));
$container->addScope(new Scope('bar', 'foo'));
```

Enter the same scope twice recursively:

``` php
$container->enterScope('foo');
// not entering bar in between
$container->enterScope('foo');
// prints warning: undefined index: bar
// at Symfony/Component/DependencyInjection/Container.php:341
```
