### PR TITLE
[DI] Strip New Lines and Whitespace for multi-line XML Parameters for Class Initialization

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -759,7 +759,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
             $service = call_user_func_array(array($factory, $definition->getFactoryMethod()), $arguments);
         } else {
-            $classDefinition = preg_replace('~[\r\n]+~', '', trim($parameterBag->resolveValue($definition->getClass())));
+            $classDefinition = trim($parameterBag->resolveValue($definition->getClass()));
             $r = new \ReflectionClass($classDefinition);
             
             $service = null === $r->getConstructor() ? $r->newInstance() : $r->newInstanceArgs($arguments);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -759,8 +759,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
             $service = call_user_func_array(array($factory, $definition->getFactoryMethod()), $arguments);
         } else {
-            $classDefinition = trim($parameterBag->resolveValue($definition->getClass()));
-            $r = new \ReflectionClass($classDefinition);
+            $r = new \ReflectionClass(trim($parameterBag->resolveValue($definition->getClass())));
             
             $service = null === $r->getConstructor() ? $r->newInstance() : $r->newInstanceArgs($arguments);
         }

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -759,8 +759,9 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
 
             $service = call_user_func_array(array($factory, $definition->getFactoryMethod()), $arguments);
         } else {
-            $r = new \ReflectionClass($parameterBag->resolveValue($definition->getClass()));
-
+            $classDefinition = preg_replace('~[\r\n]+~', '', trim($parameterBag->resolveValue($definition->getClass())));
+            $r = new \ReflectionClass($classDefinition);
+            
             $service = null === $r->getConstructor() ? $r->newInstance() : $r->newInstanceArgs($arguments);
         }
 

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -325,12 +325,28 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testCreateServiceWithNewLineWrapping()
     {
         $builder = new ContainerBuilder();
-        $builder->setParameter('foo1class',"\nFooClass\n");
-        $builder->register('foo1','%foo1class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
-        $this->assertInstanceOf('\FooClass',$builder->get('foo1'), 'New Line Wrapping \n in Parameter should be stripped out.');
-        $builder->setParameter('foo2class',"\rFooClass\r");
-        $builder->register('foo2','%foo2class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
-        $this->assertInstanceOf('\FooClass',$builder->get('foo2'), 'New Line Wrapping \r in Parameter should be stripped out.');
+        $builder->setParameter('foo1class', "\nFooClass\n");
+        $builder->register('foo1', '%foo1class%')->setFile(__DIR__ . '/Fixtures/includes/foo.php');
+        try {
+            $this->assertInstanceOf(
+                '\FooClass',
+                $builder->get('foo1'),
+                'New Line Wrapping \n in Parameter should be stripped out.'
+            );
+        } catch (\ReflectionException $e) {
+            $this->fail('FooClass is not callable due to the new lines not being stripped');
+        }
+        $builder->setParameter('foo2class', "\rFooClass\r");
+        $builder->register('foo2', '%foo2class%')->setFile(__DIR__ . '/Fixtures/includes/foo.php');
+        try {
+            $this->assertInstanceOf(
+                '\FooClass',
+                $builder->get('foo2'),
+                'New Line Wrapping \r in Parameter should be stripped out.'
+            );
+        } catch (\ReflectionException $e) {
+            $this->fail('FooClass is not callable due to the new lines not being stripped');
+        }
     }
 
     /**
@@ -339,13 +355,32 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     public function testCreateServiceWithNewLineWrappingWithWhiteSpace()
     {
         $builder = new ContainerBuilder();
-        $builder->setParameter('foo1class',"\n      FooClass     \n");
-        $builder->register('foo1','%foo1class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
-        $this->assertInstanceOf('\FooClass',$builder->get('foo1'),'New Line Wrapping \n in Parameter should be stripped out along with whitespace.');
-        $builder = new ContainerBuilder();
-        $builder->setParameter('foo2class',"\r      FooClass     \r");
-        $builder->register('foo2','%foo2class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
-        $this->assertInstanceOf('\FooClass',$builder->get('foo2'),'New Line Wrapping \r in Parameter should be stripped out along with whitespace.');
+        $builder->setParameter('foo1class', "\n      FooClass     \n");
+        $builder->register('foo1', '%foo1class%')->setFile(__DIR__ . '/Fixtures/includes/foo.php');
+        try {
+            $this->assertInstanceOf(
+                '\FooClass',
+                $builder->get('foo1'),
+                'New Line Wrapping \n in Parameter should be stripped out along with whitespace.'
+            );
+        } catch (\ReflectionException $e) {
+            $this->fail(
+                'FooClass is not callable due to the new lines not being stripped and/or whitespacing not being trimmed'
+            );
+        }
+        $builder->setParameter('foo2class', "\r      FooClass     \r");
+        $builder->register('foo2', '%foo2class%')->setFile(__DIR__ . '/Fixtures/includes/foo.php');
+        try {
+            $this->assertInstanceOf(
+                '\FooClass',
+                $builder->get('foo2'),
+                'New Line Wrapping \r in Parameter should be stripped out along with whitespace.'
+            );
+        } catch (\ReflectionException $e) {
+            $this->fail(
+                'FooClass is not callable due to the new lines not being stripped and/or whitespacing not being trimmed.'
+            );
+        }
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -320,6 +320,35 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
+     */
+    public function testCreateServiceWithNewLineWrapping()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setParameter('foo1class',"\nFooClass\n");
+        $builder->register('foo1','%foo1class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
+        $this->assertInstanceOf('\FooClass',$builder->get('foo1'), 'New Line Wrapping \n in Parameter should be stripped out.');
+        $builder->setParameter('foo2class',"\rFooClass\r");
+        $builder->register('foo2','%foo2class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
+        $this->assertInstanceOf('\FooClass',$builder->get('foo2'), 'New Line Wrapping \r in Parameter should be stripped out.');
+    }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::createService
+     */
+    public function testCreateServiceWithNewLineWrappingWithWhiteSpace()
+    {
+        $builder = new ContainerBuilder();
+        $builder->setParameter('foo1class',"\n      FooClass     \n");
+        $builder->register('foo1','%foo1class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
+        $this->assertInstanceOf('\FooClass',$builder->get('foo1'),'New Line Wrapping \n in Parameter should be stripped out along with whitespace.');
+        $builder = new ContainerBuilder();
+        $builder->setParameter('foo2class',"\r      FooClass     \r");
+        $builder->register('foo2','%foo2class%')->setFile(__DIR__.'/Fixtures/includes/foo.php');
+        $this->assertInstanceOf('\FooClass',$builder->get('foo2'),'New Line Wrapping \r in Parameter should be stripped out along with whitespace.');
+    }
+
+    /**
      * @covers Symfony\Component\DependencyInjection\ContainerBuilder::resolveServices
      */
     public function testResolveServices()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

The main purpose of this patch is when formatting your parameters in an XML configuration to use multiple lines due to the long length. 

Example:

```
<parameters>
    <parameter key="kc_media.credential.factory.aws.class">KC\Bundle\MediaBundle\DependencyInjection\Factory\Credential\AwsCredentialFactory</parameter>
</parameters>
```

May be reformatted into the following in PHPStorm:

```
<parameters>
    <parameter key="kc_media.credential.factory.aws.class">
        KC\Bundle\MediaBundle\DependencyInjection\Factory\Credential\AwsCredentialFactory
    </parameter>
</parameters>
```

After reformatting, you would get the following error:

ReflectionException: Class 
            KC\Bundle\MediaBundle\DependencyInjection\Factory\Credential\AwsCredentialFactory
         does not exist

By stripping the new lines and trimming the white space will allow the proper initialization of the class .
