### PR TITLE
Improve FormIntegrationTestCase extensibility

### DIFF
--- a/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
@@ -31,10 +31,22 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
 
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
+            ->addTypeExtensions($this->getTypeExtensions())
+            ->addTypeGuessers($this->getTypeGuessers())
             ->getFormFactory();
     }
 
     protected function getExtensions()
+    {
+        return array();
+    }
+
+    protected function getTypeExtensions()
+    {
+        return array();
+    }
+
+    protected function getTypeGuessers()
     {
         return array();
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

The test case contains a function allowing injecting an Extension but no TypeExtensions nor TypeGuessers. This would allow testing classes that require those without the need to create a test Extension. While not needed by the framework at this moment, this may be useful for developers.
