### PR TITLE
[TwigBundle] Renames twig.loader to twig.loader.filesystem.

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -58,33 +58,33 @@ class TwigExtension extends Extension
         $container->setParameter('twig.form.resources', $config['form']['resources']);
 
         $reflClass = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
-        $container->getDefinition('twig.loader')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
+        $container->getDefinition('twig.loader.filesystem')->addMethodCall('addPath', array(dirname(dirname($reflClass->getFileName())).'/Resources/views/Form'));
 
-        $twigLoaderDefinition = $container->getDefinition('twig.loader');
+        $twigFilesystemLoaderDefinition = $container->getDefinition('twig.loader.filesystem');
 
         // register user-configured paths
         foreach ($config['paths'] as $path => $namespace) {
             if (!$namespace) {
-                $twigLoaderDefinition->addMethodCall('addPath', array($path));
+                $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path));
             } else {
-                $twigLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
+                $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($path, $namespace));
             }
         }
 
         // register bundles as Twig namespaces
         foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
             if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {
-                $this->addTwigPath($twigLoaderDefinition, $dir, $bundle);
+                $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
             }
 
             $reflection = new \ReflectionClass($class);
             if (is_dir($dir = dirname($reflection->getFilename()).'/Resources/views')) {
-                $this->addTwigPath($twigLoaderDefinition, $dir, $bundle);
+                $this->addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle);
             }
         }
 
         if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/views')) {
-            $twigLoaderDefinition->addMethodCall('addPath', array($dir));
+            $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir));
         }
 
         if (!empty($config['globals'])) {
@@ -129,13 +129,13 @@ class TwigExtension extends Extension
         ));
     }
 
-    private function addTwigPath($twigLoaderDefinition, $dir, $bundle)
+    private function addTwigPath($twigFilesystemLoaderDefinition, $dir, $bundle)
     {
         $name = $bundle;
         if ('Bundle' === substr($name, -6)) {
             $name = substr($name, 0, -6);
         }
-        $twigLoaderDefinition->addMethodCall('addPath', array($dir, $name));
+        $twigFilesystemLoaderDefinition->addMethodCall('addPath', array($dir, $name));
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="twig.class">Twig_Environment</parameter>
-        <parameter key="twig.loader.class">Symfony\Bundle\TwigBundle\Loader\FilesystemLoader</parameter>
+        <parameter key="twig.loader.filesystem.class">Symfony\Bundle\TwigBundle\Loader\FilesystemLoader</parameter>
         <parameter key="templating.engine.twig.class">Symfony\Bundle\TwigBundle\TwigEngine</parameter>
         <parameter key="twig.cache_warmer.class">Symfony\Bundle\TwigBundle\CacheWarmer\TemplateCacheCacheWarmer</parameter>
         <parameter key="twig.extension.trans.class">Symfony\Bridge\Twig\Extension\TranslationExtension</parameter>
@@ -38,10 +38,12 @@
             <argument type="service" id="templating.finder" />
         </service>
 
-        <service id="twig.loader" class="%twig.loader.class%">
+        <service id="twig.loader.filesystem" class="%twig.loader.filesystem.class%" public="false">
             <argument type="service" id="templating.locator" />
             <argument type="service" id="templating.name_parser" />
         </service>
+
+        <service id="twig.loader" alias="twig.loader.filesystem" />
 
         <service id="templating.engine.twig" class="%templating.engine.twig.class%" public="false">
             <argument type="service" id="twig" />

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -121,7 +121,7 @@ class TwigExtensionTest extends TestCase
         $this->loadFromFile($container, 'full', $format);
         $this->compileContainer($container);
 
-        $def = $container->getDefinition('twig.loader');
+        $def = $container->getDefinition('twig.loader.filesystem');
         $paths = array();
         foreach ($def->getMethodCalls() as $call) {
             if ('addPath' === $call[0]) {


### PR DESCRIPTION
In the previous form of twig's service definitions, it was impossible to
use a chain loader correctly because the TwigBundle was registering paths
on the twig.loader service. This patch fixes that by creating a
twig.loader.filesystem definition and an alias twig.loader that points
to twig.loader.filesystem by default.
