### PR TITLE
[Routing] removed restriction of route names

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -20,6 +20,8 @@ CHANGELOG
    check on URL generation completely by calling `setStrictRequirements(null)`. It
    improves performance in production environment as you should know that params always
    pass the requirements (otherwise it would break your link anyway).
+ * There is no restriction on the route name anymore. So non-alphanumeric characters
+   are now also allowed.
 
 2.1.0
 -----

--- a/src/Symfony/Component/Routing/RouteCollection.php
+++ b/src/Symfony/Component/Routing/RouteCollection.php
@@ -112,16 +112,10 @@ class RouteCollection implements \IteratorAggregate, \Countable
      * @param string $name  The route name
      * @param Route  $route A Route instance
      *
-     * @throws \InvalidArgumentException When route name contains non valid characters
-     *
      * @api
      */
     public function add($name, Route $route)
     {
-        if (!preg_match('/^[a-z0-9A-Z_.]+$/', $name)) {
-            throw new \InvalidArgumentException(sprintf('The provided route name "%s" contains non valid characters. A route name must only contain digits (0-9), letters (a-z and A-Z), underscores (_) and dots (.).', $name));
-        }
-
         $this->remove($name);
 
         $this->routes[$name] = $route;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/special_route_name.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/special_route_name.yml
@@ -1,0 +1,2 @@
+"#$péß^a|":
+    pattern: "true"

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -294,6 +294,13 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/app.php/test', $this->getGenerator($routes)->generate('test'));
     }
 
+    public function testGenerateWithSpecialRouteName()
+    {
+        $routes = $this->getRoutes('$péß^a|', new Route('/bar'));
+
+        $this->assertSame('/app.php/bar', $this->getGenerator($routes)->generate('$péß^a|'));
+    }
+
     public function testUrlEncoding()
     {
         // This tests the encoding of reserved characters that are used for delimiting of URI components (defined in RFC 3986)

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -79,6 +79,16 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('incomplete.yml');
     }
 
+    public function testLoadSpecialRouteName()
+    {
+        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $routeCollection = $loader->load('special_route_name.yml');
+        $route = $routeCollection->get('#$péß^a|');
+
+        $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
+        $this->assertSame('/true', $route->getPattern());
+    }
+
     public function testLoadWithPattern()
     {
         $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));

--- a/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/UrlMatcherTest.php
@@ -158,6 +158,15 @@ class UrlMatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('_locale' => 'fr', '_route' => 'foo', 'foo' => 'foo'), $matcher->match('/fr/b/foo'));
     }
 
+    public function testMatchSpecialRouteName()
+    {
+        $collection = new RouteCollection();
+        $collection->add('$péß^a|', new Route('/bar'));
+
+        $matcher = new UrlMatcher($collection, new RequestContext());
+        $this->assertEquals(array('_route' => '$péß^a|'), $matcher->match('/bar'));
+    }
+
     public function testMatchNonAlpha()
     {
         $collection = new RouteCollection();

--- a/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCollectionTest.php
@@ -27,16 +27,6 @@ class RouteCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($collection->get('bar'), '->get() returns null if a route does not exist');
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testAddInvalidRoute()
-    {
-        $collection = new RouteCollection();
-        $route = new Route('/foo');
-        $collection->add('f o o', $route);
-    }
-
     public function testOverriddenRoute()
     {
         $collection = new RouteCollection();


### PR DESCRIPTION
bc break: no

The restriction is not relevant anymore. It was probably added when the PhpMatcherDumper compiled the route name to php methods, e.g. `DumpedMatcher::get...()`. But this is not the case anymore since 2.1. So the restriction is useless as my added tests show and it does not make any sense from an API point of view.
