### PR TITLE
[FrameworkBundle][Routing] Resolve placeholders in hostnamePattern rules

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/Router.php
@@ -78,6 +78,7 @@ class Router extends BaseRouter implements WarmableInterface
      * - the route defaults,
      * - the route requirements,
      * - the route pattern.
+     * - the route hostnamePattern.
      *
      * @param RouteCollection $collection
      */
@@ -96,6 +97,7 @@ class Router extends BaseRouter implements WarmableInterface
                 }
 
                 $route->setPattern($this->resolve($route->getPattern()));
+                $route->setHostnamePattern($this->resolve($route->getHostnamePattern()));
             }
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Routing/RouterTest.php
@@ -117,6 +117,29 @@ class RoutingTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testHostnamePatternPlaceholders()
+    {
+        $routes = new RouteCollection();
+
+        $route = new Route('foo');
+        $route->setHostnamePattern('/before/%parameter.foo%/after/%%unescaped%%');
+
+        $routes->add('foo', $route);
+
+        $sc = $this->getServiceContainer($routes);
+
+        $sc->expects($this->at(1))->method('hasParameter')->with('parameter.foo')->will($this->returnValue(true));
+        $sc->expects($this->at(2))->method('getParameter')->with('parameter.foo')->will($this->returnValue('foo'));
+
+        $router = new Router($sc, 'foo');
+        $route = $router->getRouteCollection()->get('foo');
+
+        $this->assertEquals(
+            '/before/foo/after/%unescaped%',
+            $route->getHostnamePattern()
+        );
+    }
+
     /**
      * @expectedException \Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException
      * @expectedExceptionMessage You have requested a non-existent parameter "nope".


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6135
License of the code: MIT

Currently the placeholders in the `hostname_pattern` rule are not resolved, so that's why this PR is it for.
