### PR TITLE
[DependencyInjection] allows references to be declared as "lazy"

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -22,6 +22,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Martin Hasoň <martin.hason@gmail.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  *
  * @api
  */
@@ -238,6 +239,14 @@ class XmlDumper extends Dumper
                     $element->setAttribute('on-invalid', 'null');
                 } elseif ($behaviour == ContainerInterface::IGNORE_ON_INVALID_REFERENCE) {
                     $element->setAttribute('on-invalid', 'ignore');
+                }
+
+                if ( ! $value->isStrict()) {
+                    $element->setAttribute('strict', 'false');
+                }
+
+                if ($value->isLazy()) {
+                    $element->setAttribute('lazy', 'true');
                 }
             } elseif ($value instanceof Definition) {
                 $element->setAttribute('type', 'service');

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -24,6 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * YamlDumper dumps a service container as a YAML string.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  *
  * @api
  */
@@ -212,7 +213,15 @@ class YamlDumper extends Dumper
 
             return $code;
         } elseif ($value instanceof Reference) {
-            return $this->getServiceCall((string) $value, $value);
+            $call = $this->getServiceCall((string) $value, $value);
+            if ($value->isLazy()) {
+                $call .= '~';
+            }
+            if ( ! $value->isStrict()) {
+                $call .= '=';
+            }
+
+            return $call;
         } elseif ($value instanceof Parameter) {
             return $this->getParameterCall((string) $value);
         } elseif (is_object($value) || is_resource($value)) {

--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -25,6 +25,7 @@ use Symfony\Component\DependencyInjection\Exception\RuntimeException;
  * XmlFileLoader loads XML files service definitions.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class XmlFileLoader extends FileLoader
 {

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -26,6 +26,7 @@ use Symfony\Component\Yaml\Yaml;
  * The YAML format does not support anonymous services (cf. the XML loader).
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  */
 class YamlFileLoader extends FileLoader
 {
@@ -298,14 +299,20 @@ class YamlFileLoader extends FileLoader
                 $invalidBehavior = ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE;
             }
 
+            $strict = true;
             if ('=' === substr($value, -1)) {
                 $value = substr($value, 0, -1);
                 $strict = false;
-            } else {
-                $strict = true;
+            }
+
+            $lazy = false;
+            if ('~' === substr($value, -1)) {
+                $value = substr($value, 0, -1);
+                $lazy = true;
             }
 
             $value = new Reference($value, $invalidBehavior, $strict);
+            $value->setLazy($lazy);
         }
 
         return $value;

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -126,6 +126,7 @@
     <xsd:attribute name="name" type="xsd:string" />
     <xsd:attribute name="on-invalid" type="xsd:string" />
     <xsd:attribute name="strict" type="boolean" />
+    <xsd:attribute name="lazy" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="argument" mixed="true">
@@ -139,6 +140,7 @@
     <xsd:attribute name="index" type="xsd:integer" />
     <xsd:attribute name="on-invalid" type="xsd:string" />
     <xsd:attribute name="strict" type="boolean" />
+    <xsd:attribute name="lazy" type="boolean" />
   </xsd:complexType>
 
   <xsd:complexType name="call" mixed="true">

--- a/src/Symfony/Component/DependencyInjection/Reference.php
+++ b/src/Symfony/Component/DependencyInjection/Reference.php
@@ -15,6 +15,7 @@ namespace Symfony\Component\DependencyInjection;
  * Reference represents a service reference.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  *
  * @api
  */
@@ -23,6 +24,7 @@ class Reference
     private $id;
     private $invalidBehavior;
     private $strict;
+    private $lazy = false;
 
     /**
      * Constructor.
@@ -68,5 +70,29 @@ class Reference
     public function isStrict()
     {
         return $this->strict;
+    }
+
+    /**
+     * Whether this reference should be lazily initialized if available.
+     *
+     * @return Boolean
+     */
+    public function isLazy()
+    {
+        return $this->lazy;
+    }
+
+    /**
+     * Sets the lazily initialization status for this reference.
+     *
+     * @param Boolean $bool
+     *
+     * @return Reference
+     */
+    public function setLazy($bool)
+    {
+        $this->lazy = $bool;
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -74,6 +74,11 @@ class SimpleXMLElement extends \SimpleXMLElement
                     }
 
                     $arguments[$key] = new Reference((string) $arg['id'], $invalidBehavior, $strict);
+
+                    if (isset($arg['lazy'])) {
+                        $arguments[$key]->setLazy(self::phpize($arg['lazy']));
+                    }
+
                     break;
                 case 'collection':
                     $arguments[$key] = $arg->getArgumentsAsPhp($name, false);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services6.xml
@@ -46,5 +46,9 @@
     <service id="alias_for_foo" alias="foo" />
     <service id="another_alias_for_foo" alias="foo" public="false" />
     <service id="factory_service" factory-method="getInstance" factory-service="baz_factory" />
+    <service id="lazy_deps_service">
+        <argument type="service" id="foo" lazy="true" />
+        <argument type="service" id="bar" />
+    </service>
   </services>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services6.yml
@@ -24,3 +24,5 @@ services:
         alias: foo
         public: false
     factory_service: { class: BazClass, factory_method: getInstance, factory_service: baz_factory }
+    lazy_deps_service:
+        arguments: ["@foo~", "@bar"]

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -173,6 +173,10 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('getInstance', $services['factory_service']->getFactoryMethod());
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
 
+        $args = $services['lazy_deps_service']->getArguments();
+        $this->assertTrue($args[0]->isLazy());
+        $this->assertFalse($args[1]->isLazy());
+
         $aliases = $container->getAliases();
         $this->assertTrue(isset($aliases['alias_for_foo']), '->load() parses <service> elements');
         $this->assertEquals('foo', (string) $aliases['alias_for_foo'], '->load() parses aliases');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -128,6 +128,10 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(array('setBar', array('foo', new Reference('foo'), array(true, false)))), $services['method_call2']->getMethodCalls(), '->load() parses the method_call tag');
         $this->assertEquals('baz_factory', $services['factory_service']->getFactoryService());
 
+        $args = $services['lazy_deps_service']->getArguments();
+        $this->assertTrue($args[0]->isLazy());
+        $this->assertFalse($args[1]->isLazy());
+
         $aliases = $container->getAliases();
         $this->assertTrue(isset($aliases['alias_for_foo']), '->load() parses aliases');
         $this->assertEquals('foo', (string) $aliases['alias_for_foo'], '->load() parses aliases');


### PR DESCRIPTION
I had written this patch during sflive Berlin. It allows to store additional metadata in references. It contains no code to leverage that additional metadata though.

> In contrast to regular references, a lazy reference is not guaranteed to be fully initialized upon  injection, but may instead be lazy initialized when it is first accessed by the consuming service.

Code that uses the lazy attribute could also reside outside of the core repository as it might contain additional dependencies which we probably do not want in the core component.
