### PR TITLE
[HttpFoundation] disabled Request _method feature by default

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -12,6 +12,9 @@
 
  * The Stopwatch functionality was moved from HttpKernel\Debug to its own component
 
+ * The _method request parameter support has been disabled by default (call
+   Request::enableHttpMethodParameterOverride() to enable it).
+
 #### Deprecations
 
  * The `Request::splitHttpAcceptHeader()` is deprecated and will be removed in 2.3.

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 2.2.0
 -----
 
+ * added Request::getRealMethod() to get the "real" HTTP method (getMethod() returns the "intended" HTTP method)
+ * disabled _method request parameter support by default (call Request::enableHttpMethodParameterOverride() to enable it)
  * Request::splitHttpAcceptHeader() method is deprecated and will be removed in 2.3
 
 2.1.0


### PR DESCRIPTION
It should now be explicitely enabled via a call to enableHttpMethodOverride())
