### PR TITLE
Process X-Forwarded-For header in correct order

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -607,7 +607,7 @@ class Request
             if ($this->server->has('HTTP_CLIENT_IP')) {
                 return $this->server->get('HTTP_CLIENT_IP');
             } elseif ($this->server->has('HTTP_X_FORWARDED_FOR')) {
-                $clientIp = explode(',', $this->server->get('HTTP_X_FORWARDED_FOR'));
+                $clientIp = array_reverse(explode(',', $this->server->get('HTTP_X_FORWARDED_FOR')));
 
                 foreach ($clientIp as $ipAddress) {
                     $cleanIpAddress = trim($ipAddress);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -743,9 +743,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('88.88.88.88', true, '127.0.0.1', null, '88.88.88.88'),
             array('::1', false, '::1', null, null),
             array('2620:0:1cfe:face:b00c::3', true, '::1', '2620:0:1cfe:face:b00c::3', null),
-            array('2620:0:1cfe:face:b00c::3', true, '::1', null, '2620:0:1cfe:face:b00c::3, ::1'),
-            array('88.88.88.88', true, '123.45.67.89', null, '88.88.88.88, 87.65.43.21, 127.0.0.1'),
-            array('88.88.88.88', true, '123.45.67.89', null, 'unknown, 88.88.88.88'),
+            array('2620:0:1cfe:face:b00c::3', true, '::1', null, '::1, 2620:0:1cfe:face:b00c::3'),
+            array('88.88.88.88', true, '123.45.67.89', null, '87.65.43.21, 127.0.0.1, 88.88.88.88'),
+            array('88.88.88.88', true, '123.45.67.89', null, '88.88.88.88, unknown'),
         );
     }
 


### PR DESCRIPTION
See http://en.wikipedia.org/wiki/X-Forwarded-For#Format. The IP addresses are appended to the right side so the server communicating with my managed proxy server is the last. This is the only value that can be trusted if I am behind managed proxy server, all others can be easily spoofed. The last value is also the equivalent of REMOTE_ADDR if I am not behind a reverse proxy.
