### PR TITLE
Bugfix for creating cookie on loginSuccess in AbstractRememberMeServices

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -195,6 +195,12 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             $this->logger->debug('Remember-me was requested; setting cookie.');
         }
 
+        // Remove attribute from request that sets a NULL cookie.
+        // It was set by $this->cancelCookie()
+        // (cancelCookie does other things too for some RememberMeServices
+        // so we should still call it at the start of this method)
+        $request->attributes->remove(self::COOKIE_ATTR_NAME);
+
         $this->onLoginSuccess($request, $response, $token);
     }
 

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -133,7 +133,6 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
             )
         );
 
-        $request->attributes->remove(self::COOKIE_ATTR_NAME);
         $response->headers->setCookie(
             new Cookie(
                 $this->options['name'],


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6055
Todo: -
License of the code: MIT

By a mistake setting of new cookies did not work for other RememberMe services than PersistentTokenBasedRememberMeServices
