### PR TITLE
Do not start session on get, if no prevoius session

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -655,6 +655,9 @@ class Request
     public function setSession(SessionInterface $session)
     {
         $this->session = $session;
+        if (!$this->hasPreviousSession()) {
+            $this->session->markAsEmpty();
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
+++ b/src/Symfony/Component/HttpFoundation/Session/SessionInterface.php
@@ -21,6 +21,14 @@ use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
 interface SessionInterface
 {
     /**
+     * Mark this session as empty if this session has not started.
+     * This method should be called when we have no previous session
+     * (no session cookie) and then the session will be internally
+     * marked as empty, if it has not started yet.
+     */
+    public function markAsEmpty();
+
+    /**
      * Starts the session storage.
      *
      * @return Boolean True if session started.


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6036
License of the code: MIT

The session->get function should only start the session in the current request if the session had already been started in a previous request.
