### PR TITLE
Cosmetic fix: Removed unnecessary attribute with default value from template

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -146,9 +146,13 @@
 {% spaceless %}
     {% if widget == 'single_text' %}
         {{ block('form_widget_simple') }}
-    {% else %}
+    {% elseif widget == 'text' %}
         <div {{ block('widget_container_attributes') }}>
             {{ form_widget(form.hour, { 'attr': { 'size': '1' } }) }}:{{ form_widget(form.minute, { 'attr': { 'size': '1' } }) }}{% if with_seconds %}:{{ form_widget(form.second, { 'attr': { 'size': '1' } }) }}{% endif %}
+        </div>
+    {% else %}
+        <div {{ block('widget_container_attributes') }}>
+            {{ form_widget(form.hour) }}:{{ form_widget(form.minute) }}{% if with_seconds %}:{{ form_widget(form.second) }}{% endif %}
         </div>
     {% endif %}
 {% endspaceless %}


### PR DESCRIPTION
"1" is the default value of the "size" attribute for the "select" tag, so it is not necessary (=no backwards compatibility break).

Applying this patch makes it easier to work with bootstrap, because bootstrap includes a selector that checks it the "size" attribute is present: https://github.com/twitter/bootstrap/blob/master/less/forms.less#L172

I noticed the problem when working with the Sonata AdminBundle:

Before this patch:
![patch-before](https://f.cloud.github.com/assets/362092/99811/528650b8-67c3-11e2-9b54-1fca2509d5fb.png)

After this patch:
![patch-after](https://f.cloud.github.com/assets/362092/99810/527088a0-67c3-11e2-9b55-b7d67ecdac5d.png)

The date and time fields in Sonata were not aligned because the CSS code between date and time fields was different (the size attribute was not present on date fields, only on time fields, so different CSS code was applied).
