### PR TITLE
[FrameworkBundle] Fixed DefaultValue for session.auto_start in NodeDefinition

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -179,7 +179,7 @@ class Configuration implements ConfigurationInterface
                     ->children()
                         ->booleanNode('auto_start')
                             ->info('DEPRECATED! Session starts on demand')
-                            ->defaultNull()
+                            ->defaultFalse()
                             ->beforeNormalization()
                                 ->ifTrue(function($v) { return null !== $v; })
                                 ->then(function($v) {


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: -
License of the code: MIT
Documentation PR: -

This is just for consistency with the node type.
