### PR TITLE
[HttpKernel][HttpCache] SSI-include support

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -73,6 +73,7 @@ class Configuration implements ConfigurationInterface
 
         $this->addFormSection($rootNode);
         $this->addEsiSection($rootNode);
+        $this->addSsiSection($rootNode);
         $this->addProfilerSection($rootNode);
         $this->addRouterSection($rootNode);
         $this->addSessionSection($rootNode);
@@ -108,6 +109,17 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->arrayNode('esi')
                     ->info('esi configuration')
+                    ->canBeDisabled()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addSsiSection (ArrayNodeDefinition $rootNode) {
+        $rootNode
+            ->children()
+                ->arrayNode('ssi')
+                    ->info('ssi configuration')
                     ->canBeDisabled()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -93,6 +93,9 @@ class FrameworkExtension extends Extension
         if (isset($config['esi'])) {
             $this->registerEsiConfiguration($config['esi'], $loader);
         }
+        if (isset($config['ssi'])) {
+            $this->registerSsiConfiguration($config['ssi'], $loader);
+        }
 
         if (isset($config['profiler'])) {
             $this->registerProfilerConfiguration($config['profiler'], $container, $loader);
@@ -181,6 +184,19 @@ class FrameworkExtension extends Extension
     {
         if (!empty($config['enabled'])) {
             $loader->load('esi.xml');
+        }
+    }
+
+    /**
+     * Loads the ESI configuration.
+     *
+     * @param array         $config An ESI configuration array
+     * @param XmlFileLoader $loader An XmlFileLoader instance
+     */
+    private function registerSsiConfiguration (array $config, XmlFileLoader $loader)
+    {
+        if (!empty($config['enabled'])) {
+            $loader->load('ssi.xml');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -11,20 +11,55 @@
 
 namespace Symfony\Bundle\FrameworkBundle;
 
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\HttpKernel as BaseHttpKernel;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * This HttpKernel is used to manage scope changes of the DI container.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
- *
- * @deprecated This class is deprecated in 2.2 and will be removed in 2.3
  */
-class HttpKernel extends ContainerAwareHttpKernel
+class HttpKernel extends BaseHttpKernel
 {
+    protected $container;
+
+    private $esiSupport;
+    private $ssiSupport;
+
+    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver)
+    {
+        parent::__construct($dispatcher, $controllerResolver);
+
+        $this->container = $container;
+    }
+
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        $request->headers->set('X-Php-Ob-Level', ob_get_level());
+
+        $this->container->enterScope('request');
+        $this->container->set('request', $request, 'request');
+
+        try {
+            $response = parent::handle($request, $type, $catch);
+        } catch (\Exception $e) {
+            $this->container->leaveScope('request');
+
+            throw $e;
+        }
+
+        $this->container->leaveScope('request');
+
+        return $response;
+    }
+
     /**
      * Forwards the request to another controller.
      *
@@ -33,13 +68,9 @@ class HttpKernel extends ContainerAwareHttpKernel
      * @param array  $query      An array of request query parameters
      *
      * @return Response A Response instance
-     *
-     * @deprecated in 2.2, will be removed in 2.3
      */
     public function forward($controller, array $attributes = array(), array $query = array())
     {
-        trigger_error('forward() is deprecated since version 2.2 and will be removed in 2.3.', E_USER_DEPRECATED);
-
         $attributes['_controller'] = $controller;
         $subRequest = $this->container->get('request')->duplicate($query, null, $attributes);
 
@@ -54,30 +85,171 @@ class HttpKernel extends ContainerAwareHttpKernel
      *
      * Available options:
      *
+     *  * attributes: An array of request attributes (only when the first argument is a controller)
+     *  * query: An array of request query parameters (only when the first argument is a controller)
      *  * ignore_errors: true to return an empty string in case of an error
-     *  * alt: an alternative URI to execute in case of an error
+     *  * alt: an alternative controller to execute in case of an error (can be a controller, a URI, or an array with the controller, the attributes, and the query arguments)
      *  * standalone: whether to generate an esi:include tag or not when ESI is supported
      *  * comment: a comment to add when returning an esi:include tag
      *
-     * @param string $uri     A URI
-     * @param array  $options An array of options
+     * @param string $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
+     * @param array  $options    An array of options
      *
      * @return string The Response content
-     *
-     * @throws \RuntimeException
-     * @throws \Exception
-     *
-     * @deprecated in 2.2, will be removed in 2.3 (use Symfony\Component\HttpKernel\HttpContentRenderer::render() instead)
      */
-    public function render($uri, array $options = array())
+    public function render($controller, array $options = array())
     {
-        trigger_error('render() is deprecated since version 2.2 and will be removed in 2.3. Use Symfony\Component\HttpKernel\HttpContentRenderer::render() instead.', E_USER_DEPRECATED);
+        $options = array_merge(array(
+            'attributes'    => array(),
+            'query'         => array(),
+            'ignore_errors' => !$this->container->getParameter('kernel.debug'),
+            'alt'           => array(),
+            'standalone'    => false,
+            'comment'       => '',
+        ), $options);
 
-        $options = $this->renderer->fixOptions($options);
+        if (!is_array($options['alt'])) {
+            $options['alt'] = array($options['alt']);
+        }
 
-        $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
-        unset($options['strategy']);
+        if (null === $this->esiSupport) {
+            $this->esiSupport = $this->container->has('esi') && $this->container->get('esi')->hasSurrogateCapability($this->container->get('request'));
+        }
 
-        $this->container->get('http_content_renderer')->render($uri, $strategy, $options);
+        if (null === $this->ssiSupport) {
+            $this->ssiSupport = $this->container->has('ssi') && $this->container->get('ssi')->hasSurrogateCapability($this->container->get('request'));
+        }
+
+        $renderer = null;
+        if ($this->esiSupport && (true === $options['standalone'] || 'esi' === $options['standalone'])) {
+            $renderer = $this->container->get('esi');
+        }
+
+        if ($this->ssiSupport && (true === $options['standalone'] || 'ssi' === $options['standalone'])) {
+            $renderer = $this->container->get('ssi');
+        }
+
+        if ($renderer) {
+            $uri = $this->generateInternalUri($controller, $options['attributes'], $options['query']);
+
+            $alt = '';
+            if ($options['alt']) {
+                $alt = $this->generateInternalUri($options['alt'][0], isset($options['alt'][1]) ? $options['alt'][1] : array(), isset($options['alt'][2]) ? $options['alt'][2] : array());
+            }
+
+            return $renderer->renderIncludeTag($uri, $alt, $options['ignore_errors'], $options['comment']);
+        }
+
+        if ('js' === $options['standalone']) {
+            $uri = $this->generateInternalUri($controller, $options['attributes'], $options['query'], false);
+            $defaultContent = null;
+
+            if ($template = $this->container->getParameter('templating.hinclude.default_template')) {
+                $defaultContent = $this->container->get('templating')->render($template);
+            }
+
+            return $this->renderHIncludeTag($uri, $defaultContent);
+        }
+
+        $request = $this->container->get('request');
+
+        // controller or URI?
+        if (0 === strpos($controller, '/')) {
+            $subRequest = Request::create($request->getUriForPath($controller), 'get', array(), $request->cookies->all(), array(), $request->server->all());
+            if ($session = $request->getSession()) {
+                $subRequest->setSession($session);
+            }
+        } else {
+            $options['attributes']['_controller'] = $controller;
+
+            if (!isset($options['attributes']['_format'])) {
+                $options['attributes']['_format'] = $request->getRequestFormat();
+            }
+
+            $options['attributes']['_route'] = '_internal';
+            $subRequest = $request->duplicate($options['query'], null, $options['attributes']);
+            $subRequest->setMethod('GET');
+        }
+
+        $level = ob_get_level();
+        try {
+            $response = $this->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
+
+            if (!$response->isSuccessful()) {
+                throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $request->getUri(), $response->getStatusCode()));
+            }
+
+            if (!$response instanceof StreamedResponse) {
+                return $response->getContent();
+            }
+
+            $response->sendContent();
+        } catch (\Exception $e) {
+            if ($options['alt']) {
+                $alt = $options['alt'];
+                unset($options['alt']);
+                $options['attributes'] = isset($alt[1]) ? $alt[1] : array();
+                $options['query'] = isset($alt[2]) ? $alt[2] : array();
+
+                return $this->render($alt[0], $options);
+            }
+
+            if (!$options['ignore_errors']) {
+                throw $e;
+            }
+
+            // let's clean up the output buffers that were created by the sub-request
+            while (ob_get_level() > $level) {
+                ob_get_clean();
+            }
+        }
+    }
+
+    /**
+     * Generates an internal URI for a given controller.
+     *
+     * This method uses the "_internal" route, which should be available.
+     *
+     * @param string  $controller A controller name to execute (a string like BlogBundle:Post:index), or a relative URI
+     * @param array   $attributes An array of request attributes
+     * @param array   $query      An array of request query parameters
+     * @param boolean $secure
+     *
+     * @return string An internal URI
+     */
+    public function generateInternalUri($controller, array $attributes = array(), array $query = array(), $secure = true)
+    {
+        if (0 === strpos($controller, '/')) {
+            return $controller;
+        }
+
+        $path = http_build_query($attributes, '', '&');
+        $uri = $this->container->get('router')->generate($secure ? '_internal' : '_internal_public', array(
+            'controller' => $controller,
+            'path'       => $path ?: 'none',
+            '_format'    => $this->container->get('request')->getRequestFormat(),
+        ));
+
+        if ($queryString = http_build_query($query, '', '&')) {
+            $uri .= '?'.$queryString;
+        }
+
+        return $uri;
+    }
+
+    /**
+     * Renders an HInclude tag.
+     *
+     * @param string $uri A URI
+     * @param string $defaultContent Default content
+     */
+    public function renderHIncludeTag($uri, $defaultContent = null)
+    {
+        return sprintf('<hx:include src="%s">%s</hx:include>', $uri, $defaultContent);
+    }
+
+    public function hasEsiSupport()
+    {
+        return $this->esiSupport;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="ssi.class">Symfony\Component\HttpKernel\HttpCache\Ssi</parameter>
+        <parameter key="ssi_listener.class">Symfony\Component\HttpKernel\EventListener\SsiListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="ssi" class="%ssi.class%" />
+
+        <service id="ssi_listener" class="%ssi_listener.class%">
+          <tag name="kernel.event_subscriber" />
+          <argument type="service" id="ssi" on-invalid="ignore" />
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/HttpKernel/EventListener/SsiListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/SsiListener.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\HttpCache\Ssi;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * EsiListener adds a Surrogate-Control HTTP header when the Response needs to be parsed for ESI.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class SsiListener implements EventSubscriberInterface
+{
+    private $ssi;
+
+    /**
+     * Constructor.
+     *
+     * @param Ssi $ssi An ESI instance
+     */
+    public function __construct(Ssi $ssi = null)
+    {
+        $this->ssi = $ssi;
+    }
+
+    /**
+     * Filters the Response.
+     *
+     * @param FilterResponseEvent $event A FilterResponseEvent instance
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType() || null === $this->ssi) {
+            return;
+        }
+
+        $this->ssi->addSurrogateControl($event->getResponse());
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Esi.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class Esi
+class Esi implements RendererInterface
 {
     private $contentTypes;
 
@@ -58,7 +58,7 @@ class Esi
      *
      * @return Boolean true if one surrogate has ESI/1.0 capability, false otherwise
      */
-    public function hasSurrogateEsiCapability(Request $request)
+    public function hasSurrogateCapability(Request $request)
     {
         if (null === $value = $request->headers->get('Surrogate-Capability')) {
             return false;

--- a/src/Symfony/Component/HttpKernel/HttpCache/RendererInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/RendererInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\HttpCache;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+interface RendererInterface {
+    public function hasSurrogateCapability(Request $request);
+    public function renderIncludeTag ($uri, $alt = null, $ignoreErrors = true, $comment = '');
+    public function addSurrogateControl (Response $response);
+}

--- a/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Ssi.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\HttpCache;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+/**
+ * Ssi implements the SSI capabilities to Request and Response instances.
+ */
+class Ssi implements RendererInterface
+{
+    private $contentTypes;
+
+    /**
+     * Constructor.
+     *
+     * @param array $contentTypes An array of content-type that should be parsed for ESI information.
+     *                           (default: text/html, text/xml, and application/xml)
+     */
+    public function __construct(array $contentTypes = array('text/html', 'text/xml', 'application/xml'))
+    {
+        $this->contentTypes = $contentTypes;
+    }
+
+    /**
+     * Checks that at least one surrogate has ESI/1.0 capability.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return Boolean true if one surrogate has ESI/1.0 capability, false otherwise
+     */
+    public function hasSurrogateCapability(Request $request)
+    {
+        return true;
+        if (null === $value = $request->headers->get('Surrogate-Capability')) {
+            return false;
+        }
+
+        return false !== strpos($value, 'SSI/1.0');
+    }
+
+    /**
+     * Adds HTTP headers to specify that the Response needs to be parsed for ESI.
+     *
+     * This method only adds an ESI HTTP header if the Response has some ESI tags.
+     *
+     * @param Response $response A Response instance
+     */
+    public function addSurrogateControl(Response $response)
+    {
+        if (false !== strpos($response->getContent(), '<!--#include')) {
+            $response->headers->set('Surrogate-Control', 'content="SSI/1.0"');
+        }
+    }
+
+    /**
+     * Renders an SSI tag.
+     *
+     * @param string  $uri          A URI
+     * @param string  $alt          An alternate URI
+     * @param Boolean $ignoreErrors Whether to ignore errors or not
+     * @param string  $comment      A comment to add as an esi:include tag
+     * @return string
+     */
+    public function renderIncludeTag($uri, $alt = null, $ignoreErrors = true, $comment = '')
+    {
+        $html = sprintf('<!--#include virtual="%s" -->',
+            $uri
+        );
+
+        if (!empty($comment)) {
+            return sprintf("<!-- %s -->\n%s", $comment, $html);
+        }
+
+        return $html;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/EsiTest.php
@@ -30,14 +30,14 @@ class EsiTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::create('/');
         $request->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
-        $this->assertTrue($esi->hasSurrogateEsiCapability($request));
+        $this->assertTrue($esi->hasSurrogateCapability($request));
 
         $request = Request::create('/');
         $request->headers->set('Surrogate-Capability', 'foobar');
-        $this->assertFalse($esi->hasSurrogateEsiCapability($request));
+        $this->assertFalse($esi->hasSurrogateCapability($request));
 
         $request = Request::create('/');
-        $this->assertFalse($esi->hasSurrogateEsiCapability($request));
+        $this->assertFalse($esi->hasSurrogateCapability($request));
     }
 
     public function testAddSurrogateEsiCapability()


### PR DESCRIPTION
Exactly like the already existing ESI-support, but for SSI. Idea is to allow NGinx (or other servers, that support SSI, but not ESI) cache parts of the site like it does varnish with ESI, but in enviroments, where a dedicated varnish is overhead.
