### PR TITLE
improve routing xml scheme

### DIFF
--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -8,18 +8,18 @@
   <xsd:element name="routes" type="routes" />
 
   <xsd:complexType name="routes">
-    <xsd:choice maxOccurs="unbounded" minOccurs="0">
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
       <xsd:element name="import" type="import" />
       <xsd:element name="route" type="route" />
     </xsd:choice>
   </xsd:complexType>
 
   <xsd:complexType name="route">
-    <xsd:sequence>
-      <xsd:element name="default" type="element" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="requirement" type="element" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="option" type="element" minOccurs="0" maxOccurs="unbounded" />
-    </xsd:sequence>
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="default" type="element"/>
+      <xsd:element name="requirement" type="element" />
+      <xsd:element name="option" type="element" />
+    </xsd:choice>
 
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="pattern" type="xsd:string" />
@@ -27,11 +27,11 @@
   </xsd:complexType>
 
   <xsd:complexType name="import">
-    <xsd:sequence>
-      <xsd:element name="default" type="element" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="requirement" type="element" minOccurs="0" maxOccurs="unbounded" />
-      <xsd:element name="option" type="element" minOccurs="0" maxOccurs="unbounded" />
-    </xsd:sequence>
+    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+      <xsd:element name="default" type="element" />
+      <xsd:element name="requirement" type="element" />
+      <xsd:element name="option" type="element" />
+    </xsd:choice>
 
     <xsd:attribute name="resource" type="xsd:string" />
     <xsd:attribute name="type" type="xsd:string" />

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -25,7 +25,7 @@
   <xsd:complexType name="route">
     <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
-    <xsd:attribute name="id" type="xsd:string" />
+    <xsd:attribute name="id" type="xsd:string" use="required" />
     <xsd:attribute name="pattern" type="xsd:string" />
     <xsd:attribute name="hostname-pattern" type="xsd:string" />
   </xsd:complexType>

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -14,12 +14,16 @@
     </xsd:choice>
   </xsd:complexType>
 
-  <xsd:complexType name="route">
-    <xsd:choice minOccurs="0" maxOccurs="unbounded">
-      <xsd:element name="default" type="element"/>
+  <xsd:group name="configs">
+    <xsd:choice>
+      <xsd:element name="default" type="element" />
       <xsd:element name="requirement" type="element" />
       <xsd:element name="option" type="element" />
     </xsd:choice>
+  </xsd:group>
+
+  <xsd:complexType name="route">
+    <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
     <xsd:attribute name="id" type="xsd:string" />
     <xsd:attribute name="pattern" type="xsd:string" />
@@ -27,11 +31,7 @@
   </xsd:complexType>
 
   <xsd:complexType name="import">
-    <xsd:choice minOccurs="0" maxOccurs="unbounded">
-      <xsd:element name="default" type="element" />
-      <xsd:element name="requirement" type="element" />
-      <xsd:element name="option" type="element" />
-    </xsd:choice>
+    <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
     <xsd:attribute name="resource" type="xsd:string" />
     <xsd:attribute name="type" type="xsd:string" />

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -26,7 +26,7 @@
     <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
     <xsd:attribute name="id" type="xsd:string" use="required" />
-    <xsd:attribute name="pattern" type="xsd:string" />
+    <xsd:attribute name="pattern" type="xsd:string" default="/" />
     <xsd:attribute name="hostname-pattern" type="xsd:string" />
   </xsd:complexType>
 

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -5,6 +5,16 @@
     targetNamespace="http://symfony.com/schema/routing"
     elementFormDefault="qualified">
 
+  <xsd:annotation>
+    <xsd:documentation><![CDATA[
+      Symfony XML Routing Schema, version 1.0
+      Authors: Fabien Potencier, Tobias Schultze
+
+      This scheme defines the elements and attributes that can be used to define
+      routes. A route maps an HTTP request to a set of configuration variables.
+    ]]></xsd:documentation>
+  </xsd:annotation>
+
   <xsd:element name="routes" type="routes" />
 
   <xsd:complexType name="routes">


### PR DESCRIPTION
bc break: no

Main points:
- the xml scheme only allowed defaults, requirements and options in this specific order. but the XmlFileLoader does not have the restriction and the YAML definions does not have such an restriction either. this is now fixed. so you can use

```
<requirement key="_locale">en</requirement>
<default key="_controller">Foo</default>
```

Before it had the be first all defaults, then all requirements, then all options.
- make id attribute required

For more changes see commits.
