### PR TITLE
removed wrong routing xsd statement `mixed="true"`

### DIFF
--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -32,7 +32,7 @@
     <xsd:attribute name="class" type="xsd:string" />
   </xsd:complexType>
 
-  <xsd:complexType name="element" mixed="true">
+  <xsd:complexType name="element">
     <xsd:attribute name="key" type="xsd:string" />
   </xsd:complexType>
 </xsd:schema>


### PR DESCRIPTION
mixed="true" means that the element could contain both text and other elements, e.g.
`<requirement key="_locale">text <subelement /></requirement>`
But this wrong and such a definition would not even validate against the scheme as the xsd does not define which elements would be expected inside.
