### PR TITLE
[Twig] [DI Config] Made the loader a config option

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -125,6 +125,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('strict_variables')->end()
                 ->scalarNode('auto_reload')->end()
                 ->scalarNode('optimizations')->end()
+                ->scalarNode('loader_service_id')->defaultValue('twig.loader.filesystem')->end()
                 ->arrayNode('paths')
                     ->beforeNormalization()
                         ->always()

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/TwigExtension.php
@@ -71,6 +71,8 @@ class TwigExtension extends Extension
             }
         }
 
+        $container->setAlias('twig.loader', $config['loader_service_id']);
+
         // register bundles as Twig namespaces
         foreach ($container->getParameter('kernel.bundles') as $bundle => $class) {
             if (is_dir($dir = $container->getParameter('kernel.root_dir').'/Resources/'.$bundle.'/views')) {

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/schema/twig-1.0.xsd
@@ -22,6 +22,7 @@
         <xsd:attribute name="debug" type="xsd:string" />
         <xsd:attribute name="strict-variables" type="xsd:string" />
         <xsd:attribute name="exception-controller" type="xsd:string" />
+        <xsd:attribute name="loader_service_id" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="form">

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -43,8 +43,6 @@
             <argument type="service" id="templating.name_parser" />
         </service>
 
-        <service id="twig.loader" alias="twig.loader.filesystem" />
-
         <service id="templating.engine.twig" class="%templating.engine.twig.class%" public="false">
             <argument type="service" id="twig" />
             <argument type="service" id="templating.name_parser" />

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -18,6 +18,7 @@ $container->loadFromExtension('twig', array(
      'charset'             => 'ISO-8859-1',
      'debug'               => true,
      'strict_variables'    => true,
+     'loader_service_id'   => 'foo.bar',
      'paths'               => array(
          'path1',
          'path2',

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -6,7 +6,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
                         http://symfony.com/schema/dic/twig http://symfony.com/schema/dic/twig/twig-1.0.xsd">
 
-    <twig:config auto-reload="true" autoescape="true" base-template-class="stdClass" cache="/tmp" charset="ISO-8859-1" debug="true" strict-variables="true">
+    <twig:config auto-reload="true" autoescape="true" base-template-class="stdClass" cache="/tmp" charset="ISO-8859-1" debug="true" strict-variables="true" loader_service_id="foo.bar">
         <twig:form>
             <twig:resource>MyBundle::form.html.twig</twig:resource>
         </twig:form>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -13,6 +13,7 @@ twig:
     charset:             ISO-8859-1
     debug:               true
     strict_variables:    true
+    loader_service_id:   foo.bar
     paths:
         path1: ''
         path2: ''

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -38,6 +38,7 @@ class TwigExtensionTest extends TestCase
         $this->assertEquals(__DIR__.'/twig', $options['cache'], '->load() sets default value for cache option');
         $this->assertEquals('UTF-8', $options['charset'], '->load() sets default value for charset option');
         $this->assertFalse($options['debug'], '->load() sets default value for debug option');
+        $this->assertEquals('twig.loader.filesystem', $options['loader_service_id']);
     }
 
     /**
@@ -82,6 +83,7 @@ class TwigExtensionTest extends TestCase
         $this->assertEquals('ISO-8859-1', $options['charset'], '->load() sets the charset option');
         $this->assertTrue($options['debug'], '->load() sets the debug option');
         $this->assertTrue($options['strict_variables'], '->load() sets the strict_variables option');
+        $this->assertEquals('foo.bar', $options['loader_service_id']);
     }
 
     public function testGlobalsWithDifferentTypesAndValues()


### PR DESCRIPTION
Bug fix: [no]
Feature addition: [yes]
Backwards compatibility break: [no]
Symfony2 tests pass: [yes]
License of the code: MIT
- Added "loader_service_id" to config.
- Making the choice of twig loader an application choice.

This PR makes sense to me as it allows the application to decide which twig loader to use. I need to use the Twig chain loader but adding a compiler pass to override the service alias just seemed wrong ... or maybe I am missing something.

Initially I also made the twig.loader an alias only to find out somebody beat me to it 5 days ago :)
