### PR TITLE
[Routing] improve loaders

### DIFF
--- a/src/Symfony/Component/Routing/Loader/ClosureLoader.php
+++ b/src/Symfony/Component/Routing/Loader/ClosureLoader.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Routing\Loader;
 
 use Symfony\Component\Config\Loader\Loader;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * ClosureLoader loads routes from a PHP closure.
@@ -29,6 +30,8 @@ class ClosureLoader extends Loader
      *
      * @param \Closure    $closure A Closure
      * @param string|null $type    The resource type
+     *
+     * @return RouteCollection A RouteCollection instance
      *
      * @api
      */

--- a/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/PhpFileLoader.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Component\Routing\Loader;
 
-use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * PhpFileLoader loads routes from a PHP file.
@@ -30,6 +31,8 @@ class PhpFileLoader extends FileLoader
      *
      * @param string      $file A PHP file path
      * @param string|null $type The resource type
+     *
+     * @return RouteCollection A RouteCollection instance
      *
      * @api
      */

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -112,11 +112,14 @@ class XmlFileLoader extends FileLoader
      */
     protected function parseRoute(RouteCollection $collection, \DOMElement $node, $path)
     {
+        if ('' === ($id = $node->getAttribute('id')) || !$node->hasAttribute('pattern')) {
+            throw new \InvalidArgumentException(sprintf('The <route> element in file "%s" must have an "id" and a "pattern" attribute.', $path));
+        }
+
         list($defaults, $requirements, $options) = $this->parseConfigs($node, $path);
 
         $route = new Route($node->getAttribute('pattern'), $defaults, $requirements, $options, $node->getAttribute('hostname-pattern'));
-
-        $collection->add($node->getAttribute('id'), $route);
+        $collection->add($id, $route);
     }
 
     /**
@@ -131,7 +134,10 @@ class XmlFileLoader extends FileLoader
      */
     protected function parseImport(RouteCollection $collection, \DOMElement $node, $path, $file)
     {
-        $resource = $node->getAttribute('resource');
+        if ('' === $resource = $node->getAttribute('resource')) {
+            throw new \InvalidArgumentException(sprintf('The <import> element in file "%s" must have a "resource" attribute.', $path));
+        }
+
         $type = $node->getAttribute('type');
         $prefix = $node->getAttribute('prefix');
         $hostnamePattern = $node->hasAttribute('hostname-pattern') ? $node->getAttribute('hostname-pattern') : null;

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -155,13 +155,13 @@ class XmlFileLoader extends FileLoader
 
             switch ($node->tagName) {
                 case 'default':
-                    $defaults[$node->getAttribute('key')] = trim((string) $node->nodeValue);
+                    $defaults[$node->getAttribute('key')] = trim($node->nodeValue);
                     break;
                 case 'option':
-                    $options[$node->getAttribute('key')] = trim((string) $node->nodeValue);
+                    $options[$node->getAttribute('key')] = trim($node->nodeValue);
                     break;
                 case 'requirement':
-                    $requirements[$node->getAttribute('key')] = trim((string) $node->nodeValue);
+                    $requirements[$node->getAttribute('key')] = trim($node->nodeValue);
                     break;
                 default:
                     throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -100,7 +100,7 @@ class XmlFileLoader extends FileLoader
                             $options[$n->getAttribute('key')] = trim($n->nodeValue);
                             break;
                         default:
-                            throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $n->tagName));
+                            throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "default", "requirement" or "option".', $n->tagName, $file));
                     }
                 }
 
@@ -119,7 +119,7 @@ class XmlFileLoader extends FileLoader
                 $collection->addCollection($subCollection);
                 break;
             default:
-                throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
+                throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "route" or "import".', $node->tagName, $file));
         }
     }
 
@@ -164,7 +164,7 @@ class XmlFileLoader extends FileLoader
                     $requirements[$node->getAttribute('key')] = trim($node->nodeValue);
                     break;
                 default:
-                    throw new \InvalidArgumentException(sprintf('Unable to parse tag "%s"', $node->tagName));
+                    throw new \InvalidArgumentException(sprintf('Unknown tag "%s" used in file "%s". Expected "default", "requirement" or "option".', $node->tagName, $file));
             }
         }
 

--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -166,7 +166,9 @@ class XmlFileLoader extends FileLoader
      *
      * @return \DOMDocument
      *
-     * @throws \InvalidArgumentException When loading of XML file returns error
+     * @throws \InvalidArgumentException When loading of XML file fails because of syntax errors
+     *                                   or when the XML structure is not as expected by the scheme -
+     *                                   see validate()
      */
     protected function loadFile($file)
     {

--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -21,13 +21,14 @@ use Symfony\Component\Config\Loader\FileLoader;
  * YamlFileLoader loads Yaml routing files.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Tobias Schultze <http://tobion.de>
  *
  * @api
  */
 class YamlFileLoader extends FileLoader
 {
     private static $availableKeys = array(
-        'type', 'resource', 'prefix', 'pattern', 'options', 'defaults', 'requirements', 'hostname_pattern',
+        'resource', 'type', 'prefix', 'pattern', 'hostname_pattern', 'defaults', 'requirements', 'options',
     );
 
     /**
@@ -38,7 +39,7 @@ class YamlFileLoader extends FileLoader
      *
      * @return RouteCollection A RouteCollection instance
      *
-     * @throws \InvalidArgumentException When route can't be parsed
+     * @throws \InvalidArgumentException When a route can't be parsed because YAML is invalid
      *
      * @api
      */
@@ -53,38 +54,19 @@ class YamlFileLoader extends FileLoader
 
         // empty file
         if (null === $config) {
-            $config = array();
+            return $collection;
         }
 
         // not an array
         if (!is_array($config)) {
-            throw new \InvalidArgumentException(sprintf('The file "%s" must contain a YAML array.', $file));
+            throw new \InvalidArgumentException(sprintf('The file "%s" must contain a YAML array.', $path));
         }
 
         foreach ($config as $name => $config) {
-            $config = $this->normalizeRouteConfig($config);
+            $this->validate($config, $name, $path);
 
             if (isset($config['resource'])) {
-                $type = isset($config['type']) ? $config['type'] : null;
-                $prefix = isset($config['prefix']) ? $config['prefix'] : '';
-                $defaults = isset($config['defaults']) ? $config['defaults'] : array();
-                $requirements = isset($config['requirements']) ? $config['requirements'] : array();
-                $options = isset($config['options']) ? $config['options'] : array();
-                $hostnamePattern = isset($config['hostname_pattern']) ? $config['hostname_pattern'] : null;
-
-                $this->setCurrentDir(dirname($path));
-
-                $subCollection = $this->import($config['resource'], $type, false, $file);
-                /* @var $subCollection RouteCollection */
-                $subCollection->addPrefix($prefix);
-                if (null !== $hostnamePattern) {
-                    $subCollection->setHostnamePattern($hostnamePattern);
-                }
-                $subCollection->addDefaults($defaults);
-                $subCollection->addRequirements($requirements);
-                $subCollection->addOptions($options);
-
-                $collection->addCollection($subCollection);
+                $this->parseImport($collection, $config, $path, $file);
             } else {
                 $this->parseRoute($collection, $name, $config, $path);
             }
@@ -109,20 +91,14 @@ class YamlFileLoader extends FileLoader
      * @param RouteCollection $collection A RouteCollection instance
      * @param string          $name       Route name
      * @param array           $config     Route definition
-     * @param string          $file       A Yaml file path
-     *
-     * @throws \InvalidArgumentException When config pattern is not defined for the given route
+     * @param string          $path       Full path of the YAML file being processed
      */
-    protected function parseRoute(RouteCollection $collection, $name, $config, $file)
+    protected function parseRoute(RouteCollection $collection, $name, array $config, $path)
     {
         $defaults = isset($config['defaults']) ? $config['defaults'] : array();
         $requirements = isset($config['requirements']) ? $config['requirements'] : array();
         $options = isset($config['options']) ? $config['options'] : array();
         $hostnamePattern = isset($config['hostname_pattern']) ? $config['hostname_pattern'] : null;
-
-        if (!isset($config['pattern'])) {
-            throw new \InvalidArgumentException(sprintf('You must define a "pattern" for the "%s" route.', $name));
-        }
 
         $route = new Route($config['pattern'], $defaults, $requirements, $options, $hostnamePattern);
 
@@ -130,25 +106,75 @@ class YamlFileLoader extends FileLoader
     }
 
     /**
-     * Normalize route configuration.
+     * Parses an import and adds the routes in the resource to the RouteCollection.
      *
-     * @param array $config A resource config
-     *
-     * @return array
-     *
-     * @throws \InvalidArgumentException if one of the provided config keys is not supported
+     * @param RouteCollection $collection A RouteCollection instance
+     * @param array           $config     Route definition
+     * @param string          $path       Full path of the YAML file being processed
+     * @param string          $file       Loaded file name
      */
-    private function normalizeRouteConfig(array $config)
+    protected function parseImport(RouteCollection $collection, array $config, $path, $file)
     {
-        foreach ($config as $key => $value) {
-            if (!in_array($key, self::$availableKeys)) {
-                throw new \InvalidArgumentException(sprintf(
-                    'Yaml routing loader does not support given key: "%s". Expected one of the (%s).',
-                    $key, implode(', ', self::$availableKeys)
-                ));
-            }
-        }
+        $type = isset($config['type']) ? $config['type'] : null;
+        $prefix = isset($config['prefix']) ? $config['prefix'] : '';
+        $defaults = isset($config['defaults']) ? $config['defaults'] : array();
+        $requirements = isset($config['requirements']) ? $config['requirements'] : array();
+        $options = isset($config['options']) ? $config['options'] : array();
+        $hostnamePattern = isset($config['hostname_pattern']) ? $config['hostname_pattern'] : null;
 
-        return $config;
+        $this->setCurrentDir(dirname($path));
+
+        $subCollection = $this->import($config['resource'], $type, false, $file);
+        /* @var $subCollection RouteCollection */
+        $subCollection->addPrefix($prefix);
+        if (null !== $hostnamePattern) {
+            $subCollection->setHostnamePattern($hostnamePattern);
+        }
+        $subCollection->addDefaults($defaults);
+        $subCollection->addRequirements($requirements);
+        $subCollection->addOptions($options);
+
+        $collection->addCollection($subCollection);
+    }
+
+    /**
+     * Validates the route configuration.
+     *
+     * @param array  $config A resource config
+     * @param string $name   The config key
+     * @param string $path   The loaded file path
+     *
+     * @throws \InvalidArgumentException If one of the provided config keys is not supported,
+     *                                   something is missing or the combination is nonesense
+     */
+    protected function validate($config, $name, $path)
+    {
+        if (!is_array($config)) {
+            throw new \InvalidArgumentException(sprintf('The definition of "%s" in "%s" must be a YAML array.', $name, $path));
+        }
+        if ($extraKeys = array_diff(array_keys($config), self::$availableKeys)) {
+            throw new \InvalidArgumentException(sprintf(
+                'The routing file "%s" contains unsupport keys for "%s": "%s". Expected one of: "%s".',
+                $path, $name, implode('", "', $extraKeys), implode('", "', self::$availableKeys)
+            ));
+        }
+        if (isset($config['resource']) && isset($config['pattern'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'The routing file "%s" must not specify both the "resource" key and the "pattern" key for "%s". Choose between an import and a route definition.',
+                $path, $name
+            ));
+        }
+        if (!isset($config['resource']) && isset($config['type'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'The "type" key for the route definition "%s" in "%s" is unsupported. It is only available for imports in combination with the "resource" key.',
+                $name, $path
+            ));
+        }
+        if (!isset($config['resource']) && !isset($config['pattern'])) {
+            throw new \InvalidArgumentException(sprintf(
+                'You must define a "pattern" for the route "%s" in file "%s".',
+                $name, $path
+            ));
+        }
     }
 }

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -36,7 +36,7 @@
     <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
     <xsd:attribute name="id" type="xsd:string" use="required" />
-    <xsd:attribute name="pattern" type="xsd:string" default="/" />
+    <xsd:attribute name="pattern" type="xsd:string" use="required" />
     <xsd:attribute name="hostname-pattern" type="xsd:string" />
   </xsd:complexType>
 

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -43,7 +43,7 @@
   <xsd:complexType name="import">
     <xsd:group ref="configs" minOccurs="0" maxOccurs="unbounded" />
 
-    <xsd:attribute name="resource" type="xsd:string" />
+    <xsd:attribute name="resource" type="xsd:string" use="required" />
     <xsd:attribute name="type" type="xsd:string" />
     <xsd:attribute name="prefix" type="xsd:string" />
     <xsd:attribute name="hostname-pattern" type="xsd:string" />
@@ -52,7 +52,7 @@
   <xsd:complexType name="element">
     <xsd:simpleContent>
       <xsd:extension base="xsd:string">
-        <xsd:attribute name="key" type="xsd:string" />
+        <xsd:attribute name="key" type="xsd:string" use="required" />
       </xsd:extension>
     </xsd:simpleContent>
   </xsd:complexType>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/missing_id.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/missing_id.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route pattern="/test"></route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/missing_path.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/missing_path.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="myroute"></route>
+</routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/namespaceprefix.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/namespaceprefix.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<r:routes xmlns:r="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <r:route id="blog_show" pattern="/blog/{slug}" hostname-pattern="{_locale}.example.com">
+        <r:default key="_controller">MyBundle:Blog:show</r:default>
+        <requirement xmlns="http://symfony.com/schema/routing" key="slug">\w+</requirement>
+        <r2:requirement xmlns:r2="http://symfony.com/schema/routing" key="_locale">en|fr|de</r2:requirement>
+        <r:option key="compiler_class">RouteCompiler</r:option>
+    </r:route>
+</r:routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/nonesense_resource_plus_path.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/nonesense_resource_plus_path.yml
@@ -1,0 +1,3 @@
+blog_show:
+    resource: validpattern.yml
+    pattern:  /test

--- a/src/Symfony/Component/Routing/Tests/Fixtures/nonesense_type_without_resource.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/nonesense_type_without_resource.yml
@@ -1,0 +1,3 @@
+blog_show:
+    pattern: /blog/{slug}
+    type:    custom

--- a/src/Symfony/Component/Routing/Tests/Fixtures/nonvalid2.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/nonvalid2.yml
@@ -1,0 +1,1 @@
+route: string

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationClassLoaderTest.php
@@ -11,8 +11,6 @@
 
 namespace Symfony\Component\Routing\Tests\Loader;
 
-use Symfony\Component\Routing\Loader\AnnotationClassLoader;
-
 class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
 {
     protected $loader;
@@ -42,7 +40,6 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
     }
 
     /**
-     * @covers Symfony\Component\Routing\Loader\AnnotationClassLoader::supports
      * @dataProvider provideTestSupportsChecksResource
      */
     public function testSupportsChecksResource($resource, $expectedSupports)
@@ -63,9 +60,6 @@ class AnnotationClassLoaderTest extends AbstractAnnotationLoaderTest
         );
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\AnnotationClassLoader::supports
-     */
     public function testSupportsChecksTypeIfSpecified()
     {
         $this->assertTrue($this->loader->supports('class', 'annotation'), '->supports() checks the resource type if specified');

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationDirectoryLoaderTest.php
@@ -40,9 +40,6 @@ class AnnotationDirectoryLoaderTest extends AbstractAnnotationLoaderTest
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses');
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\AnnotationDirectoryLoader::supports
-     */
     public function testSupports()
     {
         $fixturesDir = __DIR__.'/../Fixtures';

--- a/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/AnnotationFileLoaderTest.php
@@ -34,9 +34,6 @@ class AnnotationFileLoaderTest extends AbstractAnnotationLoaderTest
         $this->loader->load(__DIR__.'/../Fixtures/AnnotatedClasses/FooClass.php');
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\AnnotationFileLoader::supports
-     */
     public function testSupports()
     {
         $fixture = __DIR__.'/../Fixtures/annotated.php';

--- a/src/Symfony/Component/Routing/Tests/Loader/ClosureLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/ClosureLoaderTest.php
@@ -24,9 +24,6 @@ class ClosureLoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\ClosureLoader::supports
-     */
     public function testSupports()
     {
         $loader = new ClosureLoader();
@@ -40,9 +37,6 @@ class ClosureLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->supports($closure, 'foo'), '->supports() checks the resource type if specified');
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\ClosureLoader::load
-     */
     public function testLoad()
     {
         $loader = new ClosureLoader();

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\PhpFileLoader;
-use Symfony\Component\Routing\Route;
 
 class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
@@ -24,9 +23,6 @@ class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\PhpFileLoader::supports
-     */
     public function testSupports()
     {
         $loader = new PhpFileLoader($this->getMock('Symfony\Component\Config\FileLocator'));

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -56,6 +56,21 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('RouteCompiler', $route->getOption('compiler_class'));
     }
 
+    public function testLoadWithNamespacePrefix()
+    {
+        $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
+        $routeCollection = $loader->load('namespaceprefix.xml');
+
+        $this->assertCount(1, $routeCollection, 'One route is loaded');
+        $route = $routeCollection->get('blog_show');
+        $this->assertEquals('/blog/{slug}', $route->getPattern());
+        $this->assertEquals('MyBundle:Blog:show', $route->getDefault('_controller'));
+        $this->assertEquals('\w+', $route->getRequirement('slug'));
+        $this->assertEquals('en|fr|de', $route->getRequirement('_locale'));
+        $this->assertEquals('{_locale}.example.com', $route->getHostnamePattern());
+        $this->assertEquals('RouteCompiler', $route->getOption('compiler_class'));
+    }
+
     public function testLoadWithImport()
     {
         $loader = new XmlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
@@ -94,7 +109,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function getPathsToInvalidFiles()
     {
-        return array(array('nonvalidnode.xml'), array('nonvalidroute.xml'), array('nonvalid.xml'));
+        return array(array('nonvalidnode.xml'), array('nonvalidroute.xml'), array('nonvalid.xml'), array('missing_id.xml'), array('missing_path.xml'));
     }
 
     /**

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\Tests\Fixtures\CustomXmlFileLoader;
 
 class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
@@ -25,9 +24,6 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\XmlFileLoader::supports
-     */
     public function testSupports()
     {
         $loader = new XmlFileLoader($this->getMock('Symfony\Component\Config\FileLocator'));

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -50,29 +50,17 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \InvalidArgumentException
+     * @dataProvider getPathsToInvalidFiles
      */
-    public function testLoadThrowsExceptionIfNotAnArray()
+    public function testLoadThrowsExceptionWithInvalidFile($filePath)
     {
         $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
-        $loader->load('nonvalid.yml');
+        $loader->load($filePath);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testLoadThrowsExceptionIfArrayHasUnsupportedKeys()
+    public function getPathsToInvalidFiles()
     {
-        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
-        $loader->load('nonvalidkeys.yml');
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testLoadThrowsExceptionWhenIncomplete()
-    {
-        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
-        $loader->load('incomplete.yml');
+        return array(array('nonvalid.yml'), array('nonvalid2.yml'), array('incomplete.yml'), array('nonvalidkeys.yml'), array('nonesense_resource_plus_path.yml'), array('nonesense_type_without_resource.yml'));
     }
 
     public function testLoadSpecialRouteName()
@@ -116,14 +104,5 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('\d+', $routes['blog_show']->getRequirement('foo'));
         $this->assertEquals('bar', $routes['blog_show']->getOption('foo'));
         $this->assertEquals('{locale}.example.com', $routes['blog_show']->getHostnamePattern());
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testParseRouteThrowsExceptionWithMissingPattern()
-    {
-        $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
-        $loader->load('incomplete.yml');
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Routing\Tests\Loader;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Routing\Loader\YamlFileLoader;
-use Symfony\Component\Routing\Route;
 use Symfony\Component\Config\Resource\FileResource;
 
 class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
@@ -29,9 +28,6 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @covers Symfony\Component\Routing\Loader\YamlFileLoader::supports
-     */
     public function testSupports()
     {
         $loader = new YamlFileLoader($this->getMock('Symfony\Component\Config\FileLocator'));


### PR DESCRIPTION
BC break: no

Main points:
- fixed Xml loader that could not handle namespace prefixes but is valid xml
- fixed Yaml loader where some nonsesense configs were not validated correctly like an imported resource with a pattern key. 

Added tests for all. Some refactoring + a few tweaks like better exception messages and more consistency between Xml loader and yaml loader. See also commits.
