### PR TITLE
[Validator] made ExecutionContext more consistent

### DIFF
--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -172,9 +172,9 @@ class ExecutionContext implements ExecutionContextInterface
     /**
      * {@inheritdoc}
      */
-    public function getPropertyPath($subPath = null)
+    public function getPropertyPath($subPath = '')
     {
-        if (null !== $subPath && '' !== $this->propertyPath && '' !== $subPath && '[' !== $subPath[0]) {
+        if ('' != $subPath && '' !== $this->propertyPath && '[' !== $subPath[0]) {
             return $this->propertyPath . '.' . $subPath;
         }
 

--- a/src/Symfony/Component/Validator/ExecutionContextInterface.php
+++ b/src/Symfony/Component/Validator/ExecutionContextInterface.php
@@ -300,5 +300,5 @@ interface ExecutionContextInterface
      *                string if the validator is currently validating the
      *                root value of the validation graph.
      */
-    public function getPropertyPath($subPath = null);
+    public function getPropertyPath($subPath = '');
 }


### PR DESCRIPTION
BC break: no

The default should be an empty string instead of null because
1. a string is expected according to phpdoc
2. its more consistent with `validate($value, $groups = null, $subPath = '', $traverse = false, $deep = false)` and `validateValue($value, $constraints, $groups = null, $subPath = '')` that both have `''` as default for subPath
