### PR TITLE
[Console][Translation] yaml output support for nested messages codes

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -10,6 +10,7 @@ CHANGELOG
  * A new parameter has been added to the DIC: `router.request_context.base_url`
    You can customize it for your functional tests or for generating urls with
    the right base url when your are in the cli context.
+ * added an option to translation:update for outputing nested yaml instead of line-by-line messages
 
 2.1.0
 -----

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -131,15 +131,15 @@ EOF
 
         // save the files
         if ($input->getOption('force') === true) {
-            
-			$options = array('path' => $bundleTransPath);
-			
-			// case of nested yaml files
-			if ($input->getOption('output-format') == 'yml' && $input->hasOption('nest-level')) {
-				$options['nest-level'] = $input->getOption('nest-level');
-			}
 
-			$output->writeln('Writing files');
+            $options = array('path' => $bundleTransPath);
+
+            // case of nested yaml files
+            if ($input->getOption('output-format') == 'yml' && $input->hasOption('nest-level')) {
+                $options['nest-level'] = $input->getOption('nest-level');
+            }
+
+            $output->writeln('Writing files');
             $writer->writeTranslations($catalogue, $input->getOption('output-format'), $options);
         }
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/TranslationUpdateCommand.php
@@ -57,6 +57,10 @@ class TranslationUpdateCommand extends ContainerAwareCommand
                 new InputOption(
                     'force', null, InputOption::VALUE_NONE,
                     'Should the update be done'
+                ),
+                new InputOption(
+                    'nest-level', null, InputOption::VALUE_REQUIRED,
+                    'If YAML is used for file format, will nest message keys using dot as separator', 0
                 )
             ))
             ->setDescription('Updates the translation file')
@@ -127,8 +131,16 @@ EOF
 
         // save the files
         if ($input->getOption('force') === true) {
-            $output->writeln('Writing files');
-            $writer->writeTranslations($catalogue, $input->getOption('output-format'), array('path' => $bundleTransPath));
+            
+			$options = array('path' => $bundleTransPath);
+			
+			// case of nested yaml files
+			if ($input->getOption('output-format') == 'yml' && $input->hasOption('nest-level')) {
+				$options['nest-level'] = $input->getOption('nest-level');
+			}
+
+			$output->writeln('Writing files');
+            $writer->writeTranslations($catalogue, $input->getOption('output-format'), $options);
         }
     }
 }

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.2.0
+-----
+
+ * added support for nested yaml output instead of line-by-line messages
+
 2.1.0
 -----
 

--- a/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
@@ -21,59 +21,58 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlFileDumper extends FileDumper
 {
-	/**
-	 * @var integer Nesting depth. 0 means one line by message, 1 will
-	 * indent at most one time, and so on.
-	 */
-	public $nestLevel = 0; 
-	
-	/**
+    /**
+     * @var integer Nesting depth. 0 means one line by message, 1 will
+     * indent at most one time, and so on.
+     */
+    public $nestLevel = 0;
+
+    /**
      * {@inheritDoc}
      */
     public function dump(MessageCatalogue $messages, $options = array())
     {
-		$this->nestLevel = array_key_exists('nest-level', $options) ? $options['nest-level'] : 0;
-		print_r($options);
-        
-		parent::dump($messages, $options);
-	}
+        $this->nestLevel = array_key_exists('nest-level', $options) ? $options['nest-level'] : 0;
+        print_r($options);
+
+        parent::dump($messages, $options);
+    }
     /**
      * {@inheritDoc}
      */
     protected function format(MessageCatalogue $messages, $domain)
     {
-		$m = $messages->all($domain);
-		
-		if ($this->nestLevel > 0)
-		{
-			// build a message tree from the message list, with a max depth
-			// of $this->nestLevel
-			$tree = array();
-			foreach ($m as $key => $message) {
+        $m = $messages->all($domain);
 
-				// dots are ignored at the beginning and at the end of a key
-				$key = trim($key, "\t .");
+        if ($this->nestLevel > 0) {
+            // build a message tree from the message list, with a max depth
+            // of $this->nestLevel
+            $tree = array();
+            foreach ($m as $key => $message) {
 
-				if (strlen($key) > 0) {
-					$codes = explode('.', $key, $this->nestLevel+1);
-					$node = &$tree;
+                // dots are ignored at the beginning and at the end of a key
+                $key = trim($key, "\t .");
 
-					foreach ($codes as $code) {
-						if (strlen($code) > 0) {
-							if (!isset($node)) {
-								$node = array();
-							}
-							$node = &$node[$code];
-						}
-					}
-					$node = $message;
-				}
-			}
-			
-			return Yaml::dump($tree, $this->nestLevel+1); // second parameter at 1 outputs normal line-by-line catalogue
-		} else {
-			return Yaml::dump($m, 1);
-		}
+                if (strlen($key) > 0) {
+                    $codes = explode('.', $key, $this->nestLevel+1);
+                    $node = &$tree;
+
+                    foreach ($codes as $code) {
+                        if (strlen($code) > 0) {
+                            if (!isset($node)) {
+                                $node = array();
+                            }
+                            $node = &$node[$code];
+                        }
+                    }
+                    $node = $message;
+                }
+            }
+
+            return Yaml::dump($tree, $this->nestLevel+1); // second parameter at 1 outputs normal line-by-line catalogue
+        } else {
+            return Yaml::dump($m, 1);
+        }
     }
 
     /**

--- a/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
+++ b/src/Symfony/Component/Translation/Dumper/YamlFileDumper.php
@@ -21,12 +21,59 @@ use Symfony\Component\Yaml\Yaml;
  */
 class YamlFileDumper extends FileDumper
 {
+	/**
+	 * @var integer Nesting depth. 0 means one line by message, 1 will
+	 * indent at most one time, and so on.
+	 */
+	public $nestLevel = 0; 
+	
+	/**
+     * {@inheritDoc}
+     */
+    public function dump(MessageCatalogue $messages, $options = array())
+    {
+		$this->nestLevel = array_key_exists('nest-level', $options) ? $options['nest-level'] : 0;
+		print_r($options);
+        
+		parent::dump($messages, $options);
+	}
     /**
      * {@inheritDoc}
      */
     protected function format(MessageCatalogue $messages, $domain)
     {
-         return Yaml::dump($messages->all($domain));
+		$m = $messages->all($domain);
+		
+		if ($this->nestLevel > 0)
+		{
+			// build a message tree from the message list, with a max depth
+			// of $this->nestLevel
+			$tree = array();
+			foreach ($m as $key => $message) {
+
+				// dots are ignored at the beginning and at the end of a key
+				$key = trim($key, "\t .");
+
+				if (strlen($key) > 0) {
+					$codes = explode('.', $key, $this->nestLevel+1);
+					$node = &$tree;
+
+					foreach ($codes as $code) {
+						if (strlen($code) > 0) {
+							if (!isset($node)) {
+								$node = array();
+							}
+							$node = &$node[$code];
+						}
+					}
+					$node = $message;
+				}
+			}
+			
+			return Yaml::dump($tree, $this->nestLevel+1); // second parameter at 1 outputs normal line-by-line catalogue
+		} else {
+			return Yaml::dump($m, 1);
+		}
     }
 
     /**


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6192
Todo: -
License of the code: MIT
Documentation PR: -

`translation:update` command now accepts the option `--nest-level` which works in conjunction with YAML output format.
This options, which must have an integer value starting from 1, makes the dumper output nested YAML translation codes instead of line-by-line, as supported by the translator when using codes instead of real text in message files.

```
admin.hello: Hello administrator!
admin.exit: Quit administration
```

becomes:

```
admin:
    hello: Hello administrator!
    exit: Quit administration
```
