### PR TITLE
[WIP] [2.2] [HttpKernel] added commands to clear, cleanup and introspect the HttpCache

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/AbstractHttpCacheCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/AbstractHttpCacheCommand.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
+
+abstract class AbstractHttpCacheCommand extends ContainerAwareCommand
+{
+    /**
+     * @return array
+     */
+    protected function getDefinitionArray()
+    {
+        return array(
+            new InputArgument('uri', InputArgument::OPTIONAL, 'A full uri, including the scheme, host, path and query string'),
+            new InputOption('kernel_class_name', '', InputOption::VALUE_OPTIONAL, 'Name of the HttpCache kernel', 'AppCache'),
+        );
+    }
+
+    /**
+     * @return string cache dir
+     * @throws \RuntimeException
+     */
+    protected function getCacheDir()
+    {
+        $cacheDir = $this->getContainer()->getParameter('kernel.cache_dir').'/http_cache';
+        if (!is_readable($cacheDir)) {
+            throw new \RuntimeException(sprintf('Unable to write in the "%s" directory', $cacheDir));
+        }
+
+        return $cacheDir;
+    }
+
+    /**
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\HttpKernel\KernelInterface $kernel
+     * @return \Symfony\Component\HttpKernel\HttpCache\HttpCache
+     * @throws \RuntimeException
+     */
+    protected function getCacheKernel(InputInterface $input, KernelInterface $kernel)
+    {
+        $kernelClassName = $input->getOption('kernel_class_name');
+        if (!class_exists($kernelClassName)) {
+            throw new \RuntimeException(sprintf('Kernel class "%s" not loadable', $kernelClassName));
+        }
+
+        $cacheKernel = new $kernelClassName($kernel);
+        if (! $cacheKernel instanceof HttpCache) {
+            throw new \RuntimeException(sprintf('Kernel ("%s") is not an instance of HttpCache', get_class($kernel)));
+        }
+
+        return $cacheKernel;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/HttpCacheCleanupCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/HttpCacheCleanupCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * TODO: this command is a bit all over the place
+ * imho there should be a command for releasing locks and purging stale data
+ * and it should be able to do this for all cache entries or just a specific uri
+ * note sure if this should be two separate or just one command
+ * also this will require further changes to Store/StoreInterface
+ */
+class HttpCacheCleanupCommand extends AbstractHttpCacheCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('http:cache:cleanup')
+            ->setDefinition($this->getDefinitionArray())
+            ->setDescription('Cleans up locked files in the http cache')
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> command cleans up all locked entries in the http cache
+for a given environment and debug mode:
+
+<info>php %command.full_name% --env=dev</info>
+<info>php %command.full_name% --env=prod --no-debug</info>
+EOF
+        )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $kernel = $this->getContainer()->get('kernel');
+        $cacheKernel = $this->getCacheKernel($input, $kernel);
+
+        $uri = $input->getArgument('uri');
+        if (empty($uri)) {
+            $output->writeln(sprintf('Cleaning up the http cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+            $cacheKernel->getStore()->cleanup();
+            return 0;
+        }
+
+        $output->writeln(sprintf('Cleaning up the http cache for the uri <info>%s</info> and the <info>%s</info> environment with debug <info>%s</info>', $uri, $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
+        $store = $cacheKernel->getStore();
+        $request = Request::create($uri);
+        if ($store->isLocked($request)) {
+            $output->writeln(sprintf('Removed lock for the uri <info>%s</info>', $uri));
+            $store->unlock($request);
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/HttpCacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/HttpCacheClearCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class HttpCacheClearCommand extends AbstractHttpCacheCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('http:cache:clear')
+            ->setDefinition($this->getDefinitionArray())
+            ->setDescription('Clears the http cache')
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> command clears the application http cache for a given environment
+and debug mode:
+
+<info>php %command.full_name% --env=dev</info>
+<info>php %command.full_name% --env=prod --no-debug</info>
+EOF
+        )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $kernel = $this->getContainer()->get('kernel');
+        $cacheKernel = $this->getCacheKernel($input, $kernel);
+
+        $uri = $input->getArgument('uri');
+        if (empty($uri)) {
+            $output->writeln(sprintf('Clearing the http cache for the <info>%s</info> environment with debug <info>%s</info>', $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+            $filesystem = $this->getContainer()->get('filesystem');
+            $cacheDir = $this->getCacheDir();
+            $filesystem->remove($cacheDir);
+            return 0;
+        }
+
+        $output->writeln(sprintf('Clearing the http cache for the uri <info>%s</info> and the <info>%s</info> environment with debug <info>%s</info>', $uri, $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
+        $store = $cacheKernel->getStore();
+        $store->purge($uri);
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/HttpCacheInfoCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/HttpCacheInfoCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class HttpCacheInfoCommand extends AbstractHttpCacheCommand
+{
+    /**
+     * @see Command
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('http:cache:info')
+            ->setDefinition($this->getDefinitionArray())
+            ->setDescription('Provides information about entries in the http cache')
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> command provides information about entries in the http cache
+for a given environment and debug mode:
+
+<info>php %command.full_name% --env=dev</info>
+<info>php %command.full_name% --env=prod --no-debug</info>
+EOF
+        )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $kernel = $this->getContainer()->get('kernel');
+        $cacheKernel = $this->getCacheKernel($input, $kernel);
+
+        $uri = $input->getArgument('uri');
+
+        $output->writeln(sprintf('Reading information from the http cache for the uri <info>%s</info> and the <info>%s</info> environment with debug <info>%s</info>', $uri, $kernel->getEnvironment(), var_export($kernel->isDebug(), true)));
+
+        $store = $cacheKernel->getStore();
+        $request = Request::create($uri);
+        $txt = $store->isCached($request) ? ('cached'.($store->isLocked($request) ? ' and locked' : ' and unlocked')) : 'not cached';
+        $output->writeln(sprintf('Location (is %s): <info>%s</info>', $txt, $store->getLocation($request)));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -106,6 +106,11 @@ class Store implements StoreInterface
         return is_file($this->getPath($this->getCacheKey($request).'.lck'));
     }
 
+    public function isCached(Request $request)
+    {
+        return is_file($this->getLocation($request));
+    }
+
     /**
      * Locates a cached Response for the Request provided.
      *
@@ -359,6 +364,11 @@ class Store implements StoreInterface
         }
 
         @chmod($path, 0666 & ~umask());
+    }
+
+    public function getLocation(Request $request)
+    {
+        return $this->getPath($this->getCacheKey($request));
     }
 
     public function getPath($key)

--- a/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/StoreInterface.php
@@ -81,6 +81,24 @@ interface StoreInterface
     public function isLocked(Request $request);
 
     /**
+     * Returns whether or not a cache entry exists.
+     *
+     * @param Request $request A Request instance
+     *
+     * @return Boolean true if cache entry exists, false otherwise
+     */
+    public function isCached(Request $request);
+
+    /**
+     * Returns the location where the cache entry is stored
+     *
+     * @param Request $request A Request instance
+     *
+     * @return string Location of the cache entry for the given Request
+     */
+    public function getLocation(Request $request);
+
+    /**
      * Purges data for the given URL.
      *
      * @param string $url A URL


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes (see below) |
| Deprecations? | - |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

this is a bit hacky since its not so easy to get the HttpCache instance for the project. essentially the solution is that it is expected that the kernel class is autoloadable (and that it can be instanciated by simply passing the actual kernel as a constructor argument).

i also made some adjustments to the Store interface to be able to give more information about cache entries but to prevent BC breaks maybe this should be done in a new interface.

i am not sure if some of the logic in the commands should sit in the HttpKernel component and then extended in the Bundle, but that would make it harder to keep the redundant logic in an abstract class.

furthermore i wonder if there is a sensible way to make this pluggable with other reverse proxies. i have a simple solution for varnish purging here: https://github.com/liip/LiipCacheControlBundle/blob/master/Helper/Varnish.php

ezPublish guys have something more sophisticated here https://github.com/ezsystems/ezp-next/tree/master/eZ/Publish/Core/MVC/Symfony/Cache/Http
