### PR TITLE
[Form] Fixed the "format" option in DateType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -180,6 +180,10 @@ class DateType extends AbstractType
             );
         };
 
+        $format = function (Options $options) {
+            return $options['widget'] === 'single_text' ? self::HTML5_FORMAT : self::DEFAULT_FORMAT;
+        };
+
         // BC until Symfony 2.3
         $modelTimezone = function (Options $options) {
             return $options['data_timezone'];
@@ -196,7 +200,7 @@ class DateType extends AbstractType
             'days'           => range(1, 31),
             'widget'         => 'choice',
             'input'          => 'datetime',
-            'format'         => self::HTML5_FORMAT,
+            'format'         => $format,
             'model_timezone' => $modelTimezone,
             'view_timezone'  => $viewTimezone,
             // Deprecated timezone options

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -809,14 +809,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [@id="name_date"]
             [
                 ./select
-                    [@id="name_date_year"]
-                    [./option[@value="2011"][@selected="selected"]]
-                /following-sibling::select
                     [@id="name_date_month"]
                     [./option[@value="2"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_date_day"]
                     [./option[@value="3"][@selected="selected"]]
+                /following-sibling::select
+                    [@id="name_date_year"]
+                    [./option[@value="2011"][@selected="selected"]]
             ]
         /following-sibling::div
             [@id="name_time"]
@@ -849,13 +849,13 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [@id="name_date"]
             [
                 ./select
-                    [@id="name_date_year"]
-                    [./option[@value=""][.="[trans]Change&Me[/trans]"]]
-                /following-sibling::select
                     [@id="name_date_month"]
                     [./option[@value=""][.="[trans]Change&Me[/trans]"]]
                 /following-sibling::select
                     [@id="name_date_day"]
+                    [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+                /following-sibling::select
+                    [@id="name_date_year"]
                     [./option[@value=""][.="[trans]Change&Me[/trans]"]]
             ]
         /following-sibling::div
@@ -889,14 +889,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [@id="name_date"]
             [
                 ./select
-                    [@id="name_date_year"]
-                    [./option[@value="2011"][@selected="selected"]]
-                /following-sibling::select
                     [@id="name_date_month"]
                     [./option[@value="2"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_date_day"]
                     [./option[@value="3"][@selected="selected"]]
+                /following-sibling::select
+                    [@id="name_date_year"]
+                    [./option[@value="2011"][@selected="selected"]]
             ]
         /following-sibling::div
             [@id="name_time"]
@@ -928,14 +928,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [@id="name_date"]
             [
                 ./select
-                    [@id="name_date_year"]
-                    [./option[@value="2011"][@selected="selected"]]
-                /following-sibling::select
                     [@id="name_date_month"]
                     [./option[@value="2"][@selected="selected"]]
                 /following-sibling::select
                     [@id="name_date_day"]
                     [./option[@value="3"][@selected="selected"]]
+                /following-sibling::select
+                    [@id="name_date_year"]
+                    [./option[@value="2011"][@selected="selected"]]
             ]
         /following-sibling::div
             [@id="name_time"]
@@ -1031,14 +1031,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '/div
     [
         ./select
-            [@id="name_year"]
-            [./option[@value="2011"][@selected="selected"]]
-        /following-sibling::select
             [@id="name_month"]
             [./option[@value="2"][@selected="selected"]]
         /following-sibling::select
             [@id="name_day"]
             [./option[@value="3"][@selected="selected"]]
+        /following-sibling::select
+            [@id="name_year"]
+            [./option[@value="2011"][@selected="selected"]]
     ]
     [count(./select)=3]
 '
@@ -1058,13 +1058,13 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '/div
     [
         ./select
-            [@id="name_year"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
-        /following-sibling::select
             [@id="name_month"]
             [./option[@value=""][.="[trans]Change&Me[/trans]"]]
         /following-sibling::select
             [@id="name_day"]
+            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+        /following-sibling::select
+            [@id="name_year"]
             [./option[@value=""][.="[trans]Change&Me[/trans]"]]
     ]
     [count(./select)=3]
@@ -1085,14 +1085,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '/div
     [
         ./select
-            [@id="name_year"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
-        /following-sibling::select
             [@id="name_month"]
             [./option[@value="1"]]
         /following-sibling::select
             [@id="name_day"]
             [./option[@value="1"]]
+        /following-sibling::select
+            [@id="name_year"]
+            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
     ]
     [count(./select)=3]
 '
@@ -1110,10 +1110,6 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '/div
     [
         ./input
-            [@id="name_year"]
-            [@type="text"]
-            [@value="2011"]
-        /following-sibling::input
             [@id="name_month"]
             [@type="text"]
             [@value="2"]
@@ -1121,6 +1117,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [@id="name_day"]
             [@type="text"]
             [@value="3"]
+        /following-sibling::input
+            [@id="name_year"]
+            [@type="text"]
+            [@value="2011"]
     ]
     [count(./input)=3]
 '
@@ -1164,14 +1164,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '/div
     [
         ./select
-            [@id="name_year"]
-            [./option[@value="2000"][@selected="selected"]]
-        /following-sibling::select
             [@id="name_month"]
             [./option[@value="2"][@selected="selected"]]
         /following-sibling::select
             [@id="name_day"]
             [./option[@value="3"][@selected="selected"]]
+        /following-sibling::select
+            [@id="name_year"]
+            [./option[@value="2000"][@selected="selected"]]
     ]
     [count(./select)=3]
 '
@@ -1190,10 +1190,6 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 '/div
     [
         ./select
-            [@id="name_year"]
-            [./option[@value=""][.="[trans][/trans]"]]
-            [./option[@value="1950"][@selected="selected"]]
-        /following-sibling::select
             [@id="name_month"]
             [./option[@value=""][.="[trans][/trans]"]]
             [./option[@value="1"][@selected="selected"]]
@@ -1201,6 +1197,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [@id="name_day"]
             [./option[@value=""][.="[trans][/trans]"]]
             [./option[@value="1"][@selected="selected"]]
+        /following-sibling::select
+            [@id="name_year"]
+            [./option[@value=""][.="[trans][/trans]"]]
+            [./option[@value="1950"][@selected="selected"]]
     ]
     [count(./select)=3]
 '

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -510,18 +510,18 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date');
         $view = $form->createView();
 
-        $this->assertSame('{{ year }}-{{ month }}-{{ day }}', $view->vars['date_pattern']);
+        $this->assertSame('{{ day }}.{{ month }}.{{ year }}', $view->vars['date_pattern']);
     }
 
     public function testPassDatePatternToViewDifferentFormat()
     {
         $form = $this->factory->create('date', null, array(
-            'format' => \IntlDateFormatter::MEDIUM,
+            'format' => \IntlDateFormatter::LONG,
         ));
 
         $view = $form->createView();
 
-        $this->assertSame('{{ day }}.{{ month }}.{{ year }}', $view->vars['date_pattern']);
+        $this->assertSame('{{ day }}. {{ month }} {{ year }}', $view->vars['date_pattern']);
     }
 
     public function testPassDatePatternToViewDifferentPattern()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6141
Todo: -
License of the code: MIT
Documentation PR: -

This PR fixes a regression introduced in #4839. To quote that PR:

> This PR changes DateType and DateTimeType to support HTML5 by default when setting the option "widget" to "single_text".

In reality, the "format" option now defaults to the HTML5 format always, not just when "widget" is "single_text". This is fixed here.
