### PR TITLE
[HttpFoundation] changed UploadedFile::move() to use move_uploaded_file() when possible (closes #5878, closes #6185)

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/File.php
+++ b/src/Symfony/Component/HttpFoundation/File/File.php
@@ -524,6 +524,20 @@ class File extends \SplFileInfo
      */
     public function move($directory, $name = null)
     {
+        $target = $this->getTargetFile($directory, $name);
+
+        if (!@rename($this->getPathname(), $target)) {
+            $error = error_get_last();
+            throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
+        }
+
+        @chmod($target, 0666 & ~umask());
+
+        return $target;
+    }
+
+    protected function getTargetFile($directory, $name = null)
+    {
         if (!is_dir($directory)) {
             if (false === @mkdir($directory, 0777, true)) {
                 throw new FileException(sprintf('Unable to create the "%s" directory', $directory));
@@ -534,14 +548,7 @@ class File extends \SplFileInfo
 
         $target = $directory.DIRECTORY_SEPARATOR.(null === $name ? $this->getBasename() : $this->getName($name));
 
-        if (!@rename($this->getPathname(), $target)) {
-            $error = error_get_last();
-            throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
-        }
-
-        chmod($target, 0666);
-
-        return new File($target);
+        return new File($target, false);
     }
 
     /**


### PR DESCRIPTION
An alternative for #5878 and it fixes #6185.
