### PR TITLE
[2.0][2.1][2.2] [Config] Loader::import must return imported data

### DIFF
--- a/src/Symfony/Component/Config/Loader/Loader.php
+++ b/src/Symfony/Component/Config/Loader/Loader.php
@@ -47,10 +47,12 @@ abstract class Loader implements LoaderInterface
      *
      * @param mixed  $resource A Resource
      * @param string $type     The resource type
+     *
+     * @return mixed
      */
     public function import($resource, $type = null)
     {
-        $this->resolve($resource)->load($resource, $type);
+        return $this->resolve($resource)->load($resource, $type);
     }
 
     /**

--- a/tests/Symfony/Tests/Component/Config/Loader/LoaderTest.php
+++ b/tests/Symfony/Tests/Component/Config/Loader/LoaderTest.php
@@ -55,6 +55,15 @@ class LoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertInstanceOf('Symfony\Component\Config\Exception\FileLoaderLoadException', $e, '->resolve() throws a FileLoaderLoadException if the resource cannot be loaded');
         }
     }
+
+    public function testImport()
+    {
+        $loader = $this->getMock('Symfony\Component\Config\Loader\Loader', array('supports', 'load'));
+        $loader->expects($this->once())->method('supports')->will($this->returnValue(true));
+        $loader->expects($this->once())->method('load')->will($this->returnValue('yes'));
+
+        $this->assertEquals('yes', $loader->import('foo'));
+    }
 }
 
 class ProjectLoader1 extends Loader


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
