### PR TITLE
[OptionsResolver] Fixed unexpected behavior when using setOptional + setNormalizers

### DIFF
--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsTest.php
@@ -520,10 +520,8 @@ class OptionsTest extends \PHPUnit_Framework_TestCase
         $test = $this;
 
         $this->options->setNormalizer('foo', function (Options $options, $previousValue) use ($test) {
-            $test->assertNull($previousValue);
-
-            return '';
+            $test->fail('Should not be called');
         });
-        $this->assertEquals(array('foo' => ''), $this->options->all());
+        $this->assertEquals(array(), $this->options->all());
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6215
License of the code: MIT
