### PR TITLE
[Routing] no need to set the compiled route to null when cloning

### DIFF
--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -76,11 +76,6 @@ class Route implements \Serializable
         $this->setHostnamePattern($hostnamePattern);
     }
 
-    public function __clone()
-    {
-        $this->compiled = null;
-    }
-
     public function serialize()
     {
         return serialize(array(


### PR DESCRIPTION
The compiled reference can be reused when cloning. When the route is changed, the compiled reference is set to null anyway. So if you just clone the route, this improves performance as it does not need to recompile.
