### PR TITLE
Fixed: HeaderBag::parseCacheControl() not parsing quoted zero correctly

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/HeaderBag.php
@@ -317,7 +317,7 @@ class HeaderBag implements \IteratorAggregate, \Countable
         $cacheControl = array();
         preg_match_all('#([a-zA-Z][a-zA-Z_-]*)\s*(?:=(?:"([^"]*)"|([^ \t",;]*)))?#', $header, $matches, PREG_SET_ORDER);
         foreach ($matches as $match) {
-            $cacheControl[strtolower($match[1])] = isset($match[2]) && $match[2] ? $match[2] : (isset($match[3]) ? $match[3] : true);
+            $cacheControl[strtolower($match[1])] = isset($match[3]) ? $match[3] : (isset($match[2]) ? $match[2] : true);
         }
 
         return $cacheControl;

--- a/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HeaderBagTest.php
@@ -168,6 +168,13 @@ class HeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('max-age=10, public, s-maxage=100', $bag->get('cache-control'));
     }
 
+    public function testCacheControlDirectiveParsingQuotedZero()
+    {
+        $bag = new HeaderBag(array('cache-control' => 'max-age="0"'));
+        $this->assertTrue($bag->hasCacheControlDirective('max-age'));
+        $this->assertEquals(0, $bag->getCacheControlDirective('max-age'));
+    }
+
     public function testCacheControlDirectiveOverrideWithReplace()
     {
         $bag = new HeaderBag(array('cache-control' => 'private, max-age=100'));


### PR DESCRIPTION
When having a Cache-Control header like:

```
max-age="0"
```

`isset($match[2])` is true but `$match[2]` containing: `"0"`, it is evaluated
as `false`. The result is that `true` will be set to "max-age" entry instead of `"0"`.
