### PR TITLE
[Form] add setOption/setOptions to FormConfigBuilder

### DIFF
--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -646,6 +646,34 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function setOption($name, $value)
+    {
+        if ($this->locked) {
+            throw new FormException('The config builder cannot be modified anymore.');
+        }
+
+        $this->options[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        if ($this->locked) {
+            throw new FormException('The config builder cannot be modified anymore.');
+        }
+
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setDataMapper(DataMapperInterface $dataMapper = null)
     {
         if ($this->locked) {

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -115,6 +115,25 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setAttributes(array $attributes);
 
     /**
+     * Sets the value for an option.
+     *
+     * @param string $name  The name of the option
+     * @param string $value The value of the option
+     *
+     * @return self The configuration object.
+     */
+    public function setOption($name, $value);
+
+    /**
+     * Sets the options.
+     *
+     * @param array $options The options
+     *
+     * @return self The configuration object.
+     */
+    public function setOptions(array $options);
+
+    /**
      * Sets the data mapper used by the form.
      *
      * @param  DataMapperInterface $dataMapper


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: travis fails...
License of the code: MIT

Use case:  I have a form that inherits another.  I want to change some of the options on the parent's fields.
