### PR TITLE
[HttpKernel] ExceptionHandler is actually displaying all PHP errors

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/ExceptionHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ExceptionHandler.php
@@ -234,9 +234,6 @@ EOF;
             img { border: 0; }
             #sf-resetcontent { width:970px; margin:0 auto; }
             $css
-            .xdebug-error {
-                display: none;
-            }
         </style>
     </head>
     <body>

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -95,17 +95,18 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
     public function init()
     {
+        ini_set('display_errors', 0);
+
         if ($this->debug) {
-            ini_set('display_errors', 1);
             error_reporting(-1);
 
             DebugClassLoader::enable();
             ErrorHandler::register($this->errorReportingLevel);
             if ('cli' !== php_sapi_name()) {
                 ExceptionHandler::register();
+            } else {
+                ini_set('display_errors', 1);
             }
-        } else {
-            ini_set('display_errors', 0);
         }
     }
 


### PR DESCRIPTION
So there is no need to set display_errors to true in that case.

Partially fixes #6254.
