### PR TITLE
workaround PHP bug #55156

### DIFF
--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -248,6 +248,12 @@ class UniversalClassLoader
     public function loadClass($class)
     {
         if ($file = $this->findFile($class)) {
+
+            if (PHP_VERSION_ID < 50308) {
+                // workaround PHP bug #55156
+                eval('{}');
+            }
+
             require $file;
 
             return true;


### PR DESCRIPTION
PHP bug #55156 is related to internal parser's state not being reset correctly. To force a reset, parsing a closing curly bracket is enough. That's what this eval does.

This patch should be applied everywhere an include is done.
