### PR TITLE
[HttpKernel] remove realpath call

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -172,7 +172,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
      */
     public function registerCommands(Application $application)
     {
-        if (!$dir = realpath($this->getPath().'/Command')) {
+        if (!is_dir($dir = $this->getPath().'/Command')) {
             return;
         }
 


### PR DESCRIPTION
I'm trying to create an executable phar archive from a Symfony application, but when I run the phar, it fails to find any commands because of this php bug/feature:

https://bugs.php.net/bug.php?id=52769

After this change, my archive works just like a normal app/console call
