### PR TITLE
[HttpFoundation] Default request `_format` should be aware of HTTP Accept header

### DIFF
--- a/src/Symfony/Component/HttpFoundation/AcceptHeader.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeader.php
@@ -52,6 +52,10 @@ class AcceptHeader
      */
     public static function fromString($headerValue)
     {
+        if (empty($headerValue)) {
+            return new self(array());
+        }
+
         $index = 0;
 
         return new self(array_map(function ($itemValue) use (&$index) {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1147,6 +1147,7 @@ class Request
      *
      *  * format defined by the user (with setRequestFormat())
      *  * _format request parameter
+     *  * `Accept` header value
      *  * $default
      *
      * @param string $default The default format
@@ -1158,7 +1159,12 @@ class Request
     public function getRequestFormat($default = 'html')
     {
         if (null === $this->format) {
-            $this->format = $this->get('_format', $default);
+            $format = AcceptHeader::fromString($this->headers->get('Accept'))->first();
+            if ($format) {
+                $format = $this->getFormat($format->getValue());
+            }
+
+            $this->format = $this->get('_format', $format ?: $default);
         }
 
         return $this->format;

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1056,6 +1056,16 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $this->assertNull($request->setRequestFormat('foo'));
         $this->assertEquals('foo', $request->getRequestFormat(null));
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/xml,application/xml;q=0.9,*/*;q=0.8');
+        $this->assertEquals('xml', $request->getRequestFormat());
+        $this->assertEquals('xml', $request->getRequestFormat('json'));
+
+        $request = new Request();
+        $request->headers->set('Accept', 'text/xml,application/xml;q=0.9,*/*;q=0.8');
+        $request->setRequestFormat('foo');
+        $this->assertEquals('foo', $request->getRequestFormat());
     }
 
     public function testHasSession()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes (?)
Symfony2 tests pass: yes
Fixes the following tickets: #4567

Possible **BC break** would be in really edge case that is user sets `$default` format and expects it will be returned but now if `Accept` header is set, it has priority over default value.

> **Note:** Segfault at Travis-CI is because of some latest changes merged to master, it was passing correctly last days.
