### PR TITLE
[Yaml] Add test showing that dates before 01 Jan 1970 are correctly parsed

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/InlineTest.php
+++ b/src/Symfony/Component/Yaml/Tests/InlineTest.php
@@ -127,6 +127,8 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             '2007-10-30' => mktime(0, 0, 0, 10, 30, 2007),
             '2007-10-30T02:59:43Z' => gmmktime(2, 59, 43, 10, 30, 2007),
             '2007-10-30 02:59:43 Z' => gmmktime(2, 59, 43, 10, 30, 2007),
+            '1960-10-30 02:59:43 Z' => gmmktime(2, 59, 43, 10, 30, 1960),
+            '1730-10-30T02:59:43Z' => gmmktime(2, 59, 43, 10, 30, 1730),
 
             '"a \\"string\\" with \'quoted strings inside\'"' => 'a "string" with \'quoted strings inside\'',
             "'a \"string\" with ''quoted strings inside'''" => 'a "string" with \'quoted strings inside\'',


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes

Adds a test related to issue #6275, showing that the Yaml inline parsing supports ISO 8601 dates before 1980.
