### PR TITLE
[Validator] Card validation - Portuguese translations

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.pt.xlf
@@ -214,6 +214,14 @@
                 <source>This collection should contain exactly {{ limit }} elements.</source>
                 <target>Esta coleção deve conter exatamente {{ limit }} elemento.|Esta coleção deve conter exatamente {{ limit }} elementos.</target>
             </trans-unit>
+            <trans-unit id="57">
+                <source>Invalid card number.</source>
+                <target>Número de cartão inválido.</target>
+            </trans-unit>
+            <trans-unit id="58">
+                <source>Unsupported card type or invalid card number.</source>
+                <target>Tipo de cartão não suportado ou número de cartão inválido.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Translating new validation (57 and 58) messages to Portuguese language

``` xml
<trans-unit id="57">
                <source>Invalid card number.</source>
                <target>Número de cartão inválido.</target>
</trans-unit>
<trans-unit id="58">
                <source>Unsupported card type or invalid card number.</source>
                <target>Tipo de cartão não suportado ou número de cartão inválido.</target>
</trans-unit>
```
