### PR TITLE
[Translation] Fix loaders to check if resource exists.

### DIFF
--- a/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Locale\Tests\Stub;
 
-use Symfony\Component\Locale\Locale;
 use Symfony\Component\Locale\Stub\StubLocale;
 use Symfony\Component\Locale\Tests\TestCase as LocaleTestCase;
 
@@ -22,7 +21,7 @@ class StubLocaleTest extends LocaleTestCase
      */
     public function testGetDisplayCountriesWithUnsupportedLocale()
     {
-        $countries = StubLocale::getDisplayCountries('pt_BR');
+        StubLocale::getDisplayCountries('pt_BR');
     }
 
     public function testGetDisplayCountries()
@@ -42,7 +41,7 @@ class StubLocaleTest extends LocaleTestCase
      */
     public function testGetDisplayLanguagesWithUnsupportedLocale()
     {
-        $countries = StubLocale::getDisplayLanguages('pt_BR');
+        StubLocale::getDisplayLanguages('pt_BR');
     }
 
     public function testGetDisplayLanguages()
@@ -62,7 +61,7 @@ class StubLocaleTest extends LocaleTestCase
      */
     public function testGetCurrenciesDataWithUnsupportedLocale()
     {
-        $currencies = StubLocale::getCurrenciesData('pt_BR');
+        StubLocale::getCurrenciesData('pt_BR');
     }
 
     public function testGetCurrenciesData()
@@ -97,7 +96,7 @@ class StubLocaleTest extends LocaleTestCase
      */
     public function testGetDisplayLocalesWithUnsupportedLocale()
     {
-        $locales = StubLocale::getDisplayLocales('pt');
+        StubLocale::getDisplayLocales('pt');
     }
 
     public function testGetDisplayLocales()

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -159,8 +159,8 @@ class MoFileLoader extends ArrayLoader implements LoaderInterface
     /**
      * Reads an unsigned long from stream respecting endianess.
      *
-     * @param resource $stream
-     * @param boolean  $isBigEndian
+     * @param  resource $stream
+     * @param  boolean  $isBigEndian
      * @return integer
      */
     private function readLong($stream, $isBigEndian)

--- a/src/Symfony/Component/Translation/Loader/MoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/MoFileLoader.php
@@ -43,6 +43,10 @@ class MoFileLoader extends ArrayLoader implements LoaderInterface
 
     public function load($resource, $locale, $domain = 'messages')
     {
+        if (!file_exists($resource)) {
+            throw new \InvalidArgumentException(sprintf('File "%s" not found.', $resource));
+        }
+
         $messages = $this->parse($resource);
 
         // empty file

--- a/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PhpFileLoader.php
@@ -29,6 +29,10 @@ class PhpFileLoader extends ArrayLoader implements LoaderInterface
      */
     public function load($resource, $locale, $domain = 'messages')
     {
+        if (!file_exists($resource)) {
+            throw new \InvalidArgumentException(sprintf('File "%s" not found.', $resource));
+        }
+
         if (!stream_is_local($resource)) {
             throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $resource));
         }

--- a/src/Symfony/Component/Translation/Loader/PoFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/PoFileLoader.php
@@ -21,6 +21,10 @@ class PoFileLoader extends ArrayLoader implements LoaderInterface
 {
     public function load($resource, $locale, $domain = 'messages')
     {
+        if (!file_exists($resource)) {
+            throw new \InvalidArgumentException(sprintf('File "%s" not found.', $resource));
+        }
+
         $messages = $this->parse($resource);
 
         // empty file

--- a/src/Symfony/Component/Translation/Loader/QtTranslationsLoader.php
+++ b/src/Symfony/Component/Translation/Loader/QtTranslationsLoader.php
@@ -61,7 +61,7 @@ class QtTranslationsLoader implements LoaderInterface
     /**
      * Returns the XML errors of the internal XML parser
      *
-     * @return array  An array of errors
+     * @return array An array of errors
      */
     private function getXmlErrors()
     {

--- a/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/XliffFileLoader.php
@@ -30,6 +30,10 @@ class XliffFileLoader implements LoaderInterface
      */
     public function load($resource, $locale, $domain = 'messages')
     {
+        if (!file_exists($resource)) {
+            throw new \InvalidArgumentException(sprintf('File "%s" not found.', $resource));
+        }
+
         if (!stream_is_local($resource)) {
             throw new \InvalidArgumentException(sprintf('This is not a local file "%s".', $resource));
         }

--- a/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/CsvFileLoaderTest.php
@@ -48,7 +48,7 @@ class CsvFileLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testLoadThrowsAnExceptionIfFileNotExists()
+    public function testLoadNonExistingResource()
     {
         $loader = new CsvFileLoader();
         $resource = __DIR__.'/../fixtures/not-exists.csv';
@@ -58,7 +58,7 @@ class CsvFileLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testLoadThrowsAnExceptionIfFileNotLocal()
+    public function testLoadNonLocalResource()
     {
         $loader = new CsvFileLoader();
         $resource = 'http://example.com/resources.csv';

--- a/src/Symfony/Component/Translation/Tests/Loader/IcuDatFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IcuDatFileLoaderTest.php
@@ -56,9 +56,19 @@ class IcuDatFileLoaderTest extends LocalizedTestCase
     /**
      * @expectedException \RuntimeException
      */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new IcuDatFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.txt';
+        $loader->load($resource, 'en', 'domain1');
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
     public function testLoadInvalidResource()
     {
         $loader = new IcuDatFileLoader();
-        $catalogue = $loader->load(__DIR__.'/../fixtures/resourcebundle/res/en.txt', 'en', 'domain1');
+        $loader->load(__DIR__.'/../fixtures/resourcebundle/res/en.txt', 'en', 'domain1');
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/IcuResFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IcuResFileLoaderTest.php
@@ -43,9 +43,19 @@ class IcuResFileLoaderTest extends LocalizedTestCase
     /**
      * @expectedException \RuntimeException
      */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new IcuResFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.txt';
+        $loader->load($resource, 'en', 'domain1');
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
     public function testLoadInvalidResource()
     {
         $loader = new IcuResFileLoader();
-        $catalogue = $loader->load(__DIR__.'/../fixtures/resourcebundle/res/en.txt', 'en', 'domain1');
+        $loader->load(__DIR__.'/../fixtures/resourcebundle/res/en.txt', 'en', 'domain1');
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/IniFileLoaderTest.php
@@ -48,6 +48,16 @@ class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new IniFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.ini';
+        $loader->load($resource, 'en', 'domain1');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testLoadThrowsAnExceptionIfFileNotExists()
     {
         $loader = new IniFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/MoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/MoFileLoaderTest.php
@@ -48,10 +48,20 @@ class MoFileLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new MoFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.mo';
+        $loader->load($resource, 'en', 'domain1');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testLoadInvalidResource()
     {
         $loader = new MoFileLoader();
         $resource = __DIR__.'/../fixtures/empty.mo';
-        $catalogue = $loader->load($resource, 'en', 'domain1');
+        $loader->load($resource, 'en', 'domain1');
     }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PhpFileLoaderTest.php
@@ -37,6 +37,16 @@ class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new PhpFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.php';
+        $loader->load($resource, 'en', 'domain1');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testLoadThrowsAnExceptionIfFileNotLocal()
     {
         $loader = new PhpFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/PoFileLoaderTest.php
@@ -56,6 +56,16 @@ class PoFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new PoFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.po';
+        $loader->load($resource, 'en', 'domain1');
+    }
+
     public function testLoadEmptyTranslation()
     {
         $loader = new PoFileLoader();

--- a/src/Symfony/Component/Translation/Tests/Loader/QtTranslationsLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/QtTranslationsLoaderTest.php
@@ -33,4 +33,14 @@ class QtTranslationsLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('en', $catalogue->getLocale());
         $this->assertEquals(array(new FileResource($resource)), $catalogue->getResources());
     }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new QtTranslationsLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.ts';
+        $loader->load($resource, 'en', 'domain1');
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -48,7 +48,7 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadInvalidResource()
     {
         $loader = new XliffFileLoader();
-        $catalogue = $loader->load(__DIR__.'/../fixtures/resources.php', 'en', 'domain1');
+        $loader->load(__DIR__.'/../fixtures/resources.php', 'en', 'domain1');
     }
 
     /**
@@ -57,7 +57,17 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
     public function testLoadResourceDoesNotValidate()
     {
         $loader = new XliffFileLoader();
-        $catalogue = $loader->load(__DIR__.'/../fixtures/non-valid.xlf', 'en', 'domain1');
+        $loader->load(__DIR__.'/../fixtures/non-valid.xlf', 'en', 'domain1');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new XliffFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.xlf';
+        $loader->load($resource, 'en', 'domain1');
     }
 
     /**

--- a/src/Symfony/Component/Translation/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/YamlFileLoaderTest.php
@@ -52,6 +52,16 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
+    public function testLoadNonExistingResource()
+    {
+        $loader = new YamlFileLoader();
+        $resource = __DIR__.'/../fixtures/non-existing.yml';
+        $loader->load($resource, 'en', 'domain1');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testLoadThrowsAnExceptionIfNotAnArray()
     {
         $loader = new YamlFileLoader();


### PR DESCRIPTION
This was mentioned in #5797.

The problem is that some translation loaders throw exception when translation resource is not found, some produce warnings and some ignore this and return empty catalog.

After this fix, all of them will throw exception in such case. But still, some of them will throw `RuntimeException` and some `InvalidArgumentException` which is not perfect, but still one step in right direction.
