### PR TITLE
Update basque translation

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.eu.xlf
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="51">
                 <source>No temporary folder was configured in php.ini.</source>
-                <target>Ez da aldi baterako karpetarik konfiguratu php.ini-n</target>
+                <target>Ez da aldi baterako karpetarik konfiguratu php.ini fitxategian.</target>
             </trans-unit>
             <trans-unit id="52">
                 <source>Cannot write temporary file to disk.</source>


### PR DESCRIPTION
Update the translation for "No temporary folder was configured in php.ini" in line 195
