### PR TITLE
[Form] Fixed FileType not to throw an exception when bound empty

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FileType.php
@@ -46,7 +46,8 @@ class FileType extends AbstractType
     {
         $resolver->setDefaults(array(
             'compound' => false,
-            'data_class' => 'Symfony\Component\HttpFoundation\File\File'
+            'data_class' => 'Symfony\Component\HttpFoundation\File\File',
+            'empty_data' => null,
         ));
     }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -11,16 +11,37 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-
 class FileTypeTest extends TypeTestCase
 {
-    public function testFormBuilderIfEntityHasFile()
+    // https://github.com/symfony/symfony/pull/5028
+    public function testSetData()
     {
-        $this->factory->createBuilder('file')
-            ->getForm()
-            ->setData($this->createUploadedFileMock('abcdef', 'original.jpg', true))
-        ;
+        $form = $this->factory->createBuilder('file')->getForm();
+        $data = $this->createUploadedFileMock('abcdef', 'original.jpg', true);
+
+        $form->setData($data);
+
+        $this->assertSame($data, $form->getData());
+    }
+
+    public function testBind()
+    {
+        $form = $this->factory->createBuilder('file')->getForm();
+        $data = $this->createUploadedFileMock('abcdef', 'original.jpg', true);
+
+        $form->bind($data);
+
+        $this->assertSame($data, $form->getData());
+    }
+
+    // https://github.com/symfony/symfony/issues/6134
+    public function testBindEmpty()
+    {
+        $form = $this->factory->createBuilder('file')->getForm();
+
+        $form->bind(null);
+
+        $this->assertNull($form->getData());
     }
 
     public function testDontPassValueToView()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6134
Todo: -
License of the code: MIT
Documentation PR: -
