### PR TITLE
Webprofiler refactor

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/TwigBundle/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.2.0
 -----
 
+ * moved the exception controller to be a service (`twig.controller.exception:showAction` vs `Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController::showAction`)
  * added support for multiple loaders via the "twig.loader" tag.
  * added automatic registration of namespaced paths for registered bundles
  * added support for namespaced paths

--- a/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/TwigBundle/Controller/ExceptionController.php
@@ -101,14 +101,14 @@ class ExceptionController
         // when not in debug, try to find a template for the specific HTTP status code and format
         if (!$debug) {
             $template = new TemplateReference('TwigBundle', 'Exception', $name.$code, $format, 'twig');
-            if ($this->twig->getLoader()->exists($template)) {
+            if ($this->templateExists($template)) {
                 return $template;
             }
         }
 
         // try to find a template for the given format
         $template = new TemplateReference('TwigBundle', 'Exception', $name, $format, 'twig');
-        if ($this->twig->getLoader()->exists($template)) {
+        if ($this->templateExists($template)) {
             return $template;
         }
 
@@ -116,5 +116,23 @@ class ExceptionController
         $request->setRequestFormat('html');
 
         return new TemplateReference('TwigBundle', 'Exception', $name, 'html', 'twig');
+    }
+
+    // to be removed when the minimum required version of Twig is >= 2.0
+    protected function templateExists($template)
+    {
+        $loader = $this->twig->getLoader();
+        if ($loader instanceof \Twig_ExistsLoaderInterface && $loader->exists($template)) {
+            return true;
+        }
+
+        try {
+            $loader->getSource($template);
+
+            return true;
+        } catch (Twig_Error_Loader $e) {
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('exception_controller')->defaultValue('Symfony\\Bundle\\TwigBundle\\Controller\\ExceptionController::showAction')->end()
+                ->scalarNode('exception_controller')->defaultValue('twig.controller.exception:showAction')->end()
             ->end()
         ;
 

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -21,6 +21,7 @@
         <parameter key="twig.form.renderer.class">Symfony\Bridge\Twig\Form\TwigRenderer</parameter>
         <parameter key="twig.translation.extractor.class">Symfony\Bridge\Twig\Translation\TwigExtractor</parameter>
         <parameter key="twig.exception_listener.class">Symfony\Component\HttpKernel\EventListener\ExceptionListener</parameter>
+        <parameter key="twig.controller.exception.class">Symfony\Bundle\TwigBundle\Controller\ExceptionController</parameter>
     </parameters>
 
     <services>
@@ -110,6 +111,11 @@
             <tag name="monolog.logger" channel="request" />
             <argument>%twig.exception_listener.controller%</argument>
             <argument type="service" id="logger" on-invalid="null" />
+        </service>
+
+        <service id="twig.controller.exception" class="%twig.controller.exception.class%">
+            <argument type="service" id="twig" />
+            <argument>%kernel.debug%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
@@ -12,27 +12,37 @@
 namespace Symfony\Bundle\WebProfilerBundle\Controller;
 
 use Symfony\Component\HttpKernel\Exception\FlattenException;
-use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\TwigBundle\Controller\ExceptionController as BaseExceptionController;
 
 /**
  * ExceptionController.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ExceptionController extends BaseExceptionController
+class ExceptionController
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function showAction(FlattenException $exception, DebugLoggerInterface $logger = null, $format = 'html')
+    protected $twig;
+    protected $debug;
+
+    public function __construct(\Twig_Environment $twig, $debug)
     {
-        $template = $this->container->get('kernel')->isDebug() ? 'exception' : 'error';
+        $this->twig = $twig;
+        $this->debug = $debug;
+    }
+
+    /**
+     * Converts an Exception to a Response.
+     *
+     * @param FlattenException $exception A FlattenException instance
+     *
+     * @return Response
+     */
+    public function showAction(FlattenException $exception)
+    {
         $code = $exception->getStatusCode();
 
-        return $this->container->get('templating')->renderResponse(
-            'TwigBundle:Exception:'.$template.'.html.twig',
+        return new Response($this->twig->render(
+            '@Twig/Exception/'.($this->debug ? 'exception' : 'error').'.html.twig',
             array(
                 'status_code'    => $code,
                 'status_text'    => Response::$statusTexts[$code],
@@ -40,6 +50,6 @@ class ExceptionController extends BaseExceptionController
                 'logger'         => null,
                 'currentContent' => '',
             )
-        );
+        ));
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
@@ -82,7 +82,7 @@ class ExceptionController
         $exception = $this->profiler->loadProfile($token)->getCollector('exception')->getException();
         $template = $this->getTemplate();
 
-        if (!$this->twig->getLoader()->exists($template)) {
+        if (!$this->templateExists($template)) {
             $handler = new ExceptionHandler();
 
             return new Response($handler->getStylesheet($exception));
@@ -94,5 +94,23 @@ class ExceptionController
     protected function getTemplate()
     {
         return '@Twig/Exception/'.($this->debug ? 'exception' : 'error').'.html.twig';
+    }
+
+    // to be removed when the minimum required version of Twig is >= 2.0
+    protected function templateExists($template)
+    {
+        $loader = $this->twig->getLoader();
+        if ($loader instanceof \Twig_ExistsLoaderInterface && $loader->exists($template)) {
+            return true;
+        }
+
+        try {
+            $loader->getSource($template);
+
+            return true;
+        } catch (Twig_Error_Loader $e) {
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
@@ -107,7 +107,7 @@ class TemplateManager
                 $template = substr($template, 0, -10);
             }
 
-            if (!$this->twig->getLoader()->exists($template.'.html.twig')) {
+            if (!$this->templateExists($template.'.html.twig')) {
                 throw new \UnexpectedValueException(sprintf('The profiler template "%s.html.twig" for data collector "%s" does not exist.', $template, $name));
             }
 
@@ -115,5 +115,23 @@ class TemplateManager
         }
 
         return $templates;
+    }
+
+    // to be removed when the minimum required version of Twig is >= 2.0
+    protected function templateExists($template)
+    {
+        $loader = $this->twig->getLoader();
+        if ($loader instanceof \Twig_ExistsLoaderInterface && $loader->exists($template)) {
+            return true;
+        }
+
+        try {
+            $loader->getSource($template);
+
+            return true;
+        } catch (Twig_Error_Loader $e) {
+        }
+
+        return false;
     }
 }

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -26,6 +26,7 @@
         </service>
 
         <service id="web_profiler.controller.exception" class="%web_profiler.controller.exception.class%">
+            <argument type="service" id="profiler" />
             <argument type="service" id="twig" />
             <argument>%kernel.debug%</argument>
         </service>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/profiler.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="web_profiler.controller.profiler.class">Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController</parameter>
         <parameter key="web_profiler.controller.router.class">Symfony\Bundle\WebProfilerBundle\Controller\RouterController</parameter>
+        <parameter key="web_profiler.controller.exception.class">Symfony\Bundle\WebProfilerBundle\Controller\ExceptionController</parameter>
     </parameters>
 
     <services>
@@ -22,6 +23,11 @@
             <argument type="service" id="profiler" />
             <argument type="service" id="twig" />
             <argument type="service" id="router" on-invalid="null" />
+        </service>
+
+        <service id="web_profiler.controller.exception" class="%web_profiler.controller.exception.class%">
+            <argument type="service" id="twig" />
+            <argument>%kernel.debug%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -28,7 +28,7 @@
         </p>
     {% else %}
         <div class="sf-reset">
-            {% render 'WebProfilerBundle:Exception:show' with { 'exception': collector.exception, 'format': 'html' } %}
+            {% render 'web_profiler.controller.exception:showAction' with { 'exception': collector.exception, 'format': 'html' } %}
         </div>
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -2,7 +2,7 @@
 
 {% block head %}
     <style type="text/css">
-        {% include '@WebProfiler/Collector/exception.css.twig' %}
+        {% render 'web_profiler.controller.exception:cssAction' with { 'token': token } %}
     </style>
     {{ parent() }}
 {% endblock %}
@@ -28,7 +28,7 @@
         </p>
     {% else %}
         <div class="sf-reset">
-            {% render 'web_profiler.controller.exception:showAction' with { 'exception': collector.exception, 'format': 'html' } %}
+            {% render 'web_profiler.controller.exception:showAction' with { 'token': token } %}
         </div>
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/Profiler/TemplateManagerTest.php
@@ -80,7 +80,7 @@ class TemplateManagerTest extends TestCase
             ->method('hasCollector')
             ->will($this->returnCallback(array($this, 'profileHasCollectorCallback')));
 
-       $this->assertEquals('FooBundle:Collector:foo.html.twig', $this->templateManager->getName($profile, 'foo'));
+        $this->assertEquals('FooBundle:Collector:foo.html.twig', $this->templateManager->getName($profile, 'foo'));
     }
 
     /**
@@ -89,7 +89,6 @@ class TemplateManagerTest extends TestCase
      */
     public function testGetTemplates()
     {
-
         $profile = $this->mockProfile();
         $profile->expects($this->any())
             ->method('hasCollector')
@@ -144,6 +143,10 @@ class TemplateManagerTest extends TestCase
         $this->twigEnvironment->expects($this->any())
             ->method('loadTemplate')
             ->will($this->returnValue('loadedTemplate'));
+
+        $this->twigEnvironment->expects($this->any())
+            ->method('getLoader')
+            ->will($this->returnValue($this->getMock('\Twig_LoaderInterface')));
 
         return $this->twigEnvironment;
     }


### PR DESCRIPTION
This PR removes two hard dependencies from WebProfilerBundle:
- The dependency on the DIC;
- The dependency on TwigBundle.

It also removes the dependency on the DIC in the exception controller from TwigBundle for more consistency.
