### PR TITLE
[HttpKernel] fixed kernel re-init (when getting unserialized for eg.)

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -61,6 +61,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $startTime;
     protected $classes;
     protected $errorReportingLevel;
+    protected $initialized = false;
 
     const VERSION         = '2.2.0-DEV';
     const VERSION_ID      = '20100';
@@ -95,18 +96,22 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
     public function init()
     {
-        ini_set('display_errors', 0);
+        if (!$this->initialized) {
+            ini_set('display_errors', 0);
 
-        if ($this->debug) {
-            error_reporting(-1);
+            if ($this->debug) {
+                error_reporting(-1);
 
-            DebugClassLoader::enable();
-            ErrorHandler::register($this->errorReportingLevel);
-            if ('cli' !== php_sapi_name()) {
-                ExceptionHandler::register();
-            } else {
-                ini_set('display_errors', 1);
+                DebugClassLoader::enable();
+                ErrorHandler::register($this->errorReportingLevel);
+                if ('cli' !== php_sapi_name()) {
+                    ExceptionHandler::register();
+                } else {
+                    ini_set('display_errors', 1);
+                }
             }
+
+            $this->initialized = true;
         }
     }
 
@@ -754,6 +759,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     {
         list($environment, $debug) = unserialize($data);
 
+        $this->initialized = true;
         $this->__construct($environment, $debug);
     }
 }


### PR DESCRIPTION
fixes #6254

This was happening to me because in `app/cache/dev/appDevUrlMatcher.php.meta` I have a `Symfony\Component\HttpKernel\Config\FileLocator` serialized object, at some point a ConfigCache needs to unserialize this file, when it does, a Kernel gets unserialized too (because this FileLocator class depends on it), and it leads to re-initializing the kernel.
