### PR TITLE
[Translation] Fixed #5797.

### DIFF
--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -67,6 +67,36 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $translator->trans('bar'));
     }
 
+    /**
+     * @dataProvider      getTransFileTests
+     * @expectedException Symfony\Component\Translation\Exception\NotFoundResourceException
+     */
+    public function testTransWithoutFallbackLocaleFile($format, $loader)
+    {
+        $loaderClass = 'Symfony\\Component\\Translation\\Loader\\'.$loader;
+        $translator = new Translator('en', new MessageSelector());
+        $translator->addLoader($format, new $loaderClass());
+        $translator->addResource($format, __DIR__.'/fixtures/non-existing', 'en');
+        $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en');
+
+        // force catalogue loading
+        $translator->trans('foo');
+    }
+
+    /**
+     * @dataProvider getTransFileTests
+     */
+    public function testTransWithFallbackLocaleFile($format, $loader)
+    {
+        $loaderClass = 'Symfony\\Component\\Translation\\Loader\\'.$loader;
+        $translator = new Translator('en_GB', new MessageSelector());
+        $translator->addLoader($format, new $loaderClass());
+        $translator->addResource($format, __DIR__.'/fixtures/non-existing', 'en_GB');
+        $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en');
+
+        $this->assertEquals('bar', $translator->trans('foo'));
+    }
+
     public function testTransWithFallbackLocaleBis()
     {
         $translator = new Translator('en_US', new MessageSelector());
@@ -142,6 +172,19 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $translator->addResource('array', array((string) $id => $translation), $locale, $domain);
 
         $this->assertEquals($expected, $translator->transChoice($id, $number, $parameters, $domain, $locale));
+    }
+
+    public function getTransFileTests()
+    {
+        return array(
+            array('csv', 'CsvFileLoader'),
+            array('ini', 'IniFileLoader'),
+            array('mo', 'MoFileLoader'),
+            array('po', 'PoFileLoader'),
+            array('php', 'PhpFileLoader'),
+            array('xlf', 'XliffFileLoader'),
+            array('yml', 'YamlFileLoader'),
+        );
     }
 
     public function getTransTests()

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -92,9 +92,9 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $translator = new Translator('en_GB', new MessageSelector());
         $translator->addLoader($format, new $loaderClass());
         $translator->addResource($format, __DIR__.'/fixtures/non-existing', 'en_GB');
-        $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en');
+        $translator->addResource($format, __DIR__.'/fixtures/resources.'.$format, 'en', 'resources');
 
-        $this->assertEquals('bar', $translator->trans('foo'));
+        $this->assertEquals('bar', $translator->trans('foo', array(), 'resources'));
     }
 
     public function testTransWithFallbackLocaleBis()
@@ -182,6 +182,7 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
             array('mo', 'MoFileLoader'),
             array('po', 'PoFileLoader'),
             array('php', 'PhpFileLoader'),
+            array('ts', 'QtTranslationsLoader'),
             array('xlf', 'XliffFileLoader'),
             array('yml', 'YamlFileLoader'),
         );

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Translation;
 
 use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
 
 /**
  * Translator.
@@ -181,7 +182,13 @@ class Translator implements TranslatorInterface
 
     protected function loadCatalogue($locale)
     {
-        $this->doLoadCatalogue($locale);
+        try {
+            $this->doLoadCatalogue($locale);
+        } catch (NotFoundResourceException $e) {
+            if (!$this->computeFallbackLocales($locale)) {
+                throw $e;
+            }
+        }
         $this->loadFallbackCatalogues($locale);
     }
 


### PR DESCRIPTION
This should fix issue #5797.

What I did is prevented `Translator` to throw `NotFoundResourceException` if resource is not found and there are fallback locales to process. This happens for locales like `en_GB`, `fr_FR`...

I also tested this fix against real application which uses Validation component without full stack framework and I was able to use `en_GB` locale without any errors only after this fix.
