### PR TITLE
[Translation] QtTranslationsLoader class renamed to QtFileLoader.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/translation.xml
@@ -13,7 +13,7 @@
         <parameter key="translation.loader.xliff.class">Symfony\Component\Translation\Loader\XliffFileLoader</parameter>
         <parameter key="translation.loader.po.class">Symfony\Component\Translation\Loader\PoFileLoader</parameter>
         <parameter key="translation.loader.mo.class">Symfony\Component\Translation\Loader\MoFileLoader</parameter>
-        <parameter key="translation.loader.qt.class">Symfony\Component\Translation\Loader\QtTranslationsLoader</parameter>
+        <parameter key="translation.loader.qt.class">Symfony\Component\Translation\Loader\QtFileLoader</parameter>
         <parameter key="translation.loader.csv.class">Symfony\Component\Translation\Loader\CsvFileLoader</parameter>
         <parameter key="translation.loader.res.class">Symfony\Component\Translation\Loader\IcuResFileLoader</parameter>
         <parameter key="translation.loader.dat.class">Symfony\Component\Translation\Loader\IcuDatFileLoader</parameter>

--- a/src/Symfony/Component/Translation/CHANGELOG.md
+++ b/src/Symfony/Component/Translation/CHANGELOG.md
@@ -4,11 +4,12 @@ CHANGELOG
 2.2.0
 -----
 
+ * QtTranslationsLoader class renamed to QtFileLoader. QtTranslationsLoader is deprecated and will be removed in 2.3.
  * [BC BREAK] uniformized the exception thrown by the load() method when an error occurs. The load() method now
    throws Symfony\Component\Translation\Exception\NotFoundResourceException when a resource cannot be found
    and Symfony\Component\Translation\Exception\InvalidResourceException when a resource is invalid.
  * changed the exception class thrown by some load() methods from \RuntimeException to \InvalidArgumentException
-   (IcuDatFileLoader, IcuResFileLoader, and QtTranslationsLoader)
+   (IcuDatFileLoader, IcuResFileLoader and QtFileLoader)
 
 2.1.0
 -----

--- a/src/Symfony/Component/Translation/Loader/QtFileLoader.php
+++ b/src/Symfony/Component/Translation/Loader/QtFileLoader.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Loader;
+
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\Exception\InvalidResourceException;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
+use Symfony\Component\Config\Resource\FileResource;
+
+/**
+ * QtFileLoader loads translations from QT Translations XML files.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @api
+ */
+class QtFileLoader implements LoaderInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function load($resource, $locale, $domain = 'messages')
+    {
+        if (!stream_is_local($resource)) {
+            throw new InvalidResourceException(sprintf('This is not a local file "%s".', $resource));
+        }
+
+        if (!file_exists($resource)) {
+            throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
+        }
+
+        $dom = new \DOMDocument();
+        $current = libxml_use_internal_errors(true);
+        if (!@$dom->load($resource, defined('LIBXML_COMPACT') ? LIBXML_COMPACT : 0)) {
+            throw new InvalidResourceException(implode("\n", $this->getXmlErrors()));
+        }
+
+        $xpath = new \DOMXPath($dom);
+        $nodes = $xpath->evaluate('//TS/context/name[text()="'.$domain.'"]');
+
+        $catalogue = new MessageCatalogue($locale);
+        if ($nodes->length == 1) {
+            $translations = $nodes->item(0)->nextSibling->parentNode->parentNode->getElementsByTagName('message');
+            foreach ($translations as $translation) {
+                $catalogue->set(
+                    (string) $translation->getElementsByTagName('source')->item(0)->nodeValue,
+                    (string) $translation->getElementsByTagName('translation')->item(0)->nodeValue,
+                    $domain
+                );
+                $translation = $translation->nextSibling;
+            }
+            $catalogue->addResource(new FileResource($resource));
+        }
+
+        libxml_use_internal_errors($current);
+
+        return $catalogue;
+    }
+
+    /**
+     * Returns the XML errors of the internal XML parser
+     *
+     * @return array An array of errors
+     */
+    private function getXmlErrors()
+    {
+        $errors = array();
+        foreach (libxml_get_errors() as $error) {
+            $errors[] = sprintf('[%s %s] %s (in %s - line %d, column %d)',
+                LIBXML_ERR_WARNING == $error->level ? 'WARNING' : 'ERROR',
+                $error->code,
+                trim($error->message),
+                $error->file ? $error->file : 'n/a',
+                $error->line,
+                $error->column
+            );
+        }
+
+        libxml_clear_errors();
+        libxml_use_internal_errors(false);
+
+        return $errors;
+    }
+}

--- a/src/Symfony/Component/Translation/Loader/QtTranslationsLoader.php
+++ b/src/Symfony/Component/Translation/Loader/QtTranslationsLoader.php
@@ -11,85 +11,16 @@
 
 namespace Symfony\Component\Translation\Loader;
 
-use Symfony\Component\Translation\MessageCatalogue;
-use Symfony\Component\Translation\Exception\InvalidResourceException;
-use Symfony\Component\Translation\Exception\NotFoundResourceException;
-use Symfony\Component\Config\Resource\FileResource;
-
 /**
- * QtTranslationsLoader loads translations from QT Translations XML files.
+ * QtFileLoader loads translations from QT Translations XML files.
  *
- * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Саша Стаменковић <umpirsky@gmail.com>
  *
  * @api
+ *
+ * @deprecated Deprecated since version 2.2, to be removed in 2.3.
+ *             Use QtFileLoader instead.
  */
-class QtTranslationsLoader implements LoaderInterface
-{
-    /**
-     * {@inheritdoc}
-     *
-     * @api
-     */
-    public function load($resource, $locale, $domain = 'messages')
-    {
-        if (!stream_is_local($resource)) {
-            throw new InvalidResourceException(sprintf('This is not a local file "%s".', $resource));
-        }
-
-        if (!file_exists($resource)) {
-            throw new NotFoundResourceException(sprintf('File "%s" not found.', $resource));
-        }
-
-        $dom = new \DOMDocument();
-        $current = libxml_use_internal_errors(true);
-        if (!@$dom->load($resource, defined('LIBXML_COMPACT') ? LIBXML_COMPACT : 0)) {
-            throw new InvalidResourceException(implode("\n", $this->getXmlErrors()));
-        }
-
-        $xpath = new \DOMXPath($dom);
-        $nodes = $xpath->evaluate('//TS/context/name[text()="'.$domain.'"]');
-
-        $catalogue = new MessageCatalogue($locale);
-        if ($nodes->length == 1) {
-            $translations = $nodes->item(0)->nextSibling->parentNode->parentNode->getElementsByTagName('message');
-            foreach ($translations as $translation) {
-                $catalogue->set(
-                    (string) $translation->getElementsByTagName('source')->item(0)->nodeValue,
-                    (string) $translation->getElementsByTagName('translation')->item(0)->nodeValue,
-                    $domain
-                );
-                $translation = $translation->nextSibling;
-            }
-            $catalogue->addResource(new FileResource($resource));
-        }
-
-        libxml_use_internal_errors($current);
-
-        return $catalogue;
-    }
-
-    /**
-     * Returns the XML errors of the internal XML parser
-     *
-     * @return array An array of errors
-     */
-    private function getXmlErrors()
-    {
-        $errors = array();
-        foreach (libxml_get_errors() as $error) {
-            $errors[] = sprintf('[%s %s] %s (in %s - line %d, column %d)',
-                LIBXML_ERR_WARNING == $error->level ? 'WARNING' : 'ERROR',
-                $error->code,
-                trim($error->message),
-                $error->file ? $error->file : 'n/a',
-                $error->line,
-                $error->column
-            );
-        }
-
-        libxml_clear_errors();
-        libxml_use_internal_errors(false);
-
-        return $errors;
-    }
+class QtTranslationsLoader extends QtFileLoader
+{   
 }

--- a/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/QtFileLoaderTest.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Translation\Tests\Loader;
 
-use Symfony\Component\Translation\Loader\QtTranslationsLoader;
+use Symfony\Component\Translation\Loader\QtFileLoader;
 use Symfony\Component\Config\Resource\FileResource;
 
-class QtTranslationsLoaderTest extends \PHPUnit_Framework_TestCase
+class QtFileLoaderTest extends \PHPUnit_Framework_TestCase
 {
     protected function setUp()
     {
@@ -25,7 +25,7 @@ class QtTranslationsLoaderTest extends \PHPUnit_Framework_TestCase
 
     public function testLoad()
     {
-        $loader = new QtTranslationsLoader();
+        $loader = new QtFileLoader();
         $resource = __DIR__.'/../fixtures/resources.ts';
         $catalogue = $loader->load($resource, 'en', 'resources');
 
@@ -39,7 +39,7 @@ class QtTranslationsLoaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testLoadNonExistingResource()
     {
-        $loader = new QtTranslationsLoader();
+        $loader = new QtFileLoader();
         $resource = __DIR__.'/../fixtures/non-existing.ts';
         $loader->load($resource, 'en', 'domain1');
     }


### PR DESCRIPTION
QtTranslationsLoader class renamed to QtFileLoader. QtTranslationsLoader is deprecated and will be removed in 2.3.

Fixes #6332.
