### PR TITLE
[HttpKernel] Kernel can have its root directory specified.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -74,15 +74,16 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      *
      * @param string  $environment The environment
      * @param Boolean $debug       Whether to enable debugging or not
+     * @param string  $rootDir     Root directory
      *
      * @api
      */
-    public function __construct($environment, $debug)
+    public function __construct($environment, $debug, $rootDir = null)
     {
         $this->environment = $environment;
         $this->debug = (Boolean) $debug;
         $this->booted = false;
-        $this->rootDir = $this->getRootDir();
+        $this->rootDir = $rootDir ?: $this->getRootDir();
         $this->name = $this->getName();
         $this->classes = array();
 

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -40,6 +40,18 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($kernel->isBooted());
         $this->assertLessThanOrEqual(microtime(true), $kernel->getStartTime());
         $this->assertNull($kernel->getContainer());
+        $this->assertEquals(__DIR__.'/Fixtures', $kernel->getRootDir());
+        $this->assertEquals('Fixtures', $kernel->getName());
+    }
+
+    public function testConstructorWithRootDirectoryOverride()
+    {
+        $env = 'test_env';
+        $debug = true;
+        $kernel = new KernelForTest($env, $debug, '/root/path/override');
+
+        $this->assertEquals('/root/path/override', $kernel->getRootDir());
+        $this->assertEquals('override', $kernel->getName());
     }
 
     public function testClone()


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: uncertain
Symfony2 tests pass: yes
Fixes the following tickets: n/a
License of the code: MIT
Documentation PR: n/a

---

I would like to be able to manually set kernel.root instead of having it magically determined for me. I laid out my reasons in great detail on the mailing list [here](https://groups.google.com/d/topic/symfony-devs/TJ47ghiZdmc/discussion) but I received no feedback. This is the least intrusive of the two solutions I have come up with.

My use case is distributing a default Kernel implementation that ultimately ends up in a project's vendor directory and not in `app/` like Symfony Standard expects. In this case it makes no sense to base the root directory on the physical location of the Kernel class.

All existing tests passed without modification. I added additional tests to ensure that things were behaving as expected.

I am uncertain if this constitutes an `@api` BC break but I am hopeful it does not. It adds one argument to the method signature, the new argument is optional, and the behavior when not specified is exactly the same behavior as before.

The only thing I am uncertain about is how this might impact Framework Bundle's `CacheClearCommand::getTempKernel` or anything else that might deal with cloning a kernel.
