### PR TITLE
[Console] Add --markdown export to HelpCommand

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -269,6 +269,34 @@ class Application
     }
 
     /**
+     * Gets the help message in Markdown.
+     *
+     * @return string A help message in Markdown.
+     */
+    public function getHelpInMarkdown()
+    {
+        $messages = array(
+            $this->getLongVersionInMarkdown(),
+            '',
+            'Usage',
+            '-----',
+            sprintf("    [options] command [arguments]\n"),
+            'Options',
+            '-------'
+        );
+
+        foreach ($this->getDefinition()->getOptions() as $option) {
+            $messages[] = sprintf('    %-16s %s %s',
+                '--'.$option->getName(),
+                $option->getShortcut() ? '(-'.$option->getShortcut().')' : '    ',
+                $option->getDescription()
+            );
+        }
+
+        return implode(PHP_EOL, $messages);
+    }
+
+    /**
      * Sets whether to catch exceptions or not during commands execution.
      *
      * @param Boolean $boolean Whether to catch exceptions or not during commands execution
@@ -354,6 +382,22 @@ class Application
         }
 
         return '<info>Console Tool</info>';
+    }
+
+    /**
+     * Returns the long version of the application in Markdown.
+     *
+     * @return string The long application version in Markdown
+     *
+     * @api
+     */
+    public function getLongVersionInMarkdown()
+    {
+        if ('UNKNOWN' !== $this->getName() && 'UNKNOWN' !== $this->getVersion()) {
+            return sprintf('%s version %s', $this->getName(), $this->getVersion());
+        }
+
+        return implode(PHP_EOL, array('Console Tool', '============'));
     }
 
     /**
@@ -680,11 +724,7 @@ class Application
     {
         $commands = $namespace ? $this->all($this->findNamespace($namespace)) : $this->commands;
 
-        $width = 0;
-        foreach ($commands as $command) {
-            $width = strlen($command->getName()) > $width ? strlen($command->getName()) : $width;
-        }
-        $width += 2;
+        $width = $this->getMaximumCommandNameLength($commands) + 2;
 
         if ($raw) {
             $messages = array();
@@ -712,6 +752,43 @@ class Application
 
             foreach ($commands as $name => $command) {
                 $messages[] = sprintf("  <info>%-${width}s</info> %s", $name, $command->getDescription());
+            }
+        }
+
+        return implode(PHP_EOL, $messages);
+    }
+
+    /**
+     * Returns Markdown representation of the Application.
+     *
+     * @param string  $namespace An optional namespace name
+     *
+     * @return string Markdown representing the Application
+     */
+    public function asMarkdown($namespace = null)
+    {
+        $commands = $namespace ? $this->all($this->findNamespace($namespace)) : $this->commands;
+
+        $width = $this->getMaximumCommandNameLength($commands) + 2;
+
+        $messages = array($this->getHelpInMarkdown(), '');
+        if ($namespace) {
+            $message = sprintf("Available commands for the \"%s\" namespace", $namespace);
+            $messages[] = $message;
+            $messages[] = str_repeat('-', mb_strlen($message));
+        } else {
+            $messages[] = 'Available commands';
+            $messages[] = '------------------';
+        }
+
+        // add commands by namespace
+        foreach ($this->sortCommands($commands) as $space => $commands) {
+            if (!$namespace && '_global' !== $space) {
+                $messages[] = '';
+            }
+
+            foreach ($commands as $name => $command) {
+                $messages[] = sprintf("    %-${width}s %s", $name, $command->getDescription());
             }
         }
 
@@ -952,6 +1029,15 @@ class Application
             new DialogHelper(),
             new ProgressHelper(),
         ));
+    }
+
+    private function getMaximumCommandNameLength(array $commands) {
+        $width = 0;
+        foreach ($commands as $command) {
+            $width = strlen($command->getName()) > $width ? strlen($command->getName()) : $width;
+        }
+
+        return $width;
     }
 
     /**

--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -584,6 +584,48 @@ class Command
     }
 
     /**
+     * Returns Markdown representation of the command.
+     *
+     * @return string Markdown representing the command
+     */
+    public function asMarkdown()
+    {
+        if ($this->application && !$this->applicationDefinitionMerged) {
+            $this->getSynopsis();
+            $this->mergeApplicationDefinition(false);
+        }
+
+        $markdown = array();
+        $markdown[] = $this->name;
+        $markdown[] = \str_repeat('=', mb_strlen($this->name));
+        $markdown[] = '';
+        $markdown[] = $this->description;
+        $markdown[] = '';
+        $markdown[] = 'Usage';
+        $markdown[] = '-----';
+        $markdown[] = '    '.$this->getSynopsis();
+        $markdown[] = '';
+
+        if ($this->getAliases()) {
+            $markdown[] = 'Aliases';
+            $markdown[] = '-------';
+            foreach ($this->getAliases() as $alias) {
+                $markdown[] = '* '.$alias;
+            }
+            $markdown[] = '';
+        }
+
+        $markdown[] = $this->getNativeDefinition()->asMarkdown();
+        if ($help = $this->getProcessedHelp()) {
+            $markdown[] = 'Help';
+            $markdown[] = '----';
+            $markdown[] = '  '.strip_tags(str_replace("\n", "\n  ", $help))."\n";
+        }
+
+        return implode("\n", $markdown);
+    }
+
+    /**
      * Returns an XML representation of the command.
      *
      * @param Boolean $asDom Whether to return a DOM or an XML string

--- a/src/Symfony/Component/Console/Command/HelpCommand.php
+++ b/src/Symfony/Component/Console/Command/HelpCommand.php
@@ -37,6 +37,7 @@ class HelpCommand extends Command
             ->setName('help')
             ->setDefinition(array(
                 new InputArgument('command_name', InputArgument::OPTIONAL, 'The command name', 'help'),
+                new InputOption('markdown', null, InputOption::VALUE_NONE, 'To output help as Markdown'),
                 new InputOption('xml', null, InputOption::VALUE_NONE, 'To output help as XML'),
             ))
             ->setDescription('Displays help for a command')
@@ -76,6 +77,8 @@ EOF
 
         if ($input->getOption('xml')) {
             $output->writeln($this->command->asXml(), OutputInterface::OUTPUT_RAW);
+        } elseif ($input->getOption('markdown')) {
+            $output->writeln($this->command->asMarkdown(), OutputInterface::OUTPUT_RAW);
         } else {
             $output->writeln($this->command->asText());
         }

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -377,6 +377,15 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/application_astext2.txt', $this->normalizeLineBreaks($application->asText('foo')), '->asText() returns a text representation of the application');
     }
 
+    public function testAsMarkdown()
+    {
+        $application = new Application();
+        $application->add(new \FooCommand);
+        $this->ensureStaticCommandHelp($application);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_asmarkdown1.txt', $application->asMarkdown(), '->asMarkdown() returns Markdown representation of the application');
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_asmarkdown2.txt', $application->asMarkdown('foo'), '->asMarkdown() returns Markdown representation of the application');
+    }
+
     public function testAsXml()
     {
         $application = new Application();

--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -274,6 +274,15 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/command_astext.txt', $command->asText(), '->asText() returns a text representation of the command');
     }
 
+    public function testAsMarkdown()
+    {
+        $command = new \TestCommand();
+        $command->setApplication(new Application());
+        $tester = new CommandTester($command);
+        $tester->execute(array('command' => $command->getName()));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/command_asmarkdown.txt', $command->asMarkdown(), '->asMarkdown() returns Markdown representation of the command');
+    }
+
     public function testAsXml()
     {
         $command = new \TestCommand();

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_asmarkdown1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_asmarkdown1.txt
@@ -1,0 +1,24 @@
+Console Tool
+============
+
+Usage
+-----
+    [options] command [arguments]
+
+Options
+-------
+    --help           (-h) Display this help message.
+    --quiet          (-q) Do not output any message.
+    --verbose        (-v) Increase verbosity of messages.
+    --version        (-V) Display this application version.
+    --ansi                Force ANSI output.
+    --no-ansi             Disable ANSI output.
+    --no-interaction (-n) Do not ask any interactive question.
+
+Available commands
+------------------
+    afoobar   The foo:bar command
+    help      Displays help for a command
+    list      Lists commands
+
+    foo:bar   The foo:bar command

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_asmarkdown2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_asmarkdown2.txt
@@ -1,0 +1,20 @@
+Console Tool
+============
+
+Usage
+-----
+    [options] command [arguments]
+
+Options
+-------
+    --help           (-h) Display this help message.
+    --quiet          (-q) Do not output any message.
+    --verbose        (-v) Increase verbosity of messages.
+    --version        (-V) Display this application version.
+    --ansi                Force ANSI output.
+    --no-ansi             Disable ANSI output.
+    --no-interaction (-n) Do not ask any interactive question.
+
+Available commands for the "foo" namespace
+------------------------------------------
+    foo:bar   The foo:bar command

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_asxml1.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_asxml1.txt
@@ -2,7 +2,7 @@
 <symfony>
   <commands>
     <command id="help" name="help">
-  <usage>help [--xml] [command_name]</usage>
+  <usage>help [--markdown] [--xml] [command_name]</usage>
   <description>Displays help for a command</description>
   <help>The &lt;info&gt;help&lt;/info&gt; command displays help for a given command:
  
@@ -23,6 +23,9 @@
     </argument>
   </arguments>
   <options>
+    <option name="--markdown" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
+      <description>To output help as Markdown</description>
+    </option>
     <option name="--xml" shortcut="" accept_value="0" is_value_required="0" is_multiple="0">
       <description>To output help as XML</description>
     </option>

--- a/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/application_run2.txt
@@ -1,11 +1,12 @@
 Usage:
- help [--xml] [command_name]
+ help [--markdown] [--xml] [command_name]
 
 Arguments:
  command               The command to execute
  command_name          The command name (default: "help")
 
 Options:
+ --markdown            To output help as Markdown
  --xml                 To output help as XML
  --help (-h)           Display this help message.
  --quiet (-q)          Do not output any message.

--- a/src/Symfony/Component/Console/Tests/Fixtures/command_asmarkdown.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/command_asmarkdown.txt
@@ -1,0 +1,30 @@
+namespace:name
+==============
+
+description
+
+Usage
+-----
+    namespace:name
+
+Aliases
+-------
+* name
+
+Arguments
+---------
+    command               The command to execute
+
+Options
+-------
+    --help (-h)           Display this help message.
+    --quiet (-q)          Do not output any message.
+    --verbose (-v)        Increase verbosity of messages.
+    --version (-V)        Display this application version.
+    --ansi                Force ANSI output.
+    --no-ansi             Disable ANSI output.
+    --no-interaction (-n) Do not ask any interactive question.
+
+Help
+----
+  help

--- a/src/Symfony/Component/Console/Tests/Fixtures/definition_asmarkdown.txt
+++ b/src/Symfony/Component/Console/Tests/Fixtures/definition_asmarkdown.txt
@@ -1,0 +1,13 @@
+Arguments
+---------
+    foo        The foo argument
+    baz        The baz argument (default: true)
+    bar        The bar argument (default: ["http://foo.com/"])
+
+Options
+-------
+    --foo (-f) The foo option
+    --baz      The baz option (default: false)
+    --bar (-b) The bar option (default: "bar")
+    --qux      The qux option (default: ["http://foo.com/","bar"]) (multiple values allowed)
+    --qux2     The qux2 option (default: {"foo":"bar"}) (multiple values allowed)

--- a/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/InputDefinitionTest.php
@@ -332,6 +332,21 @@ class InputDefinitionTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(self::$fixtures.'/definition_astext.txt', $definition->asText(), '->asText() returns a textual representation of the InputDefinition');
     }
 
+    public function testAsMarkdown()
+    {
+        $definition = new InputDefinition(array(
+            new InputArgument('foo', InputArgument::OPTIONAL, 'The foo argument'),
+            new InputArgument('baz', InputArgument::OPTIONAL, 'The baz argument', true),
+            new InputArgument('bar', InputArgument::OPTIONAL | InputArgument::IS_ARRAY, 'The bar argument', array('http://foo.com/')),
+            new InputOption('foo', 'f', InputOption::VALUE_REQUIRED, 'The foo option'),
+            new InputOption('baz', null, InputOption::VALUE_OPTIONAL, 'The baz option', false),
+            new InputOption('bar', 'b', InputOption::VALUE_OPTIONAL, 'The bar option', 'bar'),
+            new InputOption('qux', '', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The qux option', array('http://foo.com/', 'bar')),
+            new InputOption('qux2', '', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The qux2 option', array('foo' => 'bar')),
+        ));
+        $this->assertStringEqualsFile(self::$fixtures.'/definition_asmarkdown.txt', $definition->asMarkdown(), '->asMarkdown() returns Markdown representation of the InputDefinition');
+    }
+
     public function testAsXml()
     {
         $definition = new InputDefinition(array(


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #6327
Todo: none
License of the code: MIT
