### PR TITLE
[Session] Fixed bug with mock file session storage

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/MockFileSessionStorage.php
@@ -97,6 +97,10 @@ class MockFileSessionStorage extends MockArraySessionStorage
      */
     public function save()
     {
+        if (!$this->started) {
+            return;
+        }
+
         file_put_contents($this->getFilePath(), serialize($this->data));
 
         // this is needed for Silex, where the session object is re-used across requests

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/MockFileSessionStorageTest.php
@@ -106,6 +106,23 @@ class MockFileSessionStorageTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $storage2->getBag('attributes')->get('foo'), 'values persist between instances');
     }
 
+    public function testSaveWithoutStart()
+    {
+        $storage1 = $this->getStorage();
+        $storage1->start();
+        $storage1->getBag('attributes')->set('foo', 'bar');
+        $storage1->save();
+
+        $storage2 = $this->getStorage();
+        $storage2->setId($storage1->getId());
+        $storage2->save();
+
+        $storage3 = $this->getStorage();
+        $storage3->setId($storage1->getId());
+        $storage3->start();
+        $this->assertEquals('bar', $storage3->getBag('attributes')->get('foo'), 'values persist between instances');
+    }
+
     private function getStorage()
     {
         $storage = new MockFileSessionStorage($this->sessionDir);


### PR DESCRIPTION
Fixed a bug where an unstarted mock session would be emptied with a save. Here are the steps to reproduce: 
1. Use the test client from `Symfony\Bundle\FrameworkBundle\Test\WebTestCase::createClient()`, and add something to its session. (I actually had it authenticate against a firewall).
2. Take the cookies of this first test client and add them to a second test client
3. Have the second test client request a URL that results in a 404
4. Since the 404 does not need to start the session, hence when save is called (automatically), the mock session is overwritten with an empty array. This does not happen with the other session handlers.  

The added unit test in this PR shows this problem. If this PR gets accepted, will it also get merged into the 2.1.x-dev branch?

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes (The broken test seems to be unrelated to this change)
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
