### PR TITLE
[Console] Add ability to select values interactively

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added support for colorization on Windows via ConEmu
  * add a method to Dialog Helper to ask for a question and hide the response
+ * added support for interactive selections in console (DialogHelper::select())
 
 2.1.0
 -----

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -25,6 +25,59 @@ class DialogHelper extends Helper
     private static $stty;
 
     /**
+     * Asks to select array value to the user.
+     *
+     * @param OutputInterface $output   An Output instance
+     * @param string|array    $question The question to ask
+     * @param array           $choices  List of choices to pick from
+     * @param Boolean         $default  The default answer if the user enters nothing
+     * @param array           $options  Display options:
+     *                                      'attempts' - Max number of times to ask before giving up (false by default,
+     *                                                  which means infinite)
+     *                                      'error_template' - Message which will be shown if invalid value from choice
+     *                                                  list would be picked. Defaults to "Value '%s' is not in provided
+     *                                                  in choice list"
+     *                                      'return' - What should be returned from choice list - 'key' or 'value'
+     *
+     * @return mixed
+     */
+    public function select(OutputInterface $output, $question, $choices, $default = null, array $options = array())
+    {
+        $options = array_merge(array(
+            'attempts' => false,
+            'error_template' => "Value '%s' is not in provided in choice list",
+            'return' => 'key'
+        ), $options);
+
+        $width = max(array_map('strlen', array_keys($choices))) + 2;
+
+        $messages = (array) $question;
+        foreach ($choices as $key => $value) {
+            $messages[] = sprintf("  <info>%-${width}s</info> %s", $key, $value);
+        }
+
+        $output->writeln($messages);
+
+        $result = $this->askAndValidate($output, '> ', function($picked) use ($choices, $options) {
+            if (empty($choices[$picked])) {
+                throw new \InvalidArgumentException(sprintf($options['error_template'], $picked));
+            }
+
+            return $picked;
+        }, $options['attempts'], $default);
+
+        switch($options['return']) {
+            case 'key':
+                return $result;
+            case 'value':
+                return $choices[$result];
+            default:
+                $tpl = 'Invalid return type specified: "%s". Should be either "key" or "value".';
+                throw new \InvalidArgumentException(sprintf($tpl . '', $options['return']));
+        }
+    }
+
+    /**
      * Asks a question to the user.
      *
      * @param OutputInterface $output   An Output instance

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -25,19 +25,22 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
         $helperSet = new HelperSet(array(new FormatterHelper()));
         $dialog->setHelperSet($helperSet);
 
-        $heroes = array('Superman', 'Batman', 'Putin');
+        $heroes = array('Superman', 'Batman', 'Spiderman');
 
-        $dialog->setInputStream($this->getInputStream("\n1\n"));
-        $this->assertEquals('2', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes, '2'));
-        $this->assertEquals('1', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes));
+        $dialog->setInputStream($this->getInputStream("\n1\nFabien\n1\nFabien\nFabien\n"));
+        $this->assertEquals('2', $dialog->select($this->getOutputStream(), 'What is your favorite superhero?', $heroes, '2'));
+        $this->assertEquals('1', $dialog->select($this->getOutputStream(), 'What is your favorite superhero?', $heroes));
+        $this->assertEquals('1', $dialog->select($output = $this->getOutputStream(), 'What is your favorite superhero?', $heroes, null, false, 'Input "%s" is not a superhero!'));
 
-        $dialog->setInputStream($this->getInputStream("\n1\n"));
-        $this->assertEquals('Putin', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes, '2', array(
-            'return' => 'value'
-        )));
-        $this->assertEquals('Batman', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes, null, array(
-            'return' => 'value'
-        )));
+        rewind($output->getStream());
+        $this->assertContains('Input "Fabien" is not a superhero!', stream_get_contents($output->getStream()));
+
+        try {
+            $this->assertEquals('1', $dialog->select($output = $this->getOutputStream(), 'What is your favorite superhero?', $heroes, null, 1));
+            $this->fail();
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('Value "Fabien" is invalid', $e->getMessage());
+        }
     }
 
     public function testAsk()

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -18,6 +18,28 @@ use Symfony\Component\Console\Output\StreamOutput;
 
 class DialogHelperTest extends \PHPUnit_Framework_TestCase
 {
+    public function testSelect()
+    {
+        $dialog = new DialogHelper();
+
+        $helperSet = new HelperSet(array(new FormatterHelper()));
+        $dialog->setHelperSet($helperSet);
+
+        $heroes = array('Superman', 'Batman', 'Putin');
+
+        $dialog->setInputStream($this->getInputStream("\n1\n"));
+        $this->assertEquals('2', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes, '2'));
+        $this->assertEquals('1', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes));
+
+        $dialog->setInputStream($this->getInputStream("\n1\n"));
+        $this->assertEquals('Putin', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes, '2', array(
+            'return' => 'value'
+        )));
+        $this->assertEquals('Batman', $dialog->select($this->getOutputStream(), 'What superhero rocks?', $heroes, null, array(
+            'return' => 'value'
+        )));
+    }
+
     public function testAsk()
     {
         $dialog = new DialogHelper();


### PR DESCRIPTION
This is a slightly modified version of #5417

Adds ability to select from value list:

```
$values = array('One', 'Two', 'Three');
$pick = $this->getHelper('dialog')->select($output, 'Pick a bundle:', $values, 2);
var_dump($pick);
```

... would give the following CLI output:

```
Pick a bundle:
  0   One
  1   Two
  2   Three
> 1
1
```
