### PR TITLE
[FrameworkBundle] Added a check on file mime type for CodeHelper::fileExcerpt()

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -145,6 +145,8 @@ class CodeHelper extends Helper
         if (is_readable($file)) {
             if (extension_loaded('fileinfo')) {
                 $finfo = new \Finfo();
+
+                // Check if the file is an application/octet-stream (eg. Phar file) because hightlight_file cannot parse these files
                 if ('application/octet-stream' === $finfo->file($file, FILEINFO_MIME_TYPE)) {
                     return;
                 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -143,6 +143,13 @@ class CodeHelper extends Helper
     public function fileExcerpt($file, $line)
     {
         if (is_readable($file)) {
+            if (extension_loaded('fileinfo')) {
+                $finfo = new \Finfo();
+                if ('application/octet-stream' === $finfo->file($file, FILEINFO_MIME_TYPE)) {
+                    return;
+                }
+            }
+
             $code = highlight_file($file, true);
             // remove main code/span tags
             $code = preg_replace('#^<code.*?>\s*<span.*?>(.*)</span>\s*</code>#s', '\\1', $code);


### PR DESCRIPTION
Fixed a bug on `CodeHelper::fileExcerpt()`.

I add a check on the file mime type because I use a phar of phpunit and when a exception throwed in a test, Symfony build a page with the stack trace of the exception.

The phpunit.phar path is in the stack trace and Symfony call `highlight_file()` function on this file path.
`highlight_file()` cannot parse the phar file and warnings are displayed.

This PR add a check on the file mime type.
**This PR can be applied on 2.0, 2.1 and master branches.**

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes (The broken test seems to be unrelated to this change)
Fixes the following tickets: -
License of the code: MIT
