### PR TITLE
[MessageCatalogue] Add Metadata to MessageCatalogue

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -245,12 +245,6 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             return $this->metadata;
         }
 
-        if (!is_string($domain)) {
-            throw new \InvalidArgumentException("Domain should be an string.");
-        }
-        if (!is_string($key)) {
-            throw new \InvalidArgumentException("Key should be an string.");
-        }
         if (isset($this->metadata[$domain])) {
             if (!empty($key)) {
                 if (isset($this->metadata[$domain][$key])) {
@@ -267,12 +261,6 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function setMetadata($key, $value, $domain = 'messages')
     {
-        if (!is_string($key)) {
-            throw new \InvalidArgumentException("Key should be an string.");
-        }
-        if (!isset($this->metadata[$domain])) {
-            $this->metadata[$domain] = array();
-        }
         $this->metadata[$domain][$key] = $value;
     }
 
@@ -284,15 +272,11 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
         if (empty($domain)) {
             $this->metadata = array();
         }
-        if (!is_string($domain)) {
-            throw new \InvalidArgumentException("Domain should be an string.");
-        }
+
         if (empty($key)) {
             unset($this->metadata[$domain]);
         }
-        if (!is_string($key)) {
-            throw new \InvalidArgumentException("Key should be an string.");
-        }
+
         unset($this->metadata[$domain][$key]);
     }
 

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
  *
  * @api
  */
-class MessageCatalogue implements MessageCatalogueInterface
+class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterface
 {
     private $messages = array();
     private $metadata = array();
@@ -238,8 +238,6 @@ class MessageCatalogue implements MessageCatalogueInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @api
      */
     public function getMetadata($domain = '', $key = '')
     {
@@ -266,8 +264,6 @@ class MessageCatalogue implements MessageCatalogueInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @api
      */
     public function setMetadata($key, $value, $domain = 'messages')
     {
@@ -282,8 +278,6 @@ class MessageCatalogue implements MessageCatalogueInterface
 
     /**
      * {@inheritdoc}
-     *
-     * @api
      */
     public function deleteMetadata($domain = '', $key = '')
     {
@@ -303,9 +297,7 @@ class MessageCatalogue implements MessageCatalogueInterface
     }
 
     /**
-     * Adds or overwrite current values with the new values.
-     *
-     * TODO: do we want to overwrite values?!?
+     * Adds current values with the new values.
      *
      * @param array $values Values to add
      */

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -177,7 +177,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             $this->addResource($resource);
         }
 
-        $metadata = $catalogue->getMetadata();
+        $metadata = $catalogue->getMetadata('', '');
         $this->addMetadata($metadata);
     }
 
@@ -239,7 +239,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     /**
      * {@inheritdoc}
      */
-    public function getMetadata($domain = '', $key = '')
+    public function getMetadata($key = '', $domain = 'messages')
     {
         if (empty($domain)) {
             return $this->metadata;
@@ -267,7 +267,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     /**
      * {@inheritdoc}
      */
-    public function deleteMetadata($domain = '', $key = '')
+    public function deleteMetadata($key = '', $domain = 'messages')
     {
         if (empty($domain)) {
             $this->metadata = array();

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -23,7 +23,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
 class MessageCatalogue implements MessageCatalogueInterface
 {
     private $messages = array();
-    private $metaData = array();
+    private $metadata = array();
     private $locale;
     private $resources;
     private $fallbackCatalogue;
@@ -177,8 +177,8 @@ class MessageCatalogue implements MessageCatalogueInterface
             $this->addResource($resource);
         }
 
-        $meta = $catalogue->getMetaData();
-        $this->addMetaData($meta);
+        $metadata = $catalogue->getMetadata();
+        $this->addMetadata($metadata);
     }
 
     /**
@@ -241,10 +241,10 @@ class MessageCatalogue implements MessageCatalogueInterface
      *
      * @api
      */
-    public function getMetaData($domain = '', $key = '')
+    public function getMetadata($domain = '', $key = '')
     {
         if (empty($domain)) {
-            return $this->metaData;
+            return $this->metadata;
         }
 
         if (!is_string($domain)) {
@@ -253,13 +253,13 @@ class MessageCatalogue implements MessageCatalogueInterface
         if (!is_string($key)) {
             throw new \InvalidArgumentException("Key should be an string.");
         }
-        if (isset($this->metaData[$domain])) {
+        if (isset($this->metadata[$domain])) {
             if (!empty($key)) {
-                if (isset($this->metaData[$domain][$key])) {
-                    return $this->metaData[$domain][$key];
+                if (isset($this->metadata[$domain][$key])) {
+                    return $this->metadata[$domain][$key];
                 }
             } else {
-                return $this->metaData[$domain];
+                return $this->metadata[$domain];
             }
         }
     }
@@ -269,15 +269,15 @@ class MessageCatalogue implements MessageCatalogueInterface
      *
      * @api
      */
-    public function setMetaData($key, $value, $domain = 'messages')
+    public function setMetadata($key, $value, $domain = 'messages')
     {
         if (!is_string($key)) {
             throw new \InvalidArgumentException("Key should be an string.");
         }
-        if (!isset($this->metaData[$domain])) {
-            $this->metaData[$domain] = array();
+        if (!isset($this->metadata[$domain])) {
+            $this->metadata[$domain] = array();
         }
-        $this->metaData[$domain][$key] = $value;
+        $this->metadata[$domain][$key] = $value;
     }
 
     /**
@@ -285,21 +285,21 @@ class MessageCatalogue implements MessageCatalogueInterface
      *
      * @api
      */
-    public function deleteMetaData($domain = '', $key = '')
+    public function deleteMetadata($domain = '', $key = '')
     {
         if (empty($domain)) {
-            $this->metaData = array();
+            $this->metadata = array();
         }
         if (!is_string($domain)) {
             throw new \InvalidArgumentException("Domain should be an string.");
         }
         if (empty($key)) {
-            unset($this->metaData[$domain]);
+            unset($this->metadata[$domain]);
         }
         if (!is_string($key)) {
             throw new \InvalidArgumentException("Key should be an string.");
         }
-        unset($this->metaData[$domain][$key]);
+        unset($this->metadata[$domain][$key]);
     }
 
     /**
@@ -309,13 +309,12 @@ class MessageCatalogue implements MessageCatalogueInterface
      *
      * @param array $values Values to add
      */
-    private function addMetaData(array $values)
+    private function addMetadata(array $values)
     {
         foreach ($values as $domain => $keys) {
             foreach ($keys as $key => $value) {
-                $this->setMetaData($key, $value, $domain);
+                $this->setMetadata($key, $value, $domain);
             }
         }
     }
-
 }

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -23,6 +23,7 @@ use Symfony\Component\Config\Resource\ResourceInterface;
 class MessageCatalogue implements MessageCatalogueInterface
 {
     private $messages = array();
+    private $metaData = array();
     private $locale;
     private $resources;
     private $fallbackCatalogue;
@@ -175,6 +176,9 @@ class MessageCatalogue implements MessageCatalogueInterface
         foreach ($catalogue->getResources() as $resource) {
             $this->addResource($resource);
         }
+
+        $meta = $catalogue->getMetaData();
+        $this->addMetaData($meta);
     }
 
     /**
@@ -231,4 +235,87 @@ class MessageCatalogue implements MessageCatalogueInterface
     {
         $this->resources[] = $resource;
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function getMetaData($domain = '', $key = '')
+    {
+        if (empty($domain)) {
+            return $this->metaData;
+        }
+
+        if (!is_string($domain)) {
+            throw new \InvalidArgumentException("Domain should be an string.");
+        }
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException("Key should be an string.");
+        }
+        if (isset($this->metaData[$domain])) {
+            if (!empty($key)) {
+                if (isset($this->metaData[$domain][$key])) {
+                    return $this->metaData[$domain][$key];
+                }
+            } else {
+                return $this->metaData[$domain];
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function setMetaData($key, $value, $domain = 'messages')
+    {
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException("Key should be an string.");
+        }
+        if (!isset($this->metaData[$domain])) {
+            $this->metaData[$domain] = array();
+        }
+        $this->metaData[$domain][$key] = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @api
+     */
+    public function deleteMetaData($domain = '', $key = '')
+    {
+        if (empty($domain)) {
+            $this->metaData = array();
+        }
+        if (!is_string($domain)) {
+            throw new \InvalidArgumentException("Domain should be an string.");
+        }
+        if (empty($key)) {
+            unset($this->metaData[$domain]);
+        }
+        if (!is_string($key)) {
+            throw new \InvalidArgumentException("Key should be an string.");
+        }
+        unset($this->metaData[$domain][$key]);
+    }
+
+    /**
+     * Adds or overwrite current values with the new values.
+     *
+     * TODO: do we want to overwrite values?!?
+     *
+     * @param array $values Values to add
+     */
+    private function addMetaData(array $values)
+    {
+        foreach ($values as $domain => $keys) {
+            foreach ($keys as $key => $value) {
+                $this->setMetaData($key, $value, $domain);
+            }
+        }
+    }
+
 }

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -169,29 +169,4 @@ interface MessageCatalogueInterface
      * @api
      */
     public function addResource(ResourceInterface $resource);
-
-    /**
-     * Gets meta data for given domain and key.
-     *
-     * @param string $key    Key to set
-     * @param string $domain The domain name
-     */
-    public function getMetaData($domain = '', $key = '');
-
-    /**
-     * Adds meta data to a message domain.
-     *
-     * @param string       $key    Key to set
-     * @param string|array $value  Value to store
-     * @param string       $domain The domain name
-     */
-    public function setMetaData($key, $value, $domain = 'messages');
-
-    /**
-     * Deletes meta data for given key and domain
-     *
-     * @param string $key    Key to set
-     * @param string $domain The domain name
-     */
-    public function deleteMetaData($domain = '', $key = '');
 }

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -169,4 +169,29 @@ interface MessageCatalogueInterface
      * @api
      */
     public function addResource(ResourceInterface $resource);
+
+    /**
+     * Gets meta data for given domain and key.
+     *
+     * @param string $key    Key to set
+     * @param string $domain The domain name
+     */
+    public function getMetaData($domain = '', $key = '');
+
+    /**
+     * Adds meta data to a message domain.
+     *
+     * @param string       $key    Key to set
+     * @param string|array $value  Value to store
+     * @param string       $domain The domain name
+     */
+    public function setMetaData($key, $value, $domain = 'messages');
+
+    /**
+     * Deletes meta data for given key and domain
+     *
+     * @param string $key    Key to set
+     * @param string $domain The domain name
+     */
+    public function deleteMetaData($domain = '', $key = '');
 }

--- a/src/Symfony/Component/Translation/MetadataAwareInterface.php
+++ b/src/Symfony/Component/Translation/MetadataAwareInterface.php
@@ -23,16 +23,16 @@ interface MetadataAwareInterface
     /**
      * Gets meta data for given domain and key.
      *
-     * @param string $key    Key to set
      * @param string $domain The domain name
+     * @param string $key    Key
      */
-    public function getMetadata($domain = '', $key = '');
+    public function getMetadata($key = '', $domain = 'messages');
 
     /**
      * Adds meta data to a message domain.
      *
-     * @param string       $key    Key to set
-     * @param string|array $value  Value to store
+     * @param string       $key    Key
+     * @param string|array $value  Value
      * @param string       $domain The domain name
      */
     public function setMetadata($key, $value, $domain = 'messages');
@@ -40,8 +40,8 @@ interface MetadataAwareInterface
     /**
      * Deletes meta data for given key and domain.
      *
-     * @param string $key    Key to set
      * @param string $domain The domain name
+     * @param string $key    Key
      */
-    public function deleteMetadata($domain = '', $key = '');
+    public function deleteMetadata($key = '', $domain = 'messages');
 }

--- a/src/Symfony/Component/Translation/MetadataAwareInterface.php
+++ b/src/Symfony/Component/Translation/MetadataAwareInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+
+/**
+ * MetadataAwareInterface.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface MetadataAwareInterface
+{
+    /**
+     * Gets meta data for given domain and key.
+     *
+     * @param string $key    Key to set
+     * @param string $domain The domain name
+     */
+    public function getMetadata($domain = '', $key = '');
+
+    /**
+     * Adds meta data to a message domain.
+     *
+     * @param string       $key    Key to set
+     * @param string|array $value  Value to store
+     * @param string       $domain The domain name
+     */
+    public function setMetadata($key, $value, $domain = 'messages');
+
+    /**
+     * Deletes meta data for given key and domain.
+     *
+     * @param string $key    Key to set
+     * @param string $domain The domain name
+     */
+    public function deleteMetadata($domain = '', $key = '');
+}

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -174,9 +174,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
     public function testMetadataDelete()
     {
         $catalogue = new MessageCatalogue('en');
-        $expected = array();
-        $actual = $catalogue->getMetadata();
-        $this->assertEquals($expected, $actual, 'Metadata is empty');
+        $this->assertEquals(array(), $catalogue->getMetadata(), 'Metadata is empty');
         $catalogue->deleteMetadata('messages', 'key');
         $catalogue->deleteMetadata('messages');
         $catalogue->deleteMetadata();
@@ -186,62 +184,29 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
     {
         $catalogue = new MessageCatalogue('en');
         $catalogue->setMetadata('key', 'value');
-        $expected = 'value';
-        $actual = $catalogue->getMetadata('messages', 'key');
-        $this->assertEquals($expected, $actual, "Metadata 'key' = 'value'");
+        $this->assertEquals('value', $catalogue->getMetadata('messages', 'key'), "Metadata 'key' = 'value'");
 
         $catalogue->setMetadata('key2', array());
-        $expected = array();
-        $actual = $catalogue->getMetadata('messages', 'key2');
-        $this->assertEquals($expected, $actual, 'Metadata key2 is array');
+        $this->assertEquals(array(), $catalogue->getMetadata('messages', 'key2'), 'Metadata key2 is array');
 
         $catalogue->deleteMetadata('messages', 'key2');
-        $expected = null;
-        $actual = $catalogue->getMetadata('messages', 'key2');
-        $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
+        $this->assertEquals(null, $catalogue->getMetadata('messages', 'key2'), 'Metadata key2 should is deleted.');
 
         $catalogue->deleteMetadata('domain', 'key2');
-        $expected = null;
-        $actual = $catalogue->getMetadata('domain', 'key2');
-        $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
-
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testMetadataExceptionsKey()
-    {
-        $catalogue = new MessageCatalogue('en');
-        $catalogue->deleteMetadata('messages', array());
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testMetadataExceptionsDomain()
-    {
-        $catalogue = new MessageCatalogue('en');
-        $catalogue->deleteMetadata(array());
+        $this->assertEquals(null, $catalogue->getMetadata('domain', 'key2'), 'Metadata key2 should is deleted.');
     }
 
     public function testMetadataMerge()
     {
         $cat1 = new MessageCatalogue('en');
-        $cat1->setMetadata('a','b');
-        $expected = array('messages'=>array('a'=>'b'));
-        $actual = $cat1->getMetadata();
-        $this->assertEquals($expected, $actual, 'Cat1 contains messages metadata.');
+        $cat1->setMetadata('a', 'b');
+        $this->assertEquals(array('messages' => array('a' => 'b')), $cat1->getMetadata(), 'Cat1 contains messages metadata.');
 
         $cat2 = new MessageCatalogue('en');
         $cat2->setMetadata('b', 'c', 'domain');
-        $expected = array('domain'=>array('b'=>'c'));
-        $actual = $cat2->getMetadata();
-        $this->assertEquals($expected, $actual, 'Cat2 contains domain metadata.');
+        $this->assertEquals(array('domain' => array('b' => 'c')), $cat2->getMetadata(), 'Cat2 contains domain metadata.');
 
         $cat1->addCatalogue($cat2);
-        $expected = array('messages'=>array('a'=>'b'),'domain'=>array('b'=>'c'));
-        $actual = $cat1->getMetadata();
-        $this->assertEquals($expected, $actual, 'Cat1 contains merged metadata.');
+        $this->assertEquals(array('messages' => array('a' => 'b'), 'domain' => array('b' => 'c')), $cat1->getMetadata(), 'Cat1 contains merged metadata.');
     }
 }

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -170,4 +170,79 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array($r, $r1), $catalogue->getResources());
     }
+
+    public function testMetaDataDelete()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $expected = array();
+        $actual = $catalogue->getMetaData();
+        $this->assertEquals($expected, $actual, 'Metadata is empty');
+        $catalogue->deleteMetaData('messages', 'key');
+        $catalogue->deleteMetaData('messages');
+        $catalogue->deleteMetaData();
+    }
+
+    public function testMetaDataSetGetDelete()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->setMetaData('key', 'value');
+        $expected = 'value';
+        $actual = $catalogue->getMetaData('messages', 'key');
+        $this->assertEquals($expected, $actual, "Metadata 'key' = 'value'");
+
+        $catalogue->setMetaData('key2', array());
+        $expected = array();
+        $actual = $catalogue->getMetaData('messages', 'key2');
+        $this->assertEquals($expected, $actual, 'Metadata key2 is array');
+
+        $catalogue->deleteMetaData('messages', 'key2');
+        $expected = null;
+        $actual = $catalogue->getMetaData('messages', 'key2');
+        $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
+
+        $catalogue->deleteMetaData('domain', 'key2');
+        $expected = null;
+        $actual = $catalogue->getMetaData('domain', 'key2');
+        $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
+
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMetaDataExceptionsKey()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->deleteMetaData('messages', array());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMetaDataExceptionsDomain()
+    {
+        $catalogue = new MessageCatalogue('en');
+        $catalogue->deleteMetaData(array());
+    }
+
+    public function testMetaDataMerge()
+    {
+        $cat1 = new MessageCatalogue('en');
+        $cat1->setMetaData('a','b');
+        $expected = array('messages'=>array('a'=>'b'));
+        $actual = $cat1->getMetaData();
+        $this->assertEquals($expected, $actual, 'Cat1 contains messages metadata.');
+
+        $cat2 = new MessageCatalogue('en');
+        $cat2->setMetaData('b', 'c', 'domain');
+        $expected = array('domain'=>array('b'=>'c'));
+        $actual = $cat2->getMetaData();
+        $this->assertEquals($expected, $actual, 'Cat2 contains domain metadata.');
+
+        $cat1->addCatalogue($cat2);
+        $expected = array('messages'=>array('a'=>'b'),'domain'=>array('b'=>'c'));
+        $actual = $cat1->getMetaData();
+        $this->assertEquals($expected, $actual, 'Cat1 contains merged metadata.');
+
+    }
 }

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -171,38 +171,38 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array($r, $r1), $catalogue->getResources());
     }
 
-    public function testMetaDataDelete()
+    public function testMetadataDelete()
     {
         $catalogue = new MessageCatalogue('en');
         $expected = array();
-        $actual = $catalogue->getMetaData();
+        $actual = $catalogue->getMetadata();
         $this->assertEquals($expected, $actual, 'Metadata is empty');
-        $catalogue->deleteMetaData('messages', 'key');
-        $catalogue->deleteMetaData('messages');
-        $catalogue->deleteMetaData();
+        $catalogue->deleteMetadata('messages', 'key');
+        $catalogue->deleteMetadata('messages');
+        $catalogue->deleteMetadata();
     }
 
-    public function testMetaDataSetGetDelete()
+    public function testMetadataSetGetDelete()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->setMetaData('key', 'value');
+        $catalogue->setMetadata('key', 'value');
         $expected = 'value';
-        $actual = $catalogue->getMetaData('messages', 'key');
+        $actual = $catalogue->getMetadata('messages', 'key');
         $this->assertEquals($expected, $actual, "Metadata 'key' = 'value'");
 
-        $catalogue->setMetaData('key2', array());
+        $catalogue->setMetadata('key2', array());
         $expected = array();
-        $actual = $catalogue->getMetaData('messages', 'key2');
+        $actual = $catalogue->getMetadata('messages', 'key2');
         $this->assertEquals($expected, $actual, 'Metadata key2 is array');
 
-        $catalogue->deleteMetaData('messages', 'key2');
+        $catalogue->deleteMetadata('messages', 'key2');
         $expected = null;
-        $actual = $catalogue->getMetaData('messages', 'key2');
+        $actual = $catalogue->getMetadata('messages', 'key2');
         $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
 
-        $catalogue->deleteMetaData('domain', 'key2');
+        $catalogue->deleteMetadata('domain', 'key2');
         $expected = null;
-        $actual = $catalogue->getMetaData('domain', 'key2');
+        $actual = $catalogue->getMetadata('domain', 'key2');
         $this->assertEquals($expected, $actual, 'Metadata key2 should is deleted.');
 
     }
@@ -210,39 +210,38 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMetaDataExceptionsKey()
+    public function testMetadataExceptionsKey()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->deleteMetaData('messages', array());
+        $catalogue->deleteMetadata('messages', array());
     }
 
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function testMetaDataExceptionsDomain()
+    public function testMetadataExceptionsDomain()
     {
         $catalogue = new MessageCatalogue('en');
-        $catalogue->deleteMetaData(array());
+        $catalogue->deleteMetadata(array());
     }
 
-    public function testMetaDataMerge()
+    public function testMetadataMerge()
     {
         $cat1 = new MessageCatalogue('en');
-        $cat1->setMetaData('a','b');
+        $cat1->setMetadata('a','b');
         $expected = array('messages'=>array('a'=>'b'));
-        $actual = $cat1->getMetaData();
+        $actual = $cat1->getMetadata();
         $this->assertEquals($expected, $actual, 'Cat1 contains messages metadata.');
 
         $cat2 = new MessageCatalogue('en');
-        $cat2->setMetaData('b', 'c', 'domain');
+        $cat2->setMetadata('b', 'c', 'domain');
         $expected = array('domain'=>array('b'=>'c'));
-        $actual = $cat2->getMetaData();
+        $actual = $cat2->getMetadata();
         $this->assertEquals($expected, $actual, 'Cat2 contains domain metadata.');
 
         $cat1->addCatalogue($cat2);
         $expected = array('messages'=>array('a'=>'b'),'domain'=>array('b'=>'c'));
-        $actual = $cat1->getMetaData();
+        $actual = $cat1->getMetadata();
         $this->assertEquals($expected, $actual, 'Cat1 contains merged metadata.');
-
     }
 }

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -174,9 +174,9 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
     public function testMetadataDelete()
     {
         $catalogue = new MessageCatalogue('en');
-        $this->assertEquals(array(), $catalogue->getMetadata(), 'Metadata is empty');
-        $catalogue->deleteMetadata('messages', 'key');
-        $catalogue->deleteMetadata('messages');
+        $this->assertEquals(array(), $catalogue->getMetadata('', ''), 'Metadata is empty');
+        $catalogue->deleteMetadata('key', 'messages');
+        $catalogue->deleteMetadata('', 'messages');
         $catalogue->deleteMetadata();
     }
 
@@ -184,29 +184,29 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
     {
         $catalogue = new MessageCatalogue('en');
         $catalogue->setMetadata('key', 'value');
-        $this->assertEquals('value', $catalogue->getMetadata('messages', 'key'), "Metadata 'key' = 'value'");
+        $this->assertEquals('value', $catalogue->getMetadata('key', 'messages'), "Metadata 'key' = 'value'");
 
         $catalogue->setMetadata('key2', array());
-        $this->assertEquals(array(), $catalogue->getMetadata('messages', 'key2'), 'Metadata key2 is array');
+        $this->assertEquals(array(), $catalogue->getMetadata('key2', 'messages'), 'Metadata key2 is array');
 
-        $catalogue->deleteMetadata('messages', 'key2');
-        $this->assertEquals(null, $catalogue->getMetadata('messages', 'key2'), 'Metadata key2 should is deleted.');
+        $catalogue->deleteMetadata('key2', 'messages');
+        $this->assertEquals(null, $catalogue->getMetadata('key2', 'messages'), 'Metadata key2 should is deleted.');
 
-        $catalogue->deleteMetadata('domain', 'key2');
-        $this->assertEquals(null, $catalogue->getMetadata('domain', 'key2'), 'Metadata key2 should is deleted.');
+        $catalogue->deleteMetadata('key2', 'domain');
+        $this->assertEquals(null, $catalogue->getMetadata('key2', 'domain'), 'Metadata key2 should is deleted.');
     }
 
     public function testMetadataMerge()
     {
         $cat1 = new MessageCatalogue('en');
         $cat1->setMetadata('a', 'b');
-        $this->assertEquals(array('messages' => array('a' => 'b')), $cat1->getMetadata(), 'Cat1 contains messages metadata.');
+        $this->assertEquals(array('messages' => array('a' => 'b')), $cat1->getMetadata('', ''), 'Cat1 contains messages metadata.');
 
         $cat2 = new MessageCatalogue('en');
         $cat2->setMetadata('b', 'c', 'domain');
-        $this->assertEquals(array('domain' => array('b' => 'c')), $cat2->getMetadata(), 'Cat2 contains domain metadata.');
+        $this->assertEquals(array('domain' => array('b' => 'c')), $cat2->getMetadata('', ''), 'Cat2 contains domain metadata.');
 
         $cat1->addCatalogue($cat2);
-        $this->assertEquals(array('messages' => array('a' => 'b'), 'domain' => array('b' => 'c')), $cat1->getMetadata(), 'Cat1 contains merged metadata.');
+        $this->assertEquals(array('messages' => array('a' => 'b'), 'domain' => array('b' => 'c')), $cat1->getMetadata('', ''), 'Cat1 contains merged metadata.');
     }
 }


### PR DESCRIPTION
rework of #4399

For improving the Gettext tools (PO, MO File Loader/Dumper) we need at least storage for their meta data.

This patch allows for issues below to store and process ie Po Header, Po Header Pluralisation rule.

Open
- [[WIP]: Allow Drupal to use Translate component](https://github.com/symfony/symfony/pull/4249)
- [[2.1][Translator] Symfony translation process & gettext](https://github.com/symfony/symfony/issues/4245)

Closed:
- [[Translation] Po/MoFileLoader parse plurization rules](https://github.com/symfony/symfony/pull/3023)

It has 1 TODO regarding addCatalogue: it now just override old values with new.
