### PR TITLE
[Form] Added an alternative signature Form::add($name, $type, $options)

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -37,7 +37,14 @@
 
 ### Form
 
-  * The PasswordType is now not trimmed by default.
+ * The PasswordType is now not trimmed by default.
+
+#### Deprecations
+
+ * The methods `getParent()`, `setParent()` and `hasParent()` in
+   `FormBuilderInterface` were deprecated and will be removed in Symfony 2.3.
+   You should not rely on these methods in your form type because the parent
+   of a form can change after building it.
 
 ### Routing
 

--- a/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
+++ b/src/Symfony/Bridge/Propel1/Form/EventListener/TranslationFormListener.php
@@ -11,7 +11,6 @@
 namespace Symfony\Bridge\Propel1\Form\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 
@@ -24,13 +23,11 @@ class TranslationFormListener implements EventSubscriberInterface
 {
     private $columns;
     private $dataClass;
-    private $formFactory;
 
-    public function __construct(FormFactoryInterface $formFactory, $columns, $dataClass)
+    public function __construct($columns, $dataClass)
     {
         $this->columns = $columns;
         $this->dataClass = $dataClass;
-        $this->formFactory = $formFactory;
     }
 
     public static function getSubscribedEvents()
@@ -78,7 +75,7 @@ class TranslationFormListener implements EventSubscriberInterface
 
             $options = array_merge($options, $customOptions);
 
-            $form->add($this->formFactory->createNamed($column, $type, null, $options));
+            $form->add($column, $type, $options);
         }
     }
 }

--- a/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
+++ b/src/Symfony/Bridge/Propel1/Form/Type/TranslationType.php
@@ -28,8 +28,9 @@ class TranslationType extends AbstractType
       */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $listener = new TranslationFormListener($builder->getFormFactory(), $options['columns'], $options['data_class']);
-        $builder->addEventSubscriber($listener);
+        $builder->addEventSubscriber(
+            new TranslationFormListener($options['columns'], $options['data_class'])
+        );
     }
 
     /**

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 -----
 
  * TrimListener now removes unicode whitespaces
+ * deprecated getParent(), setParent() and hasParent() in FormBuilderInterface
+ * FormInterface::add() now accepts a FormInterface instance OR a field's name, type and options
 
 2.1.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -83,7 +83,7 @@ class ResizeFormListener implements EventSubscriberInterface
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
-            $form->add((string) $name, $this->type, array_replace(array(
+            $form->add($name, $this->type, array_replace(array(
                 'property_path' => '['.$name.']',
             ), $this->options));
         }
@@ -115,7 +115,7 @@ class ResizeFormListener implements EventSubscriberInterface
         if ($this->allowAdd) {
             foreach ($data as $name => $value) {
                 if (!$form->has($name)) {
-                    $form->add((string) $name, $this->type, array_replace(array(
+                    $form->add($name, $this->type, array_replace(array(
                         'property_path' => '['.$name.']',
                     ), $this->options));
                 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\Extension\Core\EventListener;
 
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -24,11 +23,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ResizeFormListener implements EventSubscriberInterface
 {
-    /**
-     * @var FormFactoryInterface
-     */
-    protected $factory;
-
     /**
      * @var string
      */
@@ -51,9 +45,8 @@ class ResizeFormListener implements EventSubscriberInterface
      */
     protected $allowDelete;
 
-    public function __construct(FormFactoryInterface $factory, $type, array $options = array(), $allowAdd = false, $allowDelete = false)
+    public function __construct($type, array $options = array(), $allowAdd = false, $allowDelete = false)
     {
-        $this->factory = $factory;
         $this->type = $type;
         $this->allowAdd = $allowAdd;
         $this->allowDelete = $allowDelete;
@@ -90,9 +83,9 @@ class ResizeFormListener implements EventSubscriberInterface
 
         // Then add all rows again in the correct order
         foreach ($data as $name => $value) {
-            $form->add($this->factory->createNamed($name, $this->type, null, array_replace(array(
+            $form->add((string) $name, $this->type, array_replace(array(
                 'property_path' => '['.$name.']',
-            ), $this->options)));
+            ), $this->options));
         }
     }
 
@@ -122,9 +115,9 @@ class ResizeFormListener implements EventSubscriberInterface
         if ($this->allowAdd) {
             foreach ($data as $name => $value) {
                 if (!$form->has($name)) {
-                    $form->add($this->factory->createNamed($name, $this->type, null, array_replace(array(
+                    $form->add((string) $name, $this->type, array_replace(array(
                         'property_path' => '['.$name.']',
-                    ), $this->options)));
+                    ), $this->options));
                 }
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -256,7 +256,7 @@ class ChoiceType extends AbstractType
                     $choiceType = 'radio';
                 }
 
-                $builder->add((string) $i, $choiceType, $choiceOpts);
+                $builder->add($i, $choiceType, $choiceOpts);
             }
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/CollectionType.php
@@ -34,7 +34,6 @@ class CollectionType extends AbstractType
         }
 
         $resizeListener = new ResizeFormListener(
-            $builder->getFormFactory(),
             $options['type'],
             $options['options'],
             $options['allow_add'],

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -890,8 +890,8 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if (!$child instanceof FormInterface) {
-            if (!is_string($child)) {
-                throw new UnexpectedTypeException($child, 'string or Symfony\Component\Form\FormInterface');
+            if (!is_string($child) && !is_int($child)) {
+                throw new UnexpectedTypeException($child, 'string, integer or Symfony\Component\Form\FormInterface');
             }
 
             if (null !== $type && !is_string($type) && !$type instanceof FormTypeInterface) {

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -78,8 +78,8 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
             return $this;
         }
 
-        if (!is_string($child)) {
-            throw new UnexpectedTypeException($child, 'string or Symfony\Component\Form\FormBuilder');
+        if (!is_string($child) && !is_int($child)) {
+            throw new UnexpectedTypeException($child, 'string, integer or Symfony\Component\Form\FormBuilder');
         }
 
         if (null !== $type && !is_string($type) && !$type instanceof FormTypeInterface) {

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -23,13 +23,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormBuilderInterface
 {
     /**
-     * The form factory.
-     *
-     * @var FormFactoryInterface
-     */
-    private $factory;
-
-    /**
      * The children of the form builder.
      *
      * @var array
@@ -63,15 +56,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     {
         parent::__construct($name, $dataClass, $dispatcher, $options);
 
-        $this->factory = $factory;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getFormFactory()
-    {
-        return $this->factory;
+        $this->setFormFactory($factory);
     }
 
     /**
@@ -125,10 +110,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
         }
 
         if (null !== $type) {
-            return $this->factory->createNamedBuilder($name, $type, null, $options, $this);
+            return $this->getFormFactory()->createNamedBuilder($name, $type, null, $options, $this);
         }
 
-        return $this->factory->createBuilderForProperty($this->getDataClass(), $name, null, $options, $this);
+        return $this->getFormFactory()->createBuilderForProperty($this->getDataClass(), $name, null, $options, $this);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -52,6 +52,7 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * @throws Exception\FormException if the given child does not exist
      */
     public function get($name);
+
     /**
      * Removes the field with the given name.
      *
@@ -78,13 +79,6 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
     public function all();
 
     /**
-     * Returns the associated form factory.
-     *
-     * @return FormFactoryInterface The factory
-     */
-    public function getFormFactory();
-
-    /**
      * Creates the form.
      *
      * @return Form The form
@@ -97,6 +91,11 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * @param FormBuilderInterface $parent The parent builder
      *
      * @return FormBuilderInterface The builder object.
+     *
+     * @deprecated Deprecated since version 2.2, to be removed in 2.3. You
+     *             should not rely on the parent of a builder, because it is
+     *             likely that the parent is only set after turning the builder
+     *             into a form.
      */
     public function setParent(FormBuilderInterface $parent = null);
 
@@ -104,6 +103,11 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * Returns the parent builder.
      *
      * @return FormBuilderInterface The parent builder
+     *
+     * @deprecated Deprecated since version 2.2, to be removed in 2.3. You
+     *             should not rely on the parent of a builder, because it is
+     *             likely that the parent is only set after turning the builder
+     *             into a form.
      */
     public function getParent();
 
@@ -111,6 +115,11 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * Returns whether the builder has a parent.
      *
      * @return Boolean
+     *
+     * @deprecated Deprecated since version 2.2, to be removed in 2.3. You
+     *             should not rely on the parent of a builder, because it is
+     *             likely that the parent is only set after turning the builder
+     *             into a form.
      */
     public function hasParent();
 }

--- a/src/Symfony/Component/Form/FormBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormBuilderInterface.php
@@ -23,9 +23,9 @@ interface FormBuilderInterface extends \Traversable, \Countable, FormConfigBuild
      * If you add a nested group, this group should also be represented in the
      * object hierarchy.
      *
-     * @param string|FormBuilderInterface $child
-     * @param string|FormTypeInterface    $type
-     * @param array                       $options
+     * @param string|integer|FormBuilderInterface $child
+     * @param string|FormTypeInterface            $type
+     * @param array                               $options
      *
      * @return FormBuilderInterface The builder object.
      */

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -132,6 +132,11 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     private $dataLocked;
 
     /**
+     * @var FormFactoryInterface
+     */
+    private $formFactory;
+
+    /**
      * @var array
      */
     private $options;
@@ -614,6 +619,14 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function getFormFactory()
+    {
+        return $this->formFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getOptions()
     {
         return $this->options;
@@ -845,6 +858,20 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         }
 
         $this->dataLocked = $locked;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setFormFactory(FormFactoryInterface $formFactory)
+    {
+        if ($this->locked) {
+            throw new FormException('The config builder cannot be modified anymore.');
+        }
+
+        $this->formFactory = $formFactory;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -144,7 +144,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * Creates an empty form configuration.
      *
-     * @param string                   $name       The form name
+     * @param string|integer           $name       The form name
      * @param string                   $dataClass  The class of the form's data
      * @param EventDispatcherInterface $dispatcher The event dispatcher
      * @param array                    $options    The form options
@@ -154,15 +154,13 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public function __construct($name, $dataClass, EventDispatcherInterface $dispatcher, array $options = array())
     {
-        $name = (string) $name;
-
         self::validateName($name);
 
         if (null !== $dataClass && !class_exists($dataClass)) {
             throw new \InvalidArgumentException(sprintf('The data class "%s" is not a valid class.', $dataClass));
         }
 
-        $this->name = $name;
+        $this->name = (string) $name;
         $this->dataClass = $dataClass;
         $this->dispatcher = $dispatcher;
         $this->options = $options;
@@ -895,15 +893,15 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * Validates whether the given variable is a valid form name.
      *
-     * @param string $name The tested form name.
+     * @param string|integer $name The tested form name.
      *
-     * @throws UnexpectedTypeException   If the name is not a string.
+     * @throws UnexpectedTypeException   If the name is not a string or an integer.
      * @throws \InvalidArgumentException If the name contains invalid characters.
      */
     public static function validateName($name)
     {
-        if (!is_string($name)) {
-            throw new UnexpectedTypeException($name, 'string');
+        if (null !== $name && !is_string($name) && !is_int($name)) {
+            throw new UnexpectedTypeException($name, 'string, integer or null');
         }
 
         if (!self::isValidName($name)) {
@@ -930,6 +928,6 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public static function isValidName($name)
     {
-        return '' === $name || preg_match('/^[a-zA-Z0-9_][a-zA-Z0-9_\-:]*$/D', $name);
+        return '' === $name || null === $name || preg_match('/^[a-zA-Z0-9_][a-zA-Z0-9_\-:]*$/D', $name);
     }
 }

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -242,6 +242,13 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setDataLocked($locked);
 
     /**
+     * Sets the form factory used for creating new forms.
+     *
+     * @param FormFactoryInterface $formFactory The form factory.
+     */
+    public function setFormFactory(FormFactoryInterface $formFactory);
+
+    /**
      * Builds and returns the form configuration.
      *
      * @return FormConfigInterface

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -193,6 +193,13 @@ interface FormConfigInterface
     public function getDataLocked();
 
     /**
+     * Returns the form factory used for creating new forms.
+     *
+     * @return FormFactoryInterface The form factory.
+     */
+    public function getFormFactory();
+
+    /**
      * Returns all options passed during the construction of the form.
      *
      * @return array The passed options.

--- a/src/Symfony/Component/Form/FormFactoryInterface.php
+++ b/src/Symfony/Component/Form/FormFactoryInterface.php
@@ -37,7 +37,7 @@ interface FormFactoryInterface
      *
      * @see createNamedBuilder()
      *
-     * @param string                   $name    The name of the form
+     * @param string|integer           $name    The name of the form
      * @param string|FormTypeInterface $type    The type of the form
      * @param mixed                    $data    The initial data
      * @param array                    $options The options
@@ -83,7 +83,7 @@ interface FormFactoryInterface
     /**
      * Returns a form builder.
      *
-     * @param string                   $name    The name of the form
+     * @param string|integer           $name    The name of the form
      * @param string|FormTypeInterface $type    The type of the form
      * @param mixed                    $data    The initial data
      * @param array                    $options The options

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -41,14 +41,17 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Adds a child to the form.
      *
-     * @param  FormInterface $child The FormInterface to add as a child
+     * @param FormInterface|string $child   The FormInterface instance or the name of the child.
+     * @param string|null          $type    The child's type, if a name was passed.
+     * @param array                $options The child's options, if a name was passed.
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadyBoundException If the form has already been bound.
-     * @throws Exception\FormException         When trying to add a child to a non-compound form.
+     * @throws Exception\AlreadyBoundException   If the form has already been bound.
+     * @throws Exception\FormException           When trying to add a child to a non-compound form.
+     * @throws Exception\UnexpectedTypeException If $child or $type has an unexpected type.
      */
-    public function add(FormInterface $child);
+    public function add($child, $type = null, array $options = array());
 
     /**
      * Returns the child with the given name.

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -41,9 +41,9 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Adds a child to the form.
      *
-     * @param FormInterface|string $child   The FormInterface instance or the name of the child.
-     * @param string|null          $type    The child's type, if a name was passed.
-     * @param array                $options The child's options, if a name was passed.
+     * @param FormInterface|string|integer $child   The FormInterface instance or the name of the child.
+     * @param string|null                  $type    The child's type, if a name was passed.
+     * @param array                        $options The child's options, if a name was passed.
      *
      * @return FormInterface The form instance
      *

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -33,7 +33,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertTrue($this->form->isValid());
     }
 
-    public function testInvalidIfChildrenIsInvalid()
+    public function testInvalidIfChildIsInvalid()
     {
         $this->form->add($this->getValidForm('firstName'));
         $this->form->add($this->getInvalidForm('lastName'));
@@ -135,12 +135,71 @@ class CompoundFormTest extends AbstractFormTest
         $child = $this->getBuilder('foo')->getForm();
         $this->form->add($child);
 
+        $this->assertTrue($this->form->has('foo'));
+        $this->assertSame($this->form, $child->getParent());
+        $this->assertSame(array('foo' => $child), $this->form->all());
+    }
+
+    public function testAddUsingNameAndType()
+    {
+        $child = $this->getBuilder('foo')->getForm();
+
+        $this->factory->expects($this->once())
+            ->method('createNamed')
+            ->with('foo', 'text', null, array('bar' => 'baz'))
+            ->will($this->returnValue($child));
+
+        $this->form->add('foo', 'text', array('bar' => 'baz'));
+
+        $this->assertTrue($this->form->has('foo'));
+        $this->assertSame($this->form, $child->getParent());
+        $this->assertSame(array('foo' => $child), $this->form->all());
+    }
+
+    public function testAddUsingNameButNoType()
+    {
+        $this->form = $this->getBuilder('name', null, '\stdClass')
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->getForm();
+
+        $child = $this->getBuilder('foo')->getForm();
+
+        $this->factory->expects($this->once())
+            ->method('createForProperty')
+            ->with('\stdClass', 'foo')
+            ->will($this->returnValue($child));
+
+        $this->form->add('foo');
+
+        $this->assertTrue($this->form->has('foo'));
+        $this->assertSame($this->form, $child->getParent());
+        $this->assertSame(array('foo' => $child), $this->form->all());
+    }
+
+    public function testAddUsingNameButNoTypeAndOptions()
+    {
+        $this->form = $this->getBuilder('name', null, '\stdClass')
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->getForm();
+
+        $child = $this->getBuilder('foo')->getForm();
+
+        $this->factory->expects($this->once())
+            ->method('createForProperty')
+            ->with('\stdClass', 'foo', null, array('bar' => 'baz'))
+            ->will($this->returnValue($child));
+
+        $this->form->add('foo', null, array('bar' => 'baz'));
+
+        $this->assertTrue($this->form->has('foo'));
         $this->assertSame($this->form, $child->getParent());
         $this->assertSame(array('foo' => $child), $this->form->all());
     }
 
     /**
-     * @expectedException Symfony\Component\Form\Exception\AlreadyBoundException
+     * @expectedException \Symfony\Component\Form\Exception\AlreadyBoundException
      */
     public function testAddThrowsExceptionIfAlreadyBound()
     {
@@ -161,7 +220,7 @@ class CompoundFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException Symfony\Component\Form\Exception\AlreadyBoundException
+     * @expectedException \Symfony\Component\Form\Exception\AlreadyBoundException
      */
     public function testRemoveThrowsExceptionIfAlreadyBound()
     {

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -156,6 +156,23 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertSame(array('foo' => $child), $this->form->all());
     }
 
+    public function testAddUsingIntegerNameAndType()
+    {
+        $child = $this->getBuilder(0)->getForm();
+
+        $this->factory->expects($this->once())
+            ->method('createNamed')
+            ->with('0', 'text', null, array('bar' => 'baz'))
+            ->will($this->returnValue($child));
+
+        // in order to make casting unnecessary
+        $this->form->add(0, 'text', array('bar' => 'baz'));
+
+        $this->assertTrue($this->form->has(0));
+        $this->assertSame($this->form, $child->getParent());
+        $this->assertSame(array(0 => $child), $this->form->all());
+    }
+
     public function testAddUsingNameButNoType()
     {
         $this->form = $this->getBuilder('name', null, '\stdClass')

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -81,7 +81,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = array(1 => 'string', 2 => 'string');
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array('max_length' => '10'), false, false);
+        $listener = new ResizeFormListener('text', array('max_length' => '10'), false, false);
         $listener->preSetData($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -90,13 +90,13 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
      */
     public function testPreSetDataRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, false);
+        $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preSetData($event);
     }
 
@@ -106,7 +106,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = null;
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, false);
+        $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preSetData($event);
     }
 
@@ -121,7 +121,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = array(0 => 'string', 1 => 'string');
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array('max_length' => 10), true, false);
+        $listener = new ResizeFormListener('text', array('max_length' => 10), true, false);
         $listener->preBind($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -135,7 +135,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = array(0 => 'string');
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, true);
+        $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -149,7 +149,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = array();
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, true);
+        $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
         $this->assertFalse($this->form->has('0'));
@@ -162,7 +162,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = array(0 => 'string', 2 => 'string');
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, false);
+        $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preBind($event);
 
         $this->assertTrue($this->form->has('0'));
@@ -171,13 +171,13 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
      */
     public function testPreBindRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, false);
+        $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preBind($event);
     }
 
@@ -187,7 +187,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = null;
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, true);
+        $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -200,7 +200,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = '';
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, true);
+        $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
         $this->assertFalse($this->form->has('1'));
@@ -212,7 +212,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = array(0 => 'first', 1 => 'second', 2 => 'third');
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, true);
+        $listener = new ResizeFormListener('text', array(), false, true);
         $listener->onBind($event);
 
         $this->assertEquals(array(1 => 'second'), $event->getData());
@@ -224,20 +224,20 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = array(0 => 'first', 1 => 'second', 2 => 'third');
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, false);
+        $listener = new ResizeFormListener('text', array(), false, false);
         $listener->onBind($event);
 
         $this->assertEquals($data, $event->getData());
     }
 
     /**
-     * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
+     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
      */
     public function testOnBindNormDataRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, false);
+        $listener = new ResizeFormListener('text', array(), false, false);
         $listener->onBind($event);
     }
 
@@ -247,7 +247,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 
         $data = null;
         $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
-        $listener = new ResizeFormListener($this->factory, 'text', array(), false, true);
+        $listener = new ResizeFormListener('text', array(), false, true);
         $listener->onBind($event);
 
         $this->assertEquals(array(), $event->getData());

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -50,10 +50,10 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(method_exists($this->builder, 'setName'));
     }
 
-    public function testAddNameNoString()
+    public function testAddNameNoStringAndNoInteger()
     {
         $this->setExpectedException('Symfony\Component\Form\Exception\UnexpectedTypeException');
-        $this->builder->add(1234);
+        $this->builder->add(true);
     }
 
     public function testAddTypeNoString()
@@ -80,6 +80,13 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->builder->has('foo'));
         $this->builder->add('foo', 'text');
         $this->assertTrue($this->builder->has('foo'));
+    }
+
+    public function testAddIntegerName()
+    {
+        $this->assertFalse($this->builder->has(0));
+        $this->builder->add(0, 'text');
+        $this->assertTrue($this->builder->has(0));
     }
 
     public function testAll()

--- a/src/Symfony/Component/Form/Tests/FormConfigTest.php
+++ b/src/Symfony/Component/Form/Tests/FormConfigTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
@@ -21,8 +23,6 @@ class FormConfigTest extends \PHPUnit_Framework_TestCase
     public function getHtml4Ids()
     {
         return array(
-            array('a0', true),
-            array('a9', true),
             array('z0', true),
             array('A0', true),
             array('A9', true),
@@ -53,6 +53,16 @@ class FormConfigTest extends \PHPUnit_Framework_TestCase
             // For root forms, leading underscores will be stripped from the
             // "id" attribute to produce valid HTML4.
             array('_', true),
+            // Integers are allowed
+            array(0, true),
+            array(123, true),
+            // NULL is allowed
+            array(null, true),
+            // Other types are not
+            array(1.23, false),
+            array(5., false),
+            array(true, false),
+            array(new \stdClass(), false),
         );
     }
 
@@ -67,6 +77,11 @@ class FormConfigTest extends \PHPUnit_Framework_TestCase
             new FormConfigBuilder($name, null, $dispatcher);
             if (!$accepted) {
                 $this->fail(sprintf('The value "%s" should not be accepted', $name));
+            }
+        } catch (UnexpectedTypeException $e) {
+            // if the value was not accepted, but should be, rethrow exception
+            if ($accepted) {
+                throw $e;
             }
         } catch (\InvalidArgumentException $e) {
             // if the value was not accepted, but should be, rethrow exception


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5806
Todo: -
License of the code: MIT
Documentation PR: symfony/symfony-docs#2024
