### PR TITLE
[2.3] [Console] TableHelper

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -27,6 +27,7 @@ use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\FormatterHelper;
 use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\ProgressHelper;
+use Symfony\Component\Console\Helper\TableHelper;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleForExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
@@ -1013,6 +1014,7 @@ class Application
             new FormatterHelper(),
             new DialogHelper(),
             new ProgressHelper(),
+            new TableHelper(),
         ));
     }
 

--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.3.0
 -----
 
+ * added Table Helper for tabular data rendering
  * added support for events in `Application`
  * added a way to normalize EOLs in `ApplicationTester::getDisplay()` and `CommandTester::getDisplay()`
  * added a way to set the progress bar progress via the `setCurrent` method

--- a/src/Symfony/Component/Console/Helper/FormatterHelper.php
+++ b/src/Symfony/Component/Console/Helper/FormatterHelper.php
@@ -71,26 +71,6 @@ class FormatterHelper extends Helper
     }
 
     /**
-     * Returns the length of a string, using mb_strlen if it is available.
-     *
-     * @param string $string The string to check its length
-     *
-     * @return integer The length of the string
-     */
-    private function strlen($string)
-    {
-        if (!function_exists('mb_strlen')) {
-            return strlen($string);
-        }
-
-        if (false === $encoding = mb_detect_encoding($string)) {
-            return strlen($string);
-        }
-
-        return mb_strlen($string, $encoding);
-    }
-
-    /**
      * {@inheritDoc}
      */
     public function getName()

--- a/src/Symfony/Component/Console/Helper/Helper.php
+++ b/src/Symfony/Component/Console/Helper/Helper.php
@@ -39,4 +39,24 @@ abstract class Helper implements HelperInterface
     {
         return $this->helperSet;
     }
+
+    /**
+     * Returns the length of a string, using mb_strlen if it is available.
+     *
+     * @param string $string The string to check its length
+     *
+     * @return integer The length of the string
+     */
+    protected function strlen($string)
+    {
+        if (!function_exists('mb_strlen')) {
+            return strlen($string);
+        }
+
+        if (false === $encoding = mb_detect_encoding($string)) {
+            return strlen($string);
+        }
+
+        return mb_strlen($string, $encoding);
+    }
 }

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Console\Helper;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * The Progress class providers helpers to display progress output.
+ * The Progress class provides helpers to display progress output.
  *
  * @author Chris Jones <leeked@gmail.com>
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -320,7 +320,7 @@ class ProgressHelper extends Helper
         }
 
         if ($this->max > 0) {
-            $this->widths['max']     = $this->getLength($this->max);
+            $this->widths['max']     = $this->strlen($this->max);
             $this->widths['current'] = $this->widths['max'];
         } else {
             $this->barCharOriginal = $this->barChar;
@@ -356,7 +356,7 @@ class ProgressHelper extends Helper
                 }
             }
 
-            $emptyBars = $this->barWidth - $completeBars - $this->getLength($this->progressChar);
+            $emptyBars = $this->barWidth - $completeBars - $this->strlen($this->progressChar);
             $bar = str_repeat($this->barChar, $completeBars);
             if ($completeBars < $this->barWidth) {
                 $bar .= $this->progressChar;
@@ -419,7 +419,7 @@ class ProgressHelper extends Helper
      */
     private function overwrite(OutputInterface $output, $message)
     {
-        $length = $this->getLength($message);
+        $length = $this->strlen($message);
 
         // append whitespace to match the last line's length
         if (null !== $this->lastMessagesLength && $this->lastMessagesLength > $length) {
@@ -430,26 +430,7 @@ class ProgressHelper extends Helper
         $output->write("\x0D");
         $output->write($message);
 
-        $this->lastMessagesLength = $this->getLength($message);
-    }
-
-    /**
-     * Wrapper arround strlen: uses multi-byte function if available
-     *
-     * @param  string $string
-     * @return integer
-     */
-    private function getLength($string)
-    {
-        if (!function_exists('mb_strlen')) {
-            return strlen($string);
-        }
-
-        if (false === $encoding = mb_detect_encoding($string)) {
-            return strlen($string);
-        }
-
-        return mb_strlen($string, $encoding);
+        $this->lastMessagesLength = $this->strlen($message);
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -250,6 +250,14 @@ class TableHelper extends Helper
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'table';
+    }
+
+    /**
      * Renders horizontal header separator.
      *
      * Example: +-----+-----------+-------+
@@ -392,13 +400,5 @@ class TableHelper extends Helper
     {
         $this->columnWidths = array();
         $this->numberOfColumns = null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getName()
-    {
-        return 'table';
     }
 }

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -1,0 +1,339 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Provides helpers to display table output.
+ *
+ * @author Саша Стаменковић <umpirsky@gmail.com>
+ */
+class TableHelper extends Helper
+{
+    /**
+     * Table headers.
+     *
+     * @var array
+     */
+    private $headers = array();
+
+    /**
+     * Table rows.
+     *
+     * @var array
+     */
+    private $rows = array();
+
+    // Rendering options
+    private $backgroundChar  = ' ';
+    private $horizontalBorderChar = '-';
+    private $verticalBorderChar = '|';
+    private $edgeChar = '+';
+    private $cellHeaderFormat = '<info>%s</info>';
+    private $cellRowFormat = '<comment>%s</comment>';
+    private $borderFormat = '%s';
+    private $padType = STR_PAD_RIGHT;
+    
+    /**
+     * @var OutputInterface
+     */
+    private $output;
+
+    public function setHeaders(array $headers)
+    {
+        $this->headers = array_values($headers);
+
+        return $this;
+    }
+
+    public function setRows(array $rows)
+    {
+        $this->rows = array();
+
+        foreach ($rows as $row) {
+            $this->addRow($row);
+        }
+
+        return $this;
+    }
+
+    public function addRows(array $rows)
+    {
+        foreach ($rows as $row) {
+            $this->addRow($row);
+        }
+
+        return $this;
+    }
+
+    public function addRow(array $row)
+    {
+        $this->rows[] = array_values($row);
+
+        return $this;
+    }
+
+    public function setRow(array $row, $column)
+    {
+        $this->rows[$column] = $row;
+
+        return $this;
+    }
+
+    /**
+     * Sets background character, used for cell padding.
+     * 
+     * @param string $backgroundChar
+     */
+    public function setBackgroundChar($backgroundChar)
+    {
+        $this->backgroundChar = $backgroundChar;
+    }
+
+    /**
+     * Sets horizontal border character.
+     * 
+     * @param string $horizontalBorderChar
+     */
+    public function setHorizontalBorderChar($horizontalBorderChar)
+    {
+        $this->horizontalBorderChar = $horizontalBorderChar;
+    }
+
+    /**
+     * Sets vertical border character.
+     * 
+     * @param string $verticalBorderChar
+     */
+        public function setVerticalBorderChar($verticalBorderChar)
+    {
+        $this->verticalBorderChar = $verticalBorderChar;
+    }
+
+    /**
+     * Sets edge character.
+     * 
+     * @param string $edgeChar
+     */
+    public function setEdgeChar($edgeChar)
+    {
+        $this->edgeChar = $edgeChar;
+    }
+
+    /**
+     * Sets header cell format.
+     * 
+     * @param string $cellHeaderFormat
+     */
+    public function setCellHeaderFormat($cellHeaderFormat)
+    {
+        $this->cellHeaderFormat = $cellHeaderFormat;
+    }
+
+    /**
+     * Sets row cell format.
+     * 
+     * @param string $cellRowFormat
+     */
+    public function setCellRowFormat($cellRowFormat)
+    {
+        $this->cellRowFormat = $cellRowFormat;
+    }
+    
+    /**
+     * Sets table border format.
+     * 
+     * @param string $borderFormat
+     */
+    public function setBorderFormat($borderFormat)
+    {
+        $this->borderFormat = $borderFormat;
+    }
+
+    /**
+     * Sets cell padding type.
+     * 
+     * @param int $padType STR_PAD_*
+     */
+    public function setPadType($padType)
+    {
+        $this->padType = $padType;
+    }
+
+    /**
+     * Renders table to output.
+     * 
+     * Example:
+     * +---------------+-----------------------+------------------+
+     * | ISBN          | Title                 | Author           |
+     * +---------------+-----------------------+------------------+
+     * | 99921-58-10-7 | Divine Comedy         | Dante Alighieri  |
+     * | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
+     * | 960-425-059-0 | The Lord of the Rings | J. R. R. Tolkien |
+     * +---------------+-----------------------+------------------+
+     * 
+     * @param OutputInterface $output
+     */
+    public function render(OutputInterface $output)
+    {
+        $this->output = $output;
+        
+        $this->renderRowSeparator();
+        $this->renderRow($this->headers, $this->cellHeaderFormat);
+        if (!empty($this->headers)) {
+            $this->renderRowSeparator();
+        }
+        foreach ($this->rows as $row) {
+            $this->renderRow($row, $this->cellRowFormat);
+        }
+        if (!empty($this->rows)) {
+            $this->renderRowSeparator();
+        }
+    }
+    
+    /**
+     * Renders horizontal header separator.
+     * 
+     * Example: +-----+-----------+-------+
+     */
+    private function renderRowSeparator()
+    {
+        if (0 === $this->getNumberOfColumns()) {
+            return;
+        }
+
+        $markup = $this->edgeChar;
+        for ($column = 0; $column < $this->getNumberOfColumns(); $column++) {
+            $markup .= str_repeat($this->horizontalBorderChar, $this->getColumnWidth($column))
+                    .$this->edgeChar
+            ;
+        }
+        
+        $this->output->writeln(sprintf($this->borderFormat, $markup));
+    }
+    
+    /**
+     * Renders vertical column separator.
+     */
+    private function renderColumnSeparator()
+    {
+        $this->output->write(sprintf($this->borderFormat, $this->verticalBorderChar));
+    }
+    
+    /**
+     * Renders table row.
+     * 
+     * Example: | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
+     * 
+     * @param array  $row
+     * @param string $cellFormat
+     */
+    private function renderRow(array $row, $cellFormat)
+    {
+        if (empty($row)) {
+            return;
+        }
+
+        $this->renderColumnSeparator();
+        for ($column = 0; $column < $this->getNumberOfColumns(); $column++) {
+            $this->renderCell($row, $column, $cellFormat);
+            $this->renderColumnSeparator();
+        }
+        $this->output->writeln('');
+    }
+
+    /**
+     * Renders table cell with padding.
+     * 
+     * @param array  $row
+     * @param int    $column
+     * @param string $cellFormat
+     */
+    private function renderCell(array $row, $column, $cellFormat)
+    {
+        $cell = isset($row[$column]) ? $row[$column] : '';
+
+        $this->output->write(sprintf(
+            $cellFormat,
+            str_pad(
+                $this->backgroundChar.$cell.$this->backgroundChar,
+                $this->getColumnWidth($column),
+                $this->backgroundChar,
+                $this->padType
+            )
+        ));
+    }
+
+    /**
+     * Gets number of columns for this table.
+     * 
+     * @return int
+     */
+    private function getNumberOfColumns()
+    {
+        $columns = array(0);
+        $columns[] = count($this->headers);
+        foreach ($this->rows as $row) {
+            $columns[] = count($row);
+        }
+
+        return max($columns);
+    }
+
+    /**
+     * Gets column width.
+     * 
+     * @param int $column
+     * 
+     * @return int
+     */
+    private function getColumnWidth($column)
+    {
+        $lengths = array(0);
+        $lengths[] = $this->getCellWidth($this->headers, $column);
+        foreach ($this->rows as $row) {
+            $lengths[] = $this->getCellWidth($row, $column);
+        }
+
+        return max($lengths) + 2;
+    }
+    
+    /**
+     * Gets cell width.
+     * 
+     * @param array $row
+     * @param int   $column
+     * 
+     * @return int
+     */
+    private function getCellWidth(array $row, $column)
+    {
+        if ($column < 0) {
+            return 0;
+        }
+
+        if (isset($row[$column])) {
+            return mb_strlen($row[$column]);
+        }
+        
+        return $this->getCellWidth($row, $column - 1);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'table';
+    }
+}

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -98,6 +98,8 @@ class TableHelper extends Helper
     public function setBackgroundChar($backgroundChar)
     {
         $this->backgroundChar = $backgroundChar;
+
+        return $this;
     }
 
     /**
@@ -108,6 +110,8 @@ class TableHelper extends Helper
     public function setHorizontalBorderChar($horizontalBorderChar)
     {
         $this->horizontalBorderChar = $horizontalBorderChar;
+
+        return $this;
     }
 
     /**
@@ -115,9 +119,11 @@ class TableHelper extends Helper
      *
      * @param string $verticalBorderChar
      */
-        public function setVerticalBorderChar($verticalBorderChar)
+    public function setVerticalBorderChar($verticalBorderChar)
     {
         $this->verticalBorderChar = $verticalBorderChar;
+
+        return $this;
     }
 
     /**
@@ -128,6 +134,8 @@ class TableHelper extends Helper
     public function setEdgeChar($edgeChar)
     {
         $this->edgeChar = $edgeChar;
+
+        return $this;
     }
 
     /**
@@ -138,6 +146,8 @@ class TableHelper extends Helper
     public function setCellHeaderFormat($cellHeaderFormat)
     {
         $this->cellHeaderFormat = $cellHeaderFormat;
+
+        return $this;
     }
 
     /**
@@ -148,6 +158,8 @@ class TableHelper extends Helper
     public function setCellRowFormat($cellRowFormat)
     {
         $this->cellRowFormat = $cellRowFormat;
+
+        return $this;
     }
 
     /**
@@ -158,6 +170,8 @@ class TableHelper extends Helper
     public function setBorderFormat($borderFormat)
     {
         $this->borderFormat = $borderFormat;
+
+        return $this;
     }
 
     /**
@@ -168,6 +182,8 @@ class TableHelper extends Helper
     public function setPadType($padType)
     {
         $this->padType = $padType;
+
+        return $this;
     }
 
     /**
@@ -208,12 +224,12 @@ class TableHelper extends Helper
      */
     private function renderRowSeparator()
     {
-        if (0 === $this->getNumberOfColumns()) {
+        if (0 === $count = $this->getNumberOfColumns()) {
             return;
         }
 
         $markup = $this->edgeChar;
-        for ($column = 0; $column < $this->getNumberOfColumns(); $column++) {
+        for ($column = 0; $column < $count; $column++) {
             $markup .= str_repeat($this->horizontalBorderChar, $this->getColumnWidth($column))
                     .$this->edgeChar
             ;
@@ -245,7 +261,7 @@ class TableHelper extends Helper
         }
 
         $this->renderColumnSeparator();
-        for ($column = 0; $column < $this->getNumberOfColumns(); $column++) {
+        for ($column = 0, $count = $this->getNumberOfColumns(); $column < $count; $column++) {
             $this->renderCell($row, $column, $cellFormat);
             $this->renderColumnSeparator();
         }

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Console\Helper;
 
 use Symfony\Component\Console\Output\OutputInterface;
+use InvalidArgumentException;
 
 /**
  * Provides helpers to display table output.
@@ -20,6 +21,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class TableHelper extends Helper
 {
+    const LAYOUT_DEFAULT = 0;
+    const LAYOUT_BORDERLESS = 1;
+
     /**
      * Table headers.
      *
@@ -35,14 +39,14 @@ class TableHelper extends Helper
     private $rows = array();
 
     // Rendering options
-    private $paddingChar  = ' ';
-    private $horizontalBorderChar = '-';
-    private $verticalBorderChar = '|';
-    private $crossingChar = '+';
-    private $cellHeaderFormat = '<info>%s</info>';
-    private $cellRowFormat = '<comment>%s</comment>';
-    private $borderFormat = '%s';
-    private $padType = STR_PAD_RIGHT;
+    private $paddingChar;
+    private $horizontalBorderChar;
+    private $verticalBorderChar;
+    private $crossingChar;
+    private $cellHeaderFormat;
+    private $cellRowFormat;
+    private $borderFormat;
+    private $padType;
 
     /**
      * Column widths cache.
@@ -62,6 +66,55 @@ class TableHelper extends Helper
      * @var OutputInterface
      */
     private $output;
+
+    public function __construct()
+    {
+        $this->setLayout(self::LAYOUT_DEFAULT);
+    }
+
+    /**
+     * Sets table layout type.
+     *
+     * @param int $layout self::LAYOUT_*
+     *
+     * @return TableHelper
+     */
+    public function setLayout($layout)
+    {
+        switch ($layout) {
+            case self::LAYOUT_BORDERLESS:
+                $this
+                    ->setPaddingChar(' ')
+                    ->setHorizontalBorderChar('=')
+                    ->setVerticalBorderChar(' ')
+                    ->setCrossingChar(' ')
+                    ->setCellHeaderFormat('<info>%s</info>')
+                    ->setCellRowFormat('<comment>%s</comment>')
+                    ->setBorderFormat('%s')
+                    ->setPadType(STR_PAD_RIGHT)
+                ;
+                break;
+
+            case self::LAYOUT_DEFAULT:
+                $this
+                    ->setPaddingChar(' ')
+                    ->setHorizontalBorderChar('-')
+                    ->setVerticalBorderChar('|')
+                    ->setCrossingChar('+')
+                    ->setCellHeaderFormat('<info>%s</info>')
+                    ->setCellRowFormat('<comment>%s</comment>')
+                    ->setBorderFormat('%s')
+                    ->setPadType(STR_PAD_RIGHT)
+                ;
+                break;
+
+            default:
+                throw new InvalidArgumentException(sprintf('Invalid table layout "%s".', $layout));
+                break;
+        };
+
+        return $this;
+    }
 
     public function setHeaders(array $headers)
     {

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -191,7 +191,7 @@ class TableHelper extends Helper
     /**
      * Sets cell padding type.
      *
-     * @param int $padType STR_PAD_*
+     * @param integer $padType STR_PAD_*
      *
      * @return TableHelper
      */
@@ -287,9 +287,9 @@ class TableHelper extends Helper
     /**
      * Renders table cell with padding.
      *
-     * @param array  $row
-     * @param int    $column
-     * @param string $cellFormat
+     * @param array   $row
+     * @param integer $column
+     * @param string  $cellFormat
      */
     private function renderCell(array $row, $column, $cellFormat)
     {
@@ -325,7 +325,7 @@ class TableHelper extends Helper
     /**
      * Gets column width.
      *
-     * @param int $column
+     * @param integer $column
      *
      * @return int
      */
@@ -343,8 +343,8 @@ class TableHelper extends Helper
     /**
      * Gets cell width.
      *
-     * @param array $row
-     * @param int   $column
+     * @param array   $row
+     * @param integer $column
      *
      * @return int
      */

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -45,6 +45,20 @@ class TableHelper extends Helper
     private $padType = STR_PAD_RIGHT;
 
     /**
+     * Column widths cache.
+     *
+     * @var array
+     */
+    private $columnWidths = array();
+
+    /**
+     * Number of columns cache.
+     *
+     * @var array
+     */
+    private $numberOfColumns;
+
+    /**
      * @var OutputInterface
      */
     private $output;
@@ -231,6 +245,8 @@ class TableHelper extends Helper
         if (!empty($this->rows)) {
             $this->renderRowSeparator();
         }
+
+        $this->afterRender();
     }
 
     /**
@@ -313,13 +329,17 @@ class TableHelper extends Helper
      */
     private function getNumberOfColumns()
     {
+        if (null !== $this->numberOfColumns) {
+            return $this->numberOfColumns;
+        }
+
         $columns = array(0);
         $columns[] = count($this->headers);
         foreach ($this->rows as $row) {
             $columns[] = count($row);
         }
 
-        return max($columns);
+        return $this->numberOfColumns = max($columns);
     }
 
     /**
@@ -331,13 +351,17 @@ class TableHelper extends Helper
      */
     private function getColumnWidth($column)
     {
+        if (isset($this->columnWidths[$column])) {
+            return $this->columnWidths[$column];
+        }
+
         $lengths = array(0);
         $lengths[] = $this->getCellWidth($this->headers, $column);
         foreach ($this->rows as $row) {
             $lengths[] = $this->getCellWidth($row, $column);
         }
 
-        return max($lengths) + 2;
+        return $this->columnWidths[$column] = max($lengths) + 2;
     }
 
     /**
@@ -359,6 +383,15 @@ class TableHelper extends Helper
         }
 
         return $this->getCellWidth($row, $column - 1);
+    }
+
+    /**
+     * Called after rendering to cleanup cache data.
+     */
+    private function afterRender()
+    {
+        $this->columnWidths = array();
+        $this->numberOfColumns = null;
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -43,7 +43,7 @@ class TableHelper extends Helper
     private $cellRowFormat = '<comment>%s</comment>';
     private $borderFormat = '%s';
     private $padType = STR_PAD_RIGHT;
-    
+
     /**
      * @var OutputInterface
      */
@@ -92,7 +92,7 @@ class TableHelper extends Helper
 
     /**
      * Sets background character, used for cell padding.
-     * 
+     *
      * @param string $backgroundChar
      */
     public function setBackgroundChar($backgroundChar)
@@ -102,7 +102,7 @@ class TableHelper extends Helper
 
     /**
      * Sets horizontal border character.
-     * 
+     *
      * @param string $horizontalBorderChar
      */
     public function setHorizontalBorderChar($horizontalBorderChar)
@@ -112,7 +112,7 @@ class TableHelper extends Helper
 
     /**
      * Sets vertical border character.
-     * 
+     *
      * @param string $verticalBorderChar
      */
         public function setVerticalBorderChar($verticalBorderChar)
@@ -122,7 +122,7 @@ class TableHelper extends Helper
 
     /**
      * Sets edge character.
-     * 
+     *
      * @param string $edgeChar
      */
     public function setEdgeChar($edgeChar)
@@ -132,7 +132,7 @@ class TableHelper extends Helper
 
     /**
      * Sets header cell format.
-     * 
+     *
      * @param string $cellHeaderFormat
      */
     public function setCellHeaderFormat($cellHeaderFormat)
@@ -142,17 +142,17 @@ class TableHelper extends Helper
 
     /**
      * Sets row cell format.
-     * 
+     *
      * @param string $cellRowFormat
      */
     public function setCellRowFormat($cellRowFormat)
     {
         $this->cellRowFormat = $cellRowFormat;
     }
-    
+
     /**
      * Sets table border format.
-     * 
+     *
      * @param string $borderFormat
      */
     public function setBorderFormat($borderFormat)
@@ -162,7 +162,7 @@ class TableHelper extends Helper
 
     /**
      * Sets cell padding type.
-     * 
+     *
      * @param int $padType STR_PAD_*
      */
     public function setPadType($padType)
@@ -172,7 +172,7 @@ class TableHelper extends Helper
 
     /**
      * Renders table to output.
-     * 
+     *
      * Example:
      * +---------------+-----------------------+------------------+
      * | ISBN          | Title                 | Author           |
@@ -181,13 +181,13 @@ class TableHelper extends Helper
      * | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
      * | 960-425-059-0 | The Lord of the Rings | J. R. R. Tolkien |
      * +---------------+-----------------------+------------------+
-     * 
+     *
      * @param OutputInterface $output
      */
     public function render(OutputInterface $output)
     {
         $this->output = $output;
-        
+
         $this->renderRowSeparator();
         $this->renderRow($this->headers, $this->cellHeaderFormat);
         if (!empty($this->headers)) {
@@ -200,10 +200,10 @@ class TableHelper extends Helper
             $this->renderRowSeparator();
         }
     }
-    
+
     /**
      * Renders horizontal header separator.
-     * 
+     *
      * Example: +-----+-----------+-------+
      */
     private function renderRowSeparator()
@@ -218,10 +218,10 @@ class TableHelper extends Helper
                     .$this->edgeChar
             ;
         }
-        
+
         $this->output->writeln(sprintf($this->borderFormat, $markup));
     }
-    
+
     /**
      * Renders vertical column separator.
      */
@@ -229,12 +229,12 @@ class TableHelper extends Helper
     {
         $this->output->write(sprintf($this->borderFormat, $this->verticalBorderChar));
     }
-    
+
     /**
      * Renders table row.
-     * 
+     *
      * Example: | 9971-5-0210-0 | A Tale of Two Cities  | Charles Dickens  |
-     * 
+     *
      * @param array  $row
      * @param string $cellFormat
      */
@@ -254,7 +254,7 @@ class TableHelper extends Helper
 
     /**
      * Renders table cell with padding.
-     * 
+     *
      * @param array  $row
      * @param int    $column
      * @param string $cellFormat
@@ -276,7 +276,7 @@ class TableHelper extends Helper
 
     /**
      * Gets number of columns for this table.
-     * 
+     *
      * @return int
      */
     private function getNumberOfColumns()
@@ -292,9 +292,9 @@ class TableHelper extends Helper
 
     /**
      * Gets column width.
-     * 
+     *
      * @param int $column
-     * 
+     *
      * @return int
      */
     private function getColumnWidth($column)
@@ -307,13 +307,13 @@ class TableHelper extends Helper
 
         return max($lengths) + 2;
     }
-    
+
     /**
      * Gets cell width.
-     * 
+     *
      * @param array $row
      * @param int   $column
-     * 
+     *
      * @return int
      */
     private function getCellWidth(array $row, $column)
@@ -325,7 +325,7 @@ class TableHelper extends Helper
         if (isset($row[$column])) {
             return mb_strlen($row[$column]);
         }
-        
+
         return $this->getCellWidth($row, $column - 1);
     }
 

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -35,10 +35,10 @@ class TableHelper extends Helper
     private $rows = array();
 
     // Rendering options
-    private $backgroundChar  = ' ';
+    private $paddingChar  = ' ';
     private $horizontalBorderChar = '-';
     private $verticalBorderChar = '|';
-    private $edgeChar = '+';
+    private $crossingChar = '+';
     private $cellHeaderFormat = '<info>%s</info>';
     private $cellRowFormat = '<comment>%s</comment>';
     private $borderFormat = '%s';
@@ -74,11 +74,7 @@ class TableHelper extends Helper
     {
         $this->rows = array();
 
-        foreach ($rows as $row) {
-            $this->addRow($row);
-        }
-
-        return $this;
+        return $this->addRows($rows);
     }
 
     public function addRows(array $rows)
@@ -97,7 +93,7 @@ class TableHelper extends Helper
         return $this;
     }
 
-    public function setRow(array $row, $column)
+    public function setRow($column, array $row)
     {
         $this->rows[$column] = $row;
 
@@ -105,15 +101,15 @@ class TableHelper extends Helper
     }
 
     /**
-     * Sets background character, used for cell padding.
+     * Sets padding character, used for cell padding.
      *
-     * @param string $backgroundChar
+     * @param string $paddingChar
      *
      * @return TableHelper
      */
-    public function setBackgroundChar($backgroundChar)
+    public function setPaddingChar($paddingChar)
     {
-        $this->backgroundChar = $backgroundChar;
+        $this->paddingChar = $paddingChar;
 
         return $this;
     }
@@ -147,15 +143,15 @@ class TableHelper extends Helper
     }
 
     /**
-     * Sets edge character.
+     * Sets crossing character.
      *
-     * @param string $edgeChar
+     * @param string $crossingChar
      *
      * @return TableHelper
      */
-    public function setEdgeChar($edgeChar)
+    public function setCrossingChar($crossingChar)
     {
-        $this->edgeChar = $edgeChar;
+        $this->crossingChar = $crossingChar;
 
         return $this;
     }
@@ -246,15 +242,7 @@ class TableHelper extends Helper
             $this->renderRowSeparator();
         }
 
-        $this->afterRender();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function getName()
-    {
-        return 'table';
+        $this->cleanup();
     }
 
     /**
@@ -268,10 +256,10 @@ class TableHelper extends Helper
             return;
         }
 
-        $markup = $this->edgeChar;
+        $markup = $this->crossingChar;
         for ($column = 0; $column < $count; $column++) {
             $markup .= str_repeat($this->horizontalBorderChar, $this->getColumnWidth($column))
-                    .$this->edgeChar
+                    .$this->crossingChar
             ;
         }
 
@@ -322,9 +310,9 @@ class TableHelper extends Helper
         $this->output->write(sprintf(
             $cellFormat,
             str_pad(
-                $this->backgroundChar.$cell.$this->backgroundChar,
+                $this->paddingChar.$cell.$this->paddingChar,
                 $this->getColumnWidth($column),
-                $this->backgroundChar,
+                $this->paddingChar,
                 $this->padType
             )
         ));
@@ -387,7 +375,7 @@ class TableHelper extends Helper
         }
 
         if (isset($row[$column])) {
-            return mb_strlen($row[$column]);
+            return $this->strlen($row[$column]);
         }
 
         return $this->getCellWidth($row, $column - 1);
@@ -396,9 +384,17 @@ class TableHelper extends Helper
     /**
      * Called after rendering to cleanup cache data.
      */
-    private function afterRender()
+    private function cleanup()
     {
         $this->columnWidths = array();
         $this->numberOfColumns = null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getName()
+    {
+        return 'table';
     }
 }

--- a/src/Symfony/Component/Console/Helper/TableHelper.php
+++ b/src/Symfony/Component/Console/Helper/TableHelper.php
@@ -94,6 +94,8 @@ class TableHelper extends Helper
      * Sets background character, used for cell padding.
      *
      * @param string $backgroundChar
+     *
+     * @return TableHelper
      */
     public function setBackgroundChar($backgroundChar)
     {
@@ -106,6 +108,8 @@ class TableHelper extends Helper
      * Sets horizontal border character.
      *
      * @param string $horizontalBorderChar
+     *
+     * @return TableHelper
      */
     public function setHorizontalBorderChar($horizontalBorderChar)
     {
@@ -118,6 +122,8 @@ class TableHelper extends Helper
      * Sets vertical border character.
      *
      * @param string $verticalBorderChar
+     *
+     * @return TableHelper
      */
     public function setVerticalBorderChar($verticalBorderChar)
     {
@@ -130,6 +136,8 @@ class TableHelper extends Helper
      * Sets edge character.
      *
      * @param string $edgeChar
+     *
+     * @return TableHelper
      */
     public function setEdgeChar($edgeChar)
     {
@@ -142,6 +150,8 @@ class TableHelper extends Helper
      * Sets header cell format.
      *
      * @param string $cellHeaderFormat
+     *
+     * @return TableHelper
      */
     public function setCellHeaderFormat($cellHeaderFormat)
     {
@@ -154,6 +164,8 @@ class TableHelper extends Helper
      * Sets row cell format.
      *
      * @param string $cellRowFormat
+     *
+     * @return TableHelper
      */
     public function setCellRowFormat($cellRowFormat)
     {
@@ -166,6 +178,8 @@ class TableHelper extends Helper
      * Sets table border format.
      *
      * @param string $borderFormat
+     *
+     * @return TableHelper
      */
     public function setBorderFormat($borderFormat)
     {
@@ -178,6 +192,8 @@ class TableHelper extends Helper
      * Sets cell padding type.
      *
      * @param int $padType STR_PAD_*
+     *
+     * @return TableHelper
      */
     public function setPadType($padType)
     {

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -74,7 +74,7 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->getOutputContent($output));
     }
 
-    public static function testRenderProvider()
+    public function testRenderProvider()
     {
         return array(
             array(

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Tests\Helper;
+
+use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Output\StreamOutput;
+
+class TableHelperTest extends \PHPUnit_Framework_TestCase
+{
+    protected $stream;
+
+    protected function setUp()
+    {
+        $this->stream = fopen('php://memory', 'r+');
+    }
+
+    protected function tearDown()
+    {
+        fclose($this->stream);
+        $this->stream = null;
+    }
+
+    /**
+     * @dataProvider testRenderProvider
+     */
+    public function testRender($headers, $rows, $expected)
+    {
+        $table = new TableHelper();
+        $table
+            ->setHeaders($headers)
+            ->setRows($rows)
+        ;
+        $table->render($output = $this->getOutputStream());
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    /**
+     * @dataProvider testRenderProvider
+     */
+    public function testRenderAddRows($headers, $rows, $expected)
+    {
+        $table = new TableHelper();
+        $table
+            ->setHeaders($headers)
+            ->addRows($rows)
+        ;
+        $table->render($output = $this->getOutputStream());
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    /**
+     * @dataProvider testRenderProvider
+     */
+    public function testRenderAddRowsOneByOne($headers, $rows, $expected)
+    {
+        $table = new TableHelper();
+        $table->setHeaders($headers);
+        foreach ($rows as $row) {
+            $table->addRow($row);
+        }
+        $table->render($output = $this->getOutputStream());
+
+        $this->assertEquals($expected, $this->getOutputContent($output));
+    }
+
+    public static function testRenderProvider()
+    {
+        return array(
+            array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
+                    array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
+                    array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
+                    array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
+                ),
+<<<TABLE
++---------------+--------------------------+------------------+
+| ISBN          | Title                    | Author           |
++---------------+--------------------------+------------------+
+| 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
+| 9971-5-0210-0 | A Tale of Two Cities     | Charles Dickens  |
+| 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
+| 80-902734-1-6 | And Then There Were None | Agatha Christie  |
++---------------+--------------------------+------------------+
+
+TABLE
+            ),
+            array(
+                array('ISBN', 'Title'),
+                array(
+                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
+                    array('9971-5-0210-0'),
+                    array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
+                    array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
+                ),
+<<<TABLE
++---------------+--------------------------+------------------+
+| ISBN          | Title                    |                  |
++---------------+--------------------------+------------------+
+| 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
+| 9971-5-0210-0 |                          |                  |
+| 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
+| 80-902734-1-6 | And Then There Were None | Agatha Christie  |
++---------------+--------------------------+------------------+
+
+TABLE
+            ),
+            array(
+                array(),
+                array(
+                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
+                    array('9971-5-0210-0'),
+                    array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
+                    array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
+                ),
+<<<TABLE
++---------------+--------------------------+------------------+
+| 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
+| 9971-5-0210-0 |                          |                  |
+| 960-425-059-0 | The Lord of the Rings    | J. R. R. Tolkien |
+| 80-902734-1-6 | And Then There Were None | Agatha Christie  |
++---------------+--------------------------+------------------+
+
+TABLE
+            ),
+            array(
+                array('ISBN', 'Title'),
+                array(),
+<<<TABLE
++------+-------+
+| ISBN | Title |
++------+-------+
+
+TABLE
+            ),
+            array(
+                array(),
+                array(),
+                '',
+            ),
+        );
+    }
+
+    protected function getOutputStream()
+    {
+        return new StreamOutput($this->stream);
+    }
+
+    protected function getOutputContent(StreamOutput $output)
+    {
+        rewind($output->getStream());
+
+        return stream_get_contents($output->getStream());
+    }
+}

--- a/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/TableHelperTest.php
@@ -32,12 +32,13 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRender($headers, $rows, $expected)
+    public function testRender($headers, $rows, $layout, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
             ->setRows($rows)
+            ->setLayout($layout)
         ;
         $table->render($output = $this->getOutputStream());
 
@@ -47,12 +48,13 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRows($headers, $rows, $expected)
+    public function testRenderAddRows($headers, $rows, $layout, $expected)
     {
         $table = new TableHelper();
         $table
             ->setHeaders($headers)
             ->addRows($rows)
+            ->setLayout($layout)
         ;
         $table->render($output = $this->getOutputStream());
 
@@ -62,10 +64,13 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testRenderProvider
      */
-    public function testRenderAddRowsOneByOne($headers, $rows, $expected)
+    public function testRenderAddRowsOneByOne($headers, $rows, $layout, $expected)
     {
         $table = new TableHelper();
-        $table->setHeaders($headers);
+        $table
+            ->setHeaders($headers)
+            ->setLayout($layout)
+        ;
         foreach ($rows as $row) {
             $table->addRow($row);
         }
@@ -85,6 +90,7 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
                     array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
+                TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+--------------------------+------------------+
 | ISBN          | Title                    | Author           |
@@ -98,6 +104,17 @@ class TableHelperTest extends \PHPUnit_Framework_TestCase
 TABLE
             ),
             array(
+                array('ISBN', 'Title', 'Author'),
+                array(
+                    array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
+                    array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
+                    array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
+                    array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
+                ),
+                TableHelper::LAYOUT_BORDERLESS,
+                " =============== ========================== ================== \n  ISBN            Title                      Author            \n =============== ========================== ================== \n  99921-58-10-7   Divine Comedy              Dante Alighieri   \n  9971-5-0210-0   A Tale of Two Cities       Charles Dickens   \n  960-425-059-0   The Lord of the Rings      J. R. R. Tolkien  \n  80-902734-1-6   And Then There Were None   Agatha Christie   \n =============== ========================== ================== \n"
+            ),
+            array(
                 array('ISBN', 'Title'),
                 array(
                     array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
@@ -105,6 +122,7 @@ TABLE
                     array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
+                TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+--------------------------+------------------+
 | ISBN          | Title                    |                  |
@@ -125,6 +143,7 @@ TABLE
                     array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
                     array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
                 ),
+                TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +---------------+--------------------------+------------------+
 | 99921-58-10-7 | Divine Comedy            | Dante Alighieri  |
@@ -138,6 +157,7 @@ TABLE
             array(
                 array('ISBN', 'Title'),
                 array(),
+                TableHelper::LAYOUT_DEFAULT,
 <<<TABLE
 +------+-------+
 | ISBN | Title |
@@ -148,6 +168,7 @@ TABLE
             array(
                 array(),
                 array(),
+                TableHelper::LAYOUT_DEFAULT,
                 '',
             ),
         );


### PR DESCRIPTION
When building a console application it may be useful to display tabular data.

`TableHelper` can display table header and rows, customizable alignment of columns, cell padding and colors.

Basic usage example:

``` php
$table = $app->getHelperSet()->get('table');
$table
    ->setHeaders(array('ISBN', 'Title', 'Author'))
    ->setRows(array(
        array('99921-58-10-7', 'Divine Comedy', 'Dante Alighieri'),
        array('9971-5-0210-0', 'A Tale of Two Cities', 'Charles Dickens'),
        array('960-425-059-0', 'The Lord of the Rings', 'J. R. R. Tolkien'),
        array('80-902734-1-6', 'And Then There Were None', 'Agatha Christie'),
    ))
;
$table->render($output);
```

Output:
![table](https://f.cloud.github.com/assets/208957/14955/6fb4f500-46ca-11e2-8435-0f6b22f96e58.png)

If this PR gets merged I will submit doc PR as well.

I'm sure there is a plenty of room for improvements so any feedback is welcome.
