### PR TITLE
[HttpKernel] CLI - don't always display errors

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -104,7 +104,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             ErrorHandler::register($this->errorReportingLevel);
             if ('cli' !== php_sapi_name()) {
                 ExceptionHandler::register();
-            } else {
+            } elseif (!ini_get('log_errors') || ini_get('error_log')) {
                 ini_set('display_errors', 1);
             }
         }


### PR DESCRIPTION
With the cli sapi, imo `display_errors` shouldn't be hardcoded to true if errors are logged to stderr, as it would likely display duplicate error messages if the user doesn't redirect stderr when running the command (which should be a common case).
