### PR TITLE
[Form] empty_value should not be selectable in choice field if the field is required

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -69,7 +69,7 @@
 {% spaceless %}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
         {% if empty_value is not none %}
-            <option value="">{{ empty_value|trans({}, translation_domain) }}</option>
+            <option value="" disabled="disabled"{% if value is empty %} selected="selected"{% endif %}>{{ empty_value|trans({}, translation_domain) }}</option>
         {% endif %}
         {% if preferred_choices|length > 0 %}
             {% set options = preferred_choices %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_collapsed.html.php
@@ -2,7 +2,7 @@
     <?php echo $view['form']->block($form, 'widget_attributes') ?>
     <?php if ($multiple): ?> multiple="multiple"<?php endif ?>
 >
-    <?php if (null !== $empty_value): ?><option value=""><?php echo $view->escape($view['translator']->trans($empty_value, array(), $translation_domain)) ?></option><?php endif; ?>
+    <?php if (null !== $empty_value): ?><option value="" disabled="disabled"<?php if (empty($value) && "0" !== $value): ?> selected="selected"<?php endif ?>><?php echo $view->escape($view['translator']->trans($empty_value, array(), $translation_domain)) ?></option><?php endif; ?>
     <?php if (count($preferred_choices) > 0): ?>
         <?php echo $view['form']->block($form, 'choice_widget_options', array('choices' => $preferred_choices)) ?>
         <?php if (count($choices) > 0 && null !== $separator): ?>

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -524,7 +524,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [@name="name"]
     [not(@required)]
     [
-        ./option[@value=""][not(@selected)][.="[trans]Select&Anything&Not&Me[/trans]"]
+        ./option[@value=""][not(@selected)][@disabled][.="[trans]Select&Anything&Not&Me[/trans]"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -548,7 +548,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [@name="name"]
     [@required="required"]
     [
-        ./option[@value=""][.="[trans]Test&Me[/trans]"]
+        ./option[@value=""][not(@selected)][@disabled][.="[trans]Test&Me[/trans]"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -571,7 +571,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [@name="name"]
     [@required="required"]
     [
-        ./option[@value=""][.="[trans][/trans]"]
+        ./option[@value=""][not(@selected)][@disabled][.="[trans][/trans]"]
         /following-sibling::option[@value="&a"][@selected="selected"][.="[trans]Choice&A[/trans]"]
         /following-sibling::option[@value="&b"][not(@selected)][.="[trans]Choice&B[/trans]"]
     ]
@@ -790,7 +790,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
     [@name="name"]
-    [./option[@value=""][not(@selected)][.="[trans]Select&Country[/trans]"]]
+    [./option[@value=""][not(@selected)][@disabled][.="[trans]Select&Country[/trans]"]]
     [./option[@value="AT"][@selected="selected"][.="[trans]Austria[/trans]"]]
     [count(./option)>201]
 '
@@ -852,13 +852,13 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [
                 ./select
                     [@id="name_date_month"]
-                    [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+                    [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
                 /following-sibling::select
                     [@id="name_date_day"]
-                    [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+                    [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
                 /following-sibling::select
                     [@id="name_date_year"]
-                    [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+                    [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
             ]
         /following-sibling::div
             [@id="name_time"]
@@ -907,10 +907,10 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [
                 ./select
                     [@id="name_time_hour"]
-                    [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+                    [./option[@value=""][not(@selected)][@disabled][.="[trans]Change&Me[/trans]"]]
                 /following-sibling::select
                     [@id="name_time_minute"]
-                    [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+                    [./option[@value=""][not(@selected)][@disabled][.="[trans]Change&Me[/trans]"]]
             ]
     ]
     [count(.//select)=5]
@@ -1063,13 +1063,13 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [
         ./select
             [@id="name_month"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+            [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
         /following-sibling::select
             [@id="name_day"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+            [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
         /following-sibling::select
             [@id="name_year"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+            [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
     ]
     [count(./select)=3]
 '
@@ -1096,7 +1096,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             [./option[@value="1"]]
         /following-sibling::select
             [@id="name_year"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+            [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
     ]
     [count(./select)=3]
 '
@@ -1195,15 +1195,15 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [
         ./select
             [@id="name_month"]
-            [./option[@value=""][.="[trans][/trans]"]]
+            [./option[@value=""][not(@selected)][@disabled][.="[trans][/trans]"]]
             [./option[@value="1"][@selected="selected"]]
         /following-sibling::select
             [@id="name_day"]
-            [./option[@value=""][.="[trans][/trans]"]]
+            [./option[@value=""][not(@selected)][@disabled][.="[trans][/trans]"]]
             [./option[@value="1"][@selected="selected"]]
         /following-sibling::select
             [@id="name_year"]
-            [./option[@value=""][.="[trans][/trans]"]]
+            [./option[@value=""][not(@selected)][@disabled][.="[trans][/trans]"]]
             [./option[@value="1950"][@selected="selected"]]
     ]
     [count(./select)=3]
@@ -1635,11 +1635,11 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [
         ./select
             [@id="name_hour"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+            [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
             [count(./option)>24]
         /following-sibling::select
             [@id="name_minute"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+            [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
             [count(./option)>60]
     ]
     [count(./select)=2]
@@ -1660,7 +1660,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     [
         ./select
             [@id="name_hour"]
-            [./option[@value=""][.="[trans]Change&Me[/trans]"]]
+            [./option[@value=""][@selected][@disabled][.="[trans]Change&Me[/trans]"]]
             [count(./option)>24]
         /following-sibling::select
             [@id="name_minute"]
@@ -1710,7 +1710,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/select
-    [./option[@value=""][.="[trans]Select&Timezone[/trans]"]]
+    [./option[@value=""][@selected][@disabled][.="[trans]Select&Timezone[/trans]"]]
     [count(./optgroup)>10]
     [count(.//option)>201]
 '


### PR DESCRIPTION
When the Choice field is required one should not be able to select the empty_value. The empty_value field is supposed to be a placeholder and not a real value.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: none
Todo: nothing
License of the code: MIT
Documentation PR: none

SEE https://github.com/symfony/symfony/pull/6116
