### PR TITLE
Added an HttpKernelExtension in Twig bridge and used it in the WebProfiler

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Provides integration with the HttpKernel component.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HttpKernelExtension extends \Twig_Extension implements EventSubscriberInterface
+{
+    private $kernel;
+    private $request;
+
+    /**
+     * Constructor.
+     *
+     * @param HttpKernelInterface $kernel A HttpKernelInterface install
+     */
+    public function __construct(HttpKernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    public function getFunctions()
+    {
+        return array(
+            'render' => new \Twig_Function_Method($this, 'render', array('needs_environment' => true, 'is_safe' => array('html'))),
+        );
+    }
+
+    /**
+     * Renders a URI.
+     *
+     * @param \Twig_Environment $twig A \Twig_Environment instance
+     * @param string            $uri  The URI to render
+     *
+     * @return string The Response content
+     */
+    public function render(\Twig_Environment $twig, $uri)
+    {
+        if (null !== $this->request) {
+            $cookies = $this->request->cookies->all();
+            $server = $this->request->server->all();
+        } else {
+            $cookies = array();
+            $server = array();
+        }
+
+        $subRequest = Request::create($uri, 'get', array(), $cookies, array(), $server);
+        if (null !== $this->request && $this->request->getSession()) {
+            $subRequest->setSession($this->request->getSession());
+        }
+
+        $response = $this->kernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
+
+        if (!$response->isSuccessful()) {
+            throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $subRequest->getUri(), $response->getStatusCode()));
+        }
+
+        return $response->getContent();
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $this->request = $event->getRequest();
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array('onKernelRequest'),
+        );
+    }
+
+    public function getName()
+    {
+        return 'http_kernel';
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
+use Symfony\Bridge\Twig\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class HttpKernelExtensionTest extends TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\HttpKernel\HttpKernel')) {
+            $this->markTestSkipped('The "HttpKernel" component is not available');
+        }
+
+        if (!class_exists('Twig_Environment')) {
+            $this->markTestSkipped('Twig is not available.');
+        }
+    }
+
+    public function testRenderWithoutMasterRequest()
+    {
+        $kernel = $this->getKernel($this->returnValue(new Response('foo')));
+
+        $this->assertEquals('foo', $this->renderTemplate($kernel));
+    }
+
+    /**
+     * @expectedException \Twig_Error_Runtime
+     */
+    public function testRenderWithError()
+    {
+        $kernel = $this->getKernel($this->throwException(new \Exception('foo')));
+
+        $loader = new \Twig_Loader_Array(array('index' => '{{ render("foo") }}'));
+        $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
+        $twig->addExtension(new HttpKernelExtension($kernel));
+
+        $this->renderTemplate($kernel);
+    }
+
+    protected function getKernel($return)
+    {
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel
+            ->expects($this->once())
+            ->method('handle')
+            ->will($return)
+        ;
+
+        return $kernel;
+    }
+
+    protected function renderTemplate(HttpKernelInterface $kernel, $template = '{{ render("foo") }}')
+    {
+        $loader = new \Twig_Loader_Array(array('index' => $template));
+        $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
+        $twig->addExtension(new HttpKernelExtension($kernel));
+
+        return $twig->render('index');
+    }
+}

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "symfony/form": "2.2.*",
+        "symfony/http-kernel": "2.2.*",
         "symfony/routing": "2.2.*",
         "symfony/templating": "2.2.*",
         "symfony/translation": "2.2.*",
@@ -29,6 +30,7 @@
     },
     "suggest": {
         "symfony/form": "2.2.*",
+        "symfony/http-kernel": "2.2.*",
         "symfony/routing": "2.2.*",
         "symfony/templating": "2.2.*",
         "symfony/translation": "2.2.*",

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -17,6 +17,7 @@
         <parameter key="twig.extension.routing.class">Symfony\Bridge\Twig\Extension\RoutingExtension</parameter>
         <parameter key="twig.extension.yaml.class">Symfony\Bridge\Twig\Extension\YamlExtension</parameter>
         <parameter key="twig.extension.form.class">Symfony\Bridge\Twig\Extension\FormExtension</parameter>
+        <parameter key="twig.extension.httpkernel.class">Symfony\Bridge\Twig\Extension\HttpKernelExtension</parameter>
         <parameter key="twig.form.engine.class">Symfony\Bridge\Twig\Form\TwigRendererEngine</parameter>
         <parameter key="twig.form.renderer.class">Symfony\Bridge\Twig\Form\TwigRenderer</parameter>
         <parameter key="twig.translation.extractor.class">Symfony\Bridge\Twig\Translation\TwigExtractor</parameter>
@@ -85,6 +86,12 @@
 
         <service id="twig.extension.yaml" class="%twig.extension.yaml.class%" public="false">
             <tag name="twig.extension" />
+        </service>
+
+        <service id="twig.extension.httpkernel" class="%twig.extension.httpkernel.class%">
+            <tag name="twig.extension" />
+            <tag name="kernel.event_subscriber" />
+            <argument type="service" id="http_kernel" />
         </service>
 
         <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">

--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -166,11 +166,10 @@ class ProfilerController
      *
      * @param Request $request  The current HTTP Request
      * @param string  $token    The profiler token
-     * @param string  $position The toolbar position (top, bottom, normal, or null -- use the configuration)
      *
      * @return Response A Response instance
      */
-    public function toolbarAction(Request $request, $token, $position = null)
+    public function toolbarAction(Request $request, $token)
     {
         $session = $request->getSession();
 
@@ -189,7 +188,8 @@ class ProfilerController
             return new Response();
         }
 
-        if (null === $position) {
+        // the toolbar position (top, bottom, normal, or null -- use the configuration)
+        if (null === $position = $request->query->get('position')) {
             $position = $this->toolbarPosition;
         }
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -8,6 +8,10 @@
         <default key="_controller">web_profiler.controller.profiler:searchAction</default>
     </route>
 
+    <route id="_profiler_search_bar" pattern="/search_bar">
+        <default key="_controller">web_profiler.controller.profiler:searchBarAction</default>
+    </route>
+
     <route id="_profiler_purge" pattern="/purge">
         <default key="_controller">web_profiler.controller.profiler:purgeAction</default>
     </route>
@@ -34,6 +38,18 @@
 
     <route id="_profiler" pattern="/{token}">
         <default key="_controller">web_profiler.controller.profiler:panelAction</default>
+    </route>
+
+    <route id="_profiler_router" pattern="/{token}/router">
+        <default key="_controller">web_profiler.controller.router:panelAction</default>
+    </route>
+
+    <route id="_profiler_exception" pattern="/{token}/exception">
+        <default key="_controller">web_profiler.controller.exception:showAction</default>
+    </route>
+
+    <route id="_profiler_exception_css" pattern="/{token}/exception.css">
+        <default key="_controller">web_profiler.controller.exception:cssAction</default>
     </route>
 
     <route id="_profiler_redirect" pattern="/">

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -2,7 +2,7 @@
 
 {% block head %}
     <style type="text/css">
-        {% render 'web_profiler.controller.exception:cssAction' with { 'token': token } %}
+        {{ render(path('_profiler_exception_css', { 'token': token })) }}
     </style>
     {{ parent() }}
 {% endblock %}
@@ -28,7 +28,7 @@
         </p>
     {% else %}
         <div class="sf-reset">
-            {% render 'web_profiler.controller.exception:showAction' with { 'token': token } %}
+            {{ render(path('_profiler_exception', { 'token': token })) }}
         </div>
     {% endif %}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/exception.html.twig
@@ -1,9 +1,11 @@
 {% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block head %}
-    <style type="text/css">
-        {{ render(path('_profiler_exception_css', { 'token': token })) }}
-    </style>
+    {% if collector.hasexception %}
+        <style type="text/css">
+            {{ render(path('_profiler_exception_css', { 'token': token })) }}
+        </style>
+    {% endif %}
     {{ parent() }}
 {% endblock %}
 

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/router.html.twig
@@ -11,5 +11,5 @@
 {% endblock %}
 
 {% block panel %}
-    {% render "web_profiler.controller.router:panelAction" with {'token': token} %}
+    {{ render(path('_profiler_router', {'token': token})) }}
 {% endblock %}

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/bag.html.twig
@@ -9,7 +9,7 @@
         {% for key in bag.keys|sort %}
         <tr>
             <th>{{ key }}</th>
-            <td>{{ bag.get(key)|yaml_dump }}</td>
+            <td>{{ bag.get(key)|json_encode }}</td>
         </tr>
         {% endfor %}
     </tbody>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/info.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/info.html.twig
@@ -34,7 +34,7 @@
                     </div>
                 </div>
                 <div id="navigation">
-                    {% render 'web_profiler.controller.profiler:searchBarAction' %}
+                    {{ render(path('_profiler_search_bar')) }}
                     {% include '@WebProfiler/Profiler/admin.html.twig' with { 'token': '' } only %}
                 </div>
             </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -2,7 +2,7 @@
 
 {% block body %}
 
-    {% render 'web_profiler.controller.profiler:toolbarAction' with { 'token': token, 'position': 'normal' } %}
+    {{ render(path('_wdt', { 'token': token, 'position': 'normal' })) }}
 
     <div id="content">
         {% include '@WebProfiler/Profiler/header.html.twig' only %}
@@ -53,7 +53,7 @@
                             </li>
                         </ul>
                     {% endif %}
-                    {% render 'web_profiler.controller.profiler:searchBarAction' %}
+                    {{ render(path('_profiler_search_bar')) }}
                     {% include '@WebProfiler/Profiler/admin.html.twig' with { 'token': token } only %}
                 </div>
             </div>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/table.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/table.html.twig
@@ -9,7 +9,7 @@
         {% for key in data|keys|sort %}
             <tr>
                 <th>{{ key }}</th>
-                <td>{{ data[key]|yaml_dump }}</td>
+                <td>{{ data[key]|json_encode }}</td>
             </tr>
         {% endfor %}
     </tbody>


### PR DESCRIPTION
The first commit introduces a new HttpKernelExtension in the Twig bridge that allows the rendering of a sub-request from a template (the code mostly comes from Silex, and will replace the code there at some point).

The name `render` is probably not the best one as it does not really tell you what it does (the same goes for the `render` tag we have in Symfony2 by the way).

Here is a list of possible names:
- `render()`
- `render_request()`
- `request()`
- `subrequest()`
- `include_request()`

I don't really like the last one, but it is (perhaps) consistent with the `include` tag/function in Twig.

This new `render()` function is also a first step towards replacing the `render` tag (with support for ESI, SSI, ...). But it won't happen before we refactor the way it's managed now (a lot of the code is in the FrameworkBundle right now and that prevents Silex or Drupal to reuse it).

The other commits make use of this new extension to make the Web Profiler truly independent from TwigBundle and FrameworkBundle.
