### PR TITLE
Auto-Registration of Commands is now configurable

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -83,7 +83,7 @@ class Application extends BaseApplication
         $this->kernel->boot();
 
         foreach ($this->kernel->getBundles() as $bundle) {
-            if ($bundle instanceof Bundle) {
+            if ($bundle instanceof Bundle && $bundle->autoRegisterCommands()) {
                 $bundle->registerCommands($this);
             }
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -20,7 +20,7 @@ class ApplicationTest extends TestCase
 {
     public function testBundleInterfaceImplementation()
     {
-        $bundle = $this->getMock("Symfony\Component\HttpKernel\Bundle\BundleInterface");
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
 
         $kernel = $this->getKernel(array($bundle));
 
@@ -30,8 +30,27 @@ class ApplicationTest extends TestCase
 
     public function testBundleCommandsAreRegistered()
     {
-        $bundle = $this->getMock("Symfony\Component\HttpKernel\Bundle\Bundle");
+        $bundle = $this->getMock(
+            'Symfony\Component\HttpKernel\Bundle\Bundle',
+            array('autoRegisterCommands', 'registerCommands'));
+
+        $bundle->expects($this->once())->method('autoRegisterCommands')->will($this->returnValue(true));
         $bundle->expects($this->once())->method('registerCommands');
+
+        $kernel = $this->getKernel(array($bundle));
+
+        $application = new Application($kernel);
+        $application->doRun(new ArrayInput(array('list')), new NullOutput());
+    }
+
+    public function testBundleCommandsAreNotRegistered()
+    {
+        $bundle = $this->getMock(
+            'Symfony\Component\HttpKernel\Bundle\Bundle',
+            array('autoRegisterCommands', 'registerCommands'));
+        
+        $bundle->expects($this->once())->method('autoRegisterCommands')->will($this->returnValue(false));
+        $bundle->expects($this->never())->method('registerCommands');
 
         $kernel = $this->getKernel(array($bundle));
 
@@ -41,7 +60,7 @@ class ApplicationTest extends TestCase
 
     private function getKernel(array $bundles)
     {
-        $kernel = $this->getMock("Symfony\Component\HttpKernel\KernelInterface");
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
         $kernel
             ->expects($this->any())
             ->method('getBundles')

--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -168,6 +168,9 @@ abstract class Bundle extends ContainerAware implements BundleInterface
      * * Commands are in the 'Command' sub-directory
      * * Commands extend Symfony\Component\Console\Command\Command
      *
+     * If your commands follow these conventions but are registered in another way, override
+     * Bundle::autoRegisterCommands instead.
+     *
      * @param Application $application An Application instance
      */
     public function registerCommands(Application $application)
@@ -190,5 +193,18 @@ abstract class Bundle extends ContainerAware implements BundleInterface
                 $application->add($r->newInstance());
             }
         }
+    }
+
+    /**
+     * Returns whether this bundle's Bundle::registerCommands method should be called. If true, registerCommands should
+     * add all commands of the bundle to the application.
+     *
+     * Override this method and return false if you are using an alternative way for registering commands.
+     *
+     * @return bool
+     */
+    public function autoRegisterCommands()
+    {
+        return true;
     }
 }


### PR DESCRIPTION
This PR adds a method to HttpKernel\Bundle that is used to decide whether the commands of the bundle should be registered using Bundle::registerCommands.

This needs to be configurable since there are cases in which commands should not be registered by default. One could just override Bundle::registerCommands to solve this. However, this wouldn't be compatible with LSP.
