### PR TITLE
[Console] Add autocomplete as you type

### DIFF
--- a/src/Symfony/Component/Console/CHANGELOG.md
+++ b/src/Symfony/Component/Console/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
  * added support for colorization on Windows via ConEmu
  * add a method to Dialog Helper to ask for a question and hide the response
  * added support for interactive selections in console (DialogHelper::select())
+ * added support for autocompletion as you type in Dialog Helper
 
 2.1.0
 -----

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -54,6 +54,22 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals('What time is it?', stream_get_contents($output->getStream()));
+
+        $bundles = array('AcmeDemoBundle', 'AsseticBundle');
+
+        // Acm<NEWLINE>
+        // Ac<BACKSPACE><BACKSPACE>s<TAB>Test<NEWLINE>
+        // <NEWLINE>
+        $inputStream = $this->getInputStream("Acm\nAc\177\177s\tTest\n\n");
+        $dialog->setInputStream($inputStream);
+
+        if ($this->hasSttyAvailable()) {
+            $this->assertEquals('AcmeDemoBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+            $this->assertEquals('AsseticBundleTest', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+            $this->assertEquals('FrameworkBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+        } else {
+            $this->markTestSkipped();
+        }
     }
 
     public function testAskHiddenResponse()
@@ -127,5 +143,12 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
     protected function getOutputStream()
     {
         return new StreamOutput(fopen('php://memory', 'r+', false));
+    }
+
+    private function hasSttyAvailable()
+    {
+        exec('stty 2>&1', $output, $exitcode);
+
+        return $exitcode === 0;
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
License of the code: MIT

Finally got around to reviving the console autocomplete code.
Is now up to date with Symfony master. Also changed backspace behaviour to remove one character instead of two.

stty stuff is a mystery to a lot of people, so I've commented verbosely.

See also: https://github.com/symfony/symfony/pull/2364
