### PR TITLE
[Form] [Util] [PropertyPath] Added __call method to property path

### DIFF
--- a/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
@@ -25,20 +25,4 @@ class Magician
         return isset($this->$property) ? $this->$property : null;
     }
 
-    public function __call($methodName, $args)
-    {
-        $returnValue = null;
-        $property = lcfirst(substr($methodName, 3));
-
-        switch (substr($methodName, 0, 3)) {
-            case 'get':
-                $returnValue = $this->__get($property);
-                break;
-            case 'set':
-                $returnValue = $this->__set($property, $args);
-                break;
-        }
-
-        return $returnValue;
-    }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/Magician.php
@@ -24,4 +24,21 @@ class Magician
     {
         return isset($this->$property) ? $this->$property : null;
     }
+
+    public function __call($methodName, $args)
+    {
+        $returnValue = null;
+        $property = lcfirst(substr($methodName, 3));
+
+        switch (substr($methodName, 0, 3)) {
+            case 'get':
+                $returnValue = $this->__get($property);
+                break;
+            case 'set':
+                $returnValue = $this->__set($property, $args);
+                break;
+        }
+
+        return $returnValue;
+    }
 }

--- a/src/Symfony/Component/Form/Tests/Fixtures/MagicianCall.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/MagicianCall.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Piotr Pasich <piotr.pasich@xsolve.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Fixtures;
+
+class MagicianCall
+{
+    private $foobar;
+
+    public function __call($methodName, $args)
+    {
+        $returnValue = null;
+        $property = lcfirst(substr($methodName, 3));
+
+        switch (substr($methodName, 0, 3)) {
+            case 'get':
+                $returnValue = $this->get($property);
+                break;
+            case 'set':
+                $returnValue = $this->set($property, $args);
+                break;
+        }
+
+        return $returnValue;
+    }
+
+    private function set($property, $value)
+    {
+        $this->$property = $value;
+    }
+
+    private function get($property)
+    {
+        return isset($this->$property) ? $this->$property : null;
+    }
+
+}

--- a/src/Symfony/Component/Form/Tests/Fixtures/MagicianCall.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/MagicianCall.php
@@ -17,8 +17,10 @@ class MagicianCall
 
     public function __call($methodName, $args)
     {
+        
         $returnValue = null;
         $property = lcfirst(substr($methodName, 3));
+        $args = $this->getSimpleValue($args);
 
         switch (substr($methodName, 0, 3)) {
             case 'get':
@@ -40,6 +42,11 @@ class MagicianCall
     private function get($property)
     {
         return isset($this->$property) ? $this->$property : null;
+    }
+    
+    private function getSimpleValue($args)
+    {
+        return count($args)==1 ? current($args) : $args;
     }
 
 }

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -14,6 +14,7 @@ namespace Symfony\Component\Form\Tests\Util;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Form\Tests\Fixtures\Author;
 use Symfony\Component\Form\Tests\Fixtures\Magician;
+use Symfony\Component\Form\Tests\Fixtures\MagicianCall;
 
 class PropertyPathTest extends \PHPUnit_Framework_TestCase
 {
@@ -322,9 +323,10 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
 
     public function testSetValueUpdateMagicCall()
     {
-        $object = new Magician();
+        $object = new MagicianCall();
 
-        $object->setMagicProperty('foobar');
+        $path = new PropertyPath('magicProperty');
+        $path->setValue($object, 'foobar');
 
         $this->assertEquals('foobar', $object->getMagicProperty());
     }

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -320,6 +320,15 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $object->__get('magicProperty'));
     }
 
+    public function testSetValueUpdateMagicCall()
+    {
+        $object = new Magician();
+
+        $object->setMagicProperty('foobar');
+
+        $this->assertEquals('foobar', $object->getMagicProperty());
+    }
+
     public function testSetValueUpdatesSetters()
     {
         $object = new Author();

--- a/src/Symfony/Component/Form/Util/PropertyPath.php
+++ b/src/Symfony/Component/Form/Util/PropertyPath.php
@@ -420,6 +420,10 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 }
 
                 $result[self::VALUE] = $objectOrArray->$hasser();
+            } elseif ($reflClass->hasMethod('__call')) {
+                // needed to support magic method __call
+                $callMethod = 'get' . ucfirst($property);
+                $result[self::VALUE] = $objectOrArray->$callMethod();
             } elseif ($reflClass->hasMethod('__get')) {
                 // needed to support magic method __get
                 $result[self::VALUE] = $objectOrArray->$property;
@@ -536,6 +540,10 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
                 }
 
                 $objectOrArray->$setter($value);
+            } elseif ($reflClass->hasMethod('__call')) {
+                // needed to support magic method __call
+                $callMethod = 'set' . ucfirst($property);
+                $objectOrArray->$callMethod($value);
             } elseif ($reflClass->hasMethod('__set')) {
                 // needed to support magic method __set
                 $objectOrArray->$property = $value;


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: yes (it might be a problem when class has __call and __get and __set method)
Symfony2 tests pass: yes
Fixes the following tickets: no ticket
Todo: no todos
License of the code: MIT
Documentation PR: The situation with magical method is not probably described in documentation. 
