### PR TITLE
[Process] Reusability of ProcessBuilder

### DIFF
--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -31,17 +31,26 @@ class ProcessBuilder
 
     public function __construct(array $arguments = array())
     {
-        $this->arguments = $arguments;
-
-        $this->timeout = 60;
-        $this->options = array();
-        $this->env = array();
-        $this->inheritEnv = true;
+        $this->startNewProcess($arguments);
     }
 
     public static function create(array $arguments = array())
     {
         return new static($arguments);
+    }
+
+    /**
+     * Resets the ProcessBuilder's state in order to start the creation of a new Process.
+     */
+    public function startNewProcess($arguments)
+    {
+        $this->arguments = $arguments;
+        $this->timeout = 60;
+        $this->options = array();
+        $this->env = array();
+        $this->inheritEnv = true;
+        $this->stdin = null;
+        $this->cwd = null;
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -115,4 +115,28 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains("second", $proc->getCommandLine());
     }
+
+    /**
+     * @test
+     */
+    public function shouldStartNewProcess()
+    {
+        $pb = new ProcessBuilder(array('initial'));
+        $pb->setEnv('foo', 'bar');
+        $pb->setInput('test');
+        $pb->setOption('bar', 'foo');
+        $pb->setTimeout(30);
+        $pb->setWorkingDirectory('/tmp');
+        $pb->inheritEnvironmentVariables(true);
+
+        $pb->startNewProcess(array('second'));
+        $process = $pb->getProcess();
+
+        $this->assertContains('second', $process->getCommandLine());
+        $this->assertNotEquals(array('foo' => 'bar'), $process->getEnv());
+        $this->assertNotEquals('test', $process->getStdin());
+        $this->assertArrayNotHasKey('bar', $process->getOptions());
+        $this->assertNotEquals(30, $process->getTimeout());
+        $this->assertNotEquals('/tmp', $process->getWorkingDirectory());
+    }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets:
Todo:
License of the code: MIT
Documentation PR: 

This PR introduces a new method in the `ProcessBuilder` class: `startNewProcess`. It resets the builder's internal state.
Using this method, one can reuse a `ProcessBuilder` and create multiple processes with it. This way, a client class can have the process builder injected via DI and use it for all processes it creates. Also, this injected process builder can be replaced with a mock for unit tests.
