### PR TITLE
Show class name for security token in WDT

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -52,12 +52,10 @@ class SecurityDataCollector extends DataCollector
                 'roles'         => array(),
             );
         } else {
-            $class = explode('\\', get_class($token)); 
-
             $this->data = array(
                 'enabled'       => true,
                 'authenticated' => $token->isAuthenticated(),
-                'token_class'   => end($class),
+                'token_class'   => get_class($token),
                 'user'          => $token->getUsername(),
                 'roles'         => array_map(function ($role){ return $role->getRole();}, $token->getRoles()),
             );
@@ -105,7 +103,7 @@ class SecurityDataCollector extends DataCollector
     }
 
     /**
-     * Get the class name of the security token (without namespace).
+     * Get the class name of the security token.
      *
      * @return String The token
      */

--- a/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
+++ b/src/Symfony/Bundle/SecurityBundle/DataCollector/SecurityDataCollector.php
@@ -39,6 +39,7 @@ class SecurityDataCollector extends DataCollector
             $this->data = array(
                 'enabled'       => false,
                 'authenticated' => false,
+                'token_class'   => null,
                 'user'          => '',
                 'roles'         => array(),
             );
@@ -46,13 +47,17 @@ class SecurityDataCollector extends DataCollector
             $this->data = array(
                 'enabled'       => true,
                 'authenticated' => false,
+                'token_class'   => null,
                 'user'          => '',
                 'roles'         => array(),
             );
         } else {
+            $class = explode('\\', get_class($token)); 
+
             $this->data = array(
                 'enabled'       => true,
                 'authenticated' => $token->isAuthenticated(),
+                'token_class'   => end($class),
                 'user'          => $token->getUsername(),
                 'roles'         => array_map(function ($role){ return $role->getRole();}, $token->getRoles()),
             );
@@ -97,6 +102,16 @@ class SecurityDataCollector extends DataCollector
     public function isAuthenticated()
     {
         return $this->data['authenticated'];
+    }
+
+    /**
+     * Get the class name of the security token (without namespace).
+     *
+     * @return String The token
+     */
+    public function getTokenClass()
+    {
+        return $this->data['token_class'];
     }
 
     /**

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -21,7 +21,7 @@
             {% if collector.tokenClass != null %}
             <div class="sf-toolbar-info-piece">
                 <b>Token class</b>
-                {{ collector.tokenClass }}
+                {{ collector.tokenClass|abbr_class }}
             </div>
             {% endif %}
         {% elseif collector.enabled %}

--- a/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/views/Collector/security.html.twig
@@ -18,6 +18,12 @@
                 <b>Authenticated</b>
                 <span class="sf-toolbar-status sf-toolbar-status-{{ authentication_color_code }}">{{ authentication_color_text }}</span>
             </div>
+            {% if collector.tokenClass != null %}
+            <div class="sf-toolbar-info-piece">
+                <b>Token class</b>
+                {{ collector.tokenClass }}
+            </div>
+            {% endif %}
         {% elseif collector.enabled %}
             You are not authenticated.
         {% else %}
@@ -61,6 +67,12 @@
                 <th>Roles</th>
                 <td>{{ collector.roles|yaml_encode }}</td>
             </tr>
+            {% if collector.tokenClass != null %}
+            <tr>
+                <th>Token class</th>
+                <td>{{ collector.tokenClass }}</td>
+            </tr>
+            {% endif %}
         </table>
     {% elseif collector.enabled %}
         <p>


### PR DESCRIPTION
I found this to be really useful when creating custom authentication providers

Example:

![token](https://f.cloud.github.com/assets/363540/23829/2f28c1ac-4a70-11e2-91d4-e3ac27201b4f.png)
