### PR TITLE
[Finder] Re-enable BsdFindAdapter for Darwin shell and fix it

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -286,58 +286,25 @@ abstract class AbstractFindAdapter extends AbstractAdapter
 
     /**
      * @param Command $command
-     * @param array   $contains
-     * @param Boolean $not
-     */
-    private function buildContentFiltering(Command $command, array $contains, $not = false)
-    {
-        foreach ($contains as $contain) {
-            $expr = Expression::create($contain);
-
-            // todo: avoid forking process for each $pattern by using multiple -e options
-            $command
-                ->add('| xargs -r grep -I')
-                ->add($expr->isCaseSensitive() ? null : '-i')
-                ->add($not ? '-L' : '-l')
-                ->add('-Ee')->arg($expr->renderPattern());
-        }
-    }
-
-    /**
-     * @param Command $command
      * @param string  $sort
      *
      * @throws \InvalidArgumentException
      */
     private function buildSorting(Command $command, $sort)
     {
-        switch ($sort) {
-            case SortableIterator::SORT_BY_NAME:
-                $command->ins('sort')->add('| sort');
-
-                return;
-            case SortableIterator::SORT_BY_TYPE:
-                $format = '%y';
-                break;
-            case SortableIterator::SORT_BY_ACCESSED_TIME:
-                $format = '%A@';
-                break;
-            case SortableIterator::SORT_BY_CHANGED_TIME:
-                $format = '%C@';
-                break;
-            case SortableIterator::SORT_BY_MODIFIED_TIME:
-                $format = '%T@';
-                break;
-            default:
-                throw new \InvalidArgumentException('Unknown sort options: '.$sort.'.');
-        }
-
-        $this->buildFormatSorting($command, $format);
+        $this->buildFormatSorting($command, $sort);
     }
 
     /**
      * @param Command $command
-     * @param string  $format
+     * @param string  $sort
      */
-    abstract protected function buildFormatSorting(Command $command, $format);
+    abstract protected function buildFormatSorting(Command $command, $sort);
+
+    /**
+     * @param Command $command
+     * @param array   $contains
+     * @param Boolean $not
+     */
+    abstract protected function buildContentFiltering(Command $command, array $contains, $not = false);
 }

--- a/src/Symfony/Component/Finder/Adapter/GnuFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/GnuFindAdapter.php
@@ -13,6 +13,8 @@ namespace Symfony\Component\Finder\Adapter;
 
 use Symfony\Component\Finder\Shell\Shell;
 use Symfony\Component\Finder\Shell\Command;
+use Symfony\Component\Finder\Iterator\SortableIterator;
+use Symfony\Component\Finder\Expression\Expression;
 
 /**
  * Shell engine implementation using GNU find command.
@@ -32,8 +34,29 @@ class GnuFindAdapter extends AbstractFindAdapter
     /**
      * {@inheritdoc}
      */
-    protected function buildFormatSorting(Command $command, $format)
+    protected function buildFormatSorting(Command $command, $sort)
     {
+        switch ($sort) {
+            case SortableIterator::SORT_BY_NAME:
+                $command->ins('sort')->add('| sort');
+
+                return;
+            case SortableIterator::SORT_BY_TYPE:
+                $format = '%y';
+                break;
+            case SortableIterator::SORT_BY_ACCESSED_TIME:
+                $format = '%A@';
+                break;
+            case SortableIterator::SORT_BY_CHANGED_TIME:
+                $format = '%C@';
+                break;
+            case SortableIterator::SORT_BY_MODIFIED_TIME:
+                $format = '%T@';
+                break;
+            default:
+                throw new \InvalidArgumentException('Unknown sort options: '.$sort.'.');
+        }
+
         $command
             ->get('find')
             ->add('-printf')
@@ -58,5 +81,22 @@ class GnuFindAdapter extends AbstractFindAdapter
     protected function buildFindCommand(Command $command, $dir)
     {
       return parent::buildFindCommand($command, $dir)->add('-regextype posix-extended');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function buildContentFiltering(Command $command, array $contains, $not = false)
+    {
+        foreach ($contains as $contain) {
+            $expr = Expression::create($contain);
+
+            // todo: avoid forking process for each $pattern by using multiple -e options
+            $command
+                ->add('| xargs -r grep -I')
+                ->add($expr->isCaseSensitive() ? null : '-i')
+                ->add($not ? '-L' : '-l')
+                ->add('-Ee')->arg($expr->renderPattern());
+        }
     }
 }

--- a/src/Symfony/Component/Finder/Shell/Command.php
+++ b/src/Symfony/Component/Finder/Shell/Command.php
@@ -246,4 +246,17 @@ class Command
             function($bit) { return null !== $bit; }
         ));
     }
+
+    /**
+     * Insert a string or a Command instance before the bit at given position $index (index starts from 0).
+     *
+     * @param string|Command $bit
+     *
+     * @return Command The current Command instance
+     */
+    public function addAtIndex($bit, $index)
+    {
+        array_splice($this->bits, $index, 0, $bit);
+        return $this;
+    }
 }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -23,7 +23,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         parent::setUpBeforeClass();
 
-        self::$tmpDir = sys_get_temp_dir().'/symfony2_finder';
+        self::$tmpDir = realpath(sys_get_temp_dir().'/symfony2_finder');
     }
 
     public function testCreate()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes (tested both Mac OS X and Debian)
Fixes the following tickets: #6412

---

BSD find command needs "-E" switch to evaluate POSIX regex.
Added the ability to Command to insert bits at a given index.

On some systems (Mac OS X for example) php's function
sys_get_temp_dir() returns a directory that is a symlink.
This causes tests failures because expected paths are different
from path returned by the adapter. So, has been added a realpath.

The building of sorting command has been totally moved on the adapter so
the sorting command for BsdFindAdapter has been fixed.

The building of content filtering command has been moved on the adapter.
In BsdFindAdapter version, -r switch has been replaced with initial grep
that srips out blank lines, this way is compatible with BSD shell.
