### PR TITLE
[Form] BC change for `preg_match` and old PCRE versions.

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToStringTransformer.php
@@ -160,14 +160,14 @@ class DateTimeToStringTransformer extends BaseDateTimeTransformer
                 // Check which of the date parts are present in the pattern
                 preg_match(
                     '/(' .
-                    '(?<day>[djDl])|' .
-                    '(?<month>[FMmn])|' .
-                    '(?<year>[Yy])|' .
-                    '(?<hour>[ghGH])|' .
-                    '(?<minute>i)|' .
-                    '(?<second>s)|' .
-                    '(?<dayofyear>z)|' .
-                    '(?<timestamp>U)|' .
+                    '(?P<day>[djDl])|' .
+                    '(?P<month>[FMmn])|' .
+                    '(?P<year>[Yy])|' .
+                    '(?P<hour>[ghGH])|' .
+                    '(?P<minute>i)|' .
+                    '(?P<second>s)|' .
+                    '(?P<dayofyear>z)|' .
+                    '(?P<timestamp>U)|' .
                     '[^djDlFMmnYyghGHiszU]' .
                     ')*/',
                     $this->parseFormat,


### PR DESCRIPTION
Fix `preg_match` in `DateTimeToStringTransformer`  to work with older PCRE.
