### PR TITLE
[2.2][Upgrade] Add notes about kernel.trusted_proxies parameter

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -362,3 +362,24 @@
    protected $gender;
    ```
 
+### FrameworkBundle
+
+#### Configuration
+
+ * The 2.2 version introduces a new parameter ```trusted_proxies``` that replaces ```trust_proxy_headers``` in the framework configuration.
+
+   Before:
+
+   ```
+   # app/config/config.yml
+   framework:
+       trust_proxy_headers: false
+   ```
+
+   After:
+
+   ```
+   # app/config/config.yml
+   framework:
+      trusted_proxies: []
+   ```


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

The UPGRADE-2.2.md does not mention that we have to replace `trust_proxy_headers` with `trusted_proxies`.
