### PR TITLE
[HttpFundation] Updated Request::isXmlHttpRequest() docblock

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1404,7 +1404,7 @@ class Request
      * Returns true if the request is a XMLHttpRequest.
      *
      * It works if your JavaScript library set an X-Requested-With HTTP header.
-     * It is known to work with Prototype, Mootools, jQuery.
+     * It is known to work with Prototype, Mootools, jQuery, ExtJs.
      *
      * @return Boolean true if the request is an XMLHttpRequest, false otherwise
      *


### PR DESCRIPTION
Added ExtJs as a Javascript library which support the isXmlHttpRequest() method.
