### PR TITLE
[2.2][Routing] Used static to call constant in XmlFileLoader

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -76,7 +76,7 @@ class XmlFileLoader extends FileLoader
      */
     protected function parseNode(RouteCollection $collection, \DOMElement $node, $path, $file)
     {
-        if (self::NAMESPACE_URI !== $node->namespaceURI) {
+        if (static::NAMESPACE_URI !== $node->namespaceURI) {
             return;
         }
 
@@ -192,7 +192,7 @@ class XmlFileLoader extends FileLoader
         $requirements = array();
         $options = array();
 
-        foreach ($node->getElementsByTagNameNS(self::NAMESPACE_URI, '*') as $n) {
+        foreach ($node->getElementsByTagNameNS(static::NAMESPACE_URI, '*') as $n) {
             switch ($n->localName) {
                 case 'default':
                     $defaults[$n->getAttribute('key')] = trim($n->textContent);


### PR DESCRIPTION
It is more complicated to override XmlFileLoader if contants are called with `self`.
This PR replace `self` to `static`.

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT
