### PR TITLE
[HttpFoundation] Introducing Session Caching Support for Couchbase.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/CouchbaseSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/CouchbaseSessionHandler.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Session\Storage\Handler;
+
+/**
+ * CouchbaseSessionHandler.
+ *
+ * Couchbase based esession storage handler based on the Couchbase class
+ * provided by the PHP couchbase extension.
+ *
+ * @see http://www.couchbase.com/develop/php/current
+ *
+ * @author Michael Nitschinger <michael@nitschinger.at>
+ */
+class CouchbaseSessionHandler implements \SessionHandlerInterface
+{
+    /**
+     * @var \Couchbase Couchbase driver.
+     */
+    private $couchbase;
+
+    /**
+     * @var integer Time to live in seconds
+     */
+    private $ttl;
+
+    /**
+     * @var string Key prefix for shared environments.
+     */
+    private $prefix;
+
+    /**
+     * Constructor.
+     *
+     * List of available options:
+     *  * prefix: The prefix to use for the couchbase keys in order to avoid collision
+     *  * expiretime: The time to live in seconds
+     *
+     * @param \Couchbase $couchbase A \Couchbase instance
+     * @param array      $options   An associative array of Couchbase options
+     *
+     * @throws \InvalidArgumentException When unsupported options are passed
+     */
+    public function __construct(\Couchbase $couchbase, array $options = array())
+    {
+        $this->couchbase = $couchbase;
+
+        if ($diff = array_diff(array_keys($options), array('prefix', 'expiretime'))) {
+            throw new \InvalidArgumentException(sprintf(
+                'The following options are not supported "%s"', implode(', ', $diff)
+            ));
+        }
+
+        $this->ttl = isset($options['expiretime']) ? (int) $options['expiretime'] : 86400;
+        $this->prefix = isset($options['prefix']) ? $options['prefix'] : 'sf2s';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function open($savePath, $sessionName)
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function close()
+    {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function read($sessionId)
+    {
+        return $this->couchbase->get($this->prefix.$sessionId) ?: '';
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function write($sessionId, $data)
+    {
+        return $this->couchbase->set($this->prefix.$sessionId, $data, time() + $this->ttl);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function destroy($sessionId)
+    {
+        return $this->couchbase->delete($this->prefix.$sessionId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function gc($lifetime)
+    {
+        // not required here because couchbase will auto expire the records anyhow.
+        return true;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/CouchbaseSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/CouchbaseSessionHandlerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests\Session\Storage\Handler;
+
+use Symfony\Component\HttpFoundation\Session\Storage\Handler\CouchbaseSessionHandler;
+
+class CouchbaseSessionHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    const PREFIX = 'prefix_';
+    const TTL = 1000;
+
+    /**
+     * @var CouchbaseSessionHandler
+     */
+    protected $storage;
+
+    protected $couchbase;
+
+    protected function setUp()
+    {
+        if (!class_exists('Couchbase')) {
+            $this->markTestSkipped('Skipped tests Couchbase class is not present');
+        }
+
+        $this->couchbase = $this->getMock('Couchbase');
+        $this->storage = new CouchbaseSessionHandler(
+            $this->couchbase,
+            array('prefix' => self::PREFIX, 'expiretime' => self::TTL)
+        );
+    }
+
+    protected function tearDown()
+    {
+        $this->couchbase = null;
+        $this->storage = null;
+    }
+
+    public function testOpenSession()
+    {
+        $this->assertTrue($this->storage->open('', ''));
+    }
+
+    public function testCloseSession()
+    {
+        $this->assertTrue($this->storage->close());
+    }
+
+    public function testReadSession()
+    {
+        $this->couchbase
+            ->expects($this->once())
+            ->method('get')
+            ->with(self::PREFIX.'id')
+        ;
+
+        $this->assertEquals('', $this->storage->read('id'));
+    }
+
+    public function testWriteSession()
+    {
+        $this->couchbase
+            ->expects($this->once())
+            ->method('set')
+            ->with(self::PREFIX.'id', 'data', $this->equalTo(time() + self::TTL, 2))
+            ->will($this->returnValue(true))
+        ;
+
+        $this->assertTrue($this->storage->write('id', 'data'));
+    }
+
+    public function testDestroySession()
+    {
+        $this->couchbase
+            ->expects($this->once())
+            ->method('delete')
+            ->with(self::PREFIX.'id')
+            ->will($this->returnValue(true))
+        ;
+
+        $this->assertTrue($this->storage->destroy('id'));
+    }
+
+    public function testGcSession()
+    {
+        $this->assertTrue($this->storage->gc(123));
+    }
+
+    /**
+     * @dataProvider getOptionFixtures
+     */
+    public function testSupportedOptions($options, $supported)
+    {
+        try {
+            new CouchbaseSessionHandler($this->couchbase, $options);
+            $this->assertTrue($supported);
+        } catch (\InvalidArgumentException $e) {
+            $this->assertFalse($supported);
+        }
+    }
+
+    public function getOptionFixtures()
+    {
+        return array(
+            array(array('prefix' => 'session'), true),
+            array(array('expiretime' => 100), true),
+            array(array('prefix' => 'session', 'expiretime' => 200), true),
+            array(array('expiretime' => 100, 'foo' => 'bar'), false),
+        );
+    }
+}


### PR DESCRIPTION
This changeset introduces session caching support for Couchbase
Server in combination with its couchbase php extension.

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: same as symfony
Documentation PR: not added yet.
