### PR TITLE
[WIP] Kernel refactor

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -14,10 +14,8 @@
    After:
 
    ```
-   {% render url('post_list', { 'limit': 2 }), { 'alt': 'BlogBundle:Post:error' } %}
+   {% render controller('BlogBundle:Post:list', { 'limit': 2 }), { 'alt': 'BlogBundle:Post:error' } %}
    ```
-
-   where `post_list` is the route name for the `BlogBundle:Post:list` controller.
 
 ### HttpFoundation
 
@@ -409,7 +407,12 @@
    <?php echo $view['actions']->render($view['router']->generate('post_list', array('limit' => 2)), array('alt' => 'BlogBundle:Post:error')) ?>
    ```
 
-   where `post_list` is the route name for the `BlogBundle:Post:list` controller.
+   where `post_list` is the route name for the `BlogBundle:Post:list`
+   controller, or if you don't want to create a route:
+
+   ```
+   <?php echo $view['actions']->render(new ControllerReference('BlogBundle:Post:list', array('limit' => 2)), array('alt' => 'BlogBundle:Post:error')) ?>
+   ```
 
 #### Configuration
 

--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -4,8 +4,10 @@ CHANGELOG
 2.2.0
 -----
 
- * [BC BREAK] restricted the `render` tag to only accept URIs as reference (the signature changed)
- * added a render function to render a request
+ * added a `controller` function to help generating controller references
+ * added a `render_esi` and a `render_hinclude` function
+ * [BC BREAK] restricted the `render` tag to only accept URIs or ControllerReference instances (the signature changed)
+ * added a `render` function to render a request
  * The `app` global variable is now injected even when using the twig service directly.
  * Added an optional parameter to the `path` and `url` function which allows to generate
    relative paths (e.g. "../parent-file") and scheme-relative URLs (e.g. "//example.com/dir/file").

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -54,6 +54,8 @@ class HttpKernelExtension extends \Twig_Extension
      */
     public function render($uri, $options = array())
     {
+        $options = $this->renderer->fixOptions($options);
+
         $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
         unset($options['strategy']);
 

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -37,6 +37,7 @@ class HttpKernelExtension extends \Twig_Extension
     {
         return array(
             'render' => new \Twig_Function_Method($this, 'render', array('is_safe' => array('html'))),
+            'render_*' => new \Twig_Function_Method($this, 'renderStrategy', array('is_safe' => array('html'))),
             'controller' => new \Twig_Function_Method($this, 'controller'),
         );
     }
@@ -53,6 +54,13 @@ class HttpKernelExtension extends \Twig_Extension
      */
     public function render($uri, $options = array())
     {
+        return $this->renderer->render($uri, $options);
+    }
+
+    public function renderStrategy($strategy, $uri, $options = array())
+    {
+        $options['strategy'] = $strategy;
+
         return $this->renderer->render($uri, $options);
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -54,14 +54,15 @@ class HttpKernelExtension extends \Twig_Extension
      */
     public function render($uri, $options = array())
     {
-        return $this->renderer->render($uri, $options);
+        $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
+        unset($options['strategy']);
+
+        return $this->renderer->render($uri, $strategy, $options);
     }
 
     public function renderStrategy($strategy, $uri, $options = array())
     {
-        $options['strategy'] = $strategy;
-
-        return $this->renderer->render($uri, $options);
+        return $this->renderer->render($uri, $strategy, $options);
     }
 
     public function controller($controller, $attributes = array(), $query = array())

--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Bridge\Twig\Tests\TestCase;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpContentRenderer;
 
 class HttpKernelExtensionTest extends TestCase

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -4,11 +4,16 @@ CHANGELOG
 2.2.0
 -----
 
- * [BC BREAK] restricted the `Symfony\Bundle\FrameworkBundle\HttpKernel::render()` method to only accept URIs as reference
+ * added a new `uri_signer` service to help sign URIs
+ * deprecated `Symfony\Bundle\FrameworkBundle\HttpKernel::render()` and `Symfony\Bundle\FrameworkBundle\HttpKernel::forward()`
+ * deprecated the `Symfony\Bundle\FrameworkBundle\HttpKernel` class in favor of `Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel`
+ * added support for adding new HTTP content rendering strategies (like ESI and Hinclude)
+   in the DIC via the `kernel.content_renderer_strategy` tag
+ * [BC BREAK] restricted the `Symfony\Bundle\FrameworkBundle\HttpKernel::render()` method to only accept URIs or ControllerReference instances
    * `Symfony\Bundle\FrameworkBundle\HttpKernel::render()` method signature changed and the first argument
-     must now be a URI (the `generateInternalUri()` method was removed)
-   * The internal routes have been removed (`Resources/config/routing/internal.xml`)
-   * The `render` method of the `actions` templating helper signature and arguments changed:
+     must now be a URI or a ControllerReference instance (the `generateInternalUri()` method was removed)
+   * The internal routes (`Resources/config/routing/internal.xml`) have been replaced with a new proxy route (`Resources/config/routing/proxy.xml`)
+   * The `render` method of the `actions` templating helper signature and arguments changed
  * replaced Symfony\Bundle\FrameworkBundle\Controller\TraceableControllerResolver by Symfony\Component\HttpKernel\Controller\TraceableControllerResolver
  * replaced Symfony\Component\HttpKernel\Debug\ContainerAwareTraceableEventDispatcher by Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher
  * added Client::enableProfiler()

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/Controller.php
@@ -59,7 +59,10 @@ class Controller extends ContainerAware
      */
     public function forward($controller, array $path = array(), array $query = array())
     {
-        return $this->container->get('http_kernel')->forward($controller, $path, $query);
+        $path['_controller'] = $controller;
+        $subRequest = $this->container->get('request')->duplicate($query, null, $path);
+
+        return $this->container->get('http_kernel')->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/HttpRenderingStrategyPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/HttpRenderingStrategyPass.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+
+/**
+ * Adds services tagged kernel.content_renderer_strategy as HTTP content rendering strategies.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HttpRenderingStrategyPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (false === $container->hasDefinition('http_content_renderer')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('http_content_renderer');
+        foreach (array_keys($container->findTaggedServiceIds('kernel.content_renderer_strategy')) as $id) {
+            $definition->addMethodCall('addStrategy', array(new Reference($id)));
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -41,6 +41,7 @@ class FrameworkExtension extends Extension
 
         $loader->load('web.xml');
         $loader->load('services.xml');
+        $loader->load('content_generator.xml');
 
         // A translator must always be registered (as support is included by
         // default in the Form component). If disabled, an identity translator

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -25,6 +25,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerBuilder
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CompilerDebugDumpPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationExtractorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationDumperPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\HttpRenderingStrategyPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Scope;
@@ -65,6 +66,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new AddCacheClearerPass());
         $container->addCompilerPass(new TranslationExtractorPass());
         $container->addCompilerPass(new TranslationDumperPass());
+        $container->addCompilerPass(new HttpRenderingStrategyPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -66,7 +66,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new AddCacheClearerPass());
         $container->addCompilerPass(new TranslationExtractorPass());
         $container->addCompilerPass(new TranslationDumperPass());
-        $container->addCompilerPass(new HttpRenderingStrategyPass());
+        $container->addCompilerPass(new HttpRenderingStrategyPass(), PassConfig::TYPE_AFTER_REMOVING);
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -11,52 +11,20 @@
 
 namespace Symfony\Bundle\FrameworkBundle;
 
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpKernel\HttpKernel as BaseHttpKernel;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel;
 
 /**
  * This HttpKernel is used to manage scope changes of the DI container.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ *
+ * @deprecated This class is deprecated in 2.2 and will be removed in 2.3
  */
-class HttpKernel extends BaseHttpKernel
+class HttpKernel extends ContainerAwareHttpKernel
 {
-    protected $container;
-
-    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver)
-    {
-        parent::__construct($dispatcher, $controllerResolver);
-
-        $this->container = $container;
-    }
-
-    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
-    {
-        $request->headers->set('X-Php-Ob-Level', ob_get_level());
-
-        $this->container->enterScope('request');
-        $this->container->set('request', $request, 'request');
-
-        try {
-            $response = parent::handle($request, $type, $catch);
-        } catch (\Exception $e) {
-            $this->container->leaveScope('request');
-
-            throw $e;
-        }
-
-        $this->container->leaveScope('request');
-
-        return $response;
-    }
-
     /**
      * Forwards the request to another controller.
      *

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -65,9 +65,13 @@ class HttpKernel extends BaseHttpKernel
      * @param array  $query      An array of request query parameters
      *
      * @return Response A Response instance
+     *
+     * @deprecated in 2.2, will be removed in 2.3
      */
     public function forward($controller, array $attributes = array(), array $query = array())
     {
+        trigger_error('forward() is deprecated since version 2.2 and will be removed in 2.3.', E_USER_DEPRECATED);
+
         $attributes['_controller'] = $controller;
         $subRequest = $this->container->get('request')->duplicate($query, null, $attributes);
 

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -101,6 +101,9 @@ class HttpKernel extends BaseHttpKernel
     {
         trigger_error('render() is deprecated since version 2.2 and will be removed in 2.3. Use Symfony\Component\HttpKernel\HttpContentRenderer::render() instead.', E_USER_DEPRECATED);
 
-        $this->container->get('http_content_renderer')->render($uri, $options);
+        $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
+        unset($options['strategy']);
+
+        $this->container->get('http_content_renderer')->render($uri, $strategy, $options);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -105,6 +105,8 @@ class HttpKernel extends BaseHttpKernel
     {
         trigger_error('render() is deprecated since version 2.2 and will be removed in 2.3. Use Symfony\Component\HttpKernel\HttpContentRenderer::render() instead.', E_USER_DEPRECATED);
 
+        $options = $this->renderer->fixOptions($options);
+
         $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
         unset($options['strategy']);
 

--- a/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
+++ b/src/Symfony/Bundle/FrameworkBundle/HttpKernel.php
@@ -30,8 +30,6 @@ class HttpKernel extends BaseHttpKernel
 {
     protected $container;
 
-    private $esiSupport;
-
     public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver)
     {
         parent::__construct($dispatcher, $controllerResolver);
@@ -96,97 +94,13 @@ class HttpKernel extends BaseHttpKernel
      *
      * @throws \RuntimeException
      * @throws \Exception
+     *
+     * @deprecated in 2.2, will be removed in 2.3 (use Symfony\Component\HttpKernel\HttpContentRenderer::render() instead)
      */
     public function render($uri, array $options = array())
     {
-        $request = $this->container->get('request');
+        trigger_error('render() is deprecated since version 2.2 and will be removed in 2.3. Use Symfony\Component\HttpKernel\HttpContentRenderer::render() instead.', E_USER_DEPRECATED);
 
-        $options = array_merge(array(
-            'ignore_errors' => !$this->container->getParameter('kernel.debug'),
-            'alt'           => null,
-            'standalone'    => false,
-            'comment'       => '',
-            'default'       => null,
-        ), $options);
-
-        if (null === $this->esiSupport) {
-            $this->esiSupport = $this->container->has('esi') && $this->container->get('esi')->hasSurrogateEsiCapability($request);
-        }
-
-        if ($this->esiSupport && (true === $options['standalone'] || 'esi' === $options['standalone'])) {
-            return $this->container->get('esi')->renderIncludeTag($uri, $options['alt'], $options['ignore_errors'], $options['comment']);
-        }
-
-        if ('js' === $options['standalone']) {
-            $defaultContent = null;
-
-            $templating = $this->container->get('templating');
-
-            if ($options['default']) {
-                if ($templating->exists($options['default'])) {
-                    $defaultContent = $templating->render($options['default']);
-                } else {
-                    $defaultContent = $options['default'];
-                }
-            } elseif ($template = $this->container->getParameter('templating.hinclude.default_template')) {
-                $defaultContent = $templating->render($template);
-            }
-
-            return $this->renderHIncludeTag($uri, $defaultContent);
-        }
-
-        $subRequest = Request::create($uri, 'get', array(), $request->cookies->all(), array(), $request->server->all());
-        if ($session = $request->getSession()) {
-            $subRequest->setSession($session);
-        }
-
-        $level = ob_get_level();
-        try {
-            $response = $this->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
-
-            if (!$response->isSuccessful()) {
-                throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $request->getUri(), $response->getStatusCode()));
-            }
-
-            if (!$response instanceof StreamedResponse) {
-                return $response->getContent();
-            }
-
-            $response->sendContent();
-        } catch (\Exception $e) {
-            if ($options['alt']) {
-                $alt = $options['alt'];
-                unset($options['alt']);
-
-                return $this->render($alt, $options);
-            }
-
-            if (!$options['ignore_errors']) {
-                throw $e;
-            }
-
-            // let's clean up the output buffers that were created by the sub-request
-            while (ob_get_level() > $level) {
-                ob_get_clean();
-            }
-        }
-    }
-
-    /**
-     * Renders an HInclude tag.
-     *
-     * @param string $uri            A URI
-     * @param string $defaultContent Default content
-     *
-     * @return string
-     */
-    public function renderHIncludeTag($uri, $defaultContent = null)
-    {
-        return sprintf('<hx:include src="%s">%s</hx:include>', $uri, $defaultContent);
-    }
-
-    public function hasEsiSupport()
-    {
-        return $this->esiSupport;
+        $this->container->get('http_content_renderer')->render($uri, $options);
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
@@ -7,7 +7,6 @@
     <parameters>
         <parameter key="http_content_renderer.class">Symfony\Component\HttpKernel\HttpContentRenderer</parameter>
         <parameter key="http_content_renderer.strategy.default.class">Symfony\Component\HttpKernel\RenderingStrategy\DefaultRenderingStrategy</parameter>
-        <parameter key="http_content_renderer.strategy.esi.class">Symfony\Component\HttpKernel\RenderingStrategy\EsiRenderingStrategy</parameter>
         <parameter key="http_content_renderer.strategy.hinclude.class">Symfony\Component\HttpKernel\RenderingStrategy\HIncludeRenderingStrategy</parameter>
         <parameter key="http_content_renderer.strategy.hinclude.global_template"></parameter>
         <parameter key="http_content_renderer.listener.router_proxy.class">Symfony\Component\HttpKernel\EventListener\RouterProxyListener</parameter>
@@ -26,17 +25,10 @@
             <call method="setUrlGenerator"><argument type="service" id="router" /></call>
         </service>
 
-        <service id="http_content_renderer.strategy.esi" class="%http_content_renderer.strategy.esi.class%" public="false">
-            <tag name="kernel.content_renderer_strategy" />
-            <argument type="service" id="esi" />
-            <argument type="service" id="http_content_renderer.strategy.default" />
-            <call method="setUrlGenerator"><argument type="service" id="router" /></call>
-        </service>
-
 <!-- FIXME: this service should be private but it cannot due to a bug in PhpDumper -->
         <service id="http_content_renderer.strategy.hinclude" class="%http_content_renderer.strategy.hinclude.class%">
             <tag name="kernel.content_renderer_strategy" />
-            <argument type="service" id="templating" />
+            <argument type="service" id="templating" on-invalid="null" />
             <argument type="service" id="uri_signer" />
             <argument>%http_content_renderer.strategy.hinclude.global_template%</argument>
             <call method="setUrlGenerator"><argument type="service" id="router" /></call>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
@@ -36,12 +36,15 @@
         <service id="http_content_renderer.strategy.hinclude" class="%http_content_renderer.strategy.hinclude.class%">
             <tag name="kernel.content_renderer_strategy" />
             <argument type="service" id="templating" />
+            <argument type="service" id="uri_signer" />
             <argument>%http_content_renderer.strategy.hinclude.global_template%</argument>
+            <call method="setUrlGenerator"><argument type="service" id="router" /></call>
         </service>
 
 <!-- FIXME: make the listener registration optional via a configuration setting? -->
         <service id="http_content_renderer.listener.router_proxy" class="%http_content_renderer.listener.router_proxy.class%">
             <tag name="kernel.event_subscriber" />
+            <argument type="service" id="uri_signer" />
         </service>
 
     </services>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
@@ -19,13 +19,12 @@
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="http_content_renderer.strategy.default" class="%http_content_renderer.strategy.default.class%" public="false">
+        <service id="http_content_renderer.strategy.default" class="%http_content_renderer.strategy.default.class%">
             <tag name="kernel.content_renderer_strategy" />
             <argument type="service" id="http_kernel" />
             <call method="setUrlGenerator"><argument type="service" id="router" /></call>
         </service>
 
-<!-- FIXME: this service should be private but it cannot due to a bug in PhpDumper -->
         <service id="http_content_renderer.strategy.hinclude" class="%http_content_renderer.strategy.hinclude.class%">
             <tag name="kernel.content_renderer_strategy" />
             <argument type="service" id="templating" on-invalid="null" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
@@ -20,19 +20,20 @@
             <argument>%kernel.debug%</argument>
         </service>
 
-        <service id="http_content_renderer.strategy.default" class="%http_content_renderer.strategy.default.class%">
+        <service id="http_content_renderer.strategy.default" class="%http_content_renderer.strategy.default.class%" public="false">
             <tag name="kernel.content_renderer_strategy" />
             <argument type="service" id="http_kernel" />
             <call method="setUrlGenerator"><argument type="service" id="router" /></call>
         </service>
 
-        <service id="http_content_renderer.strategy.esi" class="%http_content_renderer.strategy.esi.class%">
+        <service id="http_content_renderer.strategy.esi" class="%http_content_renderer.strategy.esi.class%" public="false">
             <tag name="kernel.content_renderer_strategy" />
             <argument type="service" id="esi" />
             <argument type="service" id="http_content_renderer.strategy.default" />
             <call method="setUrlGenerator"><argument type="service" id="router" /></call>
         </service>
 
+<!-- FIXME: this service should be private but it cannot due to a bug in PhpDumper -->
         <service id="http_content_renderer.strategy.hinclude" class="%http_content_renderer.strategy.hinclude.class%">
             <tag name="kernel.content_renderer_strategy" />
             <argument type="service" id="templating" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="http_content_renderer.class">Symfony\Component\HttpKernel\HttpContentRenderer</parameter>
+        <parameter key="http_content_renderer.strategy.default.class">Symfony\Component\HttpKernel\RenderingStrategy\DefaultRenderingStrategy</parameter>
+        <parameter key="http_content_renderer.strategy.esi.class">Symfony\Component\HttpKernel\RenderingStrategy\EsiRenderingStrategy</parameter>
+        <parameter key="http_content_renderer.strategy.hinclude.class">Symfony\Component\HttpKernel\RenderingStrategy\HIncludeRenderingStrategy</parameter>
+        <parameter key="http_content_renderer.strategy.hinclude.global_template"></parameter>
+        <parameter key="http_content_renderer.listener.router_proxy.class">Symfony\Component\HttpKernel\EventListener\RouterProxyListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="http_content_renderer" class="%http_content_renderer.class%">
+            <tag name="kernel.event_subscriber" />
+            <argument type="collection" />
+            <argument>%kernel.debug%</argument>
+        </service>
+
+        <service id="http_content_renderer.strategy.default" class="%http_content_renderer.strategy.default.class%">
+            <tag name="kernel.content_renderer_strategy" />
+            <argument type="service" id="http_kernel" />
+            <call method="setUrlGenerator"><argument type="service" id="router" /></call>
+        </service>
+
+        <service id="http_content_renderer.strategy.esi" class="%http_content_renderer.strategy.esi.class%">
+            <tag name="kernel.content_renderer_strategy" />
+            <argument type="service" id="esi" />
+            <argument type="service" id="http_content_renderer.strategy.default" />
+            <call method="setUrlGenerator"><argument type="service" id="router" /></call>
+        </service>
+
+        <service id="http_content_renderer.strategy.hinclude" class="%http_content_renderer.strategy.hinclude.class%">
+            <tag name="kernel.content_renderer_strategy" />
+            <argument type="service" id="templating" />
+            <argument>%http_content_renderer.strategy.hinclude.global_template%</argument>
+        </service>
+
+<!-- FIXME: make the listener registration optional via a configuration setting? -->
+        <service id="http_content_renderer.listener.router_proxy" class="%http_content_renderer.listener.router_proxy.class%">
+            <tag name="kernel.event_subscriber" />
+        </service>
+
+    </services>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="esi.class">Symfony\Component\HttpKernel\HttpCache\Esi</parameter>
         <parameter key="esi_listener.class">Symfony\Component\HttpKernel\EventListener\EsiListener</parameter>
+        <parameter key="http_content_renderer.strategy.esi.class">Symfony\Component\HttpKernel\RenderingStrategy\EsiRenderingStrategy</parameter>
     </parameters>
 
     <services>
@@ -15,6 +16,13 @@
         <service id="esi_listener" class="%esi_listener.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="esi" on-invalid="ignore" />
+        </service>
+
+        <service id="http_content_renderer.strategy.esi" class="%http_content_renderer.strategy.esi.class%" public="false">
+            <tag name="kernel.content_renderer_strategy" />
+            <argument type="service" id="esi" />
+            <argument type="service" id="http_content_renderer.strategy.default" />
+            <call method="setUrlGenerator"><argument type="service" id="router" /></call>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
@@ -18,7 +18,7 @@
             <argument type="service" id="esi" on-invalid="ignore" />
         </service>
 
-        <service id="http_content_renderer.strategy.esi" class="%http_content_renderer.strategy.esi.class%" public="false">
+        <service id="http_content_renderer.strategy.esi" class="%http_content_renderer.strategy.esi.class%">
             <tag name="kernel.content_renderer_strategy" />
             <argument type="service" id="esi" />
             <argument type="service" id="http_content_renderer.strategy.default" />

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/proxy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/proxy.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<routes xmlns="http://symfony.com/schema/routing"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
+
+    <route id="_proxy" pattern="/_proxy/{_controller}.{_format}" />
+</routes>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -11,6 +11,7 @@
         <parameter key="cache_warmer.class">Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerAggregate</parameter>
         <parameter key="cache_clearer.class">Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer</parameter>
         <parameter key="file_locator.class">Symfony\Component\HttpKernel\Config\FileLocator</parameter>
+        <parameter key="uri_signer.class">Symfony\Component\HttpKernel\UriSigner</parameter>
     </parameters>
 
     <services>
@@ -50,6 +51,10 @@
         <service id="file_locator" class="%file_locator.class%">
             <argument type="service" id="kernel" />
             <argument>%kernel.root_dir%/Resources</argument>
+        </service>
+
+        <service id="uri_signer" class="%uri_signer.class%">
+            <argument>%kernel.secret%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -81,7 +81,7 @@
 
         <service id="templating.helper.actions" class="%templating.helper.actions.class%">
             <tag name="templating.helper" alias="actions" />
-            <argument type="service" id="http_kernel" />
+            <argument type="service" id="http_content_renderer" />
         </service>
 
         <service id="templating.helper.code" class="%templating.helper.code.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
@@ -46,6 +46,8 @@ class ActionsHelper extends Helper
      */
     public function render($uri, array $options = array())
     {
+        $options = $this->renderer->fixOptions($options);
+
         $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
         unset($options['strategy']);
 

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
@@ -46,7 +46,10 @@ class ActionsHelper extends Helper
      */
     public function render($uri, array $options = array())
     {
-        return $this->renderer->render($uri, $options);
+        $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
+        unset($options['strategy']);
+
+        return $this->renderer->render($uri, $strategy, $options);
     }
 
     public function controller($controller, $attributes = array(), $query = array())

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
@@ -12,7 +12,8 @@
 namespace Symfony\Bundle\FrameworkBundle\Templating\Helper;
 
 use Symfony\Component\Templating\Helper\Helper;
-use Symfony\Bundle\FrameworkBundle\HttpKernel;
+use Symfony\Component\HttpKernel\HttpContentRenderer;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
  * ActionsHelper manages action inclusions.
@@ -21,16 +22,16 @@ use Symfony\Bundle\FrameworkBundle\HttpKernel;
  */
 class ActionsHelper extends Helper
 {
-    protected $kernel;
+    private $renderer;
 
     /**
      * Constructor.
      *
-     * @param HttpKernel $kernel A HttpKernel instance
+     * @param HttpContentRenderer $kernel A HttpContentRenderer instance
      */
-    public function __construct(HttpKernel $kernel)
+    public function __construct(HttpContentRenderer $renderer)
     {
-        $this->kernel = $kernel;
+        $this->renderer = $renderer;
     }
 
     /**
@@ -41,11 +42,16 @@ class ActionsHelper extends Helper
      *
      * @return string
      *
-     * @see Symfony\Bundle\FrameworkBundle\HttpKernel::render()
+     * @see Symfony\Component\HttpKernel\HttpContentRenderer::render()
      */
     public function render($uri, array $options = array())
     {
-        return $this->kernel->render($uri, $options);
+        return $this->renderer->render($uri, $options);
+    }
+
+    public function controller($controller, $attributes = array(), $query = array())
+    {
+        return new ControllerReference($controller, $attributes, $query);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/HttpRenderingStrategyPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/HttpRenderingStrategyPassTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\HttpRenderingStrategyPass;
+
+class HttpRenderingStrategyPassTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests that content rendering not implementing RenderingStrategyInterface
+     * trigger an exception.
+     *
+     * @expectedException \InvalidArgumentException
+     */
+    public function testContentRendererWithoutInterface()
+    {
+        // one service, not implementing any interface
+        $services = array(
+            'my_content_renderer' => array(),
+        );
+
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $definition->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->will($this->returnValue('stdClass'));
+
+        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder->expects($this->any())
+            ->method('hasDefinition')
+            ->will($this->returnValue(true));
+
+        // We don't test kernel.content_renderer_strategy here
+        $builder->expects($this->atLeastOnce())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnValue($services));
+
+        $builder->expects($this->atLeastOnce())
+            ->method('getDefinition')
+            ->will($this->returnValue($definition));
+
+        $pass = new HttpRenderingStrategyPass();
+        $pass->process($builder);
+    }
+
+    public function testValidContentRenderer()
+    {
+        $services = array(
+            'my_content_renderer' => array(),
+        );
+
+        $renderer = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $renderer
+            ->expects($this->once())
+            ->method('addMethodCall')
+            ->with('addStrategy', array(new Reference('my_content_renderer')))
+        ;
+
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition');
+        $definition->expects($this->atLeastOnce())
+            ->method('getClass')
+            ->will($this->returnValue('Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler\RenderingStrategyService'));
+
+        $builder = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $builder->expects($this->any())
+            ->method('hasDefinition')
+            ->will($this->returnValue(true));
+
+        // We don't test kernel.content_renderer_strategy here
+        $builder->expects($this->atLeastOnce())
+            ->method('findTaggedServiceIds')
+            ->will($this->returnValue($services));
+
+        $builder->expects($this->atLeastOnce())
+            ->method('getDefinition')
+            ->will($this->onConsecutiveCalls($renderer, $definition));
+
+        $pass = new HttpRenderingStrategyPass();
+        $pass->process($builder);
+    }
+}
+
+class RenderingStrategyService implements \Symfony\Component\HttpKernel\RenderingStrategy\RenderingStrategyInterface
+{
+    public function render($uri, Request $request = null, array $options = array())
+    {
+    }
+
+    public function getName()
+    {
+        return 'test';
+    }
+}

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -90,8 +90,7 @@
 
         <service id="twig.extension.httpkernel" class="%twig.extension.httpkernel.class%">
             <tag name="twig.extension" />
-            <tag name="kernel.event_subscriber" />
-            <argument type="service" id="http_kernel" />
+            <argument type="service" id="http_content_renderer" />
         </service>
 
         <service id="twig.extension.form" class="%twig.extension.form.class%" public="false">

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -13,7 +13,6 @@ namespace Symfony\Component\Form\Tests\Extension\Validator\EventListener;
 
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 2.2.0
 -----
 
+ * added Request::getTrustedProxies()
+ * deprecated Request::isProxyTrusted()
  * added a IpUtils class to check if an IP belongs to a CIDR
  * added Request::getRealMethod() to get the "real" HTTP method (getMethod() returns the "intended" HTTP method)
  * disabled _method request parameter support by default (call Request::enableHttpMethodParameterOverride() to enable it)

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -527,6 +527,8 @@ class Request
      * false otherwise.
      *
      * @return boolean
+     *
+     * @deprecated Deprecated since version 2.2, to be removed in 2.3. Use getTrustedProxies instead.
      */
     public static function isProxyTrusted()
     {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -487,6 +487,16 @@ class Request
     }
 
     /**
+     * Gets the list of trusted proxies.
+     *
+     * @return array An array of trusted proxies.
+     */
+    public static function getTrustedProxies()
+    {
+        return self::$trustedProxies;
+    }
+
+    /**
      * Sets the name for trusted headers.
      *
      * The following header keys are supported:

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -926,8 +926,7 @@ class Request
      */
     public function getUri()
     {
-        $qs = $this->getQueryString();
-        if (null !== $qs) {
+        if (null !== $qs = $this->getQueryString()) {
             $qs = '?'.$qs;
         }
 

--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -4,6 +4,11 @@ CHANGELOG
 2.2.0
 -----
 
+ * added Symfony\Component\HttpKernel\UriSigner
+ * added Symfony\Component\HttpKernel\HttpContentRenderer and rendering strategies (in Symfony\Component\HttpKernel\RenderingStrategy)
+ * added Symfony\Component\HttpKernel\EventListener\RouterProxyListener
+ * added Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel
+ * added ControllerReference to create reference of Controllers (used in the HttpContentRenderer class)
  * [BC BREAK] renamed TimeDataCollector::getTotalTime() to
    TimeDataCollector::getDuration()
  * updated the MemoryDataCollector to include the memory used in the 

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerReference.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerReference.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Controller;
+
+/**
+ * ControllerReference.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ControllerReference
+{
+    public $controller;
+    public $attributes = array();
+    public $query = array();
+
+    public function __construct($controller, array $attributes = array(), array $query = array())
+    {
+        $this->controller = $controller;
+        $this->attributes = $attributes;
+        $this->query = $query;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerReference.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerReference.php
@@ -12,9 +12,16 @@
 namespace Symfony\Component\HttpKernel\Controller;
 
 /**
- * ControllerReference.
+ * Acts as a marker and a data holder for a Controller.
+ *
+ * Some methods in Symfony accept both a URI (as a string) or a controller as
+ * an argument. In the latter case, instead of passing an array representing
+ * the controller, you can use an instance of this class.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @see Symfony\Component\HttpKernel\HttpContentRenderer
+ * @see Symfony\Component\HttpKernel\RenderingStrategy\RenderingStrategyInterface
  */
 class ControllerReference
 {
@@ -22,6 +29,13 @@ class ControllerReference
     public $attributes = array();
     public $query = array();
 
+    /**
+     * Constructor.
+     *
+     * @param string $controller The controller name
+     * @param array  $attributes An array of parameters to add to the Request attributes
+     * @param array  $query      An array of parameters to add to the Request query string
+     */
     public function __construct($controller, array $attributes = array(), array $query = array())
     {
         $this->controller = $controller;

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\DependencyInjection;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * This HttpKernel is used to manage scope changes of the DI container.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ContainerAwareHttpKernel extends HttpKernel
+{
+    protected $container;
+
+    /**
+     * Constructor.
+     *
+     * @param EventDispatcherInterface    $dispatcher         An EventDispatcherInterface instance
+     * @param ContainerInterface          $container          A ContainerInterface instance
+     * @param ControllerResolverInterface $controllerResolver A ControllerResolverInterface instance
+     */
+    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver)
+    {
+        parent::__construct($dispatcher, $controllerResolver);
+
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        $request->headers->set('X-Php-Ob-Level', ob_get_level());
+
+        $this->container->enterScope('request');
+        $this->container->set('request', $request, 'request');
+
+        try {
+            $response = parent::handle($request, $type, $catch);
+        } catch (\Exception $e) {
+            $this->container->leaveScope('request');
+
+            throw $e;
+        }
+
+        $this->container->leaveScope('request');
+
+        return $response;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterProxyListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterProxyListener.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\IpUtils;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Proxies URIs when the current route name is "_proxy".
+ *
+ * If the request does not come from a trusted, it throws an
+ * AccessDeniedHttpException exception.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class RouterProxyListener implements EventSubscriberInterface
+{
+    /**
+     * Fixes request attributes when the route is '_proxy'.
+     *
+     * @param GetResponseEvent $event A GetResponseEvent instance
+     *
+     * @throws AccessDeniedHttpException if the request does not come from a trusted IP.
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        if ('_proxy' !== $request->attributes->get('_route')) {
+            return;
+        }
+
+        $this->checkRequest($request);
+
+        parse_str($request->query->get('path', ''), $attributes);
+        $request->attributes->add($attributes);
+        $request->attributes->set('_route_params', array_replace($request->attributes->get('_route_params'), $attributes));
+        $request->query->remove('path');
+    }
+
+    protected function checkRequest(Request $request)
+    {
+        $trustedIps = array_merge($this->getLocalIpAddresses(), $request->getTrustedProxies());
+        $remoteAddress = $request->server->get('REMOTE_ADDR');
+        foreach ($trustedIps as $ip) {
+            if (IpUtils::checkIp($remoteAddress, $ip)) {
+                return;
+            }
+        }
+
+        throw new AccessDeniedHttpException();
+    }
+
+    protected function getLocalIpAddresses()
+    {
+        return array('127.0.0.1', 'fe80::1', '::1');
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => array(array('onKernelRequest', 16)),
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterProxyListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterProxyListener.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 /**
  * Proxies URIs when the current route name is "_proxy".
  *
- * If the request does not come from a trusted, it throws an
+ * If the request does not come from a trusted IP, it throws an
  * AccessDeniedHttpException exception.
  *
  * @author Fabien Potencier <fabien@symfony.com>

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterProxyListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterProxyListener.php
@@ -55,7 +55,7 @@ class RouterProxyListener implements EventSubscriberInterface
 
         parse_str($request->query->get('path', ''), $attributes);
         $request->attributes->add($attributes);
-        $request->attributes->set('_route_params', array_replace($request->attributes->get('_route_params'), $attributes));
+        $request->attributes->set('_route_params', array_replace($request->attributes->get('_route_params', array()), $attributes));
         $request->query->remove('path');
     }
 
@@ -76,7 +76,8 @@ class RouterProxyListener implements EventSubscriberInterface
         }
 
         // is the Request signed?
-        if ($this->signer->check($request->getUri())) {
+        // we cannot use $request->getUri() here as we want to work with the original URI (no query string reordering)
+        if ($this->signer->check($request->getSchemeAndHttpHost().$request->getBaseUrl().$request->getPathInfo().(null !== ($qs = $request->server->get('QUERY_STRING')) ? '?'.$qs : ''))) {
             return;
         }
 

--- a/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
@@ -19,6 +19,7 @@ use Symfony\Component\HttpKernel\RenderingStrategy\RenderingStrategyInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
+ * Renders a URI using different strategies.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -28,6 +29,12 @@ class HttpContentRenderer implements EventSubscriberInterface
     private $strategies;
     private $requests;
 
+    /**
+     * Constructor.
+     *
+     * @param RenderingStrategyInterface[] $strategies An array of RenderingStrategyInterface instances
+     * @param Boolean                      $debug      Whether the debug mode is enabled or not
+     */
     public function __construct(array $strategies = array(), $debug = false)
     {
         $this->strategies = array();
@@ -38,6 +45,11 @@ class HttpContentRenderer implements EventSubscriberInterface
         $this->requests = array();
     }
 
+    /**
+     * Adds a rendering strategy.
+     *
+     * @param RenderingStrategyInterface $strategy A RenderingStrategyInterface instance
+     */
     public function addStrategy(RenderingStrategyInterface $strategy)
     {
         $this->strategies[$strategy->getName()] = $strategy;
@@ -66,13 +78,16 @@ class HttpContentRenderer implements EventSubscriberInterface
     /**
      * Renders a URI and returns the Response content.
      *
+     * When the Response is a StreamedResponse, the content is streamed immediately
+     * instead of being returned.
+     *
      *  * ignore_errors: true to return an empty string in case of an error
      *  * strategy:      the strategy to use for rendering
      *
      * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
      * @param array                      $options An array of options
      *
-     * @return string The Response content
+     * @return string|null The Response content or null when the Response is streamed
      */
     public function render($uri, array $options = array())
     {
@@ -99,6 +114,7 @@ class HttpContentRenderer implements EventSubscriberInterface
         );
     }
 
+    // to be removed in 2.3
     private function fixOptions($options)
     {
         // support for the standalone option is @deprecated in 2.2 and replaced with the strategy option

--- a/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
@@ -81,23 +81,26 @@ class HttpContentRenderer implements EventSubscriberInterface
      * When the Response is a StreamedResponse, the content is streamed immediately
      * instead of being returned.
      *
-     *  * ignore_errors: true to return an empty string in case of an error
-     *  * strategy:      the strategy to use for rendering
+     * Available options:
      *
-     * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
-     * @param array                      $options An array of options
+     *  * ignore_errors: true to return an empty string in case of an error
+     *
+     * @param string|ControllerReference $uri      A URI as a string or a ControllerReference instance
+     * @param string                     $strategy The strategy to use for the rendering
+     * @param array                      $options  An array of options
      *
      * @return string|null The Response content or null when the Response is streamed
      */
-    public function render($uri, array $options = array())
+    public function render($uri, $strategy = 'default', array $options = array())
     {
         if (!isset($options['ignore_errors'])) {
             $options['ignore_errors'] = !$this->debug;
         }
 
         $options = $this->fixOptions($options);
-
-        $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
+        if (isset($options['strategy'])) {
+            $strategy = $options['strategy'];
+        }
 
         if (!isset($this->strategies[$strategy])) {
             throw new \InvalidArgumentException(sprintf('The "%s" rendering strategy does not exist.', $strategy));

--- a/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
@@ -90,6 +90,8 @@ class HttpContentRenderer implements EventSubscriberInterface
      * @param array                      $options  An array of options
      *
      * @return string|null The Response content or null when the Response is streamed
+     *
+     * @throws \InvalidArgumentException when the strategy does not exist
      */
     public function render($uri, $strategy = 'default', array $options = array())
     {

--- a/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\RenderingStrategy\RenderingStrategyInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HttpContentRenderer implements EventSubscriberInterface
+{
+    private $debug;
+    private $strategies;
+    private $requests;
+
+    public function __construct(array $strategies = array(), $debug = false)
+    {
+        $this->strategies = array();
+        foreach ($strategies as $strategy) {
+            $this->addStrategy($strategy);
+        }
+        $this->debug = $debug;
+        $this->requests = array();
+    }
+
+    public function addStrategy(RenderingStrategyInterface $strategy)
+    {
+        $this->strategies[$strategy->getName()] = $strategy;
+    }
+
+    /**
+     * Stores the Request object.
+     *
+     * @param GetResponseEvent $event A GetResponseEvent instance
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        array_unshift($this->requests, $event->getRequest());
+    }
+
+    /**
+     * Removes the most recent Request object.
+     *
+     * @param FilterResponseEvent $event A FilterResponseEvent instance
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        array_shift($this->requests);
+    }
+
+    /**
+     * Renders a URI and returns the Response content.
+     *
+     *  * ignore_errors: true to return an empty string in case of an error
+     *  * strategy:      the strategy to use for rendering
+     *
+     * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
+     * @param array                      $options An array of options
+     *
+     * @return string The Response content
+     */
+    public function render($uri, array $options = array())
+    {
+        if (!isset($options['ignore_errors'])) {
+            $options['ignore_errors'] = !$this->debug;
+        }
+
+        $options = $this->fixOptions($options);
+
+        $strategy = isset($options['strategy']) ? $options['strategy'] : 'default';
+
+        if (!isset($this->strategies[$strategy])) {
+            throw new \InvalidArgumentException(sprintf('The "%s" rendering strategy does not exist.', $strategy));
+        }
+
+        return $this->strategies[$strategy]->render($uri, $this->requests ? $this->requests[0] : null, $options);
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST  => 'onKernelRequest',
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        );
+    }
+
+    private function fixOptions($options)
+    {
+        // support for the standalone option is @deprecated in 2.2 and replaced with the strategy option
+        if (isset($options['standalone'])) {
+            trigger_error('The "standalone" option is deprecated in version 2.2 and replaced with the "strategy" option.', E_USER_DEPRECATED);
+
+            // support for the true value is @deprecated in 2.2, will be removed in 2.3
+            if (true === $options['standalone']) {
+                trigger_error('The "true" value for the "standalone" option is deprecated in version 2.2 and replaced with the "esi" value.', E_USER_DEPRECATED);
+
+                $options['standalone'] = 'esi';
+            } elseif ('js' === $options['standalone']) {
+                trigger_error('The "js" value for the "standalone" option is deprecated in version 2.2 and replaced with the "hinclude" value.', E_USER_DEPRECATED);
+
+                $options['standalone'] = 'hinclude';
+            }
+
+            $options['strategy'] = $options['standalone'];
+        }
+
+        return $options;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
@@ -97,11 +97,6 @@ class HttpContentRenderer implements EventSubscriberInterface
             $options['ignore_errors'] = !$this->debug;
         }
 
-        $options = $this->fixOptions($options);
-        if (isset($options['strategy'])) {
-            $strategy = $options['strategy'];
-        }
-
         if (!isset($this->strategies[$strategy])) {
             throw new \InvalidArgumentException(sprintf('The "%s" rendering strategy does not exist.', $strategy));
         }
@@ -118,7 +113,7 @@ class HttpContentRenderer implements EventSubscriberInterface
     }
 
     // to be removed in 2.3
-    private function fixOptions($options)
+    public function fixOptions(array $options)
     {
         // support for the standalone option is @deprecated in 2.2 and replaced with the strategy option
         if (isset($options['standalone'])) {
@@ -136,6 +131,7 @@ class HttpContentRenderer implements EventSubscriberInterface
             }
 
             $options['strategy'] = $options['standalone'];
+            unset($options['standalone']);
         }
 
         return $options;

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/DefaultRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/DefaultRenderingStrategy.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RenderingStrategy;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class DefaultRenderingStrategy extends GeneratorAwareRenderingStrategy
+{
+    private $kernel;
+
+    public function __construct(HttpKernelInterface $kernel)
+    {
+        $this->kernel = $kernel;
+    }
+
+    public function render($uri, Request $request = null, array $options = array())
+    {
+        if ($uri instanceof ControllerReference) {
+            $uri = $this->generateProxyUri($uri, $request);
+        }
+
+        $subRequest = $this->createSubRequest($uri, $request);
+
+        $level = ob_get_level();
+        try {
+            return $this->handle($subRequest);
+        } catch (\Exception $e) {
+            // let's clean up the output buffers that were created by the sub-request
+            while (ob_get_level() > $level) {
+                ob_get_clean();
+            }
+
+            if (isset($options['alt'])) {
+                $alt = $options['alt'];
+                unset($options['alt']);
+
+                return $this->render($alt, $request, $options);
+            }
+
+            if (!isset($options['ignore_errors']) || !$options['ignore_errors']) {
+                throw $e;
+            }
+        }
+    }
+
+    protected function handle(Request $request)
+    {
+        $response = $this->kernel->handle($request, HttpKernelInterface::SUB_REQUEST, false);
+
+        if (!$response->isSuccessful()) {
+            throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $request->getUri(), $response->getStatusCode()));
+        }
+
+        if (!$response instanceof StreamedResponse) {
+            return $response->getContent();
+        }
+
+        $response->sendContent();
+    }
+
+    protected function createSubRequest($uri, Request $request = null)
+    {
+        if (null !== $request) {
+            $cookies = $request->cookies->all();
+            $server = $request->server->all();
+
+            // the sub-request is internal
+            $server['REMOTE_ADDR'] = '127.0.0.1';
+        } else {
+            $cookies = array();
+            $server = array();
+        }
+
+        $subRequest = Request::create($uri, 'get', array(), $cookies, array(), $server);
+        if (null !== $request && $session = $request->getSession()) {
+            $subRequest->setSession($session);
+        }
+
+        return $subRequest;
+    }
+
+    public function getName()
+    {
+        return 'default';
+    }
+}

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/DefaultRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/DefaultRenderingStrategy.php
@@ -36,6 +36,10 @@ class DefaultRenderingStrategy extends GeneratorAwareRenderingStrategy
 
     /**
      * {@inheritdoc}
+     *
+     * Additional available options:
+     *
+     *  * alt: an alternative URI to render in case of an error
      */
     public function render($uri, Request $request = null, array $options = array())
     {

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/DefaultRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/DefaultRenderingStrategy.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
+ * Implements the default rendering strategy where the Request is rendered by the current HTTP kernel.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -23,11 +24,19 @@ class DefaultRenderingStrategy extends GeneratorAwareRenderingStrategy
 {
     private $kernel;
 
+    /**
+     * Constructor.
+     *
+     * @param HttpKernelInterface $kernel A HttpKernelInterface instance
+     */
     public function __construct(HttpKernelInterface $kernel)
     {
         $this->kernel = $kernel;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function render($uri, Request $request = null, array $options = array())
     {
         if ($uri instanceof ControllerReference) {
@@ -94,6 +103,9 @@ class DefaultRenderingStrategy extends GeneratorAwareRenderingStrategy
         return $subRequest;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'default';

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 
 /**
+ * Implements the ESI rendering strategy.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -24,6 +25,16 @@ class EsiRenderingStrategy extends GeneratorAwareRenderingStrategy
     private $esi;
     private $defaultStrategy;
 
+    /**
+     * Constructor.
+     *
+     * The "fallback" strategy when ESI is not available should always be an
+     * instance of DefaultRenderingStrategy (or a class you are using for the
+     * default strategy).
+     *
+     * @param Esi                        $esi             An Esi instance
+     * @param RenderingStrategyInterface $defaultStrategy The default strategy to use when ESI is not supported
+     */
     public function __construct(Esi $esi, RenderingStrategyInterface $defaultStrategy)
     {
         $this->esi = $esi;
@@ -31,15 +42,17 @@ class EsiRenderingStrategy extends GeneratorAwareRenderingStrategy
     }
 
     /**
+     * {@inheritdoc}
      *
-     * Note that this method generates an esi:include tag only when both the standalone
-     * option is set to true and the request has ESI capability (@see Symfony\Component\HttpKernel\HttpCache\ESI).
+     * Note that if the current Request has no ESI capability, this method
+     * falls back to use the default rendering strategy.
      *
-     * Available options:
+     * Additional available options:
      *
-     *  * ignore_errors: true to return an empty string in case of an error
-     *  * alt: an alternative URI to execute in case of an error
+     *  * alt: an alternative URI to render in case of an error
      *  * comment: a comment to add when returning an esi:include tag
+     *
+     * @see Symfony\Component\HttpKernel\HttpCache\ESI
      */
     public function render($uri, Request $request = null, array $options = array())
     {
@@ -59,6 +72,9 @@ class EsiRenderingStrategy extends GeneratorAwareRenderingStrategy
         return $this->esi->renderIncludeTag($uri, $alt, $options['ignore_errors'], isset($options['comment']) ? $options['comment'] : '');
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'esi';

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
@@ -56,7 +56,7 @@ class EsiRenderingStrategy extends GeneratorAwareRenderingStrategy
      */
     public function render($uri, Request $request = null, array $options = array())
     {
-        if (!$this->esi->hasSurrogateEsiCapability($request)) {
+        if (null === $request || !$this->esi->hasSurrogateEsiCapability($request)) {
             return $this->defaultStrategy->render($uri, $request, $options);
         }
 
@@ -69,7 +69,7 @@ class EsiRenderingStrategy extends GeneratorAwareRenderingStrategy
             $alt = $this->generateProxyUri($alt, $request);
         }
 
-        return $this->esi->renderIncludeTag($uri, $alt, $options['ignore_errors'], isset($options['comment']) ? $options['comment'] : '');
+        return $this->esi->renderIncludeTag($uri, $alt, isset($options['ignore_errors']) ? $options['ignore_errors'] : false, isset($options['comment']) ? $options['comment'] : '');
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RenderingStrategy;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\HttpCache\Esi;
+
+/**
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class EsiRenderingStrategy extends GeneratorAwareRenderingStrategy
+{
+    private $esi;
+    private $defaultStrategy;
+
+    public function __construct(Esi $esi, RenderingStrategyInterface $defaultStrategy)
+    {
+        $this->esi = $esi;
+        $this->defaultStrategy = $defaultStrategy;
+    }
+
+    /**
+     *
+     * Note that this method generates an esi:include tag only when both the standalone
+     * option is set to true and the request has ESI capability (@see Symfony\Component\HttpKernel\HttpCache\ESI).
+     *
+     * Available options:
+     *
+     *  * ignore_errors: true to return an empty string in case of an error
+     *  * alt: an alternative URI to execute in case of an error
+     *  * comment: a comment to add when returning an esi:include tag
+     */
+    public function render($uri, Request $request = null, array $options = array())
+    {
+        if (!$this->esi->hasSurrogateEsiCapability($request)) {
+            return $this->defaultStrategy->render($uri, $request, $options);
+        }
+
+        if ($uri instanceof ControllerReference) {
+            $uri = $this->generateProxyUri($uri, $request);
+        }
+
+        $alt = isset($options['alt']) ? $options['alt'] : null;
+        if ($alt instanceof ControllerReference) {
+            $alt = $this->generateProxyUri($alt, $request);
+        }
+
+        return $this->esi->renderIncludeTag($uri, $alt, $options['ignore_errors'], isset($options['comment']) ? $options['comment'] : '');
+    }
+
+    public function getName()
+    {
+        return 'esi';
+    }
+}

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/GeneratorAwareRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/GeneratorAwareRenderingStrategy.php
@@ -46,6 +46,9 @@ abstract class GeneratorAwareRenderingStrategy implements RenderingStrategyInter
      * @param Request              $request    A Request instance
      *
      * @return string A proxy URI
+     *
+     * @throws \LogicException when the _proxy route is not available
+     * @throws \LogicException when there is no registered route generator
      */
     protected function generateProxyUri(ControllerReference $reference, Request $request = null)
     {
@@ -63,7 +66,7 @@ abstract class GeneratorAwareRenderingStrategy implements RenderingStrategyInter
         }
 
         try {
-            $uri = $this->generator->generate('_proxy', array('_controller' => $reference->controller, '_format' => $format), true);
+            $uri = $this->generator->generate('_proxy', array('_controller' => $reference->controller, '_format' => $format), UrlGeneratorInterface::ABSOLUTE_URL);
         } catch (RouteNotFoundException $e) {
             throw new \LogicException('Unable to generate a proxy URL as the "_proxy" route is not registered.', 0, $e);
         }

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/GeneratorAwareRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/GeneratorAwareRenderingStrategy.php
@@ -17,6 +17,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
 /**
+ * Adds the possibility to generate a proxy URI for a given Controller.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -24,6 +25,11 @@ abstract class GeneratorAwareRenderingStrategy implements RenderingStrategyInter
 {
     protected $generator;
 
+    /**
+     * Sets a URL generator to use for proxy URIs generation.
+     *
+     * @param UrlGeneratorInterface $generator An UrlGeneratorInterface instance
+     */
     public function setUrlGenerator(UrlGeneratorInterface $generator)
     {
         $this->generator = $generator;

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/GeneratorAwareRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/GeneratorAwareRenderingStrategy.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RenderingStrategy;
+
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+/**
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+abstract class GeneratorAwareRenderingStrategy implements RenderingStrategyInterface
+{
+    protected $generator;
+
+    public function setUrlGenerator(UrlGeneratorInterface $generator)
+    {
+        $this->generator = $generator;
+    }
+
+    /**
+     * Generates a proxy URI for a given controller.
+     *
+     * This method only works when using the Symfony Routing component and
+     * if a "_proxy" route is defined with a {_controller} and {_format}
+     * placeholders.
+     *
+     * @param ControllerReference  $reference A ControllerReference instance
+     * @param Request              $request    A Request instance
+     *
+     * @return string A proxy URI
+     */
+    protected function generateProxyUri(ControllerReference $reference, Request $request = null)
+    {
+        if (null === $this->generator) {
+            throw new \LogicException('Unable to generate a proxy URL as there is no registered route generator.');
+        }
+
+        if (isset($reference->attributes['_format'])) {
+            $format = $reference->attributes['_format'];
+            unset($reference->attributes['_format']);
+        } elseif (null !== $request) {
+            $format = $request->getRequestFormat();
+        } else {
+            $format = 'html';
+        }
+
+        try {
+            $uri = $this->generator->generate('_proxy', array('_controller' => $reference->controller, '_format' => $format), true);
+        } catch (RouteNotFoundException $e) {
+            throw new \LogicException('Unable to generate a proxy URL as the "_proxy" route is not registered.', 0, $e);
+        }
+
+        if ($path = http_build_query($reference->attributes, '', '&')) {
+            $reference->query['path'] = $path;
+        }
+
+        if ($qs = http_build_query($reference->query, '', '&')) {
+            $uri .= '?'.$qs;
+        }
+
+        return $uri;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
@@ -34,9 +34,9 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
      * @param UriSigner                         $signer                A UriSigner instance
      * @param string                            $globalDefaultTemplate The global default content (it can be a template name or the content)
      */
-    public function __construct($templating, UriSigner $signer = null, $globalDefaultTemplate = null)
+    public function __construct($templating = null, UriSigner $signer = null, $globalDefaultTemplate = null)
     {
-        if (!$templating instanceof EngineInterface && !$templating instanceof \Twig_Environment) {
+        if (null !== $templating && !$templating instanceof EngineInterface && !$templating instanceof \Twig_Environment) {
             throw new \InvalidArgumentException('The hinclude rendering strategy needs an instance of \Twig_Environment or Symfony\Component\Templating\EngineInterface');
         }
 
@@ -63,7 +63,7 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
         }
 
         $template = isset($options['default']) ? $options['default'] : $this->globalDefaultTemplate;
-        if ($this->templateExists($template)) {
+        if (null !== $this->templating && $this->templateExists($template)) {
             $content = $this->templating->render($template);
         } else {
             $content = $template;

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RenderingStrategy;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Templating\EngineInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class HIncludeRenderingStrategy implements RenderingStrategyInterface
+{
+    private $templating;
+    private $globalDefaultTemplate;
+
+    public function __construct($templating, $globalDefaultTemplate = null)
+    {
+        if (!$templating instanceof EngineInterface && !$templating instanceof \Twig_Environment) {
+            throw new \InvalidArgumentException('The hinclude rendering strategy needs an instance of \Twig_Environment or Symfony\Component\Templating\EngineInterface');
+        }
+
+        $this->templating = $templating;
+        $this->globalDefaultTemplate = $globalDefaultTemplate;
+    }
+
+    public function render($uri, Request $request = null, array $options = array())
+    {
+        if ($uri instanceof ControllerReference) {
+            // FIXME: can we sign the proxy URL instead?
+            throw new \LogicException('You must use a proper URI when using the Hinclude rendering strategy.');
+        }
+
+        $defaultTemplate = $options['default'] ?: null;
+        $defaultContent = null;
+
+        if (null !== $defaultTemplate) {
+            if ($this->templateExists($defaultTemplate)) {
+                $defaultContent = $this->templating->render($defaultContent);
+            } else {
+                $defaultContent = $defaultTemplate;
+            }
+        } elseif ($this->globalDefaultTemplate) {
+            $defaultContent = $this->templating->render($this->globalDefaultTemplate);
+        }
+
+        return $this->renderHIncludeTag($uri, $defaultContent);
+    }
+
+    /**
+     * Renders an HInclude tag.
+     *
+     * @param string $uri            A URI
+     * @param string $defaultContent Default content
+     */
+    protected function renderHIncludeTag($uri, $defaultContent = null)
+    {
+        return sprintf('<hx:include src="%s">%s</hx:include>', $uri, $defaultContent);
+    }
+
+    private function templateExists($template)
+    {
+        if ($this->templating instanceof EngineInterface) {
+            return $this->templating->exists($template);
+        }
+
+        $loader = $this->templating->getLoader();
+        if ($loader instanceof \Twig_ExistsLoaderInterface) {
+            return $loader->exists($template);
+        }
+
+        try {
+            $loader->getSource($template);
+
+            return true;
+        } catch (\Twig_Error_Loader $e) {
+        }
+
+        return false;
+    }
+
+    public function getName()
+    {
+        return 'hinclude';
+    }
+}

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
@@ -32,7 +32,7 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
      *
      * @param EngineInterface|\Twig_Environment $templating            An EngineInterface or a \Twig_Environment instance
      * @param UriSigner                         $signer                A UriSigner instance
-     * @param string                            $globalDefaultTemplate The content of the global default template
+     * @param string                            $globalDefaultTemplate The global default content (it can be a template name or the content)
      */
     public function __construct($templating, UriSigner $signer = null, $globalDefaultTemplate = null)
     {
@@ -47,6 +47,10 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
 
     /**
      * {@inheritdoc}
+     *
+     * Additional available options:
+     *
+     *  * default: The default content (it can be a template name or the content)
      */
     public function render($uri, Request $request = null, array $options = array())
     {
@@ -58,31 +62,14 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
             $uri = $this->signer->sign($this->generateProxyUri($uri, $request));
         }
 
-        $defaultTemplate = isset($options['default']) ? $options['default'] : null;
-        $defaultContent = null;
-
-        if (null !== $defaultTemplate) {
-            if ($this->templateExists($defaultTemplate)) {
-                $defaultContent = $this->templating->render($defaultContent);
-            } else {
-                $defaultContent = $defaultTemplate;
-            }
-        } elseif ($this->globalDefaultTemplate) {
-            $defaultContent = $this->templating->render($this->globalDefaultTemplate);
+        $template = isset($options['default']) ? $options['default'] : $this->globalDefaultTemplate;
+        if ($this->templateExists($template)) {
+            $content = $this->templating->render($template);
+        } else {
+            $content = $template;
         }
 
-        return $this->renderHIncludeTag($uri, $defaultContent);
-    }
-
-    /**
-     * Renders an HInclude tag.
-     *
-     * @param string $uri            A URI
-     * @param string $defaultContent Default content
-     */
-    protected function renderHIncludeTag($uri, $defaultContent = null)
-    {
-        return sprintf('<hx:include src="%s">%s</hx:include>', $uri, $defaultContent);
+        return sprintf('<hx:include src="%s">%s</hx:include>', $uri, $content);
     }
 
     private function templateExists($template)

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\UriSigner;
 
 /**
+ * Implements the Hinclude rendering strategy.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
@@ -26,6 +27,13 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
     private $globalDefaultTemplate;
     private $signer;
 
+    /**
+     * Constructor.
+     *
+     * @param EngineInterface|\Twig_Environment $templating            An EngineInterface or a \Twig_Environment instance
+     * @param UriSigner                         $signer                A UriSigner instance
+     * @param string                            $globalDefaultTemplate The content of the global default template
+     */
     public function __construct($templating, UriSigner $signer = null, $globalDefaultTemplate = null)
     {
         if (!$templating instanceof EngineInterface && !$templating instanceof \Twig_Environment) {
@@ -37,6 +45,9 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
         $this->signer = $signer;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function render($uri, Request $request = null, array $options = array())
     {
         if ($uri instanceof ControllerReference) {
@@ -95,6 +106,9 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
         return false;
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'hinclude';

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/RenderingStrategyInterface.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/RenderingStrategyInterface.php
@@ -15,17 +15,25 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
 /**
+ * Interface implemented by all rendering strategies.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @see Symfony\Component\HttpKernel\HttpContentRenderer
  */
 interface RenderingStrategyInterface
 {
     /**
      * Renders a URI and returns the Response content.
      *
+     * When the Response is a StreamedResponse, the content is streamed immediately
+     * instead of being returned.
+     *
      * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
      * @param Request                    $request A Request instance
      * @param array                      $options An array of options
+     *
+     * @return string|null The Response content or null when the Response is streamed
      */
     public function render($uri, Request $request = null, array $options = array());
 

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/RenderingStrategyInterface.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/RenderingStrategyInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RenderingStrategy;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface RenderingStrategyInterface
+{
+    /**
+     * Renders a URI and returns the Response content.
+     *
+     * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
+     * @param Request                    $request A Request instance
+     * @param array                      $options An array of options
+     */
+    public function render($uri, Request $request = null, array $options = array());
+
+    /**
+     * Gets the name of the strategy.
+     *
+     * @return string The strategy name
+     */
+    public function getName();
+}

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterProxyListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterProxyListenerTest.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\EventListener;
+
+use Symfony\Component\HttpKernel\EventListener\RouterProxyListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\UriSigner;
+
+class RouterProxyListenerTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
+            $this->markTestSkipped('The "EventDispatcher" component is not available');
+        }
+    }
+
+    public function testOnlyTrigerredOnProxyRoute()
+    {
+        $request = Request::create('http://example.com/foo?path=foo%3D=bar');
+
+        $listener = new RouterProxyListener(new UriSigner('foo'));
+        $event = $this->createGetResponseEvent($request, 'foobar');
+
+        $expected = $request->attributes->all();
+
+        $listener->onKernelRequest($event);
+
+        $this->assertEquals($expected, $request->attributes->all());
+        $this->assertTrue($request->query->has('path'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAccessDeniedWithNonSafeMethods()
+    {
+        $request = Request::create('http://example.com/foo', 'POST');
+
+        $listener = new RouterProxyListener(new UriSigner('foo'));
+        $event = $this->createGetResponseEvent($request);
+
+        $listener->onKernelRequest($event);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAccessDeniedWithNonLocalIps()
+    {
+        $request = Request::create('http://example.com/foo', 'GET', array(), array(), array(), array('REMOTE_ADDR' => '10.0.0.1'));
+
+        $listener = new RouterProxyListener(new UriSigner('foo'));
+        $event = $this->createGetResponseEvent($request);
+
+        $listener->onKernelRequest($event);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException
+     */
+    public function testAccessDeniedWithWrongSignature()
+    {
+        $request = Request::create('http://example.com/foo', 'GET', array(), array(), array(), array('REMOTE_ADDR' => '10.0.0.1'));
+
+        $listener = new RouterProxyListener(new UriSigner('foo'));
+        $event = $this->createGetResponseEvent($request);
+
+        $listener->onKernelRequest($event);
+    }
+
+    public function testWithSignatureAndNoPath()
+    {
+        $signer = new UriSigner('foo');
+        $request = Request::create($signer->sign('http://example.com/foo'), 'GET', array(), array(), array(), array('REMOTE_ADDR' => '10.0.0.1'));
+
+        $listener = new RouterProxyListener($signer);
+        $event = $this->createGetResponseEvent($request);
+
+        $listener->onKernelRequest($event);
+
+        $this->assertEquals(array('foo' => 'foo'), $request->attributes->get('_route_params'));
+        $this->assertFalse($request->query->has('path'));
+    }
+
+    public function testWithSignatureAndPath()
+    {
+        $signer = new UriSigner('foo');
+        $request = Request::create($signer->sign('http://example.com/foo?path=bar%3Dbar'), 'GET', array(), array(), array(), array('REMOTE_ADDR' => '10.0.0.1'));
+
+        $listener = new RouterProxyListener($signer);
+        $event = $this->createGetResponseEvent($request);
+
+        $listener->onKernelRequest($event);
+
+        $this->assertEquals(array('foo' => 'foo', 'bar' => 'bar'), $request->attributes->get('_route_params'));
+        $this->assertFalse($request->query->has('path'));
+    }
+
+    private function createGetResponseEvent(Request $request, $route = '_proxy')
+    {
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $request->attributes->set('_route', $route);
+        $request->attributes->set('_route_params', array('foo' => 'foo'));
+
+        return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/HttpContentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpContentRendererTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests;
+
+use Symfony\Component\HttpKernel\HttpContentRenderer;
+
+class HttpContentRendererTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
+            $this->markTestSkipped('The "EventDispatcher" component is not available');
+        }
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRenderWhenStrategyDoesNotExist()
+    {
+        $renderer = new HttpContentRenderer();
+        $renderer->render('/', 'foo');
+    }
+
+    public function testRender()
+    {
+        $strategy = $this->getMock('Symfony\Component\HttpKernel\RenderingStrategy\RenderingStrategyInterface');
+        $strategy
+            ->expects($this->any())
+            ->method('getName')
+            ->will($this->returnValue('foo'))
+        ;
+        $strategy
+            ->expects($this->any())
+            ->method('render')
+            ->with('/', null, array('foo' => 'foo', 'ignore_errors' => true))
+            ->will($this->returnValue('foo'))
+        ;
+
+        $renderer = new HttpContentRenderer();
+        $renderer->addStrategy($strategy);
+
+        $this->assertEquals('foo', $renderer->render('/', 'foo', array('foo' => 'foo')));
+    }
+
+    /**
+     * @dataProvider getFixOptionsData
+     */
+    public function testFixOptions($expected, $options)
+    {
+        $renderer = new HttpContentRenderer();
+
+        set_error_handler(function ($errorNumber, $message, $file, $line, $context) { return $errorNumber & E_USER_DEPRECATED; });
+        $this->assertEquals($expected, $renderer->fixOptions($options));
+        restore_error_handler();
+    }
+
+    public function getFixOptionsData()
+    {
+        return array(
+            array(array('strategy' => 'esi'), array('standalone' => true)),
+            array(array('strategy' => 'esi'), array('standalone' => 'esi')),
+            array(array('strategy' => 'hinclude'), array('standalone' => 'js')),
+        );
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/AbstractRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/AbstractRenderingStrategyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\RenderingStrategy;
+
+abstract class AbstractRenderingStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getUrlGenerator()
+    {
+        $generator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $generator
+            ->expects($this->any())
+            ->method('generate')
+            ->will($this->returnCallback(function ($name, $parameters, $referenceType) {
+                return '/'.$parameters['_controller'].'.'.$parameters['_format'];
+            }))
+        ;
+
+        return $generator;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/DefaultRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/DefaultRenderingStrategyTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+ namespace Symfony\Component\HttpKernel\Tests\RenderingStrategy;
+
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\RenderingStrategy\DefaultRenderingStrategy;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class DefaultRenderingStrategyTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
+            $this->markTestSkipped('The "EventDispatcher" component is not available');
+        }
+
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('The "HttpFoundation" component is not available');
+        }
+    }
+
+    public function testExceptionInSubRequestsDoesNotMangleOutputBuffers()
+    {
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
+        $resolver
+            ->expects($this->once())
+            ->method('getController')
+            ->will($this->returnValue(function () {
+                ob_start();
+                echo 'bar';
+                throw new \RuntimeException();
+            }))
+        ;
+        $resolver
+            ->expects($this->once())
+            ->method('getArguments')
+            ->will($this->returnValue(array()))
+        ;
+
+        $kernel = new HttpKernel(new EventDispatcher(), $resolver);
+        $renderer = new DefaultRenderingStrategy($kernel);
+
+        // simulate a main request with output buffering
+        ob_start();
+        echo 'Foo';
+
+        // simulate a sub-request with output buffering and an exception
+        $renderer->render('/', Request::create('/'), array('ignore_errors' => true));
+
+        $this->assertEquals('Foo', ob_get_clean());
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/EsiRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/EsiRenderingStrategyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\RenderingStrategy;
+
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\RenderingStrategy\EsiRenderingStrategy;
+use Symfony\Component\HttpKernel\HttpCache\Esi;
+use Symfony\Component\HttpFoundation\Request;
+
+class EsiRenderingStrategyTest extends AbstractRenderingStrategyTest
+{
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('The "HttpFoundation" component is not available');
+        }
+
+        if (!interface_exists('Symfony\Component\Routing\Generator\UrlGeneratorInterface')) {
+            $this->markTestSkipped('The "Routing" component is not available');
+        }
+    }
+
+    public function testRenderFallbackToDefaultStrategyIfNoRequest()
+    {
+        $strategy = new EsiRenderingStrategy(new Esi(), $this->getDefaultStrategy(true));
+        $strategy->render('/');
+    }
+
+    public function testRenderFallbackToDefaultStrategyIfEsiNotSupported()
+    {
+        $strategy = new EsiRenderingStrategy(new Esi(), $this->getDefaultStrategy(true));
+        $strategy->render('/', Request::create('/'));
+    }
+
+    public function testRender()
+    {
+        $strategy = new EsiRenderingStrategy(new Esi(), $this->getDefaultStrategy());
+        $strategy->setUrlGenerator($this->getUrlGenerator());
+
+        $request = Request::create('/');
+        $request->headers->set('Surrogate-Capability', 'ESI/1.0');
+
+        $this->assertEquals('<esi:include src="/" />', $strategy->render('/', $request));
+        $this->assertEquals("<esi:comment text=\"This is a comment\" />\n<esi:include src=\"/\" />", $strategy->render('/', $request, array('comment' => 'This is a comment')));
+        $this->assertEquals('<esi:include src="/" alt="foo" />', $strategy->render('/', $request, array('alt' => 'foo')));
+        $this->assertEquals('<esi:include src="/main_controller.html" alt="/alt_controller.html" />', $strategy->render(new ControllerReference('main_controller', array(), array()), $request, array('alt' => new ControllerReference('alt_controller', array(), array()))));
+    }
+
+    private function getDefaultStrategy($called = false)
+    {
+        $default = $this->getMockBuilder('Symfony\Component\HttpKernel\RenderingStrategy\DefaultRenderingStrategy')->disableOriginalConstructor()->getMock();
+
+        if ($called) {
+            $default->expects($this->once())->method('render');
+        }
+
+        return $default;
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/GeneratorAwareRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/GeneratorAwareRenderingStrategyTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\RenderingStrategy;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\RenderingStrategy\GeneratorAwareRenderingStrategy;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
+class GeneratorAwareRenderingStrategyTest extends AbstractRenderingStrategyTest
+{
+    protected function setUp()
+    {
+        if (!interface_exists('Symfony\Component\Routing\Generator\UrlGeneratorInterface')) {
+            $this->markTestSkipped('The "Routing" component is not available');
+        }
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testGenerateProxyUriWithNoGenerator()
+    {
+        $strategy = new Strategy();
+        $strategy->doGenerateProxyUri(new ControllerReference('controller', array(), array()));
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testGenerateProxyUriWhenRouteNotFound()
+    {
+        $generator = $this->getMock('Symfony\Component\Routing\Generator\UrlGeneratorInterface');
+        $generator
+            ->expects($this->once())
+            ->method('generate')
+            ->will($this->throwException(new RouteNotFoundException()))
+        ;
+
+        $strategy = new Strategy();
+        $strategy->setUrlGenerator($generator);
+        $strategy->doGenerateProxyUri(new ControllerReference('controller', array(), array()));
+    }
+
+    /**
+     * @dataProvider getGeneratorProxyUriData
+     */
+    public function testGenerateProxyUri($uri, $controller)
+    {
+        $this->assertEquals($uri, $this->getStrategy()->doGenerateProxyUri($controller));
+    }
+
+    public function getGeneratorProxyUriData()
+    {
+        return array(
+            array('/controller.html', new ControllerReference('controller', array(), array())),
+            array('/controller.xml', new ControllerReference('controller', array('_format' => 'xml'), array())),
+            array('/controller.json?path=foo%3Dfoo', new ControllerReference('controller', array('foo' => 'foo', '_format' => 'json'), array())),
+            array('/controller.html?bar=bar&path=foo%3Dfoo', new ControllerReference('controller', array('foo' => 'foo'), array('bar' => 'bar'))),
+            array('/controller.html?foo=foo', new ControllerReference('controller', array(), array('foo' => 'foo'))),
+        );
+    }
+
+    public function testGenerateProxyUriWithARequest()
+    {
+        $request = Request::create('/');
+        $request->attributes->set('_format', 'json');
+        $controller = new ControllerReference('controller', array(), array());
+
+        $this->assertEquals('/controller.json', $this->getStrategy()->doGenerateProxyUri($controller, $request));
+    }
+
+    private function getStrategy()
+    {
+        $strategy = new Strategy();
+        $strategy->setUrlGenerator($this->getUrlGenerator());
+
+        return $strategy;
+    }
+}
+
+class Strategy extends GeneratorAwareRenderingStrategy
+{
+    public function render($uri, Request $request = null, array $options = array()) {}
+    public function getName() {}
+
+    public function doGenerateProxyUri(ControllerReference $reference, Request $request = null)
+    {
+        return parent::generateProxyUri($reference, $request);
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/HIncludeRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/HIncludeRenderingStrategyTest.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\RenderingStrategy;
+
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\RenderingStrategy\HIncludeRenderingStrategy;
+use Symfony\Component\HttpKernel\UriSigner;
+use Symfony\Component\HttpFoundation\Request;
+
+class HIncludeRenderingStrategyTest extends AbstractRenderingStrategyTest
+{
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('The "HttpFoundation" component is not available');
+        }
+
+        if (!interface_exists('Symfony\Component\Routing\Generator\UrlGeneratorInterface')) {
+            $this->markTestSkipped('The "Routing" component is not available');
+        }
+    }
+
+    /**
+     * @expectedException \LogicException
+     */
+    public function testRenderExceptionWhenControllerAndNoSigner()
+    {
+        $strategy = new HIncludeRenderingStrategy();
+        $strategy->render(new ControllerReference('main_controller', array(), array()));
+    }
+
+    public function testRenderWithControllerAndSigner()
+    {
+        $strategy = new HIncludeRenderingStrategy(null, new UriSigner('foo'));
+        $strategy->setUrlGenerator($this->getUrlGenerator());
+        $this->assertEquals('<hx:include src="/main_controller.html?_hash=6MuxpWUHcqIddMMmoN36uPsEjws%3D"></hx:include>', $strategy->render(new ControllerReference('main_controller', array(), array())));
+    }
+
+    public function testRenderWithUri()
+    {
+        $strategy = new HIncludeRenderingStrategy();
+        $this->assertEquals('<hx:include src="/foo"></hx:include>', $strategy->render('/foo'));
+
+        $strategy = new HIncludeRenderingStrategy(null, new UriSigner('foo'));
+        $this->assertEquals('<hx:include src="/foo"></hx:include>', $strategy->render('/foo'));
+    }
+
+    public function testRenderWhithDefault()
+    {
+        // only default
+        $strategy = new HIncludeRenderingStrategy();
+        $this->assertEquals('<hx:include src="/foo">default</hx:include>', $strategy->render('/foo', null, array('default' => 'default')));
+
+        // only global default
+        $strategy = new HIncludeRenderingStrategy(null, null, 'global_default');
+        $this->assertEquals('<hx:include src="/foo">global_default</hx:include>', $strategy->render('/foo', null, array()));
+
+        // global default and default
+        $strategy = new HIncludeRenderingStrategy(null, null, 'global_default');
+        $this->assertEquals('<hx:include src="/foo">default</hx:include>', $strategy->render('/foo', null, array('default' => 'default')));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/UriSignerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests;
+
+use Symfony\Component\HttpKernel\UriSigner;
+
+class UriSignerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testSign()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertContains('?_hash=', $signer->sign('http://example.com/foo'));
+        $this->assertContains('&_hash=', $signer->sign('http://example.com/foo?foo=bar'));
+    }
+
+    public function testCheck()
+    {
+        $signer = new UriSigner('foobar');
+
+        $this->assertFalse($signer->check('http://example.com/foo?_hash=foo'));
+        $this->assertFalse($signer->check('http://example.com/foo?foo=bar&_hash=foo'));
+        $this->assertFalse($signer->check('http://example.com/foo?foo=bar&_hash=foo&bar=foo'));
+
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo')));
+        $this->assertTrue($signer->check($signer->sign('http://example.com/foo?foo=bar')));
+    }
+}

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\HttpKernel;
 
 /**
- * UriSigner.
+ * Signs URIs.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -48,19 +48,22 @@ class UriSigner
     /**
      * Checks that a URI contains the correct hash.
      *
+     * The _hash query string parameter must be the last one
+     * (as it is generated that way by the sign() method, it should
+     * never be a problem).
+     *
      * @param string $uri A signed URI
      *
      * @return Boolean True if the URI is signed correctly, false otherwise
      */
     public function check($uri)
     {
-        if (!preg_match('/(\?|&)_hash=(.+?)(&|$)/', $uri, $matches, PREG_OFFSET_CAPTURE)) {
+        if (!preg_match('/(\?|&)_hash=(.+?)$/', $uri, $matches, PREG_OFFSET_CAPTURE)) {
             return false;
         }
 
         // the naked URI is the URI without the _hash parameter (we need to keep the ? if there is some other parameters after)
-        $offset = ('?' == $matches[1][0] && '&' != $matches[3][0]) ? 0 : 1;
-        $nakedUri = substr($uri, 0, $matches[0][1] + $offset).substr($uri, $matches[0][1] + strlen($matches[0][0]));
+        $nakedUri = substr($uri, 0, $matches[0][1]).substr($uri, $matches[0][1] + strlen($matches[0][0]));
 
         return $this->computeHash($nakedUri) === $matches[2][0];
     }

--- a/src/Symfony/Component/HttpKernel/UriSigner.php
+++ b/src/Symfony/Component/HttpKernel/UriSigner.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel;
+
+/**
+ * UriSigner.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class UriSigner
+{
+    private $secret;
+
+    /**
+     * Constructor.
+     *
+     * @param string $secret A secret
+     */
+    public function __construct($secret)
+    {
+        $this->secret = $secret;
+    }
+
+    /**
+     * Signs a URI.
+     *
+     * The given URI is signed by adding a _hash query string parameter
+     * which value depends on the URI and the secret.
+     *
+     * @param string $uri A URI to sign
+     *
+     * @return string The signed URI
+     */
+    public function sign($uri)
+    {
+        return $uri.(false === (strpos($uri, '?')) ? '?' : '&').'_hash='.$this->computeHash($uri);
+    }
+
+    /**
+     * Checks that a URI contains the correct hash.
+     *
+     * @param string $uri A signed URI
+     *
+     * @return Boolean True if the URI is signed correctly, false otherwise
+     */
+    public function check($uri)
+    {
+        if (!preg_match('/(\?|&)_hash=(.+?)(&|$)/', $uri, $matches, PREG_OFFSET_CAPTURE)) {
+            return false;
+        }
+
+        // the naked URI is the URI without the _hash parameter (we need to keep the ? if there is some other parameters after)
+        $offset = ('?' == $matches[1][0] && '&' != $matches[3][0]) ? 0 : 1;
+        $nakedUri = substr($uri, 0, $matches[0][1] + $offset).substr($uri, $matches[0][1] + strlen($matches[0][0]));
+
+        return $this->computeHash($nakedUri) === $matches[2][0];
+    }
+
+    private function computeHash($uri)
+    {
+        return urlencode(base64_encode(hash_hmac('sha1', $uri, $this->secret, true)));
+    }
+}


### PR DESCRIPTION
Currently, the handling of sub-requests (including ESI and hinclude) is mostly done in FrameworkBundle. It makes these important features harder to implement for people using only HttpKernel (like Drupal and Silex for instance).

This PR moves the code to HttpKernel instead. The code has also been refactored to allow easier integration of other rendering strategies (refs #6108).

The internal route has been re-introduced but it can only be used for trusted IPs (so for the internal rendering which is managed by Symfony itself, or by a trusted reverse proxy like Varnish for ESI handling). For the hinclude strategy, when using a controller, the URL is automatically signed (see #6463).

The usage of a listener instead of a controller to handle internal sub-requests speeds up things quite a lot as it saves one sub-request handling. In Symfony 2.0 and 2.1, the handling of a sub-request actually creates two sub-requests.

Rendering a sub-request from a controller can be done with the following code:

``` jinja
{# default strategy #}
{{ render(path("partial")) }}
{{ render(controller("SomeBundle:Controller:partial")) }}

{# ESI strategy #}
{{ render(path("partial"), { strategy: 'esi' }) }}
{{ render(controller("SomeBundle:Controller:partial"), { strategy: 'esi' }) }}

{# hinclude strategy #}
{{ render(path("default1"), { strategy: 'hinclude' }) }}
```

The second commit allows to simplify the calls a little bit thanks to some nice syntactic sugar:

``` jinja
{# default strategy #}
{{ render(path("partial")) }}
{{ render(controller("SomeBundle:Controller:partial")) }}

{# ESI strategy #}
{{ render_esi(path("partial")) }}
{{ render_esi(controller("SomeBundle:Controller:partial")) }}

{# hinclude strategy #}
{{ render_hinclude(path("default1")) }}
```
