### PR TITLE
[Form] Renamed the option "empty_value" to "placeholder"

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -304,8 +304,8 @@
 
 {% block widget_attributes %}
 {% spaceless %}
-    id="{{ id }}" name="{{ full_name }}"{% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
-    {% for attrname, attrvalue in attr %}{% if attrname in ['placeholder', 'title'] %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}
+    id="{{ id }}" name="{{ full_name }}"{% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}{% if placeholder is defined %} placeholder="{{ placeholder|trans({}, translation_domain) }}"{% endif %}
+    {% for attrname, attrvalue in attr %}{% if attrname in ['title'] %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}
 {% endspaceless %}
 {% endblock widget_attributes %}
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/widget_attributes.html.php
@@ -5,6 +5,7 @@ name="<?php echo $view->escape($full_name) ?>"
 <?php if ($required): ?>required="required" <?php endif ?>
 <?php if ($max_length): ?>maxlength="<?php echo $view->escape($max_length) ?>" <?php endif ?>
 <?php if ($pattern): ?>pattern="<?php echo $view->escape($pattern) ?>" <?php endif ?>
+<?php if ($placeholder): ?>placeholder="<?php echo $view->escape($view['translator']->trans($placeholder, array(), $translation_domain)) ?>" <?php endif ?>
 <?php foreach ($attr as $k => $v): ?>
-    <?php printf('%s="%s" ', $view->escape($k), $view->escape(in_array($v, array('placeholder', 'title')) ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
+    <?php printf('%s="%s" ', $view->escape($k), $view->escape(in_array($v, array('title')) ? $view['translator']->trans($v, array(), $translation_domain) : $v)) ?>
 <?php endforeach; ?>

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -166,15 +166,13 @@ class ChoiceType extends AbstractType
         };
 
         $placeholderValue = function (Options $options) {
-            return $options['required'] ? null : '';
+            // BC until Symfony 2.3
+            return null !== $options['empty_value']
+                ? $options['empty_value']
+                : ($options['required'] ? null : '');
         };
 
         $placeholderValueNormalizer = function (Options $options, $placeholderValue) {
-            // BC until Symfony 2.3
-            if ($options['empty_value'] && !$placeholderValue) {
-                $placeholderValue = $options['empty_value'];
-            }
-
             if ($options['multiple'] || $options['expanded']) {
                 // never use an empty value for these cases
                 return null;

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -105,7 +105,7 @@ class ChoiceType extends AbstractType
         // Check if the choices already contain the empty value
         // Only add the empty value option if this is not the case
         if (0 === count($options['choice_list']->getIndicesForValues(array('')))) {
-            $view->vars['empty_value'] = $options['empty_value'];
+            $view->vars['empty_value'] = $options['placeholder'];
         }
 
         if ($options['multiple'] && !$options['expanded']) {
@@ -165,21 +165,26 @@ class ChoiceType extends AbstractType
             return '';
         };
 
-        $emptyValue = function (Options $options) {
+        $placeholderValue = function (Options $options) {
             return $options['required'] ? null : '';
         };
 
-        $emptyValueNormalizer = function (Options $options, $emptyValue) {
+        $placeholderValueNormalizer = function (Options $options, $placeholderValue) {
+            // BC until Symfony 2.3
+            if ($options['empty_value'] && !$placeholderValue) {
+                $placeholderValue = $options['empty_value'];
+            }
+
             if ($options['multiple'] || $options['expanded']) {
                 // never use an empty value for these cases
                 return null;
-            } elseif (false === $emptyValue) {
+            } elseif (false === $placeholderValue) {
                 // an empty value should be added but the user decided otherwise
                 return null;
             }
 
             // empty value has been set explicitly
-            return $emptyValue;
+            return $placeholderValue;
         };
 
         $compound = function (Options $options) {
@@ -193,7 +198,9 @@ class ChoiceType extends AbstractType
             'choices'           => array(),
             'preferred_choices' => array(),
             'empty_data'        => $emptyData,
-            'empty_value'       => $emptyValue,
+            'placeholder'       => $placeholderValue,
+            // Deprecated empty_value option
+            'empty_value'       => null,
             'error_bubbling'    => false,
             'compound'          => $compound,
             // The view data is always a string, even if the "data" option
@@ -203,7 +210,7 @@ class ChoiceType extends AbstractType
         ));
 
         $resolver->setNormalizers(array(
-            'empty_value' => $emptyValueNormalizer,
+            'placeholder' => $placeholderValueNormalizer,
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -219,7 +219,15 @@ class DateTimeType extends AbstractType
             return $options['user_timezone'];
         };
 
+        $placeholderValue = function (Options $options) {
+            // BC until Symfony 2.3
+            return isset($options['empty_value'])
+                ? $options['empty_value']
+                : ($options['required'] ? null : '');
+        };
+
         $resolver->setDefaults(array(
+            'placeholder'    => $placeholderValue,
             'input'          => 'datetime',
             'model_timezone' => $modelTimezone,
             'view_timezone'  => $viewTimezone,
@@ -248,7 +256,7 @@ class DateTimeType extends AbstractType
         // Don't add some defaults in order to preserve the defaults
         // set in DateType and TimeType
         $resolver->setOptional(array(
-            'placeholder',
+            // Deprecated empty_value option
             'empty_value',
             'years',
             'months',

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -114,6 +114,7 @@ class DateTimeType extends AbstractType
                 'years',
                 'months',
                 'days',
+                'placeholder',
                 'empty_value',
                 'required',
                 'translation_domain',
@@ -125,6 +126,7 @@ class DateTimeType extends AbstractType
                 'seconds',
                 'with_minutes',
                 'with_seconds',
+                'placeholder',
                 'empty_value',
                 'required',
                 'translation_domain',
@@ -246,6 +248,7 @@ class DateTimeType extends AbstractType
         // Don't add some defaults in order to preserve the defaults
         // set in DateType and TimeType
         $resolver->setOptional(array(
+            'placeholder',
             'empty_value',
             'years',
             'months',

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -82,11 +82,11 @@ class DateType extends AbstractType
             if ('choice' === $options['widget']) {
                 // Only pass a subset of the options to children
                 $yearOptions['choices'] = $this->formatTimestamps($formatter, '/y+/', $this->listYears($options['years']));
-                $yearOptions['empty_value'] = $options['empty_value']['year'];
+                $yearOptions['placeholder'] = $options['placeholder']['year'];
                 $monthOptions['choices'] = $this->formatTimestamps($formatter, '/[M|L]+/', $this->listMonths($options['months']));
-                $monthOptions['empty_value'] = $options['empty_value']['month'];
+                $monthOptions['placeholder'] = $options['placeholder']['month'];
                 $dayOptions['choices'] = $this->formatTimestamps($formatter, '/d+/', $this->listDays($options['days']));
-                $dayOptions['empty_value'] = $options['empty_value']['day'];
+                $dayOptions['placeholder'] = $options['placeholder']['day'];
             }
 
             // Append generic carry-along options
@@ -164,24 +164,29 @@ class DateType extends AbstractType
             return $options['widget'] !== 'single_text';
         };
 
-        $emptyValue = $emptyValueDefault = function (Options $options) {
+        $placeholderValue = $placeholderValueDefault = function (Options $options) {
             return $options['required'] ? null : '';
         };
 
-        $emptyValueNormalizer = function (Options $options, $emptyValue) use ($emptyValueDefault) {
-            if (is_array($emptyValue)) {
-                $default = $emptyValueDefault($options);
+        $placeholderValueNormalizer = function (Options $options, $placeholderValue) use ($placeholderValueDefault) {
+            // BC until Symfony 2.3
+            if ($options['empty_value'] && !$placeholderValue) {
+                $placeholderValue  = $options['empty_value'];
+            }
+
+            if (is_array($placeholderValue)) {
+                $default = $placeholderValueDefault($options);
 
                 return array_merge(
                     array('year' => $default, 'month' => $default, 'day' => $default),
-                    $emptyValue
+                    $placeholderValue
                 );
             }
 
             return array(
-                'year' => $emptyValue,
-                'month' => $emptyValue,
-                'day' => $emptyValue
+                'year' => $placeholderValue,
+                'month' => $placeholderValue,
+                'day' => $placeholderValue
             );
         };
 
@@ -211,7 +216,9 @@ class DateType extends AbstractType
             // Deprecated timezone options
             'data_timezone'  => null,
             'user_timezone'  => null,
-            'empty_value'    => $emptyValue,
+            'placeholder'    => $placeholderValue,
+            // Deprecated empty_value option
+            'empty_value'    => null,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,
@@ -225,7 +232,7 @@ class DateType extends AbstractType
         ));
 
         $resolver->setNormalizers(array(
-            'empty_value' => $emptyValueNormalizer,
+            'placeholder' => $placeholderValueNormalizer,
         ));
 
         $resolver->setAllowedValues(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -164,16 +164,18 @@ class DateType extends AbstractType
             return $options['widget'] !== 'single_text';
         };
 
-        $placeholderValue = $placeholderValueDefault = function (Options $options) {
+        $placeholderValue = function (Options $options) {
+            // BC until Symfony 2.3
+            return $options['empty_value'] !== null
+                ? $options['empty_value']
+                : ($options['required'] ? null : '');
+        };
+
+        $placeholderValueDefault = function (Options $options) {
             return $options['required'] ? null : '';
         };
 
         $placeholderValueNormalizer = function (Options $options, $placeholderValue) use ($placeholderValueDefault) {
-            // BC until Symfony 2.3
-            if ($options['empty_value'] && !$placeholderValue) {
-                $placeholderValue  = $options['empty_value'];
-            }
-
             if (is_array($placeholderValue)) {
                 $default = $placeholderValueDefault($options);
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TextType.php
@@ -12,6 +12,9 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 class TextType extends AbstractType
@@ -19,10 +22,29 @@ class TextType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars = array_replace($view->vars, array(
+            'placeholder' => $options['placeholder']
+        ));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        $placeholder = function (Options $options) {
+            if (isset($options['attr']['placeholder'])) {
+                return $options['attr']['placeholder'];
+            }
+
+            return null;
+        };
+
         $resolver->setDefaults(array(
             'compound' => false,
+            'placeholder' => $placeholder
         ));
     }
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -152,16 +152,18 @@ class TimeType extends AbstractType
             return $options['widget'] !== 'single_text';
         };
 
-        $placeholderValue = $placeholderValueDefault = function (Options $options) {
+        $placeholderValue = function (Options $options) {
+            // BC until Symfony 2.3
+            return $options['empty_value'] !== null
+                ? $options['empty_value']
+                : ($options['required'] ? null : '');
+        };
+
+        $placeholderValueDefault = function (Options $options) {
             return $options['required'] ? null : '';
         };
 
         $placeholderValueNormalizer = function (Options $options, $placeholderValue) use ($placeholderValueDefault) {
-            // BC until Symfony 2.3
-            if ($options['empty_value'] && !$placeholderValue) {
-                $placeholderValue  = $options['empty_value'];
-            }
-
             if (is_array($placeholderValue)) {
                 $default = $placeholderValueDefault($options);
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -63,7 +63,7 @@ class TimeType extends AbstractType
 
                 // Only pass a subset of the options to children
                 $hourOptions['choices'] = $hours;
-                $hourOptions['empty_value'] = $options['empty_value']['hour'];
+                $hourOptions['placeholder'] = $options['placeholder']['hour'];
 
                 if ($options['with_minutes']) {
                     foreach ($options['minutes'] as $minute) {
@@ -71,7 +71,7 @@ class TimeType extends AbstractType
                     }
 
                     $minuteOptions['choices'] = $minutes;
-                    $minuteOptions['empty_value'] = $options['empty_value']['minute'];
+                    $minuteOptions['placeholder'] = $options['placeholder']['minute'];
                 }
 
                 if ($options['with_seconds']) {
@@ -82,7 +82,7 @@ class TimeType extends AbstractType
                     }
 
                     $secondOptions['choices'] = $seconds;
-                    $secondOptions['empty_value'] = $options['empty_value']['second'];
+                    $secondOptions['placeholder'] = $options['placeholder']['second'];
                 }
 
                 // Append generic carry-along options
@@ -152,24 +152,29 @@ class TimeType extends AbstractType
             return $options['widget'] !== 'single_text';
         };
 
-        $emptyValue = $emptyValueDefault = function (Options $options) {
+        $placeholderValue = $placeholderValueDefault = function (Options $options) {
             return $options['required'] ? null : '';
         };
 
-        $emptyValueNormalizer = function (Options $options, $emptyValue) use ($emptyValueDefault) {
-            if (is_array($emptyValue)) {
-                $default = $emptyValueDefault($options);
+        $placeholderValueNormalizer = function (Options $options, $placeholderValue) use ($placeholderValueDefault) {
+            // BC until Symfony 2.3
+            if ($options['empty_value'] && !$placeholderValue) {
+                $placeholderValue  = $options['empty_value'];
+            }
+
+            if (is_array($placeholderValue)) {
+                $default = $placeholderValueDefault($options);
 
                 return array_merge(
                     array('hour' => $default, 'minute' => $default, 'second' => $default),
-                    $emptyValue
+                    $placeholderValue
                 );
             }
 
             return array(
-                'hour' => $emptyValue,
-                'minute' => $emptyValue,
-                'second' => $emptyValue
+                'hour' => $placeholderValue,
+                'minute' => $placeholderValue,
+                'second' => $placeholderValue
             );
         };
 
@@ -196,7 +201,9 @@ class TimeType extends AbstractType
             // Deprecated timezone options
             'data_timezone'  => null,
             'user_timezone'  => null,
-            'empty_value'    => $emptyValue,
+            'placeholder'    => $placeholderValue,
+            // Deprecated empty_value option
+            'empty_value'    => null,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,
@@ -210,7 +217,7 @@ class TimeType extends AbstractType
         ));
 
         $resolver->setNormalizers(array(
-            'empty_value' => $emptyValueNormalizer,
+            'placeholder' => $placeholderValueNormalizer,
         ));
 
         $resolver->setAllowedValues(array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -616,6 +616,23 @@ class ChoiceTypeTest extends TypeTestCase
     /**
      * @dataProvider getOptionsWithEmptyValue
      */
+    public function testPassPlaceholderToView($multiple, $expanded, $required, $placeholderValue, $viewValue)
+    {
+        $form = $this->factory->create('choice', null, array(
+            'multiple' => $multiple,
+            'expanded' => $expanded,
+            'required' => $required,
+            'placeholder' => $placeholderValue,
+            'choices' => $this->choices,
+        ));
+        $view = $form->createView();
+
+        $this->assertEquals($viewValue, $view->vars['empty_value']);
+    }
+
+    /**
+     * @dataProvider getOptionsWithEmptyValue
+     */
     public function testDontPassEmptyValueIfContainedInChoices($multiple, $expanded, $required, $emptyValue, $viewValue)
     {
         $form = $this->factory->create('choice', null, array(
@@ -623,6 +640,23 @@ class ChoiceTypeTest extends TypeTestCase
             'expanded' => $expanded,
             'required' => $required,
             'empty_value' => $emptyValue,
+            'choices' => array('a' => 'A', '' => 'Empty'),
+        ));
+        $view = $form->createView();
+
+        $this->assertNull($view->vars['empty_value']);
+    }
+
+    /**
+     * @dataProvider getOptionsWithEmptyValue
+     */
+    public function testDontPassPlaceholderIfContainedInChoices($multiple, $expanded, $required, $placeholderValue, $viewValue)
+    {
+        $form = $this->factory->create('choice', null, array(
+            'multiple' => $multiple,
+            'expanded' => $expanded,
+            'required' => $required,
+            'placeholder' => $placeholderValue,
             'choices' => array('a' => 'A', '' => 'Empty'),
         ));
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -320,10 +320,49 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty', $view['time']['second']->vars['empty_value']);
     }
 
+    public function testPassPlaceholderAsString()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'placeholder' => 'Empty',
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty', $view['date']['year']->vars['empty_value']);
+        $this->assertSame('Empty', $view['date']['month']->vars['empty_value']);
+        $this->assertSame('Empty', $view['date']['day']->vars['empty_value']);
+        $this->assertSame('Empty', $view['time']['hour']->vars['empty_value']);
+        $this->assertSame('Empty', $view['time']['minute']->vars['empty_value']);
+        $this->assertSame('Empty', $view['time']['second']->vars['empty_value']);
+    }
+
     public function testPassEmptyValueAsArray()
     {
         $form = $this->factory->create('datetime', null, array(
             'empty_value' => array(
+                'year' => 'Empty year',
+                'month' => 'Empty month',
+                'day' => 'Empty day',
+                'hour' => 'Empty hour',
+                'minute' => 'Empty minute',
+                'second' => 'Empty second',
+            ),
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty year', $view['date']['year']->vars['empty_value']);
+        $this->assertSame('Empty month', $view['date']['month']->vars['empty_value']);
+        $this->assertSame('Empty day', $view['date']['day']->vars['empty_value']);
+        $this->assertSame('Empty hour', $view['time']['hour']->vars['empty_value']);
+        $this->assertSame('Empty minute', $view['time']['minute']->vars['empty_value']);
+        $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
+    }
+
+    public function testPassPlaceholderValueAsArray()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
                 'day' => 'Empty day',
@@ -365,11 +404,55 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
     }
 
+    public function testPassPlaceholderAsPartialArray_addEmptyIfNotRequired()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'required' => false,
+            'placeholder' => array(
+                'year' => 'Empty year',
+                'day' => 'Empty day',
+                'hour' => 'Empty hour',
+                'second' => 'Empty second',
+            ),
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty year', $view['date']['year']->vars['empty_value']);
+        $this->assertSame('', $view['date']['month']->vars['empty_value']);
+        $this->assertSame('Empty day', $view['date']['day']->vars['empty_value']);
+        $this->assertSame('Empty hour', $view['time']['hour']->vars['empty_value']);
+        $this->assertSame('', $view['time']['minute']->vars['empty_value']);
+        $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
+    }
+
     public function testPassEmptyValueAsPartialArray_addNullIfRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => true,
             'empty_value' => array(
+                'year' => 'Empty year',
+                'day' => 'Empty day',
+                'hour' => 'Empty hour',
+                'second' => 'Empty second',
+            ),
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty year', $view['date']['year']->vars['empty_value']);
+        $this->assertNull($view['date']['month']->vars['empty_value']);
+        $this->assertSame('Empty day', $view['date']['day']->vars['empty_value']);
+        $this->assertSame('Empty hour', $view['time']['hour']->vars['empty_value']);
+        $this->assertNull($view['time']['minute']->vars['empty_value']);
+        $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
+    }
+
+    public function testPassPlaceholderAsPartialArray_addNullIfRequired()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'required' => true,
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
                 'hour' => 'Empty hour',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -620,10 +620,38 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertSame('Empty', $view['day']->vars['empty_value']);
     }
 
+    public function testPassPlaceholderAsString()
+    {
+        $form = $this->factory->create('date', null, array(
+            'placeholder' => 'Empty',
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty', $view['year']->vars['empty_value']);
+        $this->assertSame('Empty', $view['month']->vars['empty_value']);
+        $this->assertSame('Empty', $view['day']->vars['empty_value']);
+    }
+
     public function testPassEmptyValueAsArray()
     {
         $form = $this->factory->create('date', null, array(
             'empty_value' => array(
+                'year' => 'Empty year',
+                'month' => 'Empty month',
+                'day' => 'Empty day',
+            ),
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty year', $view['year']->vars['empty_value']);
+        $this->assertSame('Empty month', $view['month']->vars['empty_value']);
+        $this->assertSame('Empty day', $view['day']->vars['empty_value']);
+    }
+
+    public function testPassPlaceholderAsArray()
+    {
+        $form = $this->factory->create('date', null, array(
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'month' => 'Empty month',
                 'day' => 'Empty day',
@@ -652,11 +680,43 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertSame('Empty day', $view['day']->vars['empty_value']);
     }
 
+    public function testPassPlaceholderAsPartialArray_addEmptyIfNotRequired()
+    {
+        $form = $this->factory->create('date', null, array(
+            'required' => false,
+            'placeholder' => array(
+                'year' => 'Empty year',
+                'day' => 'Empty day',
+            ),
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty year', $view['year']->vars['empty_value']);
+        $this->assertSame('', $view['month']->vars['empty_value']);
+        $this->assertSame('Empty day', $view['day']->vars['empty_value']);
+    }
+
     public function testPassEmptyValueAsPartialArray_addNullIfRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => true,
             'empty_value' => array(
+                'year' => 'Empty year',
+                'day' => 'Empty day',
+            ),
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty year', $view['year']->vars['empty_value']);
+        $this->assertNull($view['month']->vars['empty_value']);
+        $this->assertSame('Empty day', $view['day']->vars['empty_value']);
+    }
+
+    public function testPassPlaceholderAsPartialArray_addNullIfRequired()
+    {
+        $form = $this->factory->create('date', null, array(
+            'required' => true,
+            'placeholder' => array(
                 'year' => 'Empty year',
                 'day' => 'Empty day',
             ),

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TextTypeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Core\Type;
+
+class TextTypeTest extends TypeTestCase
+{
+    public function testDontPassPlaceholderValue()
+    {
+        $form = $this->factory->create('text');
+        $view = $form->createView();
+
+        $this->assertNull($view->vars['placeholder']);
+    }
+
+    public function testPassPlaceholderValue()
+    {
+        $form = $this->factory->create('text', null, array('placeholder' => 'Empty Text'));
+        $view = $form->createView();
+
+        $this->assertSame('Empty Text', $view->vars['placeholder']);
+    }
+
+    public function testPassPlaceholderValueAsAttribute()
+    {
+        $form = $this->factory->create('text', null, array(
+            'attr' => array('placeholder' => 'Empty Text')
+        ));
+        $view = $form->createView();
+
+        $this->assertSame('Empty Text', $view->vars['placeholder']);
+    }
+}

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -523,10 +523,40 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty', $view['second']->vars['empty_value']);
     }
 
+    public function testPlaceholderValueAsString()
+    {
+        $form = $this->factory->create('time', null, array(
+            'placeholder' => 'Empty',
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty', $view['hour']->vars['empty_value']);
+        $this->assertSame('Empty', $view['minute']->vars['empty_value']);
+        $this->assertSame('Empty', $view['second']->vars['empty_value']);
+    }
+
     public function testPassEmptyValueAsArray()
     {
         $form = $this->factory->create('time', null, array(
             'empty_value' => array(
+                'hour' => 'Empty hour',
+                'minute' => 'Empty minute',
+                'second' => 'Empty second',
+            ),
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty hour', $view['hour']->vars['empty_value']);
+        $this->assertSame('Empty minute', $view['minute']->vars['empty_value']);
+        $this->assertSame('Empty second', $view['second']->vars['empty_value']);
+    }
+
+    public function testPlaceholderValueAsArray()
+    {
+        $form = $this->factory->create('time', null, array(
+            'placeholder' => array(
                 'hour' => 'Empty hour',
                 'minute' => 'Empty minute',
                 'second' => 'Empty second',
@@ -557,11 +587,45 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['second']->vars['empty_value']);
     }
 
+    public function testPassPlaceholderAsPartialArray_addEmptyIfNotRequired()
+    {
+        $form = $this->factory->create('time', null, array(
+            'required' => false,
+            'placeholder' => array(
+                'hour' => 'Empty hour',
+                'second' => 'Empty second',
+            ),
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty hour', $view['hour']->vars['empty_value']);
+        $this->assertSame('', $view['minute']->vars['empty_value']);
+        $this->assertSame('Empty second', $view['second']->vars['empty_value']);
+    }
+
     public function testPassEmptyValueAsPartialArray_addNullIfRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => true,
             'empty_value' => array(
+                'hour' => 'Empty hour',
+                'second' => 'Empty second',
+            ),
+            'with_seconds' => true,
+        ));
+
+        $view = $form->createView();
+        $this->assertSame('Empty hour', $view['hour']->vars['empty_value']);
+        $this->assertNull($view['minute']->vars['empty_value']);
+        $this->assertSame('Empty second', $view['second']->vars['empty_value']);
+    }
+
+    public function testPassPlaceholderAsPartialArray_addNullIfRequired()
+    {
+        $form = $this->factory->create('time', null, array(
+            'required' => true,
+            'placeholder' => array(
                 'hour' => 'Empty hour',
                 'second' => 'Empty second',
             ),


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5791
License of the code: MIT

This PR adds `placeholder` option to types represented in html by input element and rename `empty_value` option into `placeholder` in types represented in html by select.  
