### PR TITLE
Reduce the ACL query size and decrease potential for query buffer over-run

### DIFF
--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -257,19 +257,47 @@ SELECTCLAUSE;
             INNER JOIN {$this->options['oid_ancestors_table_name']} a ON a.object_identity_id = o.id
                WHERE (
 SELECTCLAUSE;
-
-        $where = '(o.object_identifier = %s AND c.class_type = %s)';
+                
+		$types = array();
         for ($i=0,$c=count($batch); $i<$c; $i++) {
-            $sql .= sprintf(
-                $where,
-                $this->connection->quote($batch[$i]->getIdentifier()),
-                $this->connection->quote($batch[$i]->getType())
-            );
-
-            if ($i+1 < $c) {
-                $sql .= ' OR ';
-            }
+        	if(!isset($types[$batch[$i]->getType()])) {
+        		$types[$batch[$i]->getType()] = true;
+        		if(count($batch) > 1) {
+        			break;
+        		}
+        	}  	
         }
+        
+        if(count($types) === 1) {
+        	
+        	$where = '(o.object_identifier IN (%s) AND c.class_type = %s)'; 
+        	$ids = array();
+        	for ($i=0,$c=count($batch); $i<$c; $i++) {
+				$ids[] = $this->connection->quote($batch[$i]->getIdentifier());   
+        	}
+        	
+        	$sql .= sprintf(
+        			$where,
+        			implode(',', $ids), 
+        			$this->connection->quote($batch[0]->getType())
+        	);
+        	
+        } else {
+        	
+        	$where = '(o.object_identifier = %s AND c.class_type = %s)';
+        	for ($i=0,$c=count($batch); $i<$c; $i++) {
+        		$sql .= sprintf(
+        				$where,
+        				$this->connection->quote($batch[$i]->getIdentifier()),
+        				$this->connection->quote($batch[$i]->getType())
+        		);
+        		 
+        		if ($i+1 < $c) {
+        			$sql .= ' OR ';
+        		}
+        	}
+        }
+        
 
         $sql .= ')';
 
@@ -417,8 +445,6 @@ QUERY;
      * @param array $oidLookup
      *
      * @return \SplObjectStorage mapping object identities to ACL instances
-     *
-     * @throws AclNotFoundException
      */
     private function lookupObjectIdentities(array $batch, array $sids, array $oidLookup)
     {

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -445,6 +445,8 @@ QUERY;
      * @param array $oidLookup
      *
      * @return \SplObjectStorage mapping object identities to ACL instances
+     * 
+     * @throws AclNotFoundException
      */
     private function lookupObjectIdentities(array $batch, array $sids, array $oidLookup)
     {


### PR DESCRIPTION
findAcls methods produces a query with the where clause that looks like this:

``` sql
(o.object_identifier = %s AND c.class_type = %s)  OR ...
```

If the class_type is the same, then we end up with a lot of fully qualified class names, which are simply repeated.

The above query can be cut down to just:

``` sql
(o.object_identifier IN (%s) AND c.class_type = %s)
```

when only one class_type is present. 

The pull request does exactly that.
