### PR TITLE
Add event listener to check that the kernel.secret parameter isn't set to the default

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/debug.xml
@@ -10,6 +10,7 @@
         <parameter key="debug.container.dump">%kernel.cache_dir%/%kernel.container_class%.xml</parameter>
         <parameter key="debug.controller_resolver.class">Symfony\Component\HttpKernel\Controller\TraceableControllerResolver</parameter>
         <parameter key="debug.deprecation_logger_listener.class">Symfony\Component\HttpKernel\EventListener\DeprecationLoggerListener</parameter>
+        <parameter key="debug.default_secret_listener.class">Symfony\Component\HttpKernel\EventListener\DefaultSecretListener</parameter>
     </parameters>
 
     <services>
@@ -32,6 +33,13 @@
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="deprecation" />
             <argument type="service" id="logger" on-invalid="null" />
+        </service>
+
+        <service id="debug.default_secret_listener" class="%debug.default_secret_listener.class%">
+            <tag name="kernel.event_subscriber" />
+            <tag name="monolog.logger" />
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument>%kernel.secret%</argument>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/HttpKernel/EventListener/DefaultSecretListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DefaultSecretListener.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\EventListener;
+
+use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Checks that the kernel.secret parameter isn't set to the default.
+ *
+ * @author Lee McDermott <github@leemcdermott.co.uk>
+ */
+class DefaultSecretListener implements EventSubscriberInterface
+{
+    private $logger;
+    private $secret;
+
+    public function __construct(LoggerInterface $logger = null, $secret)
+    {
+        $this->logger = $logger;
+        $this->secret = $secret;
+    }
+
+    public function onKernelRequest()
+    {
+        if ('ThisTokenIsNotSoSecretChangeIt' === $this->secret) {
+            $this->logger->alert('The "kernel.secret" parameter is currently set to the default. It is important that you change it');
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(KernelEvents::REQUEST => 'onKernelRequest');
+    }
+}


### PR DESCRIPTION
After reading https://github.com/symfony/symfony/pull/6463, I think it's becoming increasingly important that `kernel.secret` is _absolutely_ set to something secure.

I have seen (and also been guilty of for quick builds) projects that don't bother changing the secret. This PR adds a warning to the logger when this is detected.

Perhaps a compiler pass could be used to unsubscribe from the event once the issue has been resolved.

Note: threw this together in a few mins... might not comply with conventions
