### PR TITLE
[EventDispatcher] Fixed php doc of GenericEvent::__construct

### DIFF
--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -35,7 +35,7 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
     protected $arguments;
 
     /**
-     * Encapsulate an event with $subject, $args, and $data.
+     * Encapsulate an event with $subject and $args.
      *
      * @param mixed $subject   The subject of the event, usually an object.
      * @param array $arguments Arguments to store in the event.


### PR DESCRIPTION
```
Bug fix: yes (doc)
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes (no modified)
Fixes the following tickets: -
Todo: -
License of the code: MIT
```
