### PR TITLE
[EventDispatcher] Added GenericEvent::setSubject method

### DIFF
--- a/src/Symfony/Component/EventDispatcher/GenericEvent.php
+++ b/src/Symfony/Component/EventDispatcher/GenericEvent.php
@@ -49,11 +49,25 @@ class GenericEvent extends Event implements \ArrayAccess, \IteratorAggregate
     /**
      * Getter for subject property.
      *
-     * @return mixed $subject The observer subject.
+     * @return mixed $subject The observed subject.
      */
     public function getSubject()
     {
         return $this->subject;
+    }
+
+    /**
+     * Setter for subject property.
+     *
+     * @param mixed $subject The observed subject.
+     *
+     * @return GenericEvent
+     */
+    public function setSubject($subject)
+    {
+        $this->subject = $subject;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
```
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
```

It is usefull if the observed subject is not an object
and you don't want to give the subject by reference.
