### PR TITLE
[Routing] made RouteCompilerInterface::compile static

### DIFF
--- a/src/Symfony/Component/Routing/CHANGELOG.md
+++ b/src/Symfony/Component/Routing/CHANGELOG.md
@@ -79,6 +79,8 @@ CHANGELOG
    pass the requirements (otherwise it would break your link anyway).
  * There is no restriction on the route name anymore. So non-alphanumeric characters
    are now also allowed.
+ * [BC BREAK] `RouteCompilerInterface::compile(Route $route)` was made static
+   (only relevant if you implemented your own RouteCompiler).
 
 2.1.0
 -----

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -50,8 +50,6 @@ class Route implements \Serializable
      */
     private $compiled;
 
-    private static $compilers = array();
-
     /**
      * Constructor.
      *
@@ -431,11 +429,7 @@ class Route implements \Serializable
 
         $class = $this->getOption('compiler_class');
 
-        if (!isset(self::$compilers[$class])) {
-            self::$compilers[$class] = new $class;
-        }
-
-        return $this->compiled = self::$compilers[$class]->compile($this);
+        return $this->compiled = $class::compile($this);
     }
 
     private function sanitizeRequirement($key, $regex)

--- a/src/Symfony/Component/Routing/Route.php
+++ b/src/Symfony/Component/Routing/Route.php
@@ -419,6 +419,9 @@ class Route implements \Serializable
      *
      * @return CompiledRoute A CompiledRoute instance
      *
+     * @throws \LogicException If the Route cannot be compiled because the
+     *                         path or hostname pattern is invalid
+     *
      * @see RouteCompiler which is responsible for the compilation process
      */
     public function compile()

--- a/src/Symfony/Component/Routing/RouteCompiler.php
+++ b/src/Symfony/Component/Routing/RouteCompiler.php
@@ -35,7 +35,7 @@ class RouteCompiler implements RouteCompilerInterface
      * @throws \DomainException If a variable name is numeric because PHP raises an error for such
      *                          subpatterns in PCRE and thus would break matching, e.g. "(?P<123>.+)".
      */
-    public function compile(Route $route)
+    public static function compile(Route $route)
     {
         $staticPrefix = null;
         $hostnameVariables = array();
@@ -47,7 +47,7 @@ class RouteCompiler implements RouteCompilerInterface
         $hostnameTokens = array();
 
         if ('' !== $hostnamePattern = $route->getHostnamePattern()) {
-            $result = $this->compilePattern($route, $hostnamePattern, true);
+            $result = self::compilePattern($route, $hostnamePattern, true);
 
             $hostnameVariables = $result['variables'];
             $variables = array_merge($variables, $hostnameVariables);
@@ -58,7 +58,7 @@ class RouteCompiler implements RouteCompilerInterface
 
         $pattern = $route->getPattern();
 
-        $result = $this->compilePattern($route, $pattern, false);
+        $result = self::compilePattern($route, $pattern, false);
 
         $staticPrefix = $result['staticPrefix'];
 
@@ -80,7 +80,7 @@ class RouteCompiler implements RouteCompilerInterface
         );
     }
 
-    private function compilePattern(Route $route, $pattern, $isHostname)
+    private static function compilePattern(Route $route, $pattern, $isHostname)
     {
         $tokens = array();
         $variables = array();
@@ -122,7 +122,7 @@ class RouteCompiler implements RouteCompilerInterface
                 // If {page} would also match the separating dot, {_format} would never match as {page} will eagerly consume everything.
                 // Also even if {_format} was not optional the requirement prevents that {page} matches something that was originally
                 // part of {_format} when generating the URL, e.g. _format = 'mobile.html'.
-                $nextSeparator = $this->findNextSeparator($followingPattern);
+                $nextSeparator = self::findNextSeparator($followingPattern);
                 $regexp = sprintf(
                     '[^%s%s]+',
                     preg_quote($defaultSeparator, self::REGEX_DELIMITER),
@@ -162,7 +162,7 @@ class RouteCompiler implements RouteCompilerInterface
         // compute the matching regexp
         $regexp = '';
         for ($i = 0, $nbToken = count($tokens); $i < $nbToken; $i++) {
-            $regexp .= $this->computeRegexp($tokens, $i, $firstOptional);
+            $regexp .= self::computeRegexp($tokens, $i, $firstOptional);
         }
 
         return array(
@@ -180,7 +180,7 @@ class RouteCompiler implements RouteCompilerInterface
      *
      * @return string The next static character that functions as separator (or empty string when none available)
      */
-    private function findNextSeparator($pattern)
+    private static function findNextSeparator($pattern)
     {
         if ('' == $pattern) {
             // return empty string if pattern is empty or false (false which can be returned by substr)
@@ -201,7 +201,7 @@ class RouteCompiler implements RouteCompilerInterface
      *
      * @return string The regexp pattern for a single token
      */
-    private function computeRegexp(array $tokens, $index, $firstOptional)
+    private static function computeRegexp(array $tokens, $index, $firstOptional)
     {
         $token = $tokens[$index];
         if ('text' === $token[0]) {

--- a/src/Symfony/Component/Routing/RouteCompilerInterface.php
+++ b/src/Symfony/Component/Routing/RouteCompilerInterface.php
@@ -24,6 +24,9 @@ interface RouteCompilerInterface
      * @param Route $route A Route instance
      *
      * @return CompiledRoute A CompiledRoute instance
+     *
+     * @throws \LogicException If the Route cannot be compiled because the
+     *                         path or hostname pattern is invalid
      */
     public static function compile(Route $route);
 }

--- a/src/Symfony/Component/Routing/RouteCompilerInterface.php
+++ b/src/Symfony/Component/Routing/RouteCompilerInterface.php
@@ -25,5 +25,5 @@ interface RouteCompilerInterface
      *
      * @return CompiledRoute A CompiledRoute instance
      */
-    public function compile(Route $route);
+    public static function compile(Route $route);
 }


### PR DESCRIPTION
bc break: yes but probably nobody affected 

It makes much more sense that the compile method is static because having instances of a compiler is strange. Also the compiler could not use DI or anything anyway as the `Route` class was instantiating compiler instances itself and was assuming there are no constructor arguments.
