### PR TITLE
[Validator] Fix structure error in validators.it.xlf

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.it.xlf
@@ -213,6 +213,7 @@
             <trans-unit id="56">
                 <source>This collection should contain exactly {{ limit }} elements.</source>
                 <target>Questa collezione dovrebbe contenere esattamente {{ limit }} elemento.|Questa collezione dovrebbe contenere esattamente {{ limit }} elementi.</target>
+            </trans-unit>
             <trans-unit id="57">
                 <source>Invalid card number.</source>
                 <target>Numero di carta non valido.</target>
@@ -221,7 +222,8 @@
                 <source>Unsupported card type or invalid card number.</source>
                 <target>Tipo di carta non supportato o numero non valido.</target>
             </trans-unit>
-            </trans-unit>
+            <!--
+            Old messages: differents ?!
             <trans-unit id="57">
                 <source>Invalid card number.</source>
                 <target>Il numero della carta non è valido.</target>
@@ -230,6 +232,7 @@
                 <source>Unsupported card type or invalid card number.</source>
                 <target>Il tipo di carta non è supportato o il numero non è valido.</target>
             </trans-unit>
+            -->
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Fix structure error in validators.it.xlf.

Probably a copy-cut that didn't work correctly.
