### PR TITLE
added MatcherInterface as a marker for all Routing matcher classes

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -18,8 +18,8 @@ use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
-use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\Matcher\RequestMatcherInterface;
+use Symfony\Component\Routing\Matcher\MatcherInterface;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RequestContextAwareInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -38,18 +38,14 @@ class RouterListener implements EventSubscriberInterface
     /**
      * Constructor.
      *
-     * @param UrlMatcherInterface|RequestMatcherInterface $matcher The Url or Request matcher
-     * @param RequestContext|null                         $context The RequestContext (can be null when $matcher implements RequestContextAwareInterface)
-     * @param LoggerInterface|null                        $logger  The logger
+     * @param MatcherInterface     $matcher The Routing matcher
+     * @param RequestContext|null  $context The RequestContext (can be null when $matcher implements RequestContextAwareInterface)
+     * @param LoggerInterface|null $logger  The logger
      *
      * @throws \InvalidArgumentException
      */
-    public function __construct($matcher, RequestContext $context = null, LoggerInterface $logger = null)
+    public function __construct(MatcherInterface $matcher, RequestContext $context = null, LoggerInterface $logger = null)
     {
-        if (!$matcher instanceof UrlMatcherInterface && !$matcher instanceof RequestMatcherInterface) {
-            throw new \InvalidArgumentException('Matcher must either implement UrlMatcherInterface or RequestMatcherInterface.');
-        }
-
         if (null === $context && !$matcher instanceof RequestContextAwareInterface) {
             throw new \InvalidArgumentException('You must either pass a RequestContext or the matcher must implement RequestContextAwareInterface.');
         }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/RouterListenerTest.php
@@ -78,14 +78,6 @@ class RouterListenerTest extends \PHPUnit_Framework_TestCase
         return new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvalidMatcher()
-    {
-        new RouterListener(new \stdClass());
-    }
-
     public function testRequestMatcher()
     {
         $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');

--- a/src/Symfony/Component/Routing/Matcher/MatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/MatcherInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Routing\Matcher;
+
+/**
+ * MatcherInterface is the interface that all routing matcher classes must implement.
+ *
+ * It acts as a marker when you want to support UrlGeneratorInterface and RequestMatcherInterface.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ *
+ * @api
+ */
+interface MatcherInterface
+{
+}

--- a/src/Symfony/Component/Routing/Matcher/RequestMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/RequestMatcherInterface.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-interface RequestMatcherInterface
+interface RequestMatcherInterface extends MatcherInterface
 {
     /**
      * Tries to match a request with a set of routes.

--- a/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
+++ b/src/Symfony/Component/Routing/Matcher/UrlMatcherInterface.php
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\Exception\MethodNotAllowedException;
  *
  * @api
  */
-interface UrlMatcherInterface extends RequestContextAwareInterface
+interface UrlMatcherInterface extends RequestContextAwareInterface, MatcherInterface
 {
     /**
      * Tries to match a URL path with a set of routes.


### PR DESCRIPTION
This allows to use a type hint when you want to support both UrlMatcherInterface and RequestMatcherInterface
