### PR TITLE
[Locale] Fixed the StubLocaleTest for ICU versions lower than 4.8

### DIFF
--- a/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubLocaleTest.php
@@ -67,7 +67,7 @@ class StubLocaleTest extends LocaleTestCase
 
     public function testGetCurrenciesData()
     {
-        $symbol = $this->isGreaterOrEqualThanIcuVersion('4.8') ? 'BR$' : 'R$';
+        $symbol = $this->isSameAsIcuVersion('4.8') ? 'BR$' : 'R$';
 
         $currencies = StubLocale::getCurrenciesData('en');
         $this->assertEquals($symbol, $currencies['BRL']['symbol']);


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: no but for other reason in an another component
Fixes the following tickets: #5517
Todo: -
License of the code: MIT
Documentation PR: -

Symbol for Brazilian Real is BR$ only in ICU 4.8. All previous and later versions use R$.

Links to the relevant data files:
- http://source.icu-project.org/repos/icu/icu/tags/release-4-8/source/data/curr/en.txt
- http://source.icu-project.org/repos/icu/icu/tags/release-4-4/source/data/curr/en.txt
- http://source.icu-project.org/repos/icu/icu/tags/release-49-1/source/data/curr/en.txt
