### PR TITLE
[Form] Fixed failing tests for DateTimeToStringTransformer

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -23,7 +23,7 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
             array('Y-m-d H:i', '2010-02-03 16:05', '2010-02-03 16:05:00 UTC'),
             array('Y-m-d H', '2010-02-03 16', '2010-02-03 16:00:00 UTC'),
             array('Y-m-d', '2010-02-03', '2010-02-03 00:00:00 UTC'),
-            array('Y-m', '2010-02', '2010-02-01 00:00:00 UTC'),
+            array('Y-m', '2010-12', '2010-12-01 00:00:00 UTC'),
             array('Y', '2010', '2010-01-01 00:00:00 UTC'),
             array('d-m-Y', '03-02-2010', '2010-02-03 00:00:00 UTC'),
             array('H:i:s', '16:05:06', '1970-01-01 16:05:06 UTC'),


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

Tests were only failing at the end of the month. Since February was used in the test cases, date was being moved to the next month (February has less days than other months).

If a day is not passed, \DateTime's constructor will set it to the first day of the month:

``` php
var_dump(new \DateTime('2010-02'));

object(DateTime)#1 (3) {
  ["date"]=>
  string(19) "2010-02-01 00:00:00"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(13) "Europe/London"
}
```

\DateTime is used in the test assertions.

However, DateTimeToStringTransformer::reverseTransform() uses \DateTime::createFromFormat(), which sets a missing day to the current day:

``` php
var_dump(\DateTime::createFromFormat("Y-m", '2010-02'));

object(DateTime)#1 (3) {
  ["date"]=>
  string(19) "2010-03-01 20:09:26"
  ["timezone_type"]=>
  int(3)
  ["timezone"]=>
  string(13) "Europe/London"
}
```

I changed the date in the test case to avoid failures. If we need to be sure that month's not going to be changed, I'll update my PR.
