### PR TITLE
[Process] Prevented test from failing when pcntl extension is not enabled

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -233,10 +233,14 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Windows does not support POSIX signals');
         }
 
+        // SIGTERM is only defined if pcntl extension is present
+        $termSignal = defined('SIGTERM') ? SIGTERM : 15;
+
         $process = $this->getProcess('php -r "while (true) {}"');
         $process->start();
         $process->stop();
-        $this->assertEquals(SIGTERM, $process->getTermSignal());
+
+        $this->assertEquals($termSignal, $process->getTermSignal());
     }
 
     public function testPhpDeadlock()


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

_SIGTERM_ constant is only defined if pcntl extension is present. Extension is not needed to use the Process component though.
