### PR TITLE
[HttpFoundation] Check if required shell functions are not disabled in FileBinaryMimeTypeGuesser

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -45,7 +45,24 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
      */
     public static function isSupported()
     {
-        return !defined('PHP_WINDOWS_VERSION_BUILD');
+        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $disableFunctions = ini_get('disable_functions');
+            if (!$disableFunctions) {
+                return true;
+            }
+
+            $required = array('passthru', 'escapeshellarg');
+            $disabled = array_map(
+                function($item) { 
+                    return strtolower(trim($item)); 
+                },
+                explode(',', $disableFunctions)
+            );
+
+            return !array_intersect($required, $disabled);
+        }
+
+        return false;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -46,22 +46,14 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
     public static function isSupported()
     {
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $disableFunctions = ini_get('disable_functions');
-            if (!$disableFunctions) {
-                return true;
-            }
-
-            $required = array('passthru', 'escapeshellarg');
-            $disabled = array_map(
-                function($item) { 
-                    return strtolower(trim($item)); 
-                },
-                explode(',', $disableFunctions)
-            );
-
-            return !array_intersect($required, $disabled);
+			$required = array('passthru', 'escapeshellarg');
+            foreach ($required as $function) {
+                if (!function_exists($function)) {
+                    return false;	
+                }
+			}			
+            return true;
         }
-
         return false;
     }
 

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -46,12 +46,12 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
     public static function isSupported()
     {
         if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-			$required = array('passthru', 'escapeshellarg');
+            $required = array('passthru', 'escapeshellarg');
             foreach ($required as $function) {
                 if (!function_exists($function)) {
                     return false;	
                 }
-			}			
+            }			
             return true;
         }
         return false;

--- a/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/FileBinaryMimeTypeGuesser.php
@@ -45,16 +45,7 @@ class FileBinaryMimeTypeGuesser implements MimeTypeGuesserInterface
      */
     public static function isSupported()
     {
-        if (!defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $required = array('passthru', 'escapeshellarg');
-            foreach ($required as $function) {
-                if (!function_exists($function)) {
-                    return false;	
-                }
-            }			
-            return true;
-        }
-        return false;
+        return !defined('PHP_WINDOWS_VERSION_BUILD') && function_exists('passthru') && function_exists('escapeshellarg');
     }
 
     /**


### PR DESCRIPTION
On many shared hosts shell related functions are disabled for security reason, checking it first will prevent issuing a warning
