### PR TITLE
[Finder] Added support for wildcard characters (GLOB patterns)

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 
  * added Finder::path() and Finder::notPath() methods
  * added finder adapters to improve performance on specific platforms
+ * added support for wildcard characters (glob patterns) in the paths passed
+   to Finder::in()
 
 2.1.0
 -----

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -598,21 +598,25 @@ class Finder implements \IteratorAggregate, \Countable
      *
      * @return Finder The current Finder instance
      *
-     * @throws \InvalidArgumentException if one of the directory does not exist
+     * @throws \InvalidArgumentException if one of the directories does not exist
      *
      * @api
      */
     public function in($dirs)
     {
-        $dirs = (array) $dirs;
+        $resolvedDirs = array();
 
-        foreach ($dirs as $dir) {
-            if (!is_dir($dir)) {
+        foreach ((array) $dirs as $dir) {
+            if (is_dir($dir)) {
+                $resolvedDirs[] = $dir;
+            } elseif ($glob = glob($dir, GLOB_ONLYDIR)) {
+                $resolvedDirs = array_merge($resolvedDirs, $glob);
+            } else {
                 throw new \InvalidArgumentException(sprintf('The "%s" directory does not exist.', $dir));
             }
         }
 
-        $this->dirs = array_merge($this->dirs, $dirs);
+        $this->dirs = array_merge($this->dirs, $resolvedDirs);
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -314,6 +314,27 @@ class FinderTest extends Iterator\RealIteratorTestCase
     /**
      * @dataProvider getAdaptersTestData
      */
+    public function testInWithGlob($adapter)
+    {
+        $finder = $this->buildFinder($adapter);
+        $finder->in(array(__DIR__.'/Fixtures/*/B/C', __DIR__.'/Fixtures/*/*/B/C'))->getIterator();
+
+        $this->assertIterator($this->toAbsoluteFixtures(array('A/B/C/abc.dat', 'copy/A/B/C/abc.dat.copy')), $finder);
+    }
+
+    /**
+     * @dataProvider getAdaptersTestData
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInWithNonDirectoryGlob($adapter)
+    {
+        $finder = $this->buildFinder($adapter);
+        $finder->in(__DIR__.'/Fixtures/A/a*');
+    }
+
+    /**
+     * @dataProvider getAdaptersTestData
+     */
     public function testGetIterator($adapter)
     {
         $finder = $this->buildFinder($adapter);


### PR DESCRIPTION
Added support for wildcard characters in the paths passed to the _in()_ method. Each pattern has to resolve to at least one directory, otherwise exception is thrown (just like when path to an invalid directory is passed).

Example usage:

``` php
$finder = new \Symfony\Component\Finder\Finder();
$files = $finder->files()
    ->name('validators.en.*')
    ->in(array(
        'src/Symfony/*/*/Resources/translations',
    ));

foreach ($files as $file) {
    var_dump($file->getRealPath());
}
```

Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #5450
Todo: -
License of the code: MIT
Documentation PR: symfony/symfony-docs#2089
