### PR TITLE
[Finder] Added support for PHP callables for filters

### DIFF
--- a/src/Symfony/Component/Finder/CHANGELOG.md
+++ b/src/Symfony/Component/Finder/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added Finder::path() and Finder::notPath() methods
  * added finder adapters to improve performance on specific platforms
+ * The Finder::filter() method accepts all PHP callables now
 
 2.1.0
 -----

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -549,16 +549,21 @@ class Finder implements \IteratorAggregate, \Countable
      * The anonymous function receives a \SplFileInfo and must return false
      * to remove files.
      *
-     * @param \Closure $closure An anonymous function
+     * @param callable $closure A PHP callable
      *
      * @return Finder The current Finder instance
+     *
+     * @throws \InvalidArgumentException if the closure is not a PHP callable
      *
      * @see Symfony\Component\Finder\Iterator\CustomFilterIterator
      *
      * @api
      */
-    public function filter(\Closure $closure)
+    public function filter($closure)
     {
+        if (!is_callable($closure)) {
+            throw new \InvalidArgumentException('The filter must be a PHP callable');
+        }
         $this->filters[] = $closure;
 
         return $this;

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -285,6 +285,29 @@ class FinderTest extends Iterator\RealIteratorTestCase
     /**
      * @dataProvider getAdaptersTestData
      */
+    public function testFilterSupportsCallables($adapter)
+    {
+        $finder = $this->buildFinder($adapter);
+        $filterStub = new Stubs\FilterStub();
+        $finder->filter(array($filterStub, 'filter'));
+
+        $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
+    }
+
+    /**
+     * @dataProvider getAdaptersTestData
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The filter must be a PHP callable
+     */
+    public function testFilterThrowExceptionIfNoCallable($adapter)
+    {
+        $finder = $this->buildFinder($adapter);
+        $finder->filter('foo');
+    }
+
+    /**
+     * @dataProvider getAdaptersTestData
+     */
     public function testFollowLinks($adapter)
     {
         if ('\\' == DIRECTORY_SEPARATOR) {

--- a/src/Symfony/Component/Finder/Tests/Stubs/FilterStub.php
+++ b/src/Symfony/Component/Finder/Tests/Stubs/FilterStub.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Tests\Stubs;
+
+class FilterStub
+{
+    public function filter(\SplFileInfo $file)
+    {
+        return preg_match('/test/', $file) > 0;
+    }
+}


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: symfony/symfony-docs#2090
