### PR TITLE
[Process][2.1] Do not reset stdout/stderr pipes on stream_select failure

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -338,10 +338,13 @@ class Process
                 $w = null;
                 $e = null;
 
-                $n = @stream_select($r, $w, $e, $this->timeout);
+                if (false === $n = @stream_select($r, $w, $e, $this->timeout)) {
+                    $lastError = error_get_last();
 
-                if (false === $n) {
-                    $this->pipes = array();
+                    // stream_select returns false when the `select` system call is interrupted by an incoming signal
+                    if (isset($lastError['message']) && false === stripos($lastError['message'], 'interrupted system call')) {
+                        $this->pipes = array();
+                    }
 
                     continue;
                 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

When `stream_select` is called and failed, pipes are currently reset to an empty array. As a result, both error-output and output are empty whereas the exitcode is 0 (successful process).

There is no reason (at least I don't see it) to reset pipes when an error occurs.
