### PR TITLE
[Form] Fixed DateType when used with the intl extension disabled

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -83,7 +83,7 @@ class DateType extends AbstractType
                 // Only pass a subset of the options to children
                 $yearOptions['choices'] = $this->formatTimestamps($formatter, '/y+/', $this->listYears($options['years']));
                 $yearOptions['empty_value'] = $options['empty_value']['year'];
-                $monthOptions['choices'] = $this->formatTimestamps($formatter, '/M+/', $this->listMonths($options['months']));
+                $monthOptions['choices'] = $this->formatTimestamps($formatter, '/[M|L]+/', $this->listMonths($options['months']));
                 $monthOptions['empty_value'] = $options['empty_value']['month'];
                 $dayOptions['choices'] = $this->formatTimestamps($formatter, '/d+/', $this->listDays($options['days']));
                 $dayOptions['empty_value'] = $options['empty_value']['day'];


### PR DESCRIPTION
DateType's month select box returns timestamps when used with intl extension disabled (see #6485). 

The reason for this is that stubbed formats use _L_ instead of _M_ for month representation. My fix is simply taking this into account when building array for the select box.

I didn't provide unit tests since they're disabled when intl extension is not enabled. I've only manually verified if the months array contains correct data.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6485
Todo: -
License of the code: MIT
Documentation PR: -
