### PR TITLE
[Form] Fixed inheritance of "error_bubbling" in RepeatedType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/RepeatedType.php
@@ -27,6 +27,10 @@ class RepeatedType extends AbstractType
         $options['first_options']['required']  = $options['required'];
         $options['second_options']['required'] = $options['required'];
 
+        if (!isset($options['options']['error_bubbling'])) {
+            $options['options']['error_bubbling'] = $options['error_bubbling'];
+        }
+
         $builder
             ->addViewTransformer(new ValueToDuplicatesTransformer(array(
                 $options['first_name'],

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -72,6 +72,41 @@ class RepeatedTypeTest extends TypeTestCase
         $this->assertFalse($form['second']->isRequired());
     }
 
+    public function testSetErrorBubblingToTrue()
+    {
+        $form = $this->factory->create('repeated', null, array(
+            'error_bubbling' => true,
+        ));
+
+        $this->assertTrue($form->getConfig()->getOption('error_bubbling'));
+        $this->assertTrue($form['first']->getConfig()->getOption('error_bubbling'));
+        $this->assertTrue($form['second']->getConfig()->getOption('error_bubbling'));
+    }
+
+    public function testSetErrorBubblingToFalse()
+    {
+        $form = $this->factory->create('repeated', null, array(
+            'error_bubbling' => false,
+        ));
+
+        $this->assertFalse($form->getConfig()->getOption('error_bubbling'));
+        $this->assertFalse($form['first']->getConfig()->getOption('error_bubbling'));
+        $this->assertFalse($form['second']->getConfig()->getOption('error_bubbling'));
+    }
+
+    public function testSetErrorBubblingIndividually()
+    {
+        $form = $this->factory->create('repeated', null, array(
+            'error_bubbling' => true,
+            'options' => array('error_bubbling' => false),
+            'second_options' => array('error_bubbling' => true),
+        ));
+
+        $this->assertTrue($form->getConfig()->getOption('error_bubbling'));
+        $this->assertFalse($form['first']->getConfig()->getOption('error_bubbling'));
+        $this->assertTrue($form['second']->getConfig()->getOption('error_bubbling'));
+    }
+
     public function testSetOptionsPerChildAndOverwrite()
     {
         $form = $this->factory->create('repeated', null, array(


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
