### PR TITLE
[Console] Make getTerminalWidth & getTerminalHeight public

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -859,7 +859,7 @@ class Application
      *
      * @return int|null
      */
-    protected function getTerminalWidth()
+    public function getTerminalWidth()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             if ($ansicon = getenv('ANSICON')) {
@@ -881,7 +881,7 @@ class Application
      *
      * @return int|null
      */
-    protected function getTerminalHeight()
+    public function getTerminalHeight()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
             if ($ansicon = getenv('ANSICON')) {


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Fixes the following tickets: ~
Todo: -
License of the code: MIT
Documentation PR: ~

Hey!

This PR updates the visibility of the Application's methods `getTerminalWidth` & `getTerminalHeight` to **public**. This two methods should be accessible as we can need it in our commands to determine the way we display the output. (see #6550)
