### PR TITLE
[Locale] Rolled back normalizeIcuVersion() method in unit tests.

### DIFF
--- a/src/Symfony/Component/Locale/Tests/TestCase.php
+++ b/src/Symfony/Component/Locale/Tests/TestCase.php
@@ -89,16 +89,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function normalizeIcuVersion($version)
     {
-        $versionIds = explode('.', $version);
-
-        $multi = 1000;
-        $intVersion = 0;
-        foreach ($versionIds as $id) {
-            $intVersion += $id * $multi;
-            $multi = $multi / 10;
-        }
-
-        return (int) $intVersion;
+        return ((float) $version) * 100;
     }
 
     protected function getIntlExtensionIcuVersion()


### PR DESCRIPTION
We just need to check if version is 4.4 or 4.8 and we do not need to know if it is 4.8.0 or 4.8.1.1 (at least for now there are no big differences between minor ICU versions).

This change basically rolls back modifications made in #6109 to fix #5288. Those modifications didn't really fix the issue since ICU>=4.9 wasn't handled properly. Part of the roll back was made in #6515 (2.1 branch).

This change makes master branch consistent with what we have in 2.0 and 2.1 (bespoke tests are passing in those branches).

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: one test fails in the Propel1 bridge
Fixes the following tickets: #5517
Todo: -
License of the code: MIT
Documentation PR: -
