### PR TITLE
[Propel1] Fixed preferred choices in the ModelChoiceList

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
+++ b/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
@@ -104,7 +104,7 @@ class ModelChoiceList extends ObjectChoiceList
             $this->identifierAsIndex = true;
         }
 
-        parent::__construct($choices, $labelPath, array(), $groupPath);
+        parent::__construct($choices, $labelPath, $preferred, $groupPath);
     }
 
     /**


### PR DESCRIPTION
Related change was made in #6454 but for some reason part of that change was not merged from 2.1 branch.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: some Locale tests fail, fixed in #6568 
Fixes the following tickets:
Todo: -
License of the code: MIT
Documentation PR: -
