### PR TITLE
[2.1] Restrict Monolog to be in version `<1.3`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "doctrine/orm": ">=2.2.3,<2.4-dev",
         "doctrine/data-fixtures": "1.0.*",
         "propel/propel1": "dev-master",
-        "monolog/monolog": "1.*"
+        "monolog/monolog": ">=1.0,<1.3-dev"
     },
     "autoload": {
         "psr-0": {

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/http-kernel": "2.1.*",
-        "monolog/monolog": "1.*"
+        "monolog/monolog": ">=1.0,<1.3-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Monolog": "" }


### PR DESCRIPTION
Because of conflict between `HttpKernel\Log\LoggerInterface` and `Psr\Log\LoggerInterface` (PSR-3).
