### PR TITLE
[Console] Make getTerminalWith & getTerminalHeight public

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -794,7 +794,7 @@ class Application
      *
      * @return int|null
      */
-    protected function getTerminalWidth()
+    public function getTerminalWidth()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD') && $ansicon = getenv('ANSICON')) {
             return preg_replace('{^(\d+)x.*$}', '$1', $ansicon);
@@ -810,7 +810,7 @@ class Application
      *
      * @return int|null
      */
-    protected function getTerminalHeight()
+    public function getTerminalHeight()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD') && $ansicon = getenv('ANSICON')) {
             return preg_replace('{^\d+x\d+ \(\d+x(\d+)\)$}', '$1', trim($ansicon));


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: no
Fixes the following tickets: ~
Todo: -
License of the code: MIT
Documentation PR: ~

After demand in #6567, I open an other one on the 2.0 branch.
