### PR TITLE
[2.0] Restrict Monolog version to be in version <1.3

### DIFF
--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/http-kernel": "self.version",
-        "monolog/monolog": "1.*"
+        "monolog/monolog": ">=1.0,<1.3-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Monolog": "" }


### PR DESCRIPTION
Because of conflict between `HttpKernel\Log\LoggerInterface` and `Psr\Log\LoggerInterface` (PSR-3).

Main `composer.json` already restricts to proper version, but bridge allows also conflicting version.
