### PR TITLE
[2.3] [Form] Renamed option "virtual" to "inherit_data" and improved handling of such forms

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,4 +1,4 @@
-UPGRADE FROM 2.2 to 2.3
+﻿UPGRADE FROM 2.2 to 2.3
 =======================
 
 ### Form
@@ -34,6 +34,79 @@ UPGRADE FROM 2.2 to 2.3
    // equivalent notations for skipping validation
    "validation_groups" => false
    "validation_groups" => array()
+   ```
+ * The array type hint from DataMapperInterface was removed. You should adapt
+   implementations of that interface accordingly.
+
+   Before:
+
+   ```
+   use Symfony\Component\Form\DataMapperInterface;
+
+   class MyDataMapper
+   {
+       public function mapFormsToData(array $forms, $data)
+       {
+           // ...
+       }
+
+       public function mapDataToForms($data, array $forms)
+       {
+           // ...
+       }
+   }
+   ```
+
+   After:
+
+   ```
+   use Symfony\Component\Form\DataMapperInterface;
+
+   class MyDataMapper
+   {
+       public function mapFormsToData($forms, $data)
+       {
+           // ...
+       }
+
+       public function mapDataToForms($data, $forms)
+       {
+           // ...
+       }
+   }
+   ```
+
+   Instead of an array, the methods here are now passed a
+   RecursiveIteratorIterator containing an InheritDataAwareIterator by default,
+   so you don't need to handle forms inheriting their parent data (former
+   "virtual forms") in the data mapper anymore.
+
+   Before:
+
+   ```
+   use Symfony\Component\Form\Util\VirtualFormAwareIterator;
+
+   public function mapFormsToData(array $forms, $data)
+   {
+       $iterator = new \RecursiveIteratorIterator(
+           new VirtualFormAwareIterator($forms)
+       );
+
+       foreach ($iterator as $form) {
+           // ...
+       }
+   }
+   ```
+
+   After:
+
+   ```
+   public function mapFormsToData($forms, $data)
+   {
+       foreach ($forms as $form) {
+           // ...
+       }
+   }
    ```
 
 ### PropertyAccess

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -57,6 +57,42 @@ UPGRADE FROM 2.x to 3.0
    }
    ```
 
+ * The option "virtual" was renamed to "inherit_data".
+
+   Before:
+
+   ```
+   $builder->add('address', 'form', array(
+       'virtual' => true,
+   ));
+   ```
+
+   After:
+
+   ```
+   $builder->add('address', 'form', array(
+       'inherit_data' => true,
+   ));
+   ```
+
+ * The class VirtualFormAwareIterator was renamed to InheritDataAwareIterator.
+
+   Before:
+
+   ```
+   use Symfony\Component\Form\Util\VirtualFormAwareIterator;
+
+   $iterator = new VirtualFormAwareIterator($forms);
+   ```
+
+   After:
+
+   ```
+   use Symfony\Component\Form\Util\InheritDataAwareIterator;
+
+   $iterator = new InheritDataAwareIterator($forms);
+   ```
+
 ### FrameworkBundle
 
  * The `enctype` method of the `form` helper was removed. You should use the

--- a/src/Symfony/Component/Form/ButtonBuilder.php
+++ b/src/Symfony/Component/Form/ButtonBuilder.php
@@ -493,6 +493,18 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
     }
 
     /**
+     * Unsupported method.
+     *
+     * @param Boolean $inheritData
+     *
+     * @throws \BadMethodCallException
+     */
+    public function setInheritData($inheritData)
+    {
+        throw new \BadMethodCallException('Buttons do not support data inheritance.');
+    }
+
+    /**
      * Builds and returns the button configuration.
      *
      * @return FormConfigInterface
@@ -755,6 +767,16 @@ class ButtonBuilder implements \IteratorAggregate, FormBuilderInterface
      * @return null Always returns null.
      */
     public function getFormProcessor()
+    {
+        return null;
+    }
+
+    /**
+     * Unsupported method.
+     *
+     * @return null Always returns null.
+     */
+    public function getInheritData()
     {
         return null;
     }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,9 @@ CHANGELOG
  * deprecated passing a Request instance to FormInterface::bind()
  * added options "method" and "action" to FormType
  * deprecated option "virtual", renamed it to "inherit_data"
+ * deprecated VirtualFormAwareIterator in favor of InheritDataAwareIterator
+ * [BC BREAK] removed the "array" type hint from DataMapperInterface
+ * improved forms inheriting their parent data to actually return that data from getData(), getNormData() and getViewData()
 
 2.2.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * added FormProcessorInterface and FormInterface::process()
  * deprecated passing a Request instance to FormInterface::bind()
  * added options "method" and "action" to FormType
+ * deprecated option "virtual", renamed it to "inherit_data"
 
 2.2.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,7 +9,7 @@ CHANGELOG
  * added FormProcessorInterface and FormInterface::process()
  * deprecated passing a Request instance to FormInterface::bind()
  * added options "method" and "action" to FormType
- * deprecated option "virtual", renamed it to "inherit_data"
+ * deprecated option "virtual" in favor "inherit_data"
  * deprecated VirtualFormAwareIterator in favor of InheritDataAwareIterator
  * [BC BREAK] removed the "array" type hint from DataMapperInterface
  * improved forms inheriting their parent data to actually return that data from getData(), getNormData() and getViewData()

--- a/src/Symfony/Component/Form/DataMapperInterface.php
+++ b/src/Symfony/Component/Form/DataMapperInterface.php
@@ -19,20 +19,20 @@ interface DataMapperInterface
     /**
      * Maps properties of some data to a list of forms.
      *
-     * @param mixed $data  Structured data.
-     * @param array $forms A list of {@link FormInterface} instances.
+     * @param mixed           $data  Structured data.
+     * @param FormInterface[] $forms A list of {@link FormInterface} instances.
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
      */
-    public function mapDataToForms($data, array $forms);
+    public function mapDataToForms($data, $forms);
 
     /**
      * Maps the data of a list of forms into the properties of some data.
      *
-     * @param array $forms A list of {@link FormInterface} instances.
-     * @param mixed $data  Structured data.
+     * @param FormInterface[] $forms A list of {@link FormInterface} instances.
+     * @param mixed           $data  Structured data.
      *
      * @throws Exception\UnexpectedTypeException if the type of the data parameter is not supported.
      */
-    public function mapFormsToData(array $forms, &$data);
+    public function mapFormsToData($forms, &$data);
 }

--- a/src/Symfony/Component/Form/Exception/RuntimeException.php
+++ b/src/Symfony/Component/Form/Exception/RuntimeException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Exception;
+
+/**
+ * Base RuntimeException for the Form component.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class RuntimeException extends \RuntimeException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -56,7 +56,7 @@ class PropertyPathMapper implements DataMapperInterface
         $iterator = new \RecursiveIteratorIterator($iterator);
 
         foreach ($iterator as $form) {
-            /* @var FormInterface $form */
+            /* @var \Symfony\Component\Form\FormInterface $form */
             $propertyPath = $form->getPropertyPath();
             $config = $form->getConfig();
 
@@ -83,7 +83,7 @@ class PropertyPathMapper implements DataMapperInterface
         $iterator = new \RecursiveIteratorIterator($iterator);
 
         foreach ($iterator as $form) {
-            /* @var FormInterface $form */
+            /* @var \Symfony\Component\Form\FormInterface $form */
             $propertyPath = $form->getPropertyPath();
             $config = $form->getConfig();
 

--- a/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataMapper/PropertyPathMapper.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Extension\Core\DataMapper;
 
 use Symfony\Component\Form\DataMapperInterface;
-use Symfony\Component\Form\Util\VirtualFormAwareIterator;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
@@ -42,7 +41,7 @@ class PropertyPathMapper implements DataMapperInterface
     /**
      * {@inheritdoc}
      */
-    public function mapDataToForms($data, array $forms)
+    public function mapDataToForms($data, $forms)
     {
         if (null === $data || array() === $data) {
             return;
@@ -52,11 +51,7 @@ class PropertyPathMapper implements DataMapperInterface
             throw new UnexpectedTypeException($data, 'object, array or empty');
         }
 
-        $iterator = new VirtualFormAwareIterator($forms);
-        $iterator = new \RecursiveIteratorIterator($iterator);
-
-        foreach ($iterator as $form) {
-            /* @var \Symfony\Component\Form\FormInterface $form */
+        foreach ($forms as $form) {
             $propertyPath = $form->getPropertyPath();
             $config = $form->getConfig();
 
@@ -69,7 +64,7 @@ class PropertyPathMapper implements DataMapperInterface
     /**
      * {@inheritdoc}
      */
-    public function mapFormsToData(array $forms, &$data)
+    public function mapFormsToData($forms, &$data)
     {
         if (null === $data) {
             return;
@@ -79,11 +74,7 @@ class PropertyPathMapper implements DataMapperInterface
             throw new UnexpectedTypeException($data, 'object, array or empty');
         }
 
-        $iterator = new VirtualFormAwareIterator($forms);
-        $iterator = new \RecursiveIteratorIterator($iterator);
-
-        foreach ($iterator as $form) {
-            /* @var \Symfony\Component\Form\FormInterface $form */
+        foreach ($forms as $form) {
             $propertyPath = $form->getPropertyPath();
             $config = $form->getConfig();
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -48,7 +48,7 @@ class FormType extends BaseType
             ->setPropertyPath($options['property_path'])
             ->setMapped($options['mapped'])
             ->setByReference($options['by_reference'])
-            ->setVirtual($options['virtual'])
+            ->setInheritData($options['inherit_data'])
             ->setCompound($options['compound'])
             ->setData(isset($options['data']) ? $options['data'] : null)
             ->setDataLocked(isset($options['data']))
@@ -95,8 +95,8 @@ class FormType extends BaseType
             'size'       => null,
             'label_attr' => $options['label_attr'],
             'compound'   => $form->getConfig()->getCompound(),
-            'method'              => $form->getConfig()->getMethod(),
-            'action'              => $form->getConfig()->getAction(),
+            'method'     => $form->getConfig()->getMethod(),
+            'action'     => $form->getConfig()->getAction(),
         ));
     }
 
@@ -169,7 +169,7 @@ class FormType extends BaseType
             'by_reference'       => true,
             'error_bubbling'     => $errorBubbling,
             'label_attr'         => array(),
-            'virtual'            => false,
+            'inherit_data'       => false,
             'compound'           => true,
             'method'             => 'POST',
             // According to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt)

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -150,6 +150,18 @@ class FormType extends BaseType
             return $options['compound'];
         };
 
+        // BC with old "virtual" option
+        $inheritData = function (Options $options) {
+            if (null !== $options['virtual']) {
+                // Uncomment this as soon as the deprecation note should be shown
+                // trigger_error('The form option "virtual" is deprecated since version 2.3 and will be removed in 3.0. Use "inherit_data" instead.', E_USER_DEPRECATED);
+
+                return $options['virtual'];
+            }
+
+            return false;
+        };
+
         // If data is given, the form is locked to that data
         // (independent of its value)
         $resolver->setOptional(array(
@@ -169,7 +181,8 @@ class FormType extends BaseType
             'by_reference'       => true,
             'error_bubbling'     => $errorBubbling,
             'label_attr'         => array(),
-            'inherit_data'       => false,
+            'virtual'            => null,
+            'inherit_data'       => $inheritData,
             'compound'           => true,
             'method'             => 'POST',
             // According to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt)

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -88,8 +88,8 @@ class ViolationMapper implements ViolationMapperInterface
         }
 
         // This case happens if an error happened in the data under a
-        // virtual form that does not match any of the children of
-        // the virtual form.
+        // form inheriting its parent data that does not match any of the
+        // children of that form.
         if (null !== $violationPath && !$match) {
             // If we could not map the error to anything more specific
             // than the root element, map it to the innermost directly
@@ -162,7 +162,7 @@ class ViolationMapper implements ViolationMapperInterface
             }
         }
 
-        // Ignore virtual forms when iterating the children
+        // Skip forms inheriting their parent data when iterating the children
         $childIterator = new \RecursiveIteratorIterator(
             new VirtualFormAwareIterator($form->all())
         );
@@ -253,8 +253,8 @@ class ViolationMapper implements ViolationMapperInterface
             // Process child form
             $scope = $scope->get($it->current());
 
-            if ($scope->getConfig()->getVirtual()) {
-                // Form is virtual
+            if ($scope->getConfig()->getInheritData()) {
+                // Form inherits its parent data
                 // Cut the piece out of the property path and proceed
                 $propertyPathBuilder->remove($i);
             } elseif (!$scope->getConfig()->getMapped()) {

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationMapper.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Form\Extension\Validator\ViolationMapper;
 
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\Form\Util\VirtualFormAwareIterator;
+use Symfony\Component\Form\Util\InheritDataAwareIterator;
 use Symfony\Component\PropertyAccess\PropertyPathIterator;
 use Symfony\Component\PropertyAccess\PropertyPathBuilder;
 use Symfony\Component\PropertyAccess\PropertyPathIteratorInterface;
@@ -100,6 +100,9 @@ class ViolationMapper implements ViolationMapperInterface
             $scope = $form;
             $it = new ViolationPathIterator($violationPath);
 
+            // Note: acceptsErrors() will always return true for forms inheriting
+            // their parent data, because these forms can never be non-synchronized
+            // (they don't do any data transformation on their own)
             while ($this->acceptsErrors($scope) && $it->valid() && $it->mapsForm()) {
                 if (!$scope->has($it->current())) {
                     // Break if we find a reference to a non-existing child
@@ -164,7 +167,7 @@ class ViolationMapper implements ViolationMapperInterface
 
         // Skip forms inheriting their parent data when iterating the children
         $childIterator = new \RecursiveIteratorIterator(
-            new VirtualFormAwareIterator($form->all())
+            new InheritDataAwareIterator($form->all())
         );
 
         // Make the path longer until we find a matching child

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -80,7 +80,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * @var Boolean
      */
-    private $virtual = false;
+    private $inheritData = false;
 
     /**
      * @var Boolean
@@ -341,9 +341,24 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
+    public function getInheritData()
+    {
+        return $this->inheritData;
+    }
+
+    /**
+     * Alias of {@link getInheritData()}.
+     *
+     * @return FormConfigBuilder The configuration object.
+     *
+     * @deprecated Deprecated since version 2.2, to be removed in 2.3. Use
+     *             {@link getInheritData()} instead.
+     */
     public function getVirtual()
     {
-        return $this->virtual;
+        trigger_error('getVirtual() is deprecated since version 2.2 and will be removed in 2.3. Use getInheritData() instead.', E_USER_DEPRECATED);
+
+        return $this->getInheritData();
     }
 
     /**
@@ -676,15 +691,32 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     /**
      * {@inheritdoc}
      */
-    public function setVirtual($virtual)
+    public function setInheritData($inheritData)
     {
         if ($this->locked) {
             throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
-        $this->virtual = $virtual;
+        $this->inheritData = $inheritData;
 
         return $this;
+    }
+
+    /**
+     * Alias of {@link setInheritData()}.
+     *
+     * @param Boolean $inheritData Whether the form should inherit its parent's data.
+     *
+     * @return FormConfigBuilder The configuration object.
+     *
+     * @deprecated Deprecated since version 2.2, to be removed in 2.3. Use
+     *             {@link setInheritData()} instead.
+     */
+    public function setVirtual($inheritData)
+    {
+        trigger_error('setVirtual() is deprecated since version 2.2 and will be removed in 2.3. Use setInheritData() instead.', E_USER_DEPRECATED);
+
+        $this->setInheritData($inheritData);
     }
 
     /**

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -351,12 +351,13 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @deprecated Deprecated since version 2.2, to be removed in 2.3. Use
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
      *             {@link getInheritData()} instead.
      */
     public function getVirtual()
     {
-        trigger_error('getVirtual() is deprecated since version 2.2 and will be removed in 2.3. Use getInheritData() instead.', E_USER_DEPRECATED);
+        // Uncomment this as soon as the deprecation note should be shown
+        // trigger_error('getVirtual() is deprecated since version 2.3 and will be removed in 3.0. Use getInheritData() instead.', E_USER_DEPRECATED);
 
         return $this->getInheritData();
     }
@@ -709,12 +710,13 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @deprecated Deprecated since version 2.2, to be removed in 2.3. Use
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
      *             {@link setInheritData()} instead.
      */
     public function setVirtual($inheritData)
     {
-        trigger_error('setVirtual() is deprecated since version 2.2 and will be removed in 2.3. Use setInheritData() instead.', E_USER_DEPRECATED);
+        // Uncomment this as soon as the deprecation note should be shown
+        // trigger_error('setVirtual() is deprecated since version 2.3 and will be removed in 3.0. Use setInheritData() instead.', E_USER_DEPRECATED);
 
         $this->setInheritData($inheritData);
     }

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -180,13 +180,13 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setByReference($byReference);
 
     /**
-     * Sets whether the form should be virtual.
+     * Sets whether the form should read and write the data of its parent.
      *
-     * @param Boolean $virtual Whether the form should be virtual.
+     * @param Boolean $inheritData Whether the form should inherit its parent's data.
      *
      * @return self The configuration object.
      */
-    public function setVirtual($virtual);
+    public function setInheritData($inheritData);
 
     /**
      * Sets whether the form should be compound.

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -55,15 +55,11 @@ interface FormConfigInterface
     public function getByReference();
 
     /**
-     * Returns whether the form should be virtual.
+     * Returns whether the form should read and write the data of its parent.
      *
-     * When mapping data to the children of a form, the data mapper
-     * should ignore virtual forms and map to the children of the
-     * virtual form instead.
-     *
-     * @return Boolean Whether the form is virtual.
+     * @return Boolean Whether the form should inherit its parent's data.
      */
-    public function getVirtual();
+    public function getInheritData();
 
     /**
      * Returns whether the form is compound.

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -182,37 +182,6 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($form->getData());
     }
 
-    public function testMapDataToFormsSkipsFormsInheritingParentData()
-    {
-        $car = new \stdClass();
-        $engine = new \stdClass();
-        $propertyPath = $this->getPropertyPath('engine');
-
-        $this->propertyAccessor->expects($this->once())
-            ->method('getValue')
-            ->with($car, $propertyPath)
-            ->will($this->returnValue($engine));
-
-        $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
-        $config->setByReference(true);
-        $config->setInheritData(true);
-        $config->setCompound(true);
-        $config->setDataMapper($this->getDataMapper());
-        $form = $this->getForm($config);
-
-        $config = new FormConfigBuilder('engine', '\stdClass', $this->dispatcher);
-        $config->setByReference(true);
-        $config->setPropertyPath($propertyPath);
-        $child = $this->getForm($config);
-
-        $form->add($child);
-
-        $this->mapper->mapDataToForms($car, array($form));
-
-        $this->assertNull($form->getData());
-        $this->assertSame($engine, $child->getData());
-    }
-
     public function testMapFormsToDataWritesBackIfNotByReference()
     {
         $car = new \stdClass();
@@ -344,40 +313,6 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $config->setData($engine);
         $config->setDisabled(true);
         $form = $this->getForm($config);
-
-        $this->mapper->mapFormsToData(array($form), $car);
-    }
-
-    public function testMapFormsToDataSkipsFormsInheritingParentData()
-    {
-        $car = new \stdClass();
-        $engine = new \stdClass();
-        $parentPath = $this->getPropertyPath('name');
-        $childPath = $this->getPropertyPath('engine');
-
-        // getValue() and setValue() must never be invoked for $parentPath
-
-        $this->propertyAccessor->expects($this->once())
-            ->method('getValue')
-            ->with($car, $childPath);
-        $this->propertyAccessor->expects($this->once())
-            ->method('setValue')
-            ->with($car, $childPath, $engine);
-
-        $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
-        $config->setPropertyPath($parentPath);
-        $config->setInheritData(true);
-        $config->setCompound(true);
-        $config->setDataMapper($this->getDataMapper());
-        $form = $this->getForm($config);
-
-        $config = new FormConfigBuilder('engine', '\stdClass', $this->dispatcher);
-        $config->setByReference(true);
-        $config->setPropertyPath($childPath);
-        $config->setData($engine);
-        $child = $this->getForm($config);
-
-        $form->add($child);
 
         $this->mapper->mapFormsToData(array($form), $car);
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataMapper/PropertyPathMapperTest.php
@@ -182,7 +182,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($form->getData());
     }
 
-    public function testMapDataToFormsSkipsVirtualForms()
+    public function testMapDataToFormsSkipsFormsInheritingParentData()
     {
         $car = new \stdClass();
         $engine = new \stdClass();
@@ -195,7 +195,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
         $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
         $config->setByReference(true);
-        $config->setVirtual(true);
+        $config->setInheritData(true);
         $config->setCompound(true);
         $config->setDataMapper($this->getDataMapper());
         $form = $this->getForm($config);
@@ -348,7 +348,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
         $this->mapper->mapFormsToData(array($form), $car);
     }
 
-    public function testMapFormsToDataSkipsVirtualForms()
+    public function testMapFormsToDataSkipsFormsInheritingParentData()
     {
         $car = new \stdClass();
         $engine = new \stdClass();
@@ -366,7 +366,7 @@ class PropertyPathMapperTest extends \PHPUnit_Framework_TestCase
 
         $config = new FormConfigBuilder('name', '\stdClass', $this->dispatcher);
         $config->setPropertyPath($parentPath);
-        $config->setVirtual(true);
+        $config->setInheritData(true);
         $config->setCompound(true);
         $config->setDataMapper($this->getDataMapper());
         $form = $this->getForm($config);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -71,13 +71,13 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->params = array('foo' => 'bar');
     }
 
-    protected function getForm($name = 'name', $propertyPath = null, $dataClass = null, $errorMapping = array(), $virtual = false, $synchronized = true)
+    protected function getForm($name = 'name', $propertyPath = null, $dataClass = null, $errorMapping = array(), $inheritData = false, $synchronized = true)
     {
         $config = new FormConfigBuilder($name, $dataClass, $this->dispatcher, array(
             'error_mapping' => $errorMapping,
         ));
         $config->setMapped(true);
-        $config->setVirtual($virtual);
+        $config->setInheritData($inheritData);
         $config->setPropertyPath($propertyPath);
         $config->setCompound(true);
         $config->setDataMapper($this->getDataMapper());
@@ -118,7 +118,7 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         return new FormError($this->message, $this->messageTemplate, $this->params);
     }
 
-    public function testMapToVirtualFormIfDataDoesNotMatch()
+    public function testMapToFormInheritingParentDataIfDataDoesNotMatch()
     {
         $violation = $this->getConstraintViolation('children[address].data.foo');
         $parent = $this->getForm('parent');
@@ -183,7 +183,7 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName().' should not have an error, but has one');
     }
 
-    public function testAbortVirtualFormMappingIfNotSynchronized()
+    public function testAbortFormInheritingParentDataMappingIfNotSynchronized()
     {
         $violation = $this->getConstraintViolation('children[address].children[street].data.foo');
         $parent = $this->getForm('parent');
@@ -1446,7 +1446,7 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function provideVirtualFormErrorTests()
+    public function provideFormInheritingParentDataErrorTests()
     {
         return array(
             // mapping target, child name, its property path, grand child name, its property path, violation path
@@ -1472,9 +1472,9 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideVirtualFormErrorTests
+     * @dataProvider provideFormInheritingParentDataErrorTests
      */
-    public function testVirtualFormErrorMapping($target, $childName, $childPath, $grandChildName, $grandChildPath, $violationPath)
+    public function testFormInheritingParentDataErrorMapping($target, $childName, $childPath, $grandChildName, $grandChildPath, $violationPath)
     {
         $violation = $this->getConstraintViolation($violationPath);
         $parent = $this->getForm('parent');

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -183,28 +183,6 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName().' should not have an error, but has one');
     }
 
-    public function testAbortFormInheritingParentDataMappingIfNotSynchronized()
-    {
-        $violation = $this->getConstraintViolation('children[address].children[street].data.foo');
-        $parent = $this->getForm('parent');
-        $child = $this->getForm('address', 'address', null, array(), true, false);
-        // even though "street" is synchronized, it should not have any errors
-        // due to its parent not being synchronized
-        $grandChild = $this->getForm('street' , 'street', null, array(), true);
-
-        $parent->add($child);
-        $child->add($grandChild);
-
-        // bind to invoke the transformer and mark the form unsynchronized
-        $parent->bind(array());
-
-        $this->mapper->mapViolation($violation, $parent);
-
-        $this->assertCount(0, $parent->getErrors(), $parent->getName().' should not have an error, but has one');
-        $this->assertCount(0, $child->getErrors(), $child->getName().' should not have an error, but has one');
-        $this->assertCount(0, $grandChild->getErrors(), $grandChild->getName().' should not have an error, but has one');
-    }
-
     public function testAbortDotRuleMappingIfNotSynchronized()
     {
         $violation = $this->getConstraintViolation('data.address');
@@ -1446,7 +1424,7 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         }
     }
 
-    public function provideFormInheritingParentDataErrorTests()
+    public function provideErrorTestsForFormInheritingParentData()
     {
         return array(
             // mapping target, child name, its property path, grand child name, its property path, violation path
@@ -1472,9 +1450,9 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider provideFormInheritingParentDataErrorTests
+     * @dataProvider provideErrorTestsForFormInheritingParentData
      */
-    public function testFormInheritingParentDataErrorMapping($target, $childName, $childPath, $grandChildName, $grandChildPath, $violationPath)
+    public function testErrorMappingForFormInheritingParentData($target, $childName, $childPath, $grandChildName, $grandChildPath, $violationPath)
     {
         $violation = $this->getConstraintViolation($violationPath);
         $parent = $this->getForm('parent');

--- a/src/Symfony/Component/Form/Util/InheritDataAwareIterator.php
+++ b/src/Symfony/Component/Form/Util/InheritDataAwareIterator.php
@@ -19,11 +19,8 @@ namespace Symfony\Component\Form\Util;
  * the form and traverses its children as well.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
- *
- * @deprecated Deprecated since version 2.2, to be removed in 2.3. Use
- *             {@link InheritDataAwareIterator} instead.
  */
-class VirtualFormAwareIterator extends \ArrayIterator implements \RecursiveIterator
+class InheritDataAwareIterator extends VirtualFormAwareIterator
 {
     /**
      * Creates a new iterator.
@@ -32,18 +29,7 @@ class VirtualFormAwareIterator extends \ArrayIterator implements \RecursiveItera
      */
     public function __construct(array $forms)
     {
-        trigger_error('VirtualFormAwareIterator is deprecated since version 2.2 and will be removed in 2.3. Use InheritDataAwareIterator instead.', E_USER_DEPRECATED);
-
-        parent::__construct($forms);
-    }
-
-    public function getChildren()
-    {
-        return new static($this->current()->all());
-    }
-
-    public function hasChildren()
-    {
-        return $this->current()->getConfig()->getInheritData();
+        // Skip the deprecation error
+        \ArrayIterator::__construct($forms);
     }
 }

--- a/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
+++ b/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
@@ -12,10 +12,11 @@
 namespace Symfony\Component\Form\Util;
 
 /**
- * Iterator that traverses fields of a field group
+ * Iterator that returns only forms from a form tree that do not inherit their
+ * parent data.
  *
- * If the iterator encounters a virtual field group, it enters the field
- * group and traverses its children as well.
+ * If the iterator encounters a form that inherits its parent data, it enters
+ * the form and traverses its children as well.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
@@ -28,6 +29,6 @@ class VirtualFormAwareIterator extends \ArrayIterator implements \RecursiveItera
 
     public function hasChildren()
     {
-        return $this->current()->getConfig()->getVirtual();
+        return $this->current()->getConfig()->getInheritData();
     }
 }

--- a/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
+++ b/src/Symfony/Component/Form/Util/VirtualFormAwareIterator.php
@@ -20,7 +20,7 @@ namespace Symfony\Component\Form\Util;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  *
- * @deprecated Deprecated since version 2.2, to be removed in 2.3. Use
+ * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
  *             {@link InheritDataAwareIterator} instead.
  */
 class VirtualFormAwareIterator extends \ArrayIterator implements \RecursiveIterator
@@ -32,7 +32,8 @@ class VirtualFormAwareIterator extends \ArrayIterator implements \RecursiveItera
      */
     public function __construct(array $forms)
     {
-        trigger_error('VirtualFormAwareIterator is deprecated since version 2.2 and will be removed in 2.3. Use InheritDataAwareIterator instead.', E_USER_DEPRECATED);
+        // Uncomment this as soon as the deprecation note should be shown
+        // trigger_error('VirtualFormAwareIterator is deprecated since version 2.3 and will be removed in 3.0. Use InheritDataAwareIterator instead.', E_USER_DEPRECATED);
 
         parent::__construct($forms);
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #5899, #5720, #5578
Todo: -
License of the code: MIT
Documentation PR: symfony/symfony-docs#2107

This PR renames the option "virtual" to "inherit_data" for more clarity (the old option is deprecated and usable until 2.3). It also fixes the behavior of forms having that option set.

Forms with that option set will now correctly return their parents' data from `getData()`, `getNormData()` and `getViewData()`. Furthermore, `getPropertyPath()` was fixed for forms that inherit their parent data.
