### PR TITLE
[Form] Removed separator characters between choice or text fields in DateType

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
  * TrimListener now removes unicode whitespaces
  * deprecated getParent(), setParent() and hasParent() in FormBuilderInterface
  * FormInterface::add() now accepts a FormInterface instance OR a field's name, type and options
+ * removed special characters between the choice or text fields of DateType unless
+   the option "format" is set to a custom value
 
 2.1.0
 -----

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -137,13 +137,18 @@ class DateType extends AbstractType
         if ($form->getConfig()->hasAttribute('formatter')) {
             $pattern = $form->getConfig()->getAttribute('formatter')->getPattern();
 
+            // remove special characters unless the format was explicitly specified
+            if (!is_string($options['format'])) {
+                $pattern = preg_replace('/[^yMd]+/', '', $pattern);
+            }
+
             // set right order with respect to locale (e.g.: de_DE=dd.MM.yy; en_US=M/d/yy)
             // lookup various formats at http://userguide.icu-project.org/formatparse/datetime
             if (preg_match('/^([yMd]+).+([yMd]+).+([yMd]+)$/', $pattern)) {
                 $pattern = preg_replace(array('/y+/', '/M+/', '/d+/'), array('{{ year }}', '{{ month }}', '{{ day }}'), $pattern);
             } else {
                 // default fallback
-                $pattern = '{{ year }}-{{ month }}-{{ day }}';
+                $pattern = '{{ year }}{{ month }}{{ day }}';
             }
 
             $view->vars['date_pattern'] = $pattern;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -24,21 +24,21 @@ class DateTypeTest extends LocalizedTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testInvalidWidgetOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $this->factory->create('date', null, array(
             'widget' => 'fake_widget',
         ));
     }
 
     /**
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testInvalidInputOption()
     {
-        $form = $this->factory->create('date', null, array(
+        $this->factory->create('date', null, array(
             'input' => 'fake_input',
         ));
     }
@@ -271,7 +271,7 @@ class DateTypeTest extends LocalizedTestCase
      * This test is to check that the strings '0', '1', '2', '3' are no accepted
      * as valid IntlDateFormatter constants for FULL, LONG, MEDIUM or SHORT respectively.
      *
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testThrowExceptionIfFormatIsNoPattern()
     {
@@ -283,7 +283,7 @@ class DateTypeTest extends LocalizedTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testThrowExceptionIfFormatDoesNotContainYearMonthAndDay()
     {
@@ -294,7 +294,7 @@ class DateTypeTest extends LocalizedTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testThrowExceptionIfFormatIsNoConstant()
     {
@@ -304,7 +304,7 @@ class DateTypeTest extends LocalizedTestCase
     }
 
     /**
-     * @expectedException Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
      */
     public function testThrowExceptionIfFormatIsInvalid()
     {
@@ -510,7 +510,7 @@ class DateTypeTest extends LocalizedTestCase
         $form = $this->factory->create('date');
         $view = $form->createView();
 
-        $this->assertSame('{{ day }}.{{ month }}.{{ year }}', $view->vars['date_pattern']);
+        $this->assertSame('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
     }
 
     public function testPassDatePatternToViewDifferentFormat()
@@ -521,10 +521,21 @@ class DateTypeTest extends LocalizedTestCase
 
         $view = $form->createView();
 
-        $this->assertSame('{{ day }}. {{ month }} {{ year }}', $view->vars['date_pattern']);
+        $this->assertSame('{{ day }}{{ month }}{{ year }}', $view->vars['date_pattern']);
     }
 
     public function testPassDatePatternToViewDifferentPattern()
+    {
+        $form = $this->factory->create('date', null, array(
+            'format' => 'MMyyyydd'
+        ));
+
+        $view = $form->createView();
+
+        $this->assertSame('{{ month }}{{ year }}{{ day }}', $view->vars['date_pattern']);
+    }
+
+    public function testPassDatePatternToViewDifferentPatternWithSeparators()
     {
         $form = $this->factory->create('date', null, array(
             'format' => 'MM*yyyy*dd'


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

This commit was originally contained in #6217 (for 2.1) but then split away for master since it changes behavior.
