### PR TITLE
[Form] Deleted references in FormBuilder::getFormConfig() to improve performance

### DIFF
--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -205,6 +205,21 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     /**
      * {@inheritdoc}
      */
+    public function getFormConfig()
+    {
+        $config = parent::getFormConfig();
+
+        $config->factory = null;
+        $config->parent = null;
+        $config->children = array();
+        $config->unresolvedChildren = array();
+
+        return $config;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getForm()
     {
         $this->resolveChildren();

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -232,6 +232,30 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
         $this->builder->create('bar', 'text');
     }
 
+    public function testGetFormConfigErasesReferences()
+    {
+        $builder = new FormBuilder('name', null, $this->dispatcher, $this->factory);
+        $builder->setParent(new FormBuilder('parent', null, $this->dispatcher, $this->factory));
+        $builder->add(new FormBuilder('child', null, $this->dispatcher, $this->factory));
+
+        $config = $builder->getFormConfig();
+        $reflClass = new \ReflectionClass($config);
+        $factory = $reflClass->getProperty('factory');
+        $parent = $reflClass->getProperty('parent');
+        $children = $reflClass->getProperty('children');
+        $unresolvedChildren = $reflClass->getProperty('unresolvedChildren');
+
+        $factory->setAccessible(true);
+        $parent->setAccessible(true);
+        $children->setAccessible(true);
+        $unresolvedChildren->setAccessible(true);
+
+        $this->assertNull($factory->getValue($config));
+        $this->assertNull($parent->getValue($config));
+        $this->assertEmpty($children->getValue($config));
+        $this->assertEmpty($unresolvedChildren->getValue($config));
+    }
+
     private function getFormBuilder($name = 'name')
     {
         $mock = $this->getMockBuilder('Symfony\Component\Form\FormBuilder')


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6558
Todo: -
License of the code: MIT
Documentation PR: -
