### PR TITLE
[Form] Protected methods in FormConfigBuilder and FormBuilder

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -57,6 +57,13 @@
 
  * The PasswordType is now not trimmed by default.
 
+ * The class FormException is now an interface. The old class is still available
+   under the name Symfony\Component\Form\Exception\Exception, but will probably
+   be removed before 2.2. If you created FormException instances manually,
+   you are now advised to create any of the other exceptions in the
+   Symfony\Component\Form\Exception namespace or to create custom exception
+   classes for your purpose.
+
 #### Deprecations
 
  * The methods `getParent()`, `setParent()` and `hasParent()` in

--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Form\ChoiceList;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\StringCastException;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -387,12 +387,12 @@ class EntityChoiceList extends ObjectChoiceList
      *
      * @return array          The identifier values
      *
-     * @throws FormException  If the entity does not exist in Doctrine's identity map
+     * @throws Exception If the entity does not exist in Doctrine's identity map
      */
     private function getIdentifierValues($entity)
     {
         if (!$this->em->contains($entity)) {
-            throw new FormException(
+            throw new Exception(
                 'Entities passed to the choice field must be managed. Maybe ' .
                 'persist them in the entity manager?'
             );

--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Form\Type;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Bridge\Doctrine\Form\ChoiceList\EntityChoiceList;
@@ -134,7 +134,7 @@ abstract class DoctrineType extends AbstractType
             $em = $registry->getManagerForClass($options['class']);
 
             if (null === $em) {
-                throw new FormException(sprintf(
+                throw new Exception(sprintf(
                     'Class "%s" seems not to be a managed Doctrine entity. ' .
                     'Did you forget to map it?',
                     $options['class']

--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
@@ -53,7 +53,7 @@ abstract class AbstractExtension implements FormExtensionInterface
         }
 
         if (!isset($this->types[$name])) {
-            throw new FormException(sprintf('The type "%s" can not be loaded by this extension', $name));
+            throw new Exception(sprintf('The type "%s" can not be loaded by this extension', $name));
         }
 
         return $this->types[$name];

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
  * removed special characters between the choice or text fields of DateType unless
    the option "format" is set to a custom value
  * deprecated FormException and introduced ExceptionInterface instead
+ * [BC BREAK] FormException is now an interface
+ * protected FormBuilder methods from being called when it is turned into a FormConfigInterface with getFormConfig()
 
 2.1.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -9,6 +9,7 @@ CHANGELOG
  * FormInterface::add() now accepts a FormInterface instance OR a field's name, type and options
  * removed special characters between the choice or text fields of DateType unless
    the option "format" is set to a custom value
+ * deprecated FormException and introduced ExceptionInterface instead
 
 2.1.0
 -----

--- a/src/Symfony/Component/Form/Exception/AlreadyBoundException.php
+++ b/src/Symfony/Component/Form/Exception/AlreadyBoundException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class AlreadyBoundException extends FormException
+class AlreadyBoundException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/BadMethodCallException.php
+++ b/src/Symfony/Component/Form/Exception/BadMethodCallException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Exception;
+
+/**
+ * Base BadMethodCallException for the Form component.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+class BadMethodCallException extends \BadMethodCallException implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Form/Exception/CreationException.php
+++ b/src/Symfony/Component/Form/Exception/CreationException.php
@@ -16,6 +16,6 @@ namespace Symfony\Component\Form\Exception;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class CreationException extends FormException
+class CreationException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/ErrorMappingException.php
+++ b/src/Symfony/Component/Form/Exception/ErrorMappingException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class ErrorMappingException extends FormException
+class ErrorMappingException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/Exception.php
+++ b/src/Symfony/Component/Form/Exception/Exception.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Exception;
+
+/**
+ * Base exception class.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated This class is a replacement for when class FormException was
+ *             used previously. It should not be used and will be removed.
+ *             Occurrences of this class should be replaced by more specialized
+ *             exception classes, preferably derived from SPL exceptions.
+ */
+class Exception extends \Exception implements ExceptionInterface
+{
+}

--- a/src/Symfony/Component/Form/Exception/ExceptionInterface.php
+++ b/src/Symfony/Component/Form/Exception/ExceptionInterface.php
@@ -12,10 +12,10 @@
 namespace Symfony\Component\Form\Exception;
 
 /**
- * Thrown when a form type is configured incorrectly
+ * Base ExceptionInterface for the Form component.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class TypeDefinitionException extends Exception
+interface ExceptionInterface extends FormException
 {
 }

--- a/src/Symfony/Component/Form/Exception/FormException.php
+++ b/src/Symfony/Component/Form/Exception/FormException.php
@@ -11,6 +11,14 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class FormException extends \Exception
+/**
+ * Alias of {@link ExceptionInterface}.
+ *
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ *
+ * @deprecated This interface was deprecated and will be removed in Symfony 2.3.
+ *             You should code against {@link ExceptionInterface} instead.
+ */
+interface FormException
 {
 }

--- a/src/Symfony/Component/Form/Exception/InvalidConfigurationException.php
+++ b/src/Symfony/Component/Form/Exception/InvalidConfigurationException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class InvalidConfigurationException extends FormException
+class InvalidConfigurationException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/InvalidPropertyException.php
+++ b/src/Symfony/Component/Form/Exception/InvalidPropertyException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class InvalidPropertyException extends FormException
+class InvalidPropertyException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/InvalidPropertyPathException.php
+++ b/src/Symfony/Component/Form/Exception/InvalidPropertyPathException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class InvalidPropertyPathException extends FormException
+class InvalidPropertyPathException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/NotInitializedException.php
+++ b/src/Symfony/Component/Form/Exception/NotInitializedException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class NotInitializedException extends FormException
+class NotInitializedException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/NotValidException.php
+++ b/src/Symfony/Component/Form/Exception/NotValidException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class NotValidException extends FormException
+class NotValidException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/PropertyAccessDeniedException.php
+++ b/src/Symfony/Component/Form/Exception/PropertyAccessDeniedException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class PropertyAccessDeniedException extends FormException
+class PropertyAccessDeniedException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/StringCastException.php
+++ b/src/Symfony/Component/Form/Exception/StringCastException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class StringCastException extends FormException
+class StringCastException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/TransformationFailedException.php
+++ b/src/Symfony/Component/Form/Exception/TransformationFailedException.php
@@ -14,8 +14,8 @@ namespace Symfony\Component\Form\Exception;
 /**
  * Indicates a value transformation error.
  *
- * @author     Bernhard Schussek <bschussek@gmail.com>
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class TransformationFailedException extends \RuntimeException
+class TransformationFailedException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Symfony/Component/Form/Exception/TypeLoaderException.php
+++ b/src/Symfony/Component/Form/Exception/TypeLoaderException.php
@@ -11,6 +11,6 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class TypeLoaderException extends FormException
+class TypeLoaderException extends Exception
 {
 }

--- a/src/Symfony/Component/Form/Exception/UnexpectedTypeException.php
+++ b/src/Symfony/Component/Form/Exception/UnexpectedTypeException.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Exception;
 
-class UnexpectedTypeException extends FormException
+class UnexpectedTypeException extends Exception
 {
     public function __construct($value, $expectedType)
     {

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Extension\Core\ChoiceList;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 
 /**
  * A choice list that is loaded lazily
@@ -141,7 +141,7 @@ abstract class LazyChoiceList implements ChoiceListInterface
         $choiceList = $this->loadChoiceList();
 
         if (!$choiceList instanceof ChoiceListInterface) {
-            throw new FormException('loadChoiceList() should return a ChoiceListInterface instance. Got ' . gettype($choiceList));
+            throw new Exception('loadChoiceList() should return a ChoiceListInterface instance. Got ' . gettype($choiceList));
         }
 
         $this->choiceList = $choiceList;

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
 use Symfony\Component\Form\Extension\Core\EventListener\FixRadioInputListener;
 use Symfony\Component\Form\Extension\Core\EventListener\FixCheckboxInputListener;
@@ -41,7 +41,7 @@ class ChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if (!$options['choice_list'] && !is_array($options['choices']) && !$options['choices'] instanceof \Traversable) {
-            throw new FormException('Either the option "choices" or "choice_list" must be set.');
+            throw new Exception('Either the option "choices" or "choice_list" must be set.');
         }
 
         if ($options['expanded']) {

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -17,7 +17,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Extension\Core\EventListener\TrimListener;
 use Symfony\Component\Form\Extension\Core\DataMapper\PropertyPathMapper;
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
@@ -61,7 +61,7 @@ class FormType extends AbstractType
 
         if ($view->parent) {
             if ('' === $name) {
-                throw new FormException('Form node with empty name can be used only as root form node.');
+                throw new Exception('Form node with empty name can be used only as root form node.');
             }
 
             if ('' !== ($parentFullName = $view->parent->vars['full_name'])) {

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Extension\HttpFoundation\EventListener;
 
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -74,7 +74,7 @@ class BindRequestListener implements EventSubscriberInterface
                 break;
 
             default:
-                throw new FormException(sprintf(
+                throw new Exception(sprintf(
                     'The request method "%s" is not supported',
                     $request->getMethod()
                 ));

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Exception\AlreadyBoundException;
 use Symfony\Component\Form\Exception\TransformationFailedException;
@@ -152,7 +152,7 @@ class Form implements \IteratorAggregate, FormInterface
         // `setData` and `add` will not lead to the correct population of
         // the child forms.
         if ($config->getCompound() && !$config->getDataMapper()) {
-            throw new FormException('Compound forms need a data mapper');
+            throw new Exception('Compound forms need a data mapper');
         }
 
         $this->config = $config;
@@ -256,7 +256,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if (null !== $parent && '' === $this->config->getName()) {
-            throw new FormException('A form with an empty name cannot have a parent form.');
+            throw new Exception('A form with an empty name cannot have a parent form.');
         }
 
         $this->parent = $parent;
@@ -359,7 +359,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if ($this->lockSetData) {
-            throw new FormException('A cycle was detected. Listeners to the PRE_SET_DATA event must not call setData(). You should call setData() on the FormEvent object instead.');
+            throw new Exception('A cycle was detected. Listeners to the PRE_SET_DATA event must not call setData(). You should call setData() on the FormEvent object instead.');
         }
 
         $this->lockSetData = true;
@@ -394,7 +394,7 @@ class Form implements \IteratorAggregate, FormInterface
             if (null === $dataClass && is_object($viewData) && !$viewData instanceof \ArrayAccess) {
                 $expectedType = 'scalar, array or an instance of \ArrayAccess';
 
-                throw new FormException(
+                throw new Exception(
                     'The form\'s view data is expected to be of type ' . $expectedType . ', ' .
                     'but is ' . $actualType . '. You ' .
                     'can avoid this error by setting the "data_class" option to ' .
@@ -404,7 +404,7 @@ class Form implements \IteratorAggregate, FormInterface
             }
 
             if (null !== $dataClass && !$viewData instanceof $dataClass) {
-                throw new FormException(
+                throw new Exception(
                     'The form\'s view data is expected to be an instance of class ' .
                     $dataClass . ', but is '. $actualType . '. You can avoid this error ' .
                     'by setting the "data_class" option to null or by adding a view ' .
@@ -867,7 +867,7 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         if (!$this->config->getCompound()) {
-            throw new FormException('You cannot add children to a simple form. Maybe you should set the option "compound" to true?');
+            throw new Exception('You cannot add children to a simple form. Maybe you should set the option "compound" to true?');
         }
 
         // Obtain the view data

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -65,7 +66,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function add($child, $type = null, array $options = array())
     {
         if ($this->locked) {
-            throw new Exception('The form builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         if ($child instanceof self) {
@@ -102,7 +103,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function create($name, $type = null, array $options = array())
     {
         if ($this->locked) {
-            throw new Exception('The form builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         if (null === $type && null === $this->getDataClass()) {
@@ -121,6 +122,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function get($name)
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         if (isset($this->unresolvedChildren[$name])) {
             return $this->resolveChild($name);
         }
@@ -138,7 +143,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function remove($name)
     {
         if ($this->locked) {
-            throw new Exception('The form builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         unset($this->unresolvedChildren[$name]);
@@ -158,6 +163,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function has($name)
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         if (isset($this->unresolvedChildren[$name])) {
             return true;
         }
@@ -174,6 +183,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function all()
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         $this->resolveChildren();
 
         return $this->children;
@@ -184,6 +197,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function count()
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         return count($this->children);
     }
 
@@ -192,6 +209,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function getForm()
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         $this->resolveChildren();
 
         $form = new Form($this->getFormConfig());
@@ -208,6 +229,10 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function getParent()
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         return $this->parent;
     }
 
@@ -217,7 +242,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function setParent(FormBuilderInterface $parent = null)
     {
         if ($this->locked) {
-            throw new Exception('The form builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->parent = $parent;
@@ -230,7 +255,51 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function hasParent()
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         return null !== $this->parent;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
+        return new \ArrayIterator($this->children);
+    }
+
+    /**
+     * Returns the types used by this builder.
+     *
+     * @return FormTypeInterface[] An array of FormTypeInterface
+     *
+     * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
+     *             {@link FormConfigInterface::getType()} instead.
+     *
+     * @throws BadMethodCallException If the builder was turned into a {@link FormConfigInterface}
+     *                                via {@link getFormConfig()}.
+     */
+    public function getTypes()
+    {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
+        trigger_error('getTypes() is deprecated since version 2.1 and will be removed in 2.3. Use getConfig() and FormConfigInterface::getType() instead.', E_USER_DEPRECATED);
+
+        $types = array();
+
+        for ($type = $this->getType(); null !== $type; $type = $type->getParent()) {
+            array_unshift($types, $type->getInnerType());
+        }
+
+        return $types;
     }
 
     /**
@@ -260,34 +329,5 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
         }
 
         $this->unresolvedChildren = array();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getIterator()
-    {
-        return new \ArrayIterator($this->children);
-    }
-
-    /**
-     * Returns the types used by this builder.
-     *
-     * @return FormTypeInterface[] An array of FormTypeInterface
-     *
-     * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
-     *             {@link FormConfigInterface::getType()} instead.
-     */
-    public function getTypes()
-    {
-        trigger_error('getTypes() is deprecated since version 2.1 and will be removed in 2.3. Use getConfig() and FormConfigInterface::getType() instead.', E_USER_DEPRECATED);
-
-        $types = array();
-
-        for ($type = $this->getType(); null !== $type; $type = $type->getParent()) {
-            array_unshift($types, $type->getInnerType());
-        }
-
-        return $types;
     }
 }

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -65,7 +65,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function add($child, $type = null, array $options = array())
     {
         if ($this->locked) {
-            throw new FormException('The form builder cannot be modified anymore.');
+            throw new Exception('The form builder cannot be modified anymore.');
         }
 
         if ($child instanceof self) {
@@ -102,7 +102,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function create($name, $type = null, array $options = array())
     {
         if ($this->locked) {
-            throw new FormException('The form builder cannot be modified anymore.');
+            throw new Exception('The form builder cannot be modified anymore.');
         }
 
         if (null === $type && null === $this->getDataClass()) {
@@ -129,7 +129,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
             return $this->children[$name];
         }
 
-        throw new FormException(sprintf('The child with the name "%s" does not exist.', $name));
+        throw new Exception(sprintf('The child with the name "%s" does not exist.', $name));
     }
 
     /**
@@ -138,7 +138,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function remove($name)
     {
         if ($this->locked) {
-            throw new FormException('The form builder cannot be modified anymore.');
+            throw new Exception('The form builder cannot be modified anymore.');
         }
 
         unset($this->unresolvedChildren[$name]);
@@ -217,7 +217,7 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
     public function setParent(FormBuilderInterface $parent = null)
     {
         if ($this->locked) {
-            throw new FormException('The form builder cannot be modified anymore.');
+            throw new Exception('The form builder cannot be modified anymore.');
         }
 
         $this->parent = $parent;

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Form\Util\PropertyPathInterface;
@@ -172,7 +172,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addEventListener($eventName, $listener, $priority = 0)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->dispatcher->addListener($eventName, $listener, $priority);
@@ -186,7 +186,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addEventSubscriber(EventSubscriberInterface $subscriber)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->dispatcher->addSubscriber($subscriber);
@@ -202,7 +202,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('addValidator() is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->validators[] = $validator;
@@ -216,7 +216,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addViewTransformer(DataTransformerInterface $viewTransformer, $forcePrepend = false)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         if ($forcePrepend) {
@@ -234,7 +234,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function resetViewTransformers()
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->viewTransformers = array();
@@ -249,7 +249,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws FormException if the form configuration is locked
+     * @throws Exception if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link addViewTransformer()} instead.
@@ -259,7 +259,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('appendClientTransformer() is deprecated since version 2.1 and will be removed in 2.3. Use addViewTransformer() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         return $this->addViewTransformer($viewTransformer);
@@ -272,7 +272,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws FormException if the form configuration is locked
+     * @throws Exception if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
@@ -281,7 +281,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('prependClientTransformer() is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         return $this->addViewTransformer($viewTransformer, true);
@@ -292,7 +292,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws FormException if the form configuration is locked
+     * @throws Exception if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link resetViewTransformers()} instead.
@@ -302,7 +302,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('resetClientTransformers() is deprecated since version 2.1 and will be removed in 2.3. Use resetViewTransformers() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         return $this->resetViewTransformers();
@@ -314,7 +314,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addModelTransformer(DataTransformerInterface $modelTransformer, $forceAppend = false)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         if ($forceAppend) {
@@ -332,7 +332,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function resetModelTransformers()
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->modelTransformers = array();
@@ -347,7 +347,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws FormException if the form configuration is locked
+     * @throws Exception if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
@@ -356,7 +356,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('appendNormTransformer() is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         return $this->addModelTransformer($modelTransformer, true);
@@ -369,7 +369,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws FormException if the form configuration is locked
+     * @throws Exception if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link addModelTransformer()} instead.
@@ -379,7 +379,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('prependNormTransformer() is deprecated since version 2.1 and will be removed in 2.3. Use addModelTransformer() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         return $this->addModelTransformer($modelTransformer);
@@ -390,7 +390,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws FormException if the form configuration is locked
+     * @throws Exception if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link resetModelTransformers()} instead.
@@ -400,7 +400,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('resetNormTransformers() is deprecated since version 2.1 and will be removed in 2.3. Use resetModelTransformers() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         return $this->resetModelTransformers();
@@ -652,7 +652,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setAttribute($name, $value)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->attributes[$name] = $value;
@@ -666,7 +666,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setAttributes(array $attributes)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->attributes = $attributes;
@@ -680,7 +680,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setDataMapper(DataMapperInterface $dataMapper = null)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->dataMapper = $dataMapper;
@@ -694,7 +694,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setDisabled($disabled)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->disabled = (Boolean) $disabled;
@@ -708,7 +708,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setEmptyData($emptyData)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->emptyData = $emptyData;
@@ -722,7 +722,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setErrorBubbling($errorBubbling)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->errorBubbling = null === $errorBubbling ? null : (Boolean) $errorBubbling;
@@ -736,7 +736,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setRequired($required)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->required = (Boolean) $required;
@@ -750,7 +750,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setPropertyPath($propertyPath)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         if (null !== $propertyPath && !$propertyPath instanceof PropertyPathInterface) {
@@ -768,7 +768,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setMapped($mapped)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->mapped = $mapped;
@@ -782,7 +782,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setByReference($byReference)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->byReference = $byReference;
@@ -796,7 +796,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setVirtual($virtual)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->virtual = $virtual;
@@ -810,7 +810,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setCompound($compound)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->compound = $compound;
@@ -824,7 +824,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setType(ResolvedFormTypeInterface $type)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->type = $type;
@@ -838,7 +838,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setData($data)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->data = $data;
@@ -852,7 +852,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setDataLocked($locked)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->dataLocked = $locked;
@@ -866,7 +866,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setFormFactory(FormFactoryInterface $formFactory)
     {
         if ($this->locked) {
-            throw new FormException('The config builder cannot be modified anymore.');
+            throw new Exception('The config builder cannot be modified anymore.');
         }
 
         $this->formFactory = $formFactory;

--- a/src/Symfony/Component/Form/FormConfigBuilder.php
+++ b/src/Symfony/Component/Form/FormConfigBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Exception\BadMethodCallException;
 use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Util\PropertyPath;
@@ -172,7 +173,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addEventListener($eventName, $listener, $priority = 0)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->dispatcher->addListener($eventName, $listener, $priority);
@@ -186,7 +187,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addEventSubscriber(EventSubscriberInterface $subscriber)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->dispatcher->addSubscriber($subscriber);
@@ -202,7 +203,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('addValidator() is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->validators[] = $validator;
@@ -216,7 +217,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addViewTransformer(DataTransformerInterface $viewTransformer, $forcePrepend = false)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         if ($forcePrepend) {
@@ -234,7 +235,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function resetViewTransformers()
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->viewTransformers = array();
@@ -249,7 +250,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws Exception if the form configuration is locked
+     * @throws BadMethodCallException if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link addViewTransformer()} instead.
@@ -259,7 +260,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('appendClientTransformer() is deprecated since version 2.1 and will be removed in 2.3. Use addViewTransformer() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         return $this->addViewTransformer($viewTransformer);
@@ -272,7 +273,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws Exception if the form configuration is locked
+     * @throws BadMethodCallException if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
@@ -281,7 +282,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('prependClientTransformer() is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         return $this->addViewTransformer($viewTransformer, true);
@@ -292,7 +293,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws Exception if the form configuration is locked
+     * @throws BadMethodCallException if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link resetViewTransformers()} instead.
@@ -302,7 +303,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('resetClientTransformers() is deprecated since version 2.1 and will be removed in 2.3. Use resetViewTransformers() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         return $this->resetViewTransformers();
@@ -314,7 +315,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function addModelTransformer(DataTransformerInterface $modelTransformer, $forceAppend = false)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         if ($forceAppend) {
@@ -332,7 +333,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function resetModelTransformers()
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->modelTransformers = array();
@@ -347,7 +348,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws Exception if the form configuration is locked
+     * @throws BadMethodCallException if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3.
      */
@@ -356,7 +357,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('appendNormTransformer() is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         return $this->addModelTransformer($modelTransformer, true);
@@ -369,7 +370,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws Exception if the form configuration is locked
+     * @throws BadMethodCallException if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link addModelTransformer()} instead.
@@ -379,7 +380,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('prependNormTransformer() is deprecated since version 2.1 and will be removed in 2.3. Use addModelTransformer() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         return $this->addModelTransformer($modelTransformer);
@@ -390,7 +391,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      *
      * @return FormConfigBuilder The configuration object.
      *
-     * @throws Exception if the form configuration is locked
+     * @throws BadMethodCallException if the form configuration is locked
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
      *             {@link resetModelTransformers()} instead.
@@ -400,7 +401,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
         trigger_error('resetNormTransformers() is deprecated since version 2.1 and will be removed in 2.3. Use resetModelTransformers() instead.', E_USER_DEPRECATED);
 
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         return $this->resetModelTransformers();
@@ -652,7 +653,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setAttribute($name, $value)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->attributes[$name] = $value;
@@ -666,7 +667,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setAttributes(array $attributes)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->attributes = $attributes;
@@ -680,7 +681,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setDataMapper(DataMapperInterface $dataMapper = null)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->dataMapper = $dataMapper;
@@ -694,7 +695,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setDisabled($disabled)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->disabled = (Boolean) $disabled;
@@ -708,7 +709,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setEmptyData($emptyData)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->emptyData = $emptyData;
@@ -722,7 +723,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setErrorBubbling($errorBubbling)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->errorBubbling = null === $errorBubbling ? null : (Boolean) $errorBubbling;
@@ -736,7 +737,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setRequired($required)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->required = (Boolean) $required;
@@ -750,7 +751,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setPropertyPath($propertyPath)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         if (null !== $propertyPath && !$propertyPath instanceof PropertyPathInterface) {
@@ -768,7 +769,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setMapped($mapped)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->mapped = $mapped;
@@ -782,7 +783,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setByReference($byReference)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->byReference = $byReference;
@@ -796,7 +797,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setVirtual($virtual)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->virtual = $virtual;
@@ -810,7 +811,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setCompound($compound)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->compound = $compound;
@@ -824,7 +825,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setType(ResolvedFormTypeInterface $type)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->type = $type;
@@ -838,7 +839,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setData($data)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->data = $data;
@@ -852,7 +853,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setDataLocked($locked)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->dataLocked = $locked;
@@ -866,7 +867,7 @@ class FormConfigBuilder implements FormConfigBuilderInterface
     public function setFormFactory(FormFactoryInterface $formFactory)
     {
         if ($this->locked) {
-            throw new Exception('The config builder cannot be modified anymore.');
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
 
         $this->formFactory = $formFactory;
@@ -879,6 +880,10 @@ class FormConfigBuilder implements FormConfigBuilderInterface
      */
     public function getFormConfig()
     {
+        if ($this->locked) {
+            throw new BadMethodCallException('FormConfigBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
+        }
+
         // This method should be idempotent, so clone the builder
         $config = clone $this;
         $config->locked = true;

--- a/src/Symfony/Component/Form/FormRegistry.php
+++ b/src/Symfony/Component/Form/FormRegistry.php
@@ -11,8 +11,9 @@
 
 namespace Symfony\Component\Form;
 
+use Symfony\Component\Form\Exception\ExceptionInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 
 /**
  * The central registry of the Form component.
@@ -95,7 +96,7 @@ class FormRegistry implements FormRegistryInterface
             }
 
             if (!$type) {
-                throw new FormException(sprintf('Could not load type "%s"', $name));
+                throw new Exception(sprintf('Could not load type "%s"', $name));
             }
 
             $this->resolveAndAddType($type);
@@ -151,7 +152,7 @@ class FormRegistry implements FormRegistryInterface
 
         try {
             $this->getType($name);
-        } catch (FormException $e) {
+        } catch (ExceptionInterface $e) {
             return false;
         }
 

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 
 /**
@@ -88,7 +88,7 @@ class FormRenderer implements FormRendererInterface
     public function renderBlock(FormView $view, $blockName, array $variables = array())
     {
         if (0 == count($this->variableStack)) {
-            throw new FormException('This method should only be called while rendering a form element.');
+            throw new Exception('This method should only be called while rendering a form element.');
         }
 
         $viewCacheKey = $view->vars[self::CACHE_KEY_VAR];
@@ -97,7 +97,7 @@ class FormRenderer implements FormRendererInterface
         $resource = $this->engine->getResourceForBlockName($view, $blockName);
 
         if (!$resource) {
-            throw new FormException(sprintf('No block "%s" found while rendering the form.', $blockName));
+            throw new Exception(sprintf('No block "%s" found while rendering the form.', $blockName));
         }
 
         // Merge the passed with the existing attributes
@@ -217,7 +217,7 @@ class FormRenderer implements FormRendererInterface
 
         // Escape if no resource exists for this block
         if (!$resource) {
-            throw new FormException(sprintf(
+            throw new Exception(sprintf(
                 'Unable to render the form as none of the following blocks exist: "%s".',
                 implode('", "', array_reverse($blockNameHierarchy))
             ));

--- a/src/Symfony/Component/Form/PreloadedExtension.php
+++ b/src/Symfony/Component/Form/PreloadedExtension.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 
 /**
  * A form extension with preloaded types, type exceptions and type guessers.
@@ -55,7 +55,7 @@ class PreloadedExtension implements FormExtensionInterface
     public function getType($name)
     {
         if (!isset($this->types[$name])) {
-            throw new FormException(sprintf('The type "%s" can not be loaded by this extension', $name));
+            throw new Exception(sprintf('The type "%s" can not be loaded by this extension', $name));
         }
 
         return $this->types[$name];

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\FormException;
+use Symfony\Component\Form\Exception\Exception;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -46,7 +46,7 @@ class ResolvedFormType implements ResolvedFormTypeInterface
     public function __construct(FormTypeInterface $innerType, array $typeExtensions = array(), ResolvedFormTypeInterface $parent = null)
     {
         if (!preg_match('/^[a-z0-9_]*$/i', $innerType->getName())) {
-            throw new FormException(sprintf(
+            throw new Exception(sprintf(
                 'The "%s" form type name ("%s") is not valid. Names must only contain letters, numbers, and "_".',
                 get_class($innerType),
                 $innerType->getName()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/LazyChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/LazyChoiceListTest.php
@@ -82,7 +82,7 @@ class LazyChoiceListTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testLoadChoiceListShouldReturnChoiceList()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/ChoiceList/ObjectChoiceListTest.php
@@ -193,7 +193,7 @@ class ObjectChoiceListTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testInitArrayThrowsExceptionIfToStringNotFound()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -89,7 +89,7 @@ class ChoiceTypeTest extends TypeTestCase
     }
 
     /**
-     * expectedException \Symfony\Component\Form\Exception\FormException
+     * expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testEitherChoiceListOrChoicesMustBeSet()
     {

--- a/src/Symfony/Component/Form/Tests/FormBuilderTest.php
+++ b/src/Symfony/Component/Form/Tests/FormBuilderTest.php
@@ -162,7 +162,7 @@ class FormBuilderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUnknown()
     {
-        $this->setExpectedException('Symfony\Component\Form\Exception\FormException', 'The child with the name "foo" does not exist.');
+        $this->setExpectedException('Symfony\Component\Form\Exception\Exception', 'The child with the name "foo" does not exist.');
         $this->builder->get('foo');
     }
 

--- a/src/Symfony/Component/Form/Tests/FormRegistryTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRegistryTest.php
@@ -188,7 +188,7 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testGetTypeThrowsExceptionIfParentNotFound()
     {
@@ -200,7 +200,7 @@ class FormRegistryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testGetTypeThrowsExceptionIfTypeNotFound()
     {

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -741,7 +741,7 @@ class SimpleFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      * @expectedExceptionMessage A form with an empty name cannot have a parent form.
      */
     public function testFormCannotHaveEmptyNameNotInRootLevel()
@@ -787,7 +787,7 @@ class SimpleFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testViewDataMustNotBeObjectIfDataClassIsNull()
     {
@@ -817,7 +817,7 @@ class SimpleFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testViewDataMustBeObjectIfDataClassIsSet()
     {
@@ -832,7 +832,7 @@ class SimpleFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\FormException
+     * @expectedException \Symfony\Component\Form\Exception\Exception
      */
     public function testSetDataCannotInvokeItself()
     {

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathCollectionTest.php
@@ -285,7 +285,7 @@ abstract class PropertyPathCollectionTest extends \PHPUnit_Framework_TestCase
         try {
             $path->setValue($car, $axes);
             $this->fail('An expected exception was not thrown!');
-        } catch (\Symfony\Component\Form\Exception\FormException $e) {
+        } catch (\Symfony\Component\Form\Exception\Exception $e) {
             $this->assertEquals($message, $e->getMessage());
         }
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

When a form is created, a `FormConfigInterface` instance is passed to the constructor of `Form` and then accessible via `getConfig()`. For performance reasons, `FormBuilder` also implements `FormConfigInterface` and is passed here directly instead of copying its values to a new `FormConfig` instance, although protected from further modifications.

In addition to the already existing guard clauses in the setters, this PR adds guard clauses to the getters of `FormBuilder` to prevent misuse of the "config" object giving unexpected results.

Additionally, this PR introduces first improvements of the form's `Exception\` namespace as described in  #6549.
