### PR TITLE
[2.0][DomCrawler] Resolve relative URIs from Links

### DIFF
--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -126,7 +126,7 @@ class Link
         }
 
         // relative path
-        return substr($this->currentUri, 0, strrpos($this->currentUri, '/') + 1).$uri;
+        return $this->resolveRelativeUri($uri);
     }
 
     /**
@@ -153,5 +153,39 @@ class Link
         }
 
         $this->node = $node;
+    }
+
+    /**
+     * Resolves a relative URI, removing all '.' and '..' references.
+     *
+     * @param string $uri The relative URI to resolve
+     *
+     * @return string
+     */
+    protected function resolveRelativeUri($uri)
+    {
+        preg_match('#^(\w+://[^/]+)/(.*)$#', $this->currentUri, $matches);
+        $currentBaseUri = $matches[1];
+        $currentPath = preg_replace('#(^|/)([^/]*)$#', '', $matches[2]);
+
+        $currentSegments = ('' !== $currentPath) ? explode('/', $currentPath) : array();
+        $targetSegments = $currentSegments;
+
+        $segments = explode('/', $uri);
+
+        foreach ($segments as $segment) {
+            if ('.' === $segment) {
+                continue;
+            }
+
+            if ('..' === $segment) {
+                array_pop($targetSegments);
+                continue;
+            }
+
+            array_push($targetSegments, $segment);
+        }
+
+        return $currentBaseUri.'/'.implode('/', $targetSegments);
     }
 }

--- a/tests/Symfony/Tests/Component/DomCrawler/LinkTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/LinkTest.php
@@ -99,6 +99,14 @@ class LinkTest extends \PHPUnit_Framework_TestCase
             array('?foo=2', 'http://localhost/bar?foo=1', 'http://localhost/bar?foo=2'),
             array('?foo=2', 'http://localhost/bar/?foo=1', 'http://localhost/bar/?foo=2'),
             array('?bar=2', 'http://localhost?foo=1', 'http://localhost?bar=2'),
+
+            array('./bar', 'http://localhost/foo', 'http://localhost/bar'),
+            array('./bar', 'http://localhost/foo/', 'http://localhost/foo/bar'),
+            array('../bar', 'http://localhost/foo', 'http://localhost/bar'),
+            array('../bar', 'http://localhost/foo/', 'http://localhost/bar'),
+            array('../../baz', 'http://localhost/foo/bar/', 'http://localhost/baz'),
+            array('././bar', 'http://localhost/foo', 'http://localhost/bar'),
+            array('./../bar', 'http://localhost/foo/bar/baz', 'http://localhost/foo/bar'),
         );
     }
 }


### PR DESCRIPTION
Bug fix: kind of
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -

This is useful when using DomCrawler and HttpKernel\Client with an
HttpKernel that does not support relative requests to URIs.

Please check extensively and suggest additional test cases to ensure nothing is broken. Suggestions to simplify the algorithm are welcome.

If desired I can re-file against 2.1 or 2.2. But IMO this is a bugfix and as such belongs in 2.0.
