### PR TITLE
[Validator] Covering edge case for Luhn when checksum is exactly 0

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/LuhnValidator.php
@@ -51,7 +51,7 @@ class LuhnValidator extends ConstraintValidator
             $sum += (($i % 2) === $oddLength) ? array_sum(str_split($digit * 2)) : $digit;
         }
 
-        if (($sum % 10) !== 0) {
+        if ($sum === 0 || ($sum % 10) !== 0) {
             $this->context->addViolation($constraint->message);
         }
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LuhnValidatorTest.php
@@ -102,6 +102,8 @@ class LuhnValidatorTest extends \PHPUnit_Framework_TestCase
         return array(
             array('1234567812345678'),
             array('4222222222222222'),
+            array('0000000000000000'),
+            array(0),
         );
     }
 }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: 
Todo: 
License of the code: MIT
Documentation PR:

Actually not a big deal, but a Credit Card with all 0s passed validation. Now this is covered.
