### PR TITLE
[Console] Sort autocomplete values alphabetically

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -86,6 +86,7 @@ class DialogHelper extends Helper
             }
             $ret = trim($ret);
         } else {
+            sort($autocomplete);
             $ret = '';
 
             $i = 0;


### PR DESCRIPTION
I'm not sure if autocomplete matches should be sorted or not, so I've created a Pull Request to discuss. Either:

a) Matches can be scrolled through (with arrow keys) in the order they are originally supplied in the `$autocomplete` argument. This way the developer can prioritise certain matches over others.
b) Matches are sorted alphabetically. This makes the experience a little bit better for the user as they can anticipate when an item is coming up instead of browsing a seemingly random list.
