### PR TITLE
[RFC][BC][FrameworkBundle] Force users to set "kernel.secret" to something unique

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -51,7 +51,12 @@ class Configuration implements ConfigurationInterface
                         })
                     ->end()
                 ->end()
-                ->scalarNode('secret')->end()
+                ->scalarNode('secret')
+                    ->validate()
+                        ->ifTrue(function($v) { return 'ThisTokenIsNotSoSecretChangeIt' === $v; })
+                        ->thenInvalid('The "secret" parameter is currently set to the default. It is really important that you change it to something unique.')
+                    ->end()
+                ->end()
                 ->scalarNode('trust_proxy_headers')->defaultFalse()->end() // @deprecated, to be removed in 2.3
                 ->arrayNode('trusted_proxies')
                     ->beforeNormalization()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -66,7 +66,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(array());
-        $config = $processor->processConfiguration($configuration, array(array('secret' => 's3cr3t', 'trusted_proxies' => 'Not an IP address')));
+        $processor->processConfiguration($configuration, array(array('secret' => 's3cr3t', 'trusted_proxies' => 'Not an IP address')));
     }
 
     /**
@@ -76,6 +76,16 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
     {
         $processor = new Processor();
         $configuration = new Configuration(array());
-        $config = $processor->processConfiguration($configuration, array(array('secret' => 's3cr3t', 'trusted_proxies' => array('Not an IP address'))));
+        $processor->processConfiguration($configuration, array(array('secret' => 's3cr3t', 'trusted_proxies' => array('Not an IP address'))));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testDefaultSecretIsUsed()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(array());
+        $processor->processConfiguration($configuration, array(array('secret' => 'ThisTokenIsNotSoSecretChangeIt')));
     }
 }


### PR DESCRIPTION
Bug fix: kinda*
Feature addition: no
BC break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #6480
License of the code: MIT

This PR is to show different approach for "fix" suggested in #6480, as IMO there is no real point for "yet another listener" =)

This PR also introduces BC break for all users that used default value for `kernel.secret`, but IMO it's worth it.
