### PR TITLE
[2.0][HttpFoundation] Docblock for Request::isXmlHttpRequest()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1132,7 +1132,8 @@ class Request
      * Returns true if the request is a XMLHttpRequest.
      *
      * It works if your JavaScript library set an X-Requested-With HTTP header.
-     * It is known to work with Prototype, Mootools, jQuery.
+     * It is known to work with common JavaScript frameworks:
+     * @link http://en.wikipedia.org/wiki/List_of_Ajax_frameworks#JavaScript
      *
      * @return Boolean true if the request is an XMLHttpRequest, false otherwise
      *


### PR DESCRIPTION
Docblock now points to [Wikipedia entry](http://en.wikipedia.org/wiki/List_of_Ajax_frameworks#JavaScript) instead of pointing all known JS frameworks.

Replacement for #6444.
