### PR TITLE
[2.0][Form] DateTimeToTimestampTransformer should return empty string

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformer.php
@@ -25,7 +25,7 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
     /**
      * Transforms a DateTime object into a timestamp in the configured timezone.
      *
-     * @param DateTime $value A DateTime object
+     * @param \DateTime $value A DateTime object
      *
      * @return integer          A timestamp
      *
@@ -35,7 +35,7 @@ class DateTimeToTimestampTransformer extends BaseDateTimeTransformer
     public function transform($value)
     {
         if (null === $value) {
-            return null;
+            return '';
         }
 
         if (!$value instanceof \DateTime) {

--- a/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
+++ b/tests/Symfony/Tests/Component/Form/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
@@ -31,7 +31,7 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
     {
         $transformer = new DateTimeToTimestampTransformer();
 
-        $this->assertSame(null, $transformer->transform(null));
+        $this->assertSame('', $transformer->transform(null));
     }
 
     public function testTransform_differentTimezones()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no*
Symfony2 tests pass: yes

According to note in [`DataTransformerInterface`](http://api.symfony.com/master/Symfony/Component/Form/DataTransformerInterface.html#method_transform) :

> By convention, transform() should return an empty string if NULL is passed.
