### PR TITLE
[Console] Fix `DialogHelper#ask()` with autocomplete functionality

### DIFF
--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -115,12 +115,12 @@ class DialogHelper extends Helper
                         $ofs = -1;
                         $matches = $autocomplete;
                         $numMatches = count($matches);
+                    } else {
+                        $numMatches = 0;
                     }
 
                     // Pop the last character off the end of our string
                     $ret = substr($ret, 0, $i);
-
-                    $numMatches = 0;
                 } elseif ("\033" === $c) { // Did we read an escape sequence?
                     $c .= fread($inputStream, 2);
 

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -93,6 +93,8 @@ class DialogHelper extends Helper
             $matches = $autocomplete;
             $numMatches = count($matches);
 
+            $sttyMode = shell_exec('stty -g');
+
             // Disable icanon (so we can fread each keypress) and echo (we'll do echoing here instead)
             shell_exec('stty -icanon -echo');
 
@@ -183,7 +185,7 @@ class DialogHelper extends Helper
             }
 
             // Reset stty so it behaves normally again
-            shell_exec('stty icanon echo');
+            shell_exec(sprintf('stty %s', $sttyMode));
         }
 
         return strlen($ret) > 0 ? $ret : $default;
@@ -251,11 +253,11 @@ class DialogHelper extends Helper
         if ($this->hasSttyAvailable()) {
             $output->write($question);
 
-            $sttyMode = shell_exec('/usr/bin/env stty -g');
+            $sttyMode = shell_exec('stty -g');
 
-            shell_exec('/usr/bin/env stty -echo');
+            shell_exec('stty -echo');
             $value = fgets($this->inputStream ?: STDIN, 4096);
-            shell_exec(sprintf('/usr/bin/env stty %s', $sttyMode));
+            shell_exec(sprintf('stty %s', $sttyMode));
 
             if (false === $value) {
                 throw new \RuntimeException('Aborted');
@@ -376,7 +378,7 @@ class DialogHelper extends Helper
     /**
      * Return a valid unix shell
      *
-     * @return string|false  The valid shell name, false in case no valid shell is found
+     * @return string|Boolean  The valid shell name, false in case no valid shell is found
      */
     private function getShell()
     {

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -139,7 +139,7 @@ class DialogHelper extends Helper
                     }
                 } elseif (ord($c) < 32) {
                     if ("\t" === $c || "\n" === $c) {
-                        if ($numMatches > 0) {
+                        if ($numMatches > 0 && -1 !== $ofs) {
                             $ret = $matches[$ofs];
                             // Echo out remaining chars for current match
                             $output->write(substr($ret, $i));
@@ -174,7 +174,7 @@ class DialogHelper extends Helper
                 // Erase characters from cursor to end of line
                 $output->write("\033[K");
 
-                if ($numMatches > 0) {
+                if ($numMatches > 0 && -1 !== $ofs) {
                     // Save cursor position
                     $output->write("\0337");
                     // Write highlighted text

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -54,8 +54,13 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
 
         rewind($output->getStream());
         $this->assertEquals('What time is it?', stream_get_contents($output->getStream()));
+    }
 
-        $bundles = array('AcmeDemoBundle', 'AsseticBundle', 'SecurityBundle', 'FooBundle');
+    public function testAskWithAutocomplete()
+    {
+        if (!$this->hasSttyAvailable()) {
+            $this->markTestSkipped('`stty` is required to test autocomplete functionality');
+        }
 
         // Acm<NEWLINE>
         // Ac<BACKSPACE><BACKSPACE>s<TAB>Test<NEWLINE>
@@ -64,18 +69,18 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
         // <UP ARROW><UP ARROW><UP ARROW><UP ARROW><UP ARROW><TAB><NEWLINE>
         // <DOWN ARROW><NEWLINE>
         $inputStream = $this->getInputStream("Acm\nAc\177\177s\tTest\n\n\033[A\033[A\n\033[A\033[A\033[A\033[A\033[A\tTest\n\033[B\n");
+
+        $dialog = new DialogHelper();
         $dialog->setInputStream($inputStream);
 
-        if ($this->hasSttyAvailable()) {
-            $this->assertEquals('AcmeDemoBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
-            $this->assertEquals('AsseticBundleTest', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
-            $this->assertEquals('FrameworkBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
-            $this->assertEquals('SecurityBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
-            $this->assertEquals('FooBundleTest', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
-            $this->assertEquals('AcmeDemoBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
-        } else {
-            $this->markTestSkipped();
-        }
+        $bundles = array('AcmeDemoBundle', 'AsseticBundle', 'SecurityBundle', 'FooBundle');
+
+        $this->assertEquals('AcmeDemoBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+        $this->assertEquals('AsseticBundleTest', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+        $this->assertEquals('FrameworkBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+        $this->assertEquals('SecurityBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+        $this->assertEquals('FooBundleTest', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+        $this->assertEquals('AcmeDemoBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
     }
 
     public function testAskHiddenResponse()

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -66,9 +66,10 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
         // Ac<BACKSPACE><BACKSPACE>s<TAB>Test<NEWLINE>
         // <NEWLINE>
         // <UP ARROW><UP ARROW><NEWLINE>
-        // <UP ARROW><UP ARROW><UP ARROW><UP ARROW><UP ARROW><TAB><NEWLINE>
+        // <UP ARROW><UP ARROW><UP ARROW><UP ARROW><UP ARROW><TAB>Test<NEWLINE>
         // <DOWN ARROW><NEWLINE>
-        $inputStream = $this->getInputStream("Acm\nAc\177\177s\tTest\n\n\033[A\033[A\n\033[A\033[A\033[A\033[A\033[A\tTest\n\033[B\n");
+        // S<BACKSPACE><BACKSPACE><DOWN ARROW><DOWN ARROW><NEWLINE>
+        $inputStream = $this->getInputStream("Acm\nAc\177\177s\tTest\n\n\033[A\033[A\n\033[A\033[A\033[A\033[A\033[A\tTest\n\033[B\nS\177\177\033[B\033[B\n");
 
         $dialog = new DialogHelper();
         $dialog->setInputStream($inputStream);
@@ -81,6 +82,7 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('SecurityBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
         $this->assertEquals('FooBundleTest', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
         $this->assertEquals('AcmeDemoBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
+        $this->assertEquals('AsseticBundle', $dialog->ask($this->getOutputStream(), 'Please select a bundle', 'FrameworkBundle', $bundles));
     }
 
     public function testAskHiddenResponse()


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
BC break: no
Symfony2 tests pass: yes

This PR fixes failing test after: 9d94fc7 as well as correctly resets `stty` to prevent _strange_ data showing-up in console:
![console](https://f.cloud.github.com/assets/67402/47882/673a5dae-58ed-11e2-8bab-30a7c41733f5.png)
