### PR TITLE
[WIP][WebProfilerBundle] Load web profiler panels asynchronously

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -112,6 +112,10 @@ class ProfilerController
                 continue;
             }
 
+            if ($template->hasBlock('head') || $template->hasBlock('body')) {
+                continue;
+            }
+
             $renderedBlocks[$panel] = $template->renderBlock('panel', array(
                 'token'     => $token,
                 'profile'   => $profile,

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/config/routing/profiler.xml
@@ -44,6 +44,10 @@
         <default key="_controller">web_profiler.controller.router:panelAction</default>
     </route>
 
+    <route id="_profiler_panels" pattern="/{token}/panels">
+        <default key="_controller">web_profiler.controller.profiler:panelsAction</default>
+    </route>
+
     <route id="_profiler_exception" pattern="/{token}/exception">
         <default key="_controller">web_profiler.controller.exception:showAction</default>
     </route>

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/layout.html.twig
@@ -29,7 +29,9 @@
 
                     <div id="collector-content">
                         {% include '@WebProfiler/Profiler/base_js.html.twig' %}
-                        {% block panel '' %}
+                        <div id="panel-content">
+                            {% block panel '' %}
+                        </div>
                     </div>
                 </div>
                 <div id="navigation">
@@ -38,7 +40,7 @@
                             {% for name, template in templates %}
                                 {% set menu %}{{ template.renderBlock('menu', { 'collector': profile.getcollector(name)}) }}{% endset %}
                                 {% if menu != '' %}
-                                    <li class="{{ name }}{% if name == panel %} selected{% endif %}">
+                                    <li class="{{ name }}{% if name == panel %} selected{% endif %}" id="panel-link-{{ name }}">
                                         <a href="{{ path('_profiler', { 'token': token, 'panel': name }) }}">{{ menu|raw }}</a>
                                     </li>
                                 {% endif %}
@@ -131,6 +133,49 @@
                 }
             }
         }, 25);
+
+        var selectedPanel = document.getElementById('panel-link-{{ panel }}');
+
+        Sfjs.request(
+            '{{ path("_profiler_panels", { "token": token }) }}',
+            function(xhr, el) {
+                history.replaceState({ panel: '{{ panel }}' }, 'Profiler', window.location.href);
+
+                window.onpopstate = function(event) {
+                    if (event.state === null) {
+                        return true;
+                    }
+
+                    var link = document.getElementById('panel-link-' + event.state['panel']);
+                    switchContent.call(link);
+                };
+
+                function switchContent() {
+                    Sfjs.removeClass(selectedPanel, 'selected');
+                    selectedPanel = this;
+                    Sfjs.addClass(selectedPanel, 'selected');
+
+                    panelContent.innerHTML = panels[this.panelName];
+                }
+
+                function linkHandler() {
+                    switchContent.call(this);
+                    history.pushState({ panel: this.panelName }, 'Profiler', this.firstElementChild.href);
+                    return false;
+                }
+
+                var panels = JSON.parse(xhr.responseText);
+                var panelContent = document.getElementById('panel-content');
+
+                for (var name in panels) {
+                    var link = document.getElementById('panel-link-' + name);
+                    console.log(name);
+                    link.panelName = name;
+
+                    link.onclick = linkHandler;
+                }
+            }
+        );
 
     //]]></script>
 {% endblock %}


### PR DESCRIPTION
Just built this as an experiment to see if having profiler panels lazy-loaded after page load then rendered instantly when they are needed would improve the experience of using the profiler.

I think I uncovered a bug in Twig whilst building this, which prevents this PR from working without tweaking cached templates. Will report on the twig repo.

Also one other problem is the JS/canvas timeline not rendering, but I'm sure it is easily fixed. Edit: due to this: http://stackoverflow.com/questions/1197575/can-scripts-be-inserted-with-innerhtml. Easily fixable
