### PR TITLE
Falling back to first translation if no choice available

### DIFF
--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -74,7 +74,7 @@ class MessageSelector
 
         $position = PluralizationRules::get($number, $locale);
         if (!isset($standardRules[$position])) {
-            throw new \InvalidArgumentException(sprintf('Unable to choose a translation for "%s" with locale "%s". Double check that this translation has the correct plural options (e.g. "There is one apple|There are %%count%% apples").', $message, $locale));
+            return current($standardRules);
         }
 
         return $standardRules[$position];

--- a/src/Symfony/Component/Translation/MessageSelector.php
+++ b/src/Symfony/Component/Translation/MessageSelector.php
@@ -44,8 +44,6 @@ class MessageSelector
      *
      * @return string
      *
-     * @throws \InvalidArgumentException
-     *
      * @api
      */
     public function choose($message, $number, $locale)

--- a/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageSelectorTest.php
@@ -25,16 +25,6 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $selector->choose($id, $number, 'en'));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testChooseWhenNoEnoughChoices()
-    {
-        $selector = new MessageSelector();
-
-        $selector->choose('foo', 10, 'en');
-    }
-
     public function getChooseTests()
     {
         return array(
@@ -75,6 +65,9 @@ class MessageSelectorTest extends \PHPUnit_Framework_TestCase
             array('There is no apples', '{0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
             array('There is no apples', '{0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0.0),
             array('There is no apples', '{0.0} There is no apples|]0,1[There are %count% apples|{1} There is one apple|[1,Inf] There is more than one apple', 0),
+
+            // #4228
+            array('There are %count% apples', 'There are %count% apples', 10),
         );
     }
 }

--- a/src/Symfony/Component/Translation/Tests/TranslatorTest.php
+++ b/src/Symfony/Component/Translation/Tests/TranslatorTest.php
@@ -263,16 +263,13 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('10 things', $translator->transChoice('some_message2', 10, array('%count%' => 10)));
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testTransChoiceFallbackWithNoTranslation()
     {
         $translator = new Translator('ru', new MessageSelector());
         $translator->setFallbackLocale('en');
         $translator->addLoader('array', new ArrayLoader());
 
-        $this->assertEquals('10 things', $translator->transChoice('some_message2', 10, array('%count%' => 10)));
+        $this->assertEquals('some_message2', $translator->transChoice('some_message2', 10, array('%count%' => 10)));
     }
 }
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Symfony2 tests pass: yes
Fixes the following tickets: #4228
License of the code: MIT
