### PR TITLE
[HttpKernel][MonologBridge] PSR-3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": ">=2.2,<2.4-dev",
         "doctrine/orm": ">=2.2.3,<2.4-dev",
-        "monolog/monolog": ">=1.0,<1.3-dev",
+        "monolog/monolog": "~1.3",
+        "psr/log": "~1.0",
         "propel/propel1": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.3.3",
         "doctrine/common": ">2.2,<2.4-dev",
-        "twig/twig": ">=1.11.0,<2.0-dev"
+        "twig/twig": ">=1.11.0,<2.0-dev",
+        "psr/log": "~1.0"
     },
     "replace": {
         "symfony/browser-kit": "self.version",
@@ -60,7 +61,6 @@
         "doctrine/dbal": ">=2.2,<2.4-dev",
         "doctrine/orm": ">=2.2.3,<2.4-dev",
         "monolog/monolog": "~1.3",
-        "psr/log": "~1.0",
         "propel/propel1": "dev-master"
     },
     "autoload": {

--- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
+++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Logger;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Stopwatch\Stopwatch;
 use Doctrine\DBAL\Logging\SQLLogger;
 

--- a/src/Symfony/Bridge/Monolog/Handler/DebugHandler.php
+++ b/src/Symfony/Bridge/Monolog/Handler/DebugHandler.php
@@ -47,10 +47,7 @@ class DebugHandler extends TestHandler implements DebugLoggerInterface
     public function countErrors()
     {
         $cnt = 0;
-        $levels = array(Logger::ERROR, Logger::CRITICAL, Logger::ALERT);
-        if (defined('Monolog\Logger::EMERGENCY')) {
-            $levels[] = Logger::EMERGENCY;
-        }
+        $levels = array(Logger::ERROR, Logger::CRITICAL, Logger::ALERT, Logger::EMERGENCY);
         foreach ($levels as $level) {
             if (isset($this->recordsByLevel[$level])) {
                 $cnt += count($this->recordsByLevel[$level]);

--- a/src/Symfony/Bridge/Monolog/Logger.php
+++ b/src/Symfony/Bridge/Monolog/Logger.php
@@ -23,6 +23,38 @@ use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 class Logger extends BaseLogger implements LoggerInterface, DebugLoggerInterface
 {
     /**
+     * @deprecated since 2.2, to be removed in 3.0. Use emergency() which is PSR-3 compatible.
+     */
+    public function emerg($message, array $context = array())
+    {
+        return parent::addRecord(BaseLogger::EMERGENCY, $message, $context);
+    }
+
+    /**
+     * @deprecated since 2.2, to be removed in 3.0. Use critical() which is PSR-3 compatible.
+     */
+    public function crit($message, array $context = array())
+    {
+        return parent::addRecord(BaseLogger::CRITICAL, $message, $context);
+    }
+
+    /**
+     * @deprecated since 2.2, to be removed in 3.0. Use error() which is PSR-3 compatible.
+     */
+    public function err($message, array $context = array())
+    {
+        return parent::addRecord(BaseLogger::ERROR, $message, $context);
+    }
+
+    /**
+     * @deprecated since 2.2, to be removed in 3.0. Use warning() which is PSR-3 compatible.
+     */
+    public function warn($message, array $context = array())
+    {
+        return parent::addRecord(BaseLogger::WARNING, $message, $context);
+    }
+
+    /**
      * @see Symfony\Component\HttpKernel\Log\DebugLoggerInterface
      */
     public function getLogs()

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/http-kernel": "2.2.*",
-        "monolog/monolog": ">=1.0,<1.3-dev"
+        "monolog/monolog": "~1.3"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Monolog\\": "" }

--- a/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
+++ b/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bridge\Propel1\Logger;
 
 use Symfony\Component\Stopwatch\Stopwatch;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * PropelLogger.

--- a/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
+++ b/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
@@ -73,7 +73,7 @@ class PropelLogger
     public function crit($message)
     {
         if (null !== $this->logger) {
-            $this->logger->crit($message);
+            $this->logger->critical($message);
         }
     }
 
@@ -85,7 +85,7 @@ class PropelLogger
     public function err($message)
     {
         if (null !== $this->logger) {
-            $this->logger->err($message);
+            $this->logger->error($message);
         }
     }
 
@@ -97,7 +97,7 @@ class PropelLogger
     public function warning($message)
     {
         if (null !== $this->logger) {
-            $this->logger->warn($message);
+            $this->logger->warning($message);
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/ControllerResolver.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Controller;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerResolver as BaseControllerResolver;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;

--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -14,7 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Routing;
 use Symfony\Bundle\FrameworkBundle\Controller\ControllerNameParser;
 use Symfony\Component\Config\Loader\DelegatingLoader as BaseDelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * DelegatingLoader delegates route loading to other loaders using a loader resolver.

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Debugger.php
@@ -12,7 +12,7 @@
 namespace Symfony\Bundle\FrameworkBundle\Templating;
 
 use Symfony\Component\Templating\DebuggerInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Binds the Symfony templating loader debugger to the Symfony logger.

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Controller;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -58,7 +58,7 @@ class ControllerResolver implements ControllerResolverInterface
     {
         if (!$controller = $request->attributes->get('_controller')) {
             if (null !== $this->logger) {
-                $this->logger->warn('Unable to look for the controller as the "_controller" parameter is missing');
+                $this->logger->warning('Unable to look for the controller as the "_controller" parameter is missing');
             }
 
             return false;

--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
@@ -95,7 +95,7 @@ class ErrorHandler
                         : debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10)
                 );
 
-                self::$logger->warn($message, $deprecation);
+                self::$logger->warning($message, $deprecation);
             }
 
             return true;

--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\HttpKernel\Debug;
 
 use Symfony\Component\HttpKernel\Exception\FatalErrorException;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * ErrorHandler.

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\Debug;
 
 use Symfony\Component\Stopwatch\Stopwatch;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Profiler\Profile;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\HttpKernel\HttpKernelInterface;

--- a/src/Symfony/Component/HttpKernel/EventListener/DeprecationLoggerListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/DeprecationLoggerListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Debug\ErrorHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Log\DebugLoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\KernelEvents;

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -97,9 +97,9 @@ class ExceptionListener implements EventSubscriberInterface
         $isCritical = !$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500;
         if (null !== $this->logger) {
             if ($isCritical) {
-                $this->logger->crit($message);
+                $this->logger->critical($message);
             } else {
-                $this->logger->err($message);
+                $this->logger->error($message);
             }
         } elseif (!$original || $isCritical) {
             error_log($message);

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\EventListener;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;

--- a/src/Symfony/Component/HttpKernel/Log/LoggerInterface.php
+++ b/src/Symfony/Component/HttpKernel/Log/LoggerInterface.php
@@ -18,27 +18,32 @@ use Psr\Log\LoggerInterface as PsrLogger;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
+ * @deprecated since 2.2, to be removed in 3.0. Type-hint \Psr\Log\LoggerInterface instead.
  * @api
  */
 interface LoggerInterface extends PsrLogger
 {
     /**
      * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use emergency() which is PSR-3 compatible.
      */
     public function emerg($message, array $context = array());
 
     /**
      * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use critical() which is PSR-3 compatible.
      */
     public function crit($message, array $context = array());
 
     /**
      * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use error() which is PSR-3 compatible.
      */
     public function err($message, array $context = array());
 
     /**
      * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use warning() which is PSR-3 compatible.
      */
     public function warn($message, array $context = array());
 }

--- a/src/Symfony/Component/HttpKernel/Log/LoggerInterface.php
+++ b/src/Symfony/Component/HttpKernel/Log/LoggerInterface.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\HttpKernel\Log;
 
+use Psr\Log\LoggerInterface as PsrLogger;
+
 /**
  * LoggerInterface.
  *
@@ -18,17 +20,12 @@ namespace Symfony\Component\HttpKernel\Log;
  *
  * @api
  */
-interface LoggerInterface
+interface LoggerInterface extends PsrLogger
 {
     /**
      * @api
      */
     public function emerg($message, array $context = array());
-
-    /**
-     * @api
-     */
-    public function alert($message, array $context = array());
 
     /**
      * @api
@@ -44,19 +41,4 @@ interface LoggerInterface
      * @api
      */
     public function warn($message, array $context = array());
-
-    /**
-     * @api
-     */
-    public function notice($message, array $context = array());
-
-    /**
-     * @api
-     */
-    public function info($message, array $context = array());
-
-    /**
-     * @api
-     */
-    public function debug($message, array $context = array());
 }

--- a/src/Symfony/Component/HttpKernel/Log/NullLogger.php
+++ b/src/Symfony/Component/HttpKernel/Log/NullLogger.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Log;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger as PsrNullLogger;
 
 /**

--- a/src/Symfony/Component/HttpKernel/Log/NullLogger.php
+++ b/src/Symfony/Component/HttpKernel/Log/NullLogger.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Log;
 
 use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\NullLogger as PsrNullLogger;
 
 /**
  * NullLogger.
@@ -20,17 +21,11 @@ use Symfony\Component\HttpKernel\Log\LoggerInterface;
  *
  * @api
  */
-class NullLogger implements LoggerInterface
+class NullLogger extends PsrNullLogger
 {
     /**
      * @api
-     */
-    public function log($level, $message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use emergency() which is PSR-3 compatible.
      */
     public function emerg($message, array $context = array())
     {
@@ -38,20 +33,7 @@ class NullLogger implements LoggerInterface
 
     /**
      * @api
-     */
-    public function emergency($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
-     */
-    public function alert($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use critical() which is PSR-3 compatible.
      */
     public function crit($message, array $context = array())
     {
@@ -59,13 +41,7 @@ class NullLogger implements LoggerInterface
 
     /**
      * @api
-     */
-    public function critical($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use error() which is PSR-3 compatible.
      */
     public function err($message, array $context = array())
     {
@@ -73,43 +49,9 @@ class NullLogger implements LoggerInterface
 
     /**
      * @api
-     */
-    public function error($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
+     * @deprecated since 2.2, to be removed in 3.0. Use warning() which is PSR-3 compatible.
      */
     public function warn($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
-     */
-    public function warning($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
-     */
-    public function notice($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
-     */
-    public function info($message, array $context = array())
-    {
-    }
-
-    /**
-     * @api
-     */
-    public function debug($message, array $context = array())
     {
     }
 }

--- a/src/Symfony/Component/HttpKernel/Log/NullLogger.php
+++ b/src/Symfony/Component/HttpKernel/Log/NullLogger.php
@@ -25,7 +25,21 @@ class NullLogger implements LoggerInterface
     /**
      * @api
      */
+    public function log($level, $message, array $context = array())
+    {
+    }
+
+    /**
+     * @api
+     */
     public function emerg($message, array $context = array())
+    {
+    }
+
+    /**
+     * @api
+     */
+    public function emergency($message, array $context = array())
     {
     }
 
@@ -46,6 +60,13 @@ class NullLogger implements LoggerInterface
     /**
      * @api
      */
+    public function critical($message, array $context = array())
+    {
+    }
+
+    /**
+     * @api
+     */
     public function err($message, array $context = array())
     {
     }
@@ -53,7 +74,21 @@ class NullLogger implements LoggerInterface
     /**
      * @api
      */
+    public function error($message, array $context = array())
+    {
+    }
+
+    /**
+     * @api
+     */
     public function warn($message, array $context = array())
+    {
+    }
+
+    /**
+     * @api
+     */
+    public function warning($message, array $context = array())
     {
     }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -110,7 +110,7 @@ class Profiler
     public function saveProfile(Profile $profile)
     {
         if (!($ret = $this->storage->write($profile)) && null !== $this->logger) {
-            $this->logger->warn('Unable to store the profiler information.');
+            $this->logger->warning('Unable to store the profiler information.');
         }
 
         return $ret;

--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Profiler\ProfilerStorageInterface;
 use Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Profiler.

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -30,7 +30,7 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::create('/');
         $this->assertFalse($resolver->getController($request), '->getController() returns false when the request has no _controller attribute');
-        $this->assertEquals(array('Unable to look for the controller as the "_controller" parameter is missing'), $logger->getLogs('warn'));
+        $this->assertEquals(array('Unable to look for the controller as the "_controller" parameter is missing'), $logger->getLogs('warning'));
 
         $request->attributes->set('_controller', 'Symfony\Component\HttpKernel\Tests\ControllerResolverTest::testGetController');
         $controller = $resolver->getController($request);

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/ErrorHandlerTest.php
@@ -67,7 +67,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
         restore_error_handler();
 
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
 
         $that = $this;
         $warnArgCheck = function($message, $context) use ($that) {
@@ -84,7 +84,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
         $logger
             ->expects($this->once())
-            ->method('warn')
+            ->method('warning')
             ->will($this->returnCallback($warnArgCheck))
         ;
 

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -102,7 +102,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 
     public function testLogger()
     {
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
 
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch(), $logger);
@@ -117,7 +117,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
 
     public function testLoggerWithStoppedEvent()
     {
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
 
         $dispatcher = new EventDispatcher();
         $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch(), $logger);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ExceptionListenerTest.php
@@ -93,7 +93,7 @@ class ExceptionListenerTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertEquals(3, $logger->countErrors());
-        $this->assertCount(3, $logger->getLogs('crit'));
+        $this->assertCount(3, $logger->getLogs('critical'));
     }
 
     public function provider()
@@ -117,7 +117,7 @@ class TestLogger extends Logger implements DebugLoggerInterface
 {
     public function countErrors()
     {
-        return count($this->logs['crit']);
+        return count($this->logs['critical']);
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Logger.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\HttpKernel\Tests;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 class Logger implements LoggerInterface
 {

--- a/src/Symfony/Component/HttpKernel/Tests/Logger.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Logger.php
@@ -22,67 +22,107 @@ class Logger implements LoggerInterface
         $this->clear();
     }
 
-    public function getLogs($priority = false)
+    public function getLogs($level = false)
     {
-        return false === $priority ? $this->logs : $this->logs[$priority];
+        return false === $level ? $this->logs : $this->logs[$level];
     }
 
     public function clear()
     {
         $this->logs = array(
-            'emerg' => array(),
+            'emergency' => array(),
             'alert' => array(),
-            'crit' => array(),
-            'err' => array(),
-            'warn' => array(),
+            'critical' => array(),
+            'error' => array(),
+            'warning' => array(),
             'notice' => array(),
             'info' => array(),
             'debug' => array(),
         );
     }
 
-    public function log($message, $priority)
+    public function log($level, $message, array $context = array())
     {
-        $this->logs[$priority][] = $message;
+        $this->logs[$level][] = $message;
     }
 
-    public function emerg($message, array $context = array())
+    public function emergency($message, array $context = array())
     {
-        $this->log($message, 'emerg');
+        $this->log('emergency', $message, $context);
     }
 
     public function alert($message, array $context = array())
     {
-        $this->log($message, 'alert');
+        $this->log('alert', $message, $context);
     }
 
-    public function crit($message, array $context = array())
+    public function critical($message, array $context = array())
     {
-        $this->log($message, 'crit');
+        $this->log('critical', $message, $context);
     }
 
-    public function err($message, array $context = array())
+    public function error($message, array $context = array())
     {
-        $this->log($message, 'err');
+        $this->log('error', $message, $context);
     }
 
-    public function warn($message, array $context = array())
+    public function warning($message, array $context = array())
     {
-        $this->log($message, 'warn');
+        $this->log('warning', $message, $context);
     }
 
     public function notice($message, array $context = array())
     {
-        $this->log($message, 'notice');
+        $this->log('notice', $message, $context);
     }
 
     public function info($message, array $context = array())
     {
-        $this->log($message, 'info');
+        $this->log('info', $message, $context);
     }
 
     public function debug($message, array $context = array())
     {
-        $this->log($message, 'debug');
+        $this->log('debug', $message, $context);
+    }
+
+    /**
+     * @deprecated
+     */
+    public function emerg($message, array $context = array())
+    {
+        trigger_error('Use emergency() which is PSR-3 compatible', E_USER_DEPRECATED);
+
+        $this->log('emergency', $message, $context);
+    }
+
+    /**
+     * @deprecated
+     */
+    public function crit($message, array $context = array())
+    {
+        trigger_error('Use crit() which is PSR-3 compatible', E_USER_DEPRECATED);
+
+        $this->log('critical', $message, $context);
+    }
+
+    /**
+     * @deprecated
+     */
+    public function err($message, array $context = array())
+    {
+        trigger_error('Use err() which is PSR-3 compatible', E_USER_DEPRECATED);
+
+        $this->log('error', $message, $context);
+    }
+
+    /**
+     * @deprecated
+     */
+    public function warn($message, array $context = array())
+    {
+        trigger_error('Use warn() which is PSR-3 compatible', E_USER_DEPRECATED);
+
+        $this->log('warning', $message, $context);
     }
 }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,8 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "2.2.*",
-        "symfony/http-foundation": "2.2.*"
+        "symfony/http-foundation": "2.2.*",
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "symfony/browser-kit": "2.2.*",

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -47,7 +47,7 @@ class PhpGeneratorDumper extends GeneratorDumper
 
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * {$options['class']}

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -166,7 +166,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                         }
 
                         if ($this->logger) {
-                            $this->logger->err($message);
+                            $this->logger->error($message);
                         }
 
                         return null;
@@ -224,7 +224,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
                             }
 
                             if ($this->logger) {
-                                $this->logger->err($message);
+                                $this->logger->error($message);
                             }
 
                             return null;

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -16,7 +16,7 @@ use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * UrlGenerator generates a URL based on a set of routes.

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Routing;
 
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\ConfigCache;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;

--- a/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
+++ b/src/Symfony/Component/Routing/Tests/Generator/UrlGeneratorTest.php
@@ -206,14 +206,14 @@ class UrlGeneratorTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateForRouteWithInvalidOptionalParameterNonStrictWithLogger()
     {
-        if (!interface_exists('Symfony\Component\HttpKernel\Log\LoggerInterface')) {
-            $this->markTestSkipped('The "HttpKernel" component is not available');
+        if (!interface_exists('Psr\Log\LoggerInterface')) {
+            $this->markTestSkipped('The "psr/log" package is not available');
         }
 
         $routes = $this->getRoutes('test', new Route('/testing/{foo}', array('foo' => '1'), array('foo' => 'd+')));
-        $logger = $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
         $logger->expects($this->once())
-            ->method('err');
+            ->method('error');
         $generator = $this->getGenerator($routes, array(), $logger);
         $generator->setStrictRequirements(false);
         $this->assertNull($generator->generate('test', array('foo' => 'bar'), true));

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -22,7 +22,8 @@
         "symfony/config": "2.2.*",
         "symfony/yaml": "2.2.*",
         "symfony/http-kernel": "2.2.*",
-        "doctrine/common": ">=2.2,<2.4-dev"
+        "doctrine/common": ">=2.2,<2.4-dev",
+        "psr/log": "~1.0"
     },
     "suggest": {
         "symfony/config": "2.2.*",

--- a/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
+++ b/src/Symfony/Component/Security/Acl/Voter/AclVoter.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Acl\Voter;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Acl\Exception\NoAceFoundException;
 use Symfony\Component\Security\Acl\Exception\AclNotFoundException;
 use Symfony\Component\Security\Acl\Model\AclProviderInterface;

--- a/src/Symfony/Component/Security/Core/Util/SecureRandom.php
+++ b/src/Symfony/Component/Security/Core/Util/SecureRandom.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Core\Util;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * A secure random number generator implementation.

--- a/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
+++ b/src/Symfony/Component/Security/Http/Authentication/DefaultAuthenticationFailureHandler.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\Authentication;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Http\HttpUtils;

--- a/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/DigestAuthenticationEntryPoint.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
 use Symfony\Component\Security\Core\Exception\NonceExpiredException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * DigestAuthenticationEntryPoint starts an HTTP Digest authentication.

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractAuthenticationListener.php
@@ -19,7 +19,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;

--- a/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AbstractPreAuthenticatedListener.php
@@ -18,7 +18,7 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 

--- a/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AccessListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
 use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;

--- a/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/AnonymousAuthenticationListener.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\SecurityContextInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 

--- a/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/BasicAuthenticationListener.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;

--- a/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ChannelListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Http\AccessMapInterface;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;

--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -89,7 +89,7 @@ class ContextListener implements ListenerInterface
             $token = $this->refreshUser($token);
         } elseif (null !== $token) {
             if (null !== $this->logger) {
-                $this->logger->warn(sprintf('Session includes a "%s" where a security token is expected', is_object($token) ? get_class($token) : gettype($token)));
+                $this->logger->warning(sprintf('Session includes a "%s" where a security token is expected', is_object($token) ? get_class($token) : gettype($token)));
             }
 
             $token = null;
@@ -161,7 +161,7 @@ class ContextListener implements ListenerInterface
                 // let's try the next user provider
             } catch (UsernameNotFoundException $notFound) {
                 if (null !== $this->logger) {
-                    $this->logger->warn(sprintf('Username "%s" could not be found.', $user->getUsername()));
+                    $this->logger->warning(sprintf('Username "%s" could not be found.', $user->getUsername()));
                 }
 
                 return null;

--- a/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/DigestAuthenticationListener.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\EntryPoint\DigestAuthenticationEntryPoint;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -134,7 +134,7 @@ class ExceptionListener
                     }
                 } catch (\Exception $e) {
                     if (null !== $this->logger) {
-                        $this->logger->err(sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage()));
+                        $this->logger->error(sprintf('Exception thrown when handling an exception (%s: %s)', get_class($e), $e->getMessage()));
                     }
 
                     $event->setException(new \RuntimeException('Exception thrown when handling an exception.', 0, $e));

--- a/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ExceptionListener.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Exception\InsufficientAuthenticationExceptio
 use Symfony\Component\Security\Core\Exception\LogoutException;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -82,7 +82,7 @@ class RememberMeListener implements ListenerInterface
             }
         } catch (AuthenticationException $failed) {
             if (null !== $this->logger) {
-                $this->logger->warn(
+                $this->logger->warning(
                     'SecurityContext not populated with remember-me token as the'
                    .' AuthenticationManager rejected the AuthenticationToken returned'
                    .' by the RememberMeServices: '.$failed->getMessage()

--- a/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/RememberMeListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Security\Http\Firewall;
 
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;

--- a/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/SwitchUserListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\HttpFoundation\RedirectResponse;

--- a/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/UsernamePasswordFormAuthenticationListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface;
 use Symfony\Component\Security\Http\Authentication\AuthenticationSuccessHandlerInterface;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;

--- a/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/X509AuthenticationListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Security\Http\Firewall;
 
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -129,7 +129,7 @@ abstract class AbstractRememberMeServices implements RememberMeServicesInterface
             }
         } catch (UnsupportedUserException $unSupported) {
             if (null !== $this->logger) {
-                $this->logger->warn('User class for remember-me cookie not supported.');
+                $this->logger->warning('User class for remember-me cookie not supported.');
             }
         } catch (AuthenticationException $invalid) {
             if (null !== $this->logger) {

--- a/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/AbstractRememberMeServices.php
@@ -22,7 +22,7 @@ use Symfony\Component\Security\Core\Exception\CookieTheftException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpKernel\Log\LoggerInterface;
+use Psr\Log\LoggerInterface;
 
 /**
  * Base class implementing the RememberMeServicesInterface

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/RememberMeListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/RememberMeListenerTest.php
@@ -177,7 +177,7 @@ class RememberMeListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function getLogger()
     {
-        return $this->getMock('Symfony\Component\HttpKernel\Log\LoggerInterface');
+        return $this->getMock('Psr\Log\LoggerInterface');
     }
 
     protected function getManager()

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -26,7 +26,8 @@
         "symfony/routing": "2.2.*",
         "symfony/validator": "2.2.*",
         "doctrine/common": ">=2.2,<2.4-dev",
-        "doctrine/dbal": ">=2.2,<2.4-dev"
+        "doctrine/dbal": ">=2.2,<2.4-dev",
+        "psr/log": "~1.0"
     },
     "suggest": {
         "symfony/class-loader": "2.2.*",


### PR DESCRIPTION
This enables PSR-3 support and monolog 1.3+. The first commit is the main part. The rest deals with deprecation of short-hand methods (warn/err/crit/emerg) that are fully expanded in PSR-3 (warning/error/critical/emergency).

The downside of deprecating them is that for bundles it's a bit harder to support older and newer versions. If that is too much of a hassle you can drop that for now and cherry pick the first commit.

The upside is that it forces people to move towards PSR-3 compatible stuff, which means eventually we could completely drop the LoggerInterface from the framework. In any case I think the documentation should only mention the `Psr\Log\LoggerInterface` and people should start hinting against that. The change should be done in core as well I suppose.

Anyway I wanted to throw this out there as it is to get feedback.
