### PR TITLE
[WDT] Show PHP SAPI in WDT

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -35,6 +35,10 @@
                 <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasxdebug ? 'green' : 'red' }}">xdebug</span>
                 <span class="sf-toolbar-status sf-toolbar-status-{{ collector.hasaccelerator ? 'green' : 'red' }}">accel</span>
             </div>
+            <div class="sf-toolbar-info-piece">
+                <b>PHP SAPI</b>
+                <span>{{ collector.sapiName }}</span>
+            </div>
         {% endspaceless %}
     {% endset %}
     {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': false } %}

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -54,6 +54,7 @@ class ConfigDataCollector extends DataCollector
             'xcache_enabled'   => extension_loaded('xcache') && ini_get('xcache.cacher'),
             'wincache_enabled' => extension_loaded('wincache') && ini_get('wincache.ocenabled'),
             'bundles'          => array(),
+            'sapi_name'        => php_sapi_name()
         );
 
         if (isset($this->kernel)) {
@@ -186,6 +187,16 @@ class ConfigDataCollector extends DataCollector
     public function getBundles()
     {
         return $this->data['bundles'];
+    }
+
+    /**
+     * Gets the PHP SAPI name.
+     *
+     * @return string The environment
+     */
+    public function getSapiName()
+    {
+        return $this->data['sapi_name'];
     }
 
     /**


### PR DESCRIPTION
PHP running under Apache as a module:
![sapi-apache](https://f.cloud.github.com/assets/363540/53093/7709dc8a-5a48-11e2-8c09-031e0645e3ea.png)

PHP running with the in-built CLI web server (via `server:run`)
![sapi-cli](https://f.cloud.github.com/assets/363540/53094/96df9a0e-5a48-11e2-96e9-7bc2f452083d.png)
