### PR TITLE
[FrameworkBundle] Translator : Added session "_locale" check

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -7,6 +7,10 @@ in 2.1 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.1.0...v2.1.1
 
+* 2.1.7
+
+ * 7b13811: [FrameworkBundle] added session _locale
+
 * 2.1.6 (2012-12-21)
 
  * b8e5689: [FrameworkBundle] fixed ESI calls

--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -9,7 +9,7 @@ To get the diff between two versions, go to https://github.com/symfony/symfony/c
 
 * 2.1.7
 
- * 7b13811: [FrameworkBundle] added session _locale
+ * 9e1d960: [FrameworkBundle] added session _locale
 
 * 2.1.6 (2012-12-21)
 

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -67,6 +67,10 @@ class Translator extends BaseTranslator
      */
     public function getLocale()
     {
+        if (null === $this->locale && $this->container->has('session') && $this->container->get('session')->has('_locale')) {
+            $this->locale = $this->container->get('session')->get('_locale');
+        }
+
         if (null === $this->locale && $this->container->isScopeActive('request') && $this->container->has('request')) {
             $this->locale = $this->container->get('request')->getLocale();
         }


### PR DESCRIPTION
As said in the documentation : http://symfony.com/doc/current/book/translation.html#the-translation-process , the translator check if a "_locale" variable is set into session. But that comportment is not working, the session is never checked
