### PR TITLE
Enhanced the triggering of E_USER_DEPRECATED errors

### DIFF
--- a/src/Symfony/Component/Form/AbstractType.php
+++ b/src/Symfony/Component/Form/AbstractType.php
@@ -51,10 +51,20 @@ abstract class AbstractType implements FormTypeInterface
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handleBC'));
-        $resolver->setDefaults($this->getDefaultOptions(array()));
-        $resolver->addAllowedValues($this->getAllowedOptionValues(array()));
-        restore_error_handler();
+        $defaults = $this->getDefaultOptions(array());
+        $allowedTypes = $this->getAllowedOptionValues(array());
+
+        if (!empty($defaults)) {
+            trigger_error('getDefaultOptions() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
+
+            $resolver->setDefaults($defaults);
+        }
+
+        if (!empty($allowedTypes)) {
+            trigger_error('getAllowedOptionValues() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
+
+            $resolver->addAllowedValues($allowedTypes);
+        }
     }
 
     /**
@@ -69,8 +79,6 @@ abstract class AbstractType implements FormTypeInterface
      */
     public function getDefaultOptions(array $options)
     {
-        trigger_error('getDefaultOptions() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
-
         return array();
     }
 
@@ -86,8 +94,6 @@ abstract class AbstractType implements FormTypeInterface
      */
     public function getAllowedOptionValues(array $options)
     {
-        trigger_error('getAllowedOptionValues() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
-
         return array();
     }
 

--- a/src/Symfony/Component/Form/AbstractTypeExtension.php
+++ b/src/Symfony/Component/Form/AbstractTypeExtension.php
@@ -44,10 +44,20 @@ abstract class AbstractTypeExtension implements FormTypeExtensionInterface
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handleBC'));
-        $resolver->setDefaults($this->getDefaultOptions());
-        $resolver->addAllowedValues($this->getAllowedOptionValues());
-        restore_error_handler();
+        $defaults = $this->getDefaultOptions(array());
+        $allowedTypes = $this->getAllowedOptionValues(array());
+
+        if (!empty($defaults)) {
+            trigger_error('getDefaultOptions() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
+
+            $resolver->setDefaults($defaults);
+        }
+
+        if (!empty($allowedTypes)) {
+            trigger_error('getAllowedOptionValues() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
+
+            $resolver->addAllowedValues($allowedTypes);
+        }
     }
 
     /**
@@ -60,8 +70,6 @@ abstract class AbstractTypeExtension implements FormTypeExtensionInterface
      */
     public function getDefaultOptions()
     {
-        trigger_error('getDefaultOptions() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
-
         return array();
     }
 
@@ -75,8 +83,6 @@ abstract class AbstractTypeExtension implements FormTypeExtensionInterface
      */
     public function getAllowedOptionValues()
     {
-        trigger_error('getAllowedOptionValues() is deprecated since version 2.1 and will be removed in 2.3. Use setDefaultOptions() instead.', E_USER_DEPRECATED);
-
         return array();
     }
 }

--- a/src/Symfony/Component/Form/CallbackValidator.php
+++ b/src/Symfony/Component/Form/CallbackValidator.php
@@ -27,7 +27,7 @@ class CallbackValidator implements FormValidatorInterface
      */
     public function __construct($callback)
     {
-        trigger_error('CallbackValidator is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
+        trigger_error('CallbackValidator is deprecated since version 2.1 and will be removed in 2.3. Use the FormEvents::POST_BIND event instead.', E_USER_DEPRECATED);
 
         $this->callback = $callback;
     }

--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -367,11 +367,12 @@ class Form implements \IteratorAggregate, FormInterface
 
         // Hook to change content of the data
         if ($dispatcher->hasListeners(FormEvents::PRE_SET_DATA) || $dispatcher->hasListeners(FormEvents::SET_DATA)) {
-            set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handleBC'));
             $event = new FormEvent($this, $modelData);
-            restore_error_handler();
             $dispatcher->dispatch(FormEvents::PRE_SET_DATA, $event);
             // BC until 2.3
+            if ($dispatcher->hasListeners(FormEvents::SET_DATA)) {
+                trigger_error('The FormEvents::SET_DATA event is deprecated since 2.1 and will be removed in 2.3. Use the FormEvents::PRE_SET_DATA event instead.', E_USER_DEPRECATED);
+            }
             $dispatcher->dispatch(FormEvents::SET_DATA, $event);
             $modelData = $event->getData();
         }
@@ -532,11 +533,12 @@ class Form implements \IteratorAggregate, FormInterface
 
         // Hook to change content of the data bound by the browser
         if ($dispatcher->hasListeners(FormEvents::PRE_BIND) || $dispatcher->hasListeners(FormEvents::BIND_CLIENT_DATA)) {
-            set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handleBC'));
             $event = new FormEvent($this, $submittedData);
-            restore_error_handler();
             $dispatcher->dispatch(FormEvents::PRE_BIND, $event);
             // BC until 2.3
+            if ($dispatcher->hasListeners(FormEvents::BIND_CLIENT_DATA)) {
+                trigger_error('The FormEvents::BIND_CLIENT_DATA event is deprecated since 2.1 and will be removed in 2.3. Use the FormEvents::PRE_BIND event instead.', E_USER_DEPRECATED);
+            }
             $dispatcher->dispatch(FormEvents::BIND_CLIENT_DATA, $event);
             $submittedData = $event->getData();
         }
@@ -594,11 +596,12 @@ class Form implements \IteratorAggregate, FormInterface
             // Hook to change content of the data into the normalized
             // representation
             if ($dispatcher->hasListeners(FormEvents::BIND) || $dispatcher->hasListeners(FormEvents::BIND_NORM_DATA)) {
-                set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handleBC'));
                 $event = new FormEvent($this, $normData);
-                restore_error_handler();
                 $dispatcher->dispatch(FormEvents::BIND, $event);
                 // BC until 2.3
+                if ($dispatcher->hasListeners(FormEvents::BIND_NORM_DATA)) {
+                    trigger_error('The FormEvents::BIND_NORM_DATA event is deprecated since 2.1 and will be removed in 2.3. Use the FormEvents::BIND event instead.', E_USER_DEPRECATED);
+                }
                 $dispatcher->dispatch(FormEvents::BIND_NORM_DATA, $event);
                 $normData = $event->getData();
             }
@@ -621,10 +624,14 @@ class Form implements \IteratorAggregate, FormInterface
         }
 
         set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handleBC'));
-        foreach ($this->config->getValidators() as $validator) {
+        $validators = $this->config->getValidators();
+        restore_error_handler();
+
+        foreach ($validators as $validator) {
+            trigger_error(sprintf('FormConfigInterface::getValidators() is deprecated since 2.1 and will be removed in 2.3. Convert your %s class to a listener on the FormEvents::POST_BIND event.', get_class($validator)), E_USER_DEPRECATED);
+
             $validator->validate($this);
         }
-        restore_error_handler();
 
         return $this;
     }

--- a/src/Symfony/Component/Form/FormBuilder.php
+++ b/src/Symfony/Component/Form/FormBuilder.php
@@ -301,11 +301,11 @@ class FormBuilder extends FormConfigBuilder implements \IteratorAggregate, FormB
      */
     public function getTypes()
     {
+        trigger_error('getTypes() is deprecated since version 2.1 and will be removed in 2.3. Use getConfig() and FormConfigInterface::getType() instead.', E_USER_DEPRECATED);
+
         if ($this->locked) {
             throw new BadMethodCallException('FormBuilder methods cannot be accessed anymore once the builder is turned into a FormConfigInterface instance.');
         }
-
-        trigger_error('getTypes() is deprecated since version 2.1 and will be removed in 2.3. Use getConfig() and FormConfigInterface::getType() instead.', E_USER_DEPRECATED);
 
         $types = array();
 

--- a/src/Symfony/Component/Form/Test/DeprecationErrorHandler.php
+++ b/src/Symfony/Component/Form/Test/DeprecationErrorHandler.php
@@ -2,9 +2,6 @@
 
 namespace Symfony\Component\Form\Test;
 
-use Symfony\Component\Form\FormInterface as NonTestFormInterface;
-use Symfony\Component\Form\FormEvent;
-
 class DeprecationErrorHandler
 {
     public static function handle($errorNumber, $message, $file, $line, $context)
@@ -23,14 +20,5 @@ class DeprecationErrorHandler
         }
 
         return false;
-    }
-
-    public static function getFormEvent(NonTestFormInterface $form, $data)
-    {
-        set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handle'));
-        $event = new FormEvent($form, $data);
-        restore_error_handler();
-
-        return $event;
     }
 }

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -231,9 +231,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->form->remove('foo');
 
         $this->assertNull($child->getParent());
-        set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handle'));
-        $this->assertFalse($this->form->hasChildren());
-        restore_error_handler();
+        $this->assertCount(0, $this->form);
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixRadioInputListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixRadioInputListenerTest.php
@@ -11,9 +11,9 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Core\EventListener\FixRadioInputListener;
 use Symfony\Component\Form\Extension\Core\ChoiceList\SimpleChoiceList;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
 
 class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -42,7 +42,7 @@ class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = '1';
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $this->listener->preBind($event);
 
@@ -53,7 +53,7 @@ class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = '0';
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $this->listener->preBind($event);
 
@@ -64,7 +64,7 @@ class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = '';
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $this->listener->preBind($event);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Core\EventListener\FixUrlProtocolListener;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
 
 class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,7 +27,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = "www.symfony.com";
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
         $filter->onBind($event);
@@ -39,7 +39,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = "http://www.symfony.com";
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
         $filter->onBind($event);
@@ -51,7 +51,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = "ftp://www.symfony.com";
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
         $filter->onBind($event);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Core\EventListener\MergeCollectionListener;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
 
 abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -84,7 +84,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         // The original object was modified
@@ -108,7 +108,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         // The original object was modified
@@ -133,7 +133,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         // We still have the original object
@@ -157,7 +157,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         // The original object was modified
@@ -182,7 +182,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         // We still have the original object
@@ -201,7 +201,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
     public function testRequireArrayOrTraversable($allowAdd, $allowDelete)
     {
         $newData = 'no array or traversable';
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener = new MergeCollectionListener($allowAdd, $allowDelete);
         $listener->onBind($event);
     }
@@ -215,7 +215,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         $this->assertSame($originalData, $event->getData());
@@ -233,7 +233,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         $this->assertSame($newData, $event->getData());
@@ -251,7 +251,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->form->setData($originalData);
 
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $newData);
+        $event = new FormEvent($this->form, $newData);
         $listener->onBind($event);
 
         $this->assertNull($event->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
+use Symfony\Component\Form\FormEvent;
 
 class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -80,7 +80,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->getForm('2')));
 
         $data = array(1 => 'string', 2 => 'string');
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array('max_length' => '10'), false, false);
         $listener->preSetData($event);
 
@@ -95,7 +95,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     public function testPreSetDataRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preSetData($event);
     }
@@ -105,7 +105,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->factory->expects($this->never())->method('createNamed');
 
         $data = null;
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preSetData($event);
     }
@@ -120,7 +120,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($this->getForm('1')));
 
         $data = array(0 => 'string', 1 => 'string');
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array('max_length' => 10), true, false);
         $listener->preBind($event);
 
@@ -134,7 +134,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $data = array(0 => 'string');
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
@@ -148,7 +148,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('0'));
 
         $data = array();
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
@@ -161,7 +161,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $data = array(0 => 'string', 2 => 'string');
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preBind($event);
 
@@ -176,7 +176,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     public function testPreBindRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
         $listener->preBind($event);
     }
@@ -186,7 +186,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $data = null;
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
@@ -199,7 +199,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $data = '';
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
         $listener->preBind($event);
 
@@ -211,7 +211,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $data = array(0 => 'first', 1 => 'second', 2 => 'third');
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
         $listener->onBind($event);
 
@@ -223,7 +223,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $data = array(0 => 'first', 1 => 'second', 2 => 'third');
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
         $listener->onBind($event);
 
@@ -236,7 +236,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     public function testOnBindNormDataRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
         $listener->onBind($event);
     }
@@ -246,7 +246,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->add($this->getForm('1'));
 
         $data = null;
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
         $listener->onBind($event);
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
@@ -11,8 +11,8 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\EventListener;
 
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Core\EventListener\TrimListener;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
 
 class TrimListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,7 +27,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = " Foo! ";
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $filter = new TrimListener();
         $filter->preBind($event);
@@ -39,7 +39,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
     {
         $data = 1234;
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $filter = new TrimListener();
         $filter->preBind($event);
@@ -60,7 +60,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
         $data = $data."ab\ncd".$data;
 
         $form  = $this->getMock('Symfony\Component\Form\Test\FormInterface');
-        $event = DeprecationErrorHandler::getFormEvent($form, $data);
+        $event = new FormEvent($form, $data);
 
         $filter = new TrimListener();
         $filter->preBind($event);

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -12,8 +12,8 @@
 namespace Symfony\Component\Form\Tests\Extension\Csrf\EventListener;
 
 use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Extension\Csrf\EventListener\CsrfValidationListener;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
 
 class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -67,7 +67,7 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
     public function testStringFormData()
     {
         $data = "XP4HUzmHPi";
-        $event = DeprecationErrorHandler::getFormEvent($this->form, $data);
+        $event = new FormEvent($this->form, $data);
 
         $validation = new CsrfValidationListener('csrf', $this->csrfProvider, 'unknown');
         $validation->preBind($event);

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/EventListener/BindRequestListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/EventListener/BindRequestListenerTest.php
@@ -14,9 +14,9 @@ namespace Symfony\Component\Form\Tests\Extension\HttpFoundation\EventListener;
 use Symfony\Component\Form\Extension\HttpFoundation\EventListener\BindRequestListener;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigBuilder;
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
@@ -98,7 +98,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $config = new FormConfigBuilder('author', null, $dispatcher);
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);
@@ -125,7 +125,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $config = new FormConfigBuilder('', null, $dispatcher);
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);
@@ -154,7 +154,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $config->setCompound(true);
         $config->setDataMapper($this->getMock('Symfony\Component\Form\DataMapperInterface'));
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);
@@ -180,7 +180,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $config = new FormConfigBuilder('author', null, $dispatcher);
         $config->setCompound(false);
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);
@@ -203,7 +203,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $config = new FormConfigBuilder('author', null, $dispatcher);
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);
@@ -227,7 +227,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $config = new FormConfigBuilder('', null, $dispatcher);
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);
@@ -253,7 +253,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $config->setCompound(true);
         $config->setDataMapper($this->getMock('Symfony\Component\Form\DataMapperInterface'));
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);
@@ -275,7 +275,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $config = new FormConfigBuilder('author', null, $dispatcher);
         $config->setCompound(false);
         $form = new Form($config);
-        $event = DeprecationErrorHandler::getFormEvent($form, $request);
+        $event = new FormEvent($form, $request);
 
         $listener = new BindRequestListener();
         $listener->preBind($event);

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/EventListener/ValidationListenerTest.php
@@ -11,14 +11,12 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\EventListener;
 
-use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\Util\PropertyPath;
 use Symfony\Component\Form\Extension\Validator\Constraints\Form;
 use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;
 use Symfony\Component\Validator\ConstraintViolation;
-use Symfony\Component\Form\Test\DeprecationErrorHandler;
 
 class ValidationListenerTest extends \PHPUnit_Framework_TestCase
 {
@@ -109,7 +107,7 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
             ->method('mapViolation')
             ->with($violation, $form, false);
 
-        $this->listener->validateForm(DeprecationErrorHandler::getFormEvent($form, null));
+        $this->listener->validateForm(new FormEvent($form, null));
     }
 
     public function testMapViolationAllowsNonSyncIfInvalid()
@@ -126,7 +124,7 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
             // pass true now
             ->with($violation, $form, true);
 
-        $this->listener->validateForm(DeprecationErrorHandler::getFormEvent($form, null));
+        $this->listener->validateForm(new FormEvent($form, null));
     }
 
     public function testValidateIgnoresNonRoot()
@@ -142,6 +140,6 @@ class ValidationListenerTest extends \PHPUnit_Framework_TestCase
         $this->violationMapper->expects($this->never())
             ->method('mapViolation');
 
-        $this->listener->validateForm(DeprecationErrorHandler::getFormEvent($form, null));
+        $this->listener->validateForm(new FormEvent($form, null));
     }
 }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -648,7 +648,6 @@ class SimpleFormTest extends AbstractFormTest
         $form = $this->getBuilder()
             ->addValidator($validator)
             ->getForm();
-        restore_error_handler();
 
         $validator->expects($this->once())
             ->method('validate')
@@ -658,6 +657,8 @@ class SimpleFormTest extends AbstractFormTest
         }));
 
         $form->bind('foobar');
+
+        restore_error_handler();
     }
 
     public function testBindResetsErrors()

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -676,8 +676,6 @@ class Request
      *
      * @see http://en.wikipedia.org/wiki/X-Forwarded-For
      *
-     * @deprecated The proxy argument is deprecated since version 2.0 and will be removed in 2.3. Use setTrustedProxies instead.
-     *
      * @api
      */
     public function getClientIp()

--- a/src/Symfony/Component/Translation/Loader/QtTranslationsLoader.php
+++ b/src/Symfony/Component/Translation/Loader/QtTranslationsLoader.php
@@ -22,5 +22,9 @@ namespace Symfony\Component\Translation\Loader;
  *             Use QtFileLoader instead.
  */
 class QtTranslationsLoader extends QtFileLoader
-{   
+{
+    public function __construct()
+    {
+        trigger_error('QtTranslationsLoader is deprecated since version 2.2 and will be removed in 2.3. Use QtFileLoader instead.', E_USER_DEPRECATED);
+    }
 }

--- a/src/Symfony/Component/Validator/ConstraintValidator.php
+++ b/src/Symfony/Component/Validator/ConstraintValidator.php
@@ -103,6 +103,8 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      */
     public function validate($value, Constraint $constraint)
     {
+        trigger_error('isValid() is deprecated since version 2.1 and will be removed in 2.3. Implement validate() instead.', E_USER_DEPRECATED);
+
         return $this->isValid($value, $constraint);
     }
 
@@ -113,6 +115,5 @@ abstract class ConstraintValidator implements ConstraintValidatorInterface
      */
     protected function isValid($value, Constraint $constraint)
     {
-        trigger_error('isValid() is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Max.php
+++ b/src/Symfony/Component/Validator/Constraints/Max.php
@@ -28,7 +28,7 @@ class Max extends Constraint
 
     public function __construct($options = null)
     {
-        trigger_error('Max is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
+        trigger_error('Max is deprecated since version 2.1 and will be removed in 2.3. Use Range instead.', E_USER_DEPRECATED);
 
         parent::__construct($options);
     }

--- a/src/Symfony/Component/Validator/Constraints/MaxLength.php
+++ b/src/Symfony/Component/Validator/Constraints/MaxLength.php
@@ -28,7 +28,7 @@ class MaxLength extends Constraint
 
     public function __construct($options = null)
     {
-        trigger_error('MaxLength is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
+        trigger_error('MaxLength is deprecated since version 2.1 and will be removed in 2.3. Use Length instead.', E_USER_DEPRECATED);
 
         parent::__construct($options);
     }

--- a/src/Symfony/Component/Validator/Constraints/Min.php
+++ b/src/Symfony/Component/Validator/Constraints/Min.php
@@ -28,7 +28,7 @@ class Min extends Constraint
 
     public function __construct($options = null)
     {
-        trigger_error('Min is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
+        trigger_error('Min is deprecated since version 2.1 and will be removed in 2.3. Use Range instead.', E_USER_DEPRECATED);
 
         parent::__construct($options);
     }

--- a/src/Symfony/Component/Validator/Constraints/MinLength.php
+++ b/src/Symfony/Component/Validator/Constraints/MinLength.php
@@ -28,7 +28,7 @@ class MinLength extends Constraint
 
     public function __construct($options = null)
     {
-        trigger_error('MinLength is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
+        trigger_error('MinLength is deprecated since version 2.1 and will be removed in 2.3. Use Length instead.', E_USER_DEPRECATED);
 
         parent::__construct($options);
     }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadataFactory.php
@@ -70,20 +70,16 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface, MetadataFac
 
         // Include constraints from the parent class
         if ($parent = $metadata->getReflectionClass()->getParentClass()) {
-            set_error_handler(array($this, 'handleBC'));
-            $metadata->mergeConstraints($this->getClassMetadata($parent->name));
-            restore_error_handler();
+            $metadata->mergeConstraints($this->getMetadataFor($parent->name));
         }
 
         // Include constraints from all implemented interfaces
-        set_error_handler(array($this, 'handleBC'));
         foreach ($metadata->getReflectionClass()->getInterfaces() as $interface) {
             if ('Symfony\Component\Validator\GroupSequenceProviderInterface' === $interface->name) {
                 continue;
             }
-            $metadata->mergeConstraints($this->getClassMetadata($interface->name));
+            $metadata->mergeConstraints($this->getMetadataFor($interface->name));
         }
-        restore_error_handler();
 
         if (null !== $this->loader) {
             $this->loader->loadClassMetadata($metadata);
@@ -125,17 +121,5 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface, MetadataFac
         trigger_error('getClassMetadata() is deprecated since version 2.2 and will be removed in 2.3. Use getMetadataFor() instead.', E_USER_DEPRECATED);
 
         return $this->getMetadataFor($class);
-    }
-
-    /**
-     * @deprecated This is used to keep BC until deprecated methods are removed
-     */
-    public function handleBC($errorNumber, $message, $file, $line, $context)
-    {
-        if ($errorNumber & E_USER_DEPRECATED) {
-            return true;
-        }
-
-        return false;
     }
 }

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadataFactoryAdapter.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadataFactoryAdapter.php
@@ -29,6 +29,8 @@ class ClassMetadataFactoryAdapter implements MetadataFactoryInterface
 
     public function __construct(ClassMetadataFactoryInterface $innerFactory)
     {
+        trigger_error(sprintf('ClassMetadataFactoryInterface is deprecated since version 2.1 and will be removed in 2.3. Implement MetadataFactoryInterface instead on %s.', get_class($innerFactory)), E_USER_DEPRECATED);
+
         $this->innerFactory = $innerFactory;
     }
 
@@ -38,9 +40,7 @@ class ClassMetadataFactoryAdapter implements MetadataFactoryInterface
     public function getMetadataFor($value)
     {
         $class = is_object($value) ? get_class($value) : $value;
-        set_error_handler(array($this, 'handleBC'));
         $metadata = $this->innerFactory->getClassMetadata($class);
-        restore_error_handler();
 
         if (null === $metadata) {
             throw new NoSuchMetadataException('No metadata exists for class '. $class);
@@ -56,22 +56,8 @@ class ClassMetadataFactoryAdapter implements MetadataFactoryInterface
     {
         $class = is_object($value) ? get_class($value) : $value;
 
-        set_error_handler(array($this, 'handleBC'));
         $return = null !== $this->innerFactory->getClassMetadata($class);
-        restore_error_handler();
 
         return $return;
-    }
-
-    /**
-     * @deprecated This is used to keep BC until deprecated methods are removed
-     */
-    public function handleBC($errorNumber, $message, $file, $line, $context)
-    {
-        if ($errorNumber & E_USER_DEPRECATED) {
-            return true;
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Deprecations: no
Symfony2 tests pass: yes
Fixes the following tickets: none
- Removed useless error handlers around FormEvent as the triggering has
  been fixed in it.
- Enhanced the triggering of deprecation errors for places where the BC
  method provide some user logic needing to be converted to a new way.
  For instance, AbstractType should trigger the error when the type extending it overwrites the deprecated methods instead of `setDefaultOptions`, which was not the case previously.
- Enhanced the deprecation messages to mention the replacement whenever
  possible.
