### PR TITLE
[DomCrawler] Added auto-discovery and explicit registration of namespaces in filter() and filterByXPath()

### DIFF
--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+ * added auto-registration of document namespaces for `Crawler::filterXPath()` and `Crawler::filter()`
+ * improved content type guessing in `Crawler::addContent()`
+ * [BC BREAK] `Crawler::addXmlContent()` no longer removes the default document namespace
+
 2.3.0
 -----
 

--- a/src/Symfony/Component/DomCrawler/CHANGELOG.md
+++ b/src/Symfony/Component/DomCrawler/CHANGELOG.md
@@ -4,9 +4,11 @@ CHANGELOG
 2.4.0
 -----
 
- * added auto-registration of document namespaces for `Crawler::filterXPath()` and `Crawler::filter()`
+ * added support for automatic discovery and explicit registration of document
+   namespaces for `Crawler::filterXPath()` and `Crawler::filter()`
  * improved content type guessing in `Crawler::addContent()`
- * [BC BREAK] `Crawler::addXmlContent()` no longer removes the default document namespace
+ * [BC BREAK] `Crawler::addXmlContent()` no longer removes the default document
+   namespace
 
 2.3.0
 -----

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -28,6 +28,11 @@ class Crawler extends \SplObjectStorage
     protected $uri;
 
     /**
+     * @var string The default namespace prefix to be used with XPath and CSS expressions
+     */
+    private $defaultNamespacePrefix = 'default';
+
+    /**
      * Constructor.
      *
      * @param mixed  $node A Node to use as the base for the crawling
@@ -709,6 +714,16 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
+     * Overloads a default namespace prefix to be used with XPath and CSS expressions.
+     *
+     * @param string $prefix
+     */
+    public function setDefaultNamespacePrefix($prefix)
+    {
+        $this->defaultNamespacePrefix = $prefix;
+    }
+
+    /**
      * Converts string for XPath expressions.
      *
      * Escaped characters are: quotes (") and apostrophe (').
@@ -806,7 +821,7 @@ class Crawler extends \SplObjectStorage
 
         foreach ($prefixes as $prefix) {
             // ask for one namespace, otherwise we'd get a collection with an item for each node
-            $namespaces = $domxpath->query(sprintf('(//namespace::*[name()="%s"])[last()]', 'default' === $prefix ? '' : $prefix));
+            $namespaces = $domxpath->query(sprintf('(//namespace::*[name()="%s"])[last()]', $this->defaultNamespacePrefix === $prefix ? '' : $prefix));
             if ($node = $namespaces->item(0)) {
                 $domxpath->registerNamespace($prefix, $node->nodeValue);
             } else {
@@ -824,7 +839,7 @@ class Crawler extends \SplObjectStorage
      */
     private function findNamespacePrefixes($xpath)
     {
-        if (preg_match_all('/(?P<prefix>[a-zA-Z_][a-zA-Z_0-9\-\.]+):[^:]/', $xpath, $matches)) {
+        if (preg_match_all('/(?P<prefix>[a-zA-Z_][a-zA-Z_0-9\-\.]*):[^:]/', $xpath, $matches)) {
             return array_unique($matches['prefix']);
         }
 

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -197,7 +197,7 @@ class Crawler extends \SplObjectStorage
         $dom->validateOnParse = true;
 
         // remove the default namespace to make XPath expressions simpler
-        @$dom->loadXML(str_replace('xmlns', 'ns', $content), LIBXML_NONET);
+        @$dom->loadXML(str_replace('xmlns=', 'ns=', $content), LIBXML_NONET);
 
         libxml_use_internal_errors($current);
         libxml_disable_entity_loader($disableEntities);

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -195,9 +195,7 @@ class Crawler extends \SplObjectStorage
 
         $dom = new \DOMDocument('1.0', $charset);
         $dom->validateOnParse = true;
-
-        // remove the default namespace to make XPath expressions simpler
-        @$dom->loadXML(str_replace('xmlns=', 'ns=', $content), LIBXML_NONET);
+        @$dom->loadXML($content, LIBXML_NONET);
 
         libxml_use_internal_errors($current);
         libxml_disable_entity_loader($disableEntities);

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -425,8 +425,6 @@ EOF
      */
     public function testFilter()
     {
-        $this->markSkippedIfCssSelectorNotPresent();
-
         $crawler = $this->createTestCrawler();
         $this->assertNotSame($crawler, $crawler->filter('li'), '->filter() returns a new instance of a crawler');
         $this->assertInstanceOf('Symfony\\Component\\DomCrawler\\Crawler', $crawler, '->filter() returns a new instance of a crawler');
@@ -438,8 +436,6 @@ EOF
 
     public function testFilterWithDefaultNamespace()
     {
-        $this->markSkippedIfCssSelectorNotPresent();
-
         $crawler = $this->createTestXmlCrawler()->filter('default|entry default|id');
         $this->assertCount(1, $crawler, '->filter() automatically registers namespaces');
         $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
@@ -447,8 +443,6 @@ EOF
 
     public function testFilterWithNamespace()
     {
-        $this->markSkippedIfCssSelectorNotPresent();
-
         CssSelector::disableHtmlExtension();
 
         $crawler = $this->createTestXmlCrawler()->filter('yt|accessControl');
@@ -457,8 +451,6 @@ EOF
 
     public function testFilterWithMultipleNamespaces()
     {
-        $this->markSkippedIfCssSelectorNotPresent();
-
         CssSelector::disableHtmlExtension();
 
         $crawler = $this->createTestXmlCrawler()->filter('media|group yt|aspectRatio');
@@ -769,12 +761,5 @@ EOF
         $domxpath = new \DOMXPath($dom);
 
         return $domxpath->query('//div');
-    }
-
-    protected function markSkippedIfCssSelectorNotPresent()
-    {
-        if (!class_exists('Symfony\Component\CssSelector\CssSelector')) {
-            $this->markTestSkipped('The "CssSelector" component is not available');
-        }
     }
 }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DomCrawler\Tests;
 
+use Symfony\Component\CssSelector\CssSelector;
 use Symfony\Component\DomCrawler\Crawler;
 
 class CrawlerTest extends \PHPUnit_Framework_TestCase
@@ -374,6 +375,7 @@ EOF
     {
         $crawler = $this->createTestXmlCrawler()->filterXPath('//entry/id');
         $this->assertCount(1, $crawler, '->filterXPath() automatically registers a namespace');
+        $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
     }
 
     public function testFilterXPathWithNamespace()
@@ -386,6 +388,7 @@ EOF
     {
         $crawler = $this->createTestXmlCrawler()->filterXPath('//media:group/yt:aspectRatio');
         $this->assertCount(1, $crawler, '->filterXPath() automatically registers multiple namespaces');
+        $this->assertSame('widescreen', $crawler->text());
     }
 
     /**
@@ -404,12 +407,34 @@ EOF
         $this->assertCount(6, $crawler->filter('li'), '->filter() filters the node list with the CSS selector');
     }
 
+    public function testFilterWithDefaultNamespace()
+    {
+        $this->markSkippedIfCssSelectorNotPresent();
+
+        $crawler = $this->createTestXmlCrawler()->filter('entry id');
+        $this->assertCount(1, $crawler, '->filter() automatically registers namespaces');
+        $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
+    }
+
     public function testFilterWithNamespace()
     {
         $this->markSkippedIfCssSelectorNotPresent();
 
+        CssSelector::disableHtmlExtension();
+
         $crawler = $this->createTestXmlCrawler()->filter('yt|accessControl');
         $this->assertCount(2, $crawler, '->filter() automatically registers namespaces');
+    }
+
+    public function testFilterWithMultipleNamespaces()
+    {
+        $this->markSkippedIfCssSelectorNotPresent();
+
+        CssSelector::disableHtmlExtension();
+
+        $crawler = $this->createTestXmlCrawler()->filter('media|group yt|aspectRatio');
+        $this->assertCount(1, $crawler, '->filter() automatically registers namespaces');
+        $this->assertSame('widescreen', $crawler->text());
     }
 
     public function testSelectLink()

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -373,7 +373,7 @@ EOF
 
     public function testFilterXPathWithDefaultNamespace()
     {
-        $crawler = $this->createTestXmlCrawler()->filterXPath('//entry/id');
+        $crawler = $this->createTestXmlCrawler()->filterXPath('//default:entry/default:id');
         $this->assertCount(1, $crawler, '->filterXPath() automatically registers a namespace');
         $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
     }
@@ -389,6 +389,15 @@ EOF
         $crawler = $this->createTestXmlCrawler()->filterXPath('//media:group/yt:aspectRatio');
         $this->assertCount(1, $crawler, '->filterXPath() automatically registers multiple namespaces');
         $this->assertSame('widescreen', $crawler->text());
+    }
+
+    /**
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage Could not find a namespace for the prefix: "foo"
+     */
+    public function testFilterXPathWithAnInvalidNamespace()
+    {
+        $this->createTestXmlCrawler()->filterXPath('//media:group/foo:aspectRatio');
     }
 
     /**
@@ -411,7 +420,7 @@ EOF
     {
         $this->markSkippedIfCssSelectorNotPresent();
 
-        $crawler = $this->createTestXmlCrawler()->filter('entry id');
+        $crawler = $this->createTestXmlCrawler()->filter('default|entry default|id');
         $this->assertCount(1, $crawler, '->filter() automatically registers namespaces');
         $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
     }

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -378,6 +378,16 @@ EOF
         $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
     }
 
+    public function testFilterXPathWithCustomDefaultNamespace()
+    {
+        $crawler = $this->createTestXmlCrawler();
+        $crawler->setDefaultNamespacePrefix('x');
+        $crawler = $crawler->filterXPath('//x:entry/x:id');
+
+        $this->assertCount(1, $crawler, '->filterXPath() automatically registers a namespace');
+        $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
+    }
+
     public function testFilterXPathWithNamespace()
     {
         $crawler = $this->createTestXmlCrawler()->filterXPath('//yt:accessControl');

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -384,7 +384,7 @@ EOF
         $crawler->setDefaultNamespacePrefix('x');
         $crawler = $crawler->filterXPath('//x:entry/x:id');
 
-        $this->assertCount(1, $crawler, '->filterXPath() automatically registers a namespace');
+        $this->assertCount(1, $crawler, '->filterXPath() lets to override the default namespace prefix');
         $this->assertSame('tag:youtube.com,2008:video:kgZRZmEc9j4', $crawler->text());
     }
 
@@ -408,6 +408,16 @@ EOF
     public function testFilterXPathWithAnInvalidNamespace()
     {
         $this->createTestXmlCrawler()->filterXPath('//media:group/foo:aspectRatio');
+    }
+
+    public function testFilterXPathWithManuallyRegisteredNamespace()
+    {
+        $crawler = $this->createTestXmlCrawler();
+        $crawler->registerNamespace('m', 'http://search.yahoo.com/mrss/');
+
+        $crawler = $crawler->filterXPath('//m:group/yt:aspectRatio');
+        $this->assertCount(1, $crawler, '->filterXPath() uses manually registered namespace');
+        $this->assertSame('widescreen', $crawler->text());
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix: | no |
| Feature addition: | yes |
| Backwards compatibility break: | yes, default namespace is no longer removed in the `addContent` method |
| Symfony2 tests pass: | yes |
| Fixes the following tickets: | #4845 |
| Todo: | - |
| License of the code: | MIT |
| Documentation PR: | symfony/symfony-docs#2979 |
- added support for automatic discovery and explicit registration of document namespaces for `Crawler::filterXPath()` and `Crawler::filter()`
- improved content type guessing in `Crawler::addContent()`
- [BC BREAK] `Crawler::addXmlContent()` no longer removes the default document namespace

I mentioned in #4845 it would probably be possible to use [DOMNode::lookupNamespaceURI()](http://www.php.net/manual/en/domnode.lookupnamespaceuri.php) to find a namespace URI by given prefix. Unfortunately we cannot use it here since we'd have to call it on a node in the namespace we're looking for.

Current implementation makes the following query to find a namespace:

``` php
$domxpath->query('(//namespace::*[name()="media"])[last()]')
```
