### PR TITLE
FIxed some typos in the Spainsh translation of the Security component messages

### DIFF
--- a/src/Symfony/Component/Security/Resources/translations/security.es.xlf
+++ b/src/Symfony/Component/Security/Resources/translations/security.es.xlf
@@ -4,31 +4,31 @@
         <body>
             <trans-unit id="1">
                 <source>An authentication exception occurred.</source>
-                <target>Ha ocurrido una excepción de autenticación.</target>
+                <target>Ocurrió una error de autenticación.</target>
             </trans-unit>
             <trans-unit id="2">
                 <source>Authentication credentials could not be found.</source>
-                <target>No se encontraron las credenciales de autenticación.</target>
+                <target>No se encontraron los credenciales de autenticación.</target>
             </trans-unit>
             <trans-unit id="3">
                 <source>Authentication request could not be processed due to a system problem.</source>
-                <target>El pedido de autenticación no se pudo procesar debido a un problema del sistema.</target>
+                <target>La solicitud de autenticación no se pudo procesar debido a un problema del sistema.</target>
             </trans-unit>
             <trans-unit id="4">
                 <source>Invalid credentials.</source>
-                <target>Credenciales invalidas.</target>
+                <target>Credenciales no válidos.</target>
             </trans-unit>
             <trans-unit id="5">
                 <source>Cookie has already been used by someone else.</source>
-                <target>El Cookie ya ha sido usado por alguien más.</target>
+                <target>La cookie ya ha sido usada por otra persona.</target>
             </trans-unit>
             <trans-unit id="6">
                 <source>Not privileged to request the resource.</source>
-                <target>Sin privilegios para solicitar el recurso.</target>
+                <target>No tiene privilegios para solicitar el recurso.</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>Invalid CSRF token.</source>
-                <target>Token CSRF inválido.</target>
+                <target>Token CSRF no válido.</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>Digest nonce has expired.</source>
@@ -36,15 +36,15 @@
             </trans-unit>
             <trans-unit id="9">
                 <source>No authentication provider found to support the authentication token.</source>
-                <target>No se encontro un proveedor de autenticación para soportar el token de autenticación.</target>
+                <target>No se encontró un proveedor de autenticación que soporte el token de autenticación.</target>
             </trans-unit>
             <trans-unit id="10">
                 <source>No session available, it either timed out or cookies are not enabled.</source>
-                <target>No hay una sesión disponible, ha expirado o los cookies no están habilitados.</target>
+                <target>No hay ninguna sesión disponible, ha expirado o las cookies no están habilitados.</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>No token could be found.</source>
-                <target>No se encontró un token.</target>
+                <target>No se encontró ningún token.</target>
             </trans-unit>
             <trans-unit id="12">
                 <source>Username could not be found.</source>
@@ -56,15 +56,15 @@
             </trans-unit>
             <trans-unit id="14">
                 <source>Credentials have expired.</source>
-                <target>Las credenciales han expirado.</target>
+                <target>Los credenciales han expirado.</target>
             </trans-unit>
             <trans-unit id="15">
                 <source>Account is disabled.</source>
-                <target>La cuenta esta deshabilitada.</target>
+                <target>La cuenta está deshabilitada.</target>
             </trans-unit>
             <trans-unit id="16">
                 <source>Account is locked.</source>
-                <target>La cuenta esta bloqueada.</target>
+                <target>La cuenta está bloqueada.</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Hi,

In order to show the most clear and less _"robotic"_ messages in Spanish, I've fixed some typos and some incorrect translations in the Spanish translation file of the Security component.

Christian.
