### PR TITLE
[WDT] Show text description of HTTP Status Code in WDT

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Bridge\Twig\Extension;
 
+use Symfony\Component\HttpFoundation\Response;
+
 if (!defined('ENT_SUBSTITUTE')) {
     define('ENT_SUBSTITUTE', 8);
 }
@@ -54,6 +56,7 @@ class CodeExtension extends \Twig_Extension
             'format_file'           => new \Twig_Filter_Method($this, 'formatFile', array('is_safe' => array('html'))),
             'format_file_from_text' => new \Twig_Filter_Method($this, 'formatFileFromText', array('is_safe' => array('html'))),
             'file_link'             => new \Twig_Filter_Method($this, 'getFileLink', array('is_safe' => array('html'))),
+            'http_status_text'      => new \Twig_Filter_Method($this, 'httpStatusText'),
         );
     }
 
@@ -195,6 +198,18 @@ class CodeExtension extends \Twig_Extension
         }
 
         return false;
+    }
+
+    /**
+     * Returns a string from the status codes translation table.
+     *
+     * @param int $code The HTTP Status Code
+     *
+     * @return string
+     */
+    public function httpStatusText($code)
+    {
+        return Response::$statusTexts[$code];
     }
 
     public function formatFileFromText($text)

--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -16,7 +16,7 @@
     {% set request_route = collector.route ? collector.route : 'NONE' %}
     {% set icon %}
         <img width="28" height="28" alt="Request" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABwAAAAcCAQAAADYBBcfAAACvElEQVR42tVTbUhTYRTerDCnKVoUUr/KCZmypA9Koet0bXNLJ5XazDJ/WFaCUY0pExRZXxYiJgsxWWjkaL+yK+po1gjyR2QfmqWxtBmaBtqWGnabT++c11Fu4l/P4VzOPc95zoHznsNZodIbLDdRcKnc1Bu8DAK45ZsOnykQNMopsNooLxCknb0cDq5vml9FtHiIgpBR0R6iihYyFMTDt2Lg56ObPkI6TMGXSof1EV67IqCwisJSWliFAG/E0CfFIiebdNypcxi/1zgyFiIiZ3sJQr0RQx5frLa6k7SOKRo3oMFNR5t62h2rttKXEOKFqDCxtXNmmBokO2KKTlp3IdWuT2dYRNGKwEXEBCcL172G5FG0aIxC0kR9PBTVH1kkwQn+IqJnCE33EalVzT9GJQS1tAdD3CKicJYFrxqx7W2ejCEdZy1FiC5tZxHhLJKOZaRdQJAyV/YAvDliySALHxmxR4Hqe2iwvaOR/CEuZYJFSgYhVbZRkA8KGdEktrqnqra90NndCdkt77fjIHIhexOrfO6O3bbbOj/rqu5IptgyR3sU93QbOYhquZK4MCDp0Ina/PLsu5JvbCTRaapUdUmIV/RzoMdsk/0hWRNdAvKOmvqlN0drsJbJf1P4YsQ5lGrJeuosiOUgbOC8cto3LfOXTdVd7BqZsQKbse+0jUL6WPcesqs4MNSUTQAxGjwFiC8m3yzmqwHJBWYKBJ9WNqW/dHkpU/osch1Yj5RJfXPfSEe/2UPsN490NPfZG5CKyJmcV5ayHyzy7BMqsXfuHhGK/cjAIeSpR92gehR55D8TcQhDEKJwytBJ4fr4NULvrEM8NszfJPyxDoHYAQ1oPCWmIX4gifmDS/DV2DKeb25FHWr76yEG7/9L4YFPeiQQ4/8LkgJ8Et+NncTCsYqzXAEXa7CWdPZzGWdlyV+vST0JanfPvwAAAABJRU5ErkJggg=="/>
-        <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}">{{ collector.statuscode }}</span>
+        <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}"><abbr title="{{ collector.statuscode|http_status_text }}">{{ collector.statuscode }}</abbr></span>
         <span class="sf-toolbar-status sf-toolbar-info-piece-additional">{{ request_handler }}</span>
         <span class="sf-toolbar-info-piece-additional-detail">on <i>{{ request_route }}</i></span>
     {% endset %}
@@ -24,7 +24,7 @@
         {% spaceless %}
             <div class="sf-toolbar-info-piece">
                 <b>Status Code</b>
-                <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}">{{ collector.statuscode }}</span>
+                <span class="sf-toolbar-status sf-toolbar-status-{{ request_status_code_color }}"><abbr title="{{ collector.statuscode|http_status_text }}">{{ collector.statuscode }}</abbr></span>
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Controller</b>


### PR DESCRIPTION
As the title says. Didn't seem like a good idea to collect these static, unchanging strings via `RequestDataCollector`, so I created a Twig filter.

![Screen Shot 2013-01-10 at 14 54 25](https://f.cloud.github.com/assets/363540/56964/50c2dea2-5b36-11e2-959a-8a3e299c2bd0.png)
