### PR TITLE
Removed underscores from test method names to be consistent with other components

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -350,7 +350,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame(array('1', '3'), $field->getClientData());
     }
 
-    public function testSubmitMultipleNonExpandedSingleIdentifier_existingData()
+    public function testSubmitMultipleNonExpandedSingleIdentifierForExistingData()
     {
         $entity1 = new SingleIdentEntity(1, 'Foo');
         $entity2 = new SingleIdentEntity(2, 'Bar');
@@ -407,7 +407,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame(array('0', '2'), $field->getClientData());
     }
 
-    public function testSubmitMultipleNonExpandedCompositeIdentifier_existingData()
+    public function testSubmitMultipleNonExpandedCompositeIdentifierExistingData()
     {
         $entity1 = new CompositeIdentEntity(10, 20, 'Foo');
         $entity2 = new CompositeIdentEntity(30, 40, 'Bar');
@@ -583,7 +583,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertEquals(array(2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
-    public function testDisallowChoicesThatAreNotIncluded_choicesSingleIdentifier()
+    public function testDisallowChoicesThatAreNotIncludedChoicesSingleIdentifier()
     {
         $entity1 = new SingleIdentEntity(1, 'Foo');
         $entity2 = new SingleIdentEntity(2, 'Bar');
@@ -604,7 +604,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertNull($field->getData());
     }
 
-    public function testDisallowChoicesThatAreNotIncluded_choicesCompositeIdentifier()
+    public function testDisallowChoicesThatAreNotIncludedChoicesCompositeIdentifier()
     {
         $entity1 = new CompositeIdentEntity(10, 20, 'Foo');
         $entity2 = new CompositeIdentEntity(30, 40, 'Bar');

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -48,7 +48,7 @@ class GenericEventTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function test__construct()
+    public function testConstruct()
     {
         $this->assertEquals($this->event, new GenericEvent($this->subject, array('name' => 'Event')));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
@@ -57,7 +57,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($output, $this->transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $output = array(
             'first' => null,
@@ -102,7 +102,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($output, $this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty()
+    public function testReverseTransformCompletelyEmpty()
     {
         $input = array(
             'first' => '',
@@ -112,7 +112,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyNull()
+    public function testReverseTransformCompletelyNull()
     {
         $input = array(
             'first' => null,
@@ -125,7 +125,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyNull()
+    public function testReverseTransformPartiallyNull()
     {
         $input = array(
             'first' => array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
@@ -33,7 +33,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToArrayTransformer();
 
@@ -49,7 +49,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform(null));
     }
 
-    public function testTransform_empty_withFields()
+    public function testTransformEmptyWithFields()
     {
         $transformer = new DateTimeToArrayTransformer(null, null, array('year', 'minute', 'second'));
 
@@ -62,7 +62,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform(null));
     }
 
-    public function testTransform_withFields()
+    public function testTransformWithFields()
     {
         $transformer = new DateTimeToArrayTransformer('UTC', 'UTC', array('year', 'month', 'minute', 'second'));
 
@@ -78,7 +78,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform($input));
     }
 
-    public function testTransform_withPadding()
+    public function testTransformWithPadding()
     {
         $transformer = new DateTimeToArrayTransformer('UTC', 'UTC', null, true);
 
@@ -96,7 +96,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform($input));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformDifferentTimezones()
     {
         $transformer = new DateTimeToArrayTransformer('America/New_York', 'Asia/Hong_Kong');
 
@@ -161,7 +161,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($output, $transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty()
+    public function testReverseTransformCompletelyEmpty()
     {
         $transformer = new DateTimeToArrayTransformer();
 
@@ -177,7 +177,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertNull($transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty_subsetOfFields()
+    public function testReverseTransformCompletelyEmptySubsetOfFields()
     {
         $transformer = new DateTimeToArrayTransformer(null, null, array('year', 'month', 'day'));
 
@@ -193,7 +193,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_year()
+    public function testReverseTransformPartiallyEmptyYear()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -208,7 +208,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_month()
+    public function testReverseTransformPartiallyEmptyMonth()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -223,7 +223,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_day()
+    public function testReverseTransformPartiallyEmptyDay()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -238,7 +238,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_hour()
+    public function testReverseTransformPartiallyEmptyHour()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -253,7 +253,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_minute()
+    public function testReverseTransformPartiallyEmptyMinute()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -268,7 +268,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_second()
+    public function testReverseTransformPartiallyEmptySecond()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -280,14 +280,14 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         ));
     }
 
-    public function testReverseTransform_null()
+    public function testReverseTransformNull()
     {
         $transformer = new DateTimeToArrayTransformer();
 
         $this->assertNull($transformer->reverseTransform(null));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformDifferentTimezones()
     {
         $transformer = new DateTimeToArrayTransformer('America/New_York', 'Asia/Hong_Kong');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -121,14 +121,14 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertEquals('Feb 3, 2010 4:05 AM', $transformer->transform($this->dateTime));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
 
         $this->assertSame('', $transformer->transform(null));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('America/New_York', 'Asia/Hong_Kong');
 
@@ -140,7 +140,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertEquals($dateTime->format('d.m.Y H:i'), $transformer->transform($input));
     }
 
-    public function testTransform_differentPatterns()
+    public function testTransformWithDifferentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
@@ -206,7 +206,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Feb 3, 2010 04:05 AM'));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('America/New_York', 'Asia/Hong_Kong');
 
@@ -216,14 +216,14 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('03.02.2010 04:05'));
     }
 
-    public function testReverseTransform_differentPatterns()
+    public function testReverseTransformWithDifferentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
         $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -79,14 +79,14 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $this->assertEquals($output, $transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToStringTransformer();
 
         $this->assertSame('', $transformer->transform(null));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToStringTransformer('Asia/Hong_Kong', 'America/New_York', 'Y-m-d H:i:s');
 
@@ -134,14 +134,14 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $reverseTransformer = new DateTimeToStringTransformer();
 
         $this->assertNull($reverseTransformer->reverseTransform(''));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformWithDifferentTimezones()
     {
         $reverseTransformer = new DateTimeToStringTransformer('America/New_York', 'Asia/Hong_Kong', 'Y-m-d H:i:s');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
@@ -25,14 +25,14 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
         $this->assertEquals($output, $transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToTimestampTransformer();
 
         $this->assertNull($transformer->transform(null));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'America/New_York');
 
@@ -75,14 +75,14 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $reverseTransformer = new DateTimeToTimestampTransformer();
 
         $this->assertNull($reverseTransformer->reverseTransform(null));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformWithDifferentTimezones()
     {
         $reverseTransformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'America/New_York');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -32,7 +32,7 @@ class IntegerToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals(12345, $transformer->reverseTransform('12345,912'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new IntegerToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -38,7 +38,7 @@ class MoneyToLocalizedStringTransformerTest extends LocalizedTestCase
         $transformer->transform('abcd');
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new MoneyToLocalizedStringTransformer();
 
@@ -61,7 +61,7 @@ class MoneyToLocalizedStringTransformerTest extends LocalizedTestCase
         $transformer->reverseTransform(12345);
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new MoneyToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -32,7 +32,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals('12345,912', $transformer->transform(12345.9123));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new NumberToLocalizedStringTransformer();
 
@@ -75,7 +75,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals(12345.912, $transformer->reverseTransform('12345,912'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new NumberToLocalizedStringTransformer();
 
@@ -129,7 +129,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot_noGroupSep()
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
     {
         if ($this->isLowerThanIcuVersion('4.7')) {
             $this->markTestSkipped('Please upgrade ICU version to 4.7+');
@@ -185,7 +185,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma_noGroupSep()
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
         if ($this->isLowerThanIcuVersion('4.7')) {
             $this->markTestSkipped('Please upgrade ICU version to 4.7+');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -32,7 +32,7 @@ class PercentToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals('200', $transformer->transform(2));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new PercentToLocalizedStringTransformer();
 
@@ -66,7 +66,7 @@ class PercentToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals(2, $transformer->reverseTransform('200'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new PercentToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -38,7 +38,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($output, $this->transformer->transform('Foo'));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $output = array(
             'a' => null,
@@ -60,7 +60,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Foo', $this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty()
+    public function testReverseTransformCompletelyEmpty()
     {
         $input = array(
             'a' => '',
@@ -71,7 +71,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyNull()
+    public function testReverseTransformCompletelyNull()
     {
         $input = array(
             'a' => null,
@@ -85,7 +85,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyNull()
+    public function testReverseTransformPartiallyNull()
     {
         $input = array(
             'a' => 'Foo',
@@ -99,7 +99,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_differences()
+    public function testReverseTransformDifferences()
     {
         $input = array(
             'a' => 'Foo',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormError;
 
 class DateTimeTypeTest extends LocalizedTestCase
 {
-    public function testSubmit_dateTime()
+    public function testSubmitDateTime()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -42,7 +42,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertDateTimeEquals($dateTime, $form->getData());
     }
 
-    public function testSubmit_string()
+    public function testSubmitString()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -67,7 +67,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02 03:04:00', $form->getData());
     }
 
-    public function testSubmit_timestamp()
+    public function testSubmitTimestamp()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -94,7 +94,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals($dateTime->format('U'), $form->getData());
     }
 
-    public function testSubmit_withSeconds()
+    public function testSubmitWithSeconds()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -125,7 +125,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertDateTimeEquals(new \DateTime('2010-06-02 03:04:05 UTC'), $form->getData());
     }
 
-    public function testSubmit_differentTimezones()
+    public function testSubmitDifferentTimezones()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'America/New_York',
@@ -156,7 +156,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals($dateTime->format('Y-m-d H:i:s'), $form->getData());
     }
 
-    public function testSubmit_differentTimezonesDateTime()
+    public function testSubmitDifferentTimezonesDateTime()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'America/New_York',
@@ -175,7 +175,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02T03:04:00-10:00', $form->getViewData());
     }
 
-    public function testSubmit_stringSingleText()
+    public function testSubmitStringSingleText()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -190,7 +190,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02T03:04:00Z', $form->getViewData());
     }
 
-    public function testSubmit_stringSingleText_withSeconds()
+    public function testSubmitStringSingleTextWithSeconds()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -206,7 +206,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02T03:04:05Z', $form->getViewData());
     }
 
-    public function testSubmit_differentPattern()
+    public function testSubmitDifferentPattern()
     {
         $form = $this->factory->create('datetime', null, array(
             'date_format' => 'MM*yyyy*dd',
@@ -314,7 +314,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addEmptyIfNotRequired()
+    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => false,
@@ -336,7 +336,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addNullIfRequired()
+    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -313,7 +313,7 @@ class DateTypeTest extends LocalizedTestCase
         ));
     }
 
-    public function testSetData_differentTimezones()
+    public function testSetDataWithDifferentTimezones()
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -328,7 +328,7 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertEquals('01.06.2010', $form->getViewData());
     }
 
-    public function testSetData_differentTimezonesDateTime()
+    public function testSetDataWithDifferentTimezonesDateTime()
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -625,7 +625,7 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertSame('Empty day', $view['day']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addEmptyIfNotRequired()
+    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => false,
@@ -641,7 +641,7 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertSame('Empty day', $view['day']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addNullIfRequired()
+    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormError;
 
 class TimeTypeTest extends LocalizedTestCase
 {
-    public function testSubmit_dateTime()
+    public function testSubmitDateTime()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -37,7 +37,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_string()
+    public function testSubmitString()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -56,7 +56,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_timestamp()
+    public function testSubmitTimestamp()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -77,7 +77,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_array()
+    public function testSubmitArray()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -96,7 +96,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_datetimeSingleText()
+    public function testSubmitDatetimeSingleText()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -111,7 +111,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
-    public function testSubmit_arraySingleText()
+    public function testSubmitArraySingleText()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -131,7 +131,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
-    public function testSubmit_arraySingleTextWithSeconds()
+    public function testSubmitArraySingleTextWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -153,7 +153,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04:05', $form->getViewData());
     }
 
-    public function testSubmit_stringSingleText()
+    public function testSubmitStringSingleText()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -168,7 +168,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
-    public function testSetData_withSeconds()
+    public function testSetDataWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -182,7 +182,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals(array('hour' => 3, 'minute' => 4, 'second' => 5), $form->getViewData());
     }
 
-    public function testSetData_differentTimezones()
+    public function testSetDataDifferentTimezones()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'America/New_York',
@@ -208,7 +208,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($displayedData, $form->getViewData());
     }
 
-    public function testSetData_differentTimezonesDateTime()
+    public function testSetDataDifferentTimezonesDateTime()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'America/New_York',
@@ -249,7 +249,7 @@ class TimeTypeTest extends LocalizedTestCase
         ), $view['hour']->vars['choices']);
     }
 
-    public function testIsMinuteWithinRange_returnsTrueIfWithin()
+    public function testIsMinuteWithinRangeReturnsTrueIfWithin()
     {
         $form = $this->factory->create('time', null, array(
             'minutes' => array(6, 7),
@@ -263,7 +263,7 @@ class TimeTypeTest extends LocalizedTestCase
         ), $view['minute']->vars['choices']);
     }
 
-    public function testIsSecondWithinRange_returnsTrueIfWithin()
+    public function testIsSecondWithinRangeReturnsTrueIfWithin()
     {
         $form = $this->factory->create('time', null, array(
             'seconds' => array(6, 7),
@@ -278,7 +278,7 @@ class TimeTypeTest extends LocalizedTestCase
         ), $view['second']->vars['choices']);
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyEmpty()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -294,7 +294,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyEmpty_withSeconds()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyEmptyWithSeconds()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -312,7 +312,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyFilled()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyFilled()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -328,7 +328,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyFilled_withSeconds()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyFilledWithSeconds()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -346,7 +346,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsTrueIfChoiceAndHourEmpty()
+    public function testIsPartiallyFilledReturnsTrueIfChoiceAndHourEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -364,7 +364,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertTrue($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsTrueIfChoiceAndMinuteEmpty()
+    public function testIsPartiallyFilledReturnsTrueIfChoiceAndMinuteEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -382,7 +382,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertTrue($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsTrueIfChoiceAndSecondsEmpty()
+    public function testIsPartiallyFilledReturnsTrueIfChoiceAndSecondsEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -474,7 +474,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addEmptyIfNotRequired()
+    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => false,
@@ -491,7 +491,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addNullIfRequired()
+    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => true,

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -393,7 +393,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_noDotBeforeProperty()
+    public function testDotIsRequiredBeforeProperty()
     {
         new PropertyPath('[index]property');
     }
@@ -401,7 +401,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_dotAtTheBeginning()
+    public function testDotCannotBePresentAtTheBeginning()
     {
         new PropertyPath('.property');
     }
@@ -409,7 +409,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_unexpectedCharacters()
+    public function testUnexpectedCharacters()
     {
         new PropertyPath('property.$form');
     }
@@ -417,7 +417,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_empty()
+    public function testPathCannotBeEmpty()
     {
         new PropertyPath('');
     }
@@ -425,7 +425,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
      */
-    public function testInvalidPropertyPath_null()
+    public function testPathCannotBeNull()
     {
         new PropertyPath(null);
     }
@@ -433,31 +433,31 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
      */
-    public function testInvalidPropertyPath_false()
+    public function testPathCannotBeFalse()
     {
         new PropertyPath(false);
     }
 
-    public function testValidPropertyPath_zero()
+    public function testZeroIsValidPropertyPath()
     {
         new PropertyPath('0');
     }
 
-    public function testGetParent_dot()
+    public function testGetParentWithDot()
     {
         $propertyPath = new PropertyPath('grandpa.parent.child');
 
         $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
     }
 
-    public function testGetParent_index()
+    public function testGetParentWithIndex()
     {
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
     }
 
-    public function testGetParent_noParent()
+    public function testGetParentWhenThereIsNoParent()
     {
         $propertyPath = new PropertyPath('path');
 

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  */
 class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function test__Construct()
+    public function testConstruct()
     {
         $storage = new NativeSessionStorage(array('name' => 'TESTING'), new NativeFileSessionHandler(sys_get_temp_dir()));
 
@@ -42,7 +42,7 @@ class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider savePathDataProvider
      */
-    public function test__ConstructSavePath($savePath, $expectedSavePath, $path)
+    public function testConstructSavePath($savePath, $expectedSavePath, $path)
     {
         $handler = new NativeFileSessionHandler($savePath);
         $this->assertEquals($expectedSavePath, ini_get('session.save_path'));
@@ -65,7 +65,7 @@ class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function test__ConstructException()
+    public function testConstructException()
     {
         $handler = new NativeFileSessionHandler('something;invalid;with;too-many-args');
     }

--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -21,7 +21,7 @@ class PhpExecutableFinderTest extends \PHPUnit_Framework_TestCase
     /**
      * tests find() with the env var PHP_PATH
      */
-    public function testFindWithPHP_PATH()
+    public function testFindWithPhpPath()
     {
         if (defined('PHP_BINARY')) {
             $this->markTestSkipped('The PHP binary is easily available as of PHP 5.4');

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -39,7 +39,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator = null;
     }
 
-    public function testValidate_defaultGroup()
+    public function testValidateDefaultGroup()
     {
         $entity = new Entity();
         $metadata = new ClassMetadata(get_class($entity));
@@ -62,7 +62,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($violations, $this->validator->validate($entity));
     }
 
-    public function testValidate_oneGroup()
+    public function testValidateOneGroup()
     {
         $entity = new Entity();
         $metadata = new ClassMetadata(get_class($entity));
@@ -85,7 +85,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($violations, $this->validator->validate($entity, 'Custom'));
     }
 
-    public function testValidate_multipleGroups()
+    public function testValidateMultipleGroups()
     {
         $entity = new Entity();
         $metadata = new ClassMetadata(get_class($entity));
@@ -119,7 +119,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($violations, $result);
     }
 
-    public function testValidate_groupSequenceProvider()
+    public function testValidateGroupSequenceProvider()
     {
         $entity = new GroupSequenceProviderEntity();
         $metadata = new ClassMetadata(get_class($entity));


### PR DESCRIPTION
This is just a cosmetic change. It is more common (in Symfony) to use fully camel-cased names for test methods. Only some of the test methods contain underscores. To avoid confusion it is better to be consistent.

Bug fix: no
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: -
Todo: -
License of the code: MIT
Documentation PR: -
