### PR TITLE
[2.0] [Form] [Locale] PHP 5.5 compatibility fixes

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
@@ -39,7 +39,7 @@ class MonthChoiceList extends PaddedChoiceList
         $pattern = $this->formatter->getPattern();
         $timezone = $this->formatter->getTimezoneId();
 
-        if (version_compare(phpversion(), '5.5.0alpha1', '<')) {
+        if (version_compare(phpversion(), '5.5.0-dev', '<')) {
             $this->formatter->setTimezoneId('UTC');
         } else {
             $this->formatter->setTimezone('UTC');
@@ -57,7 +57,7 @@ class MonthChoiceList extends PaddedChoiceList
             $this->formatter->setPattern($pattern);
         }
 
-        if (version_compare(phpversion(), '5.5.0alpha1', '<')) {
+        if (version_compare(phpversion(), '5.5.0-dev', '<')) {
             $this->formatter->setTimezoneId($timezone);
         } else {
             $this->formatter->setTimezone($timezone);

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -188,7 +188,7 @@ class StubIntlDateFormatter
             $argumentError = 'datefmt_format: takes either an array  or an integer timestamp value ';
         } elseif (version_compare(\PHP_VERSION, '5.3.4', '>=') && !is_int($timestamp) && !$timestamp instanceof \DateTime) {
             $argumentError = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object';
-            if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=') && !is_int($timestamp)) {
+            if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=') && !is_int($timestamp)) {
                 $argumentError = sprintf('datefmt_format: string \'%s\' is not numeric, which would be required for it to be a valid date', $timestamp);
             }
         }
@@ -349,7 +349,7 @@ class StubIntlDateFormatter
         }
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+        if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
             return date_default_timezone_get();
         }
 
@@ -513,7 +513,7 @@ class StubIntlDateFormatter
     {
         if (null === $timeZoneId) {
             // In PHP 5.5 if $timeZoneId is null it fallbacks to `date_default_timezone_get()` method
-            if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+            if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
                 $timeZoneId = date_default_timezone_get();
             } else {
                 // TODO: changes were made to ext/intl in PHP 5.4.4 release that need to be investigated since it will

--- a/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
@@ -45,7 +45,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $formatter = new StubIntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
@@ -58,7 +58,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $formatter = new \IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
@@ -369,7 +369,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     public function formatErrorProvider()
     {
         // With PHP 5.5 IntlDateFormatter accepts empty values ('0')
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             return array(
                 array('y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR')
             );
@@ -437,7 +437,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         );
 
         // As of PHP 5.5, intl ext no longer fallbacks invalid time zones to UTC
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             // When time zone not exists, uses UTC by default
             $data[] = array(0, 'Foo/Bar', '1970-01-01 00:00:00');
             $data[] = array(0, 'UTC+04:30', '1970-01-01 00:00:00');
@@ -454,7 +454,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -468,7 +468,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -482,7 +482,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -496,7 +496,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -532,7 +532,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     public function testFormatWithDefaultTimezoneStubShouldUseTheTzEnvironmentVariableWhenAvailable()
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('StubIntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -555,7 +555,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     public function testFormatWithDefaultTimezoneStubShouldUseDefaultDateTimeZoneVariable()
     {
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('Only in PHP 5.5 StubIntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -585,7 +585,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
      */
     public function testFormatWithDefaultTimezoneIntlShouldUseTheTzEnvironmentVariableWhenAvailable()
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('IntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -614,7 +614,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
      */
     public function testFormatWithDefaultTimezoneIntlShouldUseDefaultDateTimeZoneVariable()
     {
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('Only in PHP 5.5 IntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -1105,7 +1105,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);
@@ -1122,7 +1122,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);
@@ -1141,7 +1141,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         );
 
         // When time zone not exists, uses UTC by default
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $data[] = array('GMT-0300', 'UTC');
             $data[] = array('Foo/Bar', 'UTC');
             $data[] = array('GMT+00:AA', 'UTC');
@@ -1163,7 +1163,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -1175,7 +1175,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -1202,7 +1202,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     protected function createDateTime($timestamp = null)
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $timeZone = date_default_timezone_get();
         } else {
             $timeZone = getenv('TZ') ?: 'UTC';


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: unknown, can't run the test suite on 2.0 due to `Doctrine\DBAL\Logging\DebugStack` not being found
Fixes the following tickets: N/A
Todo: None
License of the code: MIT
Documentation PR: N/A

A backport of #6647 to the Symfony 2.0 branch, as requested. This affects a couple of files that aren't affected on 2.1.
