### PR TITLE
[Profiler] [Redis] Fix sort of redis storage profiler rows.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -60,7 +60,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             return array();
         }
 
-        $profileList = explode("\n", $indexContent);
+        $profileList = array_reverse(explode("\n", $indexContent));
         $result = array();
 
         foreach ($profileList as $item) {
@@ -78,7 +78,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
-            $result[$itemToken] = array(
+            $result[] = array(
                 'token'  => $itemToken,
                 'ip'     => $itemIp,
                 'method' => $itemMethod,
@@ -88,14 +88,6 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             );
             --$limit;
         }
-
-        usort($result, function($a, $b) {
-            if ($a['time'] === $b['time']) {
-                return 0;
-            }
-
-            return $a['time'] > $b['time'] ? -1 : 1;
-        });
 
         return $result;
     }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

Redis profiler rows are not sorted as expected.

We have in redis:

```
- 2011-01-01 ...
- 2011-01-02 ...
- 2011-01-03 ...
```

If we limit to 2, we'll have:

```
- 2011-01-02 ...
- 2011-01-01 ...
```

Fixed this bug by reversing array.
