### PR TITLE
[HttpKernel] Remove conflicting `use` from `NullLogger`

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/NullLogger.php
+++ b/src/Symfony/Component/HttpKernel/Log/NullLogger.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\HttpKernel\Log;
 
-use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger as PsrNullLogger;
 
 /**


### PR DESCRIPTION
Without this code dies with fatal:

> Cannot use Psr\Log\LoggerInterface as LoggerInterface because the name is already in use
