### PR TITLE
[HttpFoundation] moved file hash calculation to own method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\File\Exception\FileException;
  * @author Igor Wiedler <igor@wiedler.ch>
  * @author Jordan Alliot <jordan.alliot@gmail.com>
  * @author Sergey Linnik <linniksa@gmail.com>
+ * @author Povilas Skruibis <puovils@gmail.com>
  */
 class BinaryFileResponse extends Response
 {
@@ -123,9 +124,19 @@ class BinaryFileResponse extends Response
      */
     public function setAutoEtag()
     {
-        $this->setEtag(sha1_file($this->file->getPathname()));
+        $this->setEtag($this->calculateFileHash());
 
         return $this;
+    }
+
+    /**
+     * Calculate file hash
+     *
+     * @return string
+     */
+    protected function calculateFileHash()
+    {
+        return sha1_file($this->file->getPathname());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -124,7 +124,8 @@ class BinaryFileResponse extends Response
      */
     public function setAutoEtag()
     {
-        $this->setEtag($this->calculateFileHash());
+        $hash = $this->calculateFileHash($this->file->getPathname());
+        $this->setEtag($hash);
 
         return $this;
     }
@@ -132,11 +133,13 @@ class BinaryFileResponse extends Response
     /**
      * Calculate file hash
      *
+     * @param string $filename The path to the file
+     * 
      * @return string
      */
-    protected function calculateFileHash()
+    protected function calculateFileHash($filename)
     {
-        return sha1_file($this->file->getPathname());
+        return sha1_file($filename);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -124,8 +124,7 @@ class BinaryFileResponse extends Response
      */
     public function setAutoEtag()
     {
-        $hash = $this->calculateFileHash($this->file->getPathname());
-        $this->setEtag($hash);
+        $this->setEtag($this->calculateFileHash($this->file->getPathname()));
 
         return $this;
     }


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Todo: -
Fixes the following tickets: #6101
License of the code: MIT
Documentation PR: -

This commit adds ability to change default hashing implementation by extending BinaryFileResponse.
