### PR TITLE
[HttpKernel][WIP] Implement SSI rendering strategy

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -73,6 +73,7 @@ class Configuration implements ConfigurationInterface
 
         $this->addFormSection($rootNode);
         $this->addEsiSection($rootNode);
+        $this->addSsiSection($rootNode);
         $this->addProfilerSection($rootNode);
         $this->addRouterSection($rootNode);
         $this->addSessionSection($rootNode);
@@ -112,6 +113,16 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    private function addSsiSection (ArrayNodeDefinition $rootNode) {
+        $rootNode
+            ->children()
+                ->arrayNode('ssi')
+                    ->info('ssi configuration')
+                    ->canBeDisabled()
+                ->end()
+            ->end();
     }
 
     private function addProfilerSection(ArrayNodeDefinition $rootNode)

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -94,6 +94,10 @@ class FrameworkExtension extends Extension
             $this->registerEsiConfiguration($config['esi'], $loader);
         }
 
+        if (isset($config['ssi'])) {
+            $this->registerSsiConfiguration($config['ssi'], $loader);
+        }
+
         if (isset($config['profiler'])) {
             $this->registerProfilerConfiguration($config['profiler'], $container, $loader);
         }
@@ -181,6 +185,18 @@ class FrameworkExtension extends Extension
     {
         if (!empty($config['enabled'])) {
             $loader->load('esi.xml');
+        }
+    }
+
+    /**
+     * Loads the SSI configuration.
+     *
+     * @param array         $config An SSI configuration array
+     * @param XmlFileLoader $loader An XmlFileLoader instance
+     */
+    private function registerSsiConfiguration (array $config, XmlFileLoader $loader) {
+        if (!empty($config['enabled'])) {
+            $loader->load('ssi.xml');
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/ssi.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="http_content_renderer.strategy.ssi.class">Symfony\Component\HttpKernel\RenderingStrategy\SsiRenderingStrategy</parameter>
+    </parameters>
+
+    <services>
+        <service id="http_content_renderer.strategy.ssi" class="%http_content_renderer.strategy.ssi.class%">
+            <tag name="kernel.content_renderer_strategy" />
+            <argument type="service" id="http_content_renderer.strategy.default" />
+            <call method="setUrlGenerator"><argument type="service" id="router" /></call>
+        </service>
+    </services>
+</container>

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/SsiRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/SsiRenderingStrategy.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\RenderingStrategy;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+/**
+ * Implements the ESI rendering strategy.
+ *
+ * @author Sebastian Krebs <krebs.seb@gmail.com>
+ */
+class SsiRenderingStrategy extends GeneratorAwareRenderingStrategy
+{
+    private $defaultStrategy;
+
+    /**
+     * Constructor.
+     *
+     * The "fallback" strategy when ESI is not available should always be an
+     * instance of DefaultRenderingStrategy (or a class you are using for the
+     * default strategy).
+     *
+     * @param RenderingStrategyInterface $defaultStrategy The default strategy to use when ESI is not supported
+     */
+    public function __construct(RenderingStrategyInterface $defaultStrategy)
+    {
+        $this->defaultStrategy = $defaultStrategy;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Note that if the current Request has no ESI capability, this method
+     * falls back to use the default rendering strategy.
+     *
+     * Additional available options:
+     *
+     *  * comment: a comment to add when returning an esi:include tag
+     */
+    public function render($uri, Request $request = null, array $options = array())
+    {
+        if (null === $request) {
+            return $this->defaultStrategy->render($uri, $request, $options);
+        }
+
+        if ($uri instanceof ControllerReference) {
+            $uri = $this->generateProxyUri($uri, $request);
+        }
+
+        return $this->renderIncludeTag($uri, isset($options['ignore_errors']) ? $options['ignore_errors'] : false, isset($options['comment']) ? $options['comment'] : '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'ssi';
+    }
+
+
+    private function renderIncludeTag ($uri, $ignoreErrors = true, $comment = '') {
+        $html = sprintf('<!--#include virtual="%s"%s -->',
+            $uri,
+            $ignoreErrors ? ' fmt="?"' : ''
+        );
+
+        if (!empty($comment)) {
+            return sprintf("<!-- %s -->\n%s", $comment, $html);
+        }
+
+        return $html;
+    }
+}


### PR DESCRIPTION
Well, it works, but I added the `[WIP]`-tag, because it "feels" incomplete. It currently implements SSI-support into the `HttpKernel` similar to the ESI-support, but more like `HInclude` (without `HttpCache`). This way it is only possible to (depending on the configuration) always render the SSI-tag, or never (including corresponding "missing render strategy"-exception). This makes it hard to use during development, where SSI may or may not be parsed.

The things I felt uncomfortable with:
- ESI is hardcoded into the `HttpCache`-class. It doesn't feel "clean" to do the same with SSI right next to ESI. Especially what happens, when both where used (unusual, but possible)?
- Although SSI and ESI are doing nearly exactly the same, the Esi-implementation implements very Esi-specific interfaces, classes and methods (`EsiResponseCacheStrategyInterface` for example). I would have copy and pasted them, but there must be better solutions.

At the end the main-point is, that both behave quite similar and I think there must be a way to implement both, so that they share most of the code and are useable simultaneously. I hope, it is clear, whats on my mind. Would like to hear some opinions before going on :smile: I think the "share code" is not thaaat hard, but requires to rename several classes, interfaces and methods. However, the "both were enabled and used at once" makes me thinking...
