### PR TITLE
[2.3] [Twig][Bridge]Added escaping for the trans block

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -17,6 +17,9 @@
    {% render controller('BlogBundle:Post:list', { 'limit': 2 }), { 'alt': 'BlogBundle:Post:error' } %}
    ```
 
+ * The `{% trans %}` and `{% transchoice %}` behavior has been change to allow
+   the automatic escaping of the translations.
+
 ### HttpFoundation
 
  * The MongoDbSessionHandler default field names and timestamp type have changed.

--- a/src/Symfony/Bridge/Twig/Node/TransNode.php
+++ b/src/Symfony/Bridge/Twig/Node/TransNode.php
@@ -41,7 +41,7 @@ class TransNode extends \Twig_Node
         $method = null === $this->getNode('count') ? 'trans' : 'transChoice';
 
         $compiler
-            ->write('echo $this->env->getExtension(\'translator\')->getTranslator()->'.$method.'(')
+            ->write('echo twig_escape_filter($this->env, $this->env->getExtension(\'translator\')->getTranslator()->'.$method.'(')
             ->subcompile($msg)
         ;
 
@@ -80,7 +80,7 @@ class TransNode extends \Twig_Node
                 ->subcompile($this->getNode('locale'))
             ;
         }
-        $compiler->raw(");\n");
+        $compiler->raw("), \"html\", null, true);\n");
     }
 
     protected function compileString(\Twig_NodeInterface $body, \Twig_Node_Expression_Array $vars)


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: yes
Fixes the following tickets: #2713
Todo: see below
License of the code: MIT
Documentation PR: ~

This fixes an escaping problem with using the `{% trans %}` block which wasn't escaping the translations. Also I think this applies to the `{% transchoice %}` block.

Imho since this is such a behavior change, it should be done in master branch. Also I'm not sure about it but I think I must add the change in both upgrade file and documentation.

There's one thing that I don't really like about this, the fact that I've hardcoded the 'html' string as a context but I don't know how to get the context either at compile time or in the compiled template. Any help would be great!
