### PR TITLE
[Validator] ClassMetadata use deprecated methods

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -111,7 +111,7 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
 
             foreach ($this->getConstrainedProperties() as $property) {
                 foreach ($this->getMemberMetadatas($property) as $member) {
-                    $member->accept($visitor, $member->getValue($value), $group, $pathPrefix.$property, $propagatedGroup);
+                    $member->accept($visitor, $member->getPropertyValue($value), $group, $pathPrefix.$property, $propagatedGroup);
                 }
             }
         }


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: maybe yes (I don't have the knowlegde)
Symfony2 tests pass: yes
Fixes the following tickets: ?
Todo: Nothing
License of the code: MIT
Documentation PR: Nothing

getValue() is deprecated since version 2.2 and will be removed in 2.3. Use getPropertyValue() instead.

ClassMetadata is still using the deprecated method, changed it to getPropertyValue to prevent a trigger error.
