### PR TITLE
[Validator][Constraints] Update CollectionValidator using new Validator API

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/CollectionValidator.php
@@ -36,9 +36,7 @@ class CollectionValidator extends ConstraintValidator
             throw new UnexpectedTypeException($value, 'array or Traversable and ArrayAccess');
         }
 
-        $walker = $this->context->getGraphWalker();
         $group = $this->context->getGroup();
-        $propertyPath = $this->context->getPropertyPath();
 
         foreach ($constraint->fields as $field => $fieldConstraint) {
             if (
@@ -47,10 +45,10 @@ class CollectionValidator extends ConstraintValidator
                 ($value instanceof \ArrayAccess && $value->offsetExists($field))
             ) {
                 foreach ($fieldConstraint->constraints as $constr) {
-                    $walker->walkConstraint($constr, $value[$field], $group, $propertyPath.'['.$field.']');
+                    $this->context->validateValue($value[$field], $constr, '['.$field.']', $group);
                 }
             } elseif (!$fieldConstraint instanceof Optional && !$constraint->allowMissingFields) {
-                $this->context->addViolationAtSubPath('['.$field.']', $constraint->missingFieldsMessage, array(
+                $this->context->addViolationAt('['.$field.']', $constraint->missingFieldsMessage, array(
                     '{{ field }}' => $field
                 ), null);
             }
@@ -59,7 +57,7 @@ class CollectionValidator extends ConstraintValidator
         if (!$constraint->allowExtraFields) {
             foreach ($value as $field => $fieldValue) {
                 if (!isset($constraint->fields[$field])) {
-                    $this->context->addViolationAtSubPath('['.$field.']', $constraint->extraFieldsMessage, array(
+                    $this->context->addViolationAt('['.$field.']', $constraint->extraFieldsMessage, array(
                         '{{ field }}' => $field
                     ), $fieldValue);
                 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -41,35 +41,20 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator = null;
     }
 
-    public function deprecationErrorHandler($errorNumber, $message, $file, $line, $context)
-    {
-        if ($errorNumber & E_USER_DEPRECATED) {
-            return true;
-        }
-
-        return \PHPUnit_Util_ErrorHandler::handleError($errorNumber, $message, $file, $line);
-    }
-
     abstract protected function prepareTestData(array $contents);
 
     public function testNullIsValid()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $this->context->expects($this->never())
             ->method('addViolationAt');
 
         $this->validator->validate(null, new Collection(array('fields' => array(
             'foo' => new Range(array('min' => 4)),
         ))));
-
-        restore_error_handler();
     }
 
     public function testFieldsAsDefaultOption()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $data = $this->prepareTestData(array('foo' => 'foobar'));
 
         $this->context->expects($this->never())
@@ -78,8 +63,6 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($data, new Collection(array(
             'foo' => new Range(array('min' => 4)),
         )));
-
-        restore_error_handler();
     }
 
     /**
@@ -87,20 +70,14 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
      */
     public function testThrowsExceptionIfNotTraversable()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $this->validator->validate('foobar', new Collection(array('fields' => array(
             'foo' => new Range(array('min' => 4)),
         ))));
-
-        restore_error_handler();
     }
 
     public function testWalkSingleConstraint()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
         $constraint = new Range(array('min' => 4));
-        restore_error_handler();
 
         $array = array(
             'foo' => 3,
@@ -129,12 +106,10 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testWalkMultipleConstraints()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
         $constraints = array(
             new Range(array('min' => 4)),
             new NotNull(),
         );
-        restore_error_handler();
 
         $array = array(
             'foo' => 3,
@@ -165,8 +140,6 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testExtraFieldsDisallowed()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $data = $this->prepareTestData(array(
             'foo' => 5,
             'baz' => 6,
@@ -184,15 +157,11 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ),
             'extraFieldsMessage' => 'myMessage',
         )));
-
-        restore_error_handler();
     }
 
     // bug fix
     public function testNullNotConsideredExtraField()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $data = $this->prepareTestData(array(
             'foo' => null,
         ));
@@ -207,14 +176,10 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolationAt');
 
         $this->validator->validate($data, $constraint);
-
-        restore_error_handler();
     }
 
     public function testExtraFieldsAllowed()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $data = $this->prepareTestData(array(
             'foo' => 5,
             'bar' => 6,
@@ -231,14 +196,10 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolationAt');
 
         $this->validator->validate($data, $constraint);
-
-        restore_error_handler();
     }
 
     public function testMissingFieldsDisallowed()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $data = $this->prepareTestData(array());
 
         $constraint = new Collection(array(
@@ -255,14 +216,10 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ));
 
         $this->validator->validate($data, $constraint);
-
-        restore_error_handler();
     }
 
     public function testMissingFieldsAllowed()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $data = $this->prepareTestData(array());
 
         $constraint = new Collection(array(
@@ -276,8 +233,6 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolationAt');
 
         $this->validator->validate($data, $constraint);
-
-        restore_error_handler();
     }
 
     public function testOptionalFieldPresent()
@@ -308,8 +263,6 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testOptionalFieldSingleConstraint()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $array = array(
             'foo' => 5,
         );
@@ -328,14 +281,10 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($data, new Collection(array(
             'foo' => new Optional($constraint),
         )));
-
-        restore_error_handler();
     }
 
     public function testOptionalFieldMultipleConstraints()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $array = array(
             'foo' => 5,
         );
@@ -360,8 +309,6 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($data, new Collection(array(
             'foo' => new Optional($constraints),
         )));
-
-        restore_error_handler();
     }
 
     public function testRequiredFieldPresent()
@@ -398,8 +345,6 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testRequiredFieldSingleConstraint()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $array = array(
             'foo' => 5,
         );
@@ -418,14 +363,10 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($data, new Collection(array(
             'foo' => new Required($constraint),
         )));
-
-        restore_error_handler();
     }
 
     public function testRequiredFieldMultipleConstraints()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $array = array(
             'foo' => 5,
         );
@@ -450,14 +391,10 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($array, new Collection(array(
             'foo' => new Required($constraints),
         )));
-
-        restore_error_handler();
     }
 
     public function testObjectShouldBeLeftUnchanged()
     {
-        set_error_handler(array($this, "deprecationErrorHandler"));
-
         $value = new \ArrayObject(array(
             'foo' => 3
         ));
@@ -471,7 +408,5 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(
             'foo' => 3
         ), (array) $value);
-
-        restore_error_handler();
     }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -33,9 +33,6 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context->expects($this->any())
             ->method('getGroup')
             ->will($this->returnValue('MyGroup'));
-        $this->context->expects($this->any())
-            ->method('getPropertyPath')
-            ->will($this->returnValue('foo.bar'));
     }
 
     protected function tearDown()

--- a/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CollectionValidatorTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Validator\Tests\Constraints;
 
 use Symfony\Component\Validator\ExecutionContext;
-use Symfony\Component\Validator\Constraints\Min;
+use Symfony\Component\Validator\Constraints\Range;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Collection\Required;
 use Symfony\Component\Validator\Constraints\Collection\Optional;
@@ -60,7 +60,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolationAt');
 
         $this->validator->validate(null, new Collection(array('fields' => array(
-            'foo' => new Min(4),
+            'foo' => new Range(array('min' => 4)),
         ))));
 
         restore_error_handler();
@@ -76,7 +76,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             ->method('addViolationAt');
 
         $this->validator->validate($data, new Collection(array(
-            'foo' => new Min(4),
+            'foo' => new Range(array('min' => 4)),
         )));
 
         restore_error_handler();
@@ -90,7 +90,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
         set_error_handler(array($this, "deprecationErrorHandler"));
 
         $this->validator->validate('foobar', new Collection(array('fields' => array(
-            'foo' => new Min(4),
+            'foo' => new Range(array('min' => 4)),
         ))));
 
         restore_error_handler();
@@ -99,7 +99,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
     public function testWalkSingleConstraint()
     {
         set_error_handler(array($this, "deprecationErrorHandler"));
-        $constraint = new Min(4);
+        $constraint = new Range(array('min' => 4));
         restore_error_handler();
 
         $array = array(
@@ -131,7 +131,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
     {
         set_error_handler(array($this, "deprecationErrorHandler"));
         $constraints = array(
-            new Min(4),
+            new Range(array('min' => 4)),
             new NotNull(),
         );
         restore_error_handler();
@@ -180,7 +180,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->validate($data, new Collection(array(
             'fields' => array(
-                'foo' => new Min(4),
+                'foo' => new Range(array('min' => 4)),
             ),
             'extraFieldsMessage' => 'myMessage',
         )));
@@ -199,7 +199,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Collection(array(
             'fields' => array(
-                'foo' => new Min(4),
+                'foo' => new Range(array('min' => 4)),
             ),
         ));
 
@@ -222,7 +222,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Collection(array(
             'fields' => array(
-                'foo' => new Min(4),
+                'foo' => new Range(array('min' => 4)),
             ),
             'allowExtraFields' => true,
         ));
@@ -243,7 +243,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Collection(array(
             'fields' => array(
-                'foo' => new Min(4),
+                'foo' => new Range(array('min' => 4)),
             ),
             'missingFieldsMessage' => 'myMessage',
         ));
@@ -267,7 +267,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraint = new Collection(array(
             'fields' => array(
-                'foo' => new Min(4),
+                'foo' => new Range(array('min' => 4)),
             ),
             'allowMissingFields' => true,
         ));
@@ -314,7 +314,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => 5,
         );
 
-        $constraint = new Min(4);
+        $constraint = new Range(array('min' => 4));
 
         $this->context->expects($this->once())
             ->method('validateValue')
@@ -342,7 +342,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraints = array(
             new NotNull(),
-            new Min(4),
+            new Range(array('min' => 4)),
         );
         $i = 1;
 
@@ -404,7 +404,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
             'foo' => 5,
         );
 
-        $constraint = new Min(4);
+        $constraint = new Range(array('min' => 4));
 
         $this->context->expects($this->once())
             ->method('validateValue')
@@ -432,7 +432,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $constraints = array(
             new NotNull(),
-            new Min(4),
+            new Range(array('min' => 4)),
         );
         $i = 1;
 
@@ -464,7 +464,7 @@ abstract class CollectionValidatorTest extends \PHPUnit_Framework_TestCase
 
         $this->validator->validate($value, new Collection(array(
             'fields' => array(
-                'foo' => new Min(2),
+                'foo' => new Range(array('min' => 2)),
             )
         )));
 


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6648
License of the code: MIT

In the tests `$i = 1` is because in `validate` the first call to `$this->context` is `$this->context->getGroup();`, should I write this in a comment before each declaration?
