### PR TITLE
StringInput options and arguments should not be reseted

### DIFF
--- a/src/Symfony/Bridge/Doctrine/.gitattributes
+++ b/src/Symfony/Bridge/Doctrine/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -350,7 +350,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame(array('1', '3'), $field->getClientData());
     }
 
-    public function testSubmitMultipleNonExpandedSingleIdentifier_existingData()
+    public function testSubmitMultipleNonExpandedSingleIdentifierForExistingData()
     {
         $entity1 = new SingleIdentEntity(1, 'Foo');
         $entity2 = new SingleIdentEntity(2, 'Bar');
@@ -407,7 +407,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame(array('0', '2'), $field->getClientData());
     }
 
-    public function testSubmitMultipleNonExpandedCompositeIdentifier_existingData()
+    public function testSubmitMultipleNonExpandedCompositeIdentifierExistingData()
     {
         $entity1 = new CompositeIdentEntity(10, 20, 'Foo');
         $entity2 = new CompositeIdentEntity(30, 40, 'Bar');
@@ -583,7 +583,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertEquals(array(2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
     }
 
-    public function testDisallowChoicesThatAreNotIncluded_choicesSingleIdentifier()
+    public function testDisallowChoicesThatAreNotIncludedChoicesSingleIdentifier()
     {
         $entity1 = new SingleIdentEntity(1, 'Foo');
         $entity2 = new SingleIdentEntity(2, 'Bar');
@@ -604,7 +604,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertNull($field->getData());
     }
 
-    public function testDisallowChoicesThatAreNotIncluded_choicesCompositeIdentifier()
+    public function testDisallowChoicesThatAreNotIncludedChoicesCompositeIdentifier()
     {
         $entity1 = new CompositeIdentEntity(10, 20, 'Foo');
         $entity2 = new CompositeIdentEntity(30, 40, 'Bar');

--- a/src/Symfony/Bridge/Monolog/.gitattributes
+++ b/src/Symfony/Bridge/Monolog/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Propel1/.gitattributes
+++ b/src/Symfony/Bridge/Propel1/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Swiftmailer/.gitattributes
+++ b/src/Symfony/Bridge/Swiftmailer/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bridge/Twig/.gitattributes
+++ b/src/Symfony/Bridge/Twig/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/FrameworkBundle/.gitattributes
+++ b/src/Symfony/Bundle/FrameworkBundle/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/SecurityBundle/.gitattributes
+++ b/src/Symfony/Bundle/SecurityBundle/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/TwigBundle/.gitattributes
+++ b/src/Symfony/Bundle/TwigBundle/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
+++ b/src/Symfony/Bundle/WebProfilerBundle/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/BrowserKit/.gitattributes
+++ b/src/Symfony/Component/BrowserKit/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/ClassLoader/.gitattributes
+++ b/src/Symfony/Component/ClassLoader/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Config/.gitattributes
+++ b/src/Symfony/Component/Config/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Console/.gitattributes
+++ b/src/Symfony/Component/Console/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Console\Tests\Input;
 
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 
 class StringInputTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,6 +27,18 @@ class StringInputTest extends \PHPUnit_Framework_TestCase
         $p = $r->getProperty('tokens');
         $p->setAccessible(true);
         $this->assertEquals($tokens, $p->getValue($input), $message);
+    }
+
+    public function testInputOptionWithGivenString()
+    {
+        $definition = new InputDefinition(
+            array(new InputOption('foo', null, InputOption::VALUE_REQUIRED))
+        );
+
+        $input = new StringInput('--foo=bar', $definition);
+        $actual = $input->getOption('foo');
+
+        $this->assertEquals('bar', $actual);
     }
 
     public function getTokenizeData()

--- a/src/Symfony/Component/CssSelector/.gitattributes
+++ b/src/Symfony/Component/CssSelector/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/DependencyInjection/.gitattributes
+++ b/src/Symfony/Component/DependencyInjection/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/DomCrawler/.gitattributes
+++ b/src/Symfony/Component/DomCrawler/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/EventDispatcher/.gitattributes
+++ b/src/Symfony/Component/EventDispatcher/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/GenericEventTest.php
@@ -48,7 +48,7 @@ class GenericEventTest extends \PHPUnit_Framework_TestCase
         parent::tearDown();
     }
 
-    public function test__construct()
+    public function testConstruct()
     {
         $this->assertEquals($this->event, new GenericEvent($this->subject, array('name' => 'Event')));
     }

--- a/src/Symfony/Component/Filesystem/.gitattributes
+++ b/src/Symfony/Component/Filesystem/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Finder/.gitattributes
+++ b/src/Symfony/Component/Finder/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Form/.gitattributes
+++ b/src/Symfony/Component/Form/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/MonthChoiceList.php
@@ -39,7 +39,7 @@ class MonthChoiceList extends PaddedChoiceList
         $pattern = $this->formatter->getPattern();
         $timezone = $this->formatter->getTimezoneId();
 
-        if (version_compare(phpversion(), '5.5.0alpha1', '<')) {
+        if (version_compare(phpversion(), '5.5.0-dev', '<')) {
             $this->formatter->setTimezoneId('UTC');
         } else {
             $this->formatter->setTimezone('UTC');
@@ -57,7 +57,7 @@ class MonthChoiceList extends PaddedChoiceList
             $this->formatter->setPattern($pattern);
         }
 
-        if (version_compare(phpversion(), '5.5.0alpha1', '<')) {
+        if (version_compare(phpversion(), '5.5.0-dev', '<')) {
             $this->formatter->setTimezoneId($timezone);
         } else {
             $this->formatter->setTimezone($timezone);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -263,7 +263,7 @@ class DateType extends AbstractType
         $pattern = $formatter->getPattern();
         $timezone = $formatter->getTimezoneId();
 
-        if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+        if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
             $formatter->setTimeZone(\DateTimeZone::UTC);
         } else {
             $formatter->setTimeZoneId(\DateTimeZone::UTC);
@@ -281,7 +281,7 @@ class DateType extends AbstractType
             $formatter->setPattern($pattern);
         }
 
-        if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+        if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
             $formatter->setTimeZone($timezone);
         } else {
             $formatter->setTimeZoneId($timezone);

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -263,7 +263,11 @@ class DateType extends AbstractType
         $pattern = $formatter->getPattern();
         $timezone = $formatter->getTimezoneId();
 
-        $formatter->setTimezoneId(\DateTimeZone::UTC);
+        if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+            $formatter->setTimeZone(\DateTimeZone::UTC);
+        } else {
+            $formatter->setTimeZoneId(\DateTimeZone::UTC);
+        }
 
         if (preg_match($regex, $pattern, $matches)) {
             $formatter->setPattern($matches[0]);
@@ -277,7 +281,11 @@ class DateType extends AbstractType
             $formatter->setPattern($pattern);
         }
 
-        $formatter->setTimezoneId($timezone);
+        if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+            $formatter->setTimeZone($timezone);
+        } else {
+            $formatter->setTimeZoneId($timezone);
+        }
 
         return $timestamps;
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ArrayToPartsTransformerTest.php
@@ -57,7 +57,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($output, $this->transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $output = array(
             'first' => null,
@@ -102,7 +102,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($output, $this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty()
+    public function testReverseTransformCompletelyEmpty()
     {
         $input = array(
             'first' => '',
@@ -112,7 +112,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyNull()
+    public function testReverseTransformCompletelyNull()
     {
         $input = array(
             'first' => null,
@@ -125,7 +125,7 @@ class ArrayToPartsTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyNull()
+    public function testReverseTransformPartiallyNull()
     {
         $input = array(
             'first' => array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToArrayTransformerTest.php
@@ -33,7 +33,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToArrayTransformer();
 
@@ -49,7 +49,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform(null));
     }
 
-    public function testTransform_empty_withFields()
+    public function testTransformEmptyWithFields()
     {
         $transformer = new DateTimeToArrayTransformer(null, null, array('year', 'minute', 'second'));
 
@@ -62,7 +62,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform(null));
     }
 
-    public function testTransform_withFields()
+    public function testTransformWithFields()
     {
         $transformer = new DateTimeToArrayTransformer('UTC', 'UTC', array('year', 'month', 'minute', 'second'));
 
@@ -78,7 +78,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform($input));
     }
 
-    public function testTransform_withPadding()
+    public function testTransformWithPadding()
     {
         $transformer = new DateTimeToArrayTransformer('UTC', 'UTC', null, true);
 
@@ -96,7 +96,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertSame($output, $transformer->transform($input));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformDifferentTimezones()
     {
         $transformer = new DateTimeToArrayTransformer('America/New_York', 'Asia/Hong_Kong');
 
@@ -161,7 +161,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($output, $transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty()
+    public function testReverseTransformCompletelyEmpty()
     {
         $transformer = new DateTimeToArrayTransformer();
 
@@ -177,7 +177,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         $this->assertNull($transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty_subsetOfFields()
+    public function testReverseTransformCompletelyEmptySubsetOfFields()
     {
         $transformer = new DateTimeToArrayTransformer(null, null, array('year', 'month', 'day'));
 
@@ -193,7 +193,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_year()
+    public function testReverseTransformPartiallyEmptyYear()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -208,7 +208,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_month()
+    public function testReverseTransformPartiallyEmptyMonth()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -223,7 +223,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_day()
+    public function testReverseTransformPartiallyEmptyDay()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -238,7 +238,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_hour()
+    public function testReverseTransformPartiallyEmptyHour()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -253,7 +253,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_minute()
+    public function testReverseTransformPartiallyEmptyMinute()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -268,7 +268,7 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyEmpty_second()
+    public function testReverseTransformPartiallyEmptySecond()
     {
         $transformer = new DateTimeToArrayTransformer();
         $transformer->reverseTransform(array(
@@ -280,14 +280,14 @@ class DateTimeToArrayTransformerTest extends DateTimeTestCase
         ));
     }
 
-    public function testReverseTransform_null()
+    public function testReverseTransformNull()
     {
         $transformer = new DateTimeToArrayTransformer();
 
         $this->assertNull($transformer->reverseTransform(null));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformDifferentTimezones()
     {
         $transformer = new DateTimeToArrayTransformer('America/New_York', 'Asia/Hong_Kong');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -121,14 +121,14 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertEquals('Feb 3, 2010 4:05 AM', $transformer->transform($this->dateTime));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
 
         $this->assertSame('', $transformer->transform(null));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('America/New_York', 'Asia/Hong_Kong');
 
@@ -140,7 +140,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertEquals($dateTime->format('d.m.Y H:i'), $transformer->transform($input));
     }
 
-    public function testTransform_differentPatterns()
+    public function testTransformWithDifferentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
@@ -206,7 +206,7 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('Feb 3, 2010 04:05 AM'));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('America/New_York', 'Asia/Hong_Kong');
 
@@ -216,14 +216,14 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($dateTime, $transformer->reverseTransform('03.02.2010 04:05'));
     }
 
-    public function testReverseTransform_differentPatterns()
+    public function testReverseTransformWithDifferentPatterns()
     {
         $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC', \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, \IntlDateFormatter::GREGORIAN, 'MM*yyyy*dd HH|mm|ss');
 
         $this->assertDateTimeEquals($this->dateTime, $transformer->reverseTransform('02*2010*03 04|05|06'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new DateTimeToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToStringTransformerTest.php
@@ -79,14 +79,14 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $this->assertEquals($output, $transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToStringTransformer();
 
         $this->assertSame('', $transformer->transform(null));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToStringTransformer('Asia/Hong_Kong', 'America/New_York', 'Y-m-d H:i:s');
 
@@ -134,14 +134,14 @@ class DateTimeToStringTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $reverseTransformer = new DateTimeToStringTransformer();
 
         $this->assertNull($reverseTransformer->reverseTransform(''));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformWithDifferentTimezones()
     {
         $reverseTransformer = new DateTimeToStringTransformer('America/New_York', 'Asia/Hong_Kong', 'Y-m-d H:i:s');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToTimestampTransformerTest.php
@@ -25,14 +25,14 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
         $this->assertEquals($output, $transformer->transform($input));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new DateTimeToTimestampTransformer();
 
         $this->assertNull($transformer->transform(null));
     }
 
-    public function testTransform_differentTimezones()
+    public function testTransformWithDifferentTimezones()
     {
         $transformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'America/New_York');
 
@@ -75,14 +75,14 @@ class DateTimeToTimestampTransformerTest extends DateTimeTestCase
         $this->assertDateTimeEquals($output, $reverseTransformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $reverseTransformer = new DateTimeToTimestampTransformer();
 
         $this->assertNull($reverseTransformer->reverseTransform(null));
     }
 
-    public function testReverseTransform_differentTimezones()
+    public function testReverseTransformWithDifferentTimezones()
     {
         $reverseTransformer = new DateTimeToTimestampTransformer('Asia/Hong_Kong', 'America/New_York');
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/IntegerToLocalizedStringTransformerTest.php
@@ -32,7 +32,7 @@ class IntegerToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals(12345, $transformer->reverseTransform('12345,912'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new IntegerToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/MoneyToLocalizedStringTransformerTest.php
@@ -38,7 +38,7 @@ class MoneyToLocalizedStringTransformerTest extends LocalizedTestCase
         $transformer->transform('abcd');
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new MoneyToLocalizedStringTransformer();
 
@@ -61,7 +61,7 @@ class MoneyToLocalizedStringTransformerTest extends LocalizedTestCase
         $transformer->reverseTransform(12345);
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new MoneyToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/NumberToLocalizedStringTransformerTest.php
@@ -32,7 +32,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals('12345,912', $transformer->transform(12345.9123));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new NumberToLocalizedStringTransformer();
 
@@ -75,7 +75,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals(12345.912, $transformer->reverseTransform('12345,912'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new NumberToLocalizedStringTransformer();
 
@@ -129,7 +129,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDot_noGroupSep()
+    public function testDecimalSeparatorMayNotBeDotIfGroupingSeparatorIsDotWithNoGroupSep()
     {
         if ($this->isLowerThanIcuVersion('4.7')) {
             $this->markTestSkipped('Please upgrade ICU version to 4.7+');
@@ -185,7 +185,7 @@ class NumberToLocalizedStringTransformerTest extends LocalizedTestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsComma_noGroupSep()
+    public function testDecimalSeparatorMayNotBeCommaIfGroupingSeparatorIsCommaWithNoGroupSep()
     {
         if ($this->isLowerThanIcuVersion('4.7')) {
             $this->markTestSkipped('Please upgrade ICU version to 4.7+');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/PercentToLocalizedStringTransformerTest.php
@@ -32,7 +32,7 @@ class PercentToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals('200', $transformer->transform(2));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $transformer = new PercentToLocalizedStringTransformer();
 
@@ -66,7 +66,7 @@ class PercentToLocalizedStringTransformerTest extends LocalizedTestCase
         $this->assertEquals(2, $transformer->reverseTransform('200'));
     }
 
-    public function testReverseTransform_empty()
+    public function testReverseTransformEmpty()
     {
         $transformer = new PercentToLocalizedStringTransformer();
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/ValueToDuplicatesTransformerTest.php
@@ -38,7 +38,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($output, $this->transformer->transform('Foo'));
     }
 
-    public function testTransform_empty()
+    public function testTransformEmpty()
     {
         $output = array(
             'a' => null,
@@ -60,7 +60,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('Foo', $this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyEmpty()
+    public function testReverseTransformCompletelyEmpty()
     {
         $input = array(
             'a' => '',
@@ -71,7 +71,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($this->transformer->reverseTransform($input));
     }
 
-    public function testReverseTransform_completelyNull()
+    public function testReverseTransformCompletelyNull()
     {
         $input = array(
             'a' => null,
@@ -85,7 +85,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_partiallyNull()
+    public function testReverseTransformPartiallyNull()
     {
         $input = array(
             'a' => 'Foo',
@@ -99,7 +99,7 @@ class ValueToDuplicatesTransformerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
      */
-    public function testReverseTransform_differences()
+    public function testReverseTransformDifferences()
     {
         $input = array(
             'a' => 'Foo',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormError;
 
 class DateTimeTypeTest extends LocalizedTestCase
 {
-    public function testSubmit_dateTime()
+    public function testSubmitDateTime()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -42,7 +42,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertDateTimeEquals($dateTime, $form->getData());
     }
 
-    public function testSubmit_string()
+    public function testSubmitString()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -67,7 +67,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02 03:04:00', $form->getData());
     }
 
-    public function testSubmit_timestamp()
+    public function testSubmitTimestamp()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -94,7 +94,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals($dateTime->format('U'), $form->getData());
     }
 
-    public function testSubmit_withSeconds()
+    public function testSubmitWithSeconds()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -125,7 +125,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertDateTimeEquals(new \DateTime('2010-06-02 03:04:05 UTC'), $form->getData());
     }
 
-    public function testSubmit_differentTimezones()
+    public function testSubmitDifferentTimezones()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'America/New_York',
@@ -156,7 +156,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals($dateTime->format('Y-m-d H:i:s'), $form->getData());
     }
 
-    public function testSubmit_differentTimezonesDateTime()
+    public function testSubmitDifferentTimezonesDateTime()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'America/New_York',
@@ -175,7 +175,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02T03:04:00-10:00', $form->getViewData());
     }
 
-    public function testSubmit_stringSingleText()
+    public function testSubmitStringSingleText()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -190,7 +190,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02T03:04:00Z', $form->getViewData());
     }
 
-    public function testSubmit_stringSingleText_withSeconds()
+    public function testSubmitStringSingleTextWithSeconds()
     {
         $form = $this->factory->create('datetime', null, array(
             'model_timezone' => 'UTC',
@@ -206,7 +206,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertEquals('2010-06-02T03:04:05Z', $form->getViewData());
     }
 
-    public function testSubmit_differentPattern()
+    public function testSubmitDifferentPattern()
     {
         $form = $this->factory->create('datetime', null, array(
             'date_format' => 'MM*yyyy*dd',
@@ -314,7 +314,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addEmptyIfNotRequired()
+    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => false,
@@ -336,7 +336,7 @@ class DateTimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['time']['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addNullIfRequired()
+    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('datetime', null, array(
             'required' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -313,7 +313,7 @@ class DateTypeTest extends LocalizedTestCase
         ));
     }
 
-    public function testSetData_differentTimezones()
+    public function testSetDataWithDifferentTimezones()
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -328,7 +328,7 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertEquals('01.06.2010', $form->getViewData());
     }
 
-    public function testSetData_differentTimezonesDateTime()
+    public function testSetDataWithDifferentTimezonesDateTime()
     {
         $form = $this->factory->create('date', null, array(
             'format' => \IntlDateFormatter::MEDIUM,
@@ -625,7 +625,7 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertSame('Empty day', $view['day']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addEmptyIfNotRequired()
+    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => false,
@@ -641,7 +641,7 @@ class DateTypeTest extends LocalizedTestCase
         $this->assertSame('Empty day', $view['day']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addNullIfRequired()
+    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('date', null, array(
             'required' => true,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -16,7 +16,7 @@ use Symfony\Component\Form\FormError;
 
 class TimeTypeTest extends LocalizedTestCase
 {
-    public function testSubmit_dateTime()
+    public function testSubmitDateTime()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -37,7 +37,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_string()
+    public function testSubmitString()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -56,7 +56,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_timestamp()
+    public function testSubmitTimestamp()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -77,7 +77,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_array()
+    public function testSubmitArray()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -96,7 +96,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($input, $form->getViewData());
     }
 
-    public function testSubmit_datetimeSingleText()
+    public function testSubmitDatetimeSingleText()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -111,7 +111,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
-    public function testSubmit_arraySingleText()
+    public function testSubmitArraySingleText()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -131,7 +131,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
-    public function testSubmit_arraySingleTextWithSeconds()
+    public function testSubmitArraySingleTextWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -153,7 +153,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04:05', $form->getViewData());
     }
 
-    public function testSubmit_stringSingleText()
+    public function testSubmitStringSingleText()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -168,7 +168,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals('03:04', $form->getViewData());
     }
 
-    public function testSetData_withSeconds()
+    public function testSetDataWithSeconds()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'UTC',
@@ -182,7 +182,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals(array('hour' => 3, 'minute' => 4, 'second' => 5), $form->getViewData());
     }
 
-    public function testSetData_differentTimezones()
+    public function testSetDataDifferentTimezones()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'America/New_York',
@@ -208,7 +208,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertEquals($displayedData, $form->getViewData());
     }
 
-    public function testSetData_differentTimezonesDateTime()
+    public function testSetDataDifferentTimezonesDateTime()
     {
         $form = $this->factory->create('time', null, array(
             'model_timezone' => 'America/New_York',
@@ -249,7 +249,7 @@ class TimeTypeTest extends LocalizedTestCase
         ), $view['hour']->vars['choices']);
     }
 
-    public function testIsMinuteWithinRange_returnsTrueIfWithin()
+    public function testIsMinuteWithinRangeReturnsTrueIfWithin()
     {
         $form = $this->factory->create('time', null, array(
             'minutes' => array(6, 7),
@@ -263,7 +263,7 @@ class TimeTypeTest extends LocalizedTestCase
         ), $view['minute']->vars['choices']);
     }
 
-    public function testIsSecondWithinRange_returnsTrueIfWithin()
+    public function testIsSecondWithinRangeReturnsTrueIfWithin()
     {
         $form = $this->factory->create('time', null, array(
             'seconds' => array(6, 7),
@@ -278,7 +278,7 @@ class TimeTypeTest extends LocalizedTestCase
         ), $view['second']->vars['choices']);
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyEmpty()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -294,7 +294,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyEmpty_withSeconds()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyEmptyWithSeconds()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -312,7 +312,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyFilled()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyFilled()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -328,7 +328,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsFalseIfCompletelyFilled_withSeconds()
+    public function testIsPartiallyFilledReturnsFalseIfCompletelyFilledWithSeconds()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -346,7 +346,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertFalse($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsTrueIfChoiceAndHourEmpty()
+    public function testIsPartiallyFilledReturnsTrueIfChoiceAndHourEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -364,7 +364,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertTrue($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsTrueIfChoiceAndMinuteEmpty()
+    public function testIsPartiallyFilledReturnsTrueIfChoiceAndMinuteEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -382,7 +382,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertTrue($form->isPartiallyFilled());
     }
 
-    public function testIsPartiallyFilled_returnsTrueIfChoiceAndSecondsEmpty()
+    public function testIsPartiallyFilledReturnsTrueIfChoiceAndSecondsEmpty()
     {
         $this->markTestIncomplete('Needs to be reimplemented using validators');
 
@@ -474,7 +474,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addEmptyIfNotRequired()
+    public function testPassEmptyValueAsPartialArrayAddEmptyIfNotRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => false,
@@ -491,7 +491,7 @@ class TimeTypeTest extends LocalizedTestCase
         $this->assertSame('Empty second', $view['second']->vars['empty_value']);
     }
 
-    public function testPassEmptyValueAsPartialArray_addNullIfRequired()
+    public function testPassEmptyValueAsPartialArrayAddNullIfRequired()
     {
         $form = $this->factory->create('time', null, array(
             'required' => true,

--- a/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
+++ b/src/Symfony/Component/Form/Tests/Util/PropertyPathTest.php
@@ -393,7 +393,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_noDotBeforeProperty()
+    public function testDotIsRequiredBeforeProperty()
     {
         new PropertyPath('[index]property');
     }
@@ -401,7 +401,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_dotAtTheBeginning()
+    public function testDotCannotBePresentAtTheBeginning()
     {
         new PropertyPath('.property');
     }
@@ -409,7 +409,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_unexpectedCharacters()
+    public function testUnexpectedCharacters()
     {
         new PropertyPath('property.$form');
     }
@@ -417,7 +417,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\InvalidPropertyPathException
      */
-    public function testInvalidPropertyPath_empty()
+    public function testPathCannotBeEmpty()
     {
         new PropertyPath('');
     }
@@ -425,7 +425,7 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
      */
-    public function testInvalidPropertyPath_null()
+    public function testPathCannotBeNull()
     {
         new PropertyPath(null);
     }
@@ -433,31 +433,31 @@ class PropertyPathTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException Symfony\Component\Form\Exception\UnexpectedTypeException
      */
-    public function testInvalidPropertyPath_false()
+    public function testPathCannotBeFalse()
     {
         new PropertyPath(false);
     }
 
-    public function testValidPropertyPath_zero()
+    public function testZeroIsValidPropertyPath()
     {
         new PropertyPath('0');
     }
 
-    public function testGetParent_dot()
+    public function testGetParentWithDot()
     {
         $propertyPath = new PropertyPath('grandpa.parent.child');
 
         $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
     }
 
-    public function testGetParent_index()
+    public function testGetParentWithIndex()
     {
         $propertyPath = new PropertyPath('grandpa.parent[child]');
 
         $this->assertEquals(new PropertyPath('grandpa.parent'), $propertyPath->getParent());
     }
 
-    public function testGetParent_noParent()
+    public function testGetParentWhenThereIsNoParent()
     {
         $propertyPath = new PropertyPath('path');
 

--- a/src/Symfony/Component/HttpFoundation/.gitattributes
+++ b/src/Symfony/Component/HttpFoundation/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/NativeFileSessionHandlerTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
  */
 class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    public function test__Construct()
+    public function testConstruct()
     {
         $storage = new NativeSessionStorage(array('name' => 'TESTING'), new NativeFileSessionHandler(sys_get_temp_dir()));
 
@@ -42,7 +42,7 @@ class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider savePathDataProvider
      */
-    public function test__ConstructSavePath($savePath, $expectedSavePath, $path)
+    public function testConstructSavePath($savePath, $expectedSavePath, $path)
     {
         $handler = new NativeFileSessionHandler($savePath);
         $this->assertEquals($expectedSavePath, ini_get('session.save_path'));
@@ -65,7 +65,7 @@ class NativeFileSessionHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \InvalidArgumentException
      */
-    public function test__ConstructException()
+    public function testConstructException()
     {
         $handler = new NativeFileSessionHandler('something;invalid;with;too-many-args');
     }

--- a/src/Symfony/Component/HttpKernel/.gitattributes
+++ b/src/Symfony/Component/HttpKernel/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -89,7 +89,7 @@ class ExceptionListener implements EventSubscriberInterface
             // set handling to false otherwise it wont be able to handle further more
             $handling = false;
 
-            // re-throw the exception as this is a catch-all
+            // re-throw the exception from within HttpKernel as this is a catch-all
             return;
         }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -60,7 +60,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             return array();
         }
 
-        $profileList = explode("\n", $indexContent);
+        $profileList = array_reverse(explode("\n", $indexContent));
         $result = array();
 
         foreach ($profileList as $item) {
@@ -78,7 +78,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
-            $result[$itemToken] = array(
+            $result[] = array(
                 'token'  => $itemToken,
                 'ip'     => $itemIp,
                 'method' => $itemMethod,
@@ -88,14 +88,6 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             );
             --$limit;
         }
-
-        usort($result, function($a, $b) {
-            if ($a['time'] === $b['time']) {
-                return 0;
-            }
-
-            return $a['time'] > $b['time'] ? -1 : 1;
-        });
 
         return $result;
     }

--- a/src/Symfony/Component/Locale/.gitattributes
+++ b/src/Symfony/Component/Locale/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -188,7 +188,7 @@ class StubIntlDateFormatter
             $argumentError = 'datefmt_format: takes either an array  or an integer timestamp value ';
         } elseif (version_compare(\PHP_VERSION, '5.3.4', '>=') && !is_int($timestamp) && !$timestamp instanceof \DateTime) {
             $argumentError = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object';
-            if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=') && !is_int($timestamp)) {
+            if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=') && !is_int($timestamp)) {
                 $argumentError = sprintf('datefmt_format: string \'%s\' is not numeric, which would be required for it to be a valid date', $timestamp);
             }
         }
@@ -349,7 +349,7 @@ class StubIntlDateFormatter
         }
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+        if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
             return date_default_timezone_get();
         }
 
@@ -511,7 +511,7 @@ class StubIntlDateFormatter
     {
         if (null === $timeZoneId) {
             // In PHP 5.5 if $timeZoneId is null it fallbacks to `date_default_timezone_get()` method
-            if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+            if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
                 $timeZoneId = date_default_timezone_get();
             } else {
                 // TODO: changes were made to ext/intl in PHP 5.4.4 release that need to be investigated since it will

--- a/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
+++ b/src/Symfony/Component/Locale/Stub/StubIntlDateFormatter.php
@@ -188,7 +188,7 @@ class StubIntlDateFormatter
             $argumentError = 'datefmt_format: takes either an array  or an integer timestamp value ';
         } elseif (version_compare(\PHP_VERSION, '5.3.4', '>=') && !is_int($timestamp) && !$timestamp instanceof \DateTime) {
             $argumentError = 'datefmt_format: takes either an array or an integer timestamp value or a DateTime object';
-            if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=') && !is_int($timestamp)) {
+            if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=') && !is_int($timestamp)) {
                 $argumentError = sprintf('datefmt_format: string \'%s\' is not numeric, which would be required for it to be a valid date', $timestamp);
             }
         }
@@ -349,7 +349,7 @@ class StubIntlDateFormatter
         }
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+        if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
             return date_default_timezone_get();
         }
 
@@ -513,7 +513,7 @@ class StubIntlDateFormatter
     {
         if (null === $timeZoneId) {
             // In PHP 5.5 if $timeZoneId is null it fallbacks to `date_default_timezone_get()` method
-            if (version_compare(\PHP_VERSION, '5.5.0alpha1', '>=')) {
+            if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
                 $timeZoneId = date_default_timezone_get();
             } else {
                 // TODO: changes were made to ext/intl in PHP 5.4.4 release that need to be investigated since it will

--- a/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Locale/Tests/Stub/StubIntlDateFormatterTest.php
@@ -43,7 +43,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $formatter = new StubIntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
@@ -56,7 +56,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $formatter = new \IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
@@ -367,7 +367,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     public function formatErrorProvider()
     {
         // With PHP 5.5 IntlDateFormatter accepts empty values ('0')
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             return array(
                 array('y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR')
             );
@@ -435,7 +435,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         );
 
         // As of PHP 5.5, intl ext no longer fallbacks invalid time zones to UTC
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             // When time zone not exists, uses UTC by default
             $data[] = array(0, 'Foo/Bar', '1970-01-01 00:00:00');
             $data[] = array(0, 'UTC+04:30', '1970-01-01 00:00:00');
@@ -452,7 +452,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -466,7 +466,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -480,7 +480,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -494,7 +494,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -530,7 +530,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     public function testFormatWithDefaultTimezoneStubShouldUseTheTzEnvironmentVariableWhenAvailable()
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('StubIntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -553,7 +553,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     public function testFormatWithDefaultTimezoneStubShouldUseDefaultDateTimeZoneVariable()
     {
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('Only in PHP 5.5 StubIntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -583,7 +583,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
      */
     public function testFormatWithDefaultTimezoneIntlShouldUseTheTzEnvironmentVariableWhenAvailable()
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('IntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -612,7 +612,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
      */
     public function testFormatWithDefaultTimezoneIntlShouldUseDefaultDateTimeZoneVariable()
     {
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('Only in PHP 5.5 IntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -1131,7 +1131,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);
@@ -1148,7 +1148,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);
@@ -1167,7 +1167,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         );
 
         // When time zone not exists, uses UTC by default
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $data[] = array('GMT-0300', 'UTC');
             $data[] = array('Foo/Bar', 'UTC');
             $data[] = array('GMT+00:AA', 'UTC');
@@ -1189,7 +1189,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -1201,7 +1201,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -1228,7 +1228,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     protected function createDateTime($timestamp = null)
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $timeZone = date_default_timezone_get();
         } else {
             $timeZone = getenv('TZ') ?: 'UTC';

--- a/src/Symfony/Component/OptionsResolver/.gitattributes
+++ b/src/Symfony/Component/OptionsResolver/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Process/.gitattributes
+++ b/src/Symfony/Component/Process/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Process/Exception/ProcessFailedException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessFailedException.php
@@ -30,8 +30,10 @@ class ProcessFailedException extends RuntimeException
 
         parent::__construct(
             sprintf(
-                'The command "%s" failed.'."\n\nOutput:\n================\n".$process->getOutput()."\n\nError Output:\n================\n".$process->getErrorOutput(),
-                $process->getCommandLine()
+                'The command "%s" failed.'."\n\nOutput:\n================\n%s\n\nError Output:\n================\n%s",
+                $process->getCommandLine(),
+                $process->getOutput(),
+                $process->getErrorOutput()
             )
         );
 

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -53,7 +53,7 @@ class Process
         }
 
         $this->commandline = $commandline;
-        $this->cwd = null === $cwd ? getcwd() : $cwd;
+        $this->cwd = $cwd;
         if (null !== $env) {
             $this->env = array();
             foreach ($env as $key => $value) {
@@ -359,6 +359,13 @@ class Process
      */
     public function getWorkingDirectory()
     {
+        // This is for BC only
+        if (null === $this->cwd) {
+            // getcwd() will return false if any one of the parent directories does not have
+            // the readable or search mode set, even if the current directory does
+            return getcwd() ?: null;
+        }
+
         return $this->cwd;
     }
 

--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -21,7 +21,7 @@ class PhpExecutableFinderTest extends \PHPUnit_Framework_TestCase
     /**
      * tests find() with the env var PHP_PATH
      */
-    public function testFindWithPHP_PATH()
+    public function testFindWithPhpPath()
     {
         if (defined('PHP_BINARY')) {
             $this->markTestSkipped('The PHP binary is easily available as of PHP 5.4');

--- a/src/Symfony/Component/Routing/.gitattributes
+++ b/src/Symfony/Component/Routing/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Security/.gitattributes
+++ b/src/Symfony/Component/Security/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Serializer/.gitattributes
+++ b/src/Symfony/Component/Serializer/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Templating/.gitattributes
+++ b/src/Symfony/Component/Templating/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Translation/.gitattributes
+++ b/src/Symfony/Component/Translation/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Validator/.gitattributes
+++ b/src/Symfony/Component/Validator/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -39,7 +39,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator = null;
     }
 
-    public function testValidate_defaultGroup()
+    public function testValidateDefaultGroup()
     {
         $entity = new Entity();
         $metadata = new ClassMetadata(get_class($entity));
@@ -62,7 +62,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($violations, $this->validator->validate($entity));
     }
 
-    public function testValidate_oneGroup()
+    public function testValidateOneGroup()
     {
         $entity = new Entity();
         $metadata = new ClassMetadata(get_class($entity));
@@ -85,7 +85,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($violations, $this->validator->validate($entity, 'Custom'));
     }
 
-    public function testValidate_multipleGroups()
+    public function testValidateMultipleGroups()
     {
         $entity = new Entity();
         $metadata = new ClassMetadata(get_class($entity));
@@ -119,7 +119,7 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($violations, $result);
     }
 
-    public function testValidate_groupSequenceProvider()
+    public function testValidateGroupSequenceProvider()
     {
         $entity = new GroupSequenceProviderEntity();
         $metadata = new ClassMetadata(get_class($entity));

--- a/src/Symfony/Component/Yaml/.gitattributes
+++ b/src/Symfony/Component/Yaml/.gitattributes
@@ -1,2 +1,0 @@
-/Tests export-ignore
-phpunit.xml.dist export-ignore

--- a/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
+++ b/tests/Symfony/Tests/Component/Locale/Stub/StubIntlDateFormatterTest.php
@@ -45,7 +45,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $formatter = new StubIntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
@@ -58,7 +58,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $formatter = new \IntlDateFormatter('en', StubIntlDateFormatter::MEDIUM, StubIntlDateFormatter::SHORT);
 
         // In PHP 5.5 default timezone depends on `date_default_timezone_get()` method
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->assertEquals(date_default_timezone_get(), $formatter->getTimeZoneId());
         } else {
             $this->assertNull($formatter->getTimeZoneId());
@@ -369,7 +369,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     public function formatErrorProvider()
     {
         // With PHP 5.5 IntlDateFormatter accepts empty values ('0')
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             return array(
                 array('y-M-d', 'foobar', 'datefmt_format: string \'foobar\' is not numeric, which would be required for it to be a valid date: U_ILLEGAL_ARGUMENT_ERROR')
             );
@@ -437,7 +437,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         );
 
         // As of PHP 5.5, intl ext no longer fallbacks invalid time zones to UTC
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             // When time zone not exists, uses UTC by default
             $data[] = array(0, 'Foo/Bar', '1970-01-01 00:00:00');
             $data[] = array(0, 'UTC+04:30', '1970-01-01 00:00:00');
@@ -454,7 +454,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -468,7 +468,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('Pacific/Fiji');
         } else {
             $formatter->setTimeZoneId('Pacific/Fiji');
@@ -482,7 +482,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -496,7 +496,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter('zzzz');
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+03:00');
         } else {
             $formatter->setTimeZoneId('GMT+03:00');
@@ -532,7 +532,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     public function testFormatWithDefaultTimezoneStubShouldUseTheTzEnvironmentVariableWhenAvailable()
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('StubIntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -555,7 +555,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     public function testFormatWithDefaultTimezoneStubShouldUseDefaultDateTimeZoneVariable()
     {
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('Only in PHP 5.5 StubIntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -585,7 +585,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
      */
     public function testFormatWithDefaultTimezoneIntlShouldUseTheTzEnvironmentVariableWhenAvailable()
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('IntlDateFormatter in PHP 5.5 no longer depends on TZ environment.');
         }
 
@@ -614,7 +614,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
      */
     public function testFormatWithDefaultTimezoneIntlShouldUseDefaultDateTimeZoneVariable()
     {
-        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if (!$this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $this->markTestSkipped('Only in PHP 5.5 IntlDateFormatter depends on default timezone (`date_default_timezone_get()`).');
         }
 
@@ -1105,7 +1105,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);
@@ -1122,7 +1122,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone($timeZoneId);
         } else {
             $formatter->setTimeZoneId($timeZoneId);
@@ -1141,7 +1141,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         );
 
         // When time zone not exists, uses UTC by default
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $data[] = array('GMT-0300', 'UTC');
             $data[] = array('Foo/Bar', 'UTC');
             $data[] = array('GMT+00:AA', 'UTC');
@@ -1163,7 +1163,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
     {
         $formatter = $this->createStubFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -1175,7 +1175,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
         $this->skipIfIntlExtensionIsNotLoaded();
         $formatter = $this->createIntlFormatter();
 
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $formatter->setTimeZone('GMT+00:30');
         } else {
             $formatter->setTimeZoneId('GMT+00:30');
@@ -1202,7 +1202,7 @@ class StubIntlDateFormatterTest extends LocaleTestCase
 
     protected function createDateTime($timestamp = null)
     {
-        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0alpha1')) {
+        if ($this->isGreaterOrEqualThanPhpVersion('5.5.0-dev')) {
             $timeZone = date_default_timezone_get();
         } else {
             $timeZone = getenv('TZ') ?: 'UTC';


### PR DESCRIPTION
Hi,

when using StringInput the options + arguments are reseted. I have written a test, that can be used for discussion.

Regards,
Martin
