### PR TITLE
StringInput options and arguments should not be reseted

### DIFF
--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Console\Tests\Input;
 
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 
 class StringInputTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,6 +27,18 @@ class StringInputTest extends \PHPUnit_Framework_TestCase
         $p = $r->getProperty('tokens');
         $p->setAccessible(true);
         $this->assertEquals($tokens, $p->getValue($input), $message);
+    }
+
+    public function testInputOptionWithGivenString()
+    {
+        $definition = new InputDefinition(
+            array(new InputOption('foo', null, InputOption::VALUE_REQUIRED))
+        );
+
+        $input = new StringInput('--foo=bar', $definition);
+        $actual = $input->getOption('foo');
+
+        $this->assertEquals('bar', $actual);
     }
 
     public function getTokenizeData()


### PR DESCRIPTION
Hi,

when using StringInput the options + arguments are reseted. I have written a test, that can be used for discussion.

Regards,
Martin
