### PR TITLE
[2.3] [ClassLoader] Cosmetic change to remove extra spaces in bootstrap file

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -142,6 +142,12 @@ class ClassCollectionLoader
             $token = $tokens[$i];
             if (is_string($token)) {
                 $output .= $token;
+            } elseif (T_WHITESPACE === $token[0]) {
+                if (isset($tokens[$i+1]) && T_COMMENT === $tokens[$i+1][0]) {
+                    // remove spaces before a comment
+                    $token[1] = str_replace(' ', '', $token[1]);
+                }
+                $output .= $token[1];
             } elseif (in_array($token[0], array(T_COMMENT, T_DOC_COMMENT))) {
                 // strip comments
                 continue;


### PR DESCRIPTION
Bug fix: no
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: 6752
License of the code: MIT

This patch removes spaces (from T_WHITESPACE token) before a comment (T_COMMENT token).
