### PR TITLE
Wrap the exception to get more information about where the exception comes from

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/ReplaceAliasByActualDefinitionPass.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -30,6 +31,8 @@ class ReplaceAliasByActualDefinitionPass implements CompilerPassInterface
      * Process the Container to replace aliases with service definitions.
      *
      * @param ContainerBuilder $container
+     *
+     * @throws InvalidArgumentException if the service definition does not exist
      */
     public function process(ContainerBuilder $container)
     {
@@ -39,7 +42,11 @@ class ReplaceAliasByActualDefinitionPass implements CompilerPassInterface
         foreach ($container->getAliases() as $id => $alias) {
             $aliasId = (string) $alias;
 
-            $definition = $container->getDefinition($aliasId);
+            try {
+                $definition = $container->getDefinition($aliasId);
+            } catch (InvalidArgumentException $e) {
+                throw new InvalidArgumentException(sprintf('Unable to replace alias "%s" with "%s".', $alias, $id), null, $e);
+            }
 
             if ($definition->isPublic()) {
                 continue;


### PR DESCRIPTION
Bug fix: no
Feature addition: yes
Backwards compatibility break: no
Symfony2 tests pass: yes
License of the code: MIT

This patch add more information about where the exception comes from.
Actual you get one exception

```
The service definition "fos_user.registration.form" does not exist.
```

After the patch you get

```
[2/2] Try to replace alias "fos_user.registration.form" with "hwi_oauth.registration.form". 
[1/2] The service definition "fos_user.registration.form" does not exist.
```
