### PR TITLE
[HttpKernel] fix issues with TTL based invalidation in the HttpCache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -540,6 +540,7 @@ class HttpCache implements HttpKernelInterface
     protected function store(Request $request, Response $response)
     {
         try {
+            $response->setDate(new \DateTime(null, new \DateTimeZone('UTC')));
             $this->store->write($request, $response);
 
             $this->record($request, 'store');


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6746
License of the code: MIT

Set the date in the response before passing it off to the store, to enable correct computation of the age in later requests. Note this will lead to setting the date twice in the case when the response is written to the store. Not sure if it would make sense to do a bigger refactoring.

That being said in case of a bigger refactoring I wonder if it wouldnt make more sense to change a TTL invalidation to an Expire invalidation to reduce the amount of computational work that needs to be done on a cache lookup.
