### PR TITLE
[HttpKernel] fixed circular reference detected for service "templating"

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/content_generator.xml
@@ -27,10 +27,11 @@
 
         <service id="http_content_renderer.strategy.hinclude" class="%http_content_renderer.strategy.hinclude.class%">
             <tag name="kernel.content_renderer_strategy" />
-            <argument type="service" id="templating" on-invalid="null" />
+            <argument>null</argument>
             <argument type="service" id="uri_signer" />
             <argument>%http_content_renderer.strategy.hinclude.global_template%</argument>
             <call method="setUrlGenerator"><argument type="service" id="router" /></call>
+            <call method="setContainer"><argument type="service" id="service_container" /></call>
         </service>
 
 <!-- FIXME: make the listener registration optional via a configuration setting? -->


### PR DESCRIPTION
Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: yes
Fixes the following tickets: #6730
License of the code: MIT

This fixes the "circular reference detected for service "templating" " error caused by the hinclude render strategy. I tried to keep changes minimal (yet flexible), the user can now either choose to inject the templating service by the constructor (current behavior) or by lazy loading it using the setContainer() method.
