### PR TITLE
[WDT] Fix regression in WDT path/pattern naming

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Router/panel.html.twig
@@ -33,7 +33,7 @@
             {% for trace in traces %}
                 <tr class="{{ 1 == trace.level ? 'almost' : 2 == trace.level ? 'matches' : '' }}">
                     <td>{{ trace.name }}</td>
-                    <td>{{ trace.pattern }}</td>
+                    <td>{{ trace.path }}</td>
                     <td>{{ trace.log }}</td>
                 </tr>
             {% endfor %}


### PR DESCRIPTION
Bug fix: yes (master only)
Feature addition: no
Backwards compatibility break: no
Fixes the following tickets: ~
Todo: see below
License of the code: MIT
Documentation PR: ~

This fixes a regression in WDT where clicking routing panel triggers an error.

Let me know if this should be fixed in collector as well as it could be considered a regression.
