### PR TITLE
[WebProfilerBundle] Make last toolbar info box right-aligned

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -132,6 +132,10 @@
     border-radius: 4px 4px 0 0;
 }
 
+.sf-toolbarreset > div:last-of-type .sf-toolbar-info {
+    right: -1px;
+}
+
 .sf-toolbar-block .sf-toolbar-info:empty {
     visibility: hidden;
 }


### PR DESCRIPTION
Content is less likely to go off the edge of the screen if the last box is aligned right instead of left:

![toolbar-right-align](https://f.cloud.github.com/assets/363540/73392/a88ec334-6041-11e2-8dcc-e9274c69e1d2.png)
