### PR TITLE
[WebProfilerBundle] Fix lack of padding in some WDT boxes (e.g. You are not authenticated.)

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -79,8 +79,6 @@
 }
 
 .sf-toolbar-block .sf-toolbar-info-piece {
-    padding-left: 9px;
-    padding-right: 9px;
     line-height: 19px;
     margin-bottom: 5px;
 }
@@ -259,8 +257,12 @@
 
 .sf-toolbar-block:hover .sf-toolbar-info {
     display: block;
-    min-width: 100%;
+    min-width: -webkit-calc(100% + 2px);
+    min-width: calc(100% + 2px);
     z-index: 10001;
+    box-sizing: border-box;
+    padding: 9px;
+    line-height: 19px;
 }
 
 /***** Override the setting when the toolbar is on the top *****/


### PR DESCRIPTION
Fixes bug introduced by https://github.com/symfony/symfony/pull/6615

Before:
![wdt-padding-before](https://f.cloud.github.com/assets/363540/73453/c6779f30-6044-11e2-9df5-682c822ac13c.png)

After:
![wdt-padding-after](https://f.cloud.github.com/assets/363540/73455/cbeaa44e-6044-11e2-9d9b-9184b1351554.png)
