### PR TITLE
[Yaml] fixed parsing of blocks with 'keep' chomping indicators

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -186,8 +186,9 @@ class Parser
                     }
                 }
             } else {
-                // 1-liner followed by newline
-                if (2 == count($this->lines) && empty($this->lines[1])) {
+                // 1-liner optionally followed by newline
+                $lineCount = count($this->lines);
+                if (1 === $lineCount || (2 === $lineCount && empty($this->lines[1]))) {
                     try {
                         $value = Inline::parse($this->lines[0]);
                     } catch (ParseException $e) {
@@ -543,10 +544,6 @@ class Parser
     private function cleanup($value)
     {
         $value = str_replace(array("\r\n", "\r"), "\n", $value);
-
-        if (!preg_match("#\n$#", $value)) {
-            $value .= "\n";
-        }
 
         // strip YAML header
         $count = 0;

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -106,6 +106,201 @@ EOF;
         $this->assertEquals('foo', $this->parser->parse($yaml));
     }
 
+    public function getBlockChompingTests()
+    {
+        $tests = array();
+
+        $yaml = <<<'EOF'
+foo: |-
+    one
+    two
+
+bar: |-
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo",
+            'bar' => "one\ntwo",
+        );
+        $tests['Literal block chomping strip with trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |-
+    one
+    two
+bar: |-
+    one
+    two
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo",
+            'bar' => "one\ntwo",
+        );
+        $tests['Literal block chomping strip without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |
+    one
+    two
+
+bar: |
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo\n",
+            'bar' => "one\ntwo\n",
+        );
+        $tests['Literal block chomping clip with trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |
+    one
+    two
+bar: |
+    one
+    two
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo\n",
+            'bar' => "one\ntwo\n",
+        );
+        $tests['Literal block chomping clip without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |+
+    one
+    two
+
+bar: |+
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo\n\n",
+            'bar' => "one\ntwo\n\n",
+        );
+        $tests['Literal block chomping keep with trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |+
+    one
+    two
+bar: |+
+    one
+    two
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo\n",
+            'bar' => "one\ntwo\n",
+        );
+        $tests['Literal block chomping keep without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >-
+    one
+    two
+
+bar: >-
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one two",
+            'bar' => "one two",
+        );
+        $tests['Folded block chomping strip with trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >-
+    one
+    two
+bar: >-
+    one
+    two
+EOF;
+        $expected = array(
+            'foo' => "one two",
+            'bar' => "one two",
+        );
+        $tests['Folded block chomping strip without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >
+    one
+    two
+
+bar: >
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one two\n",
+            'bar' => "one two\n",
+        );
+        $tests['Folded block chomping clip with trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >
+    one
+    two
+bar: >
+    one
+    two
+EOF;
+        $expected = array(
+            'foo' => "one two\n",
+            'bar' => "one two\n",
+        );
+        $tests['Folded block chomping clip without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >+
+    one
+    two
+
+bar: >+
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one two\n\n",
+            'bar' => "one two\n\n",
+        );
+        $tests['Folded block chomping keep with trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >+
+    one
+    two
+bar: >+
+    one
+    two
+EOF;
+        $expected = array(
+            'foo' => "one two\n",
+            'bar' => "one two\n",
+        );
+        $tests['Folded block chomping keep without trailing newline'] = array($expected, $yaml);
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider getBlockChompingTests
+     */
+    public function testBlockChomping($expected, $yaml)
+    {
+        $this->assertSame($expected, $this->parser->parse($yaml));
+    }
+
     public function testObjectsSupport()
     {
         $b = array('foo' => new B(), 'bar' => 1);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6773 |
| License | MIT |
| Doc PR | n/a |

Also added a full set of tests for all combinations of literal/folded blocks and strip/clip/keep chomping indicators in both mid-file and end-of file positions.
