### PR TITLE
[DomCrawler] Keep temporary file copy filenames

### DIFF
--- a/src/Symfony/Component/DomCrawler/Field/FileFormField.php
+++ b/src/Symfony/Component/DomCrawler/Field/FileFormField.php
@@ -62,8 +62,12 @@ class FileFormField extends FormField
             $name = basename($value);
 
             // copy to a tmp location
-            $tmp = tempnam(sys_get_temp_dir(), 'upload');
-            unlink($tmp);
+            $path = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'symfony' . DIRECTORY_SEPARATOR . uniqid();
+            mkdir($path, 0777, true);
+            $tmp = $path . DIRECTORY_SEPARATOR . $name;
+            if (is_file($tmp)) {
+                unlink($tmp);
+            }
             copy($value, $tmp);
             $value = $tmp;
         } else {

--- a/tests/Symfony/Tests/Component/DomCrawler/Field/FileFormFieldTest.php
+++ b/tests/Symfony/Tests/Component/DomCrawler/Field/FileFormFieldTest.php
@@ -58,6 +58,12 @@ class FileFormFieldTest extends FormFieldTestCase
         $this->assertEquals(basename(__FILE__), $value['name'], "->$method() sets the name of the file field");
         $this->assertEquals('', $value['type'], "->$method() sets the type of the file field");
         $this->assertInternalType('string', $value['tmp_name'], "->$method() sets the tmp_name of the file field");
+        $this->assertFileExists($value['tmp_name'], "->$method() creates a copy of the file at the tmp_name path");
+        $this->assertEquals(
+            dirname($value['tmp_name']) . DIRECTORY_SEPARATOR . basename(__FILE__),
+            $value['tmp_name'],
+            "->$method() keeps the same file name in the tmp_name copy"
+        );
         $this->assertEquals(0, $value['error'], "->$method() sets the error of the file field");
         $this->assertEquals(filesize(__FILE__), $value['size'], "->$method() sets the size of the file field");
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | kind of |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

DomCrawler's `FileFormField` takes a copy of the file and gives it a new filename (on Windows something like `upl8BF8.tmp`). Using Goutte I've tried to upload an image which is rejected by the server (in this case Drupal) since it no longer has a `.jpg` filename. This PR changes the copy so that it goes into a unique path and keeps its filename. (It also adds tests to make sure the copy is actually there.)
