### PR TITLE
[HttpFoundation] UploadedFile - moved some code from move() to isValid()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -185,7 +185,11 @@ class UploadedFile extends File
      */
     public function isValid()
     {
-        return $this->error === UPLOAD_ERR_OK;
+        $isOk = $this->error === UPLOAD_ERR_OK;
+
+        return ($this->test)
+            ? $isOk
+            : $isOk && is_uploaded_file($this->getPathname());
     }
 
     /**
@@ -196,7 +200,7 @@ class UploadedFile extends File
      *
      * @return File A File object representing the new file
      *
-     * @throws FileException if the file has not been uploaded via Http
+     * @throws FileException if, for any reason, the file could not have been moved
      *
      * @api
      */
@@ -205,21 +209,21 @@ class UploadedFile extends File
         if ($this->isValid()) {
             if ($this->test) {
                 return parent::move($directory, $name);
-            } elseif (is_uploaded_file($this->getPathname())) {
-                $target = $this->getTargetFile($directory, $name);
-
-                if (!@move_uploaded_file($this->getPathname(), $target)) {
-                    $error = error_get_last();
-                    throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
-                }
-
-                @chmod($target, 0666 & ~umask());
-
-                return $target;
             }
+
+            $target = $this->getTargetFile($directory, $name);
+
+            if (!@move_uploaded_file($this->getPathname(), $target)) {
+                $error = error_get_last();
+                throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
+            }
+
+            @chmod($target, 0666 & ~umask());
+
+            return $target;
         }
 
-        throw new FileException(sprintf('The file "%s" has not been uploaded via Http', $this->getPathname()));
+        throw new FileException(sprintf('The file "%s" is not valid', $this->getPathname()));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -197,7 +197,8 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             'original.gif',
             null,
             filesize(__DIR__.'/Fixtures/test.gif'),
-            UPLOAD_ERR_OK
+            UPLOAD_ERR_OK,
+            true
         );
 
         $this->assertTrue($file->isValid());
@@ -213,7 +214,8 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             'original.gif',
             null,
             filesize(__DIR__.'/Fixtures/test.gif'),
-            $error
+            $error,
+            true
         );
 
         $this->assertFalse($file->isValid());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |

I think `isValid()` should check if it's a real uploaded file instead of having this only in `move()`, because one could also do something else with the uploaded file than moving it (create a thumbnail from it for eg.).
