### PR TITLE
[DependencyInjection] [ContainerBuilder] Clone abstract Definintions.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -803,6 +803,36 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
     }
 
     /**
+     * Creates a clone Definition of an abstract service.
+     *
+     * Pass a Closure as second argument to modify the Definition instance.
+     *
+     * @param string   $id
+     * @param callable $callable
+     *
+     * @return Definition A concrete Definition instance
+     *
+     * @throws Exception\InvalidArgumentException
+     */
+    public function getDefinitionForAbstract($id, \Closure $callable = null)
+    {
+        $definition = $this->getDefinition($id);
+
+        if (!$definition->isAbstract()) {
+            throw new InvalidArgumentException(sprintf('The service definition "%s" is not declared abstract.', $id));
+        }
+
+        $definition = clone $definition;
+        $definition->setAbstract(false);
+
+        if ($callable) {
+            $callable($definition);
+        }
+
+        return $definition;
+    }
+
+    /**
      * Gets a service definition by id or alias.
      *
      * The method "unaliases" recursively to return a Definition instance.

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerBuilderTest.php
@@ -577,6 +577,38 @@ class ContainerBuilderTest extends \PHPUnit_Framework_TestCase
         $configs = $container->getExtensionConfig('foo');
         $this->assertEquals(array($second, $first), $configs);
     }
+
+    /**
+     * @covers Symfony\Component\DependencyInjection\ContainerBuilder::getDefinitionFromAbstract
+     */
+    public function testGetDefinitionFromAbstract()
+    {
+        $container = new ContainerBuilder();
+
+        $abstract = new Definition('stdClass');
+        $abstract->setAbstract(true);
+        $abstract->setArguments(array('abstractParam'));
+        $container->setDefinition('abstract', $abstract);
+
+        $concrete = $container->getDefinitionForAbstract('abstract');
+        $this->assertFalse($concrete->isAbstract());
+        $this->assertEquals(array('abstractParam'), $concrete->getArguments());
+
+        $concrete2 = $container->getDefinitionForAbstract('abstract');
+        $this->assertEquals($concrete, $concrete2);
+        $this->assertNotSame($concrete, $concrete2);
+
+        $concrete = $container->getDefinitionForAbstract('abstract', function($definition) {
+            $definition->addArgument('abstractTest');
+        });
+        $this->assertEquals(array('abstractParam', 'abstractTest'), $concrete->getArguments());
+
+        $this->setExpectedException('Symfony\Component\DependencyInjection\Exception\InvalidArgumentException');
+        $concrete = new Definition('stdClass');
+        $container->setDefinition('abstractConcrete', $concrete);
+
+        $container->getDefinitionForAbstract('abstractConcrete');
+    }
 }
 
 class FooClass {}


### PR DESCRIPTION
This PR makes it possible to easily fetch concrete implementations
of abstract Definintions. It is possible to configure the Definition
instance with a Closure as second argument.

Bug fix?          no
New feature?   yes
BC breaks?     no
Deprecations? no
Tests pass?    yes
Fixed tickets   None
License           MIT
Doc PR           None
