### PR TITLE
[Yaml] fixed parsing of negative integers (2.0 branch)

### DIFF
--- a/src/Symfony/Component/Yaml/Inline.php
+++ b/src/Symfony/Component/Yaml/Inline.php
@@ -393,6 +393,11 @@ class Inline
                 $cast = intval($scalar);
 
                 return '0' == $scalar[0] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
+            case '-' === $scalar[0] && ctype_digit(substr($scalar, 1)):
+                $raw = $scalar;
+                $cast = intval($scalar);
+
+                return '0' == $scalar[1] ? octdec($scalar) : (((string) $raw == (string) $cast) ? $cast : $raw);
             case 'true' === strtolower($scalar):
                 return true;
             case 'false' === strtolower($scalar):

--- a/tests/Symfony/Tests/Component/Yaml/InlineTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/InlineTest.php
@@ -19,7 +19,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
     public function testParse()
     {
         foreach ($this->getTestsForParse() as $yaml => $value) {
-            $this->assertEquals($value, Inline::parse($yaml), sprintf('::parse() converts an inline YAML to a PHP structure (%s)', $yaml));
+            $this->assertSame($value, Inline::parse($yaml), sprintf('::parse() converts an inline YAML to a PHP structure (%s)', $yaml));
         }
     }
 
@@ -73,6 +73,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             'false' => false,
             'true' => true,
             '12' => 12,
+            '-12' => -12,
             '"quoted string"' => 'quoted string',
             "'quoted string'" => 'quoted string',
             '12.30e+02' => 12.30e+02,
@@ -82,7 +83,7 @@ class InlineTest extends \PHPUnit_Framework_TestCase
             '-.Inf' => log(0),
             "'686e444'" => '686e444',
             '686e444' => 646e444,
-            '123456789123456789' => '123456789123456789',
+            '123456789123456789123456789123456789' => '123456789123456789123456789123456789',
             '"foo\r\nbar"' => "foo\r\nbar",
             "'foo#bar'" => 'foo#bar',
             "'foo # bar'" => 'foo # bar',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6770 |
| License | MIT |
| Doc PR | n/a |

Note that an unrelated test fixture for large integers had to be changed to work on systems with 64-bit integer support because of the change from `assertEquals()` to `assertSame()`. Please see the diff for clarification.
