### PR TITLE
[Console] Removing unnecessary sprintf in Application->getHelp

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -242,7 +242,7 @@ class Application
             $this->getLongVersion(),
             '',
             '<comment>Usage:</comment>',
-            sprintf("  [options] command [arguments]\n"),
+            "  [options] command [arguments]\n",
             '<comment>Options:</comment>',
         );
 

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -242,7 +242,8 @@ class Application
             $this->getLongVersion(),
             '',
             '<comment>Usage:</comment>',
-            "  [options] command [arguments]\n",
+            '  [options] command [arguments]',
+            '',
             '<comment>Options:</comment>',
         );
 


### PR DESCRIPTION
Minor change of the `Symfony\Component\Console\Application->getHelp()`  method.

I have spotted:
1. an unnecessary `sprintf` call (no `args` arguments);
2. two ways of adding a new line in the help (an empty string as new entry of the array and a `\n` at the end of the string).

It seems to be there since the begining and it looks like a forgoten change to me, so I fixed them by removing the `sprintf` call and using a new array entry (empty string) instead of the `\n`.

| Q | A |
| --- | --- |
| License | MIT |
