### PR TITLE
[Yaml] fixed ignored text when parsing an inlined mapping or sequence (closes #6786)

### DIFF
--- a/tests/Symfony/Tests/Component/Yaml/InlineTest.php
+++ b/tests/Symfony/Tests/Component/Yaml/InlineTest.php
@@ -65,6 +65,57 @@ class InlineTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($value, Inline::parse(Inline::dump($value)));
     }
 
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseScalarWithIncorrectlyQuotedStringShouldThrowException()
+    {
+        $value = "'don't do somthin' like that'";
+        Inline::parse($value);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseScalarWithIncorrectlyDoubleQuotedStringShouldThrowException()
+    {
+        $value = '"don"t do somthin" like that"';
+        Inline::parse($value);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseInvalidMappingKeyShouldThrowException()
+    {
+        $value = '{ "foo " bar": "bar" }';
+        Inline::parse($value);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseInvalidMappingShouldThrowException()
+    {
+        Inline::parse('[foo] bar');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function testParseInvalidSequenceShouldThrowException()
+    {
+        Inline::parse('{ foo: bar } bar');
+    }
+
+    public function testParseScalarWithCorrectlyQuotedStringShouldReturnString()
+    {
+        $value = "'don''t do somthin'' like that'";
+        $expect = "don't do somthin' like that";
+
+        $this->assertSame($expect, Inline::parseScalar($value));
+    }
+
     protected function getTestsForParse()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6786 |
| License | MIT |
| Doc PR | n/a |
