### PR TITLE
[FrameworkBundle] fixed requirement of the _controller placeholder for the proxy route (closes #6783)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/proxy.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing/proxy.xml
@@ -4,5 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="_proxy" pattern="/_proxy/{_controller}.{_format}" />
+    <route id="_proxy" pattern="/_proxy/controller/{_controller}/format/{_format}">
+        <requirement key="_controller">.+</requirement>
+    </route>
 </routes>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6783 |
| License | MIT |
| Doc PR | n/a |
