### PR TITLE
[FrameworkBundle] fixed Client::doRequest that must call its parent method (closes #6737)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -78,7 +78,7 @@ class Client extends BaseClient
             $this->hasPerformedRequest = true;
         }
 
-        return $this->kernel->handle($request);
+        return parent::doRequest($request);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6737 |
| License | MIT |
| Doc PR | n/A |
