### PR TITLE
[2.3] [HttpFoundation] UploadedFile - moved a security check from move() to isValid()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -166,13 +166,15 @@ class UploadedFile extends File
     /**
      * Returns whether the file was uploaded successfully.
      *
-     * @return Boolean True if no error occurred during uploading
+     * @return Boolean True if the file has been uploaded with HTTP and no error occurred.
      *
      * @api
      */
     public function isValid()
     {
-        return $this->error === UPLOAD_ERR_OK;
+        $isOk = $this->error === UPLOAD_ERR_OK;
+
+        return $this->test ? $isOk : $isOk && is_uploaded_file($this->getPathname());
     }
 
     /**
@@ -183,7 +185,7 @@ class UploadedFile extends File
      *
      * @return File A File object representing the new file
      *
-     * @throws FileException if the file has not been uploaded via Http
+     * @throws FileException if, for any reason, the file could not have been moved
      *
      * @api
      */
@@ -192,21 +194,21 @@ class UploadedFile extends File
         if ($this->isValid()) {
             if ($this->test) {
                 return parent::move($directory, $name);
-            } elseif (is_uploaded_file($this->getPathname())) {
-                $target = $this->getTargetFile($directory, $name);
-
-                if (!@move_uploaded_file($this->getPathname(), $target)) {
-                    $error = error_get_last();
-                    throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
-                }
-
-                @chmod($target, 0666 & ~umask());
-
-                return $target;
             }
+
+            $target = $this->getTargetFile($directory, $name);
+
+            if (!@move_uploaded_file($this->getPathname(), $target)) {
+                $error = error_get_last();
+                throw new FileException(sprintf('Could not move the file "%s" to "%s" (%s)', $this->getPathname(), $target, strip_tags($error['message'])));
+            }
+
+            @chmod($target, 0666 & ~umask());
+
+            return $target;
         }
 
-        throw new FileException(sprintf('The file "%s" has not been uploaded via Http', $this->getPathname()));
+        throw new FileException(sprintf('The file "%s" is not valid', $this->getPathname()));
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
@@ -215,7 +215,8 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             __DIR__.'/Fixtures/test.gif',
             'original.gif',
             null,
-            filesize(__DIR__.'/Fixtures/test.gif')
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            UPLOAD_ERR_OK
         );
 
         $this->assertFalse($file->isValid());

--- a/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
+++ b/tests/Symfony/Tests/Component/HttpFoundation/File/UploadedFileTest.php
@@ -186,7 +186,8 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             'original.gif',
             null,
             filesize(__DIR__.'/Fixtures/test.gif'),
-            UPLOAD_ERR_OK
+            UPLOAD_ERR_OK,
+            true
         );
 
         $this->assertTrue($file->isValid());
@@ -203,6 +204,18 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             null,
             filesize(__DIR__.'/Fixtures/test.gif'),
             $error
+        );
+
+        $this->assertFalse($file->isValid());
+    }
+
+    public function testIsInvalidIfNotHttpUpload()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            null,
+            filesize(__DIR__.'/Fixtures/test.gif')
         );
 
         $this->assertFalse($file->isValid());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [yes slightly] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |

Fixed and reopened against 2.0 as per @vicb comments in #6779.
