### PR TITLE
Added an error message in the DebugClassLoader when using / instead of \.

### DIFF
--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -84,6 +84,10 @@ class DebugClassLoader
             require $file;
 
             if (!class_exists($class, false) && !interface_exists($class, false) && (!function_exists('trait_exists') || !trait_exists($class, false))) {
+                if (false !== strpos($class, '/')) {
+                    throw new \RuntimeException(sprintf('Trying to autoload a class with an invalid name "%s". Be careful that the namespace separator is "\" in PHP, not "/".'));
+                }
+
                 throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but the class was not in it, the class name or namespace probably has a typo.', $class, $file));
             }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |

Using `/` instead of `\` when writing class names in a configuration seems to happen regularly. See https://github.com/symfony/symfony/commit/aba8f1e1802fbafcd954c2b6f59272492bd4e6f7#commitcomment-2461266 for the latest case I saw. I guess it may come from the fact that SensioGeneratorBundle allows using both for convenience in the CLI to get rid of escaping issues.
This will give people a better error message when they use a `/` instead of having them figure that the class name in the message using `/` and not `\` and this is the reason of the issue.
