### PR TITLE
Fix tests

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -206,7 +206,7 @@ abstract class FrameworkExtensionTest extends TestCase
             '->registerTranslatorConfiguration() finds Form translation resources'
         );
         $this->assertContains(
-            'Symfony/Component/Security/Resources/translations/security.en.xlf',
+            str_replace('/', DIRECTORY_SEPARATOR, 'Symfony/Component/Security/Resources/translations/security.en.xlf'),
             $files,
             '->registerTranslatorConfiguration() finds Security translation resources'
         );

--- a/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/IteratorTestCase.php
@@ -17,7 +17,9 @@ abstract class IteratorTestCase extends \PHPUnit_Framework_TestCase
     {
         // set iterator_to_array $use_key to false to avoid values merge
         // this made FinderTest::testAppendWithAnArray() failed with GnuFinderAdapter
-        $values = array_map(function (\SplFileInfo $fileinfo) { return $fileinfo->getPathname(); }, iterator_to_array($iterator, false));
+        $values = array_map(function (\SplFileInfo $fileinfo) { return str_replace('/', DIRECTORY_SEPARATOR, $fileinfo->getPathname()); }, iterator_to_array($iterator, false));
+
+        $expected = array_map(function ($path) { return str_replace('/', DIRECTORY_SEPARATOR, $path); }, $expected);
 
         sort($values);
         sort($expected);

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -89,7 +89,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
                 continue;
             }
 
-            $result[$itemToken] = array(
+            $result[] = array(
                 'token'  => $itemToken,
                 'ip'     => $itemIp,
                 'method' => $itemMethod,


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |

This fixes the testsuite in master.
For the Redis storage, the test failure seems to come from a bad resolution when merging 2.1 into master.
