### PR TITLE
[HttpKernel] refactored the HTTP content renderer to make it easier to extend

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Bridge\Twig\Tests\TestCase;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpContentRenderer;
 
 class HttpKernelExtensionTest extends TestCase
@@ -30,7 +31,7 @@ class HttpKernelExtensionTest extends TestCase
 
     public function testRenderWithoutMasterRequest()
     {
-        $kernel = $this->getHttpContentRenderer($this->returnValue('foo'));
+        $kernel = $this->getHttpContentRenderer($this->returnValue(new Response('foo')));
 
         $this->assertEquals('foo', $this->renderTemplate($kernel));
     }

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/EsiRenderingStrategy.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\RenderingStrategy;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\HttpCache\Esi;
 
@@ -69,7 +70,9 @@ class EsiRenderingStrategy extends GeneratorAwareRenderingStrategy
             $alt = $this->generateProxyUri($alt, $request);
         }
 
-        return $this->esi->renderIncludeTag($uri, $alt, isset($options['ignore_errors']) ? $options['ignore_errors'] : false, isset($options['comment']) ? $options['comment'] : '');
+        $tag = $this->esi->renderIncludeTag($uri, $alt, isset($options['ignore_errors']) ? $options['ignore_errors'] : false, isset($options['comment']) ? $options['comment'] : '');
+
+        return new Response($tag);
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/HIncludeRenderingStrategy.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\RenderingStrategy;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\UriSigner;
@@ -69,7 +70,7 @@ class HIncludeRenderingStrategy extends GeneratorAwareRenderingStrategy
             $content = $template;
         }
 
-        return sprintf('<hx:include src="%s">%s</hx:include>', $uri, $content);
+        return new Response(sprintf('<hx:include src="%s">%s</hx:include>', $uri, $content));
     }
 
     private function templateExists($template)

--- a/src/Symfony/Component/HttpKernel/RenderingStrategy/RenderingStrategyInterface.php
+++ b/src/Symfony/Component/HttpKernel/RenderingStrategy/RenderingStrategyInterface.php
@@ -26,14 +26,11 @@ interface RenderingStrategyInterface
     /**
      * Renders a URI and returns the Response content.
      *
-     * When the Response is a StreamedResponse, the content is streamed immediately
-     * instead of being returned.
-     *
      * @param string|ControllerReference $uri     A URI as a string or a ControllerReference instance
      * @param Request                    $request A Request instance
      * @param array                      $options An array of options
      *
-     * @return string|null The Response content or null when the Response is streamed
+     * @return Response A Response instance
      */
     public function render($uri, Request $request = null, array $options = array());
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpContentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpContentRendererTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\HttpKernel\Tests;
 
 use Symfony\Component\HttpKernel\HttpContentRenderer;
+use Symfony\Component\HttpFoundation\Response;
 
 class HttpContentRendererTest extends \PHPUnit_Framework_TestCase
 {
@@ -43,7 +44,7 @@ class HttpContentRendererTest extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('render')
             ->with('/', null, array('foo' => 'foo', 'ignore_errors' => true))
-            ->will($this->returnValue('foo'))
+            ->will($this->returnValue(new Response('foo')))
         ;
 
         $renderer = new HttpContentRenderer();

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/DefaultRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/DefaultRenderingStrategyTest.php
@@ -35,7 +35,7 @@ class DefaultRenderingStrategyTest extends AbstractRenderingStrategyTest
     {
         $strategy = new DefaultRenderingStrategy($this->getKernel($this->returnValue(new Response('foo'))));
 
-        $this->assertEquals('foo', $strategy->render('/'));
+        $this->assertEquals('foo', $strategy->render('/')->getContent());
     }
 
     public function testRenderWithControllerReference()
@@ -43,7 +43,7 @@ class DefaultRenderingStrategyTest extends AbstractRenderingStrategyTest
         $strategy = new DefaultRenderingStrategy($this->getKernel($this->returnValue(new Response('foo'))));
         $strategy->setUrlGenerator($this->getUrlGenerator());
 
-        $this->assertEquals('foo', $strategy->render(new ControllerReference('main_controller', array(), array())));
+        $this->assertEquals('foo', $strategy->render(new ControllerReference('main_controller', array(), array()))->getContent());
     }
 
     /**
@@ -53,14 +53,14 @@ class DefaultRenderingStrategyTest extends AbstractRenderingStrategyTest
     {
         $strategy = new DefaultRenderingStrategy($this->getKernel($this->throwException(new \RuntimeException('foo'))));
 
-        $this->assertEquals('foo', $strategy->render('/'));
+        $this->assertEquals('foo', $strategy->render('/')->getContent());
     }
 
     public function testRenderExceptionIgnoreErrors()
     {
         $strategy = new DefaultRenderingStrategy($this->getKernel($this->throwException(new \RuntimeException('foo'))));
 
-        $this->assertNull($strategy->render('/', null, array('ignore_errors' => true)));
+        $this->assertEmpty($strategy->render('/', null, array('ignore_errors' => true))->getContent());
     }
 
     public function testRenderExceptionIgnoreErrorsWithAlt()
@@ -70,7 +70,7 @@ class DefaultRenderingStrategyTest extends AbstractRenderingStrategyTest
             $this->returnValue(new Response('bar'))
         )));
 
-        $this->assertEquals('bar', $strategy->render('/', null, array('ignore_errors' => true, 'alt' => '/foo')));
+        $this->assertEquals('bar', $strategy->render('/', null, array('ignore_errors' => true, 'alt' => '/foo'))->getContent());
     }
 
     private function getKernel($returnValue)

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/EsiRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/EsiRenderingStrategyTest.php
@@ -49,10 +49,10 @@ class EsiRenderingStrategyTest extends AbstractRenderingStrategyTest
         $request = Request::create('/');
         $request->headers->set('Surrogate-Capability', 'ESI/1.0');
 
-        $this->assertEquals('<esi:include src="/" />', $strategy->render('/', $request));
-        $this->assertEquals("<esi:comment text=\"This is a comment\" />\n<esi:include src=\"/\" />", $strategy->render('/', $request, array('comment' => 'This is a comment')));
-        $this->assertEquals('<esi:include src="/" alt="foo" />', $strategy->render('/', $request, array('alt' => 'foo')));
-        $this->assertEquals('<esi:include src="/main_controller.html" alt="/alt_controller.html" />', $strategy->render(new ControllerReference('main_controller', array(), array()), $request, array('alt' => new ControllerReference('alt_controller', array(), array()))));
+        $this->assertEquals('<esi:include src="/" />', $strategy->render('/', $request)->getContent());
+        $this->assertEquals("<esi:comment text=\"This is a comment\" />\n<esi:include src=\"/\" />", $strategy->render('/', $request, array('comment' => 'This is a comment'))->getContent());
+        $this->assertEquals('<esi:include src="/" alt="foo" />', $strategy->render('/', $request, array('alt' => 'foo'))->getContent());
+        $this->assertEquals('<esi:include src="/main_controller.html" alt="/alt_controller.html" />', $strategy->render(new ControllerReference('main_controller', array(), array()), $request, array('alt' => new ControllerReference('alt_controller', array(), array())))->getContent());
     }
 
     private function getDefaultStrategy($called = false)

--- a/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/HIncludeRenderingStrategyTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RenderingStrategy/HIncludeRenderingStrategyTest.php
@@ -42,30 +42,30 @@ class HIncludeRenderingStrategyTest extends AbstractRenderingStrategyTest
     {
         $strategy = new HIncludeRenderingStrategy(null, new UriSigner('foo'));
         $strategy->setUrlGenerator($this->getUrlGenerator());
-        $this->assertEquals('<hx:include src="/main_controller.html?_hash=6MuxpWUHcqIddMMmoN36uPsEjws%3D"></hx:include>', $strategy->render(new ControllerReference('main_controller', array(), array())));
+        $this->assertEquals('<hx:include src="/main_controller.html?_hash=6MuxpWUHcqIddMMmoN36uPsEjws%3D"></hx:include>', $strategy->render(new ControllerReference('main_controller', array(), array()))->getContent());
     }
 
     public function testRenderWithUri()
     {
         $strategy = new HIncludeRenderingStrategy();
-        $this->assertEquals('<hx:include src="/foo"></hx:include>', $strategy->render('/foo'));
+        $this->assertEquals('<hx:include src="/foo"></hx:include>', $strategy->render('/foo')->getContent());
 
         $strategy = new HIncludeRenderingStrategy(null, new UriSigner('foo'));
-        $this->assertEquals('<hx:include src="/foo"></hx:include>', $strategy->render('/foo'));
+        $this->assertEquals('<hx:include src="/foo"></hx:include>', $strategy->render('/foo')->getContent());
     }
 
     public function testRenderWhithDefault()
     {
         // only default
         $strategy = new HIncludeRenderingStrategy();
-        $this->assertEquals('<hx:include src="/foo">default</hx:include>', $strategy->render('/foo', null, array('default' => 'default')));
+        $this->assertEquals('<hx:include src="/foo">default</hx:include>', $strategy->render('/foo', null, array('default' => 'default'))->getContent());
 
         // only global default
         $strategy = new HIncludeRenderingStrategy(null, null, 'global_default');
-        $this->assertEquals('<hx:include src="/foo">global_default</hx:include>', $strategy->render('/foo', null, array()));
+        $this->assertEquals('<hx:include src="/foo">global_default</hx:include>', $strategy->render('/foo', null, array())->getContent());
 
         // global default and default
         $strategy = new HIncludeRenderingStrategy(null, null, 'global_default');
-        $this->assertEquals('<hx:include src="/foo">default</hx:include>', $strategy->render('/foo', null, array('default' => 'default')));
+        $this->assertEquals('<hx:include src="/foo">default</hx:include>', $strategy->render('/foo', null, array('default' => 'default'))->getContent());
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | kinda |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This makes the StreamedResponse logic reusable for other strategies and it also makes the RenderingStrategy interface less fuzzy about its contract.

That also makes features like #4470 easier to implement from the outside.
