### PR TITLE
[TwigBridge] fixed format_file to include the line number even if the link text is passed

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -164,14 +164,14 @@ class CodeExtension extends \Twig_Extension
     {
         if (null === $text) {
             $file = trim($file);
-            $fileStr = $file;
-            if (0 === strpos($fileStr, $this->rootDir)) {
-                $fileStr = str_replace($this->rootDir, '', str_replace('\\', '/', $fileStr));
-                $fileStr = sprintf('<abbr title="%s">kernel.root_dir</abbr>/%s', $this->rootDir, $fileStr);
+            $text = $file;
+            if (0 === strpos($text, $this->rootDir)) {
+                $text = str_replace($this->rootDir, '', str_replace('\\', '/', $text));
+                $text = sprintf('<abbr title="%s">kernel.root_dir</abbr>/%s', $this->rootDir, $text);
             }
-
-            $text = "$fileStr at line $line";
         }
+
+        $text = "$text at line $line";
 
         if (false !== $link = $this->getFileLink($file, $line)) {
             return sprintf('<a href="%s" title="Click to open this file" class="file_link">%s</a>', htmlspecialchars($link, ENT_QUOTES | ENT_SUBSTITUTE, $this->charset), $text);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

That fixes the logs in the profiler where lines were not displayed for deprecated calls.
