### PR TITLE
[SecurityBundle] [BugFix] Registering logout listeners at the end

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/RememberMeFactory.php
@@ -48,13 +48,6 @@ class RememberMeFactory implements SecurityFactoryInterface
             $rememberMeServicesId = $templateId.'.'.$id;
         }
 
-        if ($container->hasDefinition('security.logout_listener.'.$id)) {
-            $container
-                ->getDefinition('security.logout_listener.'.$id)
-                ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
-            ;
-        }
-
         $rememberMeServices = $container->setDefinition($rememberMeServicesId, new DefinitionDecorator($templateId));
         $rememberMeServices->replaceArgument(1, $config['key']);
         $rememberMeServices->replaceArgument(2, $id);
@@ -102,6 +95,14 @@ class RememberMeFactory implements SecurityFactoryInterface
         $listenerId = 'security.authentication.listener.rememberme.'.$id;
         $listener = $container->setDefinition($listenerId, new DefinitionDecorator('security.authentication.listener.rememberme'));
         $listener->replaceArgument(1, new Reference($rememberMeServicesId));
+
+        // logout listener
+        if ($container->hasDefinition('security.logout_listener.'.$id)) {
+            $container
+                ->getDefinition('security.logout_listener.'.$id)
+                ->addMethodCall('addHandler', array(new Reference($rememberMeServicesId)))
+            ;
+        }
 
         return array($authProviderId, $listenerId, $defaultEntryPoint);
     }

--- a/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/DependencyInjection/SecurityExtension.php
@@ -273,6 +273,19 @@ class SecurityExtension extends Extension
             $listeners[] = new Reference($this->createContextListener($container, $contextKey));
         }
 
+        // Authentication listeners
+        list($authListeners, $defaultEntryPoint) = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $factories);
+
+        $listeners = array_merge($listeners, $authListeners);
+
+        // Access listener
+        $listeners[] = new Reference('security.access_listener');
+
+        // Switch user listener
+        if (isset($firewall['switch_user'])) {
+            $listeners[] = new Reference($this->createSwitchUserListener($container, $id, $firewall['switch_user'], $defaultProvider));
+        }
+
         // Logout listener
         if (isset($firewall['logout'])) {
             $listenerId = 'security.logout_listener.'.$id;
@@ -304,19 +317,6 @@ class SecurityExtension extends Extension
             foreach ($firewall['logout']['handlers'] as $handlerId) {
                 $listener->addMethodCall('addHandler', array(new Reference($handlerId)));
             }
-        }
-
-        // Authentication listeners
-        list($authListeners, $defaultEntryPoint) = $this->createAuthenticationListeners($container, $id, $firewall, $authenticationProviders, $defaultProvider, $factories);
-
-        $listeners = array_merge($listeners, $authListeners);
-
-        // Access listener
-        $listeners[] = new Reference('security.access_listener');
-
-        // Switch user listener
-        if (isset($firewall['switch_user'])) {
-            $listeners[] = new Reference($this->createSwitchUserListener($container, $id, $firewall['switch_user'], $defaultProvider));
         }
 
         // Determine default entry point


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6751 |
| License | MIT |
| Doc PR | n/a |

The current logout listener listens to the same event as the login from the other listeners.
When login out, the logout listener is currently called first, and because the token is not in the security context, it is skipped. Afterwards, the other listeners are called and populate the security context with a token.
Registering the logout listeners after everything else fixes the issue.
