### PR TITLE
[Bridge][Monolog] fix monolog dev dependency see PR #6832

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": ">=2.2,<2.4-dev",
         "doctrine/orm": ">=2.2.3,<2.4-dev",
-        "monolog/monolog": "~1.3",
+        "monolog/monolog": "1.3.*",
         "propel/propel1": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This patch fix the composer monolog dependency. Actual it installs the trunk which has a change that need a patch for symfony see PR #6832.

This PR change the monolog dependency to `1.3.*`.
