### PR TITLE
[2.3] [FrameworkBundle] [Templating] added Stopwatch support to the PHP engine

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -357,6 +357,9 @@ class FrameworkExtension extends Extension
 
         if ($container->getParameter('kernel.debug')) {
             $loader->load('templating_debug.xml');
+
+            $container->setDefinition('templating.engine.php', $container->findDefinition('debug.templating.engine.php'));
+            $container->setAlias('debug.templating.engine.php', 'templating.engine.php');
         }
 
         // create package definitions and add them to the assets helper

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_debug.xml
@@ -6,12 +6,20 @@
 
     <parameters>
         <parameter key="templating.debugger.class">Symfony\Bundle\FrameworkBundle\Templating\Debugger</parameter>
+        <parameter key="debug.templating.engine.php.class">Symfony\Bundle\FrameworkBundle\Templating\TimedPhpEngine</parameter>
     </parameters>
 
     <services>
         <service id="templating.debugger" class="%templating.debugger.class%" public="false">
             <tag name="monolog.logger" channel="templating" />
             <argument type="service" id="logger" on-invalid="null" />
+        </service>
+        <service id="debug.templating.engine.php" class="%debug.templating.engine.php.class%" public="false">
+            <argument type="service" id="templating.name_parser" />
+            <argument type="service" id="service_container" />
+            <argument type="service" id="templating.loader" />
+            <argument type="service" id="debug.stopwatch" />
+            <argument type="service" id="templating.globals" />
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TimedPhpEngine.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TimedPhpEngine.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Templating;
+
+use Symfony\Bundle\FrameworkBundle\Templating\PhpEngine;
+use Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables;
+use Symfony\Component\Templating\TemplateNameParserInterface;
+use Symfony\Component\HttpKernel\Debug\Stopwatch;
+use Symfony\Component\Templating\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Times the time spent to render a template.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TimedPhpEngine extends PhpEngine
+{
+    protected $stopwatch;
+
+    /**
+     * Constructor.
+     *
+     * @param TemplateNameParserInterface $parser      A TemplateNameParserInterface instance
+     * @param ContainerInterface          $container   A ContainerInterface instance
+     * @param LoaderInterface             $loader      A LoaderInterface instance
+     * @param Stopwatch                   $stopwatch   A Stopwatch instance
+     * @param GlobalVariables             $globals     A GlobalVariables instance
+     */
+    public function __construct(TemplateNameParserInterface $parser, ContainerInterface $container, LoaderInterface $loader, Stopwatch $stopwatch, GlobalVariables $globals = null)
+    {
+        parent::__construct($parser, $container, $loader, $globals);
+
+        $this->stopwatch = $stopwatch;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function render($name, array $parameters = array())
+    {
+        $e = $this->stopwatch->start(sprintf('template.php (%s)', $name), 'template');
+
+        $ret = parent::render($name, $parameters);
+
+        $e->stop();
+
+        return $ret;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I did not include tests nor documentation because there weren't any for TimedTwigEngine (I took it as an example). If I'm mistaken and they are needed, I'll gladly write them.
