### PR TITLE
[FrameworkBundle] Added performance tweak to DelegatingLoader

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Routing/DelegatingLoader.php
@@ -58,11 +58,13 @@ class DelegatingLoader extends BaseDelegatingLoader
 
         foreach ($collection->all() as $name => $route) {
             if ($controller = $route->getDefault('_controller')) {
-                try {
-                    $controller = $this->parser->parse($controller);
-                } catch (\Exception $e) {
-                    // unable to optimize unknown notation
-                }
+                if(strpos($controller, '::') === false) {
+					try {
+						$controller = $this->parser->parse($controller);
+					} catch (\Exception $e) {
+						// unable to optimize unknown notation
+					}
+				}
 
                 $route->setDefault('_controller', $controller);
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This patch had huge execution time impact on my system because the parsing of the controller names throws an exception if it fails (and it failed a lot in my config). so i added a check before parsing to check if the controller string can be parsed
