### PR TITLE
Fix unknown $request variable

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/HttpContentRenderer.php
@@ -127,7 +127,7 @@ class HttpContentRenderer implements EventSubscriberInterface
     protected function deliver(Response $response)
     {
         if (!$response->isSuccessful()) {
-            throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $request->getUri(), $response->getStatusCode()));
+            throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $this->request->getUri(), $response->getStatusCode()));
         }
 
         if (!$response instanceof StreamedResponse) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Fix the following error:

``` php
Fatal error: Call to a member function getUri() on a non-object in /Users/benjamin/Development/mini-scrum/vendor/symfony/symfony/src/Symfony/Component/HttpKernel/HttpContentRenderer.php on line 130
```
