### PR TITLE
removed deprecated messages coming for internal calls

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FieldType.php
@@ -22,11 +22,6 @@ use Symfony\Component\Form\AbstractType;
  */
 class FieldType extends AbstractType
 {
-    public function __construct()
-    {
-        trigger_error('FieldType is deprecated since version 2.1 and will be removed in 2.3.', E_USER_DEPRECATED);
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6407 |
| License | MIT |
| Doc PR | n/a |

It's probably not the cleanest code possible, but I don't see any other way to keep the type for BC and avoid the deprecated message when called internally.

That should fix the deprecated messages thrown by the Form and Validator components.
