### PR TITLE
[Config] secret should be overrided

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -51,7 +51,12 @@ class Configuration implements ConfigurationInterface
                         })
                     ->end()
                 ->end()
-                ->scalarNode('secret')->end()
+                ->scalarNode('secret')
+                    ->validate()
+                        ->ifTrue(function($v){ return $v === 'ThisTokenIsNotSoSecretChangeIt'; })
+                        ->thenInvalid('Invalid secret. %s is not secret')
+                    ->end()
+                ->end()
                 ->scalarNode('trust_proxy_headers')->defaultFalse()->end() // @deprecated, to be removed in 2.3
                 ->arrayNode('trusted_proxies')
                     ->beforeNormalization()

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -78,4 +78,14 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $configuration = new Configuration(array());
         $config = $processor->processConfiguration($configuration, array(array('secret' => 's3cr3t', 'trusted_proxies' => array('Not an IP address'))));
     }
+
+    /**
+     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
+     */
+    public function testInvalidValueSecret()
+    {
+        $processor = new Processor();
+        $configuration = new Configuration(array());
+        $config = $processor->processConfiguration($configuration, array(array('secret' => 'ThisTokenIsNotSoSecretChangeIt')));
+    }
 }


### PR DESCRIPTION
For security, `framework.secret` configuration should not be equals to "ThisTokenIsNotSoSecretChangeIt" (the default value in symfony-standard).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
