### PR TITLE
[Finder] fixed regression in the Finder component (it was possible to use it without using exec before, closes #6357)

### DIFF
--- a/src/Symfony/Component/Finder/Shell/Shell.php
+++ b/src/Symfony/Component/Finder/Shell/Shell.php
@@ -52,7 +52,11 @@ class Shell
     {
         if (self::TYPE_WINDOWS === $this->type) {
             // todo: find a way to test if windows command exists
-            return true;
+            return false;
+        }
+
+        if (!function_exists('exec')) {
+            return false;
         }
 
         // todo: find a better way (command could not be available)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (fixed a BC break) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6357 |
| License | MIT |
| Doc PR | n/a |
