### PR TITLE
[2.3] [FrameworkBundle] Made the Session storage keys for Attributes, Flash and Metabag configureable via parameter.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/session.xml
@@ -7,7 +7,11 @@
     <parameters>
         <parameter key="session.class">Symfony\Component\HttpFoundation\Session\Session</parameter>
         <parameter key="session.flashbag.class">Symfony\Component\HttpFoundation\Session\Flash\FlashBag</parameter>
+        <parameter key="session.flashbag.storage_key">_sf2_flashes</parameter>
+        <parameter key="session.metadata.class">Symfony\Component\HttpFoundation\Session\Storage\MetadataBag</parameter>
+        <parameter key="session.metadata.storage_key">_sf2_meta</parameter>
         <parameter key="session.attribute_bag.class">Symfony\Component\HttpFoundation\Session\Attribute\AttributeBag</parameter>
+        <parameter key="session.attribute_bag.storage_key">_sf2_attributes</parameter>
         <parameter key="session.storage.native.class">Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage</parameter>
         <parameter key="session.storage.mock_file.class">Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage</parameter>
         <parameter key="session.handler.native_file.class">Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler</parameter>
@@ -24,11 +28,20 @@
         <service id="session.storage.native" class="%session.storage.native.class%">
             <argument>%session.storage.options%</argument>
             <argument type="service" id="session.handler" />
+            <argument type="service" id="session.metadata_bag" />
         </service>
 
-        <service id="session.flash_bag" class="%session.flashbag.class%" public="false" />
+        <service id="session.metadata_bag" class="%session.metadata.class%" public="false" >
+            <argument>%session.metadata.storage_key%</argument>
+        </service>
 
-        <service id="session.attribute_bag" class="%session.attribute_bag.class%" public="false" />
+        <service id="session.flash_bag" class="%session.flashbag.class%" public="false" >
+            <argument>%session.flashbag.storage_key%</argument>
+        </service>
+
+        <service id="session.attribute_bag" class="%session.attribute_bag.class%" public="false" >
+            <argument>%session.attribute_bag.storage_key%</argument>
+        </service>
 
         <service id="session.storage.mock_file" class="%session.storage.mock_file.class%" public="false">
             <argument>%kernel.cache_dir%/sessions</argument>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
