### PR TITLE
Added missing parameter to Exception in DebugClassLoader 

### DIFF
--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -85,7 +85,7 @@ class DebugClassLoader
 
             if (!class_exists($class, false) && !interface_exists($class, false) && (!function_exists('trait_exists') || !trait_exists($class, false))) {
                 if (false !== strpos($class, '/')) {
-                    throw new \RuntimeException(sprintf('Trying to autoload a class with an invalid name "%s". Be careful that the namespace separator is "\" in PHP, not "/".'));
+                    throw new \RuntimeException(sprintf('Trying to autoload a class with an invalid name "%s". Be careful that the namespace separator is "\" in PHP, not "/".', $class));
                 }
 
                 throw new \RuntimeException(sprintf('The autoloader expected class "%s" to be defined in file "%s". The file was found but the class was not in it, the class name or namespace probably has a typo.', $class, $file));


### PR DESCRIPTION
The DebugClassLoader was missing the $class argument to sprintf() when it tries to throw the exception, making the actual error you are getting more daunting :)
