### PR TITLE
Revert "[Yaml] fixed typo"

### DIFF
--- a/src/Symfony/Component/Yaml/Yaml.php
+++ b/src/Symfony/Component/Yaml/Yaml.php
@@ -149,7 +149,7 @@ class Yaml
      *
      * @api
      */
-    public static function dump($array, $inline = 2, $indent = 2, $exceptionOnInvalidType = false, $objectSupport = false)
+    public static function dump($array, $inline = 2, $indent = 4, $exceptionOnInvalidType = false, $objectSupport = false)
     {
         $yaml = new Dumper();
         $yaml->setIndentation($indent);


### PR DESCRIPTION
This reverts commit 51d1948327227f4064f81cf61f5659e97cb929da.

See: https://github.com/symfony/symfony/commit/51d1948327227f4064f81cf61f5659e97cb929da#commitcomment-2507801 for more information.

This has been detected on the PropelBundle, and Propel2.
