### PR TITLE
[Security] decoupled UserPassword constraint from SecurityBundle

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -519,6 +519,52 @@
    }
    ```
 
+### Security
+
+  * The existing ``UserPassword`` validator constraint class has been modified
+    to make it decoupled from the ``SecurityBundle``. It's no more validated by
+    the ``security.validator.user_password`` service and its namespace has been
+    changed to better fit the Symfony coding convention.
+
+    Before:
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
+    ```
+
+    After: (note the `s` at the end of `Constraint`)
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+    ```
+
+  * If you were using the ``UserPassword`` validator constraint class in your
+    Symfony Standard Edition based application to validate the current logged-in
+    user's password, you must now use the new extended ``UserPassword``
+    validator constraint class from the ``SecurityBundle`` instead. This is
+    because the original ``UserPassword`` constraint class from the ``Security``
+    component is no more validated by the ``security.validator.user_password``
+    service of the ``SecurityBundle``.
+
+    Before:
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
+    ```
+
+    After: (note the `s` at the end of `Constraint`)
+
+    ```
+    use Symfony\Bundle\SecurityBundle\Validator\Constraints\UserPassword;
+    ```
+
+### Serializer
+
+ * All serializer interfaces (Serializer, Normalizer, Encoder) have been
+   extended with an optional `$context` array. This was necessary to allow for
+   more complex use-cases that require context information during the
+   (de)normalization and en-/decoding steps.
+
 ### FrameworkBundle
 
  * The `render` method of the `actions` templating helper signature and arguments changed:
@@ -563,9 +609,36 @@
       trusted_proxies: ['127.0.0.1', '10.0.0.1'] # a list of proxy IPs you trust
    ```
 
-### Serializer
+### SecurityBundle
 
- * All serializer interfaces (Serializer, Normalizer, Encoder) have been
-   extended with an optional `$context` array. This was necessary to allow for
-   more complex use-cases that require context information during the
-   (de)normalization and en-/decoding steps.
+  * A ``UserPassword`` validator constraint class has been reintroduced in the
+    ``SecurityBundle``. It extends the base ``UserPassword`` validator
+    constraint class located in the ``Security`` component.
+
+    This is the validator constraint class you should now use to validate the
+    current logged-in user's password while securing your application with the
+    ``SecurityBundle``.
+
+    Before:
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
+    ```
+
+    After:
+
+    ```
+    use Symfony\Bundle\SecurityBundle\Validator\Constraints\UserPassword;
+    ```
+
+  * The new ``UserPassword`` validator constraint class now accepts a new
+    ``service`` option, which allows to specify a custom validator service name
+    instead to validate the current logged-in user's password.
+
+    ```
+    use Symfony\Bundle\SecurityBundle\Validator\Constraints\UserPassword;
+
+    $constraint = new UserPassword(array(
+        'service' => 'my.custom.validator.user_password',
+    ));
+    ```

--- a/src/Symfony/Bundle/SecurityBundle/Validator/Constraints/UserPassword.php
+++ b/src/Symfony/Bundle/SecurityBundle/Validator/Constraints/UserPassword.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\SecurityBundle\Validator\Constraints;
+
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword as BaseUserPassword;
+
+/**
+ * This class defines a constraint to validate the current logged-in user's
+ * password.
+ *
+ * @Annotation
+ *
+ * @author Hugo Hamon <webmaster@apprendre-php.com>
+ */
+class UserPassword extends BaseUserPassword
+{
+    public $service = 'security.validator.user_password';
+
+    public function validatedBy()
+    {
+        return $this->service;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Security\Core\Validator\Constraint;
+namespace Symfony\Component\Security\Core\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
@@ -19,9 +19,4 @@ use Symfony\Component\Validator\Constraint;
 class UserPassword extends Constraint
 {
     public $message = 'This value should be the user current password.';
-
-    public function validatedBy()
-    {
-        return 'security.validator.user_password';
-    }
 }

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Security\Core\Validator\Constraint;
+namespace Symfony\Component\Security\Core\Validator\Constraints;
 
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
@@ -34,7 +34,7 @@ class UserPasswordValidator extends ConstraintValidator
         $user = $this->securityContext->getToken()->getUser();
 
         if (!$user instanceof UserInterface) {
-            throw new ConstraintDefinitionException('The User must extend UserInterface');
+            throw new ConstraintDefinitionException('The User must be an instance of the UserInterface interface.');
         }
 
         $encoder = $this->encoderFactory->getEncoder($user);

--- a/src/Symfony/Component/Security/Tests/Core/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Validator/Constraints/UserPasswordValidatorTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Tests\Core\Validator\Constraints;
+
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
+
+class UserPasswordValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    const PASSWORD_VALID   = true;
+    const PASSWORD_INVALID = false;
+
+    protected $context;
+
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\Validator\Validator', true)) {
+            $this->markTestSkipped('The Validator component is required for this test.');
+        }
+ 
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+    }
+
+    protected function tearDown()
+    {
+        $this->context = null;
+    }
+
+    public function testPasswordIsValid()
+    {
+        $user = $this->createUser();
+        $securityContext = $this->createSecurityContext($user);
+
+        $encoder = $this->createPasswordEncoder(static::PASSWORD_VALID);
+        $encoderFactory = $this->createEncoderFactory($encoder);
+
+        $validator = new UserPasswordValidator($securityContext, $encoderFactory);
+        $validator->initialize($this->context);
+
+        $this
+            ->context
+            ->expects($this->never())
+            ->method('addViolation')
+        ;
+
+        $validator->validate('secret', new UserPassword());
+    }
+
+    public function testPasswordIsNotValid()
+    {
+        $user = $this->createUser();
+        $securityContext = $this->createSecurityContext($user);
+
+        $encoder = $this->createPasswordEncoder(static::PASSWORD_INVALID);
+        $encoderFactory = $this->createEncoderFactory($encoder);
+
+        $validator = new UserPasswordValidator($securityContext, $encoderFactory);
+        $validator->initialize($this->context);
+
+        $this
+            ->context
+            ->expects($this->once())
+            ->method('addViolation')
+        ;
+
+        $validator->validate('secret', new UserPassword());
+    }
+
+    public function testUserIsNotValid()
+    {
+        $this->setExpectedException('Symfony\Component\Validator\Exception\ConstraintDefinitionException');
+
+        $user = $this->getMock('Foo\Bar\User');
+        $encoderFactory = $this->getMock('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface');
+        $securityContext = $this->createSecurityContext($user);
+
+        $validator = new UserPasswordValidator($securityContext, $encoderFactory);
+        $validator->initialize($this->context);
+        $validator->validate('secret', new UserPassword());
+    }
+
+    protected function createUser()
+    {
+        $mock = $this->getMock('Symfony\Component\Security\Core\User\UserInterface');
+
+        $mock
+            ->expects($this->once())
+            ->method('getPassword')
+            ->will($this->returnValue('s3Cr3t'))
+        ;
+
+        $mock
+            ->expects($this->once())
+            ->method('getSalt')
+            ->will($this->returnValue('^S4lt$'))
+        ;
+
+        return $mock;
+    }
+
+    protected function createPasswordEncoder($isPasswordValid = true)
+    {
+        $mock = $this->getMock('Symfony\Component\Security\Core\Encoder\PasswordEncoderInterface');
+
+        $mock
+            ->expects($this->once())
+            ->method('isPasswordValid')
+            ->will($this->returnValue($isPasswordValid))
+        ;
+
+        return $mock;
+    }
+
+    protected function createEncoderFactory($encoder = null)
+    {
+        $mock = $this->getMock('Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface');
+
+        $mock
+            ->expects($this->once())
+            ->method('getEncoder')
+            ->will($this->returnValue($encoder))
+        ;
+
+        return $mock;
+    }
+
+    protected function createSecurityContext($user = null)
+    {
+        $token = $this->createAuthenticationToken($user);
+
+        $mock = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $mock
+            ->expects($this->once())
+            ->method('getToken')
+            ->will($this->returnValue($token))
+        ;
+
+        return $mock;
+    }
+
+    protected function createAuthenticationToken($user = null)
+    {
+        $mock = $this->getMock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
+        $mock
+            ->expects($this->once())
+            ->method('getUser')
+            ->will($this->returnValue($user))
+        ;
+
+        return $mock;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes (for people already using the `UserPassword` constraint class in their code) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6889 |
| License | MIT |
| Doc PR | - |
