### PR TITLE
[Routing] Improve RouteNotFoundException messages

### DIFF
--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -111,7 +111,7 @@ EOF;
     public function generate(\$name, \$parameters = array(), \$referenceType = self::ABSOLUTE_PATH)
     {
         if (!isset(self::\$declaredRoutes[\$name])) {
-            throw new RouteNotFoundException(sprintf('Route "%s" does not exist.', \$name));
+            throw new RouteNotFoundException(sprintf('A route named "%s" does not exist.', \$name));
         }
 
         list(\$variables, \$defaults, \$requirements, \$tokens, \$hostTokens) = self::\$declaredRoutes[\$name];

--- a/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
+++ b/src/Symfony/Component/Routing/Generator/Dumper/PhpGeneratorDumper.php
@@ -111,7 +111,7 @@ EOF;
     public function generate(\$name, \$parameters = array(), \$referenceType = self::ABSOLUTE_PATH)
     {
         if (!isset(self::\$declaredRoutes[\$name])) {
-            throw new RouteNotFoundException(sprintf('A route named "%s" does not exist.', \$name));
+            throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', \$name));
         }
 
         list(\$variables, \$defaults, \$requirements, \$tokens, \$hostTokens) = self::\$declaredRoutes[\$name];

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -131,7 +131,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         if (null === $route = $this->routes->get($name)) {
-            throw new RouteNotFoundException(sprintf('Route "%s" does not exist.', $name));
+            throw new RouteNotFoundException(sprintf('A route named "%s" does not exist.', $name));
         }
 
         // the Route has a cache of its own and is not recompiled as long as it does not get modified

--- a/src/Symfony/Component/Routing/Generator/UrlGenerator.php
+++ b/src/Symfony/Component/Routing/Generator/UrlGenerator.php
@@ -131,7 +131,7 @@ class UrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInt
     public function generate($name, $parameters = array(), $referenceType = self::ABSOLUTE_PATH)
     {
         if (null === $route = $this->routes->get($name)) {
-            throw new RouteNotFoundException(sprintf('A route named "%s" does not exist.', $name));
+            throw new RouteNotFoundException(sprintf('Unable to generate a URL for the named route "%s" as such route does not exist.', $name));
         }
 
         // the Route has a cache of its own and is not recompiled as long as it does not get modified


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | Travis? |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The error message that is generated when a named route is not found can be a little confusing in the sense that one could think the name actually references a path for the route. This PR should make that a little clearer.

See [this Laravel ticket](https://github.com/laravel/framework/issues/177) for reference.
