### PR TITLE
[FrameworkBundle] made so IDEs will catch up right Response class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Client.php
@@ -62,6 +62,18 @@ class Client extends BaseClient
     }
 
     /**
+     * Returns the current Response instance.
+     *
+     * @return Response A Response instance
+     *
+     * @api
+     */
+    public function getResponse()
+    {
+        return parent::getResponse();
+    }
+
+    /**
      * Makes a request.
      *
      * @param Request $request A Request instance


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6903 |
| License | MIT |
| Doc PR | - |

When using `FrameworkBundle/Test/WebTestCase` and trying to get a `getResponse()` IDEs catching up `BrowserKit\Response` instead of `HttpFoundation\Response`. This causes false-errors and wrong code completion when accessing

``` php
$client = static::createClient();
// ...
$headers = $client->getResponse()->headers
```
- [ ] gather feedback my changes
- [ ] probably there are some annotations magic that can override return class of a method, so nothing will be overloaded
