### PR TITLE
[Finder] Fixes iterator keys

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/FilePathsIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/FilePathsIterator.php
@@ -41,6 +41,11 @@ class FilePathsIterator extends \ArrayIterator
     private $subPathname;
 
     /**
+     * @var SplFileInfo
+     */
+    private $current;
+
+    /**
      * @param array  $paths   List of paths returned by shell command
      * @param string $baseDir Base dir for relative path building
      */
@@ -70,21 +75,27 @@ class FilePathsIterator extends \ArrayIterator
      */
     public function current()
     {
-        return new SplFileInfo(parent::current(), $this->subPath, $this->subPathname);
+        return $this->current;
+    }
+
+    /**
+     * @return string
+     */
+    public function key()
+    {
+        return $this->current->getPathname();
     }
 
     public function next()
     {
         parent::next();
-
-        $this->buildSubPath();
+        $this->buildProperties();
     }
 
     public function rewind()
     {
         parent::rewind();
-
-        $this->buildSubPath();
+        $this->buildProperties();
     }
 
     /**
@@ -103,7 +114,7 @@ class FilePathsIterator extends \ArrayIterator
         return $this->subPathname;
     }
 
-    private function buildSubPath()
+    private function buildProperties()
     {
         $absolutePath = parent::current();
 
@@ -114,5 +125,7 @@ class FilePathsIterator extends \ArrayIterator
         } else {
             $this->subPath = $this->subPathname = '';
         }
+
+        $this->current = new SplFileInfo(parent::current(), $this->subPath, $this->subPathname);
     }
 }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -576,6 +576,19 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertEquals(1, count($finder));
     }
 
+    /**
+     * Iterator keys must be the file pathname.
+     *
+     * @dataProvider getAdaptersTestData
+     */
+    public function testIteratorKeys(Adapter\AdapterInterface $adapter)
+    {
+        $finder = $this->buildFinder($adapter)->in(self::$tmpDir);
+        foreach ($finder as $key => $file) {
+            $this->assertEquals($file->getPathname(), $key);
+        }
+    }
+
     public function testAdaptersOrdering()
     {
         $finder = Finder::create()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6891 |
| License | MIT |

Previous PR I did on finder introduced a BR break (finder iterator keys must be the pathname of the file, not an incremented index). This PR adds a test to ensure this wont be broken again and fixes the BC break.
