### PR TITLE
Fixed the NullLogger to implement the HttpKernel interface again

### DIFF
--- a/src/Symfony/Component/HttpKernel/Log/NullLogger.php
+++ b/src/Symfony/Component/HttpKernel/Log/NullLogger.php
@@ -20,7 +20,7 @@ use Psr\Log\NullLogger as PsrNullLogger;
  *
  * @api
  */
-class NullLogger extends PsrNullLogger
+class NullLogger extends PsrNullLogger implements LoggerInterface
 {
     /**
      * @api


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no (reverting one introduced by mistake) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |

This BC breaking mistake has been reported in https://github.com/schmittjoh/JMSSecurityExtraBundle/pull/105#issuecomment-12908659
