### PR TITLE
Correct comment in NativeSessionStorage regarding session.save_handler

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -332,9 +332,9 @@ class NativeSessionStorage implements SessionStorageInterface
      * Registers save handler as a PHP session handler.
      *
      * To use internal PHP session save handlers, override this method using ini_set with
-     * session.save_handlers and session.save_path e.g.
+     * session.save_handler and session.save_path e.g.
      *
-     *     ini_set('session.save_handlers', 'files');
+     *     ini_set('session.save_handler', 'files');
      *     ini_set('session.save_path', /tmp');
      *
      * @see http://php.net/session-set-save-handler


### PR DESCRIPTION
It's save_handler, not save_handlers.
