### PR TITLE
[2.3] Improve preferred language detection

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1309,6 +1309,9 @@ class Request
                     for ($i = 0, $max = count($codes); $i < $max; $i++) {
                         if ($i == 0) {
                             $lang = strtolower($codes[0]);
+                            if(!in_array($lang, $this->languages) {
+                                $this->languages[] = $lang;
+                            }
                         } else {
                             $lang .= '_'.strtoupper($codes[$i]);
                         }


### PR DESCRIPTION
getPreferredLanguage does a simple intersect between the given languages and the ones from the request.
e.g. if you call getPreferredLanguage(array('fr', 'de', 'en')) and your Browser sends "en-US,en" as the accepted languages, the expected behaviour would be to have it return "en". This works most of the time. However, Safari (and possibly other browsers) only send the longer version (in the above example it would only send "en-us"), so getPreferredLanguage would not return "en" but the first result, which would be "fr".

This patch adds the shorter language code to the array of requested languages in order to fix this. I'm not sure if this patch is the best approach, so I'd appreciate feedback.
