### PR TITLE
[Validator][ChoiceValidator] Replaced call that triggers deprecated error

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/ChoiceValidator.php
@@ -45,8 +45,8 @@ class ChoiceValidator extends ConstraintValidator
         }
 
         if ($constraint->callback) {
-            if (is_callable(array($this->context->getCurrentClass(), $constraint->callback))) {
-                $choices = call_user_func(array($this->context->getCurrentClass(), $constraint->callback));
+            if (is_callable(array($this->context->getClassName(), $constraint->callback))) {
+                $choices = call_user_func(array($this->context->getClassName(), $constraint->callback));
             } elseif (is_callable($constraint->callback)) {
                 $choices = call_user_func($constraint->callback);
             } else {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

This removes the deprecation warnings from the ChoiceValidator.
