### PR TITLE
[2.3] [Process] Improve the usability of the PhpExecutableFinder

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.2.0
 -----
 
+ * added PhpExecutableFinder::create() to ease usage of the class
  * added ProcessBuilder::setArguments() to reset the arguments on a builder
  * added a way to retrieve the standard and error output incrementally
  * added Process:restart()

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -19,11 +19,31 @@ namespace Symfony\Component\Process;
  */
 class PhpExecutableFinder
 {
+    /**
+     * @var ExecutableFinder
+     */
     private $executableFinder;
+
+    /**
+     * @var PhpExecutableFinder
+     */
+    private static $finder;
 
     public function __construct()
     {
         $this->executableFinder = new ExecutableFinder();
+    }
+
+    /**
+     * @return PhpExecutableFinder An instance of the PhpExecutableFinder
+     */
+    public static function create()
+    {
+        if (!self::$finder) {
+            self::$finder = new self();
+        }
+
+        return self::$finder;
     }
 
     /**

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -49,8 +49,6 @@ class PhpExecutableFinder
     /**
      * Finds The PHP executable.
      *
-     * @FIXME Symfony3: return null instead of false
-     *
      * @return string|false The PHP executable path or false if it cannot be found
      */
     public function find()

--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -49,6 +49,8 @@ class PhpExecutableFinder
     /**
      * Finds The PHP executable.
      *
+     * @FIXME Symfony3: return null instead of false
+     *
      * @return string|false The PHP executable path or false if it cannot be found
      */
     public function find()

--- a/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
+++ b/src/Symfony/Component/Process/Tests/PhpExecutableFinderTest.php
@@ -61,4 +61,13 @@ class PhpExecutableFinderTest extends \PHPUnit_Framework_TestCase
             $this->assertTrue((bool) preg_match('/'.addSlashes(DIRECTORY_SEPARATOR).'php\.(exe|bat|cmd|com)$/i', $current), '::find() returns the executable php with suffixes');
         }
     }
+
+    public function testCreateAlwaysReturnsTheSameInstance()
+    {
+        $finder = PhpExecutableFinder::create();
+
+        $this->assertInstanceOf('Symfony\Component\Process\PhpExecutableFinder', $finder);
+
+        $this->assertSame($finder, PhpExecutableFinder::create());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

I first wanted to make `find` static but that would probably be considered as an unrequired BC break.
