### PR TITLE
[HttpKernel] fixed regression when rendering an inline controller and passing some objects (closes #6822)

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -44,11 +44,18 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
      */
     public function render($uri, Request $request, array $options = array())
     {
+        $reference = null;
         if ($uri instanceof ControllerReference) {
+            $reference = $uri;
             $uri = $this->generateFragmentUri($uri, $request);
         }
 
         $subRequest = $this->createSubRequest($uri, $request);
+
+        // override Request attributes as they can be objects (which are not supported by the generated URI)
+        if (null !== $reference) {
+            $subRequest->attributes->add($reference->attributes);
+        }
 
         $level = ob_get_level();
         try {

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -45,6 +45,29 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $strategy->render(new ControllerReference('main_controller', array(), array()), Request::create('/'))->getContent());
     }
 
+    public function testRenderWithObjectsAsAttributes()
+    {
+        $object = new \stdClass();
+
+        $subRequest = Request::create('/_fragment?_path=_format%3Dhtml%26_controller%3Dmain_controller');
+        $subRequest->attributes->replace(array(
+            'object'      => $object,
+            '_format'     => 'html',
+            '_controller' => 'main_controller',
+        ));
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
+        $kernel
+            ->expects($this->any())
+            ->method('handle')
+            ->with($subRequest)
+        ;
+
+        $strategy = new InlineFragmentRenderer($kernel);
+
+        $strategy->render(new ControllerReference('main_controller', array('object' => $object), array()), Request::create('/'));
+    }
+
     /**
      * @expectedException \RuntimeException
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6822 |
| License | MIT |
| Doc PR | n/a |
