### PR TITLE
[FrameworkBundle] fixed wrong indentation on route debug output

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -128,10 +128,10 @@ EOF
 
         $output->writeln($this->getHelper('formatter')->formatSection('router', sprintf('Route "%s"', $name)));
 
-        $output->writeln(sprintf('<comment>Name</comment>      %s', $name));
-        $output->writeln(sprintf('<comment>Pattern</comment>   %s', $route->getPath()));
-        $output->writeln(sprintf('<comment>Host</comment>      %s', $host));
-        $output->writeln(sprintf('<comment>Class</comment>     %s', get_class($route)));
+        $output->writeln(sprintf('<comment>Name</comment>             %s', $name));
+        $output->writeln(sprintf('<comment>Pattern</comment>          %s', $route->getPath()));
+        $output->writeln(sprintf('<comment>Host</comment>             %s', $host));
+        $output->writeln(sprintf('<comment>Class</comment>            %s', get_class($route)));
 
         $defaults = '';
         $d = $route->getDefaults();


### PR DESCRIPTION
I'm not sure this is something to fix, but with this PR the debug output for a single route is like the lower part of the image, instead of the currently displayed upper part.

![output](https://f.cloud.github.com/assets/254808/120850/f2b6e8ce-6d43-11e2-9fdd-24200eb2e93b.jpg)
