### PR TITLE
[2.3] [FrameworkBundle] added route debug information when path matches url

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterMatchCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
 
@@ -76,6 +77,11 @@ EOF
                 $output->writeln(sprintf('<fg=yellow>Route "%s" almost matches but %s</>', $trace['name'], lcfirst($trace['log'])));
             } elseif (TraceableUrlMatcher::ROUTE_MATCHES == $trace['level']) {
                 $output->writeln(sprintf('<fg=green>Route "%s" matches</>', $trace['name']));
+
+                $routerDebugcommand = $this->getApplication()->find('router:debug');
+                $output->writeln('');
+                $routerDebugcommand->run(new ArrayInput(array('name' => $trace['name'])), $output);
+
                 $matches = true;
             } elseif ($input->getOption('verbose')) {
                 $output->writeln(sprintf('Route "%s" does not match: %s', $trace['name'], $trace['log']));


### PR DESCRIPTION
the result of the command `app/console router:match /demo/hello/foo` would be:

![Schermata 02-2456326 alle 17 04 42](https://f.cloud.github.com/assets/254808/120934/a1499432-6d52-11e2-8b67-46a164c30ea0.png)

instead of just:

```
Route "_demo_hello" matches
```
