### PR TITLE
[2.3] [Serializer] Enabled camelCase format to be used on denormalize method

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer.php
@@ -38,6 +38,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
 {
     protected $callbacks = array();
     protected $ignoredAttributes = array();
+    protected $camelizedAttributes = array();
 
     /**
      * Set normalization callbacks
@@ -64,6 +65,16 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
     public function setIgnoredAttributes(array $ignoredAttributes)
     {
         $this->ignoredAttributes = $ignoredAttributes;
+    }
+
+    /**
+     * Set attributes to be camelized on denormalize
+     *
+     * @param array $camelizedAttributes
+     */
+    public function setCamelizedAttributes(array $camelizedAttributes)
+    {
+        $this->camelizedAttributes = $camelizedAttributes;
     }
 
     /**
@@ -111,7 +122,7 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
 
             $params = array();
             foreach ($constructorParameters as $constructorParameter) {
-                $paramName = lcfirst($constructorParameter->name);
+                $paramName = lcfirst($this->formatAttribute($constructorParameter->name));
 
                 if (isset($data[$paramName])) {
                     $params[] = $data[$paramName];
@@ -132,13 +143,35 @@ class GetSetMethodNormalizer extends SerializerAwareNormalizer implements Normal
         }
 
         foreach ($data as $attribute => $value) {
-            $setter = 'set'.$attribute;
+            $setter = 'set'.$this->formatAttribute($attribute);
+
             if (method_exists($object, $setter)) {
                 $object->$setter($value);
             }
         }
 
         return $object;
+    }
+
+    /**
+     * Format attribute name to access parameters or methods
+     * As option, if attribute name is found on camelizedAttributes array
+     * returns attribute name in camelcase format
+     *
+     * @param string $attribute
+     * @return string
+     */
+    protected function formatAttribute($attributeName)
+    {
+        if (in_array($attributeName, $this->camelizedAttributes)) {
+            return preg_replace_callback(
+                '/(^|_|\.)+(.)/', function ($match) { 
+                    return ('.' === $match[1] ? '_' : '').strtoupper($match[2]); 
+                }, $attributeName
+            );
+        }
+
+        return $attributeName;
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/GetSetMethodNormalizerTest.php
@@ -26,8 +26,9 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         $obj = new GetSetDummy;
         $obj->setFoo('foo');
         $obj->setBar('bar');
+        $obj->setCamelCase('camelcase');
         $this->assertEquals(
-            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar'),
+            array('foo' => 'foo', 'bar' => 'bar', 'fooBar' => 'foobar', 'camelCase' => 'camelcase'),
             $this->normalizer->normalize($obj, 'any')
         );
     }
@@ -41,6 +42,39 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertEquals('foo', $obj->getFoo());
         $this->assertEquals('bar', $obj->getBar());
+    }
+
+    public function testDenormalizeOnCamelCaseFormat()
+    {
+        $this->normalizer->setCamelizedAttributes(array('camel_case'));
+        $obj = $this->normalizer->denormalize(
+            array('camel_case' => 'camelCase'),
+            __NAMESPACE__.'\GetSetDummy'
+        );
+        $this->assertEquals('camelCase', $obj->getCamelCase());
+    }
+
+    /**
+     * @dataProvider attributeProvider
+     */
+    public function testFormatAttribute($attribute, $camelizedAttributes, $result)
+    {
+        $r = new \ReflectionObject($this->normalizer);
+        $m = $r->getMethod('formatAttribute');
+        $m->setAccessible(true);
+
+        $this->normalizer->setCamelizedAttributes($camelizedAttributes);
+        $this->assertEquals($m->invoke($this->normalizer, $attribute, $camelizedAttributes), $result);
+    }
+
+    public function attributeProvider()
+    {
+        return array(
+            array('attribute_test', array('attribute_test'),'AttributeTest'),
+            array('attribute_test', array('any'),'attribute_test'),
+            array('attribute', array('attribute'),'Attribute'),
+            array('attribute', array(), 'attribute'),
+        );
     }
 
     public function testConstructorDenormalize()
@@ -82,7 +116,7 @@ class GetSetMethodNormalizerTest extends \PHPUnit_Framework_TestCase
 
     public function testIgnoredAttributes()
     {
-        $this->normalizer->setIgnoredAttributes(array('foo', 'bar'));
+        $this->normalizer->setIgnoredAttributes(array('foo', 'bar', 'camelCase'));
 
         $obj = new GetSetDummy;
         $obj->setFoo('foo');
@@ -160,6 +194,7 @@ class GetSetDummy
 {
     protected $foo;
     private $bar;
+    protected $camelCase;
 
     public function getFoo()
     {
@@ -184,6 +219,16 @@ class GetSetDummy
     public function getFooBar()
     {
         return $this->foo . $this->bar;
+    }
+
+    public function getCamelCase()
+    {
+        return $this->camelCase;
+    }
+
+    public function setCamelCase($camelCase)
+    {
+        $this->camelCase = $camelCase;
     }
 
     public function otherMethod()


### PR DESCRIPTION
 Enabled camelCase formater , that way when hydrating from arrays, attributes as attribute_name could be implemented as attributteName parameter, with getAttributeName and setAttributeName, giving different formating option from setAttribute_name  getAttribute_name.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |
