### PR TITLE
[Security] Return 401 when using use_forward for form authentication

### DIFF
--- a/src/Symfony/Component/Security/CHANGELOG.md
+++ b/src/Symfony/Component/Security/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.3.0
 -----
 
+ * [BC BREAK] return 401 instead of 500 when using use_forward during for form authentication
  * added a `require_previous_session` option to `AbstractAuthenticationListener`
 
 2.2.0

--- a/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
+++ b/src/Symfony/Component/Security/Http/EntryPoint/FormAuthenticationEntryPoint.php
@@ -53,7 +53,12 @@ class FormAuthenticationEntryPoint implements AuthenticationEntryPointInterface
         if ($this->useForward) {
             $subRequest = $this->httpUtils->createRequest($request, $this->loginPath);
 
-            return $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+            $response = $this->httpKernel->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
+            if (200 === $response->getStatusCode()) {
+                $response->headers->set('X-Status-Code', 401);
+            }
+
+            return $response;
         }
 
         return $this->httpUtils->createRedirectResponse($request, $this->loginPath);

--- a/src/Symfony/Component/Security/Tests/Http/EntryPoint/FormAuthenticationEntryPointTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/EntryPoint/FormAuthenticationEntryPointTest.php
@@ -50,7 +50,7 @@ class FormAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
         $subRequest = $this->getMock('Symfony\Component\HttpFoundation\Request', array(), array(), '', false, false);
-        $response = $this->getMock('Symfony\Component\HttpFoundation\Response');
+        $response = new \Symfony\Component\HttpFoundation\Response('', 200);
 
         $httpUtils = $this->getMock('Symfony\Component\Security\Http\HttpUtils');
         $httpUtils
@@ -70,6 +70,9 @@ class FormAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
 
         $entryPoint = new FormAuthenticationEntryPoint($httpKernel, $httpUtils, '/the/login/path', true);
 
-        $this->assertEquals($response, $entryPoint->start($request));
+        $entryPointResponse = $entryPoint->start($request);
+
+        $this->assertEquals($response, $entryPointResponse);
+        $this->assertEquals(401, $entryPointResponse->headers->get('X-Status-Code'));
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
- [x] document the BC breaks in UPDATE and CHANGELOG

Currently, unauthenticated requests gets handled as exceptions and forwarded to the FormAuthenticationEntryPoint::start. When using use_forward = true, this method does not modify the status code, which means that final response to the end user will use a 500 status code. This is not right, as there is not a server problem, the problem is that the user is not authenticated. The status code should be 401.

This PR checks if the sub request to the form view is successful, and sets an X-Status-Code header if it is.This might break applications that rely on the 500 error code being returned for unauthenticated requests.
