### PR TITLE
[Security] renamed Constraint namespace to Constraints for validator classes in order to be consistent with the whole current validator API.

### DIFF
--- a/UPGRADE-2.2.md
+++ b/UPGRADE-2.2.md
@@ -567,6 +567,55 @@
       trusted_proxies: ['127.0.0.1', '10.0.0.1'] # a list of proxy IPs you trust
    ```
 
+### Security
+
+  * The existing ``UserPassword`` validator constraint class has been modified.
+    Its namespace has been changed to better fit the Symfony coding conventions.
+
+    Before:
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
+    ```
+
+    After: (note the `s` at the end of `Constraint`)
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+    ```
+
+  * The new ``UserPassword`` validator constraint class now accepts a new
+    ``service`` option that allows to specify a custom validator service name in
+    order to validate the current logged-in user's password.
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+
+    $constraint = new UserPassword(array(
+        'service' => 'my.custom.validator.user_password',
+    ));
+    ```
+
+#### Deprecations
+
+  * The two previous ``UserPassword`` and ``UserPasswordValidator`` classes in
+    the ``Symfony\Component\Security\Core\Validator\Constraint`` namespace have
+    been deprecated and will be removed in 2.3.
+
+    Before:
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
+    use Symfony\Component\Security\Core\Validator\Constraint\UserPasswordValidator;
+    ```
+
+    After:
+
+    ```
+    use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+    use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
+    ```
+
 ### Serializer
 
  * All serializer interfaces (Serializer, Normalizer, Encoder) have been

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security.xml
@@ -41,7 +41,7 @@
 
         <parameter key="security.http_utils.class">Symfony\Component\Security\Http\HttpUtils</parameter>
 
-        <parameter key="security.validator.user_password.class">Symfony\Component\Security\Core\Validator\Constraint\UserPasswordValidator</parameter>
+        <parameter key="security.validator.user_password.class">Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator</parameter>
     </parameters>
 
     <services>

--- a/src/Symfony/Component/Security/Core/Validator/Constraint/UserPassword.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraint/UserPassword.php
@@ -11,18 +11,19 @@
 
 namespace Symfony\Component\Security\Core\Validator\Constraint;
 
-use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword as BaseUserPassword;
 
 /**
  * @Annotation
+ *
+ * @deprecated Deprecated since version 2.2, to be removed in 2.3.
  */
-class UserPassword extends Constraint
+class UserPassword extends BaseUserPassword
 {
-    public $message = 'This value should be the user current password.';
-    public $service = 'security.validator.user_password';
-
-    public function validatedBy()
+    public function __construct($options = null)
     {
-        return $this->service;
+        trigger_error('UserPassword class in Symfony\Component\Security\Core\Validator\Constraint namespace is deprecated since version 2.2 and will be removed in 2.3. Use the Symfony\Component\Security\Core\Validator\Constraints\UserPassword class instead.', E_USER_DEPRECATED);
+
+        parent::__construct($options);
     }
 }

--- a/src/Symfony/Component/Security/Core/Validator/Constraint/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraint/UserPasswordValidator.php
@@ -11,36 +11,19 @@
 
 namespace Symfony\Component\Security\Core\Validator\Constraint;
 
-use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\ConstraintValidator;
-use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator as BaseUserPasswordValidator;
 
-class UserPasswordValidator extends ConstraintValidator
+/**
+ * @deprecated Deprecated since version 2.2, to be removed in 2.3.
+ */
+class UserPasswordValidator extends BaseUserPasswordValidator
 {
-    private $securityContext;
-    private $encoderFactory;
-
     public function __construct(SecurityContextInterface $securityContext, EncoderFactoryInterface $encoderFactory)
     {
-        $this->securityContext = $securityContext;
-        $this->encoderFactory = $encoderFactory;
-    }
+        trigger_error('UserPasswordValidator class in Symfony\Component\Security\Core\Validator\Constraint namespace is deprecated since version 2.2 and will be removed in 2.3. Use the Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator class instead.', E_USER_DEPRECATED);
 
-    public function validate($password, Constraint $constraint)
-    {
-        $user = $this->securityContext->getToken()->getUser();
-
-        if (!$user instanceof UserInterface) {
-            throw new ConstraintDefinitionException('The User must extend UserInterface');
-        }
-
-        $encoder = $this->encoderFactory->getEncoder($user);
-
-        if (!$encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt())) {
-            $this->context->addViolation($constraint->message);
-        }
+        parent::__construct($securityContext, $encoderFactory);
     }
 }

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPassword.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class UserPassword extends Constraint
+{
+    public $message = 'This value should be the user current password.';
+    public $service = 'security.validator.user_password';
+
+    public function validatedBy()
+    {
+        return $this->service;
+    }
+}

--- a/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
+++ b/src/Symfony/Component/Security/Core/Validator/Constraints/UserPasswordValidator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Security\Core\Validator\Constraints;
+
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\SecurityContextInterface;
+use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\ConstraintDefinitionException;
+
+class UserPasswordValidator extends ConstraintValidator
+{
+    private $securityContext;
+    private $encoderFactory;
+
+    public function __construct(SecurityContextInterface $securityContext, EncoderFactoryInterface $encoderFactory)
+    {
+        $this->securityContext = $securityContext;
+        $this->encoderFactory = $encoderFactory;
+    }
+
+    public function validate($password, Constraint $constraint)
+    {
+        $user = $this->securityContext->getToken()->getUser();
+
+        if (!$user instanceof UserInterface) {
+            throw new ConstraintDefinitionException('The User object must implement the UserInterface interface.');
+        }
+
+        $encoder = $this->encoderFactory->getEncoder($user);
+
+        if (!$encoder->isPasswordValid($user->getPassword(), $password, $user->getSalt())) {
+            $this->context->addViolation($constraint->message);
+        }
+    }
+}

--- a/src/Symfony/Component/Security/Tests/Core/Validator/Constraints/UserPasswordValidatorTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Validator/Constraints/UserPasswordValidatorTest.php
@@ -9,10 +9,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Component\Security\Tests\Core\Validator\Constraint;
+namespace Symfony\Component\Security\Tests\Core\Validator\Constraints;
 
-use Symfony\Component\Security\Core\Validator\Constraint\UserPassword;
-use Symfony\Component\Security\Core\Validator\Constraint\UserPasswordValidator;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPassword;
+use Symfony\Component\Security\Core\Validator\Constraints\UserPasswordValidator;
 
 class UserPasswordValidatorTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes (for people already using the `UserPassword` constraint class in their code) |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
