### PR TITLE
[2.3] [HttpFoundation] Protect JSONResponse against CSRF attacks

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,7 +4,7 @@ CHANGELOG
 2.3.0
 -----
 
- * added JsonResponse::prefixJson() to mitigate CRSF attacks by prepending a prefix
+ * added JsonResponse::setPrefix() to mitigate CRSF attacks by prepending a prefix
    to the generated JSON
 
 2.2.0

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+2.3.0
+-----
+
+ * added JsonResponse::prefixJson() to mitigate CRSF attacks by prepending a prefix
+   to the generated JSON
+
 2.2.0
 -----
 

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -90,15 +90,16 @@ class JsonResponse extends Response
     }
 
     /**
-     * Mitigates CSRF attack by prepending a prefix to the generated JSON.
+     * Prepends the given prefix to the generated JSON.
      *
+     * This could help mitigating CSRF attacks.
      * @see http://stackoverflow.com/questions/2669690
      *
-     * @param string $prefix The prefix to prepend to the generated JSON
+     * @param string $prefix The prefix to use in front of the generated JSON
      *
      * @return JsonResponse
      */
-    public function prefixJson($prefix = 'while(1);')
+    public function setPrefix($prefix = 'while(1);')
     {
         $this->prefix = $prefix;
 
@@ -121,8 +122,8 @@ class JsonResponse extends Response
 
         // Only set the header when there is none or when it equals 'text/javascript' (from a previous update with callback)
         // in order to not overwrite a custom definition.
-        if (!$this->headers->has('Content-Type') || 'text/javascript' === $this->headers->get('Content-Type')) {
-            $this->headers->set('Content-Type', 'application/json');
+        if (!$this->headers->has('Content-Type') || in_array($this->headers->get('Content-Type'), array('application/json', 'text/javascript'))) {
+            $this->headers->set('Content-Type', empty($this->prefix) ? 'application/json' : 'text/javascript');
         }
 
         return $this->setContent($this->prefix . $this->data);

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -20,6 +20,7 @@ class JsonResponse extends Response
 {
     protected $data;
     protected $callback;
+    protected $prefix = '';
 
     /**
      * Constructor.
@@ -89,6 +90,22 @@ class JsonResponse extends Response
     }
 
     /**
+     * Mitigates CSRF attack by prepending a prefix to the generated JSON.
+     *
+     * @see http://stackoverflow.com/questions/2669690
+     *
+     * @param string $prefix The prefix to prepend to the generated JSON
+     *
+     * @return JsonResponse
+     */
+    public function prefixJson($prefix = 'while(1);')
+    {
+        $this->prefix = $prefix;
+
+        return $this->update();
+    }
+
+    /**
      * Updates the content and headers according to the json data and callback.
      *
      * @return JsonResponse
@@ -108,6 +125,6 @@ class JsonResponse extends Response
             $this->headers->set('Content-Type', 'application/json');
         }
 
-        return $this->setContent($this->data);
+        return $this->setContent($this->prefix . $this->data);
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -105,7 +105,7 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('{"foo":"bar"}', $response->getContent());
     }
 
-    public function testStaticCreateWithSimpleTypes()
+    public function testStaticCreateWithScalarTypes()
     {
         $response = JsonResponse::create('foo');
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
@@ -130,24 +130,47 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(202, $response->getStatusCode());
     }
 
-    public function testStaticCreateAddsContentTypeHeader()
+    public function testStaticCreateWithoutPrefixAddsContentTypeHeader()
     {
         $response = JsonResponse::create();
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
     }
 
-    public function testStaticCreateWithCustomHeaders()
+    public function testStaticCreateWithoutPrefixWithCustomHeaders()
     {
         $response = JsonResponse::create(array(), 200, array('ETag' => 'foo'));
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
         $this->assertSame('foo', $response->headers->get('ETag'));
     }
 
-    public function testStaticCreateWithCustomContentType()
+    public function testStaticCreateWithoutPrefixWithCustomContentType()
     {
         $headers = array('Content-Type' => 'application/vnd.acme.blog-v1+json');
 
         $response = JsonResponse::create(array(), 200, $headers);
+        $this->assertSame('application/vnd.acme.blog-v1+json', $response->headers->get('Content-Type'));
+    }
+
+    public function testStaticCreateWithPrefixAddsContentTypeHeader()
+    {
+        $response = JsonResponse::create()->setPrefix();
+        $this->assertSame('text/javascript', $response->headers->get('Content-Type'));
+        $response = JsonResponse::create()->setPrefix()->setPrefix('');
+        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+    }
+
+    public function testStaticCreateWithPrefixWithCustomHeaders()
+    {
+        $response = JsonResponse::create(array(), 200, array('ETag' => 'foo'))->setPrefix();
+        $this->assertSame('text/javascript', $response->headers->get('Content-Type'));
+        $this->assertSame('foo', $response->headers->get('ETag'));
+    }
+
+    public function testStaticCreateWithPrefixWithCustomContentType()
+    {
+        $headers = array('Content-Type' => 'application/vnd.acme.blog-v1+json');
+
+        $response = JsonResponse::create(array(), 200, $headers)->setPrefix();
         $this->assertSame('application/vnd.acme.blog-v1+json', $response->headers->get('Content-Type'));
     }
 
@@ -174,18 +197,20 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('"\u003C\u003E\u0027\u0026\u0022"', $response->getContent());
     }
 
-    public function testPrefixJsonPrependADefaultPrefix()
+    public function testSetPrefixPrependADefaultPrefix()
     {
-        $response = JsonResponse::create(array())->prefixJson();
+        $response = JsonResponse::create(array())->setPrefix();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertEquals('while(1);[]', $response->getContent());
+        $this->assertEquals('text/javascript', $response->headers->get('Content-Type'));
     }
 
-    public function testPrefixJsonCanSetACustomPrefix()
+    public function testSetPrefixCanSetACustomPrefix()
     {
-        $response = JsonResponse::create(array())->prefixJson('for(;;);');
+        $response = JsonResponse::create(array())->setPrefix('for(;;);');
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
         $this->assertEquals('for(;;);[]', $response->getContent());
+        $this->assertEquals('text/javascript', $response->headers->get('Content-Type'));
     }
 
     public function testPrefixJsonDoNoAffectJsonP()

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -215,7 +215,7 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
 
     public function testPrefixJsonDoNoAffectJsonP()
     {
-        $response = JsonResponse::create(array())->setCallback('cb')->prefixJson();
+        $response = JsonResponse::create(array())->setCallback('cb')->setPrefix();
         $this->assertEquals('cb([]);', $response->getContent());
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -173,4 +173,24 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('"\u003C\u003E\u0027\u0026\u0022"', $response->getContent());
     }
+
+    public function testPrefixJsonPrependADefaultPrefix()
+    {
+        $response = JsonResponse::create(array())->prefixJson();
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertEquals('while(1);[]', $response->getContent());
+    }
+
+    public function testPrefixJsonCanSetACustomPrefix()
+    {
+        $response = JsonResponse::create(array())->prefixJson('for(;;);');
+        $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
+        $this->assertEquals('for(;;);[]', $response->getContent());
+    }
+
+    public function testPrefixJsonDoNoAffectJsonP()
+    {
+        $response = JsonResponse::create(array())->setCallback('cb')->prefixJson();
+        $this->assertEquals('cb([]);', $response->getContent());
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/2212 |
