### PR TITLE
Use REQUEST_TIME_FLOAT if available.

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/TimeDataCollector.php
@@ -35,8 +35,12 @@ class TimeDataCollector extends DataCollector
      */
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
+        if (null === $this->kernel) {
+            $requestTime = $request->server->get('REQUEST_TIME_FLOAT', $request->server->get('REQUEST_TIME'));
+        }
+
         $this->data = array(
-            'start_time' => (null !== $this->kernel ? $this->kernel->getStartTime() : $_SERVER['REQUEST_TIME']) * 1000,
+            'start_time' => (isset($requestTime) ? $requestTime : $this->kernel->getStartTime()) * 1000,
             'events'     => array(),
         );
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/TimeDataCollectorTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\DataCollector;
+
+use Symfony\Component\HttpKernel\DataCollector\TimeDataCollector;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class TimeDataCollectorTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('The "HttpFoundation" component is not available');
+        }
+    }
+
+    public function testCollectWithoutKernel()
+    {
+        $c = new TimeDataCollector;
+
+        $request = new Request();
+        $request->server->set('REQUEST_TIME', 1);
+
+        $c->collect($request, new Response());
+
+        $this->assertEquals(1000, $c->getStartTime());
+
+        $request->server->set('REQUEST_TIME_FLOAT', 2);
+
+        $c->collect($request, new Response());
+
+        $this->assertEquals(2000, $c->getStartTime());
+    }
+
+}


### PR DESCRIPTION
This will give a more correct initialization time when using the
DataCollectors without a KernelInterface implementation such as Silex.

`REQUEST_TIME_FLOAT` is available as of 5.4.0
