### PR TITLE
[Validator] Add check for existing metadata on property

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -301,6 +301,11 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
         return $this->members[$property];
     }
 
+    public function hasPropertyMetadata($property)
+    {
+        return array_key_exists($property, $this->members);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadata.php
@@ -301,6 +301,9 @@ class ClassMetadata extends ElementMetadata implements MetadataInterface, ClassB
         return $this->members[$property];
     }
 
+    /**
+     * {@inheritdoc}
+     */
     public function hasPropertyMetadata($property)
     {
         return array_key_exists($property, $this->members);

--- a/src/Symfony/Component/Validator/PropertyMetadataContainerInterface.php
+++ b/src/Symfony/Component/Validator/PropertyMetadataContainerInterface.php
@@ -19,6 +19,15 @@ namespace Symfony\Component\Validator;
 interface PropertyMetadataContainerInterface
 {
     /**
+     * Check if there's any metadata attached to the given named property.
+     *
+     * @param string $property The property name.
+     *
+     * @return Boolean
+     */
+    public function hasPropertyMetadata($property);
+
+    /**
      * Returns all metadata instances for the given named property.
      *
      * If your implementation does not support properties, simply throw an

--- a/src/Symfony/Component/Validator/Tests/ValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/ValidatorTest.php
@@ -187,6 +187,10 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $result = $this->validator->validateProperty($entity, 'firstName');
 
         $this->assertCount(1, $result);
+
+        $result = $this->validator->validateProperty($entity, 'lastName');
+
+        $this->assertCount(0, $result);
     }
 
     public function testValidatePropertyValue()

--- a/src/Symfony/Component/Validator/Validator.php
+++ b/src/Symfony/Component/Validator/Validator.php
@@ -112,6 +112,10 @@ class Validator implements ValidatorInterface
         }
 
         foreach ($this->resolveGroups($groups) as $group) {
+            if (!$metadata->hasPropertyMetadata($property)) {
+                continue;
+            }
+
             foreach ($metadata->getPropertyMetadata($property) as $propMeta) {
                 $propMeta->accept($visitor, $propMeta->getPropertyValue($containingValue), $group, $property);
             }
@@ -139,6 +143,10 @@ class Validator implements ValidatorInterface
         }
 
         foreach ($this->resolveGroups($groups) as $group) {
+            if (!$metadata->hasPropertyMetadata($property)) {
+                continue;
+            }
+
             foreach ($metadata->getPropertyMetadata($property) as $propMeta) {
                 $propMeta->accept($visitor, $value, $group, $property);
             }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no (sort of) |
| New feature? | no |
| BC breaks? | no (I don't think so) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |

Todo:
- [x] Check if the new method should be added to the interface as well.

This adds a check for metadata existence before usage else the code will emit a warning.

This should not be a BC break or a bug fix as the patched code is 2.2 specific.

@bschussek let me know if I should add the method in the interface as well. Thank you.
