### PR TITLE
[2.3] [Translator][FrameworkBundle] Allow remote message sources

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/TranslationLoader.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\FrameworkBundle\Translation;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Translation\MessageCatalogue;
 use Symfony\Component\Translation\Loader\LoaderInterface;
+use Symfony\Component\Translation\Loader\RemoteLoaderInterface;
 
 /**
  * TranslationLoader loads translation messages from translation files.
@@ -48,6 +49,27 @@ class TranslationLoader
     public function loadMessages($directory, MessageCatalogue $catalogue)
     {
         foreach ($this->loaders as $format => $loader) {
+            // load data from remote providers
+            if ($loader instanceof RemoteLoaderInterface) {
+                $resources = $loader->getRemoteResources();
+
+                foreach ($resources as $resource) {
+                    $locales = $loader->getLocalesForResource($resource);
+
+                    foreach ($locales as $locale) {
+                        $domains = $loader->getDomainsForLocale($resource, $locale);
+
+                        foreach ($domains as $domain) {
+                            $catalogue->addCatalogue(
+                                $loader->load($resource, $locale, $domain)
+                            );
+                        }
+                    }
+                }
+
+                continue;
+            }
+
             // load any existing translation files
             $finder = new Finder();
             $extension = $catalogue->getLocale().'.'.$format;

--- a/src/Symfony/Component/Translation/Loader/RemoteLoaderInterface.php
+++ b/src/Symfony/Component/Translation/Loader/RemoteLoaderInterface.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Loader;
+
+/**
+ * RemoteLoaderInterface is the interface implemented by all translation
+ * loaders, that do not use files located in project resources.
+ *
+ * @author Dariusz Górecki <darek.krk@gmail.com>
+ */
+interface RemoteLoaderInterface extends LoaderInterface
+{
+    /**
+     * Returns array of available resources handled by this loader.
+     * eg: array of Entity managers, or database connections to use,
+     * this resources will be passed to load method.
+     *
+     * @return mixed List of resources
+     */
+    function getRemoteResources();
+
+    /**
+     * Returns list of available locales in given resource.
+     *
+     * @param  mixed $resource Resource to scan for message domains
+     * @return mixed           List of found locales
+     */
+    function getLocalesForResource($resource);
+
+    /**
+     * Returns list of available translation domains in given resource.
+     *
+     * @param  mixed  $resource Resource to scan for message domains
+     * @param  string $locale   Locale to scan for message domains
+     * @return mixed            List of found translation domains
+     */
+    function getDomainsForLocale($resource, $locale);
+}

--- a/src/Symfony/Component/Translation/Tests/Loader/RemoteLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/RemoteLoaderTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Loader;
+
+use Symfony\Component\Translation\Tests\fixtures\RemoteLoader;
+
+class RemoteLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testEmptyLoader()
+    {
+        $loader = new RemoteLoader(array());
+
+        $this->assertEquals(array(), $loader->getRemoteResources());
+        $this->assertEquals(array(), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array(), $loader->getDomainsForLocale('foo', 'bar'));
+        $this->assertEquals(array(), $loader->load('foo', 'bar', 'baz'));
+    }
+
+    public function testEmptyResources()
+    {
+        $loader = new RemoteLoader(array(
+            'foo' => array(),
+        ));
+
+        $this->assertEquals(array('foo'), $loader->getRemoteResources());
+        $this->assertEquals(array(), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array(), $loader->getDomainsForLocale('foo', 'bar'));
+        $this->assertEquals(array(), $loader->load('foo', 'bar', 'baz'));
+    }
+
+    public function testEmptyLocales()
+    {
+        $loader = new RemoteLoader(array(
+            'foo' => array(
+                'pl_PL' => array(),
+            ),
+        ));
+
+        $this->assertEquals(array('foo'), $loader->getRemoteResources());
+        $this->assertEquals(array('pl_PL'), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array(), $loader->getDomainsForLocale('foo', 'bar'));
+        $this->assertEquals(array(), $loader->load('foo', 'bar', 'baz'));
+    }
+
+    public function testEmptyDomains()
+    {
+        $loader = new RemoteLoader(array(
+            'foo' => array(
+                'pl_PL' => array(
+                    'messages' => array(),
+                ),
+            ),
+        ));
+
+        $this->assertEquals(array('foo'), $loader->getRemoteResources());
+        $this->assertEquals(array('pl_PL'), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array('messages'), $loader->getDomainsForLocale('foo', 'pl_PL'));
+        $this->assertEquals(array(), $loader->load('foo', 'pl_PL', 'messages'));
+    }
+
+    public function testLoad()
+    {
+        $loader = new RemoteLoader(array(
+            'foo' => array(
+                'pl_PL' => array(
+                    'messages' => array(
+                        'key1' => 'value1',
+                        'key2' => 'value2',
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertEquals(array('foo'), $loader->getRemoteResources());
+        $this->assertEquals(array('pl_PL'), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array('messages'), $loader->getDomainsForLocale('foo', 'pl_PL'));
+        $this->assertEquals(array('key1' => 'value1', 'key2' => 'value2'), $loader->load('foo', 'pl_PL', 'messages'));
+    }
+
+    public function testLoadMultipleLocales()
+    {
+        $loader = new RemoteLoader(array(
+            'foo' => array(
+                'pl_PL' => array(
+                    'messages' => array(
+                        'key1' => 'value1',
+                        'key2' => 'value2',
+                    ),
+                ),
+                'en_US' => array(
+                    'messages' => array(
+                        'key3' => 'value3',
+                        'key4' => 'value4',
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertEquals(array('foo'), $loader->getRemoteResources());
+        $this->assertEquals(array('pl_PL', 'en_US'), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array('messages'), $loader->getDomainsForLocale('foo', 'pl_PL'));
+        $this->assertEquals(array('messages'), $loader->getDomainsForLocale('foo', 'en_US'));
+        $this->assertEquals(array('key1' => 'value1', 'key2' => 'value2'), $loader->load('foo', 'pl_PL', 'messages'));
+        $this->assertEquals(array('key3' => 'value3', 'key4' => 'value4'), $loader->load('foo', 'en_US', 'messages'));
+    }
+
+    public function testLoadMultipleResources()
+    {
+        $loader = new RemoteLoader(array(
+            'foo' => array(
+                'pl_PL' => array(
+                    'messages' => array(
+                        'key1' => 'value1',
+                        'key2' => 'value2',
+                    ),
+                ),
+            ),
+            'bar' => array(
+                'en_US' => array(
+                    'messages' => array(
+                        'key3' => 'value3',
+                        'key4' => 'value4',
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertEquals(array('foo', 'bar'), $loader->getRemoteResources());
+        $this->assertEquals(array('pl_PL'), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array('en_US'), $loader->getLocalesForResource('bar'));
+        $this->assertEquals(array('messages'), $loader->getDomainsForLocale('foo', 'pl_PL'));
+        $this->assertEquals(array('messages'), $loader->getDomainsForLocale('bar', 'en_US'));
+        $this->assertEquals(array('key1' => 'value1', 'key2' => 'value2'), $loader->load('foo', 'pl_PL', 'messages'));
+        $this->assertEquals(array('key3' => 'value3', 'key4' => 'value4'), $loader->load('bar', 'en_US', 'messages'));
+    }
+
+    public function testLoadMultipleDomains()
+    {
+        $loader = new RemoteLoader(array(
+            'foo' => array(
+                'pl_PL' => array(
+                    'messages' => array(
+                        'key1' => 'value1',
+                        'key2' => 'value2',
+                    ),
+                    'site' => array(
+                        'key3' => 'value3',
+                        'key4' => 'value4',
+                    ),
+                ),
+            ),
+        ));
+
+        $this->assertEquals(array('foo'), $loader->getRemoteResources());
+        $this->assertEquals(array('pl_PL'), $loader->getLocalesForResource('foo'));
+        $this->assertEquals(array('messages', 'site'), $loader->getDomainsForLocale('foo', 'pl_PL'));
+        $this->assertEquals(array('key1' => 'value1', 'key2' => 'value2'), $loader->load('foo', 'pl_PL', 'messages'));
+        $this->assertEquals(array('key3' => 'value3', 'key4' => 'value4'), $loader->load('foo', 'pl_PL', 'site'));
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/fixtures/RemoteLoader.php
+++ b/src/Symfony/Component/Translation/Tests/fixtures/RemoteLoader.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Tests\Fixtures;
+
+use Symfony\Component\Translation\Loader\RemoteLoaderInterface;
+
+class RemoteLoader implements RemoteLoaderInterface
+{
+    private $source;
+
+    public function __construct(array $source)
+    {
+        $this->source = $source;
+    }
+
+    public function getRemoteResources()
+    {
+        return array_keys($this->source);
+    }
+
+    public function getLocalesForResource($resource)
+    {
+        if (array_key_exists($resource, $this->source)) {
+            return array_keys($this->source[$resource]);
+        }
+
+        return array();
+    }
+
+    public function getDomainsForLocale($resource, $locale)
+    {
+        if (array_key_exists($resource, $this->source)) {
+            if (array_key_exists($locale, $this->source[$resource])) {
+                return array_keys($this->source[$resource][$locale]);
+            }
+        }
+
+        return array();
+    }
+
+    public function load($resource, $locale, $domain = 'messages')
+    {
+        if (array_key_exists($resource, $this->source)) {
+            if (array_key_exists($locale, $this->source[$resource])) {
+                if (array_key_exists($domain, $this->source[$resource][$locale])) {
+                    return $this->source[$resource][$locale][$domain];
+                }
+            }
+        }
+
+        return array();
+    }
+}


### PR DESCRIPTION
Currently you have to create dummy empty files in yours Resources folder
when you use customized Translation Loader Interface, because loader from
Framework Bundle omits all loaders that don't have file.

This PR attempts to fix this behaviour without BC breaks;

Example usage:
You have messages stored in MongoDB, collections are yours message domains groups.
Via DI you inject Mongo connection to loader, and then through yours implementation discover avaliable domains.

| Q | A |
| --- | --- |
| Bug fix? | yes - by feature addition |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6930 |
| License | MIT |
| Doc PR | - |
### TODO if feature gets positive feedback
- [ ] submit changes to the documentation
- [x] write unit tests
