### PR TITLE
[MANY] Fixed require versions for 2.3-dev projects.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -20,19 +20,19 @@
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "symfony/stopwatch": "2.2.*",
-        "symfony/dependency-injection": "2.2.*",
-        "symfony/form": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
-        "symfony/security": "2.2.*",
-        "symfony/validator": "2.2.*",
+        "symfony/stopwatch": "2.3.*",
+        "symfony/dependency-injection": "2.3.*",
+        "symfony/form": "2.3.*",
+        "symfony/http-kernel": "2.3.*",
+        "symfony/security": "2.3.*",
+        "symfony/validator": "2.3.*",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.2",
         "doctrine/orm": "~2.2,>=2.2.3"
     },
     "suggest": {
-        "symfony/form": "2.2.*",
-        "symfony/validator": "2.2.*",
+        "symfony/form": "2.3.*",
+        "symfony/validator": "2.3.*",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.2",
         "doctrine/orm": "~2.2,>=2.2.3"

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/http-kernel": "2.3.*",
         "monolog/monolog": "~1.3"
     },
     "autoload": {

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-foundation": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
-        "symfony/form": "2.2.*",
+        "symfony/http-foundation": "2.3.*",
+        "symfony/http-kernel": "2.3.*",
+        "symfony/form": "2.3.*",
         "propel/propel1": "1.6.*"
     },
     "require-dev": {
-        "symfony/stopwatch": "2.2.*"
+        "symfony/stopwatch": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Propel1\\": "" }

--- a/src/Symfony/Bridge/Swiftmailer/composer.json
+++ b/src/Symfony/Bridge/Swiftmailer/composer.json
@@ -20,7 +20,7 @@
         "swiftmailer/swiftmailer": ">=4.2.0,<4.4-dev"
     },
     "suggest": {
-        "symfony/http-kernel": "2.2.*"
+        "symfony/http-kernel": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Swiftmailer\\": "" }

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -20,22 +20,22 @@
         "twig/twig": "~1.11"
     },
     "require-dev": {
-        "symfony/form": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
-        "symfony/routing": "2.2.*",
-        "symfony/templating": "2.2.*",
-        "symfony/translation": "2.2.*",
-        "symfony/yaml": "2.2.*",
-        "symfony/security": "2.2.*"
+        "symfony/form": "2.3.*",
+        "symfony/http-kernel": "2.3.*",
+        "symfony/routing": "2.3.*",
+        "symfony/templating": "2.3.*",
+        "symfony/translation": "2.3.*",
+        "symfony/yaml": "2.3.*",
+        "symfony/security": "2.3.*"
     },
     "suggest": {
-        "symfony/form": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
-        "symfony/routing": "2.2.*",
-        "symfony/templating": "2.2.*",
-        "symfony/translation": "2.2.*",
-        "symfony/yaml": "2.2.*",
-        "symfony/security": "2.2.*"
+        "symfony/form": "2.3.*",
+        "symfony/http-kernel": "2.3.*",
+        "symfony/routing": "2.3.*",
+        "symfony/templating": "2.3.*",
+        "symfony/translation": "2.3.*",
+        "symfony/yaml": "2.3.*",
+        "symfony/security": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Twig\\": "" }

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -19,24 +19,24 @@
         "php": ">=5.3.3",
         "symfony/dependency-injection" : "2.2.*",
         "symfony/config" : "2.2.*",
-        "symfony/event-dispatcher": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
-        "symfony/filesystem": "2.2.*",
-        "symfony/routing": "2.2.*",
-        "symfony/stopwatch": "2.2.*",
-        "symfony/templating": "2.2.*",
-        "symfony/translation": "2.2.*",
+        "symfony/event-dispatcher": "2.3.*",
+        "symfony/http-kernel": "2.3.*",
+        "symfony/filesystem": "2.3.*",
+        "symfony/routing": "2.3.*",
+        "symfony/stopwatch": "2.3.*",
+        "symfony/templating": "2.3.*",
+        "symfony/translation": "2.3.*",
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "symfony/finder": "2.2.*",
-        "symfony/security": "2.2.*"
+        "symfony/finder": "2.3.*",
+        "symfony/security": "2.3.*"
     },
     "suggest": {
-        "symfony/console": "2.2.*",
-        "symfony/finder": "2.2.*",
-        "symfony/form": "2.2.*",
-        "symfony/validator": "2.2.*"
+        "symfony/console": "2.3.*",
+        "symfony/finder": "2.3.*",
+        "symfony/form": "2.3.*",
+        "symfony/validator": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\FrameworkBundle\\": "" }

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/security": "2.2.*"
+        "symfony/security": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\SecurityBundle\\": "" }

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -17,10 +17,10 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/twig-bridge": "2.2.*"
+        "symfony/twig-bridge": "2.3.*"
     },
     "require-dev": {
-        "symfony/stopwatch": "2.2.*"
+        "symfony/stopwatch": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-kernel": "2.2.*",
-        "symfony/routing": "2.2.*",
-        "symfony/twig-bridge": "2.2.*"
+        "symfony/http-kernel": "2.3.*",
+        "symfony/routing": "2.3.*",
+        "symfony/twig-bridge": "2.3.*"
     },
     "require-dev": {
-        "symfony/config": "2.2.*",
-        "symfony/dependency-injection": "2.2.*",
-        "symfony/stopwatch": "2.2.*"
+        "symfony/config": "2.3.*",
+        "symfony/dependency-injection": "2.3.*",
+        "symfony/stopwatch": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\WebProfilerBundle\\": "" }

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -17,14 +17,14 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/dom-crawler": "2.2.*"
+        "symfony/dom-crawler": "2.3.*"
     },
     "require-dev": {
-        "symfony/process": "2.2.*",
-        "symfony/css-selector": "2.2.*"
+        "symfony/process": "2.3.*",
+        "symfony/css-selector": "2.3.*"
     },
     "suggest": {
-        "symfony/process": "2.2.*"
+        "symfony/process": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\BrowserKit\\": "" }

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/finder": "2.2.*"
+        "symfony/finder": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\ClassLoader\\": "" }

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -19,12 +19,12 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/yaml": "2.2.*",
-        "symfony/config": "2.2.*"
+        "symfony/yaml": "2.3.*",
+        "symfony/config": "2.3.*"
     },
     "suggest": {
-        "symfony/yaml": "2.2.*",
-        "symfony/config": "2.2.*"
+        "symfony/yaml": "2.3.*",
+        "symfony/config": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\DependencyInjection\\": "" }

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -19,10 +19,10 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/css-selector": "2.2.*"
+        "symfony/css-selector": "2.3.*"
     },
     "suggest": {
-        "symfony/css-selector": "2.2.*"
+        "symfony/css-selector": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\DomCrawler\\": "" }

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -19,11 +19,11 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/dependency-injection": "2.2.*"
+        "symfony/dependency-injection": "2.3.*"
     },
     "suggest": {
-        "symfony/dependency-injection": "2.2.*",
-        "symfony/http-kernel": "2.2.*"
+        "symfony/dependency-injection": "2.3.*",
+        "symfony/http-kernel": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\EventDispatcher\\": "" }

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -17,18 +17,18 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": "2.2.*",
-        "symfony/locale": "2.2.*",
-        "symfony/options-resolver": "2.2.*",
-        "symfony/property-access": "2.2.*"
+        "symfony/event-dispatcher": "2.3.*",
+        "symfony/locale": "2.3.*",
+        "symfony/options-resolver": "2.3.*",
+        "symfony/property-access": "2.3.*"
     },
     "require-dev": {
-        "symfony/validator": "2.2.*",
-        "symfony/http-foundation": "2.2.*"
+        "symfony/validator": "2.3.*",
+        "symfony/http-foundation": "2.3.*"
     },
     "suggest": {
-        "symfony/validator": "2.2.*",
-        "symfony/http-foundation": "2.2.*"
+        "symfony/validator": "2.3.*",
+        "symfony/http-foundation": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Form\\": "" }

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,28 +17,28 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": "2.2.*",
-        "symfony/http-foundation": "2.2.*",
+        "symfony/event-dispatcher": "2.3.*",
+        "symfony/http-foundation": "2.3.*",
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "2.2.*",
-        "symfony/class-loader": "2.2.*",
-        "symfony/config": "2.2.*",
-        "symfony/console": "2.2.*",
-        "symfony/dependency-injection": "2.2.*",
-        "symfony/finder": "2.2.*",
-        "symfony/process": "2.2.*",
-        "symfony/routing": "2.2.*",
-        "symfony/stopwatch": "2.2.*"
+        "symfony/browser-kit": "2.3.*",
+        "symfony/class-loader": "2.3.*",
+        "symfony/config": "2.3.*",
+        "symfony/console": "2.3.*",
+        "symfony/dependency-injection": "2.3.*",
+        "symfony/finder": "2.3.*",
+        "symfony/process": "2.3.*",
+        "symfony/routing": "2.3.*",
+        "symfony/stopwatch": "2.3.*"
     },
     "suggest": {
-        "symfony/browser-kit": "2.2.*",
-        "symfony/class-loader": "2.2.*",
-        "symfony/config": "2.2.*",
-        "symfony/console": "2.2.*",
-        "symfony/dependency-injection": "2.2.*",
-        "symfony/finder": "2.2.*"
+        "symfony/browser-kit": "2.3.*",
+        "symfony/class-loader": "2.3.*",
+        "symfony/config": "2.3.*",
+        "symfony/console": "2.3.*",
+        "symfony/dependency-injection": "2.3.*",
+        "symfony/finder": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\HttpKernel\\": "" }

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -19,15 +19,15 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/config": "2.2.*",
-        "symfony/yaml": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/config": "2.3.*",
+        "symfony/yaml": "2.3.*",
+        "symfony/http-kernel": "2.3.*",
         "doctrine/common": "~2.2",
         "psr/log": "~1.0"
     },
     "suggest": {
-        "symfony/config": "2.2.*",
-        "symfony/yaml": "2.2.*",
+        "symfony/config": "2.3.*",
+        "symfony/yaml": "2.3.*",
         "doctrine/common": "~2.2"
     },
     "autoload": {

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -17,24 +17,24 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": "2.2.*",
-        "symfony/http-foundation": "2.2.*",
-        "symfony/http-kernel": "2.2.*"
+        "symfony/event-dispatcher": "2.3.*",
+        "symfony/http-foundation": "2.3.*",
+        "symfony/http-kernel": "2.3.*"
     },
     "require-dev": {
-        "symfony/form": "2.2.*",
-        "symfony/routing": "2.2.*",
-        "symfony/validator": "2.2.*",
+        "symfony/form": "2.3.*",
+        "symfony/routing": "2.3.*",
+        "symfony/validator": "2.3.*",
         "doctrine/common": "~2.2",
         "doctrine/dbal": "~2.2",
         "psr/log": "~1.0"
     },
     "suggest": {
-        "symfony/class-loader": "2.2.*",
-        "symfony/finder": "2.2.*",
-        "symfony/form": "2.2.*",
-        "symfony/validator": "2.2.*",
-        "symfony/routing": "2.2.*",
+        "symfony/class-loader": "2.3.*",
+        "symfony/finder": "2.3.*",
+        "symfony/form": "2.3.*",
+        "symfony/validator": "2.3.*",
+        "symfony/routing": "2.3.*",
         "doctrine/dbal": "to use the built-in ACL implementation"
     },
     "autoload": {

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -19,12 +19,12 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/config": "2.2.*",
-        "symfony/yaml": "2.2.*"
+        "symfony/config": "2.3.*",
+        "symfony/yaml": "2.3.*"
     },
     "suggest": {
-        "symfony/config": "2.2.*",
-        "symfony/yaml": "2.2.*"
+        "symfony/config": "2.3.*",
+        "symfony/yaml": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Translation\\": "" }

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,20 +17,20 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/translation": "2.2.*"
+        "symfony/translation": "2.3.*"
     },
     "require-dev": {
-        "symfony/http-foundation": "2.2.*",
-        "symfony/locale": "2.2.*",
-        "symfony/yaml": "2.2.*",
-        "symfony/config": "2.2.*"
+        "symfony/http-foundation": "2.3.*",
+        "symfony/locale": "2.3.*",
+        "symfony/yaml": "2.3.*",
+        "symfony/config": "2.3.*"
     },
     "suggest": {
         "doctrine/common": "~2.2",
-        "symfony/http-foundation": "2.2.*",
-        "symfony/locale": "2.2.*",
-        "symfony/yaml": "2.2.*",
-        "symfony/config": "2.2.*"
+        "symfony/http-foundation": "2.3.*",
+        "symfony/locale": "2.3.*",
+        "symfony/yaml": "2.3.*",
+        "symfony/config": "2.3.*"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Validator\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| License | MIT |

It looks to me like a 2.2 merge into master caused a bunch of Composer incompatibilities. For example, requiring Framework bundle 2.3.\* will try to require symfony/dependency-injection 2.2.*. This is probably not what is expected.

The following composer.json shows the behavior:

``` json
{
    "require": {
        "symfony/http-kernel": "2.3.*"
    },
    "minimum-stability": "dev"
}
```

Output:

```
Loading composer repositories with package information
Installing dependencies
  - Installing psr/log (1.0.0)

  - Installing symfony/http-foundation (2.2.x-dev v2.2.0-RC1)
    Cloning v2.2.0-RC1

  - Installing symfony/event-dispatcher (2.2.x-dev v2.2.0-RC1)
    Cloning v2.2.0-RC1

  - Installing symfony/http-kernel (dev-master 164dd88)
    Cloning 164dd884b88382dd8e37caa43a534553a4887b98

symfony/event-dispatcher suggests installing symfony/dependency-injection (2.2.*)
symfony/http-kernel suggests installing symfony/browser-kit (2.2.*)
symfony/http-kernel suggests installing symfony/class-loader (2.2.*)
symfony/http-kernel suggests installing symfony/config (2.2.*)
symfony/http-kernel suggests installing symfony/console (2.2.*)
symfony/http-kernel suggests installing symfony/dependency-injection (2.2.*)
symfony/http-kernel suggests installing symfony/finder (2.2.*)
Writing lock file
Generating autoload files
```

I did a blanket sweep on anything requiring symfony/\* 2.2.\* and replaced with 2.3._. If there are any legitimate cases where symfony/_ 2.2.\* should be used this might have broken that.
