### PR TITLE
[Validator] gracefully handle transChoice errors

### DIFF
--- a/src/Symfony/Component/Validator/ExecutionContext.php
+++ b/src/Symfony/Component/Validator/ExecutionContext.php
@@ -89,10 +89,18 @@ class ExecutionContext implements ExecutionContextInterface
      */
     public function addViolation($message, array $params = array(), $invalidValue = null, $pluralization = null, $code = null)
     {
+        if (null === $pluralization) {
+            $translatedMessage = $this->translator->trans($message, $params, $this->translationDomain);
+        } else {
+            try {
+                $translatedMessage = $this->translator->transChoice($message, $pluralization, $params, $this->translationDomain);
+            } catch (\InvalidArgumentException $e) {
+                $translatedMessage = $this->translator->trans($message, $params, $this->translationDomain);
+            }
+        }
+
         $this->globalContext->getViolations()->add(new ConstraintViolation(
-            null === $pluralization
-                ? $this->translator->trans($message, $params, $this->translationDomain)
-                : $this->translator->transChoice($message, $pluralization, $params, $this->translationDomain),
+            $translatedMessage,
             $message,
             $params,
             $this->globalContext->getRoot(),

--- a/src/Symfony/Component/Validator/Tests/ExecutionContextTest.php
+++ b/src/Symfony/Component/Validator/Tests/ExecutionContextTest.php
@@ -376,6 +376,19 @@ class ExecutionContextTest extends \PHPUnit_Framework_TestCase
         )), $this->context->getViolations());
     }
 
+    public function testAddViolationPluralTranslationError()
+    {
+        $this->translator->expects($this->once())
+            ->method('transChoice')
+            ->with('foo')
+            ->will($this->throwException(new \InvalidArgumentException()));
+        $this->translator->expects($this->once())
+            ->method('trans')
+            ->with('foo');
+
+        $this->context->addViolation('foo', array(), null, 2);
+    }
+
     public function testGetPropertyPath()
     {
         $this->assertEquals('foo.bar', $this->context->getPropertyPath());


### PR DESCRIPTION
This validator annotation was throwing an error for me:

```
/** @Assert\Length(min=6, minMessage="Must be 6 characters") */
```

To avoid this error in the current code I would need to provide a message template that accommodates the minimum length being 1, even though that's not the case.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | ~ |
| License | MIT |
| Doc PR | ~ |
