### PR TITLE
[Form]fixed FormRenderer::humanize() to humanize camel cased label

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -22,6 +22,7 @@ CHANGELOG
  * added an optional PropertyAccessorInterface parameter to FormType,
    ObjectChoiceList and PropertyPathMapper
  * [BC BREAK] PropertyPathMapper and FormType now have a constructor
+ * FormRenderer::humanize() also humanizes camel cased field name
 
 2.1.0
 -----

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+
+2.3.0
+------
+
+ * changed FormRenderer::humanize() to humanize also camel cased field name
+
 2.2.0
 -----
 
@@ -22,7 +28,6 @@ CHANGELOG
  * added an optional PropertyAccessorInterface parameter to FormType,
    ObjectChoiceList and PropertyPathMapper
  * [BC BREAK] PropertyPathMapper and FormType now have a constructor
- * FormRenderer::humanize() also humanizes camel cased field name
 
 2.1.0
 -----

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -280,6 +280,6 @@ class FormRenderer implements FormRendererInterface
      */
     public function humanize($text)
     {
-        return ucfirst(trim(strtolower(preg_replace('/[_\s]+/', ' ', preg_replace('/([A-Z])/', '_$1', $text)))));
+        return ucfirst(trim(strtolower(preg_replace(array('/([A-Z])/', '/[_\s]+/'), array('_$1', ' '), $text))));
     }
 }

--- a/src/Symfony/Component/Form/FormRenderer.php
+++ b/src/Symfony/Component/Form/FormRenderer.php
@@ -280,6 +280,6 @@ class FormRenderer implements FormRendererInterface
      */
     public function humanize($text)
     {
-        return ucfirst(trim(strtolower(preg_replace('/[_\s]+/', ' ', $text))));
+        return ucfirst(trim(strtolower(preg_replace('/[_\s]+/', ' ', preg_replace('/([A-Z])/', '_$1', $text)))));
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormRendererTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRendererTest.php
@@ -6,22 +6,14 @@ use Symfony\Component\Form\FormRenderer;
 
 class FormRendererTest extends \PHPUnit_Framework_TestCase
 {
-    private $renderer;
-    
-    public function setUp()
-    {
-        $engine = $this->getMock('Symfony\Component\Form\FormRendererEngineInterface');
-        $this->renderer = new FormRenderer($engine);
-    }
-    
     public function testHumanize()
     {
-        $this->assertEquals('Is active', $this->renderer->humanize('is_active'));
-        $this->assertEquals('Is active', $this->renderer->humanize('isActive'));
-    }
-    
-    public function tearDown()
-    {
-        $this->renderer = null;
+        $engine = $this->getMock('Symfony\Component\Form\FormRendererEngineInterface');
+        $renderer = new FormRenderer($engine);
+
+        $this->assertEquals('Is active', $renderer->humanize('is_active'));
+        $this->assertEquals('Is active', $renderer->humanize('isActive'));
+
+        $renderer = null;
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormRendererTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRendererTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Symfony\Component\Form\Test;
+
+use Symfony\Component\Templating\PhpEngine;
+use Symfony\Component\Templating\TemplateNameParser;
+use Symfony\Component\Templating\Loader\FilesystemLoader;
+use Symfony\Component\Form\Extension\Templating\TemplatingRendererEngine;
+use Symfony\Component\Form\FormRenderer;
+
+class FormRendererTest extends \PHPUnit_Framework_TestCase
+{
+    private $renderer;
+    
+    public function setUp()
+    {
+        $parser = new TemplateNameParser();
+        $loader = new FilesystemLoader(array());
+        $phpEngine = new PhpEngine($parser, $loader);
+        $engine = new TemplatingRendererEngine($phpEngine);
+        $this->renderer = new FormRenderer($engine);
+    }
+    
+    public function testHumanize()
+    {
+        $this->assertEquals('Is active', $this->renderer->humanize('is_active'));
+        $this->assertEquals('Is active', $this->renderer->humanize('isActive'));
+    }
+    
+    public function tearDown()
+    {
+        $this->renderer = null;
+    }
+}

--- a/src/Symfony/Component/Form/Tests/FormRendererTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRendererTest.php
@@ -14,7 +14,5 @@ class FormRendererTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Is active', $renderer->humanize('is_active'));
         $this->assertEquals('Is active', $renderer->humanize('isActive'));
-
-        $renderer = null;
     }
 }

--- a/src/Symfony/Component/Form/Tests/FormRendererTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRendererTest.php
@@ -2,10 +2,6 @@
 
 namespace Symfony\Component\Form\Test;
 
-use Symfony\Component\Templating\PhpEngine;
-use Symfony\Component\Templating\TemplateNameParser;
-use Symfony\Component\Templating\Loader\FilesystemLoader;
-use Symfony\Component\Form\Extension\Templating\TemplatingRendererEngine;
 use Symfony\Component\Form\FormRenderer;
 
 class FormRendererTest extends \PHPUnit_Framework_TestCase
@@ -14,10 +10,7 @@ class FormRendererTest extends \PHPUnit_Framework_TestCase
     
     public function setUp()
     {
-        $parser = new TemplateNameParser();
-        $loader = new FilesystemLoader(array());
-        $phpEngine = new PhpEngine($parser, $loader);
-        $engine = new TemplatingRendererEngine($phpEngine);
+        $engine = $this->getMock('Symfony\Component\Form\FormRendererEngineInterface');
         $this->renderer = new FormRenderer($engine);
     }
     

--- a/src/Symfony/Component/Form/Tests/FormRendererTest.php
+++ b/src/Symfony/Component/Form/Tests/FormRendererTest.php
@@ -2,14 +2,15 @@
 
 namespace Symfony\Component\Form\Test;
 
-use Symfony\Component\Form\FormRenderer;
-
 class FormRendererTest extends \PHPUnit_Framework_TestCase
 {
     public function testHumanize()
     {
-        $engine = $this->getMock('Symfony\Component\Form\FormRendererEngineInterface');
-        $renderer = new FormRenderer($engine);
+        $renderer = $this->getMockBuilder('Symfony\Component\Form\FormRenderer')
+            ->setMethods(null)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
 
         $this->assertEquals('Is active', $renderer->humanize('is_active'));
         $this->assertEquals('Is active', $renderer->humanize('isActive'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

FormRenderer::humanize() only converts underscored_field_name to humanized field name(just the same as sfInflector::humanize()).
Sensio\Bundle\GeneratorBundle\Generator\DoctrineFormGenerator does not convert camelCased field names to underscored one, however.
I have to edit manually field names in the generated FormType class everytime I use doctrine:generate:form Command, too messy.
so I suggest humanize() is to take care of it.
