### PR TITLE
[HttpFoundation] fixed Request::create() method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.2.0
 -----
 
+ * fixed the Request::create() precedence (URI information always take precedence now)
  * added Request::getTrustedProxies()
  * deprecated Request::isProxyTrusted()
  * [BC BREAK] JsonResponse does not turn a top level empty array to an object anymore, use an ArrayObject to enforce objects


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

When creating a Request with Request::create(), some information can
come from the URI and the server variable. Until now, it was not clear
which information had precedence over the other and as a matter of fact,
this method was not consistent.

Now, information contained in the URI always take precedence over
information coming from the server array. That makes sense as the server
array is often copied from another existing Request object.
