### PR TITLE
[HttpKernel] fixed the hinclude fragment renderer when the template is empty

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -65,7 +65,7 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
         }
 
         $template = isset($options['default']) ? $options['default'] : $this->globalDefaultTemplate;
-        if (null !== $this->templating && $this->templateExists($template)) {
+        if (null !== $this->templating && $template && $this->templateExists($template)) {
             $content = $this->templating->render($template);
         } else {
             $content = $template;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
