### PR TITLE
[HttpCache] made HttpCache updating the request as a reverse proxy would

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -172,6 +172,7 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
     {
         // FIXME: catch exceptions and implement a 500 error page here? -> in Varnish, there is a built-in error page mechanism
         if (HttpKernelInterface::MASTER_REQUEST === $type) {
+            $this->updateRequest($request);
             $this->traces = array();
             $this->request = $request;
             if (null !== $this->esi) {
@@ -656,5 +657,21 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $path .= '?'.$qs;
         }
         $this->traces[$request->getMethod().' '.$path][] = $event;
+    }
+
+    /**
+     * Set a Request to the same state it'd be with real reverse proxy.
+     *
+     * @param Request $request A Request instance
+     */
+    private function updateRequest(Request $request)
+    {
+        $forwardedFor = $request->server->get('REMOTE_ADDR');
+        if (in_array($forwardedFor, array('127.0.0.1', 'fe80::1', '::1'))) {
+            return;
+        }
+
+        $request->headers->set('X_FORWARDED_FOR', $forwardedFor);
+        $request->server->set('REMOTE_ADDR', '127.0.0.1');
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/HttpCacheTest.php
@@ -1034,4 +1034,24 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertEquals('Hello World!', $this->response->getContent());
         $this->assertEquals(12, $this->response->headers->get('Content-Length'));
     }
+
+    /**
+     * @dataProvider getIpForwardedForData
+     */
+    public function testRequestIpForwardedFor($ip, $forwardedFor = null, $expectedForwardedFor = null)
+    {
+        $this->setNextResponse(200);
+        $this->request('GET', '/', array('REMOTE_ADDR' => $ip, 'HTTP_X_FORWARDED_FOR' => $forwardedFor));
+        $this->assertEquals('127.0.0.1', $this->request->server->get('REMOTE_ADDR'));
+        $this->assertEquals($expectedForwardedFor, $this->request->headers->get('X_FORWARDED_FOR'));
+    }
+
+    public function getIpForwardedForData()
+    {
+        return array(
+            array('10.20.30.40', null, '10.20.30.40'),
+            array('10.20.30.40', '11.22.33.44', '10.20.30.40'),
+            array('127.0.0.1', null, null),
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [#6982] |
| License | MIT |

On 2.2, it also fixes another issue I'm getting, apparently ESIs can't be rendered, 403 responses are sent instead, because REMOTE_ADDR isn't a local IP or in the trusted IPs list, some new security checks with the new fragments stuff I guess,
