### PR TITLE
[HttpKernel] CLI - don't always display errors

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -105,7 +105,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             ErrorHandler::register($this->errorReportingLevel);
             if ('cli' !== php_sapi_name()) {
                 ExceptionHandler::register();
-            } else {
+            } elseif (!ini_get('log_errors') || ini_get('error_log')) {
                 ini_set('display_errors', 1);
             }
         }


### PR DESCRIPTION
I had closed #6370 by mistake when cleaning up my branches.
