### PR TITLE
[BugFix][Router] Fix TraceableUrlMatcher

### DIFF
--- a/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
+++ b/src/Symfony/Component/Routing/Matcher/TraceableUrlMatcher.php
@@ -70,6 +70,14 @@ class TraceableUrlMatcher extends UrlMatcher
                 continue;
             }
 
+            // check host requirement
+            $hostMatches = array();
+            if ($compiledRoute->getHostRegex() && !preg_match($compiledRoute->getHostRegex(), $this->context->getHost(), $hostMatches)) {
+                $this->addTrace(sprintf('Host "%s" does not match the required ("%s")', $route->getHost(), $this->context->getHost()), self::ROUTE_ALMOST_MATCHES, $name, $route);
+
+                return true;
+            }
+
             // check HTTP method requirement
             if ($req = $route->getRequirement('_method')) {
                 // HEAD and GET are equivalent as per RFC

--- a/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/TraceableUrlMatcherTest.php
@@ -24,21 +24,27 @@ class TraceableUrlMatcherTest extends \PHPUnit_Framework_TestCase
         $coll->add('foo', new Route('/foo', array(), array('_method' => 'POST')));
         $coll->add('bar', new Route('/bar/{id}', array(), array('id' => '\d+')));
         $coll->add('bar1', new Route('/bar/{name}', array(), array('id' => '\w+', '_method' => 'POST')));
+        $coll->add('bar2', new Route('/foo', array(), array(), array(), 'baz'));
+        $coll->add('bar3', new Route('/foo1', array(), array(), array(), 'baz'));
 
         $context = new RequestContext();
+        $context->setHost('baz');
 
         $matcher = new TraceableUrlMatcher($coll, $context);
         $traces = $matcher->getTraces('/babar');
-        $this->assertEquals(array(0, 0, 0), $this->getLevels($traces));
+        $this->assertEquals(array(0, 0, 0, 0, 0), $this->getLevels($traces));
 
         $traces = $matcher->getTraces('/foo');
-        $this->assertEquals(array(1, 0, 0), $this->getLevels($traces));
+        $this->assertEquals(array(1, 0, 0, 2), $this->getLevels($traces));
 
         $traces = $matcher->getTraces('/bar/12');
         $this->assertEquals(array(0, 2), $this->getLevels($traces));
 
         $traces = $matcher->getTraces('/bar/dd');
-        $this->assertEquals(array(0, 1, 1), $this->getLevels($traces));
+        $this->assertEquals(array(0, 1, 1, 0, 0), $this->getLevels($traces));
+
+        $traces = $matcher->getTraces('/foo1');
+        $this->assertEquals(array(0, 0, 0, 0, 2), $this->getLevels($traces));
 
         $context->setMethod('POST');
         $traces = $matcher->getTraces('/foo');


### PR DESCRIPTION
TraceableUrlMatcher does not take care with new host route features

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6744 |
| License | MIT |
| Doc PR | n/a |
