### PR TITLE
[Security] fixed session creation on login (closes #7011)

### DIFF
--- a/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
+++ b/src/Symfony/Component/Security/Http/Firewall/ContextListener.php
@@ -117,14 +117,16 @@ class ContextListener implements ListenerInterface
         }
 
         $request = $event->getRequest();
-        $session = $request->hasPreviousSession() ? $request->getSession() : null;
+        $session = $request->getSession();
 
         if (null === $session) {
             return;
         }
 
         if ((null === $token = $this->context->getToken()) || ($token instanceof AnonymousToken)) {
-            $session->remove('_security_'.$this->contextKey);
+            if ($request->hasPreviousSession()) {
+                $session->remove('_security_'.$this->contextKey);
+            }
         } else {
             $session->set('_security_'.$this->contextKey, serialize($token));
         }

--- a/src/Symfony/Component/Security/Tests/Http/Firewall/ContextListenerTest.php
+++ b/src/Symfony/Component/Security/Tests/Http/Firewall/ContextListenerTest.php
@@ -99,6 +99,25 @@ class ContextListenerTest extends \PHPUnit_Framework_TestCase
         $listener = new ContextListener($this->securityContext, array(), 'session');
         $listener->onKernelResponse($event);
 
+        $this->assertTrue($session->isStarted());
+    }
+
+    public function testOnKernelResponseWithoutSessionNorToken()
+    {
+        $request = new Request();
+        $session = new Session(new MockArraySessionStorage());
+        $request->setSession($session);
+
+        $event = new FilterResponseEvent(
+            $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            new Response()
+        );
+
+        $listener = new ContextListener($this->securityContext, array(), 'session');
+        $listener->onKernelResponse($event);
+
         $this->assertFalse($session->isStarted());
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7011 |
| License | MIT |
| Doc PR | n/a |

I fixed the test with UsernamePasswordToken (should start the session) and added a new test without token (should not start session).
