### PR TITLE
[WDT] Fix style for abbr elements in toolbar

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Profiler/toolbar.css.twig
@@ -41,6 +41,10 @@
     bottom: 0;
     border-top: 1px solid #bbb;
 }
+.sf-toolbarreset abbr {
+    border-bottom: 1px dotted #000000;
+    cursor: help;
+}
 .sf-toolbarreset span,
 .sf-toolbarreset div {
     font-size: 11px;
@@ -323,11 +327,6 @@
         background-image: -webkit-gradient(linear, 0% 0%, 100% 0%, from(#cbcbcb), to(#e8e8e8)); !important;
         background-image: -o-linear-gradient(180deg, #cbcbcb, #e8e8e8); !important;
         background: linear-gradient(90deg, #cbcbcb, #e8e8e8); !important;
-    }
-
-    .sf-toolbarreset abbr {
-        border-bottom: 1px dotted #000000;
-        cursor: help;
     }
 {% endif %}
 


### PR DESCRIPTION
Styling for `abbr` elements (e.g. dotted underline) weren't being applied unless you were viewing a profile.
