### PR TITLE
[HttpKernel] exception listener, allow easier overloading of the default behavior

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -27,8 +27,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ExceptionListener implements EventSubscriberInterface
 {
-    private $controller;
-    private $logger;
+    protected $controller;
+    protected $logger;
 
     public function __construct($controller, LoggerInterface $logger = null)
     {


### PR DESCRIPTION
Hi Fabien,

This commit you wrote about a month ago helped me to overload the 'logException' method:
https://github.com/symfony/symfony/commit/1a6c9b31438e45180001957bb64f97d1cf54ca4f

Because the logger property was private I could not access it from the subclass. This PR changes both properties: controller and logger from private to protected members. So they can be used from 'logException'.
