### PR TITLE
[WIP][FrameworkBundle] Allow cleaning container from unwanted services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerCleanerPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ContainerCleanerPass.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Removes from container unneeded services registered by 3rd party bundles
+ *
+ * @author Dariusz Górecki <darek.krk@gmail.com>
+ */
+class ContainerCleanerPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        foreach (explode('|', $container->getParameter('framework.services_to_remove')) as $serviceID) {
+            if ($container->has($serviceID)) {
+                $container->removeDefinition($serviceID);
+            }
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -81,6 +81,7 @@ class Configuration implements ConfigurationInterface
         $this->addTranslatorSection($rootNode);
         $this->addValidationSection($rootNode);
         $this->addAnnotationsSection($rootNode);
+        $this->addContainerCleanerSection($rootNode);
 
         return $treeBuilder;
     }
@@ -406,6 +407,24 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('cache')->defaultValue('file')->end()
                         ->scalarNode('file_cache_dir')->defaultValue('%kernel.cache_dir%/annotations')->end()
                         ->booleanNode('debug')->defaultValue('%kernel.debug%')->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addContainerCleanerSection(ArrayNodeDefinition $rootNode)
+    {
+        $rootNode
+            ->children()
+                ->arrayNode('container_cleaner')
+                    ->info('list of services to remove before dumping container')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->arrayNode('services_to_remove')
+                            ->defaultValue(array())
+                            ->prototype('scalar')->end()
+                        ->end()
                     ->end()
                 ->end()
             ->end()

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -101,6 +101,7 @@ class FrameworkExtension extends Extension
         }
 
         $this->registerAnnotationsConfiguration($config['annotations'], $container, $loader);
+        $this->registerContainerCleanerConfiguration($config['container_cleaner'], $container);
 
         $this->addClassesToCompile(array(
             'Symfony\\Component\\HttpFoundation\\ParameterBag',
@@ -677,6 +678,11 @@ class FrameworkExtension extends Extension
             ;
             $container->setAlias('annotation_reader', 'annotations.cached_reader');
         }
+    }
+
+    public function registerContainerCleanerConfiguration(array $config, ContainerBuilder $container)
+    {
+        $container->setParameter('framework.services_to_remove', implode('|', $config['services_to_remove']));
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle;
 
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddConstraintValidatorsPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\AddValidatorInitializersPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ContainerCleanerPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FormPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TemplatingPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\RegisterKernelListenersPass;
@@ -67,6 +68,7 @@ class FrameworkBundle extends Bundle
         $container->addCompilerPass(new TranslationExtractorPass());
         $container->addCompilerPass(new TranslationDumperPass());
         $container->addCompilerPass(new FragmentRendererPass(), PassConfig::TYPE_AFTER_REMOVING);
+        $container->addCompilerPass(new ContainerCleanerPass());
 
         if ($container->getParameter('kernel.debug')) {
             $container->addCompilerPass(new ContainerBuilderDebugDumpPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -125,6 +125,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'file_cache_dir' => '%kernel.cache_dir%/annotations',
                 'debug'          => '%kernel.debug%',
             ),
+            'container_cleaner' => array(
+                'services_to_remove' => array(),
+            ),
         );
     }
 }


### PR DESCRIPTION
This PR is a prof of concept, it enables user to remove from container services that are unwanted before dumping container, via framework configuration.

I'm open for ideas, improvements and critic ;]

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2107 |
| License | MIT |
| Doc PR | n/a |
- [x] write some unit tests
- [x] decide on configuration look
- [x] allow removing of tags from services
