### PR TITLE
"[HttpFoundation] fixed Request::create() method" breaks BrowserKit Client

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -325,7 +325,9 @@ class Request
             case 'POST':
             case 'PUT':
             case 'DELETE':
-                $server['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+                if (!isset($server['CONTENT_TYPE'])) {
+                    $server['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+                }
             case 'PATCH':
                 $request = $parameters;
                 $query = array();


### PR DESCRIPTION
To functional test a REST service I call 'Symfony\Bundle\FrameworkBundle\Client::request' with the 'server' parameter. This parameter contains:

```
[HTTP_CONTENT-TYPE] => application/json
[HTTP_ACCEPT] => application/json
```

Since latest commit (this PR in particular: https://github.com/symfony/symfony/pull/6995) it fails my functional tests. I suspect the problem is somewhere near this piece of code (line: 320|329):

```
-    $defaults['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
+    $server['CONTENT_TYPE'] = 'application/x-www-form-urlencoded';
```
