### PR TITLE
Update Composer deps

### DIFF
--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -23,7 +23,7 @@
         "symfony/stopwatch": ">=2.2,<2.3-dev",
         "symfony/dependency-injection": "~2.0",
         "symfony/form": ">=2.2,<2.3-dev",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/http-kernel": ">=2.2,<2.3-dev",
         "symfony/security": ">=2.2,<2.3-dev",
         "symfony/validator": ">=2.2,<2.3-dev",
         "doctrine/data-fixtures": "1.0.*",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/stopwatch": ">=2.2,<2.3-dev",
         "symfony/dependency-injection": "~2.0",
-        "symfony/form": "2.2.*",
+        "symfony/form": ">=2.2,<2.3-dev",
         "symfony/http-kernel": "2.2.*",
         "symfony/security": ">=2.2,<2.3-dev",
         "symfony/validator": ">=2.2,<2.3-dev",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -25,7 +25,7 @@
         "symfony/form": "2.2.*",
         "symfony/http-kernel": "2.2.*",
         "symfony/security": ">=2.2,<2.3-dev",
-        "symfony/validator": "2.2.*",
+        "symfony/validator": ">=2.2,<2.3-dev",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.2",
         "doctrine/orm": "~2.2,>=2.2.3"

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "symfony/stopwatch": ">=2.2,<2.3-dev",
-        "symfony/dependency-injection": "2.2.*",
+        "symfony/dependency-injection": "~2.0",
         "symfony/form": "2.2.*",
         "symfony/http-kernel": "2.2.*",
         "symfony/security": ">=2.2,<2.3-dev",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -20,7 +20,7 @@
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "symfony/stopwatch": "2.2.*",
+        "symfony/stopwatch": ">=2.2,<2.3-dev",
         "symfony/dependency-injection": "2.2.*",
         "symfony/form": "2.2.*",
         "symfony/http-kernel": "2.2.*",

--- a/src/Symfony/Bridge/Doctrine/composer.json
+++ b/src/Symfony/Bridge/Doctrine/composer.json
@@ -24,7 +24,7 @@
         "symfony/dependency-injection": "2.2.*",
         "symfony/form": "2.2.*",
         "symfony/http-kernel": "2.2.*",
-        "symfony/security": "2.2.*",
+        "symfony/security": ">=2.2,<2.3-dev",
         "symfony/validator": "2.2.*",
         "doctrine/data-fixtures": "1.0.*",
         "doctrine/dbal": "~2.2",

--- a/src/Symfony/Bridge/Monolog/composer.json
+++ b/src/Symfony/Bridge/Monolog/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/http-kernel": ">=2.2,<2.3-dev",
         "monolog/monolog": "~1.3"
     },
     "autoload": {

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/http-foundation": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/http-kernel": "~2.0",
         "symfony/form": ">=2.2,<2.3-dev",
         "propel/propel1": "1.6.*"
     },

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -23,7 +23,7 @@
         "propel/propel1": "1.6.*"
     },
     "require-dev": {
-        "symfony/stopwatch": "2.2.*"
+        "symfony/stopwatch": ">=2.2,<2.3-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bridge\\Propel1\\": "" }

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/http-foundation": "2.2.*",
         "symfony/http-kernel": "2.2.*",
-        "symfony/form": "2.2.*",
+        "symfony/form": ">=2.2,<2.3-dev",
         "propel/propel1": "1.6.*"
     },
     "require-dev": {

--- a/src/Symfony/Bridge/Propel1/composer.json
+++ b/src/Symfony/Bridge/Propel1/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-foundation": "2.2.*",
+        "symfony/http-foundation": "~2.0",
         "symfony/http-kernel": "~2.0",
         "symfony/form": ">=2.2,<2.3-dev",
         "propel/propel1": "1.6.*"

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -24,7 +24,7 @@
         "symfony/http-kernel": "2.2.*",
         "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/templating": "~2.1",
-        "symfony/translation": "2.2.*",
+        "symfony/translation": ">=2.0,<2.3-dev",
         "symfony/yaml": "~2.0",
         "symfony/security": ">=2.0,<2.3-dev"
     },

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -23,7 +23,7 @@
         "symfony/form": "2.2.*",
         "symfony/http-kernel": "2.2.*",
         "symfony/routing": "2.2.*",
-        "symfony/templating": "2.2.*",
+        "symfony/templating": "~2.1",
         "symfony/translation": "2.2.*",
         "symfony/yaml": "~2.0",
         "symfony/security": "2.2.*"

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -25,7 +25,7 @@
         "symfony/routing": "2.2.*",
         "symfony/templating": "2.2.*",
         "symfony/translation": "2.2.*",
-        "symfony/yaml": "2.2.*",
+        "symfony/yaml": "~2.0",
         "symfony/security": "2.2.*"
     },
     "suggest": {

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -26,7 +26,7 @@
         "symfony/templating": "~2.1",
         "symfony/translation": "2.2.*",
         "symfony/yaml": "~2.0",
-        "symfony/security": "2.2.*"
+        "symfony/security": ">=2.0,<2.3-dev"
     },
     "suggest": {
         "symfony/form": "2.2.*",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/form": "2.2.*",
         "symfony/http-kernel": "2.2.*",
-        "symfony/routing": "2.2.*",
+        "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/templating": "~2.1",
         "symfony/translation": "2.2.*",
         "symfony/yaml": "~2.0",

--- a/src/Symfony/Bridge/Twig/composer.json
+++ b/src/Symfony/Bridge/Twig/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "symfony/form": "2.2.*",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/http-kernel": ">=2.2,<2.3-dev",
         "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/templating": "~2.1",
         "symfony/translation": ">=2.0,<2.3-dev",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -25,8 +25,8 @@
         "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/stopwatch": ">=2.2,<2.3-dev",
         "symfony/templating": "~2.1",
-        "symfony/translation": "2.2.*",
-        "doctrine/common": "~2.2"
+        "symfony/translation": ">=2.2,<2.3-dev",
+        "doctrine/common": ">=2.2,<2.4-dev"
     },
     "require-dev": {
         "symfony/finder": "~2.0",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "symfony/finder": "~2.0",
-        "symfony/security": "2.2.*"
+        "symfony/security": ">=2.2,<2.3-dev"
     },
     "suggest": {
         "symfony/console": "2.2.*",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/dependency-injection" : "~2.0",
         "symfony/config" : ">=2.2,<2.3-dev",
         "symfony/event-dispatcher": "~2.1",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/http-kernel": ">=2.2,<2.3-dev",
         "symfony/filesystem": ">=2.1,<2.3-dev",
         "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/stopwatch": ">=2.2,<2.3-dev",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -29,7 +29,7 @@
         "doctrine/common": "~2.2"
     },
     "require-dev": {
-        "symfony/finder": "2.2.*",
+        "symfony/finder": "~2.0",
         "symfony/security": "2.2.*"
     },
     "suggest": {

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/dependency-injection" : "2.2.*",
         "symfony/config" : "2.2.*",
-        "symfony/event-dispatcher": "2.2.*",
+        "symfony/event-dispatcher": "~2.1",
         "symfony/http-kernel": "2.2.*",
         "symfony/filesystem": ">=2.1,<2.3-dev",
         "symfony/routing": "2.2.*",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-kernel": "2.2.*",
         "symfony/filesystem": ">=2.1,<2.3-dev",
-        "symfony/routing": "2.2.*",
+        "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/stopwatch": ">=2.2,<2.3-dev",
         "symfony/templating": "~2.1",
         "symfony/translation": "2.2.*",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/dependency-injection" : "2.2.*",
+        "symfony/dependency-injection" : "~2.0",
         "symfony/config" : "2.2.*",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-kernel": "2.2.*",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -24,7 +24,7 @@
         "symfony/filesystem": ">=2.1,<2.3-dev",
         "symfony/routing": "2.2.*",
         "symfony/stopwatch": ">=2.2,<2.3-dev",
-        "symfony/templating": "2.2.*",
+        "symfony/templating": "~2.1",
         "symfony/translation": "2.2.*",
         "doctrine/common": "~2.2"
     },

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/dependency-injection" : "~2.0",
-        "symfony/config" : "2.2.*",
+        "symfony/config" : ">=2.2,<2.3-dev",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-kernel": "2.2.*",
         "symfony/filesystem": ">=2.1,<2.3-dev",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -21,7 +21,7 @@
         "symfony/config" : "2.2.*",
         "symfony/event-dispatcher": "2.2.*",
         "symfony/http-kernel": "2.2.*",
-        "symfony/filesystem": "2.2.*",
+        "symfony/filesystem": ">=2.1,<2.3-dev",
         "symfony/routing": "2.2.*",
         "symfony/stopwatch": "2.2.*",
         "symfony/templating": "2.2.*",

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -23,7 +23,7 @@
         "symfony/http-kernel": "2.2.*",
         "symfony/filesystem": ">=2.1,<2.3-dev",
         "symfony/routing": "2.2.*",
-        "symfony/stopwatch": "2.2.*",
+        "symfony/stopwatch": ">=2.2,<2.3-dev",
         "symfony/templating": "2.2.*",
         "symfony/translation": "2.2.*",
         "doctrine/common": "~2.2"

--- a/src/Symfony/Bundle/SecurityBundle/composer.json
+++ b/src/Symfony/Bundle/SecurityBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/security": "2.2.*"
+        "symfony/security": ">=2.2,<2.3-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\SecurityBundle\\": "" }

--- a/src/Symfony/Bundle/TwigBundle/composer.json
+++ b/src/Symfony/Bundle/TwigBundle/composer.json
@@ -20,7 +20,7 @@
         "symfony/twig-bridge": "2.2.*"
     },
     "require-dev": {
-        "symfony/stopwatch": "2.2.*"
+        "symfony/stopwatch": ">=2.2,<2.3-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\TwigBundle\\": "" }

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -22,7 +22,7 @@
         "symfony/twig-bridge": "2.2.*"
     },
     "require-dev": {
-        "symfony/config": "2.2.*",
+        "symfony/config": ">=2.2,<2.3-dev",
         "symfony/dependency-injection": "~2.0",
         "symfony/stopwatch": ">=2.2,<2.3-dev"
     },

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/http-kernel": "2.2.*",
+        "symfony/http-kernel": ">=2.2,<2.3-dev",
         "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/twig-bridge": "2.2.*"
     },

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "symfony/config": "2.2.*",
-        "symfony/dependency-injection": "2.2.*",
+        "symfony/dependency-injection": "~2.0",
         "symfony/stopwatch": ">=2.2,<2.3-dev"
     },
     "autoload": {

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/http-kernel": "2.2.*",
-        "symfony/routing": "2.2.*",
+        "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/twig-bridge": "2.2.*"
     },
     "require-dev": {

--- a/src/Symfony/Bundle/WebProfilerBundle/composer.json
+++ b/src/Symfony/Bundle/WebProfilerBundle/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "symfony/config": "2.2.*",
         "symfony/dependency-injection": "2.2.*",
-        "symfony/stopwatch": "2.2.*"
+        "symfony/stopwatch": ">=2.2,<2.3-dev"
     },
     "autoload": {
         "psr-0": { "Symfony\\Bundle\\WebProfilerBundle\\": "" }

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "symfony/process": "2.2.*",
-        "symfony/css-selector": "2.2.*"
+        "symfony/css-selector": "~2.0"
     },
     "suggest": {
         "symfony/process": "2.2.*"

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/dom-crawler": "2.2.*"
+        "symfony/dom-crawler": "~2.0"
     },
     "require-dev": {
         "symfony/process": "2.2.*",

--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -20,7 +20,7 @@
         "symfony/dom-crawler": "~2.0"
     },
     "require-dev": {
-        "symfony/process": "2.2.*",
+        "symfony/process": "~2.0",
         "symfony/css-selector": "~2.0"
     },
     "suggest": {

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/finder": "2.2.*"
+        "symfony/finder": "~2.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\ClassLoader\\": "" }

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/yaml": "2.2.*",
+        "symfony/yaml": "~2.0",
         "symfony/config": "2.2.*"
     },
     "suggest": {

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony/yaml": "~2.0",
-        "symfony/config": "2.2.*"
+        "symfony/config": ">=2.2.*,<2.3-dev"
     },
     "suggest": {
         "symfony/yaml": "2.2.*",

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/css-selector": "2.2.*"
+        "symfony/css-selector": "~2.0"
     },
     "suggest": {
         "symfony/css-selector": "2.2.*"

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/dependency-injection": "2.2.*"
+        "symfony/dependency-injection": "~2.0"
     },
     "suggest": {
         "symfony/dependency-injection": "2.2.*",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -23,7 +23,7 @@
         "symfony/property-access": ">=2.2,<2.3-dev"
     },
     "require-dev": {
-        "symfony/validator": "2.2.*",
+        "symfony/validator": ">=2.2,<2.3-dev",
         "symfony/http-foundation": "2.2.*"
     },
     "suggest": {

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "2.2.*",
-        "symfony/locale": "2.2.*",
+        "symfony/locale": "~2.0",
         "symfony/options-resolver": "2.2.*",
         "symfony/property-access": "2.2.*"
     },

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": "2.2.*",
+        "symfony/event-dispatcher": "~2.1",
         "symfony/locale": "~2.0",
         "symfony/options-resolver": ">=2.1,<2.3-dev",
         "symfony/property-access": ">=2.2,<2.3-dev"

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "2.2.*",
         "symfony/locale": "~2.0",
-        "symfony/options-resolver": "2.2.*",
+        "symfony/options-resolver": ">=2.1,<2.3-dev",
         "symfony/property-access": ">=2.2,<2.3-dev"
     },
     "require-dev": {

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -20,7 +20,7 @@
         "symfony/event-dispatcher": "2.2.*",
         "symfony/locale": "~2.0",
         "symfony/options-resolver": "2.2.*",
-        "symfony/property-access": "2.2.*"
+        "symfony/property-access": ">=2.2,<2.3-dev"
     },
     "require-dev": {
         "symfony/validator": "2.2.*",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -24,7 +24,7 @@
     },
     "require-dev": {
         "symfony/validator": ">=2.2,<2.3-dev",
-        "symfony/http-foundation": "2.2.*"
+        "symfony/http-foundation": ">=2.1,<2.3-dev"
     },
     "suggest": {
         "symfony/validator": "2.2.*",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -26,7 +26,7 @@
         "symfony/class-loader": "~2.1",
         "symfony/config": "2.2.*",
         "symfony/console": "2.2.*",
-        "symfony/dependency-injection": "2.2.*",
+        "symfony/dependency-injection": "~2.0",
         "symfony/finder": "~2.0",
         "symfony/process": "~2.0",
         "symfony/routing": ">=2.2,<2.3-dev",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.1",
-        "symfony/http-foundation": "2.2.*",
+        "symfony/http-foundation": ">=2.2,<2.3-dev",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": "2.2.*",
+        "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "2.2.*",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -30,7 +30,7 @@
         "symfony/finder": "~2.0",
         "symfony/process": "~2.0",
         "symfony/routing": "2.2.*",
-        "symfony/stopwatch": "2.2.*"
+        "symfony/stopwatch": ">=2.2,<2.3-dev"
     },
     "suggest": {
         "symfony/browser-kit": "2.2.*",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "symfony/browser-kit": "2.2.*",
         "symfony/class-loader": "~2.1",
-        "symfony/config": "2.2.*",
+        "symfony/config": "~2.0",
         "symfony/console": "2.2.*",
         "symfony/dependency-injection": "~2.0",
         "symfony/finder": "~2.0",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -28,7 +28,7 @@
         "symfony/console": "2.2.*",
         "symfony/dependency-injection": "2.2.*",
         "symfony/finder": "~2.0",
-        "symfony/process": "2.2.*",
+        "symfony/process": "~2.0",
         "symfony/routing": "2.2.*",
         "symfony/stopwatch": "2.2.*"
     },

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -27,7 +27,7 @@
         "symfony/config": "2.2.*",
         "symfony/console": "2.2.*",
         "symfony/dependency-injection": "2.2.*",
-        "symfony/finder": "2.2.*",
+        "symfony/finder": "~2.0",
         "symfony/process": "2.2.*",
         "symfony/routing": "2.2.*",
         "symfony/stopwatch": "2.2.*"

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "symfony/browser-kit": "2.2.*",
-        "symfony/class-loader": "2.2.*",
+        "symfony/class-loader": "~2.1",
         "symfony/config": "2.2.*",
         "symfony/console": "2.2.*",
         "symfony/dependency-injection": "2.2.*",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -29,7 +29,7 @@
         "symfony/dependency-injection": "2.2.*",
         "symfony/finder": "~2.0",
         "symfony/process": "~2.0",
-        "symfony/routing": "2.2.*",
+        "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/stopwatch": ">=2.2,<2.3-dev"
     },
     "suggest": {

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony/config": "2.2.*",
-        "symfony/yaml": "2.2.*",
+        "symfony/yaml": "~2.0",
         "symfony/http-kernel": "2.2.*",
         "doctrine/common": "~2.2",
         "psr/log": "~1.0"

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/config": "2.2.*",
+        "symfony/config": ">=2.2.*,<2.3-dev",
         "symfony/yaml": "~2.0",
         "symfony/http-kernel": "2.2.*",
         "doctrine/common": "~2.2",

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -21,7 +21,6 @@
     "require-dev": {
         "symfony/config": ">=2.2.*,<2.3-dev",
         "symfony/yaml": "~2.0",
-        "symfony/http-kernel": "2.2.*",
         "doctrine/common": "~2.2",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "2.2.*",
-        "symfony/http-kernel": "2.2.*"
+        "symfony/http-kernel": ">=2.1,<=2.3-dev"
     },
     "require-dev": {
         "symfony/form": "~2.0",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -24,8 +24,8 @@
     "require-dev": {
         "symfony/form": "2.2.*",
         "symfony/routing": ">=2.2,<2.3-dev",
-        "symfony/validator": "2.2.*",
-        "doctrine/common": "~2.2",
+        "symfony/validator": ">=2.2,<2.3-dev",
+        "doctrine/common": ">=2.2,<2.4-dev",
         "doctrine/dbal": "~2.2",
         "psr/log": "~1.0"
     },

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "symfony/form": "2.2.*",
-        "symfony/routing": "2.2.*",
+        "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/validator": "2.2.*",
         "doctrine/common": "~2.2",
         "doctrine/dbal": "~2.2",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "2.2.*"
     },
     "require-dev": {
-        "symfony/form": "2.2.*",
+        "symfony/form": "~2.0",
         "symfony/routing": ">=2.2,<2.3-dev",
         "symfony/validator": ">=2.2,<2.3-dev",
         "doctrine/common": ">=2.2,<2.4-dev",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/event-dispatcher": "2.2.*",
+        "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": "2.2.*",
         "symfony/http-kernel": "2.2.*"
     },

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.1",
-        "symfony/http-foundation": "2.2.*",
+        "symfony/http-foundation": ">=2.1,<2.3-dev",
         "symfony/http-kernel": ">=2.1,<=2.3-dev"
     },
     "require-dev": {

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "symfony/config": "2.2.*",
+        "symfony/config": ">=2.0,<2.3-dev",
         "symfony/yaml": "~2.2"
     },
     "suggest": {

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "symfony/config": "2.2.*",
-        "symfony/yaml": "2.2.*"
+        "symfony/yaml": "~2.2"
     },
     "suggest": {
         "symfony/config": "2.2.*",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -20,7 +20,7 @@
         "symfony/translation": "~2.0"
     },
     "require-dev": {
-        "symfony/http-foundation": "2.2.*",
+        "symfony/http-foundation": "~2.1",
         "symfony/locale": "~2.0",
         "symfony/yaml": "~2.0",
         "symfony/config": ">=2.2,<2.3-dev"

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -22,7 +22,7 @@
     "require-dev": {
         "symfony/http-foundation": "2.2.*",
         "symfony/locale": "2.2.*",
-        "symfony/yaml": "2.2.*",
+        "symfony/yaml": "~2.0",
         "symfony/config": "2.2.*"
     },
     "suggest": {

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -23,7 +23,7 @@
         "symfony/http-foundation": "2.2.*",
         "symfony/locale": "~2.0",
         "symfony/yaml": "~2.0",
-        "symfony/config": "2.2.*"
+        "symfony/config": ">=2.2,<2.3-dev"
     },
     "suggest": {
         "doctrine/common": "~2.2",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "symfony/http-foundation": "2.2.*",
-        "symfony/locale": "2.2.*",
+        "symfony/locale": "~2.0",
         "symfony/yaml": "~2.0",
         "symfony/config": "2.2.*"
     },

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/translation": "2.2.*"
+        "symfony/translation": "~2.0"
     },
     "require-dev": {
         "symfony/http-foundation": "2.2.*",


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Since we adopted Composer in Symfony, we limit the Symfony Components deps for any Symfony Component to the current version of Symfony. That's very limited as for instance, any version of Yaml can be used as a dependency for any other Symfony Component. So, this PR changes the version constraints for dependencies to the largest range possible.

The idea is also to open the range even more when new versions of Symfony comes.
