### PR TITLE
[2.3] [Routing] Added access to querystring in RequestContext

### DIFF
--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -29,6 +29,7 @@ class RequestContext
     private $scheme;
     private $httpPort;
     private $httpsPort;
+    private $queryString;
 
     /**
      * @var array
@@ -38,17 +39,18 @@ class RequestContext
     /**
      * Constructor.
      *
-     * @param string  $baseUrl   The base URL
-     * @param string  $method    The HTTP method
-     * @param string  $host      The HTTP host name
-     * @param string  $scheme    The HTTP scheme
-     * @param integer $httpPort  The HTTP port
-     * @param integer $httpsPort The HTTPS port
-     * @param string  $path      The path
+     * @param string  $baseUrl      The base URL
+     * @param string  $method       The HTTP method
+     * @param string  $host         The HTTP host name
+     * @param string  $scheme       The HTTP scheme
+     * @param integer $httpPort     The HTTP port
+     * @param integer $httpsPort    The HTTPS port
+     * @param string  $path         The path
+     * @param string  $queryString  The query string
      *
      * @api
      */
-    public function __construct($baseUrl = '', $method = 'GET', $host = 'localhost', $scheme = 'http', $httpPort = 80, $httpsPort = 443, $path = '/')
+    public function __construct($baseUrl = '', $method = 'GET', $host = 'localhost', $scheme = 'http', $httpPort = 80, $httpsPort = 443, $path = '/', $queryString = '')
     {
         $this->baseUrl = $baseUrl;
         $this->method = strtoupper($method);
@@ -57,6 +59,7 @@ class RequestContext
         $this->httpPort = $httpPort;
         $this->httpsPort = $httpsPort;
         $this->pathInfo = $path;
+        $this->queryString = $queryString;
     }
 
     public function fromRequest(Request $request)
@@ -68,10 +71,7 @@ class RequestContext
         $this->setScheme($request->getScheme());
         $this->setHttpPort($request->isSecure() ? $this->httpPort : $request->getPort());
         $this->setHttpsPort($request->isSecure() ? $request->getPort() : $this->httpsPort);
-
-        if ($request->server->get('QUERY_STRING') !== '') {
-            $this->setParameter('QUERY_STRING', $request->server->get('QUERY_STRING'));
-        }
+        $this->setQueryString($request->server->get('QUERY_STRING'));
     }
 
     /**
@@ -226,6 +226,28 @@ class RequestContext
     public function setHttpsPort($httpsPort)
     {
         $this->httpsPort = $httpsPort;
+    }
+
+    /**
+     * Gets the query string.
+     *
+     * @return string The query string
+     */
+    public function getQueryString()
+    {
+        return $this->queryString;
+    }
+
+    /**
+     * Sets the query string.
+     *
+     * @param string $queryString The query string
+     *
+     * @api
+     */
+    public function setQueryString($queryString)
+    {
+        $this->queryString = $queryString;
     }
 
     /**

--- a/src/Symfony/Component/Routing/RequestContext.php
+++ b/src/Symfony/Component/Routing/RequestContext.php
@@ -68,6 +68,10 @@ class RequestContext
         $this->setScheme($request->getScheme());
         $this->setHttpPort($request->isSecure() ? $this->httpPort : $request->getPort());
         $this->setHttpsPort($request->isSecure() ? $request->getPort() : $this->httpsPort);
+
+        if ($request->server->get('QUERY_STRING') !== '') {
+            $this->setParameter('QUERY_STRING', $request->server->get('QUERY_STRING'));
+        }
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is related to a Silex change request: https://github.com/fabpot/Silex/pull/623
