### PR TITLE
[WIP][HttpFoundation] Add array type hinting for Request::create() arguments

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -268,7 +268,7 @@ class Request
      *
      * @api
      */
-    public static function create($uri, $method = 'GET', $parameters = array(), $cookies = array(), $files = array(), $server = array(), $content = null)
+    public static function create($uri, $method = 'GET', array $parameters = array(), array $cookies = array(), array $files = array(), array $server = array(), $content = null)
     {
         $server = array_replace(array(
             'SERVER_NAME'          => 'localhost',


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
- [ ] document the BC breaks

This PR adds missing `array` type hinting for array arguments (`$parameters`, `$cookies`, etc.) in `Request::create()` which makes it more consistent with `__construct()`, `initialize()` and  `duplicate()` definitions.
