### PR TITLE
[HttpCache] removed x-debug-token from response metadata before storing it

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -410,6 +410,7 @@ class Store implements StoreInterface
      */
     private function persistResponse(Response $response)
     {
+        $response->headers->remove('X-Debug-Token');
         $headers = $response->headers->all();
         $headers['X-Status'] = array($response->getStatusCode());
 

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -90,6 +90,15 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('ena94a8fe5ccb19ba61c4c0873d391e987982fbbd3', $res['x-content-digest'][0]);
     }
 
+    public function testStoresWithoutXDebugToken()
+    {
+        $request = Request::create('/foo');
+        $this->store->write($request, new Response('foo', 200, array('X-Debug-Token' => uniqid())));
+
+        $response = $this->store->lookup($request);
+        $this->assertFalse($response->headers->has('X-Debug-Token'));
+    }
+
     public function testFindsAStoredEntryWithLookup()
     {
         $this->storeSimpleEntry();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [#6227] |
| License | MIT |

When using HttpCache on dev environment, looking up and finding a response satisfying the master request leads to a bug with the stopwatch component, because it tries to open a section that doesn't exists, the X-Debug-Token is from an older request.
