### PR TITLE
[FrameworkBundle] Enable replacing of services

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ServiceReplacementsPass.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/ServiceReplacementsPass.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * Overwrites a service with an alias to a new service.
+ *
+ * @author Dariusz Górecki <darek.krk@gmail.com>
+ * @author Christophe Coevoet <stof@notk.org>
+ */
+class ServiceReplacementsPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $replacements = array();
+
+        foreach ($container->findTaggedServiceIds('framework.service_replacer') as $serviceId => $tag) {
+            if (!isset($tag[0]['replaces'])) {
+                continue;
+            }
+
+            $oldId = $tag[0]['replaces'];
+            $newId = isset($tag[0]['renameTo'])
+                ? $tag[0]['renameTo']
+                : $oldId.'.orig';
+
+            if ($container->hasAlias($oldId)) {
+                // Service we're overwriting is an alias.
+                // Register a private alias for this service to inject it as the parent
+                $container->setAlias($newId, new Alias($oldId, false));
+            } else {
+                // Service we're overwriting is a definition.
+                // Register it again as a private service to inject it as the parent.
+                $definition = $container->getDefinition($oldId);
+                $definition->setPublic(false);
+                // Replacing definition should be properly tagged
+                // so it's processed instead of old one.
+                // Old service looses their tags.
+                $definition->clearTags();
+                $container->setDefinition($newId, $definition);
+            }
+
+            $container->setAlias($oldId, $serviceId);
+        }
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -26,6 +26,7 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\CompilerDebugDum
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationExtractorPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationDumperPass;
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FragmentRendererPass;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ServiceReplacementsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\Scope;
@@ -54,6 +55,7 @@ class FrameworkBundle extends Bundle
 
         $container->addScope(new Scope('request'));
 
+        $container->addCompilerPass(new ServiceReplacementsPass());
         $container->addCompilerPass(new RoutingResolverPass());
         $container->addCompilerPass(new ProfilerPass());
         $container->addCompilerPass(new RegisterKernelListenersPass(), PassConfig::TYPE_AFTER_REMOVING);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ServiceReplacementsPassTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Compiler/ServiceReplacementsPassTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\ServiceReplacementsPass;
+
+class ServiceReplacementsPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testReplacemntOfAlias()
+    {
+        $service = array(
+            'my_replacemnt.service' => array(0 => array('replaces' => 'service.alias')),
+        );
+
+        $alias = new Alias('service.alias', false);
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $container->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('framework.service_replacer')
+            ->will($this->returnValue($service));
+        $container->expects($this->once())
+            ->method('hasAlias')
+            ->with('service.alias')
+            ->will($this->returnValue(true));
+        $container->expects($this->at(2))
+            ->method('setAlias')
+            ->with(
+                'service.alias.orig', $alias
+            );
+        $container->expects($this->at(3))
+            ->method('setAlias')
+            ->with(
+                'service.alias', 'my_replacemnt.service'
+            );
+
+        $pass = new ServiceReplacementsPass();
+        $pass->process($container);
+    }
+
+    public function testReplacemntOfAliasWithRename()
+    {
+        $service = array(
+            'my_replacemnt.service' => array(0 => array(
+                'replaces' => 'service.alias',
+                'renameTo' => 'old.service.alias',
+            )),
+        );
+
+        $alias = new Alias('service.alias', false);
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+
+        $container->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('framework.service_replacer')
+            ->will($this->returnValue($service));
+        $container->expects($this->once())
+            ->method('hasAlias')
+            ->with('service.alias')
+            ->will($this->returnValue(true));
+        $container->expects($this->at(2))
+            ->method('setAlias')
+            ->with(
+                'old.service.alias', $alias
+            );
+        $container->expects($this->at(3))
+            ->method('setAlias')
+            ->with(
+                'service.alias', 'my_replacemnt.service'
+            );
+
+        $pass = new ServiceReplacementsPass();
+        $pass->process($container);
+    }
+
+    public function testReplacemntOfService()
+    {
+        $service = array(
+            'my_replacemnt.service' => array(0 => array('replaces' => 'service.to.replace')),
+        );
+
+        $container  = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', array(
+            'clearTags', 'setPublic'
+        ), array('service.to.replace'));
+
+        $container->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('framework.service_replacer')
+            ->will($this->returnValue($service));
+        $container->expects($this->once())
+            ->method('hasAlias')
+            ->with('service.to.replace')
+            ->will($this->returnValue(false));
+        $container->expects($this->once())
+            ->method('getDefinition')
+            ->with('service.to.replace')
+            ->will($this->returnValue($definition));
+        $container->expects($this->once())
+            ->method('setDefinition')
+            ->with(
+                'service.to.replace.orig', $definition
+            );
+        $container->expects($this->once())
+            ->method('setAlias')
+            ->with(
+                'service.to.replace', 'my_replacemnt.service'
+            );
+
+        $definition->expects($this->once())
+            ->method('setPublic')
+            ->with(false);
+        $definition->expects($this->once())
+            ->method('clearTags');
+
+        $pass = new ServiceReplacementsPass();
+        $pass->process($container);
+    }
+
+    public function testReplacemntOfServiceWithRename()
+    {
+        $service = array(
+            'my_replacemnt.service' => array(0 => array(
+                'replaces' => 'service.to.replace',
+                'renameTo' => 'old.service.to.replace'
+            )),
+        );
+
+        $container  = $this->getMock('Symfony\Component\DependencyInjection\ContainerBuilder');
+        $definition = $this->getMock('Symfony\Component\DependencyInjection\Definition', array(
+            'clearTags', 'setPublic'
+        ), array('service.to.replace'));
+
+        $container->expects($this->once())
+            ->method('findTaggedServiceIds')
+            ->with('framework.service_replacer')
+            ->will($this->returnValue($service));
+        $container->expects($this->once())
+            ->method('hasAlias')
+            ->with('service.to.replace')
+            ->will($this->returnValue(false));
+        $container->expects($this->once())
+            ->method('getDefinition')
+            ->with('service.to.replace')
+            ->will($this->returnValue($definition));
+        $container->expects($this->once())
+            ->method('setDefinition')
+            ->with(
+                'old.service.to.replace', $definition
+            );
+        $container->expects($this->once())
+            ->method('setAlias')
+            ->with(
+                'service.to.replace', 'my_replacemnt.service'
+            );
+
+        $definition->expects($this->once())
+            ->method('setPublic')
+            ->with(false);
+        $definition->expects($this->once())
+            ->method('clearTags');
+
+        $pass = new ServiceReplacementsPass();
+        $pass->process($container);
+    }
+}


### PR DESCRIPTION
Now bundles can register services, that will replace other services/aliases, tagging system fits this scenarion quite well, and makes solution generic.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5920 |
| License | MIT |
| Doc PR | symfony/symfony-docs#2228 |
- [x] Write Unit Tests
- [ ] Find good name for tag, and arguments
- [ ] Decide should this belong to DI component or FrameworkBundle?
- [x] If accepted write cookbook entry
