### PR TITLE
[FrameworkBundle] Integrate console command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,7 @@
             "src/Symfony/Component/Locale/Resources/stubs"
         ]
     },
+    "bin": ["src/Symfony/Bundle/FrameworkBundle/Resources/bin/symfony"],
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/bin/symfony
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/bin/symfony
@@ -1,0 +1,31 @@
+#!/usr/bin/env php
+<?php
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArgvInput;
+
+// if you don't want to setup permissions the proper way, just uncomment the following PHP line
+// read http://symfony.com/doc/current/book/installation.html#configuration-and-setup for more information
+//umask(0000);
+
+set_time_limit(0);
+$path = __DIR__;
+do {
+    $path = dirname($path);
+} while ($path &&  $path != '/' && !file_exists($path . '/app'));
+
+if ($path == '/') {
+    echo <<<TEXT
+This command is only valid within an Symfony2 application.
+TEXT;
+    exit(1);
+}
+($loader = @include $path.'/app/bootstrap.php.cache') or (require $path . '/app/autoload.php');
+require $path.'/app/AppKernel.php';
+
+$input = new ArgvInput();
+$env = $input->getParameterOption(array('--env', '-e'), getenv('SYMFONY_ENV') ?: 'dev');
+$debug = getenv('SYMFONY_DEBUG') !== '0' && !$input->hasParameterOption(array('--no-debug', '')) && $env !== 'prod';
+
+$kernel = new AppKernel($env, $debug);
+$application = new Application($kernel);
+$application->run($input);

--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -42,6 +42,7 @@
         "psr-0": { "Symfony\\Bundle\\FrameworkBundle\\": "" }
     },
     "target-dir": "Symfony/Bundle/FrameworkBundle",
+    "bin":["Resources/bin/symfony"],
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In fact this PR only ports the `app/console`-command into the `FrameworkBundle` and update `composer.json`, so it is handled by composer. The idea is to provide the command even if one creates an application, that isn't based directly on `symfony-standard` and additional this keeps the "binaries" together in one folder.
