### PR TITLE
[WIP][Routing] added possibility to mark optional parts in the pattern

### DIFF
--- a/src/Symfony/Component/Routing/CompiledRoute.php
+++ b/src/Symfony/Component/Routing/CompiledRoute.php
@@ -18,6 +18,21 @@ namespace Symfony\Component\Routing;
  */
 class CompiledRoute
 {
+    /**
+     * A token representing static text in the pattern
+     */
+    const TEXT_TOKEN = 'text';
+
+    /**
+     * A token representing a variable placeholder in the pattern
+     */
+    const VARIABLE_TOKEN = 'variable';
+
+    /**
+     * An token representing an optional part that can itself have text/variable/optional tokens
+     */
+    const OPTIONAL_TOKEN = 'optional';
+
     private $variables;
     private $tokens;
     private $staticPrefix;

--- a/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteCompilerTest.php
@@ -181,6 +181,15 @@ class RouteCompilerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Variable name "spéßial" cannot be empty and must only contain letters, digits and underscores in route pattern "/prefix/{spéßial}" at position 8.
+     */
+    public function testInvalidVariableName()
+    {
+        \Symfony\Component\Routing\RouteCompiler::parsePattern('/prefix/{spéßial}');
+    }
+
+    /**
      * @dataProvider provideCompileWithHostnameData
      */
     public function testCompileWithHostname($name, $arguments, $prefix, $regex, $variables, $pathVariables, $tokens, $hostnameRegex, $hostnameVariables, $hostnameTokens)

--- a/src/Symfony/Component/Routing/Tests/RouteTest.php
+++ b/src/Symfony/Component/Routing/Tests/RouteTest.php
@@ -23,6 +23,46 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => '\d+'), $route->getRequirements(), '__construct() takes requirements as its third argument');
         $this->assertEquals('bar', $route->getOption('foo'), '__construct() takes options as its fourth argument');
         $this->assertEquals('{locale}.example.com', $route->getHostnamePattern(), '__construct() takes a hostname pattern as its fifth argument');
+
+        var_dump($t = \Symfony\Component\Routing\RouteCompiler::parsePattern('/prefix/{test}{product}-{bla}'));
+        var_dump(\Symfony\Component\Routing\RouteCompiler::convertImplicitOptionals($t, array('bla' => 'b', 'product' => 'p', 'test' => 't')));
+
+        var_dump($t = \Symfony\Component\Routing\RouteCompiler::parsePattern('/{test}'));
+        var_dump(\Symfony\Component\Routing\RouteCompiler::convertImplicitOptionals($t, array('test' => 't')));
+
+        var_dump(\Symfony\Component\Routing\RouteCompiler::parsePattern('/prefix/{tèst}{prod}uct}{a(b{var}uct})c}{a(b)c}(wrong)-{foo}()((-by-){criterion}).{_format}(.{ext}))'));
+
+        preg_match_all('#(?<!\\\\)\{.*?(?<!\\\\)\}|(?<!\\\\)\((?:[^()]++|((?<=\\\\)[()])++|(?R))*(?<!\\\\)\)#', '/prefix/{}{prod\}uct}(sad\)(f)((-by-{criterion}).{_format}(:{method}))', $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        var_dump($matches);
+
+        preg_match_all('#\{\w+\}#', '/prefix/{product}((-by-{criterion}).{_format})', $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        //var_dump($matches);
+
+        preg_match_all('#(.*?)\{(\w+)\}#', '/prefix/{product}((-by-{criterion}).{_format})', $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        //var_dump($matches);
+
+        preg_match_all('#(.*?)(\{(\w+)\}|\(((?>[^()]+)|(?R))*\))#', '/prefix/{product}((-by-{criterion}).{_format})', $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        //var_dump($matches);
+
+        preg_match_all('#\((?R)\)|\{(\w+)\}#', '/prefix/{product}((-by-{criterion}).{_format})', $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        //var_dump($matches);
+
+        preg_match_all('#\((.*)\)|\{(\w+)\}#', '/prefix/{product}(wrong)-{foo}()((-by-{criterion}).{_format})', $matches, PREG_OFFSET_CAPTURE | PREG_SET_ORDER);
+        //var_dump($matches);
+
+        /*
+        var_dump(preg_match('#^/(?P<product>[^/\-\.]++)(?:(?:\-by\-(?P<criterion>[^/\.]++))?\.(?P<_format>[^/]++))?a$#s', '/prod-by-prize.htmla', $matches));
+        var_dump($matches);
+
+        var_dump(preg_match('#^/(?P<product>[^/\-\.]++)(?:(?:\-by\-(?P<criterion>[^/\.]++))?\.(?P<_format>[^/]++))?$#s', '/prod-by-prize', $matches));
+        var_dump($matches);
+
+        var_dump(preg_match('#^/(?P<product>[^/\-\.]++)(?:(?:\-by\-(?P<criterion>[^/\.]++))?\.(?P<_format>[^/]++))?$#s', '/prod.html', $matches));
+        var_dump($matches);
+
+        var_dump(preg_match('#^/(?P<product>[^/\-\.]++)(?:(?:\-by\-(?P<criterion>[^/\.]++))?\.(?P<_format>[^/]++))?$#s', '/prod', $matches));
+        var_dump($matches);
+        */
     }
 
     public function testPattern()


### PR DESCRIPTION
WIP: An early stage that only implements the algorithm to get a parse tree of the pattern that can contain optionals parts (which itself can be nested at any depth). It also implements the escaping syntax for `(){}` with `\`. The regex is quite nice ^^.

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [yes] |
| Deprecations? | [no] |
| Tests pass? | [no] |
| Fixed tickets | [#5424, #4563, #5918] |
| License | MIT |
| Doc PR | [todo] |

The BC break will most likely only be in terms of the tokens representation of the compiled route which should probably not affect anybody as people don't work that low-level.
