### PR TITLE
trim placeholder to remove whitespaces

### DIFF
--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -77,7 +77,8 @@ class TwigExtractor implements ExtractorInterface
         $this->twig->parse($this->twig->tokenize($template));
 
         foreach ($visitor->getMessages() as $message) {
-            $catalogue->set($message[0], $this->prefix.$message[0], $message[1] ? $message[1] : $this->defaultDomain);
+            $placeholder = trim($message[0]);
+            $catalogue->set($placeholder, $this->prefix.$placeholder, $message[1] ? $message[1] : $this->defaultDomain);
         }
 
         $visitor->disable();


### PR DESCRIPTION
Just another try to explain why my changes are required ;-)

in the template we can write {% trans %}placeholder{% endtrans %} or {% trans %} placeholder {% endtrans %}
it would both match witch the string 'placeholder' in the translation file

when we call the console script translation:update the first would be created to 'placeholder' and the second to ' placeholder ', which are two different values, but the first one is correct and work with both trans tags.
