### PR TITLE
Remove array type hint from GetResponseForControllerResultEvent::setControllerResult()

### DIFF
--- a/src/Symfony/Component/HttpKernel/Event/GetResponseForControllerResultEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/GetResponseForControllerResultEvent.php
@@ -56,11 +56,11 @@ class GetResponseForControllerResultEvent extends GetResponseEvent
     /**
      * Assigns the return value of the controller.
      *
-     * @param array The controller return value
+     * @param mixed The controller return value
      *
      * @api
      */
-    public function setControllerResult(array $controllerResult)
+    public function setControllerResult($controllerResult)
     {
         $this->controllerResult = $controllerResult;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I don't see a good reason to limit responses to arrays. The method was introduced in 2.2, so there is no real BC break.
