### PR TITLE
[Translator] several fixes and refactorings

### DIFF
--- a/src/Symfony/Component/Translation/IdentityTranslator.php
+++ b/src/Symfony/Component/Translation/IdentityTranslator.php
@@ -59,7 +59,7 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
     {
-        return strtr($id, $parameters);
+        return strtr((string) $id, $parameters);
     }
 
     /**
@@ -69,6 +69,6 @@ class IdentityTranslator implements TranslatorInterface
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
     {
-        return strtr($this->selector->choose($id, (int) $number, $locale), $parameters);
+        return strtr($this->selector->choose((string) $id, (int) $number, $locale), $parameters);
     }
 }

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -176,8 +176,10 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
             $this->addResource($resource);
         }
 
-        $metadata = $catalogue->getMetadata('', '');
-        $this->addMetadata($metadata);
+        if ($catalogue instanceof MetadataAwareInterface) {
+            $metadata = $catalogue->getMetadata('', '');
+            $this->addMetadata($metadata);
+        }
     }
 
     /**
@@ -238,19 +240,21 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function getMetadata($key = '', $domain = 'messages')
     {
-        if (empty($domain)) {
+        if ('' == $domain) {
             return $this->metadata;
         }
 
         if (isset($this->metadata[$domain])) {
-            if (!empty($key)) {
-                if (isset($this->metadata[$domain][$key])) {
-                    return $this->metadata[$domain][$key];
-                }
-            } else {
+            if ('' == $key) {
                 return $this->metadata[$domain];
             }
+
+            if (isset($this->metadata[$domain][$key])) {
+                return $this->metadata[$domain][$key];
+            }
         }
+
+        return null;
     }
 
     /**
@@ -266,15 +270,13 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function deleteMetadata($key = '', $domain = 'messages')
     {
-        if (empty($domain)) {
+        if ('' == $domain) {
             $this->metadata = array();
-        }
-
-        if (empty($key)) {
+        } elseif ('' == $key) {
             unset($this->metadata[$domain]);
+        } else {
+            unset($this->metadata[$domain][$key]);
         }
-
-        unset($this->metadata[$domain][$key]);
     }
 
     /**

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -204,9 +204,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     }
 
     /**
-     * Gets the fallback catalogue.
-     *
-     * @return MessageCatalogueInterface A MessageCatalogueInterface instance
+     * {@inheritdoc}
      *
      * @api
      */

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -24,8 +24,8 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
 {
     private $messages = array();
     private $metadata = array();
+    private $resources = array();
     private $locale;
-    private $resources;
     private $fallbackCatalogue;
     private $parent;
 
@@ -41,7 +41,6 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
     {
         $this->locale = $locale;
         $this->messages = $messages;
-        $this->resources = array();
     }
 
     /**

--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -220,7 +220,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function getResources()
     {
-        return array_values(array_unique($this->resources));
+        return array_values($this->resources);
     }
 
     /**
@@ -230,7 +230,7 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function addResource(ResourceInterface $resource)
     {
-        $this->resources[] = $resource;
+        $this->resources[$resource->__toString()] = $resource;
     }
 
     /**

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -103,7 +103,7 @@ interface MessageCatalogueInterface
     /**
      * Sets translations for a given domain.
      *
-     * @param string $messages An array of translations
+     * @param array  $messages An array of translations
      * @param string $domain   The domain name
      *
      * @api
@@ -113,7 +113,7 @@ interface MessageCatalogueInterface
     /**
      * Adds translations for a given domain.
      *
-     * @param string $messages An array of translations
+     * @param array  $messages An array of translations
      * @param string $domain   The domain name
      *
      * @api

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -146,7 +146,7 @@ interface MessageCatalogueInterface
     /**
      * Gets the fallback catalogue.
      *
-     * @return MessageCatalogueInterface A MessageCatalogueInterface instance
+     * @return MessageCatalogueInterface|null A MessageCatalogueInterface instance or null when no fallback has been set
      *
      * @api
      */

--- a/src/Symfony/Component/Translation/MetadataAwareInterface.php
+++ b/src/Symfony/Component/Translation/MetadataAwareInterface.php
@@ -19,27 +19,36 @@ namespace Symfony\Component\Translation;
 interface MetadataAwareInterface
 {
     /**
-     * Gets meta data for given domain and key.
+     * Gets metadata for the given domain and key.
+     *
+     * Passing an empty domain will return an array with all metadata indexed by
+     * domain and then by key. Passing an empty key will return an array with all
+     * metadata for the given domain.
      *
      * @param string $domain The domain name
-     * @param string $key    Key
+     * @param string $key    The key
+     *
+     * @return mixed The value that was set or an array with the domains/keys or null
      */
     public function getMetadata($key = '', $domain = 'messages');
 
     /**
-     * Adds meta data to a message domain.
+     * Adds metadata to a message domain.
      *
-     * @param string       $key    Key
-     * @param string|array $value  Value
-     * @param string       $domain The domain name
+     * @param string $key    The key
+     * @param mixed  $value  The value
+     * @param string $domain The domain name
      */
     public function setMetadata($key, $value, $domain = 'messages');
 
     /**
-     * Deletes meta data for given key and domain.
+     * Deletes metadata for the given key and domain.
+     *
+     * Passing an empty domain will delete all metadata. Passing an empty key will
+     * delete all metadata for the given domain.
      *
      * @param string $domain The domain name
-     * @param string $key    Key
+     * @param string $key    The key
      */
     public function deleteMetadata($key = '', $domain = 'messages');
 }

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -56,15 +56,15 @@ class Translator implements TranslatorInterface
     /**
      * Constructor.
      *
-     * @param string          $locale   The locale
-     * @param MessageSelector $selector The message selector for pluralization
+     * @param string               $locale   The locale
+     * @param MessageSelector|null $selector The message selector for pluralization
      *
      * @api
      */
     public function __construct($locale, MessageSelector $selector = null)
     {
         $this->locale = $locale;
-        $this->selector = null === $selector ? new MessageSelector() : $selector;
+        $this->selector = $selector ?: new MessageSelector();
     }
 
     /**
@@ -129,7 +129,7 @@ class Translator implements TranslatorInterface
         // needed as the fallback locales are linked to the already loaded catalogues
         $this->catalogues = array();
 
-        $this->fallbackLocales = is_array($locales) ? $locales : array($locales);
+        $this->fallbackLocales = (array) $locales;
     }
 
     /**
@@ -139,7 +139,7 @@ class Translator implements TranslatorInterface
      */
     public function trans($id, array $parameters = array(), $domain = 'messages', $locale = null)
     {
-        if (!isset($locale)) {
+        if (null === $locale) {
             $locale = $this->getLocale();
         }
 
@@ -157,7 +157,7 @@ class Translator implements TranslatorInterface
      */
     public function transChoice($id, $number, array $parameters = array(), $domain = 'messages', $locale = null)
     {
-        if (!isset($locale)) {
+        if (null === $locale) {
             $locale = $this->getLocale();
         }
 

--- a/src/Symfony/Component/Translation/Translator.php
+++ b/src/Symfony/Component/Translation/Translator.php
@@ -177,7 +177,7 @@ class Translator implements TranslatorInterface
             }
         }
 
-        return strtr($this->selector->choose($catalogue->get($id, $domain), (float) $number, $locale), $parameters);
+        return strtr($this->selector->choose($catalogue->get($id, $domain), (int) $number, $locale), $parameters);
     }
 
     protected function loadCatalogue($locale)

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -23,7 +23,7 @@ interface TranslatorInterface
     /**
      * Translates the given message.
      *
-     * @param string $id         The message id
+     * @param string $id         The message id (may also be an object that can be cast to string)
      * @param array  $parameters An array of parameters for the message
      * @param string $domain     The domain for the message
      * @param string $locale     The locale
@@ -37,7 +37,7 @@ interface TranslatorInterface
     /**
      * Translates the given choice message by choosing a translation according to a number.
      *
-     * @param string  $id         The message id
+     * @param string  $id         The message id (may also be an object that can be cast to string)
      * @param integer $number     The number to use to find the indice of the message
      * @param array   $parameters An array of parameters for the message
      * @param string  $domain     The domain for the message


### PR DESCRIPTION
Reasoning see individual commits.

BC break: no <del>yes because I added an array typehint to `MessageCatalogueInterface::add` and `::replace` since it's required. I could remove the typhint again so there would be no bc break, but IMO having it is much more explicit and consistent as there are already other array typhints as in the constructor.</del>
