### PR TITLE
[Process] Warn user with a useful message when tmpfile() failed

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -213,6 +213,9 @@ class Process
             $this->fileHandles = array(
                 self::STDOUT => tmpfile(),
             );
+            if (false === $this->fileHandles[self::STDOUT]) {
+                throw new RuntimeException('A temporary file could not be opened to write the process output to, verify that your TEMP environment variable is writable');
+            }
             $this->readBytes = array(
                 self::STDOUT => 0,
             );


### PR DESCRIPTION
Simple warning so users know what's going on instead of getting a proc_open error, see composer/composer#1581. 

Can't get the PR template since ~~symfony.com~~ my dns resolver is dead :)
