### PR TITLE
Use concrete Class Methods to check validations

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
+++ b/src/Symfony/Component/Validator/Mapping/GetterMetadata.php
@@ -44,7 +44,8 @@ class GetterMetadata extends MemberMetadata
      */
     public function getPropertyValue($object)
     {
-        return $this->getReflectionMember()->invoke($object);
+        $refl = new \ReflectionMethod(get_class($object), $this->getName());
+        return $refl->invoke($object);
     }
 
     /**


### PR DESCRIPTION
Please use the concrete Class Methods to check validations. Its realy unexpected that Validator don't use the normal Object way and invoke the conrete object with another class.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
