### PR TITLE
[2.3] [Security] Add a getter for providers to the ChainUserProvider class

### DIFF
--- a/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
+++ b/src/Symfony/Component/Security/Core/User/ChainUserProvider.php
@@ -32,6 +32,14 @@ class ChainUserProvider implements UserProviderInterface
     }
 
     /**
+     * @return array
+     */
+    public function getProviders()
+    {
+        return $this->providers;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function loadUserByUsername($username)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

I've got a use case where I need to check if any of the chained user providers implement a particular interface. This getter would really help with that.
