### PR TITLE
[HttpKernel] added error display suppression when using the ErrorHandler (if not, errors are displayed twice, refs #6254)

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
@@ -58,6 +58,7 @@ class ErrorHandler
         $handler = new static();
         $handler->setLevel($level);
 
+        ini_set('display_errors', 0);
         set_error_handler(array($handler, 'handle'));
         register_shutdown_function(array($handler, 'handleFatal'));
         $handler->reservedMemory = str_repeat('x', 10240);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
