### PR TITLE
[HttpKernel] hinclude fragment renderer must escape URIs properly to return valid html

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/HIncludeFragmentRenderer.php
@@ -64,6 +64,9 @@ class HIncludeFragmentRenderer extends RoutableFragmentRenderer
             $uri = $this->signer->sign($this->generateFragmentUri($uri, $request));
         }
 
+        // We need to replace ampersands in the URI with the encoded form in order to return valid html/xml content.
+        $uri = str_replace('&', '&amp;', $uri);
+
         $template = isset($options['default']) ? $options['default'] : $this->globalDefaultTemplate;
         if (null !== $this->templating && $template && $this->templateExists($template)) {
             $content = $this->templating->render($template);

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/HIncludeFragmentRendererTest.php
@@ -38,7 +38,7 @@ class HIncludeFragmentRendererTest extends \PHPUnit_Framework_TestCase
     {
         $strategy = new HIncludeFragmentRenderer(null, new UriSigner('foo'));
 
-        $this->assertEquals('<hx:include src="http://localhost/_fragment?_path=_format%3Dhtml%26_controller%3Dmain_controller&_hash=VI25qJj8J0qveB3bGKPhsJtexKg%3D"></hx:include>', $strategy->render(new ControllerReference('main_controller', array(), array()), Request::create('/'))->getContent());
+        $this->assertEquals('<hx:include src="http://localhost/_fragment?_path=_format%3Dhtml%26_controller%3Dmain_controller&amp;_hash=VI25qJj8J0qveB3bGKPhsJtexKg%3D"></hx:include>', $strategy->render(new ControllerReference('main_controller', array(), array()), Request::create('/'))->getContent());
     }
 
     public function testRenderWithUri()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [-] |
| License | MIT |
| Doc PR | [-] |

Since rendering of hinclude fragments returns html/xml, it is marked as safe. So it's not auto-escaped of course. But that means it must properly escape it's input (the URI) when outputting in html context. 
Btw, this does not need to be done for esi because esi tags are processed in middleware which do not go to the client/browser.
