### PR TITLE
[HttpKernel/HttpCache] Fix "REMOTE_ADDR" for cached subrequests

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -418,18 +418,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         $subRequest->headers->remove('if_modified_since');
         $subRequest->headers->remove('if_none_match');
 
-        // modify the X-Forwarded-For header if needed
-        $forwardedFor = $subRequest->headers->get('X-Forwarded-For');
-        if ($forwardedFor) {
-            $subRequest->headers->set('X-Forwarded-For', $forwardedFor.', '.$subRequest->server->get('REMOTE_ADDR'));
-        } else {
-            $subRequest->headers->set('X-Forwarded-For', $subRequest->server->get('REMOTE_ADDR'));
-        }
-
-        // fix the client IP address by setting it to 127.0.0.1 as HttpCache
-        // is always called from the same process as the backend.
-        $subRequest->server->set('REMOTE_ADDR', '127.0.0.1');
-
         $response = $this->forward($subRequest, $catch);
 
         if ($this->isPrivateRequest($request) && !$response->headers->hasCacheControlDirective('public')) {
@@ -459,6 +447,18 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         if ($this->esi) {
             $this->esi->addSurrogateEsiCapability($request);
         }
+
+        // modify the X-Forwarded-For header if needed
+        $forwardedFor = $request->headers->get('X-Forwarded-For');
+        if ($forwardedFor) {
+            $request->headers->set('X-Forwarded-For', $forwardedFor.', '.$request->server->get('REMOTE_ADDR'));
+        } else {
+            $request->headers->set('X-Forwarded-For', $request->server->get('REMOTE_ADDR'));
+        }
+
+        // fix the client IP address by setting it to 127.0.0.1 as HttpCache
+        // is always called from the same process as the backend.
+        $request->server->set('REMOTE_ADDR', '127.0.0.1');
 
         // always a "master" request (as the real master request can be in cache)
         $response = $this->kernel->handle($request, HttpKernelInterface::MASTER_REQUEST, $catch);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | none that I know of |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 7091 |
| License | MIT |

I moved the code that modifies the REMOTE_ADDR variable further up the chain so that cached subrequests also receive the local IP address. Before, only new subrequests received the local IP address and cached ones received the original IP, which made "validateRequest" in FragmentListener fail.

Please review. I'm not sure about side-effects of this patch, including possible security issues.

Fixes #7091
