### PR TITLE
[Config] tweaked dumper to indent multi-line info

### DIFF
--- a/src/Symfony/Component/Config/Definition/ReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/ReferenceDumper.php
@@ -119,6 +119,8 @@ class ReferenceDumper
 
         if ($info = $node->getInfo()) {
             $this->writeLine('');
+            // indenting multi-line info
+            $info = str_replace("\n", sprintf("\n%" . $depth * 4 . "s# ", ' '), $info);
             $this->writeLine('# '.$info, $depth * 4);
         }
 

--- a/src/Symfony/Component/Config/Definition/ReferenceDumper.php
+++ b/src/Symfony/Component/Config/Definition/ReferenceDumper.php
@@ -115,7 +115,7 @@ class ReferenceDumper
         $default = (string) $default != '' ? ' '.$default : '';
         $comments = count($comments) ? '# '.implode(', ', $comments) : '';
 
-        $text = sprintf('%-20s %s %s', $node->getName().':', $default, $comments);
+        $text = rtrim(sprintf('%-20s %s %s', $node->getName() . ':', $default, $comments), ' ');
 
         if ($info = $node->getInfo()) {
             $this->writeLine('');

--- a/src/Symfony/Component/Config/Tests/Definition/ReferenceDumperTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/ReferenceDumperTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Definition;
+
+use Symfony\Component\Config\Definition\ReferenceDumper;
+use Symfony\Component\Config\Tests\Fixtures\Configuration\ExampleConfiguration;
+
+class ReferenceDumperTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDumper()
+    {
+        $configuration = new ExampleConfiguration();
+
+        $dumper = new ReferenceDumper();
+        $this->assertEquals($this->getConfigurationAsString(), $dumper->dump($configuration));
+    }
+
+    private function getConfigurationAsString()
+    {
+      return <<<EOL
+root:
+    boolean:              true
+    scalar_empty:         ~
+    scalar_null:          ~
+    scalar_true:          true
+    scalar_false:         false
+    scalar_default:       default
+    scalar_array_empty:   []
+    scalar_array_defaults:
+
+        # Defaults:
+        - elem1
+        - elem2
+
+    # some info
+    array:
+        child1:               ~
+        child2:               ~
+
+        # this is a long
+        # multi-line info text
+        # which should be indented
+        child3:               ~ # Example: example setting
+    array_prototype:
+        parameters:
+
+            # Prototype
+            name:
+                value:                ~ # Required
+
+EOL;
+    }
+}

--- a/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
+++ b/src/Symfony/Component/Config/Tests/Fixtures/Configuration/ExampleConfiguration.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config\Tests\Fixtures\Configuration;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+class ExampleConfiguration implements ConfigurationInterface
+{
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('root');
+
+        $rootNode
+            ->children()
+                ->booleanNode('boolean')->defaultTrue()->end()
+                ->scalarNode('scalar_empty')->end()
+                ->scalarNode('scalar_null')->defaultNull()->end()
+                ->scalarNode('scalar_true')->defaultTrue()->end()
+                ->scalarNode('scalar_false')->defaultFalse()->end()
+                ->scalarNode('scalar_default')->defaultValue('default')->end()
+                ->scalarNode('scalar_array_empty')->defaultValue(array())->end()
+                ->scalarNode('scalar_array_defaults')->defaultValue(array('elem1', 'elem2'))->end()
+                ->arrayNode('array')
+                    ->info('some info')
+                    ->canBeUnset()
+                    ->children()
+                        ->scalarNode('child1')->end()
+                        ->scalarNode('child2')->end()
+                        ->scalarNode('child3')
+                            ->info(
+                                "this is a long\n".
+                                "multi-line info text\n".
+                                "which should be indented"
+                            )
+                            ->example('example setting')
+                        ->end()
+                    ->end()
+                ->end()
+                ->arrayNode('array_prototype')
+                    ->children()
+                        ->arrayNode('parameters')
+                            ->useAttributeAsKey('name')
+                            ->prototype('array')
+                                ->children()
+                                    ->scalarNode('value')->isRequired()->end()
+                                ->end()
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Little cosmetic tweak.

before:

``` yaml
    # router configuration
    router:               
        resource:             ~ # Required
        type:                 ~ 
        http_port:            80 
        https_port:           443 

        # set to true to throw an exception when a parameter does not match the requirements
set to false to disable exceptions when a parameter does not match the requirements (and return null instead)
set to null to disable parameter checks against requirements
'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production
        strict_requirements:  true 

    # session configuration
    session:              
```

after:

``` yaml
    # router configuration
    router:               
        resource:             ~ # Required
        type:                 ~ 
        http_port:            80 
        https_port:           443 

        # set to true to throw an exception when a parameter does not match the requirements
        # set to false to disable exceptions when a parameter does not match the requirements (and return null instead)
        # set to null to disable parameter checks against requirements
        # 'true' is the preferred configuration in development mode, while 'false' or 'null' might be preferred in production
        strict_requirements:  true 

    # session configuration
```
