### PR TITLE
[Process][2.0] getcwd failure fix

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -54,6 +54,10 @@ class Process
 
         $this->commandline = $commandline;
         $this->cwd = $cwd;
+        // on windows, if the cwd changed via chdir(), proc_open defaults to the dir where php was started
+        if (null === $this->cwd && defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->cwd = getcwd();
+        }
         if (null !== $env) {
             $this->env = array();
             foreach ($env as $key => $value) {


### PR DESCRIPTION
Fix regression introduced in #6620
Fixes #7082

For reference, here is the current behavior I saw:

PHP 5.4.11, windows:

```
5.4.11\php.exe -r "chdir('c:\\'); var_dump(getcwd()); $p = proc_open('pwd', [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']], $pipes, null); var_dump(stream_get_contents($pipes[1]));"
string(3) "C:\\"
string(14) "/c/Users/seld\n"
```

(I use pwd which is a unix util so it dumps a funny path, but don't look at that)

PHP 5.5alpha4, windows (seems fixed):

```
5.5.0a4\php.exe  -r "chdir('c:\\'); var_dump(getcwd()); $p = proc_open('pwd', [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']], $pipes, null); var_dump(stream_get_contents($pipes[1]));"
string(3) "C:\"
string(3) "/c\n"
```

PHP 5.3.10, ubuntu:

```
php -r "chdir('/'); var_dump(getcwd()); \$p = proc_open('pwd', array(array('pipe', 'r'), array('p
ipe', 'w'), array('pipe', 'w')), \$pipes, null); var_dump(stream_get_contents(\$pipes[1]));"
string(1) "/"
string(2) "/\n"
```

Since the permission issue that #6620 originally was fixing is most likely not gonna happen on windows, this seems like a safe enough compromise. Ideally a check for PHP<5.5 should be introduced, but I would like to be sure it's been fixed and is not just a lucky coincidence (/cc @PierreJoye)

I would recommend merging fast and maybe adding the version check later, since it breaks composer create-project on windows. The workaround being: cd in the dir and run `composer install` again to finalize the project setup.
