### PR TITLE
Removed some leaking deprecation warning in the Form component

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -209,7 +209,7 @@ class EntityTypeTest extends TypeTestCase
         $field->setData(null);
 
         $this->assertNull($field->getData());
-        $this->assertSame('', $field->getClientData());
+        $this->assertSame('', $field->getViewData());
     }
 
     public function testSetDataMultipleExpandedNull()
@@ -223,7 +223,7 @@ class EntityTypeTest extends TypeTestCase
         $field->setData(null);
 
         $this->assertNull($field->getData());
-        $this->assertSame(array(), $field->getClientData());
+        $this->assertSame(array(), $field->getViewData());
     }
 
     public function testSetDataMultipleNonExpandedNull()
@@ -237,7 +237,7 @@ class EntityTypeTest extends TypeTestCase
         $field->setData(null);
 
         $this->assertNull($field->getData());
-        $this->assertSame(array(), $field->getClientData());
+        $this->assertSame(array(), $field->getViewData());
     }
 
     public function testSubmitSingleExpandedNull()
@@ -251,7 +251,7 @@ class EntityTypeTest extends TypeTestCase
         $field->bind(null);
 
         $this->assertNull($field->getData());
-        $this->assertSame(array(), $field->getClientData());
+        $this->assertSame(array(), $field->getViewData());
     }
 
     public function testSubmitSingleNonExpandedNull()
@@ -265,7 +265,7 @@ class EntityTypeTest extends TypeTestCase
         $field->bind(null);
 
         $this->assertNull($field->getData());
-        $this->assertSame('', $field->getClientData());
+        $this->assertSame('', $field->getViewData());
     }
 
     public function testSubmitMultipleNull()
@@ -278,7 +278,7 @@ class EntityTypeTest extends TypeTestCase
         $field->bind(null);
 
         $this->assertEquals(new ArrayCollection(), $field->getData());
-        $this->assertSame(array(), $field->getClientData());
+        $this->assertSame(array(), $field->getViewData());
     }
 
     public function testSubmitSingleNonExpandedSingleIdentifier()
@@ -300,7 +300,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
-        $this->assertSame('2', $field->getClientData());
+        $this->assertSame('2', $field->getViewData());
     }
 
     public function testSubmitSingleNonExpandedCompositeIdentifier()
@@ -323,7 +323,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
-        $this->assertSame('1', $field->getClientData());
+        $this->assertSame('1', $field->getViewData());
     }
 
     public function testSubmitMultipleNonExpandedSingleIdentifier()
@@ -348,7 +348,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->assertTrue($field->isSynchronized());
         $this->assertEquals($expected, $field->getData());
-        $this->assertSame(array('1', '3'), $field->getClientData());
+        $this->assertSame(array('1', '3'), $field->getViewData());
     }
 
     public function testSubmitMultipleNonExpandedSingleIdentifierForExistingData()
@@ -379,7 +379,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertEquals($expected, $field->getData());
         // same object still, useful if it is a PersistentCollection
         $this->assertSame($existing, $field->getData());
-        $this->assertSame(array('1', '3'), $field->getClientData());
+        $this->assertSame(array('1', '3'), $field->getViewData());
     }
 
     public function testSubmitMultipleNonExpandedCompositeIdentifier()
@@ -405,7 +405,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->assertTrue($field->isSynchronized());
         $this->assertEquals($expected, $field->getData());
-        $this->assertSame(array('0', '2'), $field->getClientData());
+        $this->assertSame(array('0', '2'), $field->getViewData());
     }
 
     public function testSubmitMultipleNonExpandedCompositeIdentifierExistingData()
@@ -436,7 +436,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertEquals($expected, $field->getData());
         // same object still, useful if it is a PersistentCollection
         $this->assertSame($existing, $field->getData());
-        $this->assertSame(array('0', '2'), $field->getClientData());
+        $this->assertSame(array('0', '2'), $field->getViewData());
     }
 
     public function testSubmitSingleExpanded()
@@ -460,8 +460,8 @@ class EntityTypeTest extends TypeTestCase
         $this->assertSame($entity2, $field->getData());
         $this->assertFalse($field['1']->getData());
         $this->assertTrue($field['2']->getData());
-        $this->assertNull($field['1']->getClientData());
-        $this->assertSame('2', $field['2']->getClientData());
+        $this->assertNull($field['1']->getViewData());
+        $this->assertSame('2', $field['2']->getViewData());
     }
 
     public function testSubmitMultipleExpanded()
@@ -489,9 +489,9 @@ class EntityTypeTest extends TypeTestCase
         $this->assertTrue($field['1']->getData());
         $this->assertFalse($field['2']->getData());
         $this->assertTrue($field['3']->getData());
-        $this->assertSame('1', $field['1']->getClientData());
-        $this->assertNull($field['2']->getClientData());
-        $this->assertSame('3', $field['3']->getClientData());
+        $this->assertSame('1', $field['1']->getViewData());
+        $this->assertNull($field['2']->getViewData());
+        $this->assertSame('3', $field['3']->getViewData());
     }
 
     public function testOverrideChoices()
@@ -515,7 +515,7 @@ class EntityTypeTest extends TypeTestCase
         $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
-        $this->assertSame('2', $field->getClientData());
+        $this->assertSame('2', $field->getViewData());
     }
 
     public function testGroupByChoices()
@@ -537,7 +537,7 @@ class EntityTypeTest extends TypeTestCase
 
         $field->bind('2');
 
-        $this->assertSame('2', $field->getClientData());
+        $this->assertSame('2', $field->getViewData());
         $this->assertEquals(array(
             'Group1' => array(1 => new ChoiceView($item1, '1', 'Foo'), 2 => new ChoiceView($item2, '2', 'Bar')),
             'Group2' => array(3 => new ChoiceView($item3, '3', 'Baz')),
@@ -716,7 +716,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity1, $field->getData());
-        $this->assertSame('foo', $field->getClientData());
+        $this->assertSame('foo', $field->getViewData());
     }
 
     public function testSubmitCompositeStringIdentifier()
@@ -738,7 +738,7 @@ class EntityTypeTest extends TypeTestCase
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity1, $field->getData());
-        $this->assertSame('0', $field->getClientData());
+        $this->assertSame('0', $field->getViewData());
     }
 
     public function testGetManagerForClassIfNoEm()

--- a/src/Symfony/Component/Form/ResolvedFormType.php
+++ b/src/Symfony/Component/Form/ResolvedFormType.php
@@ -62,7 +62,9 @@ class ResolvedFormType implements ResolvedFormTypeInterface
         // BC
         if ($innerType instanceof AbstractType) {
             /* @var AbstractType $innerType */
+            set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handleBC'));
             $innerType->setExtensions($typeExtensions);
+            restore_error_handler();
         }
 
         $this->innerType = $innerType;

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -601,9 +601,11 @@ class FormTypeTest extends TypeTestCase
     // BC
     public function testPropertyPathFalseImpliesDefaultNotMapped()
     {
+        set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handle'));
         $form = $this->factory->createNamed('name', 'form', null, array(
             'property_path' => false,
         ));
+        restore_error_handler();
 
         $this->assertEquals(new PropertyPath('name'), $form->getPropertyPath());
         $this->assertFalse($form->getConfig()->getMapped());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/MoneyTypeTest.php
@@ -42,7 +42,7 @@ class MoneyTypeTest extends LocalizedTestCase
         $view1 = $form1->createView();
         $view2 = $form2->createView();
 
-        $this->assertSame('{{ widget }} £', $view1->get('money_pattern'));
-        $this->assertSame('{{ widget }} €', $view2->get('money_pattern'));
+        $this->assertSame('{{ widget }} £', $view1->vars['money_pattern']);
+        $this->assertSame('{{ widget }} €', $view2->vars['money_pattern']);
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -231,7 +231,7 @@ class TimeTypeTest extends LocalizedTestCase
 
         $form->setData(new \DateTime('03:04:05 UTC'));
 
-        $this->assertEquals(array('hour' => 3), $form->getClientData());
+        $this->assertEquals(array('hour' => 3), $form->getViewData());
     }
 
     public function testSetDataWithSeconds()

--- a/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
@@ -32,13 +32,6 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
             ->getFormFactory();
-
-        set_error_handler(array('Symfony\Component\Form\Test\DeprecationErrorHandler', 'handle'));
-    }
-
-    protected function tearDown()
-    {
-        restore_error_handler();
     }
 
     protected function getExtensions()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | #7101 |
| License | MIT |

I have removed the error handler in the integration test case so that the testsuite can show any leaked deprecation message from the core and replaced deprecated methods in the type testcases.
This keeps only 2 cases where the handlign was needed: the test ensuring the BC for `property_path`, and the code triggering #7101 because of its BC call
