### PR TITLE
[Form] Fixes php fatal error in CsrfValidationListener when form is bound with a string

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -67,8 +67,10 @@ class CsrfValidationListener implements EventSubscriberInterface
             if (!isset($data[$this->fieldName]) || !$this->csrfProvider->isCsrfTokenValid($this->intention, $data[$this->fieldName])) {
                 $form->addError(new FormError('The CSRF token is invalid. Please try to resubmit the form.'));
             }
-
-            unset($data[$this->fieldName]);
+            if (is_array($data))
+            {
+                unset($data[$this->fieldName]);
+            }
         }
 
         $event->setData($data);

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -196,6 +196,26 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
         $this->assertFalse($form->isValid());
     }
 
+    public function testFailIfRootAndCompoundAndBoundDataIsString()
+    {
+        $form = $this->factory
+            ->createBuilder('form', null, array(
+                'csrf_field_name' => 'csrf',
+                'csrf_provider' => $this->csrfProvider,
+                'intention' => '%INTENTION%',
+                'compound' => true,
+            ))
+            ->add('child', 'text')
+            ->getForm();
+
+        $form->bind('malformed request');
+
+        $this->assertSame(array('child' => null), $form->getData());
+
+        // Validate accordingly
+        $this->assertFalse($form->isValid());
+    }
+
     public function testDontValidateTokenIfCompoundButNoRoot()
     {
         $this->csrfProvider->expects($this->never())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |

Original PR : https://github.com/symfony/symfony/pull/7126

This PR includes a php unit test to reproduce the php fatal error.

$ phpunit src/Symfony/Component/Form/Tests/Extension/Csrf
PHPUnit 3.7.14 by Sebastian Bergmann.

..............PHP Fatal error:  Cannot unset string offsets in src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php on line 70
