### PR TITLE
[2.3] Update src/Symfony/Component/HttpFoundation/Request.php

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1649,6 +1649,7 @@ class Request
             'rdf'  => array('application/rdf+xml'),
             'atom' => array('application/atom+xml'),
             'rss'  => array('application/rss+xml'),
+            'form' => array('application/x-www-form-urlencoded'),
         );
     }
 


### PR DESCRIPTION
This makes `getContentType()` work when a regular form is submitted. It would return `"form"`
