### PR TITLE
Expanded fault-tolerance for unusual cookie dates

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -208,8 +208,8 @@ class Cookie
         }
 
         // attempt a fallback for unusual formatting
-        if (false !== $dateTimestamp = strtotime($dateValue)) {
-            return $dateTimestamp;
+	if (false !== $date = date_create($dateValue, new \DateTimeZone('GMT'))) {
+            return $date->getTimestamp();
         }
 
         throw new \InvalidArgumentException(sprintf('Could not parse date "%s".', $dateValue));

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -208,7 +208,7 @@ class Cookie
         }
 
         // attempt a fallback for unusual formatting
-	if (false !== $date = date_create($dateValue, new \DateTimeZone('GMT'))) {
+        if (false !== $date = date_create($dateValue, new \DateTimeZone('GMT'))) {
             return $date->getTimestamp();
         }
 

--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -30,6 +30,8 @@ class Cookie
         'D, d M Y H:i:s T',
         'D, d-M-y H:i:s T',
         'D, d-M-Y H:i:s T',
+        'D, d-m-y H:i:s T',
+        'D, d-m-Y H:i:s T',
         'D M j G:i:s Y',
         'D M d H:i:s Y T',
     );
@@ -203,6 +205,11 @@ class Cookie
             if (false !== $date = \DateTime::createFromFormat($dateFormat, $dateValue, new \DateTimeZone('GMT'))) {
                 return $date->getTimestamp();
             }
+        }
+
+        // attempt a fallback for unusual formatting
+        if (false !== $dateTimestamp = strtotime($dateValue)) {
+            return $dateTimestamp;
         }
 
         throw new \InvalidArgumentException(sprintf('Could not parse date "%s".', $dateValue));

--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -56,9 +56,12 @@ class CookieTest extends \PHPUnit_Framework_TestCase
         return array(
             array('foo=bar; expires=Fri, 31-Jul-2020 08:49:37 GMT'),
             array('foo=bar; expires=Fri, 31 Jul 2020 08:49:37 GMT'),
+            array('foo=bar; expires=Fri, 31-07-2020 08:49:37 GMT'),
+            array('foo=bar; expires=Fri, 31-07-20 08:49:37 GMT'),
             array('foo=bar; expires=Friday, 31-Jul-20 08:49:37 GMT'),
             array('foo=bar; expires=Fri Jul 31 08:49:37 2020'),
             array('foo=bar; expires=\'Fri Jul 31 08:49:37 2020\''),
+            array('foo=bar; expires=Friday July 31st 2020, 08:49:37 GMT'),
         );
     }
 
@@ -86,7 +89,7 @@ class CookieTest extends \PHPUnit_Framework_TestCase
     public function testFromStringThrowsAnExceptionIfCookieDateIsNotValid()
     {
         $this->setExpectedException('InvalidArgumentException');
-        Cookie::FromString('foo=bar; expires=foo');
+        Cookie::FromString('foo=bar; expires=Friday July 31st 2020, 08:49:37 GMT');
     }
 
     public function testFromStringThrowsAnExceptionIfUrlIsNotValid()

--- a/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieTest.php
@@ -89,7 +89,7 @@ class CookieTest extends \PHPUnit_Framework_TestCase
     public function testFromStringThrowsAnExceptionIfCookieDateIsNotValid()
     {
         $this->setExpectedException('InvalidArgumentException');
-        Cookie::FromString('foo=bar; expires=Friday July 31st 2020, 08:49:37 GMT');
+        Cookie::FromString('foo=bar; expires=Flursday July 31st 2020, 08:49:37 GMT');
     }
 
     public function testFromStringThrowsAnExceptionIfUrlIsNotValid()


### PR DESCRIPTION
Building on pull #1793, this resolves situations where the Cookie's date field uses a numeric month. Also, expanding on the 7 most typical formats we fall-back to date_create() before throwing an exception.
