### PR TITLE
[Console] fixed shell bug (#7068)

### DIFF
--- a/src/Symfony/Component/Console/Command/Command.php
+++ b/src/Symfony/Component/Console/Command/Command.php
@@ -564,7 +564,7 @@ class Command
     {
         if ($this->application && !$this->applicationDefinitionMerged) {
             $this->getSynopsis();
-            $this->mergeApplicationDefinition(false);
+            $this->mergeApplicationDefinition();
         }
 
         $messages = array(

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -494,6 +494,22 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('called'.PHP_EOL, $tester->getDisplay(), '->run() does not call interact() if -n is passed');
     }
 
+    public function testIssue7068()
+    {
+        $application = new Application();
+        $application->setAutoExit(false);
+        $application->setCatchExceptions(false);
+
+        $this->ensureStaticCommandHelp($application);
+        $tester = new ApplicationTester($application);
+
+        $tester->run(array('command' => 'list', '--help' => true), array('decorated' => false));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_run3.txt', $this->normalizeLineBreaks($tester->getDisplay()), '->run() displays the help if --help is passed');
+
+        $tester->run(array('command' => 'list'), array('decorated' => false));
+        $this->assertStringEqualsFile(self::$fixturesPath.'/application_run1.txt', $this->normalizeLineBreaks($tester->getDisplay()), '->run() displays the help if -h is passed');
+    }
+
     /**
      * @expectedException \LogicException
      * @dataProvider getAddingAlreadySetDefinitionElementData


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7068 |
| License | MIT |
| Doc PR |  |

When "<command> --help" is called first, the mergeApplicationDefinition merge only the options for <command> and set applicationDefinitionMerged = true.
The second time "<command>" is called, the arguments is not merged because the applicationDefinitionMerged has been already set.
