### PR TITLE
Defined stable version point of Doctrine.

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/composer.json
+++ b/src/Symfony/Bundle/FrameworkBundle/composer.json
@@ -26,7 +26,7 @@
         "symfony/stopwatch": ">=2.2,<2.4-dev",
         "symfony/templating": "~2.1",
         "symfony/translation": ">=2.2,<2.4-dev",
-        "doctrine/common": ">=2.2,<2.4-dev"
+        "doctrine/common": "~2.2"
     },
     "require-dev": {
         "symfony/finder": "~2.0",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -25,7 +25,7 @@
         "symfony/form": "~2.0",
         "symfony/routing": ">=2.2,<2.4-dev",
         "symfony/validator": ">=2.2,<2.4-dev",
-        "doctrine/common": ">=2.2,<2.4-dev",
+        "doctrine/common": "~2.2",
         "doctrine/dbal": "~2.2",
         "psr/log": "~1.0"
     },


### PR DESCRIPTION
As per @stof comments, here is the stable minimum version definition for Doctrine libraries on master.

```
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
```

PS: Broken tests are totally unrelated with this patch. It seems there's an issue with Locale component that fails Brazilian assertions... what a lucky situation. =) Will fix the broken tests of Locale in a few.
