### PR TITLE
Update src/Symfony/Component/HttpKernel/Kernel.php

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -513,7 +513,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
             foreach ($hierarchy as $bundle) {
                 $this->bundleMap[$bundle] = $bundleMap;
-                array_pop($bundleMap);
+                array_shift($bundleMap);
             }
         }
 


### PR DESCRIPTION
The bundleMap is not filled properly when dealing with chained inheriting bundles
( 'A' parent of 'B' parent of 'C' ) 
Using array_pop, the lowest child is deleted which is wrong. We want to delete the uppermost parent here.
Now the bundleMap is filled wrong for chained inheriting bundles (or what is the right name for A inheriting from B inheriting from C)

The problem occurs when calling the getBundle method from Kernel.php
, only giving the name parameter. The funtion will return the first element of $this->bundleMap[$name]
When projects have chained inheriting bundles, this gives wrong results

I detected this bug using the translation:update command

Kind regards
Hans Stevens
