### PR TITLE
[2.3] [HttpCache] better decoupling between HttpCache and Store

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -602,7 +602,6 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         if ($request->isMethod('HEAD') || 304 === $response->getStatusCode()) {
             $response->setContent(null);
             $response->headers->remove('X-Body-Eval');
-            $response->headers->remove('X-Body-File');
 
             return;
         }
@@ -610,24 +609,14 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
         if ($response->headers->has('X-Body-Eval')) {
             ob_start();
 
-            if ($response->headers->has('X-Body-File')) {
-                include $response->headers->get('X-Body-File');
-            } else {
-                eval('; ?>'.$response->getContent().'<?php ;');
-            }
+            eval('; ?>'.$response->getContent().'<?php ;');
 
             $response->setContent(ob_get_clean());
             $response->headers->remove('X-Body-Eval');
             if (!$response->headers->has('Transfer-Encoding')) {
                 $response->headers->set('Content-Length', strlen($response->getContent()));
             }
-        } elseif ($response->headers->has('X-Body-File')) {
-            $response->setContent(file_get_contents($response->headers->get('X-Body-File')));
-        } else {
-            return;
         }
-
-        $response->headers->remove('X-Body-File');
     }
 
     protected function processResponseBody(Request $request, Response $response)

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -137,7 +137,7 @@ class Store implements StoreInterface
         }
 
         list($req, $headers) = $match;
-        if (is_file($body = $this->getPath($headers['x-content-digest'][0]))) {
+        if ($body = $this->load($headers['x-content-digest'][0])) {
             return $this->restoreResponse($headers, $body);
         }
 
@@ -424,14 +424,10 @@ class Store implements StoreInterface
      *
      * @return Response
      */
-    private function restoreResponse($headers, $body = null)
+    private function restoreResponse($headers, $body = '')
     {
         $status = $headers['X-Status'][0];
         unset($headers['X-Status']);
-
-        if (null !== $body) {
-            $headers['X-Body-File'] = array($body);
-        }
 
         return new Response($body, $status, $headers);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpCache/StoreTest.php
@@ -130,14 +130,14 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $this->storeSimpleEntry();
         $response = $this->store->lookup($this->request);
 
-        $this->assertEquals($response->headers->all(), array_merge(array('content-length' => 4, 'x-body-file' => array($this->getStorePath($response->headers->get('X-Content-Digest')))), $this->response->headers->all()));
+        $this->assertEquals($response->headers->all(), array_merge(array('content-length' => 4), $this->response->headers->all()));
     }
 
     public function testRestoresResponseContentFromEntityStoreWithLookup()
     {
         $this->storeSimpleEntry();
         $response = $this->store->lookup($this->request);
-        $this->assertEquals($this->getStorePath('en'.sha1('test')), $response->getContent());
+        $this->assertEquals('test', $response->getContent());
     }
 
     public function testInvalidatesMetaAndEntityStoreEntriesWithInvalidate()
@@ -180,9 +180,9 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $res3 = new Response('test 3', 200, array('Vary' => 'Foo Bar'));
         $this->store->write($req3, $res3);
 
-        $this->assertEquals($this->getStorePath('en'.sha1('test 3')), $this->store->lookup($req3)->getContent());
-        $this->assertEquals($this->getStorePath('en'.sha1('test 2')), $this->store->lookup($req2)->getContent());
-        $this->assertEquals($this->getStorePath('en'.sha1('test 1')), $this->store->lookup($req1)->getContent());
+        $this->assertEquals('test 3', $this->store->lookup($req3)->getContent());
+        $this->assertEquals('test 2', $this->store->lookup($req2)->getContent());
+        $this->assertEquals('test 1', $this->store->lookup($req1)->getContent());
 
         $this->assertCount(3, $this->getStoreMetadata($key));
     }
@@ -192,17 +192,17 @@ class StoreTest extends \PHPUnit_Framework_TestCase
         $req1 = Request::create('/test', 'get', array(), array(), array(), array('HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'));
         $res1 = new Response('test 1', 200, array('Vary' => 'Foo Bar'));
         $key = $this->store->write($req1, $res1);
-        $this->assertEquals($this->getStorePath('en'.sha1('test 1')), $this->store->lookup($req1)->getContent());
+        $this->assertEquals('test 1', $this->store->lookup($req1)->getContent());
 
         $req2 = Request::create('/test', 'get', array(), array(), array(), array('HTTP_FOO' => 'Bling', 'HTTP_BAR' => 'Bam'));
         $res2 = new Response('test 2', 200, array('Vary' => 'Foo Bar'));
         $this->store->write($req2, $res2);
-        $this->assertEquals($this->getStorePath('en'.sha1('test 2')), $this->store->lookup($req2)->getContent());
+        $this->assertEquals('test 2', $this->store->lookup($req2)->getContent());
 
         $req3 = Request::create('/test', 'get', array(), array(), array(), array('HTTP_FOO' => 'Foo', 'HTTP_BAR' => 'Bar'));
         $res3 = new Response('test 3', 200, array('Vary' => 'Foo Bar'));
         $key = $this->store->write($req3, $res3);
-        $this->assertEquals($this->getStorePath('en'.sha1('test 3')), $this->store->lookup($req3)->getContent());
+        $this->assertEquals('test 3', $this->store->lookup($req3)->getContent());
 
         $this->assertCount(2, $this->getStoreMetadata($key));
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [yes] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |

When trying to implement a custom Store, I realized that currently HttpCache assumes the Store is storing data into files, and returns a custom `X-Body-File` header, then it handles the data fetching itself instead of relying on the Store.

For example here https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L614 or here https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php#L625.

This patch makes the store fetching the response content itself, leaving to HttpCache only the parsing part.

I prefer sending it to the master branch, and I suggest setting the HttpCache method in question (which is private) to protected for maintenance branches.
