### PR TITLE
added a DebuClassLoader::findFile() method to make the wrapping less invasive

### DIFF
--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -70,6 +70,18 @@ class DebugClassLoader
     }
 
     /**
+     * Finds a file by class name
+     *
+     * @param string $class A class name to resolve to file
+     *
+     * @return string|null
+     */
+    public function findFile($class)
+    {
+        return $this->classFinder->findFile($class);
+    }
+
+    /**
      * Loads the given class or interface.
      *
      * @param string $class The name of the class


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |

i have classified it as a bug fix, since due to the wrapping it can break assumptions about the loaded class loader, so implementing this method at least doesnt break the assumption that `findFile()` is available.

actually i think we should also introduced a loader interface to reduce the duct typing
