### PR TITLE
Webprofiler redis add select

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -199,7 +199,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
 
             $host = $matches[1] ?: $matches[2];
             $port = $matches[3];
-            $dbnum = isset($matches[4]) ? (int) $matches[4] : false;
+            $dbnum = !empty($matches[4]) ? intval($matches[4]) : -1;
 
             if (!extension_loaded('redis')) {
                 throw new \RuntimeException('RedisProfilerStorage requires that the redis extension is loaded.');
@@ -208,7 +208,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             $redis = new Redis;
             $redis->connect($host, $port);
             
-            if(false !== $dbnum) {
+            if(-1 < $dbnum) {
                 $redis->select($dbnum);
             }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -193,12 +193,13 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     protected function getRedis()
     {
         if (null === $this->redis) {
-            if (!preg_match('#^redis://(?(?=\[.*\])\[(.*)\]|(.*)):(.*)$#', $this->dsn, $matches)) {
-                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Redis with an invalid dsn "%s". The expected format is "redis://[host]:port".', $this->dsn));
+            if (!preg_match('#^redis://(?(?=\[.*\])\[(.*)\]|(.*)):(\d+)(?(?=/\d+)/(\d+))$#', $this->dsn, $matches)) {
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Redis with an invalid dsn "%s". The expected format is "redis://[host]:port[/db-number]".', $this->dsn));
             }
 
             $host = $matches[1] ?: $matches[2];
             $port = $matches[3];
+            $dbnum = isset($matches[4]) ? (int) $matches[4] : false;
 
             if (!extension_loaded('redis')) {
                 throw new \RuntimeException('RedisProfilerStorage requires that the redis extension is loaded.');
@@ -206,6 +207,10 @@ class RedisProfilerStorage implements ProfilerStorageInterface
 
             $redis = new Redis;
             $redis->connect($host, $port);
+            
+            if(false !== $dbnum) {
+                $redis->select($dbnum);
+            }
 
             $redis->setOption(self::REDIS_OPT_PREFIX, self::TOKEN_PREFIX);
 

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -238,4 +238,17 @@ class RedisMock
 
         return true;
     }
+    
+    public function select($dbnum)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+        
+        if(0 > $dbnum) {
+            return false;
+        }
+        
+        return true;   
+    }
 }


### PR DESCRIPTION
[HttpKernel] [Profiler] [RedisProfilerStorage] added select for a db-number/db-index to dsn-patttern

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets |  |
| License | MIT |

Usage with index/db-number = 7 :

``` xml
<!-- config_dev.yml -->

<symfony:profiler only-exceptions="false" dsn="redis://192.168.1.101:6380/7" lifetime="3600" />

```

``` yml
#config_dev.yml

framework:
...
    profiler:
    ...
        dsn: redis://127.0.0.1:6379/7

```
