### PR TITLE
RedisProfilerStorage wrong db-number/index-number selected

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -193,13 +193,13 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     protected function getRedis()
     {
         if (null === $this->redis) {
-            if (!preg_match('#^redis://(?(?=\[.*\])\[(.*)\]|(.*)):(\d+)(?(?=/\d+)/(\d+))$#', $this->dsn, $matches)) {
+            if (!preg_match('#^redis://(?(?=\[.*\])\[(.*)\]|(.*)):(\d+)(/(\d+))?$#', $this->dsn, $matches)) {
                 throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Redis with an invalid dsn "%s". The expected format is "redis://[host]:port[/db-number]".', $this->dsn));
             }
 
             $host = $matches[1] ?: $matches[2];
             $port = $matches[3];
-            $dbnum = !empty($matches[4]) ? intval($matches[4]) : -1;
+            $dbnum = !empty($matches[5]) ? intval($matches[5]) : -1;
 
             if (!extension_loaded('redis')) {
                 throw new \RuntimeException('RedisProfilerStorage requires that the redis extension is loaded.');

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -209,7 +209,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             $redis->connect($host, $port);
             
             // if a valid dbnumber is given select the redis index
-            if(-1 < $dbnum) {
+            if (-1 < $dbnum) {
                 $redis->select($dbnum);
             }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -199,7 +199,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
 
             $host = $matches[1] ?: $matches[2];
             $port = $matches[3];
-            $dbnum = isset($matches[4]) ? (int) $matches[4] : false;
+            $dbnum = !empty($matches[4]) ? intval($matches[4]) : -1;
 
             if (!extension_loaded('redis')) {
                 throw new \RuntimeException('RedisProfilerStorage requires that the redis extension is loaded.');
@@ -208,7 +208,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             $redis = new Redis;
             $redis->connect($host, $port);
             
-            if(false !== $dbnum) {
+            if(-1 < $dbnum) {
                 $redis->select($dbnum);
             }
 

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -208,6 +208,7 @@ class RedisProfilerStorage implements ProfilerStorageInterface
             $redis = new Redis;
             $redis->connect($host, $port);
             
+            // if a valid dbnumber is given select the redis index
             if(-1 < $dbnum) {
                 $redis->select($dbnum);
             }

--- a/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/RedisProfilerStorage.php
@@ -193,12 +193,13 @@ class RedisProfilerStorage implements ProfilerStorageInterface
     protected function getRedis()
     {
         if (null === $this->redis) {
-            if (!preg_match('#^redis://(?(?=\[.*\])\[(.*)\]|(.*)):(.*)$#', $this->dsn, $matches)) {
-                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Redis with an invalid dsn "%s". The expected format is "redis://[host]:port".', $this->dsn));
+            if (!preg_match('#^redis://(?(?=\[.*\])\[(.*)\]|(.*)):(\d+)(?(?=/\d+)/(\d+))$#', $this->dsn, $matches)) {
+                throw new \RuntimeException(sprintf('Please check your configuration. You are trying to use Redis with an invalid dsn "%s". The expected format is "redis://[host]:port[/db-number]".', $this->dsn));
             }
 
             $host = $matches[1] ?: $matches[2];
             $port = $matches[3];
+            $dbnum = isset($matches[4]) ? (int) $matches[4] : false;
 
             if (!extension_loaded('redis')) {
                 throw new \RuntimeException('RedisProfilerStorage requires that the redis extension is loaded.');
@@ -206,6 +207,10 @@ class RedisProfilerStorage implements ProfilerStorageInterface
 
             $redis = new Redis;
             $redis->connect($host, $port);
+            
+            if(false !== $dbnum) {
+                $redis->select($dbnum);
+            }
 
             $redis->setOption(self::REDIS_OPT_PREFIX, self::TOKEN_PREFIX);
 

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -245,7 +245,7 @@ class RedisMock
             return false;
         }
         
-        if(0 > $dbnum) {
+        if (0 > $dbnum) {
             return false;
         }
         

--- a/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Profiler/Mock/RedisMock.php
@@ -238,4 +238,17 @@ class RedisMock
 
         return true;
     }
+    
+    public function select($dbnum)
+    {
+        if (!$this->connected) {
+            return false;
+        }
+        
+        if(0 > $dbnum) {
+            return false;
+        }
+        
+        return true;   
+    }
 }


### PR DESCRIPTION
bug: in the webprofiler the wrong database (0) is selected when storage should not go to index 0. on redis connect the default behaviour is to select index/database number 0, but it is necessary to select a special index/database.
see: http://rediscookbook.org/multiple_databases.html

[HttpKernel] [Profiler] [RedisProfilerStorage] added select for a db-number/db-index to dsn-patttern

| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets |  |
| License | MIT |

Usage with index/db-number = 7 :

``` xml
<!-- config_dev.xml -->

<symfony:profiler only-exceptions="false" dsn="redis://127.0.0.1:6379/7" lifetime="3600" />

```

``` yml
#config_dev.yml

framework:
...
    profiler:
    ...
        dsn: redis://127.0.0.1:6379/7

```
