### PR TITLE
[2.3] [DomCrawler] adds schema relative URL support to link

### DIFF
--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -120,6 +120,11 @@ class Link
             return $baseUri.$uri;
         }
 
+        // absolute URL with relative schema
+        if (0 === strpos($uri, '//')) {
+            return preg_replace('#^([^/]*)//.*$#', '$1', $this->currentUri).$uri;
+        }
+
         // absolute path
         if ('/' === $uri[0]) {
             return preg_replace('#^(.*?//[^/]+)(?:\/.*)?$#', '$1', $this->currentUri).$uri;

--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -94,6 +94,10 @@ class LinkTest extends \PHPUnit_Framework_TestCase
 
             array('http://login.foo.com/foo', 'http://localhost/bar/', 'http://login.foo.com/foo'),
 
+            // tests schema relative URL (issue #7169)
+            array('//login.foo.com/foo', 'http://localhost/bar/', 'http://login.foo.com/foo'),
+            array('//login.foo.com/foo', 'https://localhost/bar/', 'https://login.foo.com/foo'),
+
             array('?foo=2', 'http://localhost?foo=1', 'http://localhost?foo=2'),
             array('?foo=2', 'http://localhost/?foo=1', 'http://localhost/?foo=2'),
             array('?foo=2', 'http://localhost/bar?foo=1', 'http://localhost/bar?foo=2'),


### PR DESCRIPTION
Adds support for `//relative/schema` URLs to `DomCrawler` links.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7169 |
