### PR TITLE
[HttpKernel] Fixes AppCache + ESI + Stopwatch problem

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -388,7 +388,14 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
                 break;
             case KernelEvents::TERMINATE:
                 $token = $event->getResponse()->headers->get('X-Debug-Token');
-                $this->stopwatch->openSection($token);
+                // There is a very special case when using builtin AppCache class as kernel wrapper, in the case
+                // of an ESI request leading to a `stale` response [B]  inside a `fresh` cached response [A].
+                // In this case, `$token` contains the [B] debug token, but the  open `stopwatch` section ID
+                // is equal to the [A] debug token. Trying to reopen section with the [B] token throws an exception
+                // which must be caught.
+                try {
+                    $this->stopwatch->openSection($token);
+                } catch (\LogicException $e) {}
                 break;
         }
     }
@@ -410,7 +417,11 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
                 break;
             case KernelEvents::TERMINATE:
                 $token = $event->getResponse()->headers->get('X-Debug-Token');
-                $this->stopwatch->stopSection($token);
+                // In the special case described in th `preDispatch` method above, the `$token` section
+                // does not exist, then closing it throws an exception which must be caught.
+                try {
+                    $this->stopwatch->stopSection($token);
+                } catch (\LogicException $e) {}
                 // The children profiles have been updated by the previous 'kernel.response'
                 // event. Only the root profile need to be updated with the 'kernel.terminate'
                 // timing informations.

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -417,7 +417,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
                 break;
             case KernelEvents::TERMINATE:
                 $token = $event->getResponse()->headers->get('X-Debug-Token');
-                // In the special case described in th `preDispatch` method above, the `$token` section
+                // In the special case described in the `preDispatch` method above, the `$token` section
                 // does not exist, then closing it throws an exception which must be caught.
                 try {
                     $this->stopwatch->stopSection($token);


### PR DESCRIPTION
There is a very special case when using builtin AppCache class as kernel wrapper, in the case of an ESI request leading to a `stale` response [B]  inside a `fresh` cached response [A]. In this case, `$token` contains the [B] debug token, but the  open `stopwatch` section ID is equal to the [A] debug token. Trying to reopen section with the [B] token throws an exception which must be caught.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| Bug mask? | no, does @vicb agree? |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6227, #6230 |

I tried to find a better solution than just wrapping thrown exceptions with `try/catch`, but IMHO the #6230 solution from @lsmith77 was in fine the best one. I just added some comments in the code to avoid the WTF reactions while reading it.
