### PR TITLE
[HttpFoundation] Fixed messed up headers

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
+++ b/src/Symfony/Component/HttpFoundation/ResponseHeaderBag.php
@@ -67,6 +67,8 @@ class ResponseHeaderBag extends HeaderBag
             $cookies .= 'Set-Cookie: '.$cookie."\r\n";
         }
 
+        ksort($this->headerNames);
+
         return parent::__toString().$cookies;
     }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseHeaderBagTest.php
@@ -235,6 +235,20 @@ class ResponseHeaderBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $headers->makeDisposition($disposition, $filename, $filenameFallback));
     }
 
+    public function testToStringDoesntMessUpHeaders()
+    {
+        $headers = new ResponseHeaderBag();
+
+        $headers->set('Location', 'http://www.symfony.com');
+        $headers->set('Content-type', 'text/html');
+
+        (string) $headers;
+
+        $allHeaders = $headers->allPreserveCase();
+        $this->assertEquals(array('http://www.symfony.com'), $allHeaders['Location']);
+        $this->assertEquals(array('text/html'), $allHeaders['Content-type']);
+    }
+
     public function provideMakeDisposition()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

I ran into this when somewhere in our code the Response object was cast into a string. After that, when send()'ing the Response, the headers would be all mixed up. This is because the __toString in HeaderBag ksorts the headers, while the __toString in ResponseHeaderBag doesn't ksort the corresponding headerNames. This patch ksorts that one as well.

allPreserveCase() is new to 2.2, so this bug doesn't seem to affect earlier versions.

To be exact, this is where it got introduced: https://github.com/symfony/symfony/commit/63a228c45613bb
