### PR TITLE
[Finder] Adds expandable globs support to shell adapters

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -154,6 +154,11 @@ abstract class AbstractFindAdapter extends AbstractAdapter
         foreach ($names as $i => $name) {
             $expr = Expression::create($name);
 
+            // Find does not support expandable globs ("*.{a,b}" syntax).
+            if ($expr->isGlob() && $expr->getGlob()->isExpandable()) {
+                $expr = Expression::create($expr->getGlob()->toRegex(false));
+            }
+
             // Fixes 'not search' and 'full path matching' regex problems.
             // - Jokers '.' are replaced by [^/].
             // - We add '[^/]*' before and after regex (if no ^|$ flags are present).
@@ -196,6 +201,11 @@ abstract class AbstractFindAdapter extends AbstractAdapter
 
         foreach ($paths as $i => $path) {
             $expr = Expression::create($path);
+
+            // Find does not support expandable globs ("*.{a,b}" syntax).
+            if ($expr->isGlob() && $expr->getGlob()->isExpandable()) {
+                $expr = Expression::create($expr->getGlob()->toRegex(false));
+            }
 
             // Fixes 'not search' regex problems.
             if ($expr->isRegex()) {

--- a/src/Symfony/Component/Finder/Expression/Expression.php
+++ b/src/Symfony/Component/Finder/Expression/Expression.php
@@ -123,6 +123,20 @@ class Expression implements ValueInterface
     }
 
     /**
+     * @throws \LogicException
+     *
+     * @return Glob
+     */
+    public function getGlob()
+    {
+        if (self::TYPE_GLOB !== $this->value->getType()) {
+            throw new \LogicException('Regex cant be transformed to glob.');
+        }
+
+        return $this->value;
+    }
+
+    /**
      * @return Regex
      */
     public function getRegex()

--- a/src/Symfony/Component/Finder/Expression/Glob.php
+++ b/src/Symfony/Component/Finder/Expression/Glob.php
@@ -82,6 +82,17 @@ class Glob implements ValueInterface
     }
 
     /**
+     * Tests if glob is expandable ("*.{a,b}" syntax).
+     *
+     * @return bool
+     */
+    public function isExpandable()
+    {
+        return false !== strpos($this->pattern, '{')
+            && false !== strpos($this->pattern, '}');
+    }
+
+    /**
      * @param bool $strictLeadingDot
      * @param bool $strictWildcardSlash
      *

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -106,6 +106,10 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder = $this->buildFinder($adapter);
         $finder->name('~\\.php$~i');
         $this->assertIterator($this->toAbsolute(array('test.php')), $finder->in(self::$tmpDir)->getIterator());
+
+        $finder = $this->buildFinder($adapter);
+        $finder->name('test.p{hp,y}');
+        $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->in(self::$tmpDir)->getIterator());
     }
 
     /**
@@ -127,6 +131,12 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder->name('test.py');
         $finder->notName('*.php');
         $finder->notName('*.py');
+        $this->assertIterator(array(), $finder->in(self::$tmpDir)->getIterator());
+
+        $finder = $this->buildFinder($adapter);
+        $finder->name('test.ph*');
+        $finder->name('test.py');
+        $finder->notName('*.p{hp,y}');
         $this->assertIterator(array(), $finder->in(self::$tmpDir)->getIterator());
     }
 


### PR DESCRIPTION
As expandable globs, i mean glob following `*.{a,b}` syntax.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6586 |
