### PR TITLE
[Finder] Unified tests

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -17,14 +17,6 @@ use Symfony\Component\Finder\Tests\FakeAdapter;
 
 class FinderTest extends Iterator\RealIteratorTestCase
 {
-    protected static $tmpDir;
-
-    public static function setUpBeforeClass()
-    {
-        parent::setUpBeforeClass();
-
-        self::$tmpDir = realpath(sys_get_temp_dir().'/symfony2_finder');
-    }
 
     public function testCreate()
     {
@@ -501,26 +493,6 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         $finder = Finder::create()->files();
         count($finder);
-    }
-
-    protected function toAbsolute($files)
-    {
-        $f = array();
-        foreach ($files as $file) {
-            $f[] = self::$tmpDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $file);
-        }
-
-        return $f;
-    }
-
-    protected function toAbsoluteFixtures($files)
-    {
-        $f = array();
-        foreach ($files as $file) {
-            $f[] = __DIR__.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$file;
-        }
-
-        return $f;
     }
 
     /**

--- a/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DateRangeFilterIteratorTest.php
@@ -30,10 +30,45 @@ class DateRangeFilterIteratorTest extends RealIteratorTestCase
 
     public function getAcceptData()
     {
+        $since20YearsAgo = array(
+            '.git',
+            'test.py',
+            'foo',
+            'foo/bar.tmp',
+            'test.php',
+            'toto',
+            '.bar',
+            '.foo',
+            '.foo/.bar',
+            'foo bar',
+            '.foo/bar',
+        );
+
+        $since2MonthsAgo = array(
+            '.git',
+            'test.py',
+            'foo',
+            'toto',
+            '.bar',
+            '.foo',
+            '.foo/.bar',
+            'foo bar',
+            '.foo/bar',
+        );
+
+        $untilLastMonth = array(
+            '.git',
+            'foo',
+            'foo/bar.tmp',
+            'test.php',
+            'toto',
+            '.foo',
+        );
+
         return array(
-            array(array(new DateComparator('since 20 years ago')), array(sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/test.py', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/foo/bar.tmp', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/toto', sys_get_temp_dir().'/symfony2_finder/.bar', sys_get_temp_dir().'/symfony2_finder/.foo', sys_get_temp_dir().'/symfony2_finder/.foo/.bar', sys_get_temp_dir().'/symfony2_finder/foo bar', sys_get_temp_dir().'/symfony2_finder/.foo/bar')),
-            array(array(new DateComparator('since 2 months ago')), array(sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/test.py', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/toto', sys_get_temp_dir().'/symfony2_finder/.bar', sys_get_temp_dir().'/symfony2_finder/.foo', sys_get_temp_dir().'/symfony2_finder/.foo/.bar', sys_get_temp_dir().'/symfony2_finder/foo bar', sys_get_temp_dir().'/symfony2_finder/.foo/bar')),
-            array(array(new DateComparator('until last month')), array(sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/foo/bar.tmp', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/toto', sys_get_temp_dir().'/symfony2_finder/.foo')),
+            array(array(new DateComparator('since 20 years ago')), $this->toAbsolute($since20YearsAgo)),
+            array(array(new DateComparator('since 2 months ago')), $this->toAbsolute($since2MonthsAgo)),
+            array(array(new DateComparator('until last month')), $this->toAbsolute($untilLastMonth)),
         );
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/DepthRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DepthRangeFilterIteratorTest.php
@@ -20,7 +20,7 @@ class DepthRangeFilterIteratorTest extends RealIteratorTestCase
      */
     public function testAccept($minDepth, $maxDepth, $expected)
     {
-        $inner = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->getAbsolutePath(''), \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
+        $inner = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->toAbsolute(), \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
 
         $iterator = new DepthRangeFilterIterator($inner, $minDepth, $maxDepth);
 
@@ -32,17 +32,50 @@ class DepthRangeFilterIteratorTest extends RealIteratorTestCase
 
     public function getAcceptData()
     {
+        $lessThan1 = array(
+            '.git',
+            'test.py',
+            'foo',
+            'test.php',
+            'toto',
+            '.foo',
+            '.bar',
+            'foo bar',
+        );
+
+        $lessThanOrEqualTo1 = array(
+            '.git',
+            'test.py',
+            'foo',
+            'foo/bar.tmp',
+            'test.php',
+            'toto',
+            '.foo',
+            '.foo/.bar',
+            '.bar',
+            'foo bar',
+            '.foo/bar',
+        );
+
+        $graterThanOrEqualTo1 = array(
+            'foo/bar.tmp',
+            '.foo/.bar',
+            '.foo/bar',
+        );
+
+        $equalTo1 = array(
+            'foo/bar.tmp',
+            '.foo/.bar',
+            '.foo/bar',
+        );
+
         return array(
-            array(0, 0, array($this->getAbsolutePath('/.git'), $this->getAbsolutePath('/test.py'), $this->getAbsolutePath('/foo'), $this->getAbsolutePath('/test.php'), $this->getAbsolutePath('/toto'), $this->getAbsolutePath('/.foo'), $this->getAbsolutePath('/.bar'), $this->getAbsolutePath('/foo bar'))),
-            array(0, 1, array($this->getAbsolutePath('/.git'), $this->getAbsolutePath('/test.py'), $this->getAbsolutePath('/foo'), $this->getAbsolutePath('/foo/bar.tmp'), $this->getAbsolutePath('/test.php'), $this->getAbsolutePath('/toto'), $this->getAbsolutePath('/.foo'), $this->getAbsolutePath('/.foo/.bar'), $this->getAbsolutePath('/.bar'), $this->getAbsolutePath('/foo bar'), $this->getAbsolutePath('/.foo/bar'))),
+            array(0, 0, $this->toAbsolute($lessThan1)),
+            array(0, 1, $this->toAbsolute($lessThanOrEqualTo1)),
             array(2, INF, array()),
-            array(1, INF, array($this->getAbsolutePath('/foo/bar.tmp'), $this->getAbsolutePath('/.foo/.bar'), $this->getAbsolutePath('/.foo/bar'))),
-            array(1, 1, array($this->getAbsolutePath('/foo/bar.tmp'), $this->getAbsolutePath('/.foo/.bar'), $this->getAbsolutePath('/.foo/bar'))),
+            array(1, INF, $this->toAbsolute($graterThanOrEqualTo1)),
+            array(1, 1, $this->toAbsolute($equalTo1)),
         );
     }
 
-    protected function getAbsolutePath($path)
-    {
-        return sys_get_temp_dir().'/symfony2_finder'.str_replace('/', DIRECTORY_SEPARATOR, $path);
-    }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/ExcludeDirectoryFilterIteratorTest.php
@@ -21,7 +21,7 @@ class ExcludeDirectoryFilterIteratorTest extends RealIteratorTestCase
      */
     public function testAccept($directories, $expected)
     {
-        $inner = new \RecursiveIteratorIterator(new RecursiveDirectoryIterator(sys_get_temp_dir().'/symfony2_finder', \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
+        $inner = new \RecursiveIteratorIterator(new RecursiveDirectoryIterator($this->toAbsolute(), \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
 
         $iterator = new ExcludeDirectoryFilterIterator($inner, $directories);
 
@@ -30,33 +30,36 @@ class ExcludeDirectoryFilterIteratorTest extends RealIteratorTestCase
 
     public function getAcceptData()
     {
-        $tmpDir = sys_get_temp_dir().'/symfony2_finder';
+        $foo = array(
+            '.bar',
+            '.foo',
+            '.foo/.bar',
+            '.foo/bar',
+            '.git',
+            'test.py',
+            'test.php',
+            'toto',
+            'foo bar'
+        );
+
+        $fo = array(
+            '.bar',
+            '.foo',
+            '.foo/.bar',
+            '.foo/bar',
+            '.git',
+            'test.py',
+            'foo',
+            'foo/bar.tmp',
+            'test.php',
+            'toto',
+            'foo bar'
+        );
 
         return array(
-            array(array('foo'), array(
-                $tmpDir.DIRECTORY_SEPARATOR.'.bar',
-                $tmpDir.DIRECTORY_SEPARATOR.'.foo',
-                $tmpDir.DIRECTORY_SEPARATOR.'.foo'.DIRECTORY_SEPARATOR.'.bar',
-                $tmpDir.DIRECTORY_SEPARATOR.'.foo'.DIRECTORY_SEPARATOR.'bar',
-                $tmpDir.DIRECTORY_SEPARATOR.'.git',
-                $tmpDir.DIRECTORY_SEPARATOR.'test.py',
-                $tmpDir.DIRECTORY_SEPARATOR.'test.php',
-                $tmpDir.DIRECTORY_SEPARATOR.'toto',
-                $tmpDir.DIRECTORY_SEPARATOR.'foo bar',
-            )),
-            array(array('fo'), array(
-                $tmpDir.DIRECTORY_SEPARATOR.'.bar',
-                $tmpDir.DIRECTORY_SEPARATOR.'.foo',
-                $tmpDir.DIRECTORY_SEPARATOR.'.foo'.DIRECTORY_SEPARATOR.'.bar',
-                $tmpDir.DIRECTORY_SEPARATOR.'.foo'.DIRECTORY_SEPARATOR.'bar',
-                $tmpDir.DIRECTORY_SEPARATOR.'.git',
-                $tmpDir.DIRECTORY_SEPARATOR.'test.py',
-                $tmpDir.DIRECTORY_SEPARATOR.'foo',
-                $tmpDir.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'bar.tmp',
-                $tmpDir.DIRECTORY_SEPARATOR.'test.php',
-                $tmpDir.DIRECTORY_SEPARATOR.'toto',
-                $tmpDir.DIRECTORY_SEPARATOR.'foo bar',
-            )),
+            array(array('foo'), $this->toAbsolute($foo)),
+            array(array('fo'), $this->toAbsolute($fo)),
         );
     }
+
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FileTypeFilterIteratorTest.php
@@ -29,9 +29,26 @@ class FileTypeFilterIteratorTest extends RealIteratorTestCase
 
     public function getAcceptData()
     {
+        $onlyFiles = array(
+            'test.py',
+            'foo/bar.tmp',
+            'test.php',
+            '.bar',
+            '.foo/.bar',
+            '.foo/bar',
+            'foo bar',
+        );
+
+        $onlyDirectories = array(
+            '.git',
+            'foo',
+            'toto',
+            '.foo',
+        );
+
         return array(
-            array(FileTypeFilterIterator::ONLY_FILES, array(sys_get_temp_dir().'/symfony2_finder/test.py', sys_get_temp_dir().'/symfony2_finder/foo/bar.tmp', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/.bar', sys_get_temp_dir().'/symfony2_finder/.foo/.bar', sys_get_temp_dir().'/symfony2_finder/foo bar', sys_get_temp_dir().'/symfony2_finder/.foo/bar')),
-            array(FileTypeFilterIterator::ONLY_DIRECTORIES, array(sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/toto', sys_get_temp_dir().'/symfony2_finder/.foo')),
+            array(FileTypeFilterIterator::ONLY_FILES, $this->toAbsolute($onlyFiles)),
+            array(FileTypeFilterIterator::ONLY_DIRECTORIES, $this->toAbsolute($onlyDirectories)),
         );
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/FilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/FilterIteratorTest.php
@@ -18,7 +18,7 @@ class FilterIteratorTest extends RealIteratorTestCase
 {
     public function testFilterFilesystemIterators()
     {
-        $i = new \FilesystemIterator(sys_get_temp_dir().'/symfony2_finder');
+        $i = new \FilesystemIterator($this->toAbsolute());
 
         // it is expected that there are test.py test.php in the tmpDir
         $i = $this->getMockForAbstractClass('Symfony\Component\Finder\Iterator\FilterIterator', array($i));

--- a/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/RealIteratorTestCase.php
@@ -13,54 +13,96 @@ namespace Symfony\Component\Finder\Tests\Iterator;
 
 abstract class RealIteratorTestCase extends IteratorTestCase
 {
+
+    protected static $tmpDir;
     protected static $files;
 
     public static function setUpBeforeClass()
     {
-        $tmpDir = sys_get_temp_dir().'/symfony2_finder';
+        self::$tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'symfony2_finder';
+
         self::$files = array(
-            $tmpDir.'/.git/',
-            $tmpDir.'/.foo/',
-            $tmpDir.'/.foo/.bar',
-            $tmpDir.'/.foo/bar',
-            $tmpDir.'/.bar',
-            $tmpDir.'/test.py',
-            $tmpDir.'/foo/',
-            $tmpDir.'/foo/bar.tmp',
-            $tmpDir.'/test.php',
-            $tmpDir.'/toto/',
-            $tmpDir.'/foo bar',
+            '.git/',
+            '.foo/',
+            '.foo/.bar',
+            '.foo/bar',
+            '.bar',
+            'test.py',
+            'foo/',
+            'foo/bar.tmp',
+            'test.php',
+            'toto/',
+            'foo bar'
         );
 
-        if (is_dir($tmpDir)) {
+        self::$files = self::toAbsolute(self::$files);
+
+        if (is_dir(self::$tmpDir)) {
             self::tearDownAfterClass();
         } else {
-            mkdir($tmpDir);
+            mkdir(self::$tmpDir);
         }
 
         foreach (self::$files as $file) {
-            if ('/' === $file[strlen($file) - 1]) {
+            if (DIRECTORY_SEPARATOR === $file[strlen($file) - 1]) {
                 mkdir($file);
             } else {
                 touch($file);
             }
         }
 
-        file_put_contents($tmpDir.'/test.php', str_repeat(' ', 800));
-        file_put_contents($tmpDir.'/test.py', str_repeat(' ', 2000));
+        file_put_contents(self::toAbsolute('test.php'), str_repeat(' ', 800));
+        file_put_contents(self::toAbsolute('test.py'), str_repeat(' ', 2000));
 
-        touch($tmpDir.'/foo/bar.tmp', strtotime('2005-10-15'));
-        touch($tmpDir.'/test.php', strtotime('2005-10-15'));
+        touch(self::toAbsolute('foo/bar.tmp'), strtotime('2005-10-15'));
+        touch(self::toAbsolute('test.php'), strtotime('2005-10-15'));
     }
 
     public static function tearDownAfterClass()
     {
         foreach (array_reverse(self::$files) as $file) {
-            if ('/' === $file[strlen($file) - 1]) {
+            if (DIRECTORY_SEPARATOR === $file[strlen($file) - 1]) {
                 @rmdir($file);
             } else {
                 @unlink($file);
             }
         }
     }
+
+    protected static function toAbsolute($files = null)
+    {
+        /*
+         * Without the call to setUpBeforeClass() property can be null.
+         */
+        if (!self::$tmpDir) {
+            self::$tmpDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'symfony2_finder';
+        }
+
+        if (is_array($files)) {
+            $f = array();
+            foreach ($files as $file) {
+                $f[] = self::$tmpDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $file);
+            }
+
+            return $f;
+        }
+
+        if (is_string($files)) {
+
+            return self::$tmpDir . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $files);
+        }
+
+        return self::$tmpDir;
+    }
+
+    protected static function toAbsoluteFixtures($files)
+    {
+        $f = array();
+        foreach ($files as $file) {
+            $f[] = realpath(__DIR__.DIRECTORY_SEPARATOR.'..'.DIRECTORY_SEPARATOR.'Fixtures'.DIRECTORY_SEPARATOR.$file);
+        }
+
+        return $f;
+    }
+
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/SizeRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SizeRangeFilterIteratorTest.php
@@ -30,8 +30,16 @@ class SizeRangeFilterIteratorTest extends RealIteratorTestCase
 
     public function getAcceptData()
     {
+        $lessThan1KGreaterThan05K = array(
+            '.foo',
+            '.git',
+            'foo',
+            'test.php',
+            'toto',
+        );
+
         return array(
-            array(array(new NumberComparator('< 1K'), new NumberComparator('> 0.5K')), array(sys_get_temp_dir().'/symfony2_finder/.foo', sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/toto')),
+            array(array(new NumberComparator('< 1K'), new NumberComparator('> 0.5K')), $this->toAbsolute($lessThan1KGreaterThan05K)),
         );
     }
 }

--- a/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SortableIteratorTest.php
@@ -39,10 +39,53 @@ class SortableIteratorTest extends RealIteratorTestCase
 
     public function getAcceptData()
     {
+
+        $sortByName = array(
+            '.bar',
+            '.foo',
+            '.foo/.bar',
+            '.foo/bar',
+            '.git',
+            'foo',
+            'foo bar',
+            'foo/bar.tmp',
+            'test.php',
+            'test.py',
+            'toto',
+        );
+
+        $sortByType = array(
+            '.foo',
+            '.git',
+            'foo',
+            'toto',
+            '.bar',
+            '.foo/.bar',
+            '.foo/bar',
+            'foo bar',
+            'foo/bar.tmp',
+            'test.php',
+            'test.py',
+        );
+
+        $customComparison = array(
+            '.bar',
+            '.foo',
+            '.foo/.bar',
+            '.foo/bar',
+            '.git',
+            'foo',
+            'foo bar',
+            'foo/bar.tmp',
+            'test.php',
+            'test.py',
+            'toto',
+        );
+
         return array(
-            array(SortableIterator::SORT_BY_NAME, array(sys_get_temp_dir().'/symfony2_finder/.bar', sys_get_temp_dir().'/symfony2_finder/.foo', sys_get_temp_dir().'/symfony2_finder/.foo/.bar', sys_get_temp_dir().'/symfony2_finder/.foo/bar', sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/foo bar', sys_get_temp_dir().'/symfony2_finder/foo/bar.tmp', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/test.py', sys_get_temp_dir().'/symfony2_finder/toto')),
-            array(SortableIterator::SORT_BY_TYPE, array(sys_get_temp_dir().'/symfony2_finder/.foo', sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/toto', sys_get_temp_dir().'/symfony2_finder/.bar', sys_get_temp_dir().'/symfony2_finder/.foo/.bar', sys_get_temp_dir().'/symfony2_finder/.foo/bar', sys_get_temp_dir().'/symfony2_finder/foo bar', sys_get_temp_dir().'/symfony2_finder/foo/bar.tmp', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/test.py')),
-            array(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealpath(), $b->getRealpath()); }, array(sys_get_temp_dir().'/symfony2_finder/.bar', sys_get_temp_dir().'/symfony2_finder/.foo', sys_get_temp_dir().'/symfony2_finder/.foo/.bar', sys_get_temp_dir().'/symfony2_finder/.foo/bar', sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/foo bar', sys_get_temp_dir().'/symfony2_finder/foo/bar.tmp', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/test.py', sys_get_temp_dir().'/symfony2_finder/toto')),
+            array(SortableIterator::SORT_BY_NAME, $this->toAbsolute($sortByName)),
+            array(SortableIterator::SORT_BY_TYPE, $this->toAbsolute($sortByType)),
+            array(function (\SplFileInfo $a, \SplFileInfo $b) { return strcmp($a->getRealpath(), $b->getRealpath()); }, $this->toAbsolute($customComparison)),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Tests for `Finder` are very difficult to read because they contain calls to:

```
sys_get_temp_dir() . '/symfony2_finder/'
```

This improved version simplifies adding and removing new dirs and files.
