### PR TITLE
[HttpKernel] Fix for getBundle function, not returning the right bundle when there is bundle inheritance

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -460,7 +460,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      * Initializes the data structures related to the bundle management.
      *
      *  - the bundles property maps a bundle name to the bundle instance,
-     *  - the bundleMap property maps a bundle name to the bundle inheritance hierarchy (most derived bundle first).
+     *  - the bundleMap property maps a bundle name to the bundle inheritance hierarchy (parents bundles first).
      *
      * @throws \LogicException if two bundles share a common name
      * @throws \LogicException if a bundle tries to extend a non-registered bundle
@@ -498,7 +498,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         if (count($diff = array_values(array_diff(array_keys($directChildren), array_keys($this->bundles))))) {
             throw new \LogicException(sprintf('Bundle "%s" extends bundle "%s", which is not registered.', $directChildren[$diff[0]], $diff[0]));
         }
-
+		
         // inheritance
         $this->bundleMap = array();
         foreach ($topMostBundles as $name => $bundle) {
@@ -507,13 +507,13 @@ abstract class Kernel implements KernelInterface, TerminableInterface
 
             while (isset($directChildren[$name])) {
                 $name = $directChildren[$name];
-                array_unshift($bundleMap, $this->bundles[$name]);
+                array_push($bundleMap, $this->bundles[$name]);
                 $hierarchy[] = $name;
             }
 
             foreach ($hierarchy as $bundle) {
                 $this->bundleMap[$bundle] = $bundleMap;
-                array_pop($bundleMap);
+                array_shift($bundleMap);
             }
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/KernelForTest.php
@@ -20,6 +20,11 @@ class KernelForTest extends Kernel
     {
         return $this->bundleMap;
     }
+	
+	public function getBundleByName($name)
+	{
+		return parent::getBundle($name);
+	}
 
     public function registerBundles()
     {

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -592,7 +592,7 @@ EOF;
         $kernel->initializeBundles();
 
         $map = $kernel->getBundleMap();
-        $this->assertEquals(array($child, $parent), $map['ParentABundle']);
+        $this->assertEquals(array($parent, $child), $map['ParentABundle']);
     }
 
     public function testInitializeBundlesSupportInheritanceCascade()
@@ -611,8 +611,8 @@ EOF;
         $kernel->initializeBundles();
 
         $map = $kernel->getBundleMap();
-        $this->assertEquals(array($child, $parent, $grandparent), $map['GrandParentBBundle']);
-        $this->assertEquals(array($child, $parent), $map['ParentBBundle']);
+        $this->assertEquals(array($grandparent, $parent, $child), $map['GrandParentBBundle']);
+        $this->assertEquals(array($parent, $child), $map['ParentBBundle']);
         $this->assertEquals(array($child), $map['ChildBBundle']);
     }
 
@@ -648,8 +648,9 @@ EOF;
         $kernel->initializeBundles();
 
         $map = $kernel->getBundleMap();
-        $this->assertEquals(array($child, $parent, $grandparent), $map['GrandParentCCundle']);
-        $this->assertEquals(array($child, $parent), $map['ParentCCundle']);
+		
+        $this->assertEquals(array($grandparent, $parent, $child), $map['GrandParentCCundle']);
+        $this->assertEquals(array($parent, $child), $map['ParentCCundle']);
         $this->assertEquals(array($child), $map['ChildCCundle']);
     }
 
@@ -702,6 +703,27 @@ EOF;
             ->will($this->returnValue(array($circularRef)))
         ;
         $kernel->initializeBundles();
+    }
+	
+    public function testGetBundleSupportInheritanceCascade()
+    {
+        $grandparent = $this->getBundle(null, null, 'GrandParentEBundle');
+        $parent = $this->getBundle(null, 'GrandParentEBundle', 'ParentEBundle');
+        $child = $this->getBundle(null, 'ParentEBundle', 'ChildEBundle');
+
+        $kernel = $this->getKernel();
+        $kernel
+            ->expects($this->once())
+            ->method('registerBundles')
+            ->will($this->returnValue(array($grandparent, $parent, $child)))
+        ;
+
+        $kernel->initializeBundles();
+
+        $map = $kernel->getBundleMap();
+		$this->assertEquals($grandparent, $kernel->getBundleByName('GrandParentEBundle'));
+		$this->assertEquals($parent, $kernel->getBundleByName('ParentEBundle'));
+		$this->assertEquals($child, $kernel->getBundleByName('ChildEBundle'));
     }
 
     public function testTerminateReturnsSilentlyIfKernelIsNotBooted()


### PR DESCRIPTION
Hi

I've noticed that the getBundle function (in src/Symfony/Component/HttpKernel/Kernel.php) currently does not return the correct bundle when an application has bundle inheritance

Example:
GrandParentBunde > ParentBundle > ChildBundle

php app/console doctrine:generate:entities FOOGrandParentBundle
will generate the entities for ChildBundle

the same goes for:
php app/console doctrine:generate:entities FOOParentBundle
will generate the entities for ChildBundle

The translation:update command has the same issue.

I think the order of bundleMap must be inversed te make it work properly. This is because the getBundle function takes the first element of the bundleMap array when the second parameter "first" === true.

I've also updated the existing tests and added a test which really tests the getBundle method 

Kind regards
Hans Stevens
