### PR TITLE
[Finder] adds adapter selection/unselection capabilities

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -105,17 +105,13 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
-     * Removes adapter selection adapter to use best one.
+     * Sets the selected adapter to the best one according to the current platform the code is run on.
      *
      * @return Finder The current Finder instance
      */
     public function useBestAdapter()
     {
-        $this->adapters = array_map(function (array $properties) {
-            $properties['selected'] = false;
-
-            return $properties;
-        }, $this->adapters);
+        $this->resetAdapterSelection();
 
         return $this->sortAdapters();
     }
@@ -132,10 +128,10 @@ class Finder implements \IteratorAggregate, \Countable
     public function setAdapter($name)
     {
         if (!isset($this->adapters[$name])) {
-            throw new \InvalidArgumentException(sprintf('There is no registered adapter with "%s" name.', $name));
+            throw new \InvalidArgumentException(sprintf('Adapter "%s" does not exist.', $name));
         }
 
-        $this->useBestAdapter();
+        $this->resetAdapterSelection();
         $this->adapters[$name]['selected'] = true;
 
         return $this->sortAdapters();
@@ -799,5 +795,17 @@ class Finder implements \IteratorAggregate, \Countable
             ->setSort($this->sort)
             ->setPath($this->paths)
             ->setNotPath($this->notPaths);
+    }
+
+    /**
+     * Unselects all adapters.
+     */
+    private function resetAdapterSelection()
+    {
+        $this->adapters = array_map(function (array $properties) {
+            $properties['selected'] = false;
+
+            return $properties;
+        }, $this->adapters);
     }
 }

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -68,7 +68,8 @@ class Finder implements \IteratorAggregate, \Countable
         $this
             ->addAdapter(new GnuFindAdapter())
             ->addAdapter(new BsdFindAdapter())
-            ->setAdapter(new PhpAdapter(), -50)
+            ->addAdapter(new PhpAdapter(), -50)
+            ->setAdapter('php')
         ;
     }
 
@@ -122,19 +123,20 @@ class Finder implements \IteratorAggregate, \Countable
     /**
      * Selects the adapter to use.
      *
-     * @param Adapter\AdapterInterface $adapter
-     * @param int                      $priority
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
      *
      * @return Finder The current Finder instance
      */
-    public function setAdapter(Adapter\AdapterInterface $adapter, $priority = 0)
+    public function setAdapter($name)
     {
-        if (!isset($this->adapters[$adapter->getName()])) {
-            $this->addAdapter($adapter, $priority);
+        if (!isset($this->adapters[$name])) {
+            throw new \InvalidArgumentException(sprintf('There is no registered adapter with "%s" name.', $name));
         }
 
         $this->useBestAdapter();
-        $this->adapters[$adapter->getName()]['selected'] = true;
+        $this->adapters[$name]['selected'] = true;
 
         return $this->sortAdapters();
     }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -690,7 +690,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertTrue($adapters[0] instanceof Adapter\PhpAdapter);
 
         // test another adapter selection
-        $adapters = Finder::create()->setAdapter(new Adapter\GnuFindAdapter())->getAdapters();
+        $adapters = Finder::create()->setAdapter('gnu_find')->getAdapters();
         $this->assertTrue($adapters[0] instanceof Adapter\GnuFindAdapter);
 
         // test that useBestAdapter method removes selection

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -683,6 +683,21 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsoluteFixtures($expected), $finder);
     }
 
+    public function testAdapterSelection()
+    {
+        // test that by default, PhpAdapter is selected
+        $adapters = Finder::create()->getAdapters();
+        $this->assertTrue($adapters[0] instanceof Adapter\PhpAdapter);
+
+        // test another adapter selection
+        $adapters = Finder::create()->setAdapter(new Adapter\GnuFindAdapter())->getAdapters();
+        $this->assertTrue($adapters[0] instanceof Adapter\GnuFindAdapter);
+
+        // test that useBestAdapter method removes selection
+        $adapters = Finder::create()->useBestAdapter()->getAdapters();
+        $this->assertFalse($adapters[0] instanceof Adapter\PhpAdapter);
+    }
+
     public function getTestPathData()
     {
         $tests = array(


### PR DESCRIPTION
As we have many issues with the native finder adapter, it would be good to:
-  permit selection of a particular adapter which will be choosed over the others until its unselection
-  permit unselection of adapters to get the finder select trhe best on (by priority)
-  have `PhpAdapter` selected by default

This PR adds 2 methods to the `Finder`:
-  `setAdapter($adapter)`: selects an adapter by its name
-  `useBestAdapter()`: tells the finder to select best adapter by their priority

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
