### PR TITLE
[DomCrawler] fixed handling of schemes by Link::getUri()

### DIFF
--- a/src/Symfony/Component/DomCrawler/Link.php
+++ b/src/Symfony/Component/DomCrawler/Link.php
@@ -89,7 +89,7 @@ class Link
         $uri = trim($this->getRawUri());
 
         // absolute URL?
-        if (0 === strpos($uri, 'http')) {
+        if (null !== parse_url($uri, PHP_URL_SCHEME)) {
             return $uri;
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -93,6 +93,8 @@ class LinkTest extends \PHPUnit_Framework_TestCase
             array('?a=b', 'http://localhost/bar/', 'http://localhost/bar/?a=b'),
 
             array('http://login.foo.com/foo', 'http://localhost/bar/', 'http://login.foo.com/foo'),
+            array('https://login.foo.com/foo', 'https://localhost/bar/', 'https://login.foo.com/foo'),
+            array('mailto:foo@bar.com', 'http://localhost/foo', 'mailto:foo@bar.com'),
 
             array('?foo=2', 'http://localhost?foo=1', 'http://localhost?foo=2'),
             array('?foo=2', 'http://localhost/?foo=1', 'http://localhost/?foo=2'),


### PR DESCRIPTION
A link (anchor tag with an href attr) in pages crawled by the Crawler
can contain any valid URI, including mailto: links.

Currently this is not correctly supported by `Link::getUri`.
Schemes that do not start with 'http' are treated as relative URIs
and appenden to the base URI. This leads to strange URIs like this:
http://foo.com/mailto:foo@bar.com

Fixed `Link::getUri` to treat any URI with a schema part as an
absolute URL. Updated the unit tests to test for this.
