### PR TITLE
[Console] fixes unparsed StringInput tokens

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -68,6 +68,7 @@ class ArgvInput extends Input
     protected function setTokens(array $tokens)
     {
         $this->tokens = $tokens;
+        $this->parse();
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Console\Tests\Input;
 
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 
 class StringInputTest extends \PHPUnit_Framework_TestCase
 {
@@ -25,6 +27,18 @@ class StringInputTest extends \PHPUnit_Framework_TestCase
         $p = $r->getProperty('tokens');
         $p->setAccessible(true);
         $this->assertEquals($tokens, $p->getValue($input), $message);
+    }
+
+    public function testInputOptionWithGivenString()
+    {
+        $definition = new InputDefinition(
+            array(new InputOption('foo', null, InputOption::VALUE_REQUIRED))
+        );
+
+        $input = new StringInput('--foo=bar', $definition);
+        $actual = $input->getOption('foo');
+
+        $this->assertEquals('bar', $actual);
     }
 
     public function getTokenizeData()


### PR DESCRIPTION
`StringInput` instances call `setToken` after constructor, `parse` method is called in constructor, so `StringInput` tokens where never parsed.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6749 |
