### PR TITLE
Updating services xml schema file to support additional tag attrs 

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -96,6 +96,9 @@
 
   <xsd:complexType name="tag">
     <xsd:attribute name="name" type="xsd:string" />
+    <xsd:attribute name="event" type="xsd:string" />
+    <xsd:attribute name="method" type="xsd:string" />
+    <xsd:attribute name="priority" type="xsd:integer" />
     <xsd:anyAttribute namespace="##any" processContents="lax" />
   </xsd:complexType>
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |

I noticed in the XML schema file for services, the `<tag />` tag does not support the following attributes:
- event
- method
- priority

I have updated the schema to support these attributes.
