### PR TITLE
[Form][Validation] Add `forbid_extra_data` option

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -105,8 +105,8 @@ class FormValidator extends ConstraintValidator
             }
         }
 
-        // Mark the form with an error if it contains extra fields
-        if (count($form->getExtraData()) > 0) {
+        // Mark the form with an error if it contains not allowed extra fields
+        if (!$config->getOption('ignore_extra_data') && count($form->getExtraData()) > 0) {
             $this->context->addViolation(
                 $config->getOption('extra_fields_message'),
                 array('{{ extra_fields }}' => implode('", "', array_keys($form->getExtraData()))),

--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -106,7 +106,7 @@ class FormValidator extends ConstraintValidator
         }
 
         // Mark the form with an error if it contains not allowed extra fields
-        if (!$config->getOption('ignore_extra_data') && count($form->getExtraData()) > 0) {
+        if ($config->getOption('forbid_extra_data') && count($form->getExtraData()) > 0) {
             $this->context->addViolation(
                 $config->getOption('extra_fields_message'),
                 array('{{ extra_fields }}' => implode('", "', array_keys($form->getExtraData()))),

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -85,6 +85,7 @@ class FormTypeValidatorExtension extends AbstractTypeExtension
             'cascade_validation'         => false,
             'invalid_message'            => 'This value is not valid.',
             'invalid_message_parameters' => array(),
+            'ignore_extra_data'          => false,
             'extra_fields_message'       => 'This form should not contain extra fields.',
             'post_max_size_message'      => 'The uploaded file was too large. Please try to upload a smaller file.',
         ));

--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -85,7 +85,7 @@ class FormTypeValidatorExtension extends AbstractTypeExtension
             'cascade_validation'         => false,
             'invalid_message'            => 'This value is not valid.',
             'invalid_message_parameters' => array(),
-            'ignore_extra_data'          => false,
+            'forbid_extra_data'          => true,
             'extra_fields_message'       => 'This form should not contain extra fields.',
             'post_max_size_message'      => 'The uploaded file was too large. Please try to upload a smaller file.',
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -433,8 +433,12 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
     public function testViolationIfExtraData()
     {
         $context = $this->getMockExecutionContext();
+        $options = array(
+            'extra_fields_message' => 'Extra!', 
+            'forbid_extra_data'    => true,
+        );
 
-        $form = $this->getBuilder('parent', null, array('extra_fields_message' => 'Extra!'))
+        $form = $this->getBuilder('parent', null, $options)
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->add($this->getBuilder('child'))
@@ -456,11 +460,11 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($form, new Form());
     }
 
-    public function testDontMarkInvalidIfExtraDataIsIgnored()
+    public function testDontMarkInvalidIfNotForbidExtraData()
     {
         $context = $this->getMockExecutionContext();
 
-        $form = $this->getBuilder('parent', null, array('ignore_extra_data' => false))
+        $form = $this->getBuilder('parent', null, array('forbid_extra_data' => false))
             ->setCompound(true)
             ->setDataMapper($this->getDataMapper())
             ->add($this->getBuilder('child'))

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -456,6 +456,27 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($form, new Form());
     }
 
+    public function testDontMarkInvalidIfExtraDataIsIgnored()
+    {
+        $context = $this->getMockExecutionContext();
+
+        $form = $this->getBuilder('parent', null, array('ignore_extra_data' => false))
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->add($this->getBuilder('child'))
+            ->getForm();
+
+        $form->bind(array('foo' => 'bar'));
+
+        $context->expects($this->never())
+            ->method('addViolation');
+        $context->expects($this->never())
+            ->method('addViolationAt');
+
+        $this->validator->initialize($context);
+        $this->validator->validate($form, new Form());
+    }
+
     /**
      * @dataProvider getPostMaxSizeFixtures
      */


### PR DESCRIPTION
Fixed indentation.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7209 |
| License | MIT |

Added `ignore_extra_data` option to allow form validation pass, even with extra data.
