### PR TITLE
[Console] fixes tests

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -68,7 +68,6 @@ class ArgvInput extends Input
     protected function setTokens(array $tokens)
     {
         $this->tokens = $tokens;
-        $this->parse();
     }
 
     /**

--- a/src/Symfony/Component/Console/Input/StringInput.php
+++ b/src/Symfony/Component/Console/Input/StringInput.php
@@ -33,6 +33,8 @@ class StringInput extends ArgvInput
      * @param string          $input      An array of parameters from the CLI (in the argv format)
      * @param InputDefinition $definition A InputDefinition instance
      *
+     * @deprecated The second argument is deprecated as it does not work (will be removed in 3.0), use 'bind' method instead
+     *
      * @api
      */
     public function __construct($input, InputDefinition $definition = null)

--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -11,6 +11,8 @@
 
 namespace Symfony\Component\Console\Tests\Input;
 
+use Symfony\Component\Console\Input\InputDefinition;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StringInput;
 
 class StringInputTest extends \PHPUnit_Framework_TestCase
@@ -25,6 +27,19 @@ class StringInputTest extends \PHPUnit_Framework_TestCase
         $p = $r->getProperty('tokens');
         $p->setAccessible(true);
         $this->assertEquals($tokens, $p->getValue($input), $message);
+    }
+
+    public function testInputOptionWithGivenString()
+    {
+        $definition = new InputDefinition(
+            array(new InputOption('foo', null, InputOption::VALUE_REQUIRED))
+        );
+
+        $input = new StringInput('--foo=bar');
+        $input->bind($definition);
+        $actual = $input->getOption('foo');
+
+        $this->assertEquals('bar', $actual);
     }
 
     public function getTokenizeData()

--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -12,8 +12,6 @@
 namespace Symfony\Component\Console\Tests\Input;
 
 use Symfony\Component\Console\Input\StringInput;
-use Symfony\Component\Console\Input\InputDefinition;
-use Symfony\Component\Console\Input\InputOption;
 
 class StringInputTest extends \PHPUnit_Framework_TestCase
 {
@@ -27,18 +25,6 @@ class StringInputTest extends \PHPUnit_Framework_TestCase
         $p = $r->getProperty('tokens');
         $p->setAccessible(true);
         $this->assertEquals($tokens, $p->getValue($input), $message);
-    }
-
-    public function testInputOptionWithGivenString()
-    {
-        $definition = new InputDefinition(
-            array(new InputOption('foo', null, InputOption::VALUE_REQUIRED))
-        );
-
-        $input = new StringInput('--foo=bar', $definition);
-        $actual = $input->getOption('foo');
-
-        $this->assertEquals('bar', $actual);
     }
 
     public function getTokenizeData()


### PR DESCRIPTION
Previous `StringInputTest::testInputOptionWithGivenString` test was broken.
Trying make it pass broke the way `StringInput` is used in the console.

Two things to know abour the `StringInput` class in its actual state:
-  the second argument in the constructor is useless
-  the `bind` method **must** be called in order to access arguments/options

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
