### PR TITLE
[Routing] make xml loader more tolerant

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -126,8 +126,8 @@ class XmlFileLoader extends FileLoader
             $node->removeAttribute('pattern');
         }
 
-        $schemes = array_filter(explode(' ', $node->getAttribute('schemes')));
-        $methods = array_filter(explode(' ', $node->getAttribute('methods')));
+        $schemes = preg_split('/[\s,\|]++/', $node->getAttribute('schemes'), -1, PREG_SPLIT_NO_EMPTY);
+        $methods = preg_split('/[\s,\|]++/', $node->getAttribute('methods'), -1, PREG_SPLIT_NO_EMPTY);
 
         list($defaults, $requirements, $options) = $this->parseConfigs($node, $path);
 
@@ -154,8 +154,8 @@ class XmlFileLoader extends FileLoader
         $type = $node->getAttribute('type');
         $prefix = $node->getAttribute('prefix');
         $host = $node->hasAttribute('host') ? $node->getAttribute('host') : null;
-        $schemes = $node->hasAttribute('schemes') ? array_filter(explode(' ', $node->getAttribute('schemes'))) : null;
-        $methods = $node->hasAttribute('methods') ? array_filter(explode(' ', $node->getAttribute('methods'))) : null;
+        $schemes = $node->hasAttribute('schemes') ? preg_split('/[\s,\|]++/', $node->getAttribute('schemes'), -1, PREG_SPLIT_NO_EMPTY) : null;
+        $methods = $node->hasAttribute('methods') ? preg_split('/[\s,\|]++/', $node->getAttribute('methods'), -1, PREG_SPLIT_NO_EMPTY) : null;
 
         list($defaults, $requirements, $options) = $this->parseConfigs($node, $path);
 

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -17,16 +17,6 @@
 
   <xsd:element name="routes" type="routes" />
 
-  <xsd:simpleType name="word">
-    <xsd:restriction base="xsd:string">
-      <xsd:pattern value="([a-zA-Z]){3,}"/>
-    </xsd:restriction>
-  </xsd:simpleType>
-
-  <xsd:simpleType name="stringlist">
-    <xsd:list itemType="word"/>
-  </xsd:simpleType>
-
   <xsd:complexType name="routes">
     <xsd:choice minOccurs="0" maxOccurs="unbounded">
       <xsd:element name="import" type="import" />
@@ -49,8 +39,8 @@
     <xsd:attribute name="path" type="xsd:string" />
     <xsd:attribute name="pattern" type="xsd:string" />
     <xsd:attribute name="host" type="xsd:string" />
-    <xsd:attribute name="schemes" type="stringlist" />
-    <xsd:attribute name="methods" type="stringlist" />
+    <xsd:attribute name="schemes" type="xsd:string" />
+    <xsd:attribute name="methods" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="import">
@@ -60,8 +50,8 @@
     <xsd:attribute name="type" type="xsd:string" />
     <xsd:attribute name="prefix" type="xsd:string" />
     <xsd:attribute name="host" type="xsd:string" />
-    <xsd:attribute name="schemes" type="stringlist" />
-    <xsd:attribute name="methods" type="stringlist" />
+    <xsd:attribute name="schemes" type="xsd:string" />
+    <xsd:attribute name="methods" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:complexType name="element">

--- a/src/Symfony/Component/Routing/Tests/Fixtures/missing_id.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/missing_id.xml
@@ -4,5 +4,5 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route pattern="/test"></route>
+    <route path="/test"></route>
 </routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/namespaceprefix.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/namespaceprefix.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <r:route id="blog_show" pattern="/blog/{slug}" host="{_locale}.example.com">
+    <r:route id="blog_show" path="/blog/{slug}" host="{_locale}.example.com">
         <r:default key="_controller">MyBundle:Blog:show</r:default>
         <requirement xmlns="http://symfony.com/schema/routing" key="slug">\w+</requirement>
         <r2:requirement xmlns:r2="http://symfony.com/schema/routing" key="_locale">en|fr|de</r2:requirement>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/nonvalid.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/nonvalid.xml
@@ -4,9 +4,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="blog_show" pattern="/blog/{slug}">
+    <route id="blog_show" path="/blog/{slug}">
         <default key="_controller">MyBundle:Blog:show</default>
         <requirement key="_method">GET</requirement>
-        <option key="segment_separators">/</option>
     <!-- </route> -->
 </routes>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/nonvalidroute.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/nonvalidroute.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="blog_show" pattern="/blog/{slug}">
+    <route id="blog_show" path="/blog/{slug}">
         <default key="_controller">MyBundle:Blog:show</default>
         <requirement key="_method">GET</requirement>
         <option key="compiler_class">RouteCompiler</option>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.php
@@ -6,18 +6,18 @@ $collection = new RouteCollection();
 $collection->add('blog_show', new Route(
     '/blog/{slug}',
     array('_controller' => 'MyBlogBundle:Blog:show'),
-    array('_method' => 'GET', 'locale' => '\w+', '_scheme' => 'https'),
-    array('compiler_class' => 'RouteCompiler'),
-    '{locale}.example.com'
-));
-$collection->add('blog_show_legacy', new Route(
-    '/blog/{slug}',
-    array('_controller' => 'MyBlogBundle:Blog:show'),
     array('locale' => '\w+'),
     array('compiler_class' => 'RouteCompiler'),
     '{locale}.example.com',
     array('https'),
-    array('GET')
+    array('GET','POST','put','OpTiOnS')
+));
+$collection->add('blog_show_legacy', new Route(
+    '/blog/{slug}',
+    array('_controller' => 'MyBlogBundle:Blog:show'),
+    array('_method' => 'GET|POST|put|OpTiOnS', '_scheme' => 'https', 'locale' => '\w+',),
+    array('compiler_class' => 'RouteCompiler'),
+    '{locale}.example.com'
 ));
 
 return $collection;

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="blog_show" path="/blog/{slug}" host="{locale}.example.com" methods="GET" schemes="https">
+    <route id="blog_show" path="/blog/{slug}" host="{locale}.example.com" methods="GET|POST  put,OpTiOnS" schemes="hTTps">
         <default key="_controller">MyBundle:Blog:show</default>
         <requirement key="locale">\w+</requirement>
         <option key="compiler_class">RouteCompiler</option>
@@ -12,8 +12,8 @@
 
     <route id="blog_show_legacy" pattern="/blog/{slug}" host="{locale}.example.com">
         <default key="_controller">MyBundle:Blog:show</default>
-        <requirement key="_method">GET</requirement>
-        <requirement key="_scheme">https</requirement>
+        <requirement key="_method">GET|POST|put|OpTiOnS</requirement>
+        <requirement key="_scheme">hTTps</requirement>
         <requirement key="locale">\w+</requirement>
         <option key="compiler_class">RouteCompiler</option>
     </route>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.yml
@@ -1,17 +1,17 @@
 blog_show:
     path:         /blog/{slug}
-    defaults:     { _controller: MyBlogBundle:Blog:show }
+    defaults:     { _controller: "MyBundle:Blog:show" }
     host:         "{locale}.example.com"
     requirements: { 'locale': '\w+' }
-    methods:      ['GET']
+    methods:      ['GET','POST','put','OpTiOnS']
     schemes:      ['https']
     options:
         compiler_class: RouteCompiler
 
 blog_show_legacy:
     pattern:      /blog/{slug}
-    defaults:     { _controller: MyBlogBundle:Blog:show }
+    defaults:     { _controller: "MyBundle:Blog:show" }
     host:         "{locale}.example.com"
-    requirements: { '_method': 'GET', 'locale': '\w+', _scheme: 'https' }
+    requirements: { '_method': 'GET|POST|put|OpTiOnS', _scheme: https, 'locale': '\w+' }
     options:
         compiler_class: RouteCompiler

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validresource.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validresource.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <import resource="validpattern.xml" prefix="/{foo}" host="{locale}.example.com">
+    <import resource="validpattern.xml" prefix="/{foo}" host="">
         <default key="foo">123</default>
         <requirement key="foo">\d+</requirement>
         <option key="foo">bar</option>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validresource.yml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validresource.yml
@@ -1,7 +1,7 @@
-blog_show:
+_blog:
     resource:     validpattern.yml
     prefix:       /{foo}
     defaults:     { 'foo': '123' }
     requirements: { 'foo': '\d+' }
     options:      { 'foo': 'bar' }
-    host:         "{locale}.example.com"
+    host:         ""

--- a/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/PhpFileLoaderTest.php
@@ -44,12 +44,12 @@ class PhpFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
 
         foreach ($routes as $route) {
-            $this->assertEquals('/blog/{slug}', $route->getPath());
-            $this->assertEquals('MyBlogBundle:Blog:show', $route->getDefault('_controller'));
-            $this->assertEquals('GET', $route->getRequirement('_method'));
-            $this->assertEquals('https', $route->getRequirement('_scheme'));
-            $this->assertEquals('{locale}.example.com', $route->getHost());
-            $this->assertEquals('RouteCompiler', $route->getOption('compiler_class'));
+            $this->assertSame('/blog/{slug}', $route->getPath());
+            $this->assertSame('MyBlogBundle:Blog:show', $route->getDefault('_controller'));
+            $this->assertSame('{locale}.example.com', $route->getHost());
+            $this->assertSame('RouteCompiler', $route->getOption('compiler_class'));
+            $this->assertEquals(array('GET', 'POST', 'PUT', 'OPTIONS'), $route->getMethods());
+            $this->assertEquals(array('https'), $route->getSchemes());
         }
     }
 }

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -43,14 +43,16 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(2, $routes, 'Two routes are loaded');
         $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
-        $route = $routes['blog_show'];
-        $this->assertEquals('/blog/{slug}', $route->getPath());
-        $this->assertEquals('MyBundle:Blog:show', $route->getDefault('_controller'));
-        $this->assertEquals('GET', $route->getRequirement('_method'));
-        $this->assertEquals('https', $route->getRequirement('_scheme'));
-        $this->assertEquals('\w+', $route->getRequirement('locale'));
-        $this->assertEquals('{locale}.example.com', $route->getHost());
-        $this->assertEquals('RouteCompiler', $route->getOption('compiler_class'));
+
+        foreach ($routes as $route) {
+            $this->assertSame('/blog/{slug}', $route->getPath());
+            $this->assertSame('{locale}.example.com', $route->getHost());
+            $this->assertSame('MyBundle:Blog:show', $route->getDefault('_controller'));
+            $this->assertSame('\w+', $route->getRequirement('locale'));
+            $this->assertSame('RouteCompiler', $route->getOption('compiler_class'));
+            $this->assertEquals(array('GET', 'POST', 'PUT', 'OPTIONS'), $route->getMethods());
+            $this->assertEquals(array('https'), $route->getSchemes());
+        }
     }
 
     public function testLoadWithNamespacePrefix()
@@ -61,12 +63,12 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(1, $routeCollection->all(), 'One route is loaded');
 
         $route = $routeCollection->get('blog_show');
-        $this->assertEquals('/blog/{slug}', $route->getPath());
-        $this->assertEquals('MyBundle:Blog:show', $route->getDefault('_controller'));
-        $this->assertEquals('\w+', $route->getRequirement('slug'));
-        $this->assertEquals('en|fr|de', $route->getRequirement('_locale'));
-        $this->assertEquals('{_locale}.example.com', $route->getHost());
-        $this->assertEquals('RouteCompiler', $route->getOption('compiler_class'));
+        $this->assertSame('/blog/{slug}', $route->getPath());
+        $this->assertSame('{_locale}.example.com', $route->getHost());
+        $this->assertSame('MyBundle:Blog:show', $route->getDefault('_controller'));
+        $this->assertSame('\w+', $route->getRequirement('slug'));
+        $this->assertSame('en|fr|de', $route->getRequirement('_locale'));
+        $this->assertSame('RouteCompiler', $route->getOption('compiler_class'));
     }
 
     public function testLoadWithImport()
@@ -79,12 +81,11 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
 
         foreach ($routes as $route) {
-            $this->assertEquals('/{foo}/blog/{slug}', $routes['blog_show']->getPath());
-            $this->assertEquals('MyBundle:Blog:show', $routes['blog_show']->getDefault('_controller'));
-            $this->assertEquals('123', $routes['blog_show']->getDefault('foo'));
-            $this->assertEquals('\d+', $routes['blog_show']->getRequirement('foo'));
-            $this->assertEquals('bar', $routes['blog_show']->getOption('foo'));
-            $this->assertEquals('{locale}.example.com', $routes['blog_show']->getHost());
+            $this->assertSame('/{foo}/blog/{slug}', $route->getPath());
+            $this->assertSame('123', $route->getDefault('foo'));
+            $this->assertSame('\d+', $route->getRequirement('foo'));
+            $this->assertSame('bar', $route->getOption('foo'));
+            $this->assertSame('', $route->getHost());
         }
     }
 

--- a/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/YamlFileLoaderTest.php
@@ -73,7 +73,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('/true', $route->getPath());
     }
 
-    public function testLoadWithPattern()
+    public function testLoadWithRoute()
     {
         $loader = new YamlFileLoader(new FileLocator(array(__DIR__.'/../Fixtures')));
         $routeCollection = $loader->load('validpattern.yml');
@@ -83,13 +83,13 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
 
         foreach ($routes as $route) {
-            $this->assertEquals('/blog/{slug}', $route->getPath());
-            $this->assertEquals('MyBlogBundle:Blog:show', $route->getDefault('_controller'));
-            $this->assertEquals('GET', $route->getRequirement('_method'));
-            $this->assertEquals('https', $route->getRequirement('_scheme'));
-            $this->assertEquals('\w+', $route->getRequirement('locale'));
-            $this->assertEquals('{locale}.example.com', $route->getHost());
-            $this->assertEquals('RouteCompiler', $route->getOption('compiler_class'));
+            $this->assertSame('/blog/{slug}', $route->getPath());
+            $this->assertSame('{locale}.example.com', $route->getHost());
+            $this->assertSame('MyBundle:Blog:show', $route->getDefault('_controller'));
+            $this->assertSame('\w+', $route->getRequirement('locale'));
+            $this->assertSame('RouteCompiler', $route->getOption('compiler_class'));
+            $this->assertEquals(array('GET', 'POST', 'PUT', 'OPTIONS'), $route->getMethods());
+            $this->assertEquals(array('https'), $route->getSchemes());
         }
     }
 
@@ -101,11 +101,13 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(2, $routes, 'Two routes are loaded');
         $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
-        $this->assertEquals('/{foo}/blog/{slug}', $routes['blog_show']->getPath());
-        $this->assertEquals('MyBlogBundle:Blog:show', $routes['blog_show']->getDefault('_controller'));
-        $this->assertEquals('123', $routes['blog_show']->getDefault('foo'));
-        $this->assertEquals('\d+', $routes['blog_show']->getRequirement('foo'));
-        $this->assertEquals('bar', $routes['blog_show']->getOption('foo'));
-        $this->assertEquals('{locale}.example.com', $routes['blog_show']->getHost());
+
+        foreach ($routes as $route) {
+            $this->assertSame('/{foo}/blog/{slug}', $route->getPath());
+            $this->assertSame('123', $route->getDefault('foo'));
+            $this->assertSame('\d+', $route->getRequirement('foo'));
+            $this->assertSame('bar', $route->getOption('foo'));
+            $this->assertSame('', $route->getHost());
+        }
     }
 }


### PR DESCRIPTION
schemes and methods may also be delimited by whitespace, comma or pipe.
Fixes https://github.com/symfony/symfony/pull/6049#issuecomment-11315698
this eases migration as now `methods="GET|POST"` also works
the second commit unifies the tests and fixes some strange assertions that were useless

| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [yes but not really] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |
