### PR TITLE
[Twig] asset extended helper

### DIFF
--- a/src/Symfony/Component/Templating/Asset/PathPackage.php
+++ b/src/Symfony/Component/Templating/Asset/PathPackage.php
@@ -48,6 +48,8 @@ class PathPackage extends Package
             return $path;
         }
 
+        $path = $this->applyRegex($path);
+
         $url = $this->applyVersion($path);
 
         // apply the base path
@@ -56,6 +58,31 @@ class PathPackage extends Package
         }
 
         return $url;
+    }
+
+    /**
+     * Returns assets path which matches by $path simple regex.
+     * Applies to paths with .js or .css ending and * suffix.
+     *
+     * For example :
+     *     js/jquery*.js => js/jquery-1.8.0.js (jquery-1.8.0.js should be in the /web/js folder)
+     *
+     * @param string   $path      A path
+     * @param callback $globFunc Optional callback to use as php glob function, defaults to glob($pattern)
+     *
+     * @return string The regex matched path
+     */
+    public function applyRegex($path, $globFunc = null)
+    {
+        if (!is_callable($globFunc)) {
+            $globFunc = function ($pattern) { return glob($pattern); };
+        }
+
+        if (substr_count($path, '*') === 1 && preg_match("/.(js|css)$/i", $path) && $files = $globFunc($path)) {
+            $path = $files[0];
+        }
+
+        return $path;
     }
 
     /**

--- a/src/Symfony/Component/Templating/Tests/Asset/PathPackageTest.php
+++ b/src/Symfony/Component/Templating/Tests/Asset/PathPackageTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Templating\Tests\Helper;
+use Symfony\Component\Templating\Asset\PathPackage;
+
+class PathPackageTest extends \PHPUnit_Framework_TestCase
+{
+
+  public function testApplyRegex()
+  {
+    $helper = new PathPackage();
+
+    // Making private method accessible
+    $method = new \ReflectionMethod($helper, 'applyRegex');
+    $method->setAccessible(TRUE);
+
+    $emulatedGlob = function($p) { return array("foo/jquery-1.8.0.js", "foo/jquery-ui-1.8.23.js"); };
+    $emptyGlob = function($p) { return array(); };
+
+    $this->assertEquals('foo/jquery.js',
+        $method->invoke($helper, 'foo/jquery.js', $emulatedGlob),
+        '->applyRegex() does nothing when there is no *');
+    $this->assertEquals('foo/jquery-1.8.0.js',
+        $method->invoke($helper, 'foo/jquery*.js', $emulatedGlob),
+        '->applyRegex() should work with simple regex with *');
+    $this->assertEquals('foo/jquery**.js',
+        $method->invoke($helper, 'foo/jquery**.js', $emulatedGlob),
+        '->applyRegex() shouldn\'t work with regexps with more than one *');
+    $this->assertEquals('foo/jquery*.js',
+        $method->invoke($helper, 'foo/jquery*.js', $emptyGlob),
+        '->applyRegex() shouldn\'t change path if no files have been found');
+  }
+}
+


### PR DESCRIPTION
Matching for  js or css file with \* in `asset` helper, the first matched asset file will be included.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | symfony/symfony-docs#2276 |

For code

```
<script src="{{ asset('js/jquery*.js') }}" type="text/javascript"></script> 
```

resulting template will include link to js/jquery-1.8.3.js if it exists.

It is useful when you want to use assets from bundles supplied by third-party vendors.

The same feature exists in AsseticBundle, but It could be heavy or not neccessary to recreate static file from public folder. Also we need to write more code for same behavior, e.g.

```
{% javascripts 'js/jquery*.js' %}
<script src="{{ asset_url }}"></script>
{% endjavascripts %}
```
