### PR TITLE
[FrameworkBundle] switched to setFallbackLocale() in DI extension

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -533,7 +533,7 @@ class FrameworkExtension extends Extension
         // Use the "real" translator instead of the identity default
         $container->setAlias('translator', 'translator.default');
         $translator = $container->findDefinition('translator.default');
-        $translator->addMethodCall('setFallbackLocales', array($config['fallback']));
+        $translator->addMethodCall('setFallbackLocale', array($config['fallback']));
 
         // Discover translation directories
         $dirs = array();


### PR DESCRIPTION
Shouldn't the old method still getting called for BC?
