### PR TITLE
Property accessor custom array object fix

### DIFF
--- a/src/Symfony/Component/PropertyAccess/Tests/Fixtures/CustomArrayObject.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/Fixtures/CustomArrayObject.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\PropertyAccess\Tests\Fixtures;
+
+/**
+ * This class is a hand written simplified version of PHP native `ArrayObject`
+ * class, to show that it behaves differently than the PHP native implementation.
+ */
+class CustomArrayObject implements \ArrayAccess, \IteratorAggregate, \Countable, \Serializable
+{
+    private $array;
+
+    public function __construct(array $array = null)
+    {
+        $this->array = $array ?: array();
+    }
+
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->array);
+    }
+
+    public function offsetGet($offset)
+    {
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        if (null === $offset) {
+            $this->array[] = $value;
+        } else {
+            $this->array[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset)
+    {
+        unset($this->array[$offset]);
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->array);
+    }
+
+    public function count()
+    {
+        return count($this->array);
+    }
+
+    public function serialize()
+    {
+        return serialize($this->array);
+    }
+
+    public function unserialize($serialized)
+    {
+        $this->array = (array) unserialize((string) $serialized);
+    }
+}

--- a/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCustomArrayObjectTest.php
+++ b/src/Symfony/Component/PropertyAccess/Tests/PropertyAccessorCustomArrayObjectTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\PropertyAccess\Tests;
 
-use Symfony\Component\Form\Tests\Fixtures\CustomArrayObject;
+use Symfony\Component\PropertyAccess\Tests\Fixtures\CustomArrayObject;
 
 class PropertyAccessorCustomArrayObjectTest extends PropertyAccessorCollectionTest
 {


### PR DESCRIPTION
Copied `Symfony\Component\Form\Tests\Fixtures\CustomArrayObject` to Fixtures dir, and used it in tests to be able run tests separately from Form component,
