### PR TITLE
[2.2][HttpKernel] fixed wrong option name in FragmentHandler::fixOptions

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -147,9 +147,9 @@ class FragmentHandler implements EventSubscriberInterface
     // to be removed in 2.3
     public function fixOptions(array $options)
     {
-        // support for the standalone option is @deprecated in 2.2 and replaced with the renderer option
+        // support for the standalone option is @deprecated in 2.2 and replaced with the strategy option
         if (isset($options['standalone'])) {
-            trigger_error('The "standalone" option is deprecated in version 2.2 and replaced with the "renderer" option.', E_USER_DEPRECATED);
+            trigger_error('The "standalone" option is deprecated in version 2.2 and replaced with the "strategy" option.', E_USER_DEPRECATED);
 
             // support for the true value is @deprecated in 2.2, will be removed in 2.3
             if (true === $options['standalone']) {
@@ -166,7 +166,7 @@ class FragmentHandler implements EventSubscriberInterface
                 $options['standalone'] = 'hinclude';
             }
 
-            $options['renderer'] = $options['standalone'];
+            $options['strategy'] = $options['standalone'];
             unset($options['standalone']);
         }
 

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -76,9 +76,9 @@ class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
     public function getFixOptionsData()
     {
         return array(
-            array(array('renderer' => 'esi'), array('standalone' => true)),
-            array(array('renderer' => 'esi'), array('standalone' => 'esi')),
-            array(array('renderer' => 'hinclude'), array('standalone' => 'js')),
+            array(array('strategy' => 'esi'), array('standalone' => true)),
+            array(array('strategy' => 'esi'), array('standalone' => 'esi')),
+            array(array('strategy' => 'hinclude'), array('standalone' => 'js')),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/7309 |
