### PR TITLE
[HttpKernel] made the classmap lazy-loaded

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -60,6 +60,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $name;
     protected $startTime;
     protected $classes;
+    protected $loadClassCache;
     protected $errorReportingLevel;
 
     const VERSION         = '2.3.0-DEV';
@@ -130,6 +131,10 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     {
         if (true === $this->booted) {
             return;
+        }
+
+        if (!empty($this->loadClassCache)) {
+            call_user_func_array(array($this, 'doLoadClassCache'), $this->loadClassCache);
         }
 
         // init bundles
@@ -403,9 +408,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
      */
     public function loadClassCache($name = 'classes', $extension = '.php')
     {
-        if (!$this->booted && is_file($this->getCacheDir().'/classes.map')) {
-            ClassCollectionLoader::load(include($this->getCacheDir().'/classes.map'), $this->getCacheDir(), $name, $this->debug, false, $extension);
-        }
+        $this->loadClassCache = array($name, $extension);
     }
 
     /**
@@ -454,6 +457,13 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     public function getCharset()
     {
         return 'UTF-8';
+    }
+
+    protected function doLoadClassCache($name, $extension)
+    {
+        if (!$this->booted && is_file($this->getCacheDir().'/classes.map')) {
+            ClassCollectionLoader::load(include($this->getCacheDir().'/classes.map'), $this->getCacheDir(), $name, $this->debug, false, $extension);
+        }
     }
 
     /**

--- a/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/KernelTest.php
@@ -108,6 +108,52 @@ class KernelTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($kernel->isBooted());
     }
 
+    public function testClassCacheIsLoaded()
+    {
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->disableOriginalConstructor()
+            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles', 'doLoadClassCache'))
+            ->getMock();
+        $kernel->loadClassCache('name', '.extension');
+        $kernel->expects($this->any())
+            ->method('getBundles')
+            ->will($this->returnValue(array()));
+        $kernel->expects($this->once())
+            ->method('doLoadClassCache')
+            ->with('name', '.extension');
+
+        $kernel->boot();
+    }
+
+    public function testClassCacheIsNotLoadedByDefault()
+    {
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->disableOriginalConstructor()
+            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles', 'doLoadClassCache'))
+            ->getMock();
+        $kernel->expects($this->any())
+            ->method('getBundles')
+            ->will($this->returnValue(array()));
+        $kernel->expects($this->never())
+            ->method('doLoadClassCache');
+
+        $kernel->boot();
+    }
+
+    public function testClassCacheIsNotLoadedWhenKernelIsNotBooted()
+    {
+        $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')
+            ->disableOriginalConstructor()
+            ->setMethods(array('initializeBundles', 'initializeContainer', 'getBundles', 'doLoadClassCache'))
+            ->getMock();
+        $kernel->loadClassCache();
+        $kernel->expects($this->any())
+            ->method('getBundles')
+            ->will($this->returnValue(array()));
+        $kernel->expects($this->never())
+            ->method('doLoadClassCache');
+    }
+
     public function testBootKernelSeveralTimesOnlyInitializesBundlesOnce()
     {
         $kernel = $this->getMockBuilder('Symfony\Component\HttpKernel\Tests\Fixtures\KernelForTest')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |

see https://github.com/symfony/symfony-standard/pull/437#issuecomment-14667140

Instead of managing this from HttpCache, I suggest to handle it at Kernel's level, what do you think?
