### PR TITLE
[Finder] fix xargs pipe to work with spaces in dir names

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/BsdFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/BsdFindAdapter.php
@@ -92,10 +92,12 @@ class BsdFindAdapter extends AbstractFindAdapter
             // todo: avoid forking process for each $pattern by using multiple -e options
             $command
                 ->add('| grep -v \'^$\'')
-                ->add('| xargs grep -I')
+                ->add('| xargs -I{} grep -I')
                 ->add($expr->isCaseSensitive() ? null : '-i')
                 ->add($not ? '-L' : '-l')
-                ->add('-Ee')->arg($expr->renderPattern());
+                ->add('-Ee')->arg($expr->renderPattern())
+                ->add('{}')
+            ;
         }
     }
 }

--- a/src/Symfony/Component/Finder/Adapter/GnuFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/GnuFindAdapter.php
@@ -93,10 +93,12 @@ class GnuFindAdapter extends AbstractFindAdapter
 
             // todo: avoid forking process for each $pattern by using multiple -e options
             $command
-                ->add('| xargs -r grep -I')
+                ->add('| xargs -I{} -r grep -I')
                 ->add($expr->isCaseSensitive() ? null : '-i')
                 ->add($not ? '-L' : '-l')
-                ->add('-Ee')->arg($expr->renderPattern());
+                ->add('-Ee')->arg($expr->renderPattern())
+                ->add('{}')
+            ;
         }
     }
 }

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -707,6 +707,11 @@ class FinderTest extends Iterator\RealIteratorTestCase
                     'copy'.DIRECTORY_SEPARATOR.'A'.DIRECTORY_SEPARATOR.'B'.DIRECTORY_SEPARATOR.'C'.DIRECTORY_SEPARATOR.'abc.dat.copy',
                 )
             ),
+            array('/^with space\//', 'foobar',
+                array(
+                    'with space'.DIRECTORY_SEPARATOR.'foo.txt',
+                )
+            ),
         );
 
         return $this->buildTestData($tests);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

.. otherwise grep fails:

```
grep: : No such file or directory
grep: /Users/havvg/Web: No such file or directory
grep: Development/symfony2/src/Symfony/Component/Finder/Tests/Fixtures/dolor.txt: No such file or directory
```
