### PR TITLE
[HttpKernel] switched Kernel::init() method call to userland

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -1,0 +1,19 @@
+UPGRADE FROM 2.2 to 2.3
+=======================
+
+### HttpKernel
+
+ * The `init()` method has to be called after Kernel instanciation.
+
+   Before:
+
+   ```
+   $kernel = new AppKernel('dev', true);
+   ```
+
+   After:
+
+   ```
+   $kernel = new AppKernel('dev', true);
+   $kernel->init();
+   ```

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -90,10 +90,15 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         if ($this->debug) {
             $this->startTime = microtime(true);
         }
-
-        $this->init();
     }
 
+    /**
+     * Initialize the Kernel.
+     * 
+     * This is the right place to deal with PHP ini settings, debugging tools, etc.
+     *
+     * @api
+     */
     public function init()
     {
         ini_set('display_errors', 0);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [yes] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets | [#6834] |
| License | MIT |

See #6834, as @fabpot said, a fix would be to move the code to userland, I suggest to keep it in this `init()` method though, and tag it as api, for a few reasons : 
- assuming it's content belongs to the dev front controller is wrong, it only depends on the debug mode.
- it can become the recommended place where one can set its application specific php ini settings (not sure if there is such place currently for a symfony project? I usually do this in my front controllers) and also set up its own debugging tools, xhprof and so.
