### PR TITLE
[FrameworkBundle] adds --clean option translation:update command

### DIFF
--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Catalogue;
+
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * Base catalogues binary operation class.
+ *
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+abstract class AbstractOperation implements OperationInterface
+{
+    /**
+     * @var MessageCatalogueInterface
+     */
+    protected $source;
+
+    /**
+     * @var MessageCatalogueInterface
+     */
+    protected $target;
+
+    /**
+     * @var MessageCatalogue
+     */
+    protected $result;
+
+    /**
+     * @var null|array
+     */
+    private $domains;
+
+    /**
+     * @var array
+     */
+    protected $messages;
+
+    /**
+     * @param MessageCatalogueInterface $source
+     * @param MessageCatalogueInterface $target
+     *
+     * @throws \LogicException
+     */
+    public function __construct(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    {
+        if ($source->getLocale() !== $target->getLocale()) {
+            throw new \LogicException('Operated catalogues must belong to the same locale.');
+        }
+
+        $this->source = $source;
+        $this->target = $target;
+        $this->result = new MessageCatalogue($source->getLocale());
+        $this->domains = null;
+        $this->messages = array();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDomains()
+    {
+        if (null === $this->domains) {
+            $this->domains = array_values(array_unique(array_merge($this->source->getDomains(), $this->target->getDomains())));
+        }
+
+        return $this->domains;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessages($domain)
+    {
+        if (!in_array($domain, $this->getDomains())) {
+            throw new \InvalidArgumentException('Invalid domain: '.$domain.'.');
+        }
+
+        if (!isset($this->messages[$domain]['all'])) {
+            $this->processDomain($domain);
+        }
+
+        return $this->messages[$domain]['all'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNewMessages($domain)
+    {
+        if (!in_array($domain, $this->getDomains())) {
+            throw new \InvalidArgumentException('Invalid domain: '.$domain.'.');
+        }
+
+        if (!isset($this->messages[$domain]['new'])) {
+            $this->processDomain($domain);
+        }
+
+        return $this->messages[$domain]['new'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getObsoleteMessages($domain)
+    {
+        if (!in_array($domain, $this->getDomains())) {
+            throw new \InvalidArgumentException('Invalid domain: '.$domain.'.');
+        }
+
+        if (!isset($this->messages[$domain]['obsolete'])) {
+            $this->processDomain($domain);
+        }
+
+        return $this->messages[$domain]['obsolete'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResult()
+    {
+        foreach ($this->getDomains() as $domain) {
+            if (!isset($this->messages[$domain])) {
+                $this->processDomain($domain);
+            }
+        }
+
+        return $this->result;
+    }
+
+    /**
+     * @param string $domain
+     */
+    abstract protected function processDomain($domain);
+}

--- a/src/Symfony/Component/Translation/Catalogue/DiffOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/DiffOperation.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Catalogue;
+
+/**
+ * Diff operation between two catalogues.
+ *
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class DiffOperation extends AbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function processDomain($domain)
+    {
+        $this->messages[$domain] = array(
+            'all'      => array(),
+            'new'      => array(),
+            'obsolete' => array(),
+        );
+
+        foreach ($this->source->all($domain) as $id => $message) {
+            if ($this->target->has($id, $domain)) {
+                $this->messages[$domain]['all'][$id] = $message;
+                $this->result->add(array($id => $message), $domain);
+            } else {
+                $this->messages[$domain]['obsolete'][$id] = $message;
+            }
+        }
+
+        foreach ($this->target->all($domain) as $id => $message) {
+            if (!$this->source->has($id, $domain)) {
+                $this->messages[$domain]['all'][$id] = $message;
+                $this->messages[$domain]['new'][$id] = $message;
+                $this->result->add(array($id => $message), $domain);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/Catalogue/MergeOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/MergeOperation.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Catalogue;
+
+/**
+ * Merge operation between two catalogues.
+ *
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class MergeOperation extends AbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function processDomain($domain)
+    {
+        $this->messages[$domain] = array(
+            'all'      => array(),
+            'new'      => array(),
+            'obsolete' => array(),
+        );
+
+        foreach ($this->source->all($domain) as $id => $message) {
+            $this->messages[$domain]['all'][$id] = $message;
+            $this->result->add(array($id => $message), $domain);
+        }
+
+        foreach ($this->target->all($domain) as $id => $message) {
+            if (!$this->source->has($id, $domain)) {
+                $this->messages[$domain]['all'][$id] = $message;
+                $this->messages[$domain]['new'][$id] = $message;
+                $this->result->add(array($id => $message), $domain);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Translation/Catalogue/OperationInterface.php
+++ b/src/Symfony/Component/Translation/Catalogue/OperationInterface.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Catalogue;
+
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+/**
+ * Represents an operation on catalogue(s).
+ *
+ * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ */
+interface OperationInterface
+{
+    /**
+     * Returns domains affected by operation.
+     *
+     * @return array
+     */
+    public function getDomains();
+
+    /**
+     * Returns all valid messages after operation.
+     *
+     * @param string $domain
+     *
+     * @return array
+     */
+    public function getMessages($domain);
+
+    /**
+     * Returns new messages after operation.
+     *
+     * @param string $domain
+     *
+     * @return array
+     */
+    public function getNewMessages($domain);
+
+    /**
+     * Returns obsolete messages after operation.
+     *
+     * @param string $domain
+     *
+     * @return array
+     */
+    public function getObsoleteMessages($domain);
+
+    /**
+     * Returns resulting catalogue.
+     *
+     * @return MessageCatalogueInterface
+     */
+    public function getResult();
+}

--- a/src/Symfony/Component/Translation/Tests/Catalogue/AbstractOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/AbstractOperationTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Test\Catalogue;
+
+use Symfony\Bundle\FrameworkBundle\Tests\TestCase;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+abstract class AbstractOperationTest extends TestCase
+{
+    public function testGetEmptyDomains()
+    {
+        $this->assertEquals(
+            array(),
+            $this->createOperation(
+                new MessageCatalogue('en'),
+                new MessageCatalogue('en')
+            )->getDomains()
+        );
+    }
+
+    public function testGetMergedDomains()
+    {
+        $this->assertEquals(
+            array('a', 'b', 'c'),
+            $this->createOperation(
+                new MessageCatalogue('en', array('a' => array(), 'b' => array())),
+                new MessageCatalogue('en', array('b' => array(), 'c' => array()))
+            )->getDomains()
+        );
+    }
+
+    public function testGetMessagesFromUnknownDomain()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $this->createOperation(
+            new MessageCatalogue('en'),
+            new MessageCatalogue('en')
+        )->getMessages('domain');
+    }
+
+    public function testGetEmptyMessages()
+    {
+        $this->assertEquals(
+            array(),
+            $this->createOperation(
+                new MessageCatalogue('en', array('a' => array())),
+                new MessageCatalogue('en')
+            )->getMessages('a')
+        );
+    }
+
+    public function testGetEmptyResult()
+    {
+        $this->assertEquals(
+            new MessageCatalogue('en'),
+            $this->createOperation(
+                new MessageCatalogue('en'),
+                new MessageCatalogue('en')
+            )->getResult()
+        );
+    }
+
+    abstract protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target);
+}

--- a/src/Symfony/Component/Translation/Tests/Catalogue/DiffOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/DiffOperationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Test\Catalogue;
+
+use Symfony\Component\Translation\Catalogue\DiffOperation;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+class DiffOperationTest extends AbstractOperationTest
+{
+    public function testGetMessagesFromSingleDomain()
+    {
+        $operation = $this->createOperation(
+            new MessageCatalogue('en', array('messages' => array('a' => 'old_a', 'b' => 'old_b'))),
+            new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'c' => 'new_c')))
+        );
+
+        $this->assertEquals(
+            array('a' => 'old_a', 'c' => 'new_c'),
+            $operation->getMessages('messages')
+        );
+
+        $this->assertEquals(
+            array('c' => 'new_c'),
+            $operation->getNewMessages('messages')
+        );
+
+        $this->assertEquals(
+            array('b' => 'old_b'),
+            $operation->getObsoleteMessages('messages')
+        );
+    }
+
+    public function testGetResultFromSingleDomain()
+    {
+        $this->assertEquals(
+            new MessageCatalogue('en', array(
+                'messages' => array('a' => 'old_a', 'c' => 'new_c')
+            )),
+            $this->createOperation(
+                new MessageCatalogue('en', array('messages' => array('a' => 'old_a', 'b' => 'old_b'))),
+                new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'c' => 'new_c')))
+            )->getResult()
+        );
+    }
+
+    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    {
+        return new DiffOperation($source, $target);
+    }
+}

--- a/src/Symfony/Component/Translation/Tests/Catalogue/MergeOperationTest.php
+++ b/src/Symfony/Component/Translation/Tests/Catalogue/MergeOperationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Translation\Test\Catalogue;
+
+use Symfony\Component\Translation\Catalogue\MergeOperation;
+use Symfony\Component\Translation\MessageCatalogue;
+use Symfony\Component\Translation\MessageCatalogueInterface;
+
+class MergeOperationTest extends AbstractOperationTest
+{
+    public function testGetMessagesFromSingleDomain()
+    {
+        $operation = $this->createOperation(
+            new MessageCatalogue('en', array('messages' => array('a' => 'old_a', 'b' => 'old_b'))),
+            new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'c' => 'new_c')))
+        );
+
+        $this->assertEquals(
+            array('a' => 'old_a', 'b' => 'old_b', 'c' => 'new_c'),
+            $operation->getMessages('messages')
+        );
+
+        $this->assertEquals(
+            array('c' => 'new_c'),
+            $operation->getNewMessages('messages')
+        );
+
+        $this->assertEquals(
+            array(),
+            $operation->getObsoleteMessages('messages')
+        );
+    }
+
+    public function testGetResultFromSingleDomain()
+    {
+        $this->assertEquals(
+            new MessageCatalogue('en', array(
+                'messages' => array('a' => 'old_a', 'b' => 'old_b', 'c' => 'new_c')
+            )),
+            $this->createOperation(
+                new MessageCatalogue('en', array('messages' => array('a' => 'old_a', 'b' => 'old_b'))),
+                new MessageCatalogue('en', array('messages' => array('a' => 'new_a', 'c' => 'new_c')))
+            )->getResult()
+        );
+    }
+
+    protected function createOperation(MessageCatalogueInterface $source, MessageCatalogueInterface $target)
+    {
+        return new MergeOperation($source, $target);
+    }
+}


### PR DESCRIPTION
This PR adds `--clean` option to `translation:update` command.
This options activates unused translation removal.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6592 |
