### PR TITLE
[FrameworkBundle] adds log for sub requests rendering with ignore_errors

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/ActionsHelper.php
@@ -40,6 +40,8 @@ class ActionsHelper extends Helper
      * @param array  $attributes An array of request attributes
      * @param array  $options    An array of options
      *
+     * @return string
+     * 
      * @see Symfony\Bundle\FrameworkBundle\HttpKernel::render()
      */
     public function render($controller, array $attributes = array(), array $options = array())


### PR DESCRIPTION
When rendering a sub request with `ignore_errors` set to `true` (default behavior in non-debug mode), if sub request throws an exception, alternative content is rendered (if any) and nothing is logged (because the `kernel.exception` event is never dispatched). This PR just dispatches this event.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6400 |
