### PR TITLE
[2.2][Finder] fix assets:install issue

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
@@ -21,7 +21,7 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $followLinks = false;
     protected $mode        = 0;
     protected $minDepth    = 0;
-    protected $maxDepth    = INF;
+    protected $maxDepth    = PHP_INT_MAX;
     protected $exclude     = array();
     protected $names       = array();
     protected $notNames    = array();
@@ -76,7 +76,7 @@ abstract class AbstractAdapter implements AdapterInterface
     public function setDepths(array $depths)
     {
         $this->minDepth = 0;
-        $this->maxDepth = INF;
+        $this->maxDepth = PHP_INT_MAX;
 
         foreach ($depths as $comparator) {
             switch ($comparator->getOperator()) {

--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -60,9 +60,8 @@ abstract class AbstractFindAdapter extends AbstractAdapter
         }
 
         $find->add('-mindepth')->add($this->minDepth + 1);
-        // warning! INF < INF => true ; INF == INF => false ; INF === INF => true
-        // https://bugs.php.net/bug.php?id=9118
-        if (INF !== $this->maxDepth) {
+
+        if (PHP_INT_MAX !== $this->maxDepth) {
             $find->add('-maxdepth')->add($this->maxDepth + 1);
         }
 

--- a/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
@@ -36,7 +36,7 @@ class PhpAdapter extends AbstractAdapter
             \RecursiveIteratorIterator::SELF_FIRST
         );
 
-        if ($this->minDepth > 0 || $this->maxDepth < INF) {
+        if ($this->minDepth > 0 || $this->maxDepth < PHP_INT_MAX) {
             $iterator = new Iterator\DepthRangeFilterIterator($iterator, $this->minDepth, $this->maxDepth);
         }
 

--- a/src/Symfony/Component/Finder/Iterator/DepthRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/DepthRangeFilterIterator.php
@@ -27,7 +27,7 @@ class DepthRangeFilterIterator extends FilterIterator
      * @param int                        $minDepth    The min depth
      * @param int                        $maxDepth    The max depth
      */
-    public function __construct(\RecursiveIteratorIterator $iterator, $minDepth = 0, $maxDepth = INF)
+    public function __construct(\RecursiveIteratorIterator $iterator, $minDepth = 0, $maxDepth = PHP_INT_MAX)
     {
         $this->minDepth = $minDepth;
         $iterator->setMaxDepth(PHP_INT_MAX === $maxDepth ? -1 : $maxDepth);

--- a/src/Symfony/Component/Finder/Tests/Iterator/DepthRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/DepthRangeFilterIteratorTest.php
@@ -72,8 +72,8 @@ class DepthRangeFilterIteratorTest extends RealIteratorTestCase
         return array(
             array(0, 0, $this->toAbsolute($lessThan1)),
             array(0, 1, $this->toAbsolute($lessThanOrEqualTo1)),
-            array(2, INF, array()),
-            array(1, INF, $this->toAbsolute($graterThanOrEqualTo1)),
+            array(2, PHP_INT_MAX, array()),
+            array(1, PHP_INT_MAX, $this->toAbsolute($graterThanOrEqualTo1)),
             array(1, 1, $this->toAbsolute($equalTo1)),
         );
     }


### PR DESCRIPTION
I have some bundle with assets, and when i do.

```
app/console assets:install --env=prod
```

I don't have any of my file inside web/bundles, only empty first level directory like "css"
bug issue introduced by 7c66dffa6b
