### PR TITLE
Fixed not initialized data variable

### DIFF
--- a/src/Symfony/Bridge/Twig/NodeVisitor/Scope.php
+++ b/src/Symfony/Bridge/Twig/NodeVisitor/Scope.php
@@ -34,6 +34,7 @@ class Scope
     {
         $this->parent = $parent;
         $this->left = false;
+        $this->data = array();
     }
 
     /**


### PR DESCRIPTION
Fixed not initialized data variable in the Scope class, which leads to a PHP warnings when using `array_key_exists()`.
