### PR TITLE
[BrowserKit] adds ability to ignore malformed set-cookie header

### DIFF
--- a/src/Symfony/Component/BrowserKit/CookieJar.php
+++ b/src/Symfony/Component/BrowserKit/CookieJar.php
@@ -109,7 +109,11 @@ class CookieJar
         }
 
         foreach ($cookies as $cookie) {
-            $this->set(Cookie::fromString($cookie, $uri));
+            try {
+                $this->set(Cookie::fromString($cookie, $uri));
+            } catch (\InvalidArgumentException $e) {
+                // invalid cookies are just ignored
+            }
         }
     }
 

--- a/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/CookieJarTest.php
@@ -82,6 +82,13 @@ class CookieJarTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $cookieJar->get('bar')->getValue(), '->updateFromSetCookie() keeps existing cookies');
     }
 
+    public function testUpdateFromEmptySetCookie()
+    {
+        $cookieJar = new CookieJar();
+        $cookieJar->updateFromSetCookie(array(''));
+        $this->assertEquals(array(), $cookieJar->all());
+    }
+
     public function testUpdateFromSetCookieWithMultipleCookies()
     {
         $timestamp = time() + 3600;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7039 |
