### PR TITLE
[DependencyInjection] Added @@ escaping strategy for YamlFileLoader and YamlDumper

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -260,7 +260,7 @@ class YamlDumper extends Dumper
         foreach ($parameters as $key => $value) {
             if (is_array($value)) {
                 $value = $this->prepareParameters($value, $escape);
-            } elseif ($value instanceof Reference) {
+            } elseif ($value instanceof Reference || is_string($value) && 0 === strpos($value, '@')) {
                 $value = '@'.$value;
             }
 

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -290,7 +290,10 @@ class YamlFileLoader extends FileLoader
         if (is_array($value)) {
             $value = array_map(array($this, 'resolveServices'), $value);
         } elseif (is_string($value) &&  0 === strpos($value, '@')) {
-            if (0 === strpos($value, '@?')) {
+            if (0 === strpos($value, '@@')) {
+                $value = substr($value, 1);
+                $invalidBehavior = null;
+            } elseif (0 === strpos($value, '@?')) {
                 $value = substr($value, 2);
                 $invalidBehavior = ContainerInterface::IGNORE_ON_INVALID_REFERENCE;
             } else {
@@ -305,7 +308,9 @@ class YamlFileLoader extends FileLoader
                 $strict = true;
             }
 
-            $value = new Reference($value, $invalidBehavior, $strict);
+            if (null !== $invalidBehavior) {
+                $value = new Reference($value, $invalidBehavior, $strict);
+            }
         }
 
         return $value;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container8.php
@@ -7,6 +7,7 @@ $container = new ContainerBuilder(new ParameterBag(array(
     'FOO'    => '%baz%',
     'baz'    => 'bar',
     'bar'    => 'foo is %%foo bar',
+    'escape' => '@escapeme',
     'values' => array(true, false, null, 0, 1000.3, 'true', 'false', 'null'),
 )));
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services8.php
@@ -37,6 +37,7 @@ class ProjectServiceContainer extends Container
             'foo' => '%baz%',
             'baz' => 'bar',
             'bar' => 'foo is %%foo bar',
+            'escape' => '@escapeme',
             'values' => array(
                 0 => true,
                 1 => false,

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services8.xml
@@ -7,6 +7,7 @@
     <parameter key="foo">%baz%</parameter>
     <parameter key="baz">bar</parameter>
     <parameter key="bar">foo is %%foo bar</parameter>
+    <parameter key="escape">@escapeme</parameter>
     <parameter key="values" type="collection">
       <parameter>true</parameter>
       <parameter>false</parameter>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services2.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services2.yml
@@ -6,6 +6,7 @@ parameters:
         - 0
         - 1000.3
     bar: foo
+    escape: @@escapeme
     foo_bar: @foo_bar
     MixedCase:
         MixedCaseKey: value

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services8.yml
@@ -2,5 +2,6 @@ parameters:
     foo: '%baz%'
     baz: bar
     bar: 'foo is %%foo bar'
+    escape: '@@escapeme'
     values: [true, false, null, 0, 1000.3, 'true', 'false', 'null']
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -84,7 +84,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder();
         $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
         $loader->load('services2.yml');
-        $this->assertEquals(array('foo' => 'bar', 'mixedcase' => array('MixedCaseKey' => 'value'), 'values' => array(true, false, 0, 1000.3), 'bar' => 'foo', 'foo_bar' => new Reference('foo_bar')), $container->getParameterBag()->all(), '->load() converts YAML keys to lowercase');
+        $this->assertEquals(array('foo' => 'bar', 'mixedcase' => array('MixedCaseKey' => 'value'), 'values' => array(true, false, 0, 1000.3), 'bar' => 'foo', 'escape' => '@escapeme', 'foo_bar' => new Reference('foo_bar')), $container->getParameterBag()->all(), '->load() converts YAML keys to lowercase');
     }
 
     public function testLoadImports()
@@ -99,7 +99,7 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services4.yml');
 
         $actual = $container->getParameterBag()->all();
-        $expected = array('foo' => 'bar', 'values' => array(true, false), 'bar' => '%foo%', 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'imported_from_ini' => true, 'imported_from_xml' => true);
+        $expected = array('foo' => 'bar', 'values' => array(true, false), 'bar' => '%foo%', 'escape' => '@escapeme', 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'imported_from_ini' => true, 'imported_from_xml' => true);
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
 
         // Bad import throws no exception due to ignore_errors value.


### PR DESCRIPTION
Added the possibility to to use `@@` as an escaping strategy for
parameters that should be treated as strings but start with `@`
(i.e. safe mailer passwords).

This PR is deprecating https://github.com/symfony/symfony/pull/7307, since as a new feature it has to be compared against the master branch.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #4889 |
