### PR TITLE
[FrameworkBundle] fixes cahe:clear command's warmup

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -142,6 +142,14 @@ EOF
     }
 
     /**
+     * @deprecated to be removed in 2.3
+     */
+    protected function getTempSuffix()
+    {
+        return '';
+    }
+
+    /**
      * @param KernelInterface $parent
      * @param string          $namespace
      * @param string          $parentClass


### PR DESCRIPTION
Solution taken is to replace the last char of the cache directory name to create a temporary cache directory, this way the temporary cache path has the same length than the real one. I tested this on several projects, in dev and prod environments.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6203 |
