### PR TITLE
[HttpKernel] Updated TraceableEventDispatcher.php

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -132,6 +132,10 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
 
         $this->firstCalledEvent[$eventName] = $this->stopwatch->start($eventName.'.loading', 'event_listener_loading');
 
+        if (!$this->dispatcher->getListeners($eventName)) {
+            $this->firstCalledEvent[$eventName]->stop();
+        }
+
         $this->dispatcher->dispatch($eventName, $event);
 
         // reset the id as another event might have been dispatched during the dispatching of this event

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -132,7 +132,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
 
         $this->firstCalledEvent[$eventName] = $this->stopwatch->start($eventName.'.loading', 'event_listener_loading');
 
-        if (!$this->dispatcher->getListeners($eventName)) {
+        if (!$this->dispatcher->hasListeners($eventName)) {
             $this->firstCalledEvent[$eventName]->stop();
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Currently, if no listeners are registered for an dispatched event, the StopwatchEvent "$eventName.'.loading'" is never being stopped.
