### PR TITLE
[HttpKernel] RequestDataCollector: collect data if the controller is a Closure

### DIFF
--- a/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/RequestDataCollector.php
@@ -133,7 +133,13 @@ class RequestDataCollector extends DataCollector implements EventSubscriberInter
                     }
                 }
             } elseif ($controller instanceof \Closure) {
-                $this->data['controller'] = 'Closure';
+                $r = new \ReflectionFunction($controller);
+                $this->data['controller'] = array(
+                    'class'  => $r->getName(),
+                    'method' => null,
+                    'file'   => $r->getFilename(),
+                    'line'   => $r->getStartLine(),
+                );
             } else {
                 $this->data['controller'] = (string) $controller ?: 'n/a';
             }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/RequestDataCollectorTest.php
@@ -81,7 +81,12 @@ class RequestDataCollectorTest extends \PHPUnit_Framework_TestCase
             array(
                 'Closure',
                 function() { return 'foo'; },
-                'Closure',
+                array(
+                    'class' => __NAMESPACE__ . '\{closure}',
+                    'method' => null,
+                    'file' => __FILE__,
+                    'line' => __LINE__ - 5,
+                ),
             ),
 
             array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

Use the same format as object methods to describe closures and collect the file and the line where it's been declared.

Currently, the `file` and `line` parameters are not shown by the webprofiler, but they could be useful to find a closure.
