### PR TITLE
[WebProfiler] add missing typehint to RouterController

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/RouterController.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\WebProfilerBundle\Controller;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
 use Symfony\Component\Routing\Matcher\TraceableUrlMatcher;
+use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 
@@ -29,14 +30,14 @@ class RouterController
     private $matcher;
     private $routes;
 
-    public function __construct(Profiler $profiler, \Twig_Environment $twig, UrlMatcherInterface $matcher = null, $routes = null)
+    public function __construct(Profiler $profiler, \Twig_Environment $twig, UrlMatcherInterface $matcher = null, RouteCollection $routes = null)
     {
         $this->profiler = $profiler;
         $this->twig = $twig;
         $this->matcher = $matcher;
         $this->routes = $routes;
 
-        if (null === $this->routes && null !== $this->matcher && $this->matcher instanceof RouterInterface) {
+        if (null === $this->routes && $this->matcher instanceof RouterInterface) {
             $this->routes = $matcher->getRouteCollection();
         }
     }


### PR DESCRIPTION
It must be a RouteCollection because TraceableUrlMatcher expects it anyway.

| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |
