### PR TITLE
[HttpRequest] fixes Request::getLanguages() bug

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1309,7 +1309,9 @@ class Request
                     for ($i = 0, $max = count($codes); $i < $max; $i++) {
                         if ($i == 0) {
                             $lang = strtolower($codes[0]);
-                            if(!in_array($lang, $this->languages) {
+                            // First segment of compound language codes
+                            // is added to supported languages list
+                            if (!in_array($lang, $this->languages)) {
                                 $this->languages[] = $lang;
                             }
                         } else {
@@ -1319,7 +1321,9 @@ class Request
                 }
             }
 
-            $this->languages[] = $lang;
+            if (!in_array($lang, $this->languages)) {
+                $this->languages[] = $lang;
+            }
         }
 
         return $this->languages;

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1309,6 +1309,9 @@ class Request
                     for ($i = 0, $max = count($codes); $i < $max; $i++) {
                         if ($i == 0) {
                             $lang = strtolower($codes[0]);
+                            if(!in_array($lang, $this->languages) {
+                                $this->languages[] = $lang;
+                            }
                         } else {
                             $lang .= '_'.strtoupper($codes[$i]);
                         }

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -951,8 +951,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request = new Request();
         $request->headers->set('Accept-language', 'zh, en-us; q=0.8, en; q=0.6');
-        $this->assertEquals(array('zh', 'en_US', 'en'), $request->getLanguages());
-        $this->assertEquals(array('zh', 'en_US', 'en'), $request->getLanguages());
+        $this->assertEquals(array('zh', 'en', 'en_US'), $request->getLanguages());
+        $this->assertEquals(array('zh', 'en', 'en_US'), $request->getLanguages());
 
         $request = new Request();
         $request->headers->set('Accept-language', 'zh, en-us; q=0.6, en; q=0.8');
@@ -969,6 +969,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $request->headers->set('Accept-language', 'zh, i-cherokee; q=0.6');
         $this->assertEquals(array('zh', 'cherokee'), $request->getLanguages());
+
+        $request = new Request();
+        $request->headers->set('Accept-language', 'en-us');
+        $this->assertEquals(array('en', 'en_US'), $request->getLanguages());
     }
 
     public function testGetRequestFormat()


### PR DESCRIPTION
This PR adds to suported languages the first segment of all compouds languages codes.
When receiving `Accept-Language: en-us` header, accepted languages will now be `en, en_US`.

This should not be a BC break as most browsers already send the long **and** short versions of language codes... but some dont.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6928 |
