### PR TITLE
[2.2] sub-requests are now created with the same class as their parent

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -89,7 +89,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         // the sub-request is internal
         $server['REMOTE_ADDR'] = '127.0.0.1';
 
-        $subRequest = Request::create($uri, 'get', array(), $cookies, array(), $server);
+        $subRequest = $request::create($uri, 'get', array(), $cookies, array(), $server);
         if ($session = $request->getSession()) {
             $subRequest->setSession($session);
         }


### PR DESCRIPTION
Following #7381

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7185, #7186 |
