### PR TITLE
[travis-ci] removing xdebug extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
     - php: 5.5
 
 before_script:
+    - echo '' > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
     - COMPOSER_ROOT_VERSION=dev-master composer --prefer-source --dev install
     - php src/Symfony/Component/Locale/Resources/data/build-data.php
     - export USE_INTL_ICU_DATA_VERSION=1


### PR DESCRIPTION
we don't need it (no coverage), and removing it speeds travis build by 1 minute approx (composer + icu + phpunit)
