### PR TITLE
[Config] Add possibility to get "parent bundle resource file" in import file loading process

### DIFF
--- a/src/Symfony/Component/Config/Loader/FileLoader.php
+++ b/src/Symfony/Component/Config/Loader/FileLoader.php
@@ -67,11 +67,19 @@ abstract class FileLoader extends Loader
             $loader = $this->resolve($resource, $type);
 
             if ($loader instanceof FileLoader && null !== $this->currentDir) {
-                $resource = $this->locator->locate($resource, $this->currentDir);
+                $resource = $this->locator->locate($resource, $this->currentDir, false);
             }
 
-            if (isset(self::$loading[$resource])) {
-                throw new FileLoaderImportCircularReferenceException(array_keys(self::$loading));
+            $resources = is_array($resource) ? $resource : array($resource);
+            for ($i = 0; $i < $resourcesCount = count($resources); $i++ ) {
+                if (isset(self::$loading[$resources[$i]])) {
+                    if ($i == $resourcesCount-1) {
+                        throw new FileLoaderImportCircularReferenceException(array_keys(self::$loading));
+                    }
+                } else {
+                    $resource = $resources[$i];
+                    break;
+                }
             }
             self::$loading[$resource] = true;
 

--- a/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
+++ b/src/Symfony/Component/Config/Tests/Loader/FileLoaderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+
+namespace Symfony\Component\Config\Tests\Loader;
+
+use Symfony\Component\Config\Loader\FileLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\Config\Exception\FileLoaderImportCircularReferenceException;
+
+class FileLoaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers Symfony\Component\Config\Loader\FileLoader::import
+     */
+    public function testImport()
+    {
+        $locatorMock = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
+        $locatorMock->expects($this->any())->method('locate')->will($this->onConsecutiveCalls(
+                array('path/to/file1'),                    // Default
+                array('path/to/file1', 'path/to/file2'),   // First is imported
+                array('path/to/file1', 'path/to/file2'),   // Second is imported
+                array('path/to/file1'),                    // Exception
+                array('path/to/file1', 'path/to/file2')    // Exception
+                ));
+
+        $fileLoader = new TestFileLoader($locatorMock);
+        $fileLoader->setCurrentDir('.');
+        $fileLoader->setResolver($loaderResolver = new LoaderResolver(array($fileLoader)));
+
+        // Default case
+        $this->assertSame('path/to/file1', $fileLoader->import('my_resource'));
+
+        // Check first file is imported if not already loading
+        $this->assertSame('path/to/file1', $fileLoader->import('my_resource'));
+
+        // Check second file is imported if first is already loading
+        $fileLoader->addLoading('path/to/file1');
+        $this->assertSame('path/to/file2', $fileLoader->import('my_resource'));
+
+        // Check exception throws if first (and only available) file is already loading
+        try {
+            $fileLoader->import('my_resource');
+            $this->fail('->import() throws a FileLoaderImportCircularReferenceException if the resource is already loading');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Symfony\Component\Config\Exception\FileLoaderImportCircularReferenceException', $e, '->import() throws a FileLoaderImportCircularReferenceException if the resource is already loading');
+        }
+
+        // Check exception throws if all files are already loading
+        try {
+            $fileLoader->addLoading('path/to/file2');
+            $fileLoader->import('my_resource');
+            $this->fail('->import() throws a FileLoaderImportCircularReferenceException if the resource is already loading');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('Symfony\Component\Config\Exception\FileLoaderImportCircularReferenceException', $e, '->import() throws a FileLoaderImportCircularReferenceException if the resource is already loading');
+        }
+    }
+}
+
+class TestFileLoader extends FileLoader
+{
+    public function load($resource, $type = null)
+    {
+        return $resource;
+    }
+
+    public function supports($resource, $type = null)
+    {
+        return true;
+    }
+
+    public function addLoading($resource)
+    {
+        self::$loading[$resource] = true;
+    }
+
+    public function removeLoading($resource)
+    {
+        unset(self::$loading[$resource]);
+    }
+
+    public function clearLoading()
+    {
+        self::$loading = array();
+    }
+}


### PR DESCRIPTION
FileLoader doesn't throw FileLoaderImportCircularReferenceException anymore if another file matchs import request.

Currently if a Bundle is defined as child of another Bundle and if we try to import a Resource from parent Bundle into the same "overrided" Resource, we get a FileLoaderImportCircularReferenceException.

Now, FileLoader locates "available files" and try to import one of them (rule is "the first that is not currently loading").

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes? |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
