### PR TITLE
Invalid multibyte sequences in request URL causes errors

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -181,7 +181,7 @@ class ClassLoader
         $classPath .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
         foreach ($this->prefixes as $prefix => $dirs) {
-            if (0 === strpos($class, $prefix)) {
+            if ($class === strstr($class, $prefix)) {
                 foreach ($dirs as $dir) {
                     if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
                         return $dir . DIRECTORY_SEPARATOR . $classPath;

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -102,7 +102,12 @@ class RedirectResponse extends Response
          * otherwise latin-1 site lead browsers to request url-encoded multibyte sequences
          * instead of (urlencoded) single-byte non-ascii chars (umlauts for example).
          */
-        $encoding = mb_detect_encoding($url, 'UTF-8, ISO-8859-1, ISO-8859-15, cp866, cp1251, cp1252, KOI8-R');
+        if (function_exists('mb_detect_encoding')) {
+            $encoding = mb_detect_encoding($url, 'UTF-8, ISO-8859-1, ISO-8859-15, cp866, cp1251, cp1252, KOI8-R');
+        } else {
+            $encoding = 'utf-8'; // as it was previously assumed
+        }
+
         $urlencodedUrl = implode("/", array_map("rawurlencode", explode("/", $url)));
 
         $this->setContent(

--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -85,11 +85,31 @@ class RedirectResponse extends Response
 
         $this->targetUrl = $url;
 
+        /*
+         * We're a bit lost here as we don't know the encoding of the URL given
+         * and we also don't know what the target system/app expects.
+         *
+         * RFC 1630 mandates ASCII-only URLs (so use urlencode()), but there's
+         * still a difference in having a (e. g.) latin-1 or utf-8 string
+         * urlencoded.
+         *
+         * For links, browsers will usually use the encoding of the page containing
+         * the link before applying url-encoding. So for cross-site links or
+         * URLs entered directly YMMV.
+         *
+         * Thus, we try our best to keep the encoding that was probably used. Note that we also
+         * don't convert the URL to utf-8 for the redirect page, as that would on an
+         * otherwise latin-1 site lead browsers to request url-encoded multibyte sequences
+         * instead of (urlencoded) single-byte non-ascii chars (umlauts for example).
+         */
+        $encoding = mb_detect_encoding($url, 'UTF-8, ISO-8859-1, ISO-8859-15, cp866, cp1251, cp1252, KOI8-R');
+        $urlencodedUrl = implode("/", array_map("rawurlencode", explode("/", $url)));
+
         $this->setContent(
             sprintf('<!DOCTYPE html>
 <html>
     <head>
-        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta http-equiv="Content-Type" content="text/html; charset=%2$s" />
         <meta http-equiv="refresh" content="1;url=%1$s" />
 
         <title>Redirecting to %1$s</title>
@@ -97,9 +117,9 @@ class RedirectResponse extends Response
     <body>
         Redirecting to <a href="%1$s">%1$s</a>.
     </body>
-</html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8')));
+</html>', htmlspecialchars($url, ENT_QUOTES), $encoding));
 
-        $this->headers->set('Location', $url);
+        $this->headers->set('Location', $urlencodedUrl);
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -18,11 +18,7 @@ class RedirectResponseTest extends \PHPUnit_Framework_TestCase
     public function testGenerateMetaRedirect()
     {
         $response = new RedirectResponse('foo.bar');
-
-        $this->assertEquals(1, preg_match(
-            '#<meta http-equiv="refresh" content="\d+;url=foo\.bar" />#',
-            preg_replace(array('/\s+/', '/\'/'), array(' ', '"'), $response->getContent())
-        ));
+        $this->assertMetaRefreshUrl('foo.bar', $response->getContent());
     }
 
     /**
@@ -81,11 +77,36 @@ class RedirectResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(301, $response->getStatusCode());
     }
 
-    public function testInvalidMultibyteCharacters()
+    /** @dataProvider provideUrlencodedUrls */
+    public function testVariousEncodingUrls($urlencodedUrl)
     {
         # This is necessary due to http://www.php.net/manual/en/function.htmlspecialchars.php#102871:
         ini_set('display_errors', false);
 
-        $response = RedirectResponse::create(urldecode('foo/bar/%A0'));
+        // $urlencodedUrl is what is sent by the browser on the HTTP level
+        $decoded = urldecode($urlencodedUrl); // This is what we get in PHP (webserver does the decoding)
+        $test = "/test-";
+
+        $response = RedirectResponse::create($test.$decoded);
+
+        $this->assertEquals($test.$urlencodedUrl, $response->headers->get('Location'));
+        $this->assertMetaRefreshUrl($test.$decoded, $response->getContent());
+    }
+
+    public function provideUrlencodedUrls() {
+        return array(
+            array("%C3%A4"), // german umlaut, utf-8 and url-encoded
+            array("%E4"), // german umlaut, latin-1 and url-encoded
+        );
+    }
+
+    protected function assertMetaRefreshUrl($url, $content)
+    {
+        $url = preg_quote($url, '#');
+
+        $this->assertEquals(1, preg_match(
+            '#<meta http-equiv="refresh" content="\d+;url='.$url.'" />#',
+            preg_replace(array('/\s+/', '/\'/'), array(' ', '"'), $content)
+        ));
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -80,4 +80,12 @@ class RedirectResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
     }
+
+    public function testInvalidMultibyteCharacters()
+    {
+        # This is necessary due to http://www.php.net/manual/en/function.htmlspecialchars.php#102871:
+        ini_set('display_errors', false);
+
+        $response = RedirectResponse::create(urldecode('foo/bar/%A0'));
+    }
 }


### PR DESCRIPTION
**The simple/obvious problem**

When an URI like "/foo/%A0" is requested, the urlencoded "%A0" gets decoded before it shows up in PHP. Thus, the request uri contains a single byte value > 128 that is not valid in multibyte character encodings.

Symfony's Matcher might want to forward to the same address with a trailing slash added and creates a RedirectResponse. Internally, htmlspecialchars() is called which stumbles upon the invalid multibyte sequence (as it always tries to generate an UTF-8 response body) and emits a PHP warning.

**The more fundamental look**

The HTTP spec does not (at least I haven't found it until now; RFC 3986?) say anything regarding the character encoding of URLs in the HTTP _request_. For the response, the Content-Type header gives the encoding of the body, but there seems to be no such thing for the request. 

That's a problem as [it does not make sense to have a string without knowing what encoding it uses](http://www.joelonsoftware.com/articles/Unicode.html).

Browsers seem to use the encoding of the current page for the URL when following a link from that page. That is, when an URL with a non-ascii (think of German umlauts) charcter is picked from a latin1 page, the request URL will be in latin1; when the same link appears on an utf-8 encoded page, the request is sent with a multibyte encoded character in that place.

This becomes a problem when the link is forwarded by other means - search engines, e-mail, messaging. In that case, the link-receiving and requesting browser might only see an umlaut (for example) in the URL but has no idea whether to request it with an latin1 or utf-8 encoded URL. Note that percent-encoding does not matter here as it only avoids sending bytes outside ASCII, but depending on the decision for latin1/utf-8, the percent-encoded URL will contain one, two (or even more) %.. sequences for every character.

In consequence, you can not be sure which encoding your request data (parameters, pathinfo, ...) will be in.

**Fixing this in the HttpFoundation?**

The HttpFoundation might be able to address this issue as it might apply magic (mb_detect_encoding() comes to mind) to figure out the encoding the requesting client used and convert the request to a desired (framework.charset?) encoding.

Thoughts?
