### PR TITLE
Changed bytes conversion method

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
@@ -29,18 +29,12 @@ class ServerParams
             return null;
         }
 
-        $max = (int) $iniMax;
-
-        switch (substr($iniMax, -1)) {
-            case 'G':
-                $max *= 1024;
-            case 'M':
-                $max *= 1024;
-            case 'K':
-                $max *= 1024;
+        if (preg_match('#^(\d+)([bkmgt])#i', $iniMax, $match)) {
+            $shift = array('b' => 0, 'k' => 10, 'm' => 20, 'g' => 30, 't' => 40);
+            $iniMax = ($match[1] * (1 << $shift[strtolower($match[2])]));
         }
 
-        return $max;
+        return (int) $iniMax;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -235,13 +235,9 @@ class UploadedFile extends File
             return PHP_INT_MAX;
         }
 
-        switch (strtolower(substr($max, -1))) {
-            case 'g':
-                $max *= 1024;
-            case 'm':
-                $max *= 1024;
-            case 'k':
-                $max *= 1024;
+        if (preg_match('#^(\d+)([bkmgt])#i', $max, $match)) {
+            $shift = array('b' => 0, 'k' => 10, 'm' => 20, 'g' => 30, 't' => 40);
+            $max = ($match[1] * (1 << $shift[strtolower($match[2])]));
         }
 
         return (integer) $max;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

**The old way:**

``` php
switch (strtolower(substr($memory, -1))) {
    case 'g':
        $memory *= 1024;
    case 'm':
        $memory *= 1024;
    case 'k':
        $memory *= 1024;
}
```

**The new way:**

``` php
if (preg_match('#^(\d+)([bkmgt])#i', $memory, $match)) {
    $shift = array('b' => 0, 'k' => 10, 'm' => 20, 'g' => 30, 't' => 40);
    $memory = ($match[1] * (1 << $shift[strtolower($match[2])]));
}
```
