### PR TITLE
[2.3][HttpFoundation] Allow MimeTypeGuesser to be constructed and customized outside of the singleton scope

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
+++ b/src/Symfony/Component/HttpFoundation/File/MimeType/MimeTypeGuesser.php
@@ -48,31 +48,11 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
     protected $guessers = array();
 
     /**
-     * Returns the singleton instance
-     *
-     * @return MimeTypeGuesser
+     * Defines the current MimeTypeGuesser as the instance returned by getInstance method.
      */
-    public static function getInstance()
+    public function defineAsInstance()
     {
-        if (null === self::$instance) {
-            self::$instance = new self();
-        }
-
-        return self::$instance;
-    }
-
-    /**
-     * Registers all natively provided mime type guessers
-     */
-    private function __construct()
-    {
-        if (FileBinaryMimeTypeGuesser::isSupported()) {
-            $this->register(new FileBinaryMimeTypeGuesser());
-        }
-
-        if (FileinfoMimeTypeGuesser::isSupported()) {
-            $this->register(new FileinfoMimeTypeGuesser());
-        }
+        self::$instance = $this;
     }
 
     /**
@@ -120,5 +100,30 @@ class MimeTypeGuesser implements MimeTypeGuesserInterface
                 return $mimeType;
             }
         }
+    }
+
+    /**
+     * Returns the singleton instance.
+     *
+     * If the instance needs to be built, builds it and registers default
+     * mime-type guessers.
+     *
+     * @return MimeTypeGuesser
+     */
+    public static function getInstance()
+    {
+        if (null === self::$instance) {
+            self::$instance = new self();
+
+            if (FileBinaryMimeTypeGuesser::isSupported()) {
+                self::$instance->register(new FileBinaryMimeTypeGuesser());
+            }
+
+            if (FileinfoMimeTypeGuesser::isSupported()) {
+                self::$instance->register(new FileinfoMimeTypeGuesser());
+            }
+        }
+
+        return self::$instance;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/MimeType/MimeTypeTest.php
@@ -94,6 +94,22 @@ class MimeTypeTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testDefinesAsInstance()
+    {
+        $guesser = new MimeTypeGuesser();
+        $instance1 = MimeTypeGuesser::getInstance();
+
+        $this->assertNotEquals($instance1, $guesser);
+
+        $guesser->defineAsInstance();
+        $instance2 = MimeTypeGuesser::getInstance();
+
+        $this->assertEquals($instance2, $guesser);
+
+        // revert instances changes
+        $instance1->defineAsInstance();
+    }
+
     public static function tearDownAfterClass()
     {
         $path = __DIR__.'/../Fixtures/to_delete';


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5615 |
| License | MIT |

Allow singleton customization with the method `defineAsInstance`.

For example, to use a unique `CustomMimeTypeGuesser` : 

``` php
$guesser = new MimeTypeGuesser();
$guesser->register(new CustomMimeTypeGuesser());
$guesser->defineAsInstance();
```

the following call to `MimeTypeGuesser::getInstance();` will return the previously defined `$guesser`.
