### PR TITLE
[ClassLoader] fixed heredocs handling

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassCollectionLoader.php
@@ -178,6 +178,7 @@ class ClassCollectionLoader
                     $token = next($tokens);
                     $output .= is_string($token) ? $token : $token[1];
                 } while ($token[0] !== T_END_HEREDOC);
+                $output .= "\n";
                 $rawChunk = '';
             } elseif (T_CONSTANT_ENCAPSED_STRING === $token[0]) {
                 $output .= self::compressCode($rawChunk).$token[1];

--- a/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
+++ b/src/Symfony/Component/ClassLoader/Tests/ClassCollectionLoaderTest.php
@@ -228,20 +228,22 @@ class WithComments
 public static \$loaded = true;
 }
 \$string ='string shoult not be   modified {\$string}';
-\$heredoc =<<<HD
+\$heredoc = (<<<HD
 
 
 Heredoc should not be   modified {\$string}
 
 
-HD;
+HD
+);
 \$nowdoc =<<<'ND'
 
 
 Nowdoc should not be   modified {\$string}
 
 
-ND;
+ND
+;
 }
 namespace
 {

--- a/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithComments.php
+++ b/src/Symfony/Component/ClassLoader/Tests/Fixtures/Namespaced/WithComments.php
@@ -19,13 +19,14 @@ class WithComments
 
 $string = 'string shoult not be   modified {$string}';
 
-$heredoc = <<<HD
+$heredoc = (<<<HD
 
 
 Heredoc should not be   modified {$string}
 
 
-HD;
+HD
+);
 
 $nowdoc = <<<'ND'
 


### PR DESCRIPTION
The end of an hereodc must have a newline to avoid PHP syntax errors.
