### PR TITLE
change wrapped exception message to be more usefull

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/XmlFileLoader.php
@@ -210,7 +210,7 @@ class XmlFileLoader extends FileLoader
         try {
             $dom = XmlUtils::loadFile($file, array($this, 'validateSchema'));
         } catch (\InvalidArgumentException $e) {
-            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+            throw new InvalidArgumentException(sprintf('Unable to parse file "%s".', $file), $e->getCode(), $e);
         }
 
         $this->validateExtensions($dom, $file);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

When you try to parse a yml file with the XMLLoader you get the following Exception

```
[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]
[ERROR 4] Start tag expected, '<' not found (in n/a - line 1, column 1)

[InvalidArgumentException]
[ERROR 4] Start tag expected, '<' not found (in n/a - line 1, column 1)
```

after the patch

```
[Symfony\Component\DependencyInjection\Exception\InvalidArgumentException]      
Unable to parse file "/home/.../src/Application/FOS/UserBundle/DependencyInjection/../Resources/config/services.yml".

[InvalidArgumentException]
[ERROR 4] Start tag expected, '<' not found (in n/a - line 1, column 1)
```
