### PR TITLE
[DomCrawler] added support for query string with slash

### DIFF
--- a/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/LinkTest.php
@@ -102,6 +102,8 @@ class LinkTest extends \PHPUnit_Framework_TestCase
             array('?foo=2', 'http://localhost/bar/?foo=1', 'http://localhost/bar/?foo=2'),
             array('?bar=2', 'http://localhost?foo=1', 'http://localhost?bar=2'),
 
+            array('foo', 'http://login.foo.com/bar/baz?/query/string', 'http://login.foo.com/bar/foo'),
+
             array('.', 'http://localhost/foo/bar/baz', 'http://localhost/foo/bar/'),
             array('./', 'http://localhost/foo/bar/baz', 'http://localhost/foo/bar/'),
             array('./foo', 'http://localhost/foo/bar/baz', 'http://localhost/foo/bar/foo'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Link\getUri() failed to return correct uri when current query string contains slash
Test pass on branch 2.1 but fails on master
