### PR TITLE
Bugs when RememberMe use token_provider

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_rememberme.xml
@@ -45,11 +45,6 @@
                  class="%security.authentication.rememberme.services.persistent.class%"
                  parent="security.authentication.rememberme.services.abstract"
                  abstract="true">
-            <argument type="collection" /> <!--  User Providers -->
-            <argument /> <!-- Shared Token Key -->
-            <argument /> <!-- Shared Provider Key -->
-            <argument type="collection" /> <!-- Options -->
-            <argument type="service" id="logger" on-invalid="null" />
             <argument type="service" id="security.secure_random" />
         </service>
 

--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -20,6 +20,7 @@ use Symfony\Component\Security\Core\Exception\CookieTheftException;
 use Symfony\Component\Security\Core\Authentication\RememberMe\PersistentToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Util\SecureRandomInterface;
+use Symfony\Component\HttpKernel\Log\LoggerInterface;
 
 /**
  * Concrete implementation of the RememberMeServicesInterface which needs


### PR DESCRIPTION
When token_provider is used for remember_me in security.yml, it produces an Exception :

Catchable Fatal Error: Argument 5 passed to Symfony\Component\Security\Http\RememberMe\PersistentTokenBasedRememberMeServices::__construct() must be an instance of Symfony\Component\Security\Http\RememberMe\LoggerInterface, instance of Symfony\Bridge\Monolog\Logger given, called in /home/overblog/public_html/OverblogUser/app/cache/dev/appDevDebugProjectContainer.php on line 2358 and defined in /home/overblog/public_html/OverblogUser/vendor/symfony/symfony/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php line 46

The problem comes from missing use in PersistentTokenBasedRememberMeServices and wrong inheritance in security_rememberme.xml.
