### PR TITLE
[Form] made DefaultCsrfProvider using session_status() when available

### DIFF
--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.php
@@ -65,7 +65,11 @@ class DefaultCsrfProvider implements CsrfProviderInterface
      */
     protected function getSessionId()
     {
-        if (!session_id()) {
+        if (version_compare(PHP_VERSION, '5.4', '>=')) {
+            if (PHP_SESSION_NONE === session_status()) {
+                session_start();
+            }
+        } elseif (!session_id()) {
             session_start();
         }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/CsrfProvider/DefaultCsrfProviderTest.php
@@ -22,7 +22,8 @@ class DefaultCsrfProviderTest extends \PHPUnit_Framework_TestCase
 
     public static function setUpBeforeClass()
     {
-        @session_start();
+        ini_set('session.save_handler', 'files');
+        ini_set('session.save_path', sys_get_temp_dir());
     }
 
     protected function setUp()
@@ -37,13 +38,33 @@ class DefaultCsrfProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testGenerateCsrfToken()
     {
+        session_start();
+
         $token = $this->provider->generateCsrfToken('foo');
 
         $this->assertEquals(sha1('SECRET'.'foo'.session_id()), $token);
     }
 
+    public function testGenerateCsrfTokenOnUnstartedSession()
+    {
+        session_id('touti');
+
+        if (!version_compare(PHP_VERSION, '5.4', '>=')) {
+            $this->markTestSkipped('This test requires PHP >= 5.4');
+        }
+
+        $this->assertSame(PHP_SESSION_NONE, session_status());
+
+        $token = $this->provider->generateCsrfToken('foo');
+
+        $this->assertEquals(sha1('SECRET'.'foo'.session_id()), $token);
+        $this->assertSame(PHP_SESSION_ACTIVE, session_status());
+    }
+
     public function testIsCsrfTokenValidSucceeds()
     {
+        session_start();
+
         $token = sha1('SECRET'.'foo'.session_id());
 
         $this->assertTrue($this->provider->isCsrfTokenValid('foo', $token));
@@ -51,6 +72,8 @@ class DefaultCsrfProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testIsCsrfTokenValidFails()
     {
+        session_start();
+
         $token = sha1('SECRET'.'bar'.session_id());
 
         $this->assertFalse($this->provider->isCsrfTokenValid('foo', $token));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [on PHP 5.4] |
| Tests pass? | [yes] |
| License | MIT |
