### PR TITLE
[Yaml] fixed bugs with folded scalar parsing (2.1 branch)

### DIFF
--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -113,7 +113,6 @@ EOF;
 foo: |-
     one
     two
-
 bar: |-
     one
     two
@@ -123,7 +122,24 @@ EOF;
             'foo' => "one\ntwo",
             'bar' => "one\ntwo",
         );
-        $tests['Literal block chomping strip with trailing newline'] = array($expected, $yaml);
+        $tests['Literal block chomping strip with single trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |-
+    one
+    two
+
+bar: |-
+    one
+    two
+
+
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo",
+            'bar' => "one\ntwo",
+        );
+        $tests['Literal block chomping strip with multiple trailing newlines'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: |-
@@ -143,7 +159,6 @@ EOF;
 foo: |
     one
     two
-
 bar: |
     one
     two
@@ -153,7 +168,24 @@ EOF;
             'foo' => "one\ntwo\n",
             'bar' => "one\ntwo\n",
         );
-        $tests['Literal block chomping clip with trailing newline'] = array($expected, $yaml);
+        $tests['Literal block chomping clip with single trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |
+    one
+    two
+
+bar: |
+    one
+    two
+
+
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo\n",
+            'bar' => "one\ntwo\n",
+        );
+        $tests['Literal block chomping clip with multiple trailing newlines'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: |
@@ -165,9 +197,24 @@ bar: |
 EOF;
         $expected = array(
             'foo' => "one\ntwo\n",
-            'bar' => "one\ntwo\n",
+            'bar' => "one\ntwo",
         );
         $tests['Literal block chomping clip without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: |+
+    one
+    two
+bar: |+
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one\ntwo\n",
+            'bar' => "one\ntwo\n",
+        );
+        $tests['Literal block chomping keep with single trailing newline'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: |+
@@ -178,12 +225,13 @@ bar: |+
     one
     two
 
+
 EOF;
         $expected = array(
             'foo' => "one\ntwo\n\n",
             'bar' => "one\ntwo\n\n",
         );
-        $tests['Literal block chomping keep with trailing newline'] = array($expected, $yaml);
+        $tests['Literal block chomping keep with multiple trailing newlines'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: |+
@@ -195,9 +243,24 @@ bar: |+
 EOF;
         $expected = array(
             'foo' => "one\ntwo\n",
-            'bar' => "one\ntwo\n",
+            'bar' => "one\ntwo",
         );
         $tests['Literal block chomping keep without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >-
+    one
+    two
+bar: >-
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one two",
+            'bar' => "one two",
+        );
+        $tests['Folded block chomping strip with single trailing newline'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: >-
@@ -208,12 +271,13 @@ bar: >-
     one
     two
 
+
 EOF;
         $expected = array(
             'foo' => "one two",
             'bar' => "one two",
         );
-        $tests['Folded block chomping strip with trailing newline'] = array($expected, $yaml);
+        $tests['Folded block chomping strip with multiple trailing newlines'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: >-
@@ -233,7 +297,6 @@ EOF;
 foo: >
     one
     two
-
 bar: >
     one
     two
@@ -243,7 +306,24 @@ EOF;
             'foo' => "one two\n",
             'bar' => "one two\n",
         );
-        $tests['Folded block chomping clip with trailing newline'] = array($expected, $yaml);
+        $tests['Folded block chomping clip with single trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >
+    one
+    two
+
+bar: >
+    one
+    two
+
+
+EOF;
+        $expected = array(
+            'foo' => "one two\n",
+            'bar' => "one two\n",
+        );
+        $tests['Folded block chomping clip with multiple trailing newlines'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: >
@@ -255,9 +335,24 @@ bar: >
 EOF;
         $expected = array(
             'foo' => "one two\n",
-            'bar' => "one two\n",
+            'bar' => "one two",
         );
         $tests['Folded block chomping clip without trailing newline'] = array($expected, $yaml);
+
+        $yaml = <<<'EOF'
+foo: >+
+    one
+    two
+bar: >+
+    one
+    two
+
+EOF;
+        $expected = array(
+            'foo' => "one two\n",
+            'bar' => "one two\n",
+        );
+        $tests['Folded block chomping keep with single trailing newline'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: >+
@@ -268,12 +363,13 @@ bar: >+
     one
     two
 
+
 EOF;
         $expected = array(
             'foo' => "one two\n\n",
             'bar' => "one two\n\n",
         );
-        $tests['Folded block chomping keep with trailing newline'] = array($expected, $yaml);
+        $tests['Folded block chomping keep with multiple trailing newlines'] = array($expected, $yaml);
 
         $yaml = <<<'EOF'
 foo: >+
@@ -285,7 +381,7 @@ bar: >+
 EOF;
         $expected = array(
             'foo' => "one two\n",
-            'bar' => "one two\n",
+            'bar' => "one two",
         );
         $tests['Folded block chomping keep without trailing newline'] = array($expected, $yaml);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This is a re-do of #7445, which was submitted against 2.0, which is no longer supported. Additionally, the previous PR broke some tests because literal tabs were accidentally changed to spaces, and GitHub's diff engine seemingly ignored the change, although the differences showed up when using git diff directly. This PR leaves the literals untouched, and hence the tests should now pass.

**From the original PR:**

I found some more bugs with the parsing of folded scalars. I'd also made some mistakes in the tests introduced by me in #6785. This PR fixes the incorrect tests, and introduces more related tests.

I had to completely rewrite the `Parser::parseFoldedScalar()` method. I think it came out simpler in the end - less 'special cases'. I've done some basic profiling by running the parser tests on repeat and haven't noticed any difference in parsing performance.
