### PR TITLE
Improve bytes conversion method

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
@@ -29,12 +29,14 @@ class ServerParams
             return null;
         }
 
-        if (preg_match('#^(\d+)([bkmgt])#i', $iniMax, $match)) {
-            $shift = array('b' => 0, 'k' => 10, 'm' => 20, 'g' => 30, 't' => 40);
-            $iniMax = ($match[1] * (1 << $shift[strtolower($match[2])]));
+        if (preg_match('#^\+?(0x?)?([^kmg]*)([KMG]?)#', $iniMax, $match)) {
+            $shifts = array('' => 0, 'K' => 10, 'M' => 20, 'G' => 30);
+            $bases = array('' => 10, '0' => 8, '0x' => 16);
+
+            return (intval($match[2], $bases[$match[1]]) * (1 << $shifts[$match[3]]));
         }
 
-        return (int) $iniMax;
+        return 0;
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -229,17 +229,19 @@ class UploadedFile extends File
      */
     public static function getMaxFilesize()
     {
-        $max = trim(ini_get('upload_max_filesize'));
+        $max = strtolower(ini_get('upload_max_filesize'));
 
         if ('' === $max) {
             return PHP_INT_MAX;
         }
 
-        if (preg_match('#^(\d+)([bkmgt])#i', $max, $match)) {
-            $shift = array('b' => 0, 'k' => 10, 'm' => 20, 'g' => 30, 't' => 40);
-            $max = ($match[1] * (1 << $shift[strtolower($match[2])]));
+        if (preg_match('#^\+?(0x?)?([^kmg]*)([kmg]?)#', $max, $match)) {
+            $shifts = array('' => 0, 'k' => 10, 'm' => 20, 'g' => 30);
+            $bases = array('' => 10, '0' => 8, '0x' => 16);
+
+            return (intval($match[2], $bases[$match[1]]) * (1 << $shifts[$match[3]]));
         }
 
-        return (integer) $max;
+        return 0;
     }
 }

--- a/src/Symfony/Component/HttpKernel/DataCollector/MemoryDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/MemoryDataCollector.php
@@ -25,7 +25,7 @@ class MemoryDataCollector extends DataCollector
     {
         $this->data = array(
             'memory'       => 0,
-            'memory_limit' => $this->convertToBytes(ini_get('memory_limit')),
+            'memory_limit' => $this->convertToBytes(strtolower(ini_get('memory_limit'))),
         );
     }
 
@@ -75,11 +75,17 @@ class MemoryDataCollector extends DataCollector
 
     private function convertToBytes($memoryLimit)
     {
-        if (preg_match('#^(\d+)([bkmgt])#i', $memoryLimit, $match)) {
-            $shift = array('b' => 0, 'k' => 10, 'm' => 20, 'g' => 30, 't' => 40);
-            $memoryLimit = ($match[1] * (1 << $shift[strtolower($match[2])]));
+        if ('-1' === $memoryLimit) {
+            return -1;
         }
 
-        return (int) $memoryLimit;
+        if (preg_match('#^\+?(0x?)?([^kmg]*)([kmg]?)#', $memoryLimit, $match)) {
+            $shifts = array('' => 0, 'k' => 10, 'm' => 20, 'g' => 30);
+            $bases = array('' => 10, '0' => 8, '0x' => 16);
+
+            return (intval($match[2], $bases[$match[1]]) * (1 << $shifts[$match[3]]));
+        }
+
+        return 0;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/MemoryDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/MemoryDataCollectorTest.php
@@ -46,9 +46,14 @@ class MemoryDataCollectorTest extends \PHPUnit_Framework_TestCase
     public function getBytesConversionTestData()
     {
         return array(
-            array('-1', -1),
             array('2k', 2048),
-            array('2K', 2048),
+            array('2 k', 2048),
+            array('+2 k', 2048),
+            array('+2???k', 2048),
+            array('0x10', 16),
+            array('0xf', 15),
+            array('010', 8),
+            array('+0x10 k', 16 * 1024),
             array('1g', 1024 * 1024 * 1024),
         );
     }


### PR DESCRIPTION
This PR improves bytes conversion `regex` method introduced in #7413 (thanks to @vicb's comments).
- Adds support of `+` prefix.
- Adds support of blank chars between `+`, number and unit.
- Adds support of octal/hexa bases.

Notice that this can not be unit tested for `ServerParams` and `UploadedFile` classes because `ini_set()` function does not work with `post_max_size` and `upload_max_filesize` settings.

For information, this convertion is located in 3 classes:
- `Symfony\Component\Form\Extension\Validator\Util\ServerParams`
- `Symfony\Component\HttpFoundation\File\UploadedFile`
- `Symfony\Component\HttpKernel\DataCollector\MemoryDataCollector`

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7413 |
