### PR TITLE
moved the request scope creation to the ContainerAwareHttpKernel class

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
+++ b/src/Symfony/Bundle/FrameworkBundle/FrameworkBundle.php
@@ -28,7 +28,6 @@ use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\TranslationDumpe
 use Symfony\Bundle\FrameworkBundle\DependencyInjection\Compiler\FragmentRendererPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
-use Symfony\Component\DependencyInjection\Scope;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -55,8 +54,6 @@ class FrameworkBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         parent::build($container);
-
-        $container->addScope(new Scope('request'));
 
         $container->addCompilerPass(new RoutingResolverPass());
         $container->addCompilerPass(new ProfilerPass());

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckReferenceValidityPass.php
@@ -72,8 +72,8 @@ class CheckReferenceValidityPass implements CompilerPassInterface
                 $this->currentScopeChildren = array_keys($scopes);
                 $this->currentScopeAncestors = array();
             } elseif (ContainerInterface::SCOPE_PROTOTYPE !== $scope) {
-                $this->currentScopeChildren = $children[$scope];
-                $this->currentScopeAncestors = $ancestors[$scope];
+                $this->currentScopeChildren = isset($children[$scope]) ? $children[$scope] : array();
+                $this->currentScopeAncestors = isset($ancestors[$scope]) ? $ancestors[$scope] : array();
             }
 
             $this->validateReferences($definition->getArguments());

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -18,9 +18,10 @@ use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Scope;
 
 /**
- * This HttpKernel is used to manage scope changes of the DI container.
+ * Adds a managed request scope.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
@@ -41,6 +42,7 @@ class ContainerAwareHttpKernel extends HttpKernel
         parent::__construct($dispatcher, $controllerResolver);
 
         $this->container = $container;
+        $container->addScope(new Scope('request'));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#2343 |

While updating the scope documentation, I realized that the request scope was created in the FrameworkBundle while the HttpKernel that manages it was in the HttpKernel component. So, this PR makes things more consistent.
