### PR TITLE
[Form] fixes ServerParams::getPostMaxSize() regex pattern

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Util/ServerParams.php
@@ -29,9 +29,9 @@ class ServerParams
             return null;
         }
 
-        if (preg_match('#^\+?(0x?)?([^kmg]*)([KMG]?)#', $iniMax, $match)) {
+        if (preg_match('#^\+?(0X?)?([^KMG]*)([KMG]?)#', $iniMax, $match)) {
             $shifts = array('' => 0, 'K' => 10, 'M' => 20, 'G' => 30);
-            $bases = array('' => 10, '0' => 8, '0x' => 16);
+            $bases = array('' => 10, '0' => 8, '0X' => 16);
 
             return (intval($match[2], $bases[$match[1]]) * (1 << $shifts[$match[3]]));
         }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Util/ServerParamsTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Util/ServerParamsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Util;
+
+class ServerParamsTest extends \PHPUnit_Framework_TestCase
+{
+    /** @dataProvider getGetPostMaxSizeTestData */
+    public function testGetPostMaxSize($size, $bytes)
+    {
+        $serverParams = $this->getMock('Symfony\Component\Form\Extension\Validator\Util\ServerParams', array('getNormalizedIniPostMaxSize'));
+        $serverParams
+            ->expects($this->any())
+            ->method('getNormalizedIniPostMaxSize')
+            ->will($this->returnValue(strtoupper($size)));
+
+        $this->assertEquals($bytes, $serverParams->getPostMaxSize());
+    }
+
+    public function getGetPostMaxSizeTestData()
+    {
+        return array(
+            array('2k', 2048),
+            array('2 k', 2048),
+            array('+2 k', 2048),
+            array('+2???k', 2048),
+            array('0x10', 16),
+            array('0xf', 15),
+            array('010', 8),
+            array('+0x10 k', 16 * 1024),
+            array('1g', 1024 * 1024 * 1024),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7480 |
