### PR TITLE
[2.2][2.3][Bridge][Doctrine] Fixing long multibyte parameter logging in DbalLogger:startQuery

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
+++ b/src/Symfony/Bridge/Doctrine/Logger/DbalLogger.php
@@ -61,10 +61,17 @@ class DbalLogger implements SQLLogger
                     continue;
                 }
 
-                // too long string must be shorten
-                if (self::MAX_STRING_LENGTH < strlen($params[$index])) {
-                    $params[$index] = substr($params[$index], 0, self::MAX_STRING_LENGTH - 6).' [...]';
-                    continue;
+                // detect if the too long string must be shorten
+                if (function_exists('mb_detect_encoding') && false !== $encoding = mb_detect_encoding($params[$index])) {
+                    if (self::MAX_STRING_LENGTH < mb_strlen($params[$index], $encoding)) {
+                        $params[$index] = mb_substr($params[$index], 0, self::MAX_STRING_LENGTH - 6, $encoding).' [...]';
+                        continue;
+                    }
+                } else {
+                    if (self::MAX_STRING_LENGTH < strlen($params[$index])) {
+                        $params[$index] = substr($params[$index], 0, self::MAX_STRING_LENGTH - 6).' [...]';
+                        continue;
+                    }
                 }
             }
         }

--- a/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Logger/DbalLoggerTest.php
@@ -81,8 +81,10 @@ class DbalLoggerTest extends \PHPUnit_Framework_TestCase
             ->getMock()
         ;
 
-        $shortString = str_repeat('a', DbalLogger::MAX_STRING_LENGTH);
-        $longString = str_repeat('a', DbalLogger::MAX_STRING_LENGTH + 1);
+        $testString = 'abc';
+
+        $shortString = str_pad('', DbalLogger::MAX_STRING_LENGTH, $testString);
+        $longString = str_pad('', DbalLogger::MAX_STRING_LENGTH+1, $testString);
 
         $dbalLogger
             ->expects($this->once())
@@ -95,4 +97,43 @@ class DbalLoggerTest extends \PHPUnit_Framework_TestCase
             'long'  => $longString,
         ));
     }
+
+    public function testLogUTF8LongString()
+    {
+        if (!function_exists('mb_detect_encoding')) {
+            $this->markTestSkipped('Testing log shortening of utf8 charsets requires the mb_detect_encoding() function.');
+        }
+
+        $logger = $this->getMock('Symfony\\Component\\HttpKernel\\Log\\LoggerInterface');
+
+        $dbalLogger = $this
+            ->getMockBuilder('Symfony\\Bridge\\Doctrine\\Logger\\DbalLogger')
+            ->setConstructorArgs(array($logger, null))
+            ->setMethods(array('log'))
+            ->getMock()
+        ;
+
+        $testStringArray = array('é', 'á', 'ű', 'ő', 'ú', 'ö', 'ü', 'ó', 'í');
+        $testStringCount = count($testStringArray);
+
+        $shortString = '';
+        $longString = '';
+        for($i=1; $i<=DbalLogger::MAX_STRING_LENGTH; $i++) {
+            $shortString .= $testStringArray[$i % $testStringCount];
+            $longString .= $testStringArray[$i % $testStringCount];
+        }
+        $longString .= $testStringArray[$i % $testStringCount];
+
+        $dbalLogger
+            ->expects($this->once())
+            ->method('log')
+            ->with('SQL', array('short' => $shortString, 'long' => mb_substr($longString, 0, DbalLogger::MAX_STRING_LENGTH - 6, mb_detect_encoding($longString)).' [...]'))
+        ;
+
+        $dbalLogger->startQuery('SQL', array(
+                'short' => $shortString,
+                'long'  => $longString,
+            ));
+    }
+
 }


### PR DESCRIPTION
DbalLogger:startQuery function cut the incoming parameters with use of wrong function (substr instead of mb_substr) and with wrong parameters.
