### PR TITLE
[WIP][Validator][TypeGuesser] Respect validation groups

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
+++ b/src/Symfony/Bridge/Doctrine/Form/DoctrineOrmTypeGuesser.php
@@ -35,7 +35,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessType($class, $property)
+    public function guessType($class, $property, array $options = array())
     {
         if (!$ret = $this->getMetadata($class)) {
             return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
@@ -82,7 +82,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessRequired($class, $property)
+    public function guessRequired($class, $property, array $options = array())
     {
         $classMetadatas = $this->getMetadata($class);
 
@@ -122,7 +122,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessMaxLength($class, $property)
+    public function guessMaxLength($class, $property, array $options = array())
     {
         $ret = $this->getMetadata($class);
         if ($ret && $ret[0]->hasField($property) && !$ret[0]->hasAssociation($property)) {
@@ -141,7 +141,7 @@ class DoctrineOrmTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessPattern($class, $property)
+    public function guessPattern($class, $property, array $options = array())
     {
         $ret = $this->getMetadata($class);
         if ($ret && $ret[0]->hasField($property) && !$ret[0]->hasAssociation($property)) {

--- a/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
+++ b/src/Symfony/Bridge/Propel1/Form/PropelTypeGuesser.php
@@ -28,7 +28,7 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessType($class, $property)
+    public function guessType($class, $property, array $options = array())
     {
         if (!$table = $this->getTable($class)) {
             return new TypeGuess('text', array(), Guess::LOW_CONFIDENCE);
@@ -103,7 +103,7 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessRequired($class, $property)
+    public function guessRequired($class, $property, array $options = array())
     {
         if ($column = $this->getColumn($class, $property)) {
             return new ValueGuess($column->isNotNull(), Guess::HIGH_CONFIDENCE);
@@ -113,7 +113,7 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessMaxLength($class, $property)
+    public function guessMaxLength($class, $property, array $options = array())
     {
         if ($column = $this->getColumn($class, $property)) {
             if ($column->isText()) {
@@ -132,7 +132,7 @@ class PropelTypeGuesser implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessPattern($class, $property)
+    public function guessPattern($class, $property, array $options = array())
     {
         if ($column = $this->getColumn($class, $property)) {
             switch ($column->getType()) {

--- a/src/Symfony/Component/Form/FormFactory.php
+++ b/src/Symfony/Component/Form/FormFactory.php
@@ -96,10 +96,10 @@ class FormFactory implements FormFactoryInterface
             return $this->createNamedBuilder($property, 'text', $data, $options, $parent);
         }
 
-        $typeGuess = $guesser->guessType($class, $property);
-        $maxLengthGuess = $guesser->guessMaxLength($class, $property);
-        $requiredGuess = $guesser->guessRequired($class, $property);
-        $patternGuess = $guesser->guessPattern($class, $property);
+        $typeGuess = $guesser->guessType($class, $property, $options);
+        $maxLengthGuess = $guesser->guessMaxLength($class, $property, $options);
+        $requiredGuess = $guesser->guessRequired($class, $property, $options);
+        $patternGuess = $guesser->guessPattern($class, $property, $options);
 
         $type = $typeGuess ? $typeGuess->getType() : 'text';
 

--- a/src/Symfony/Component/Form/FormTypeGuesserChain.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserChain.php
@@ -43,7 +43,7 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessType($class, $property)
+    public function guessType($class, $property, array $options = array())
     {
         return $this->guess(function ($guesser) use ($class, $property) {
             return $guesser->guessType($class, $property);
@@ -53,7 +53,7 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessRequired($class, $property)
+    public function guessRequired($class, $property, array $options = array())
     {
         return $this->guess(function ($guesser) use ($class, $property) {
             return $guesser->guessRequired($class, $property);
@@ -63,7 +63,7 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessMaxLength($class, $property)
+    public function guessMaxLength($class, $property, array $options = array())
     {
         return $this->guess(function ($guesser) use ($class, $property) {
             return $guesser->guessMaxLength($class, $property);
@@ -73,7 +73,7 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
     /**
      * {@inheritDoc}
      */
-    public function guessPattern($class, $property)
+    public function guessPattern($class, $property, array $options = array())
     {
         return $this->guess(function ($guesser) use ($class, $property) {
             return $guesser->guessPattern($class, $property);

--- a/src/Symfony/Component/Form/FormTypeGuesserInterface.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserInterface.php
@@ -21,30 +21,33 @@ interface FormTypeGuesserInterface
      *
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
+     * @param array  $options  The current configuration options for guessed field
      *
      * @return Guess\TypeGuess A guess for the field's type and options
      */
-    public function guessType($class, $property);
+    public function guessType($class, $property, array $options = array());
 
     /**
      * Returns a guess whether a property of a class is required
      *
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
+     * @param array  $options  The current configuration options for guessed field
      *
      * @return Guess\Guess A guess for the field's required setting
      */
-    public function guessRequired($class, $property);
+    public function guessRequired($class, $property, array $options = array());
 
     /**
      * Returns a guess about the field's maximum length
      *
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
+     * @param array  $options  The current configuration options for guessed field
      *
      * @return Guess\Guess A guess for the field's maximum length
      */
-    public function guessMaxLength($class, $property);
+    public function guessMaxLength($class, $property, array $options = array());
 
     /**
      * Returns a guess about the field's pattern
@@ -57,8 +60,9 @@ interface FormTypeGuesserInterface
      *
      * @param string $class    The fully qualified class name
      * @param string $property The name of the property to guess for
+     * @param array  $options  The current configuration options for guessed field
      *
      * @return Guess\Guess A guess for the field's required pattern
      */
-    public function guessPattern($class, $property);
+    public function guessPattern($class, $property, array $options = array());
 }


### PR DESCRIPTION
This is attempt to fix very long standing issue #2387 that type guessers don't consider
validation groups while doing guess. I've ran into this (again) when I wanted to have different field type when in one group and different in another (Possible with MongoDB)

| Q | A |
| --- | --- |
| Bug fix? | yes? |
| New feature? | yes |
| BC breaks? | yes (Change in interface, but tests passing without touch) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #2387 |
| License | MIT |

I'll be graceful for reviews and hints, also I'd some problems with figuring out how to unit test new behaviour
- [ ] gather feedback
- [ ] write unit tests
