### PR TITLE
[Form] Add ability to disable choice in form

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -88,6 +88,7 @@ class FormExtension extends \Twig_Extension
     {
         return array(
             'selectedchoice' => new \Twig_Test_Method($this, 'isSelectedChoice'),
+            'choicedisabled' => new \Twig_Test_Method($this, 'isChoiceDisabled'),
         );
     }
 
@@ -121,6 +122,11 @@ class FormExtension extends \Twig_Extension
         }
 
         return $choice->value === $selectedValue;
+    }
+
+    public function isChoiceDisabled(ChoiceView $choice)
+    {
+        return $choice->disabled;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -88,7 +88,6 @@ class FormExtension extends \Twig_Extension
     {
         return array(
             'selectedchoice' => new \Twig_Test_Method($this, 'isSelectedChoice'),
-            'choicedisabled' => new \Twig_Test_Method($this, 'isChoiceDisabled'),
         );
     }
 
@@ -122,11 +121,6 @@ class FormExtension extends \Twig_Extension
         }
 
         return $choice->value === $selectedValue;
-    }
-
-    public function isChoiceDisabled(ChoiceView $choice)
-    {
-        return $choice->disabled;
     }
 
     /**

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -93,7 +93,7 @@
                 {{ block('choice_widget_options') }}
             </optgroup>
         {% else %}
-            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}{% if choice is choicedisabled(value) %} disabled="disabled"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
+            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}{% if choice.disabled %} disabled="disabled"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
         {% endif %}
     {% endfor %}
 {% endspaceless %}

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -93,7 +93,7 @@
                 {{ block('choice_widget_options') }}
             </optgroup>
         {% else %}
-            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
+            <option value="{{ choice.value }}"{% if choice is selectedchoice(value) %} selected="selected"{% endif %}{% if choice is choicedisabled(value) %} disabled="disabled"{% endif %}>{{ choice.label|trans({}, translation_domain) }}</option>
         {% endif %}
     {% endfor %}
 {% endspaceless %}

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/views/Form/choice_widget_options.html.php
@@ -6,6 +6,6 @@
             <?php echo $formHelper->block($form, 'choice_widget_options', array('choices' => $choice)) ?>
         </optgroup>
     <?php else: ?>
-        <option value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choice->label, array(), $translation_domain)) ?></option>
+        <option value="<?php echo $view->escape($choice->value) ?>"<?php if ($is_selected($choice->value, $value)): ?> selected="selected"<?php endif?><?php if ($choice->disabled): ?> disabled="disabled"<?php endif?>><?php echo $view->escape($translatorHelper->trans($choice->label, array(), $translation_domain)) ?></option>
     <?php endif ?>
 <?php endforeach ?>

--- a/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
+++ b/src/Symfony/Component/Form/Extension/Core/View/ChoiceView.php
@@ -40,16 +40,25 @@ class ChoiceView
     public $label;
 
     /**
+     * Is choice disabled.
+     *
+     * @var Boolean
+     */
+    public $disabled;
+
+    /**
      * Creates a new ChoiceView.
      *
      * @param mixed  $data  The original choice.
      * @param string $value The view representation of the choice.
      * @param string $label The label displayed to humans.
+     * @param string $disabled Is choice disabled.
      */
-    public function __construct($data, $value, $label)
+    public function __construct($data, $value, $label, $disabled = false)
     {
         $this->data = $data;
         $this->value = $value;
         $this->label = $label;
+        $this->disabled = $disabled;
     }
 }


### PR DESCRIPTION
## Example:

``` php
private $choiceList;

    public function __construct(EntityChoiceList $choiceList = null)
    {
        $this->choiceList = $choiceList;
    }

    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $options = array(
            'class' => 'AcmeDemoBundle:Category',
            'required' => true,
        );

        if ($this->choiceList) {
            $options['choice_list'] = $this->choiceList;
        }

        $builder->add('category', 'entity', $options);

    }

    public function finishView(FormView $view, FormInterface $form, array $options)
    {
       $ids = $this->getEmptyCategoryIds();

        foreach ($view->children['category']->vars['choices'] as $category) {
            if (in_array($category->value, $ids, true)) {
                $category->disabled = true;
            }
        }
    }

    private function getEmptyCategoryIds()
    {
        return ['2', '4'];
    }
```
