### PR TITLE
[Form] Add getErrorsAsArray method

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -633,6 +633,33 @@ class Form implements \IteratorAggregate, FormInterface
         return $errors;
     }
 
+   /**
+    * Returns an array representation of all form errors (including children errors).
+    *
+    * @return array An array representation of all errors
+    */
+    public function getErrorsAsArray()
+    {
+        $errors = array();
+        foreach ($this->errors as $key => $error) {
+            $template = $error->getMessageTemplate();
+            if (null !== $template) {
+                $parameters = $error->getMessageParameters();
+                $errors[$key] = strtr($template, $parameters);
+            } else {
+                $errors[$key] = $error->getMessage();
+            }
+        }
+
+        foreach ($this->children as $child) {
+            if (!$child->isValid()) {
+                $errors[$child->getName()] = $child->getErrorsAsArray();
+            }
+        }
+
+        return $errors;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -679,10 +679,10 @@ class CompoundFormTest extends AbstractFormTest
         ));
 
         $form = $this->getBuilder('')
-        ->setCompound(true)
-        ->setDataMapper($this->getDataMapper())
-        ->addEventSubscriber(new BindRequestListener())
-        ->getForm();
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->addEventSubscriber(new BindRequestListener())
+            ->getForm();
 
         $firstName = $this->getBuilder('firstName')->getForm();
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -635,6 +635,72 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertEquals("name:\n    ERROR: Error!\nfoo:\n    No errors\n", $parent->getErrorsAsString());
     }
 
+    public function testGetErrorsAsArrayDeep()
+    {
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('The "HttpFoundation" component is not available');
+        }
+
+        $request = new Request(array(), array(), array(), array(), array(), array(
+            'REQUEST_METHOD' => 'GET',
+        ));
+
+        $form = $this->getBuilder('')
+            ->setCompound(true)
+            ->setDataMapper($this->getDataMapper())
+            ->addEventSubscriber(new BindRequestListener())
+            ->getForm();
+
+        $firstName = $this->getBuilder('firstName')->getForm();
+
+        $form->add($firstName);
+        $form->add($this->getBuilder('lastName')->getForm());
+
+        $form->bind($request);
+
+        $firstName->addError(new FormError('Error 1'));
+        $firstName->addError(new FormError('Error 2'));
+
+        $expected = array(
+            'firstName' => array('Error 1', 'Error 2'),
+        );
+
+        $this->assertEquals($expected, $form->getErrorsAsArray());
+    }
+
+    public function testGetErrorsAsArrayWithTemplate()
+    {
+        if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
+            $this->markTestSkipped('The "HttpFoundation" component is not available');
+        }
+
+        $request = new Request(array(), array(), array(), array(), array(), array(
+            'REQUEST_METHOD' => 'GET',
+        ));
+
+        $form = $this->getBuilder('')
+        ->setCompound(true)
+        ->setDataMapper($this->getDataMapper())
+        ->addEventSubscriber(new BindRequestListener())
+        ->getForm();
+
+        $firstName = $this->getBuilder('firstName')->getForm();
+
+        $form->add($firstName);
+        $form->add($this->getBuilder('lastName')->getForm());
+
+        $form->bind($request);
+
+        $firstName->addError(new FormError('Error 1', 'Error {{ replacementTag }}', array('{{ replacementTag }}' => 'foo')));
+        $firstName->addError(new FormError('Error 2'));
+
+        $expected = array(
+            'firstName' => array('Error foo', 'Error 2'),
+        );
+
+        $this->assertEquals($expected, $form->getErrorsAsArray());
+    }
+
     protected function createForm()
     {
         return $this->getBuilder()

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -705,6 +705,13 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertEquals("ERROR: Error!\n", $this->form->getErrorsAsString());
     }
 
+    public function testGetErrorsAsArray()
+    {
+        $this->form->addError(new FormError('Error!'));
+
+        $this->assertEquals(array("Error!"), $this->form->getErrorsAsArray());
+    }
+
     public function testFormCanHaveEmptyName()
     {
         $form = $this->getBuilder('')->getForm();


### PR DESCRIPTION
Usefull to return form errors through JsonResponse. 

See https://github.com/symfony/symfony/issues/7205

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 7205 |
| License | MIT |
| Doc PR | Is it needed for this kind of addition? |

```
modified:   src/Symfony/Component/Form/Form.php
modified:   src/Symfony/Component/Form/Tests/CompoundFormTest.php
modified:   src/Symfony/Component/Form/Tests/SimpleFormTest.php
```
