### PR TITLE
Documentation links to most current edition.

### DIFF
--- a/src/Symfony/Component/Form/README.md
+++ b/src/Symfony/Component/Form/README.md
@@ -14,7 +14,7 @@ https://github.com/fabpot/Silex/blob/master/src/Silex/Provider/FormServiceProvid
 
 Documentation:
 
-http://symfony.com/doc/2.0/book/forms.html
+http://symfony.com/doc/current/book/forms.html
 
 Resources
 ---------


### PR DESCRIPTION
Documentation pointed to the old 2.0 documentation.  This now references "current".
