### PR TITLE
[2.2][Form] Add bind method to the FormInterface

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -649,11 +649,11 @@ class Form implements \IteratorAggregate, FormInterface
      * @throws FormException if the method of the request is not one of GET, POST or PUT
      *
      * @deprecated Deprecated since version 2.1, to be removed in 2.3. Use
-     *             {@link FormConfigInterface::bind()} instead.
+     *             {@link FormInterface::bind()} instead.
      */
     public function bindRequest(Request $request)
     {
-        trigger_error('bindRequest() is deprecated since version 2.1 and will be removed in 2.3. Use FormConfigInterface::bind() instead.', E_USER_DEPRECATED);
+        trigger_error('bindRequest() is deprecated since version 2.1 and will be removed in 2.3. Use FormInterface::bind() instead.', E_USER_DEPRECATED);
 
         return $this->bind($request);
     }

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -152,6 +152,14 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the field is bound.
      *
+     * @param  mixed $submittedData The data to bind the Form with
+     * @return FormInterface The Form
+     */
+    public function bind($submittedData);
+
+    /**
+     * Returns whether the field is bound.
+     *
      * @return Boolean true if the form is bound to input values, false otherwise
      */
     public function isBound();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | in a way |
| New feature? | no |
| BC breaks? | I don't think so |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

In the `Symfony\Component\Form\Form` class the method `bind` inherits its doc  from the implemented interface `Symfony\Component\Form\FormInterface` where this method does not exist.
See https://github.com/symfony/symfony/blob/2.2/src/Symfony/Component/Form/Form.php#L501.

Furthermore, the now deprecated method `bindRequest` refers to the method `bind` of the same name of the `Symfony\Component\Form\FormConfigInterface` which does not contain this method either. And I think it should be `FormInterface` instead of `FormConfigInterface`.
See https://github.com/symfony/symfony/blob/2.2/src/Symfony/Component/Form/Form.php#L652.
