### PR TITLE
[Finder] adds a way to ignore AccessDeniedException

### DIFF
--- a/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractAdapter.php
@@ -33,6 +33,7 @@ abstract class AbstractAdapter implements AdapterInterface
     protected $sort        = false;
     protected $paths       = array();
     protected $notPaths    = array();
+    protected $ignoreUnreadableDirs = false;
 
     private static $areSupported = array();
 
@@ -206,6 +207,16 @@ abstract class AbstractAdapter implements AdapterInterface
     public function setNotPath(array $notPaths)
     {
         $this->notPaths = $notPaths;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function ignoreUnreadableDirs($ignore = true)
+    {
+        $this->ignoreUnreadableDirs = (Boolean) $ignore;
 
         return $this;
     }

--- a/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/AbstractFindAdapter.php
@@ -92,9 +92,12 @@ abstract class AbstractFindAdapter extends AbstractAdapter
             $this->buildSorting($command, $this->sort);
         }
 
-        $command->setErrorHandler(function ($stderr) {
-            throw new AccessDeniedException($stderr);
-        });
+        $command->setErrorHandler(
+            $this->ignoreUnreadableDirs
+                // If directory is unreadable and finder is set to ignore it, `stderr` is ignored.
+                ? function ($stderr) { return; }
+                : function ($stderr) { throw new AccessDeniedException($stderr); }
+        );
 
         $paths = $this->shell->testCommand('uniq') ? $command->add('| uniq')->execute() : array_unique($command->execute());
         $iterator = new Iterator\FilePathsIterator($paths, $dir);

--- a/src/Symfony/Component/Finder/Adapter/AdapterInterface.php
+++ b/src/Symfony/Component/Finder/Adapter/AdapterInterface.php
@@ -115,6 +115,13 @@ interface AdapterInterface
     public function setNotPath(array $notPaths);
 
     /**
+     * @param boolean $ignore
+     *
+     * @return AdapterInterface Current instance
+     */
+    public function ignoreUnreadableDirs($ignore = true);
+
+    /**
      * @param string $dir
      *
      * @return \Iterator Result iterator

--- a/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/PhpAdapter.php
@@ -32,7 +32,7 @@ class PhpAdapter extends AbstractAdapter
         }
 
         $iterator = new \RecursiveIteratorIterator(
-            new Iterator\RecursiveDirectoryIterator($dir, $flags),
+            new Iterator\RecursiveDirectoryIterator($dir, $flags, $this->ignoreUnreadableDirs),
             \RecursiveIteratorIterator::SELF_FIRST
         );
 

--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -55,6 +55,7 @@ class Finder implements \IteratorAggregate, \Countable
     private $adapters    = array();
     private $paths       = array();
     private $notPaths    = array();
+    private $ignoreUnreadableDirs = false;
 
     private static $vcsPatterns = array('.svn', '_svn', 'CVS', '_darcs', '.arch-params', '.monotone', '.bzr', '.git', '.hg');
 
@@ -627,6 +628,22 @@ class Finder implements \IteratorAggregate, \Countable
     }
 
     /**
+     * Tells finder to ignore unreadable directories.
+     *
+     * By default, scanning unreadable directories content throws an AccessDeniedException.
+     *
+     * @param boolean $ignore
+     *
+     * @return Finder The current Finder instance
+     */
+    public function ignoreUnreadableDirs($ignore = true)
+    {
+        $this->ignoreUnreadableDirs = (Boolean) $ignore;
+
+        return $this;
+    }
+
+    /**
      * Searches files and directories which match defined rules.
      *
      * @param string|array $dirs A directory path or an array of directories
@@ -794,7 +811,8 @@ class Finder implements \IteratorAggregate, \Countable
             ->setFilters($this->filters)
             ->setSort($this->sort)
             ->setPath($this->paths)
-            ->setNotPath($this->notPaths);
+            ->setNotPath($this->notPaths)
+            ->ignoreUnreadableDirs($this->ignoreUnreadableDirs);
     }
 
     /**

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -725,16 +725,34 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $finder = $this->buildFinder($adapter);
         $finder->files()->in(self::$tmpDir);
 
-        // make 'foo' directory non-openable
+        // make 'foo' directory non-readable
         chmod(self::$tmpDir.DIRECTORY_SEPARATOR.'foo', 0333);
 
         try {
-            $this->assertIterator($this->toAbsolute(array('test.php', 'test.py')), $finder->getIterator());
+            $this->assertIterator($this->toAbsolute(array('foo bar', 'test.php', 'test.py')), $finder->getIterator());
             $this->fail('Finder should throw an exception when opening a non-readable directory.');
         } catch (\Exception $e) {
             $this->assertEquals('Symfony\\Component\\Finder\\Exception\\AccessDeniedException', get_class($e));
         }
 
+        // restore original permissions
+        chmod(self::$tmpDir.DIRECTORY_SEPARATOR.'foo', 0777);
+    }
+
+    /**
+     * @dataProvider getAdaptersTestData
+     */
+    public function testIgnoredAccessDeniedException(Adapter\AdapterInterface $adapter)
+    {
+        $finder = $this->buildFinder($adapter);
+        $finder->files()->ignoreUnreadableDirs()->in(self::$tmpDir);
+
+        // make 'foo' directory non-readable
+        chmod(self::$tmpDir.DIRECTORY_SEPARATOR.'foo', 0333);
+
+        $this->assertIterator($this->toAbsolute(array('foo bar', 'test.php', 'test.py')), $finder->getIterator());
+
+        // restore original permissions
         chmod(self::$tmpDir.DIRECTORY_SEPARATOR.'foo', 0777);
     }
 


### PR DESCRIPTION
This PR adds a `Finder::ignoreUnreadableDirs()` method which tells `Finder` to ignore unreadable directories instead of throwing an `AccessDeniedException`.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6981 |
