### PR TITLE
[Form] [Doctrine] [EntityChoiceList] idAsIndex should be true with a smallint id field.

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
+++ b/src/Symfony/Bridge/Doctrine/Form/ChoiceList/EntityChoiceList.php
@@ -111,7 +111,7 @@ class EntityChoiceList extends ObjectChoiceList
             $this->idField = $identifier[0];
             $this->idAsValue = true;
 
-            if ('integer' === $this->classMetadata->getTypeOfField($this->idField)) {
+            if (in_array($this->classMetadata->getTypeOfField($this->idField), array('integer', 'smallint', 'bigint'))) {
                 $this->idAsIndex = true;
             }
         }


### PR DESCRIPTION
When the id of an entity is a smallint, $this->idAsIndex should also be true.
It was not the case.

Bug fix: yes
Feature addition: no
Backwards compatibility break: no
Symfony2 tests pass: should
License of the code: MIT
