### PR TITLE
[Security/Http/RememberMe] PersistentTokenBasedRememberMeServices bugfix

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/PersistentTokenBasedRememberMeServices.php
@@ -99,7 +99,7 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
         }
 
         $series = $persistentToken->getSeries();
-        $tokenValue = $this->secureRandom->nextBytes(64);
+        $tokenValue = base64_encode($this->secureRandom->nextBytes(64));
         $this->tokenProvider->updateToken($series, $tokenValue, new \DateTime());
         $request->attributes->set(self::COOKIE_ATTR_NAME,
             new Cookie(
@@ -121,8 +121,8 @@ class PersistentTokenBasedRememberMeServices extends AbstractRememberMeServices
      */
     protected function onLoginSuccess(Request $request, Response $response, TokenInterface $token)
     {
-        $series = $this->secureRandom->nextBytes(64);
-        $tokenValue = $this->secureRandom->nextBytes(64);
+        $series = base64_encode($this->secureRandom->nextBytes(64));
+        $tokenValue = base64_encode($this->secureRandom->nextBytes(64));
 
         $this->tokenProvider->createNewToken(
             new PersistentToken(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

The database and debug layer cannot handle raw random strings. It may contain invalid ut8 characters and whatnot. So, in order to avoid a lot of database bugs, we must base64_encode the random strings.
