### PR TITLE
AF_* constants are only available with the sockets extension

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -39,6 +39,10 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
      */
     public function testIpv6($matches, $remoteAddr, $cidr)
     {
+        if (!extension_loaded('sockets')) {
+            $this->markTestSkipped('Only works when the socket extension is enabled');
+        }
+
         if (!defined('AF_INET6')) {
             $this->markTestSkipped('Only works when PHP is compiled without the option "disable-ipv6".');
         }
@@ -62,6 +66,10 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
      */
     public function testAnIpv6WithOptionDisabledIpv6()
     {
+        if (!extension_loaded('sockets')) {
+            $this->markTestSkipped('Only works when the socket extension is enabled');
+        }
+
         if (defined('AF_INET6')) {
             $this->markTestSkipped('Only works when PHP is compiled with the option "disable-ipv6".');
         }

--- a/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/IpUtilsTest.php
@@ -39,10 +39,6 @@ class IpUtilsTest extends \PHPUnit_Framework_TestCase
      */
     public function testIpv6($matches, $remoteAddr, $cidr)
     {
-        if (!extension_loaded('sockets')) {
-            $this->markTestSkipped('Only works when the socket extension is enabled');
-        }
-
         if (!defined('AF_INET6')) {
             $this->markTestSkipped('Only works when PHP is compiled without the option "disable-ipv6".');
         }


### PR DESCRIPTION
Skip test if the extension is not available
