### PR TITLE
#7531: [HttpKernel][Config] FileLocator adds NULL as global resource path

### DIFF
--- a/src/Symfony/Component/HttpKernel/Config/FileLocator.php
+++ b/src/Symfony/Component/HttpKernel/Config/FileLocator.php
@@ -28,14 +28,16 @@ class FileLocator extends BaseFileLocator
      * Constructor.
      *
      * @param KernelInterface $kernel A KernelInterface instance
-     * @param string          $path   The path the global resource directory
-     * @param string|array    $paths  A path or an array of paths where to look for resources
+     * @param null|string     $path   The path the global resource directory
+     * @param array           $paths  An array of paths where to look for resources
      */
     public function __construct(KernelInterface $kernel, $path = null, array $paths = array())
     {
         $this->kernel = $kernel;
-        $this->path = $path;
-        $paths[] = $path;
+        if(null !== $path) {
+            $this->path = $path;
+            $paths[] = $path;
+        }
 
         parent::__construct($paths);
     }

--- a/src/Symfony/Component/HttpKernel/Tests/Config/FileLocatorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Config/FileLocatorTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests\Config;
+
+use Symfony\Component\HttpKernel\Config\FileLocator;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class FileLocatorTest extends \PHPUnit_Framework_TestCase
+{
+
+    /** @var KernelInterface */
+    private $kernel;
+    
+    public function setUp()
+    {
+        $this->kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
+    }
+
+    public function tearDown()
+    {
+        $this->kernel = null;
+    }
+
+    public function testLocate()
+    {
+        $this->kernel
+            ->expects($this->atLeastOnce())
+            ->method('locateResource')
+            ->with('@BundleName/some/path', null, true)
+            ->will($this->returnValue('/bundle-name/some/path'));
+        $locator = new FileLocator($this->kernel);
+        $this->assertEquals('/bundle-name/some/path', $locator->locate('@BundleName/some/path'));
+
+        $this->kernel
+            ->expects($this->never())
+            ->method('locateResource');
+        $this->setExpectedException('LogicException');
+        $locator->locate('/some/path');
+    }
+
+    public function testLocateWithGlobalResourcePath()
+    {
+        $this->kernel
+            ->expects($this->atLeastOnce())
+            ->method('locateResource')
+            ->with('@BundleName/some/path', '/global/resource/path', false);
+
+        $locator = new FileLocator($this->kernel, '/global/resource/path');
+        $locator->locate('@BundleName/some/path', null, false);
+    }
+
+}


### PR DESCRIPTION
Fixed FileLocator in HttpKernel\Config package if global path ($path) is NULL (default).
