### PR TITLE
[WebProfilerBundle] removed next pointer class in a template

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/request.html.twig
@@ -9,7 +9,7 @@
                 {{ collector.controller.method }}
             </span>
         {% else %}
-            <span class="sf-toolbar-info-class sf-toolbar-info-with-next-pointer">{{ collector.controller }}</span>
+            <span class="sf-toolbar-info-class">{{ collector.controller }}</span>
         {% endif %}
     {% endset %}
     {% set request_status_code_color = (400 > collector.statuscode) ? ((200 == collector.statuscode) ? 'green' : 'yellow') : 'red'%}


### PR DESCRIPTION
It's not needed as there is nothing after the span here, eg. on a 404, see : 
http://awesomescreenshot.com/0d5149an51

It displays "n/a ::".
