### PR TITLE
[Form] Added widget option 'hidden'

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -113,8 +113,11 @@
 
 {% block datetime_widget %}
 {% spaceless %}
-    {% if widget == 'single_text' %}
+    {% if widget == 'single_text' or widget == 'hidden_single_text' %}
         {{ block('form_widget_simple') }}
+    {% elseif widget == 'hidden' %}
+        {{ form_widget(form.date) }}
+        {{ form_widget(form.time) }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {{ form_errors(form.date) }}
@@ -128,8 +131,14 @@
 
 {% block date_widget %}
 {% spaceless %}
-    {% if widget == 'single_text' %}
+    {% if widget == 'single_text' or widget == 'hidden_single_text' %}
         {{ block('form_widget_simple') }}
+    {% elseif widget == 'hidden' %}
+        {{ date_pattern|replace({
+            '{{ year }}':  form_widget(form.year),
+            '{{ month }}': form_widget(form.month),
+            '{{ day }}':   form_widget(form.day),
+        })|raw }}
     {% else %}
         <div {{ block('widget_container_attributes') }}>
             {{ date_pattern|replace({
@@ -144,8 +153,10 @@
 
 {% block time_widget %}
 {% spaceless %}
-    {% if widget == 'single_text' %}
+    {% if widget == 'single_text' or widget == 'hidden_single_text' %}
         {{ block('form_widget_simple') }}
+    {% elseif widget == 'hidden' %}
+        {{ form_widget(form.hour) }}{% if with_minutes %}{{ form_widget(form.minute) }}{% endif %}{% if with_seconds %}{{ form_widget(form.second) }}{% endif %}
     {% else %}
         {% set vars = widget == 'text' ? { 'attr': { 'size': 1 }} : {} %}
         <div {{ block('widget_container_attributes') }}>

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 2.3.0
 ------
 
+ * added "hidden" and "hidden_single_text" on widget option of DateTimeType, DateType and TimeType
+   "hidden" value will generate separates hidden inputs (day, month, year...) for rendering the formType
+   "hidden_single_text" value will generate a single hidden input for rendering the formType
  * changed FormRenderer::humanize() to humanize also camel cased field name
 
 2.2.0

--- a/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/HiddenType.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\Options;
 
 class HiddenType extends AbstractType
 {
@@ -21,12 +22,22 @@ class HiddenType extends AbstractType
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
+        //force required attribute to false
+        $requiredNormalizer = function (Options $options, $required)
+        {
+            return false;
+        };
+
         $resolver->setDefaults(array(
             // hidden fields cannot have a required attribute
             'required'       => false,
             // Pass errors to the parent
             'error_bubbling' => true,
             'compound'       => false,
+        ));
+
+        $resolver->setNormalizers(array(
+            'required' => $requiredNormalizer,
         ));
     }
 


### PR DESCRIPTION
[Form] [DateTimeType][DateType][TimeType] added widget option on DateTimeType, DateType and TimeType

"hidden" value will generate separate hidden inputs (day, month,year...) for rendering the formType
"hidden_single_text" value will generate a single hidden input for rendering the formType
On DateTimeType date part can be hidden and not time parts and vice versa

_This is usefull for me because on a an app i am developping i have a form for an entity which contains datetime fields where the date part is set by javascript (so hidden) and the time part is set by the user._

| Q | A |
| --: | :-: |
| Bug fix | no |
| New feature | yes |
| BC breaks | no |
| Deprecations | no |
| Tests pass | no |
| License | MIT |
