### PR TITLE
Fix namespace paths that are breaking in Composer's autoloader

### DIFF
--- a/src/Symfony/Component/BrowserKit/composer.json
+++ b/src/Symfony/Component/BrowserKit/composer.json
@@ -27,7 +27,7 @@
         "symfony/process": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\BrowserKit\\": "" }
+        "psr-0": { "Symfony\\Component\\BrowserKit": "" }
     },
     "target-dir": "Symfony/Component/BrowserKit",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/ClassLoader/composer.json
+++ b/src/Symfony/Component/ClassLoader/composer.json
@@ -23,7 +23,7 @@
         "symfony/finder": "~2.0"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\ClassLoader\\": "" }
+        "psr-0": { "Symfony\\Component\\ClassLoader": "" }
     },
     "target-dir": "Symfony/Component/ClassLoader",
     "extra": {

--- a/src/Symfony/Component/Config/composer.json
+++ b/src/Symfony/Component/Config/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Config\\": "" }
+        "psr-0": { "Symfony\\Component\\Config": "" }
     },
     "target-dir": "Symfony/Component/Config",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Console/composer.json
+++ b/src/Symfony/Component/Console/composer.json
@@ -22,7 +22,7 @@
         "symfony/event-dispatcher": "~2.1"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Console\\": "" }
+        "psr-0": { "Symfony\\Component\\Console": "" }
     },
     "target-dir": "Symfony/Component/Console",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/CssSelector/composer.json
+++ b/src/Symfony/Component/CssSelector/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\CssSelector\\": "" }
+        "psr-0": { "Symfony\\Component\\CssSelector": "" }
     },
     "target-dir": "Symfony/Component/CssSelector",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/DependencyInjection/composer.json
+++ b/src/Symfony/Component/DependencyInjection/composer.json
@@ -27,7 +27,7 @@
         "symfony/config": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\DependencyInjection\\": "" }
+        "psr-0": { "Symfony\\Component\\DependencyInjection": "" }
     },
     "target-dir": "Symfony/Component/DependencyInjection",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/DomCrawler/composer.json
+++ b/src/Symfony/Component/DomCrawler/composer.json
@@ -25,7 +25,7 @@
         "symfony/css-selector": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\DomCrawler\\": "" }
+        "psr-0": { "Symfony\\Component\\DomCrawler": "" }
     },
     "target-dir": "Symfony/Component/DomCrawler",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/EventDispatcher/composer.json
+++ b/src/Symfony/Component/EventDispatcher/composer.json
@@ -26,7 +26,7 @@
         "symfony/http-kernel": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\EventDispatcher\\": "" }
+        "psr-0": { "Symfony\\Component\\EventDispatcher": "" }
     },
     "target-dir": "Symfony/Component/EventDispatcher",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Filesystem/composer.json
+++ b/src/Symfony/Component/Filesystem/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Filesystem\\": "" }
+        "psr-0": { "Symfony\\Component\\Filesystem": "" }
     },
     "target-dir": "Symfony/Component/Filesystem",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Finder/composer.json
+++ b/src/Symfony/Component/Finder/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Finder\\": "" }
+        "psr-0": { "Symfony\\Component\\Finder": "" }
     },
     "target-dir": "Symfony/Component/Finder",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Form/composer.json
+++ b/src/Symfony/Component/Form/composer.json
@@ -31,7 +31,7 @@
         "symfony/http-foundation": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Form\\": "" }
+        "psr-0": { "Symfony\\Component\\Form": "" }
     },
     "target-dir": "Symfony/Component/Form",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/HttpFoundation/composer.json
+++ b/src/Symfony/Component/HttpFoundation/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\HttpFoundation\\": "" },
+        "psr-0": { "Symfony\\Component\\HttpFoundation": "" },
         "classmap": [ "Symfony/Component/HttpFoundation/Resources/stubs" ]
     },
     "target-dir": "Symfony/Component/HttpFoundation",

--- a/src/Symfony/Component/HttpKernel/composer.json
+++ b/src/Symfony/Component/HttpKernel/composer.json
@@ -41,7 +41,7 @@
         "symfony/finder": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\HttpKernel\\": "" }
+        "psr-0": { "Symfony\\Component\\HttpKernel": "" }
     },
     "target-dir": "Symfony/Component/HttpKernel",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Locale/composer.json
+++ b/src/Symfony/Component/Locale/composer.json
@@ -22,7 +22,7 @@
         "ext-intl": "to use other locales than built-in `en`"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Locale\\": "" },
+        "psr-0": { "Symfony\\Component\\Locale": "" },
         "classmap": [ "Symfony/Component/Locale/Resources/stubs" ]
     },
     "target-dir": "Symfony/Component/Locale",

--- a/src/Symfony/Component/OptionsResolver/composer.json
+++ b/src/Symfony/Component/OptionsResolver/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\OptionsResolver\\": "" }
+        "psr-0": { "Symfony\\Component\\OptionsResolver": "" }
     },
     "target-dir": "Symfony/Component/OptionsResolver",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Process\\": "" }
+        "psr-0": { "Symfony\\Component\\Process": "" }
     },
     "target-dir": "Symfony/Component/Process",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/PropertyAccess/composer.json
+++ b/src/Symfony/Component/PropertyAccess/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\PropertyAccess\\": "" }
+        "psr-0": { "Symfony\\Component\\PropertyAccess": "" }
     },
     "target-dir": "Symfony/Component/PropertyAccess",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Routing/composer.json
+++ b/src/Symfony/Component/Routing/composer.json
@@ -30,7 +30,7 @@
         "doctrine/common": "~2.2"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Routing\\": "" }
+        "psr-0": { "Symfony\\Component\\Routing": "" }
     },
     "target-dir": "Symfony/Component/Routing",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -38,7 +38,7 @@
         "doctrine/dbal": "to use the built-in ACL implementation"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Security\\": "" }
+        "psr-0": { "Symfony\\Component\\Security": "" }
     },
     "target-dir": "Symfony/Component/Security",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Serializer/composer.json
+++ b/src/Symfony/Component/Serializer/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Serializer\\": "" }
+        "psr-0": { "Symfony\\Component\\Serializer": "" }
     },
     "target-dir": "Symfony/Component/Serializer",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Stopwatch/composer.json
+++ b/src/Symfony/Component/Stopwatch/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Stopwatch\\": "" }
+        "psr-0": { "Symfony\\Component\\Stopwatch": "" }
     },
     "target-dir": "Symfony/Component/Stopwatch",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Templating/composer.json
+++ b/src/Symfony/Component/Templating/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Templating\\": "" }
+        "psr-0": { "Symfony\\Component\\Templating": "" }
     },
     "target-dir": "Symfony/Component/Templating",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Translation/composer.json
+++ b/src/Symfony/Component/Translation/composer.json
@@ -27,7 +27,7 @@
         "symfony/yaml": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Translation\\": "" }
+        "psr-0": { "Symfony\\Component\\Translation": "" }
     },
     "target-dir": "Symfony/Component/Translation",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Validator/composer.json
+++ b/src/Symfony/Component/Validator/composer.json
@@ -33,7 +33,7 @@
         "symfony/config": "2.2.*"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Validator\\": "" }
+        "psr-0": { "Symfony\\Component\\Validator": "" }
     },
     "target-dir": "Symfony/Component/Validator",
     "minimum-stability": "dev",

--- a/src/Symfony/Component/Yaml/composer.json
+++ b/src/Symfony/Component/Yaml/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3"
     },
     "autoload": {
-        "psr-0": { "Symfony\\Component\\Yaml\\": "" }
+        "psr-0": { "Symfony\\Component\\Yaml": "" }
     },
     "target-dir": "Symfony/Component/Yaml",
     "minimum-stability": "dev",


### PR DESCRIPTION
Updated the namespace paths in the composer.json files so that Composer's vendor/autoload.php doesn't break.

Symfony 2.2.\* Components are the first build versions to break Composer's autoloader. 2.1.\* builds did not have this issue.
