### PR TITLE
Update InlineFragmentRenderer.php

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -86,9 +86,6 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $cookies = $request->cookies->all();
         $server = $request->server->all();
 
-        // the sub-request is internal
-        $server['REMOTE_ADDR'] = '127.0.0.1';
-
         $subRequest = $request::create($uri, 'get', array(), $cookies, array(), $server);
         if ($session = $request->getSession()) {
             $subRequest->setSession($session);


### PR DESCRIPTION
this is wrong:
"// the sub-request is internal
 $server['REMOTE_ADDR'] = '127.0.0.1';"

I always want to know the client IP address...
If I was behind a proxy/varnish, I should be able to get the reverse instead of localhost
