### PR TITLE
[HttpKernel] InlineFragmentRenderer should add the X-Forwarded-For of real client IP

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -699,7 +699,12 @@ class Request
 
         //If is there any forward_for IP address, this is the real client IP address
         if ($this->headers->has(self::$trustedHeaders[self::HEADER_CLIENT_IP])) {
-            return $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_IP]);
+            $forwarded  = $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_IP]);
+            $forwarded  = explode(",",$forwarded);
+            $forwarded  = trim($forwarded[0]);
+
+
+            return $forwarded;
         }
 
         //If it is not a forwarded IP, the Client IP should be in the trusted proxies

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -696,6 +696,18 @@ class Request
         $clientIps[] = $ip;
 
         $trustedProxies = self::$trustProxy && !self::$trustedProxies ? array($ip) : self::$trustedProxies;
+
+        //If is there any forward_for IP address, this is the real client IP address
+        if ($this->headers->has(self::$trustedHeaders[self::HEADER_CLIENT_IP])) {
+            return $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_IP]);
+        }
+
+        //If it is not a forwarded IP, the Client IP should be in the trusted proxies
+        if (!$this->headers->has(self::$trustedHeaders[self::HEADER_CLIENT_IP])) {
+            array_push($trustedProxies, $this->getClientIp());
+            $this->setTrustedProxies($trustedProxies); 
+        }
+
         $clientIps = array_diff($clientIps, $trustedProxies);
 
         return array_pop($clientIps);

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -708,10 +708,8 @@ class Request
         }
 
         //If it is not a forwarded IP, the Client IP should be in the trusted proxies
-        if (!$this->headers->has(self::$trustedHeaders[self::HEADER_CLIENT_IP])) {
-            array_push($trustedProxies, $this->getClientIp());
-            $this->setTrustedProxies($trustedProxies); 
-        }
+        array_push($trustedProxies, $this->getClientIp());
+        $this->setTrustedProxies($trustedProxies);
 
         $clientIps = array_diff($clientIps, $trustedProxies);
 

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -769,9 +769,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('127.0.0.1',                false, '127.0.0.1',    '88.88.88.88',                         null),
             array('88.88.88.88',              true,  '127.0.0.1',    '88.88.88.88',                         null),
             array('2620:0:1cfe:face:b00c::3', true,  '::1',          '2620:0:1cfe:face:b00c::3',            null),
-            array('88.88.88.88',              true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', null),
-            array('87.65.43.21',              true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
-            array('87.65.43.21',              false, '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+            array('127.0.0.1',                true,  '123.45.67.89', '127.0.0.1, 88.88.88.88, 87.65.43.21', null),
+            array('127.0.0.1',                true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+            array('127.0.0.1',                false, '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
         );
     }
 
@@ -1281,7 +1281,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $request->headers->set('X_FORWARDED_HOST', 'foo.example.com, real.example.com:8080');
         $request->headers->set('X_FORWARDED_PROTO', 'https');
         $request->headers->set('X_FORWARDED_PORT', 443);
-        $request->headers->set('X_MY_FOR', '3.3.3.3, 4.4.4.4');
+        $request->headers->set('X_MY_FOR', '3.3.3.3, 4.4.4.4');//X-Forwarded-For: client[3.3.3.3], proxy1, proxy2
         $request->headers->set('X_MY_HOST', 'my.example.com');
         $request->headers->set('X_MY_PROTO', 'http');
         $request->headers->set('X_MY_PORT', 81);
@@ -1306,12 +1306,12 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(443, $request->getPort());
         $this->assertTrue($request->isSecure());
 
-        // custom header names
+        // custom header names : X-Forwarded-For: client[3.3.3.3], proxy1, proxy2
         Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, 'X_MY_FOR');
         Request::setTrustedHeaderName(Request::HEADER_CLIENT_HOST, 'X_MY_HOST');
         Request::setTrustedHeaderName(Request::HEADER_CLIENT_PORT, 'X_MY_PORT');
         Request::setTrustedHeaderName(Request::HEADER_CLIENT_PROTO, 'X_MY_PROTO');
-        $this->assertEquals('4.4.4.4', $request->getClientIp());
+        $this->assertEquals('3.3.3.3', $request->getClientIp());
         $this->assertEquals('my.example.com', $request->getHost());
         $this->assertEquals(81, $request->getPort());
         $this->assertFalse($request->isSecure());

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -86,9 +86,6 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $cookies = $request->cookies->all();
         $server = $request->server->all();
 
-        // the sub-request is internal
-        $server['REMOTE_ADDR'] = '127.0.0.1';
-
         $subRequest = $request::create($uri, 'get', array(), $cookies, array(), $server);
         if ($session = $request->getSession()) {
             $subRequest->setSession($session);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 7554 |
| License | MIT |

InlineFragmentRenderer should add the X-Forwarded-For of real client IP, just like EsiFragmentRenderer expects.

To this work, the getClientIp was updated with a fix for that.

```
This is related to this ISSUE https://github.com/symfony/symfony/pull/7554
And this PR https://github.com/kinncj/symfony/commit/9c4eb20a9420c80b9cd910cc906e15a41842fe13
```
