### PR TITLE
[HttpFoundation] [HttpKernel] Internal sub-requests should have X-Forwarded-For header providing real client IP

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -696,7 +696,7 @@ class Request
         $clientIps[] = $ip;
 
         $trustedProxies = self::$trustProxy && !self::$trustedProxies ? array($ip) : self::$trustedProxies;
-        $clientIps = array_diff($clientIps, $trustedProxies);
+        $clientIps = array_diff($clientIps, array_merge($trustedProxies, $this->getLocalIpAddresses()));
 
         return array_pop($clientIps);
     }
@@ -1611,6 +1611,16 @@ class Request
             'atom' => array('application/atom+xml'),
             'rss'  => array('application/rss+xml'),
         );
+    }
+
+    /**
+     * Return a list of local IP addresses.
+     *
+     * @return array
+     */
+    protected function getLocalIpAddresses()
+    {
+        return array('127.0.0.1', 'fe80::1', '::1');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -516,6 +516,24 @@ class Request
     }
 
     /**
+     * Gets the trusted proxy header name.
+     *
+     * @param string $key The header key
+     *
+     * @return string The header name
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function getTrustedHeaderName($key)
+    {
+        if (!array_key_exists($key, self::$trustedHeaders)) {
+            throw new \InvalidArgumentException(sprintf('Unable to get the trusted header name for key "%s".', $key));
+        }
+
+        return self::$trustedHeaders[$key];
+    }
+
+    /**
      * Normalizes a query string.
      *
      * It builds a normalized query string, where keys/value pairs are alphabetized,
@@ -696,7 +714,7 @@ class Request
         $clientIps[] = $ip;
 
         $trustedProxies = self::$trustProxy && !self::$trustedProxies ? array($ip) : self::$trustedProxies;
-        $clientIps = array_diff($clientIps, array_merge($trustedProxies, $this->getLocalIpAddresses()));
+        $clientIps = array_diff($clientIps, $trustedProxies);
 
         return array_pop($clientIps);
     }
@@ -1611,16 +1629,6 @@ class Request
             'atom' => array('application/atom+xml'),
             'rss'  => array('application/rss+xml'),
         );
-    }
-
-    /**
-     * Return a list of local IP addresses.
-     *
-     * @return array
-     */
-    protected function getLocalIpAddresses()
-    {
-        return array('127.0.0.1', 'fe80::1', '::1');
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -1328,6 +1328,10 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         // reset
         Request::setTrustedProxies(array());
+        Request::setTrustedHeaderName(Request::HEADER_CLIENT_IP, 'X_FORWARDED_FOR');
+        Request::setTrustedHeaderName(Request::HEADER_CLIENT_HOST, 'X_FORWARDED_HOST');
+        Request::setTrustedHeaderName(Request::HEADER_CLIENT_PORT, 'X_FORWARDED_PORT');
+        Request::setTrustedHeaderName(Request::HEADER_CLIENT_PROTO, 'X_FORWARDED_PROTO');
     }
 }
 

--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -87,9 +87,15 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $server = $request->server->all();
 
         // the sub-request is internal
+        $originalXForwardedFor = isset($server['HTTP_X_FORWARDED_FOR'])
+            ? $server['HTTP_X_FORWARDED_FOR'] . ', '
+            : '';
+
+        $server['HTTP_X_FORWARDED_FOR'] = $originalXForwardedFor . $server['REMOTE_ADDR'];
         $server['REMOTE_ADDR'] = '127.0.0.1';
 
         $subRequest = $request::create($uri, 'get', array(), $cookies, array(), $server);
+
         if ($session = $request->getSession()) {
             $subRequest->setSession($session);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -55,6 +55,12 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
             '_format'     => 'html',
             '_controller' => 'main_controller',
         ));
+        $subRequest->headers->add(array(
+            'x-forwarded-for' => array('127.0.0.1'),
+        ));
+        $subRequest->server->add(array(
+            'HTTP_X_FORWARDED_FOR' => '127.0.0.1',
+        ));
 
         $kernel = $this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface');
         $kernel


### PR DESCRIPTION
This is a better alternative to fix issue highlighted in #7554 and #7557.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7554, #7557 |
| License | MIT |

When dealing with inline fragment renderer, it emulates an internal request by overriding the REMOTE_ADDR on Request. This is true, since conceptually request came from local server.
The problem that this introduces is that overriding the server value, it turns into an impossible state to retrieve the real client ip, only returning the local server IP (which is hardcoded to 127.0.0.1).

This patch takes the same approach as a Varnish call (it behaves the exact same way, reusing all code built for handling client ip handling on sub-requests), populating the X-Forwarded-For header and also making getClientIp smarter by removing possible local IP addresses from being considered as the client IP address.
