### PR TITLE
[Security] [ACL] Fix finding ACLs from ObjectIdentity's with different types

### DIFF
--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -263,6 +263,13 @@ SELECTCLAUSE;
         for ($i = 0; $i < $count; $i++) {
             if (!isset($types[$batch[$i]->getType()])) {
                 $types[$batch[$i]->getType()] = true;
+
+                // if there is more than one type we can safely break out of the
+                // loop, because it is the differentiator factor on whether to
+                // query for only one or more class types
+                if (count($types) > 1) {
+                    break;
+                }
             }
         }
 

--- a/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/AclProvider.php
@@ -263,9 +263,6 @@ SELECTCLAUSE;
         for ($i = 0; $i < $count; $i++) {
             if (!isset($types[$batch[$i]->getType()])) {
                 $types[$batch[$i]->getType()] = true;
-                if ($count > 1) {
-                    break;
-                }
             }
         }
 

--- a/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Dbal/AclProviderTest.php
@@ -72,6 +72,23 @@ class AclProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($oids[1]->equals($acl1->getObjectIdentity()));
     }
 
+    public function testFindAclsWithDifferentTypes()
+    {
+        $oids = array();
+        $oids[] = new ObjectIdentity('123', 'Bundle\SomeVendor\MyBundle\Entity\SomeEntity');
+        $oids[] = new ObjectIdentity('123', 'Bundle\MyBundle\Entity\AnotherEntity');
+
+        $provider = $this->getProvider();
+
+        $acls = $provider->findAcls($oids);
+        $this->assertInstanceOf('SplObjectStorage', $acls);
+        $this->assertCount(2, $acls);
+        $this->assertInstanceOf('Symfony\Component\Security\Acl\Domain\Acl', $acl0 = $acls->offsetGet($oids[0]));
+        $this->assertInstanceOf('Symfony\Component\Security\Acl\Domain\Acl', $acl1 = $acls->offsetGet($oids[1]));
+        $this->assertTrue($oids[0]->equals($acl0->getObjectIdentity()));
+        $this->assertTrue($oids[1]->equals($acl1->getObjectIdentity()));
+    }
+
     public function testFindAclCachesAclInMemory()
     {
         $oid = new ObjectIdentity('1', 'foo');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

If more than one ObjectIdentity with different Type (Class name) is given to AclProvider::findAcls() it would throw an exception stating that it could not find the ACLs

This fixes this issue which was introduced in 2.2.0-RC3 - see commit 3c3a90b9e5c78f89027169a33e80cfa76b6f6c62

/cc @iBiryukov @schmittjoh 
