### PR TITLE
[Symfony\Bridge\Twig\Extension] fixed two methods' documentation blocks

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -45,8 +45,8 @@ class HttpKernelExtension extends \Twig_Extension
     /**
      * Renders a fragment.
      *
-     * @param string $uri     A URI
-     * @param array  $options An array of options
+     * @param string|ControllerReference $uri      A URI as a string or a ControllerReference instance
+     * @param array                      $options  An array of options
      *
      * @return string The fragment content
      *
@@ -65,9 +65,9 @@ class HttpKernelExtension extends \Twig_Extension
     /**
      * Renders a fragment.
      *
-     * @param string $strategy A strategy name
-     * @param string $uri      A URI
-     * @param array  $options  An array of options
+     * @param string                     $strategy A strategy name
+     * @param string|ControllerReference $uri      A URI as a string or a ControllerReference instance
+     * @param array                      $options  An array of options
      *
      * @return string The fragment content
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | None |
| License | MIT |

Fixed phpdoc blocks to show that $uri can be passed as a string or ControllerReference (rather than just as a string)
