### PR TITLE
[HttpKernel] Use a simple isError from Response for HandleException

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1119,6 +1119,18 @@ class Response
     }
 
     /**
+     * Was there a server or client side error?
+     *
+     * @return Boolean
+     *
+     * @api
+     */
+    public function isError()
+    {
+        return $this->statusCode >= 400 && $this->statusCode < 600;
+    }
+
+    /**
      * Is the response OK?
      *
      * @return Boolean

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -664,6 +664,15 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($response->isOk());
     }
 
+    public function testIsError()
+    {
+        $response = new Response('', 404);
+        $this->assertTrue($response->isError());
+
+        $response = new Response('', 500);
+        $this->assertTrue($response->isError());
+    }
+
     public function testIsServerOrClientError()
     {
         $response = new Response('', 404);

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -201,7 +201,7 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
             $response->setStatusCode($response->headers->get('X-Status-Code'));
 
             $response->headers->remove('X-Status-Code');
-        } elseif (!$response->isClientError() && !$response->isServerError() && !$response->isRedirect()) {
+        } elseif (!$response->isError() && !$response->isRedirect()) {
             // ensure that we actually have an error response
             if ($e instanceof HttpExceptionInterface) {
                 // keep the HTTP status code and headers


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (but they did not pass at all) |
| License | MIT |
