### PR TITLE
[2.1][Process] Fix timeout in Process::stop method

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -591,13 +591,17 @@ class Process
      */
     public function stop($timeout=10)
     {
-        $timeoutMicro = (int) $timeout*10E6;
+        $timeoutMicro = (int) $timeout*1E6;
         if ($this->isRunning()) {
             proc_terminate($this->process);
             $time = 0;
             while (1 == $this->isRunning() && $time < $timeoutMicro) {
                 $time += 1000;
                 usleep(1000);
+            }
+
+            if (!defined('PHP_WINDOWS_VERSION_BUILD') && $this->isRunning()) {
+                proc_terminate($this->process, SIGKILL);
             }
 
             foreach ($this->pipes as $pipe) {

--- a/src/Symfony/Component/Process/Tests/NonStopableProcess.php
+++ b/src/Symfony/Component/Process/Tests/NonStopableProcess.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Runs a PHP script that can be stopped only with a SIGKILL (9) signal for 3 seconds
+ *
+ * @args duration Run this script with a custom duration
+ *
+ * @example `php NonStopableProcess.php 42` will run the script for 42 seconds
+ */
+
+function handleSignal($signal)
+{
+    switch ($signal) {
+        case SIGTERM:
+            $name = 'SIGTERM';
+            break;
+        case SIGINT:
+            $name = 'SIGINT';
+            break;
+        default:
+            $name = $signal . ' (unknown)';
+            break;
+    }
+
+    echo "received signal $name\n";
+}
+
+declare(ticks=1);
+pcntl_signal(SIGTERM, 'handleSignal');
+pcntl_signal(SIGINT, 'handleSignal');
+
+$duration = isset($argv[1]) ? (int) $argv[1] : 3;
+$start = microtime(true);
+
+while ($duration > (microtime(true) - $start)) {
+    usleep(1000);
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7579 |
| License | MIT |
- The timeout is ten times more than set.
- The timeout does not occurs, it is actually blocking until the process dies.
