### PR TITLE
[Routing][XML Loader] Add a possibility to set a default value to null

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -215,7 +215,11 @@ class XmlFileLoader extends FileLoader
         foreach ($node->getElementsByTagNameNS(self::NAMESPACE_URI, '*') as $n) {
             switch ($n->localName) {
                 case 'default':
-                    $defaults[$n->getAttribute('key')] = trim($n->textContent);
+                    if ($n->hasAttribute('xsi:nil') && 'true' == $n->getAttribute('xsi:nil')) {
+                        $defaults[$n->getAttribute('key')] = null;
+                    } else {
+                        $defaults[$n->getAttribute('key')] = trim($n->textContent);
+                    }
                     break;
                 case 'requirement':
                     $requirements[$n->getAttribute('key')] = trim($n->textContent);

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -26,7 +26,7 @@
 
   <xsd:group name="configs">
     <xsd:choice>
-      <xsd:element name="default" type="element" />
+      <xsd:element name="default" nillable="true" type="element" />
       <xsd:element name="requirement" type="element" />
       <xsd:element name="option" type="element" />
     </xsd:choice>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/7335 |
| License | MIT |

Example:

```
<route id="acme_user_show" pattern="/{id}">
    <default key="_controller">AcmeUserBundle:User:show</default>
    <default key="id" xsi:nil="true" />
    <requirement key="id">\d+</requirement>
</route>
```
