### PR TITLE
[CssSelector] Updated parsers to support namespaces (fix for ClassParser included)

### DIFF
--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ClassParser.php
@@ -31,9 +31,18 @@ class ClassParser implements ParserInterface
      */
     public function parse($source)
     {
-        // matches "<selector>.<name>"
-        if (preg_match('~^[ \t\r\n\f]*([a-zA-Z]*)\.([a-zA-Z][a-zA-Z0-9_-]*)[ \t\r\n\f]*$~', $source, $matches)) {
-            return array(new SelectorNode(new ClassNode(new ElementNode($matches[1] ?: null), $matches[2])));
+        // Matches an optional namespace, optional element, and required class
+        // $source = 'test|input.ab6bd_field';
+        // $matches = array (size=5)
+        //     0 => string 'test:input.ab6bd_field' (length=22)
+        //     1 => string 'test:' (length=5)
+        //     2 => string 'test' (length=4)
+        //     3 => string 'input' (length=5)
+        //     4 => string 'ab6bd_field' (length=11)
+        if (preg_match('/^(([a-z]+)\|)?([\w-]+|\*)?\.([\w-]+)$/i', trim($source), $matches)) {
+            return array(
+                new SelectorNode(new ClassNode(new ElementNode($matches[2] ?: null, $matches[3] ?: null), $matches[4]))
+            );
         }
 
         return array();

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/ElementParser.php
@@ -30,9 +30,15 @@ class ElementParser implements ParserInterface
      */
     public function parse($source)
     {
-        // matches "<element>"
-        if (preg_match('~^[ \t\r\n\f]*([a-zA-Z][a-zA-Z0-9_-]*|\\*)[ \t\r\n\f]*$~', $source, $matches)) {
-            return array(new SelectorNode(new ElementNode(null, $matches[1])));
+        // Matches an optional namespace, required element or `*`
+        // $source = 'testns|testel';
+        // $matches = array (size=4)
+        //     0 => string 'testns:testel' (length=13)
+        //     1 => string 'testns:' (length=7)
+        //     2 => string 'testns' (length=6)
+        //     3 => string 'testel' (length=6)
+        if (preg_match('/^(([a-z]+)\|)?([\w-]+|\*)$/i', trim($source), $matches)) {
+            return array(new SelectorNode(new ElementNode($matches[2] ?: null, $matches[3])));
         }
 
         return array();

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/EmptyStringParser.php
@@ -34,8 +34,8 @@ class EmptyStringParser implements ParserInterface
      */
     public function parse($source)
     {
-        // matches ""
-        if (preg_match('~^$~', $source, $matches)) {
+        // Matches an empty string
+        if ($source == '') {
             return array(new SelectorNode(new ElementNode(null, '*')));
         }
 

--- a/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
+++ b/src/Symfony/Component/CssSelector/Parser/Shortcut/HashParser.php
@@ -31,9 +31,18 @@ class HashParser implements ParserInterface
      */
     public function parse($source)
     {
-        // matches "<selector>#<id>"
-        if (preg_match('~^[ \t\r\n\f]*([a-zA-Z][a-zA-Z0-9_-]*|\\*)?#([a-zA-Z0-9_-]+)[ \t\r\n\f]*$~', $source, $matches)) {
-            return array(new SelectorNode(new HashNode(new ElementNode(null, $matches[1] ?: null), $matches[2])));
+        // Matches an optional namespace, optional element, and required id
+        // $source = 'test|input#ab6bd_field';
+        // $matches = array (size=5)
+        //     0 => string 'test:input#ab6bd_field' (length=22)
+        //     1 => string 'test:' (length=5)
+        //     2 => string 'test' (length=4)
+        //     3 => string 'input' (length=5)
+        //     4 => string 'ab6bd_field' (length=11)
+        if (preg_match('/^(([a-z]+)\|)?([\w-]+|\*)?#([\w-]+)$/i', trim($source), $matches)) {
+            return array(
+                new SelectorNode(new HashNode(new ElementNode($matches[2] ?: null, $matches[3] ?: null), $matches[4]))
+            );
         }
 
         return array();

--- a/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/ClassParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/ClassParserTest.php
@@ -34,7 +34,11 @@ class ClassParserTest extends \PHPUnit_Framework_TestCase
     public function getParseTestData()
     {
         return array(
-            array('.class', 'Class[Element[*].class]'),
+            array('.testclass', 'Class[Element[*].testclass]'),
+            array('testel.testclass', 'Class[Element[testel].testclass]'),
+            array('testns|.testclass', 'Class[Element[testns|*].testclass]'),
+            array('testns|*.testclass', 'Class[Element[testns|*].testclass]'),
+            array('testns|testel.testclass', 'Class[Element[testns|testel].testclass]'),
         );
     }
 }

--- a/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/ElementParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/ElementParserTest.php
@@ -34,9 +34,10 @@ class ElementParserTest extends \PHPUnit_Framework_TestCase
     public function getParseTestData()
     {
         return array(
-            array('p', 'Element[p]'),
             array('*', 'Element[*]'),
-            array('h1', 'Element[h1]'),
+            array('testel', 'Element[testel]'),
+            array('testns|*', 'Element[testns|*]'),
+            array('testns|testel', 'Element[testns|testel]'),
         );
     }
 }

--- a/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/EmptyStringParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/EmptyStringParserTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\CssSelector\Tests\Parser\Shortcut;
+
+use Symfony\Component\CssSelector\Node\SelectorNode;
+use Symfony\Component\CssSelector\Parser\Shortcut\EmptyStringParser;
+
+/**
+ * @author Jean-François Simon <jeanfrancois.simon@sensiolabs.com>
+ */
+class EmptyStringParserTest extends \PHPUnit_Framework_TestCase
+{
+    public function testParse()
+    {
+        $parser = new EmptyStringParser();
+        $selectors = $parser->parse('');
+        $this->assertEquals(1, count($selectors));
+
+        /** @var SelectorNode $selector */
+        $selector = $selectors[0];
+        $this->assertEquals('Element[*]', (string) $selector->getTree());
+
+        $selectors = $parser->parse('this will produce an empty array');
+        $this->assertEquals(0, count($selectors));
+    }
+}

--- a/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/HashParserTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/Parser/Shortcut/HashParserTest.php
@@ -34,8 +34,11 @@ class HashParserTest extends \PHPUnit_Framework_TestCase
     public function getParseTestData()
     {
         return array(
-            array('#id', 'Hash[Element[*]#id]'),
-            array('h1#main', 'Hash[Element[h1]#main]'),
+            array('#testid', 'Hash[Element[*]#testid]'),
+            array('testel#testid', 'Hash[Element[testel]#testid]'),
+            array('testns|#testid', 'Hash[Element[testns|*]#testid]'),
+            array('testns|*#testid', 'Hash[Element[testns|*]#testid]'),
+            array('testns|testel#testid', 'Hash[Element[testns|testel]#testid]'),
         );
     }
 }


### PR DESCRIPTION
ClassParser was passing improper parameters to `ElementNode`, as well as namespaces simply not being supported in the various parsers. This is a natural extension of #6650, by properly parsing the requested CSS filter if supplied.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | NA |
| License | MIT |
| Doc PR | NA |
