### PR TITLE
[2.2][HttpKernel] Remove args from 5.3 stack traces to avoid filling log files

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/HttpKernel/Debug/ErrorHandler.php
@@ -87,7 +87,17 @@ class ErrorHandler
 
         if ($level & (E_USER_DEPRECATED | E_DEPRECATED)) {
             if (null !== self::$logger) {
-                $stack = version_compare(PHP_VERSION, '5.4', '<') ? array_slice(debug_backtrace(false), 0, 10) : debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+                if (version_compare(PHP_VERSION, '5.4', '<')) {
+                    $stack = array_map(
+                        function ($row) {
+                            unset($row['args']);
+                            return $row;
+                        },
+                        array_slice(debug_backtrace(false), 0, 10)
+                    );
+                } else {
+                    $stack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 10);
+                }
 
                 self::$logger->warning($message, array('type' => self::TYPE_DEPRECATION, 'stack' => $stack));
             }


### PR DESCRIPTION
Fixes #7259 - it just makes the PHP 5.3 behavior match the one on 5.4.
