### PR TITLE
[Security] [Acl] [BasicPermissionMap] Made $map protected and moved it to __construct

### DIFF
--- a/src/Symfony/Component/Security/Acl/Permission/BasicPermissionMap.php
+++ b/src/Symfony/Component/Security/Acl/Permission/BasicPermissionMap.php
@@ -28,58 +28,63 @@ class BasicPermissionMap implements PermissionMapInterface
     const PERMISSION_MASTER      = 'MASTER';
     const PERMISSION_OWNER       = 'OWNER';
 
-    private $map = array(
-        self::PERMISSION_VIEW => array(
-            MaskBuilder::MASK_VIEW,
-            MaskBuilder::MASK_EDIT,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
+    protected $map;
 
-        self::PERMISSION_EDIT => array(
-            MaskBuilder::MASK_EDIT,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_CREATE => array(
-            MaskBuilder::MASK_CREATE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_DELETE => array(
-            MaskBuilder::MASK_DELETE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_UNDELETE => array(
-            MaskBuilder::MASK_UNDELETE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_OPERATOR => array(
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_MASTER => array(
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ),
-
-        self::PERMISSION_OWNER => array(
-            MaskBuilder::MASK_OWNER,
-        ),
-    );
+    public function __construct()
+    {
+        $this->map = array(
+            self::PERMISSION_VIEW => array(
+                MaskBuilder::MASK_VIEW,
+                MaskBuilder::MASK_EDIT,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_EDIT => array(
+                MaskBuilder::MASK_EDIT,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_CREATE => array(
+                MaskBuilder::MASK_CREATE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_DELETE => array(
+                MaskBuilder::MASK_DELETE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_UNDELETE => array(
+                MaskBuilder::MASK_UNDELETE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_OPERATOR => array(
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_MASTER => array(
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ),
+    
+            self::PERMISSION_OWNER => array(
+                MaskBuilder::MASK_OWNER,
+            ),
+        );
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

By making $map protected and moving it to the construct, you can simply extend the BasicPermissionMap class if you want to simply add some extra permissions. In it's current form, you have to copy/paste the entire array AND the getMasks and contains functions. 
