### PR TITLE
[HttpFoundation] fixes creation of sub requests under IIS & Rewite Module

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -1435,11 +1435,14 @@ class Request
     {
         $requestUri = '';
 
-        if ($this->headers->has('X_ORIGINAL_URL') && false !== stripos(PHP_OS, 'WIN')) {
+        if ($this->headers->has('X_ORIGINAL_URL')) {
             // IIS with Microsoft Rewrite Module
             $requestUri = $this->headers->get('X_ORIGINAL_URL');
             $this->headers->remove('X_ORIGINAL_URL');
-        } elseif ($this->headers->has('X_REWRITE_URL') && false !== stripos(PHP_OS, 'WIN')) {
+            $this->server->remove('HTTP_X_ORIGINAL_URL');
+            $this->server->remove('UNENCODED_URL');
+            $this->server->remove('IIS_WasUrlRewritten');
+        } elseif ($this->headers->has('X_REWRITE_URL')) {
             // IIS with ISAPI_Rewrite
             $requestUri = $this->headers->get('X_REWRITE_URL');
             $this->headers->remove('X_REWRITE_URL');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6936, #6923 |
| License | MIT |
| Doc PR | N/A |

There are a few bugs to address.
1. `HTTP_X_ORIGINAL_URL` wasn't removed from the server parameters, so is picked back up [here](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/ServerBag.php#L33) upon recreation of a sub request.
2. When `X_ORIGINAL_URL` is passed in the headers by IIS, `IIS_WasUrlRewritten` and `UNENCODED_URL` can also be passed as server vars, so they must also be removed for sub request URI's to be resolved correctly.

Additionally, I have removed the OS check for windows, because it was only done for 2 out of 4 of the IIS specific checks, and it made the code untestable.

Also added tests for all scenarios as there were none.
