### PR TITLE
add 204 No Content to isRedirect

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -1165,7 +1165,7 @@ class Response
      */
     public function isRedirect($location = null)
     {
-        return in_array($this->statusCode, array(201, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
+        return in_array($this->statusCode, array(201, 204, 301, 302, 303, 307, 308)) && (null === $location ?: $location == $this->headers->get('Location'));
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -624,6 +624,16 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response = new Response('', 301, array('Location' => '/good-uri'));
         $this->assertFalse($response->isRedirect('/bad-uri'));
         $this->assertTrue($response->isRedirect('/good-uri'));
+
+        $response = new Response('', 201, array('Location' => '/good-uri'));
+        $this->assertFalse($response->isRedirection());
+        $this->assertFalse($response->isRedirect('/bad-uri'));
+        $this->assertTrue($response->isRedirect('/good-uri'));
+
+        $response = new Response('', 204, array('Location' => '/good-uri'));
+        $this->assertFalse($response->isRedirection());
+        $this->assertFalse($response->isRedirect('/bad-uri'));
+        $this->assertTrue($response->isRedirect('/good-uri'));
     }
 
     public function testIsNotFound()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

Add `No Content` to `isRedirect` method. Add tests for 201 and 204.
See also http://stackoverflow.com/questions/2342579/http-status-code-for-update-and-delete
