### PR TITLE
[HttpFoundation] Split getClientIp into two methods for better flexibility

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -710,7 +710,9 @@ class Request
      */
     public function getClientIp()
     {
-        return array_pop($this->getClientIps());
+        $ipAddresses = $this->getClientIps();
+
+        return array_pop($ipAddresses);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -664,19 +664,9 @@ class Request
     /**
      * Returns the client IP addresses.
      *
-     * This method can read the client IP address from the "X-Forwarded-For" header
-     * when trusted proxies were set via "setTrustedProxies()". The "X-Forwarded-For"
-     * header value is a comma+space separated list of IP addresses, the left-most
-     * being the original client, and each successive proxy that passed the request
-     * adding the IP address where it received the request from.
-     *
-     * If your reverse proxy uses a different header name than "X-Forwarded-For",
-     * ("Client-Ip" for instance), configure it via "setTrustedHeaderName()" with
-     * the "client-ip" key.
-     *
      * @return array The client IP addresses
      *
-     * @see http://en.wikipedia.org/wiki/X-Forwarded-For
+     * @see getClientIp()
      */
     public function getClientIps()
     {
@@ -702,9 +692,20 @@ class Request
     /**
      * Returns the client IP address.
      *
+     * This method can read the client IP address from the "X-Forwarded-For" header
+     * when trusted proxies were set via "setTrustedProxies()". The "X-Forwarded-For"
+     * header value is a comma+space separated list of IP addresses, the left-most
+     * being the original client, and each successive proxy that passed the request
+     * adding the IP address where it received the request from.
+     *
+     * If your reverse proxy uses a different header name than "X-Forwarded-For",
+     * ("Client-Ip" for instance), configure it via "setTrustedHeaderName()" with
+     * the "client-ip" key.
+     *
      * @return string The client IP address
      *
      * @see getClientIps()
+     * @see http://en.wikipedia.org/wiki/X-Forwarded-For
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -677,8 +677,6 @@ class Request
      * @return array The client IP addresses
      *
      * @see http://en.wikipedia.org/wiki/X-Forwarded-For
-     *
-     * @api
      */
     public function getClientIps()
     {

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -662,7 +662,7 @@ class Request
     }
 
     /**
-     * Returns the client IP address.
+     * Returns the client IP addresses.
      *
      * This method can read the client IP address from the "X-Forwarded-For" header
      * when trusted proxies were set via "setTrustedProxies()". The "X-Forwarded-For"
@@ -674,22 +674,22 @@ class Request
      * ("Client-Ip" for instance), configure it via "setTrustedHeaderName()" with
      * the "client-ip" key.
      *
-     * @return string The client IP address
+     * @return array The client IP addresses
      *
      * @see http://en.wikipedia.org/wiki/X-Forwarded-For
      *
      * @api
      */
-    public function getClientIp()
+    public function getClientIps()
     {
         $ip = $this->server->get('REMOTE_ADDR');
 
         if (!self::$trustProxy) {
-            return $ip;
+            return array($ip);
         }
 
         if (!self::$trustedHeaders[self::HEADER_CLIENT_IP] || !$this->headers->has(self::$trustedHeaders[self::HEADER_CLIENT_IP])) {
-            return $ip;
+            return array($ip);
         }
 
         $clientIps = array_map('trim', explode(',', $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_IP])));
@@ -698,7 +698,19 @@ class Request
         $trustedProxies = self::$trustProxy && !self::$trustedProxies ? array($ip) : self::$trustedProxies;
         $clientIps = array_diff($clientIps, $trustedProxies);
 
-        return array_pop($clientIps);
+        return $clientIps;
+    }
+
+    /**
+     * Returns the client IP address. See getClientIps() for more information.
+     *
+     * @return string The client IP address
+     *
+     * @api
+     */
+    public function getClientIp()
+    {
+        return array_pop($this->getClientIps());
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -702,9 +702,11 @@ class Request
     }
 
     /**
-     * Returns the client IP address. See getClientIps() for more information.
+     * Returns the client IP address.
      *
      * @return string The client IP address
+     *
+     * @see getClientIps()
      *
      * @api
      */

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -739,40 +739,20 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @dataProvider testGetClientIpsProvider
+     * @dataProvider testGetClientIpProvider
      */
-    public function testGetClientIps($expected, $proxy, $remoteAddr, $httpForwardedFor, $trustedProxies, $multiple = false)
+    public function testGetClientIp($expected, $proxy, $remoteAddr, $httpForwardedFor, $trustedProxies)
     {
-        $request = new Request();
+        $request = $this->getRequestInstanceForClientIpTests($proxy, $remoteAddr, $httpForwardedFor, $trustedProxies);
 
-        $server = array('REMOTE_ADDR' => $remoteAddr);
-        if (null !== $httpForwardedFor) {
-            $server['HTTP_X_FORWARDED_FOR'] = $httpForwardedFor;
-        }
-
-        if ($proxy || $trustedProxies) {
-            Request::setTrustedProxies(null === $trustedProxies ? array($remoteAddr) : $trustedProxies);
-        }
-
-        $request->initialize(array(), array(), array(), array(), array(), $server);
-        $result = $multiple ? $request->getClientIps() : $request->getClientIp();
-        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $request->getClientIp());
 
         Request::setTrustedProxies(array());
     }
 
-    public function testGetClientIpsProvider()
+    public function testGetClientIpProvider()
     {
         return array(
-            array(array('88.88.88.88'),                             false, '88.88.88.88',  null,                                  null,                                 true),
-            array(array('127.0.0.1'),                               false, '127.0.0.1',    null,                                  null,                                 true),
-            array(array('::1'),                                     false, '::1',          null,                                  null,                                 true),
-            array(array('127.0.0.1'),                               false, '127.0.0.1',    '88.88.88.88',                         null,                                 true),
-            array(array('88.88.88.88'),                             true,  '127.0.0.1',    '88.88.88.88',                         null,                                 true),
-            array(array('2620:0:1cfe:face:b00c::3'),                true,  '::1',          '2620:0:1cfe:face:b00c::3',            null,                                 true),
-            array(array('127.0.0.1', '87.65.43.21', '88.88.88.88'), true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', null,                                 true),
-            array(array('127.0.0.1', '87.65.43.21'),                true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88'), true),
-            array(array('127.0.0.1', '87.65.43.21'),                false, '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88'), true),
             array('88.88.88.88',              false, '88.88.88.88',  null,                                  null),
             array('127.0.0.1',                false, '127.0.0.1',    null,                                  null),
             array('::1',                      false, '::1',          null,                                  null),
@@ -782,6 +762,33 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('88.88.88.88',              true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', null),
             array('87.65.43.21',              true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
             array('87.65.43.21',              false, '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+        );
+    }
+
+    /**
+     * @dataProvider testGetClientIpsProvider
+     */
+    public function testGetClientIps($expected, $proxy, $remoteAddr, $httpForwardedFor, $trustedProxies)
+    {
+        $request = $this->getRequestInstanceForClientIpTests($proxy, $remoteAddr, $httpForwardedFor, $trustedProxies);
+
+        $this->assertEquals($expected, $request->getClientIps());
+
+        Request::setTrustedProxies(array());
+    }
+
+    public function testGetClientIpsProvider()
+    {
+        return array(
+            array(array('88.88.88.88'),                             false, '88.88.88.88',  null,                                  null),
+            array(array('127.0.0.1'),                               false, '127.0.0.1',    null,                                  null),
+            array(array('::1'),                                     false, '::1',          null,                                  null),
+            array(array('127.0.0.1'),                               false, '127.0.0.1',    '88.88.88.88',                         null),
+            array(array('88.88.88.88'),                             true,  '127.0.0.1',    '88.88.88.88',                         null),
+            array(array('2620:0:1cfe:face:b00c::3'),                true,  '::1',          '2620:0:1cfe:face:b00c::3',            null),
+            array(array('127.0.0.1', '87.65.43.21', '88.88.88.88'), true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', null),
+            array(array('127.0.0.1', '87.65.43.21'),                true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+            array(array('127.0.0.1', '87.65.43.21'),                false, '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
         );
     }
 
@@ -1281,6 +1288,24 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $property = $class->getProperty('httpMethodParameterOverride');
         $property->setAccessible(true);
         $property->setValue(false);
+    }
+
+    private function getRequestInstanceForClientIpTests($proxy, $remoteAddr, $httpForwardedFor, $trustedProxies)
+    {
+        $request = new Request();
+
+        $server = array('REMOTE_ADDR' => $remoteAddr);
+        if (null !== $httpForwardedFor) {
+            $server['HTTP_X_FORWARDED_FOR'] = $httpForwardedFor;
+        }
+
+        if ($proxy || $trustedProxies) {
+            Request::setTrustedProxies(null === $trustedProxies ? array($remoteAddr) : $trustedProxies);
+        }
+
+        $request->initialize(array(), array(), array(), array(), array(), $server);
+
+        return $request;
     }
 
     public function testTrustedProxies()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | Locally: NO (HttpFoundation tests passes, but all Symfony tests fails because of my local setup). Travis : YES |
| Fixed tickets | #7349 |
| License | MIT |
| Doc PR | none (yet?) |

Split the `Request::getClientIp` method in two to allow better overriding flexibility. See #7349 for more information.
