### PR TITLE
[Form] DateTimeToRfc3339Transformer use proper transformation exteption in reverse transformation

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToRfc3339Transformer.php
@@ -53,7 +53,11 @@ class DateTimeToRfc3339Transformer extends BaseDateTimeTransformer
             return null;
         }
 
-        $dateTime = new \DateTime($rfc3339);
+        try {
+            $dateTime = new \DateTime($rfc3339);
+        } catch (\Exception $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
 
         if ($this->outputTimezone !== $this->inputTimezone) {
             try {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -119,4 +119,14 @@ class DateTimeToRfc3339TransformerTest extends DateTimeTestCase
 
         $transformer->reverseTransform('2010-04-31T04:05Z');
     }
+
+    /**
+     * @expectedException Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformExpectsValidDateString()
+    {        
+        $transformer = new DateTimeToRfc3339Transformer('UTC', 'UTC');
+
+        $transformer->reverseTransform('2010-2010-2010');
+    }
 }


### PR DESCRIPTION
Handle _Exception_ throwed by DateTime constructor if an invalid date is passed.
Then throws proper transformation exception.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |
