### PR TITLE
Enforce sprintf for exceptions

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -109,13 +109,11 @@ EOF
         $configuration = $extension->getConfiguration(array(), $containerBuilder);
 
         if (!$configuration) {
-            throw new \LogicException('The extension with alias "'.$extension->getAlias().
-                    '" does not have it\'s getConfiguration() method setup');
+            throw new \LogicException(sprintf('The extension with alias "%s" does not have it\'s getConfiguration() method setup', $extension->getAlias()));
         }
 
         if (!$configuration instanceof ConfigurationInterface) {
-            throw new \LogicException(sprintf(
-                'Configuration class "%s" should implement ConfigurationInterface in order to be dumpable', get_class($configuration)));
+            throw new \LogicException(sprintf('Configuration class "%s" should implement ConfigurationInterface in order to be dumpable', get_class($configuration)));
         }
 
         $output->writeln($message);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -84,7 +84,7 @@ EOF
             }
 
             if (!$extension) {
-                throw new \LogicException('No extensions with configuration available for "'.$name.'"');
+                throw new \LogicException(sprintf('No extensions with configuration available for "%s"', $name));
             }
 
             $message = 'Default configuration for "'.$name.'"';
@@ -100,7 +100,7 @@ EOF
             }
 
             if (!$extension) {
-                throw new \LogicException('No extension with alias "'.$name.'" is enabled');
+                throw new \LogicException(sprintf('No extension with alias "%s" is enabled', $name));
             }
 
             $message = 'Default configuration for extension with alias: "'.$name.'"';

--- a/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ConfigDumpReferenceCommand.php
@@ -114,9 +114,8 @@ EOF
         }
 
         if (!$configuration instanceof ConfigurationInterface) {
-            throw new \LogicException(
-                'Configuration class "'.get_class($configuration).
-                '" should implement ConfigurationInterface in order to be dumpable');
+            throw new \LogicException(sprintf(
+                'Configuration class "%s" should implement ConfigurationInterface in order to be dumpable', get_class($configuration)));
         }
 
         $output->writeln($message);

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -184,7 +184,7 @@ class TwigExtensionTest extends TestCase
                 $loader = new YamlFileLoader($container, $locator);
                 break;
             default:
-                throw new \InvalidArgumentException('Unsupported format: '.$format);
+                throw new \InvalidArgumentException(sprintf('Unsupported format: %s', $format));
         }
 
         $loader->load($file.'.'.$format);

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -293,7 +293,7 @@ abstract class Client
         $process->run();
 
         if (!$process->isSuccessful() || !preg_match('/^O\:\d+\:/', $process->getOutput())) {
-            throw new \RuntimeException('OUTPUT: '.$process->getOutput().' ERROR OUTPUT: '.$process->getErrorOutput());
+            throw new \RuntimeException(sprintf('OUTPUT: %s ERROR OUTPUT: %s', $process->getOutput(), $process->getErrorOutput()));
         }
 
         return unserialize($process->getOutput());

--- a/src/Symfony/Component/Console/Formatter/OutputFormatter.php
+++ b/src/Symfony/Component/Console/Formatter/OutputFormatter.php
@@ -130,7 +130,7 @@ class OutputFormatter implements OutputFormatterInterface
     public function getStyle($name)
     {
         if (!$this->hasStyle($name)) {
-            throw new \InvalidArgumentException('Undefined style: '.$name);
+            throw new \InvalidArgumentException(sprintf('Undefined style: %s', $name));
         }
 
         return $this->styles[strtolower($name)];

--- a/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
+++ b/src/Symfony/Component/CssSelector/Parser/Handler/StringHandler.php
@@ -64,7 +64,7 @@ class StringHandler implements HandlerInterface
         $match = $reader->findPattern($this->patterns->getQuotedStringPattern($quote));
 
         if (!$match) {
-            throw new InternalErrorException('Should have found at least an empty match at '.$reader->getPosition().'.');
+            throw new InternalErrorException(sprintf('Should have found at least an empty match at %s.', $reader->getPosition()));
         }
 
         // check unclosed strings

--- a/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
+++ b/src/Symfony/Component/CssSelector/XPath/Extension/FunctionExtension.php
@@ -58,7 +58,7 @@ class FunctionExtension extends AbstractExtension
         try {
             list($a, $b) = Parser::parseSeries($function->getArguments());
         } catch (SyntaxErrorException $e) {
-            throw new ExpressionErrorException('Invalid series: '.implode(', ', $function->getArguments()), 0, $e);
+            throw new ExpressionErrorException(sprintf('Invalid series: %s', implode(', ', $function->getArguments())), 0, $e);
         }
 
         $xpath->addStarPrefix();

--- a/src/Symfony/Component/CssSelector/XPath/Translator.php
+++ b/src/Symfony/Component/CssSelector/XPath/Translator.php
@@ -175,7 +175,7 @@ class Translator implements TranslatorInterface
     public function getExtension($name)
     {
         if (!isset($this->extensions[$name])) {
-            throw new ExpressionErrorException('Extension "'.$name.'" not registered.');
+            throw new ExpressionErrorException(sprintf('Extension "%s" not registered.', $name));
         }
 
         return $this->extensions[$name];
@@ -205,7 +205,7 @@ class Translator implements TranslatorInterface
     public function nodeToXPath(NodeInterface $node)
     {
         if (!isset($this->nodeTranslators[$node->getNodeName()])) {
-            throw new ExpressionErrorException('Node "'.$node->getNodeName().'" not supported.');
+            throw new ExpressionErrorException(sprintf('Node "%s" not supported.', $node->getNodeName()));
         }
 
         return call_user_func($this->nodeTranslators[$node->getNodeName()], $node);
@@ -223,7 +223,7 @@ class Translator implements TranslatorInterface
     public function addCombination($combiner, NodeInterface $xpath, NodeInterface $combinedXpath)
     {
         if (!isset($this->combinationTranslators[$combiner])) {
-            throw new ExpressionErrorException('Combiner "'.$combiner.'" not supported.');
+            throw new ExpressionErrorException(sprintf('Combiner "%s" not supported.', $combiner));
         }
 
         return call_user_func($this->combinationTranslators[$combiner], $this->nodeToXPath($xpath), $this->nodeToXPath($combinedXpath));
@@ -240,7 +240,7 @@ class Translator implements TranslatorInterface
     public function addFunction(XPathExpr $xpath, FunctionNode $function)
     {
         if (!isset($this->functionTranslators[$function->getName()])) {
-            throw new ExpressionErrorException('Function "'.$function->getName().'" not supported.');
+            throw new ExpressionErrorException(sprintf('Function "%s" not supported.', $function->getName()));
         }
 
         return call_user_func($this->functionTranslators[$function->getName()], $xpath, $function);
@@ -257,7 +257,7 @@ class Translator implements TranslatorInterface
     public function addPseudoClass(XPathExpr $xpath, $pseudoClass)
     {
         if (!isset($this->pseudoClassTranslators[$pseudoClass])) {
-            throw new ExpressionErrorException('Pseudo-class "'.$pseudoClass.'" not supported.');
+            throw new ExpressionErrorException(sprintf('Pseudo-class "%s" not supported.', $pseudoClass));
         }
 
         return call_user_func($this->pseudoClassTranslators[$pseudoClass], $xpath);
@@ -276,7 +276,7 @@ class Translator implements TranslatorInterface
     public function addAttributeMatching(XPathExpr $xpath, $operator, $attribute, $value)
     {
         if (!isset($this->attributeMatchingTranslators[$operator])) {
-            throw new ExpressionErrorException('Attribute matcher operator "'.$operator.'" not supported.');
+            throw new ExpressionErrorException(sprintf('Attribute matcher operator "%s" not supported.', $operator));
         }
 
         return call_user_func($this->attributeMatchingTranslators[$operator], $xpath, $attribute, $value);

--- a/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
+++ b/src/Symfony/Component/DependencyInjection/ContainerBuilder.php
@@ -640,7 +640,7 @@ class ContainerBuilder extends Container implements TaggedContainerInterface
         }
 
         if ($alias === strtolower($id)) {
-            throw new InvalidArgumentException('An alias can not reference itself, got a circular reference on "'.$alias.'".');
+            throw new InvalidArgumentException(sprintf('An alias can not reference itself, got a circular reference on "%s".', $alias));
         }
 
         unset($this->definitions[$alias]);

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -660,7 +660,7 @@ EOF;
                 return sprintf("        $return{$instantiation}%s->%s(%s);\n", $this->getServiceCall($definition->getFactoryService()), $definition->getFactoryMethod(), implode(', ', $arguments));
             }
 
-            throw new RuntimeException('Factory method requires a factory service or factory class in service definition for '.$id);
+            throw new RuntimeException(sprintf('Factory method requires a factory service or factory class in service definition for %s', $id));
         }
 
         if (false !== strpos($class, '$')) {

--- a/src/Symfony/Component/Finder/Adapter/BsdFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/BsdFindAdapter.php
@@ -62,7 +62,7 @@ class BsdFindAdapter extends AbstractFindAdapter
                 $format = '%m';
                 break;
             default:
-                throw new \InvalidArgumentException('Unknown sort options: '.$sort.'.');
+                throw new \InvalidArgumentException(sprintf('Unknown sort options: %s.', $sort));
         }
 
         $command

--- a/src/Symfony/Component/Finder/Adapter/GnuFindAdapter.php
+++ b/src/Symfony/Component/Finder/Adapter/GnuFindAdapter.php
@@ -54,7 +54,7 @@ class GnuFindAdapter extends AbstractFindAdapter
                 $format = '%T@';
                 break;
             default:
-                throw new \InvalidArgumentException('Unknown sort options: '.$sort.'.');
+                throw new \InvalidArgumentException(sprintf('Unknown sort options: %s.', $sort));
         }
 
         $command

--- a/src/Symfony/Component/Finder/Shell/Command.php
+++ b/src/Symfony/Component/Finder/Shell/Command.php
@@ -166,7 +166,7 @@ class Command
     public function ins($label)
     {
         if (isset($this->labels[$label])) {
-            throw new \RuntimeException('Label "'.$label.'" already exists.');
+            throw new \RuntimeException(sprintf('Label "%s" already exists.', $label));
         }
 
         $this->bits[] = self::create($this);
@@ -187,7 +187,7 @@ class Command
     public function get($label)
     {
         if (!isset($this->labels[$label])) {
-            throw new \RuntimeException('Label "'.$label.'" does not exists.');
+            throw new \RuntimeException(sprintf('Label "%s" does not exists.', $label));
         }
 
         return $this->bits[$this->labels[$label]];

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ChoiceList.php
@@ -345,13 +345,13 @@ class ChoiceList implements ChoiceListInterface
         $index = $this->createIndex($choice);
 
         if ('' === $index || null === $index || !FormConfigBuilder::isValidName((string) $index)) {
-            throw new InvalidConfigurationException('The index "'.$index.'" created by the choice list is invalid. It should be a valid, non-empty Form name.');
+            throw new InvalidConfigurationException(sprintf('The index "%s" created by the choice list is invalid. It should be a valid, non-empty Form name.', $index));
         }
 
         $value = $this->createValue($choice);
 
         if (!is_string($value)) {
-            throw new InvalidConfigurationException('The value created by the choice list is of type "'.gettype($value).'", but should be a string.');
+            throw new InvalidConfigurationException(sprintf('The value created by the choice list is of type "%s", but should be a string.', gettype($value)));
         }
 
         $view = new ChoiceView($choice, $value, $label);

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/LazyChoiceList.php
@@ -141,7 +141,7 @@ abstract class LazyChoiceList implements ChoiceListInterface
         $choiceList = $this->loadChoiceList();
 
         if (!$choiceList instanceof ChoiceListInterface) {
-            throw new Exception('loadChoiceList() should return a ChoiceListInterface instance. Got '.gettype($choiceList));
+            throw new Exception(sprintf('loadChoiceList() should return a ChoiceListInterface instance. Got %s', gettype($choiceList)));
         }
 
         $this->choiceList = $choiceList;

--- a/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
+++ b/src/Symfony/Component/Form/Extension/Core/ChoiceList/ObjectChoiceList.php
@@ -176,7 +176,7 @@ class ObjectChoiceList extends ChoiceList
             } elseif (method_exists($choice, '__toString')) {
                 $labels[$i] = (string) $choice;
             } else {
-                throw new StringCastException('A "__toString()" method was not found on the objects of type "'.get_class($choice).'" passed to the choice field. To read a custom getter instead, set the argument $labelPath to the desired property path.');
+                throw new StringCastException(sprintf('A "__toString()" method was not found on the objects of type "%s" passed to the choice field. To read a custom getter instead, set the argument $labelPath to the desired property path.', get_class($choice)));
             }
         }
     }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToBooleanArrayTransformer.php
@@ -98,7 +98,7 @@ class ChoiceToBooleanArrayTransformer implements DataTransformerInterface
                 if (isset($choices[$i])) {
                     return $choices[$i] === '' ? null : $choices[$i];
                 } else {
-                    throw new TransformationFailedException('The choice "'.$i.'" does not exist');
+                    throw new TransformationFailedException(sprintf('The choice "%s" does not exist', $i));
                 }
             }
         }

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoiceToValueTransformer.php
@@ -53,7 +53,7 @@ class ChoiceToValueTransformer implements DataTransformerInterface
         $choices = $this->choiceList->getChoicesForValues(array($value));
 
         if (1 !== count($choices)) {
-            throw new TransformationFailedException('The choice "'.$value.'" does not exist or is not unique');
+            throw new TransformationFailedException(sprintf('The choice "%s" does not exist or is not unique', $value));
         }
 
         $choice = current($choices);

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ChoicesToBooleanArrayTransformer.php
@@ -109,7 +109,7 @@ class ChoicesToBooleanArrayTransformer implements DataTransformerInterface
         }
 
         if (count($unknown) > 0) {
-            throw new TransformationFailedException('The choices "'.implode('", "', $unknown).'" were not found');
+            throw new TransformationFailedException(sprintf('The choices "%s" were not found', implode('", "', $unknown)));
         }
 
         return $result;

--- a/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
+++ b/src/Symfony/Component/Form/Extension/Validator/ViolationMapper/ViolationPath.php
@@ -155,7 +155,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
     public function getElement($index)
     {
         if (!isset($this->elements[$index])) {
-            throw new \OutOfBoundsException('The index '.$index.' is not within the violation path');
+            throw new \OutOfBoundsException(sprintf('The index %s is not within the violation path', $index));
         }
 
         return $this->elements[$index];
@@ -167,7 +167,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
     public function isProperty($index)
     {
         if (!isset($this->isIndex[$index])) {
-            throw new \OutOfBoundsException('The index '.$index.' is not within the violation path');
+            throw new \OutOfBoundsException(sprintf('The index %s is not within the violation path', $index));
         }
 
         return !$this->isIndex[$index];
@@ -179,7 +179,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
     public function isIndex($index)
     {
         if (!isset($this->isIndex[$index])) {
-            throw new \OutOfBoundsException('The index '.$index.' is not within the violation path');
+            throw new \OutOfBoundsException(sprintf('The index %s is not within the violation path', $index));
         }
 
         return $this->isIndex[$index];
@@ -206,7 +206,7 @@ class ViolationPath implements \IteratorAggregate, PropertyPathInterface
     public function mapsForm($index)
     {
         if (!isset($this->mapsForm[$index])) {
-            throw new \OutOfBoundsException('The index '.$index.' is not within the violation path');
+            throw new \OutOfBoundsException(sprintf('The index %s is not within the violation path', $index));
         }
 
         return $this->mapsForm[$index];

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -355,7 +355,7 @@ class Response
     public function setContent($content)
     {
         if (null !== $content && !is_string($content) && !is_numeric($content) && !is_callable(array($content, '__toString'))) {
-            throw new \UnexpectedValueException('The Response content must be a string or object implementing __toString(), "'.gettype($content).'" given.');
+            throw new \UnexpectedValueException(sprintf('The Response content must be a string or object implementing __toString(), "%s" given.', gettype($content)));
         }
 
         $this->content = (string) $content;

--- a/src/Symfony/Component/OptionsResolver/Options.php
+++ b/src/Symfony/Component/OptionsResolver/Options.php
@@ -225,7 +225,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
         $this->reading = true;
 
         if (!array_key_exists($option, $this->options)) {
-            throw new \OutOfBoundsException('The option "'.$option.'" does not exist.');
+            throw new \OutOfBoundsException(sprintf('The option "%s" does not exist.', $option));
         }
 
         if (isset($this->lazy[$option])) {
@@ -459,7 +459,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
                 }
             }
 
-            throw new OptionDefinitionException('The options "'.implode('", "', $conflicts).'" have a cyclic dependency.');
+            throw new OptionDefinitionException(sprintf('The options "%s" have a cyclic dependency.', implode('", "', $conflicts)));
         }
 
         $this->lock[$option] = true;
@@ -497,7 +497,7 @@ class Options implements \ArrayAccess, \Iterator, \Countable
                 }
             }
 
-            throw new OptionDefinitionException('The options "'.implode('", "', $conflicts).'" have a cyclic dependency.');
+            throw new OptionDefinitionException(sprintf('The options "%s" have a cyclic dependency.', implode('", "', $conflicts)));
         }
 
         /** @var \Closure $normalizer */

--- a/src/Symfony/Component/PropertyAccess/PropertyPath.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPath.php
@@ -193,7 +193,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     public function getElement($index)
     {
         if (!isset($this->elements[$index])) {
-            throw new OutOfBoundsException('The index '.$index.' is not within the property path');
+            throw new OutOfBoundsException(sprintf('The index %s is not within the property path', $index));
         }
 
         return $this->elements[$index];
@@ -205,7 +205,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     public function isProperty($index)
     {
         if (!isset($this->isIndex[$index])) {
-            throw new OutOfBoundsException('The index '.$index.' is not within the property path');
+            throw new OutOfBoundsException(sprintf('The index %s is not within the property path', $index));
         }
 
         return !$this->isIndex[$index];
@@ -217,7 +217,7 @@ class PropertyPath implements \IteratorAggregate, PropertyPathInterface
     public function isIndex($index)
     {
         if (!isset($this->isIndex[$index])) {
-            throw new OutOfBoundsException('The index '.$index.' is not within the property path');
+            throw new OutOfBoundsException(sprintf('The index %s is not within the property path', $index));
         }
 
         return $this->isIndex[$index];

--- a/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
+++ b/src/Symfony/Component/PropertyAccess/PropertyPathBuilder.php
@@ -97,7 +97,7 @@ class PropertyPathBuilder
     public function remove($offset, $length = 1)
     {
         if (!isset($this->elements[$offset])) {
-            throw new OutOfBoundsException('The offset '.$offset.' is not within the property path');
+            throw new OutOfBoundsException(sprintf('The offset %s is not within the property path', $offset));
         }
 
         $this->resize($offset, $length, 0);
@@ -119,7 +119,7 @@ class PropertyPathBuilder
     public function replace($offset, $length, PropertyPathInterface $path, $pathOffset = 0, $pathLength = 0)
     {
         if (!isset($this->elements[$offset])) {
-            throw new OutOfBoundsException('The offset '.$offset.' is not within the property path');
+            throw new OutOfBoundsException(sprintf('The offset %s is not within the property path', $offset));
         }
 
         if (0 === $pathLength) {
@@ -145,7 +145,7 @@ class PropertyPathBuilder
     public function replaceByIndex($offset, $name = null)
     {
         if (!isset($this->elements[$offset])) {
-            throw new OutOfBoundsException('The offset '.$offset.' is not within the property path');
+            throw new OutOfBoundsException(sprintf('The offset %s is not within the property path', $offset));
         }
 
         if (null !== $name) {
@@ -166,7 +166,7 @@ class PropertyPathBuilder
     public function replaceByProperty($offset, $name = null)
     {
         if (!isset($this->elements[$offset])) {
-            throw new OutOfBoundsException('The offset '.$offset.' is not within the property path');
+            throw new OutOfBoundsException(sprintf('The offset %s is not within the property path', $offset));
         }
 
         if (null !== $name) {

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -341,7 +341,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
             return $this->appendNode($parentNode, $data, 'data');
         }
 
-        throw new UnexpectedValueException('An unexpected value could not be serialized: '.var_export($data, true));
+        throw new UnexpectedValueException(sprintf('An unexpected value could not be serialized: %s', var_export($data, true)));
     }
 
     /**

--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -75,7 +75,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     final public function serialize($data, $format, array $context = array())
     {
         if (!$this->supportsEncoding($format)) {
-            throw new UnexpectedValueException('Serialization for the format '.$format.' is not supported');
+            throw new UnexpectedValueException(sprintf('Serialization for the format %s is not supported', $format));
         }
 
         if ($this->encoder->needsNormalization($format)) {
@@ -91,7 +91,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
     final public function deserialize($data, $type, $format, array $context = array())
     {
         if (!$this->supportsDecoding($format)) {
-            throw new UnexpectedValueException('Deserialization for the format '.$format.' is not supported');
+            throw new UnexpectedValueException(sprintf('Deserialization for the format %s is not supported', $format));
         }
 
         $data = $this->decode($data, $format, $context);
@@ -128,7 +128,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
 
             return $data;
         }
-        throw new UnexpectedValueException('An unexpected value could not be normalized: '.var_export($data, true));
+        throw new UnexpectedValueException(sprintf('An unexpected value could not be normalized: %s', var_export($data, true)));
     }
 
     /**
@@ -246,7 +246,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
             }
         }
 
-        throw new UnexpectedValueException('Could not normalize object of type '.$class.', no supporting normalizer found.');
+        throw new UnexpectedValueException(sprintf('Could not normalize object of type %s, no supporting normalizer found.', $class));
     }
 
     /**
@@ -280,7 +280,7 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
             }
         }
 
-        throw new UnexpectedValueException('Could not denormalize object of type '.$class.', no supporting normalizer found.');
+        throw new UnexpectedValueException(sprintf('Could not denormalize object of type %s, no supporting normalizer found.', $class));
     }
 
     /**

--- a/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
+++ b/src/Symfony/Component/Translation/Catalogue/AbstractOperation.php
@@ -83,7 +83,7 @@ abstract class AbstractOperation implements OperationInterface
     public function getMessages($domain)
     {
         if (!in_array($domain, $this->getDomains())) {
-            throw new \InvalidArgumentException('Invalid domain: '.$domain.'.');
+            throw new \InvalidArgumentException(sprintf('Invalid domain: %s.', $domain));
         }
 
         if (!isset($this->messages[$domain]['all'])) {
@@ -99,7 +99,7 @@ abstract class AbstractOperation implements OperationInterface
     public function getNewMessages($domain)
     {
         if (!in_array($domain, $this->getDomains())) {
-            throw new \InvalidArgumentException('Invalid domain: '.$domain.'.');
+            throw new \InvalidArgumentException(sprintf('Invalid domain: %s.', $domain));
         }
 
         if (!isset($this->messages[$domain]['new'])) {
@@ -115,7 +115,7 @@ abstract class AbstractOperation implements OperationInterface
     public function getObsoleteMessages($domain)
     {
         if (!in_array($domain, $this->getDomains())) {
-            throw new \InvalidArgumentException('Invalid domain: '.$domain.'.');
+            throw new \InvalidArgumentException(sprintf('Invalid domain: %s.', $domain));
         }
 
         if (!isset($this->messages[$domain]['obsolete'])) {

--- a/src/Symfony/Component/Validator/Constraints/All.php
+++ b/src/Symfony/Component/Validator/Constraints/All.php
@@ -36,11 +36,11 @@ class All extends Constraint
 
         foreach ($this->constraints as $constraint) {
             if (!$constraint instanceof Constraint) {
-                throw new ConstraintDefinitionException('The value '.$constraint.' is not an instance of Constraint in constraint '.__CLASS__);
+                throw new ConstraintDefinitionException(sprintf('The value %s is not an instance of Constraint in constraint %s', $constraint, __CLASS__));
             }
 
             if ($constraint instanceof Valid) {
-                throw new ConstraintDefinitionException('The constraint Valid cannot be nested inside constraint '.__CLASS__.'. You can only declare the Valid constraint directly on a field or method.');
+                throw new ConstraintDefinitionException(sprintf('The constraint Valid cannot be nested inside constraint %s. You can only declare the Valid constraint directly on a field or method.', __CLASS__));
             }
         }
     }

--- a/src/Symfony/Component/Validator/Constraints/Collection.php
+++ b/src/Symfony/Component/Validator/Constraints/Collection.php
@@ -43,7 +43,7 @@ class Collection extends Constraint
         parent::__construct($options);
 
         if (!is_array($this->fields)) {
-            throw new ConstraintDefinitionException('The option "fields" is expected to be an array in constraint '.__CLASS__);
+            throw new ConstraintDefinitionException(sprintf('The option "fields" is expected to be an array in constraint %s', __CLASS__));
         }
 
         foreach ($this->fields as $fieldName => $field) {
@@ -57,11 +57,11 @@ class Collection extends Constraint
 
             foreach ($field->constraints as $constraint) {
                 if (!$constraint instanceof Constraint) {
-                    throw new ConstraintDefinitionException('The value '.$constraint.' of the field '.$fieldName.' is not an instance of Constraint in constraint '.__CLASS__);
+                    throw new ConstraintDefinitionException(sprintf('The value %s of the field %s is not an instance of Constraint in constraint %s', $constraint, $fieldName, __CLASS__));
                 }
 
                 if ($constraint instanceof Valid) {
-                    throw new ConstraintDefinitionException('The constraint Valid cannot be nested inside constraint '.__CLASS__.'. You can only declare the Valid constraint directly on a field or method.');
+                    throw new ConstraintDefinitionException(sprintf('The constraint Valid cannot be nested inside constraint %s. You can only declare the Valid constraint directly on a field or method.', __CLASS__));
                 }
             }
         }

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -39,7 +39,10 @@ class Count extends Constraint
         parent::__construct($options);
 
         if (null === $this->min && null === $this->max) {
-            throw new MissingOptionsException('Either option "min" or "max" must be given for constraint '.__CLASS__, array('min', 'max'));
+            throw new MissingOptionsException(sprintf(
+                'Either option "min" or "max" must be given for constraint %s',
+                __CLASS__
+            ), array('min', 'max'));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Count.php
+++ b/src/Symfony/Component/Validator/Constraints/Count.php
@@ -39,10 +39,7 @@ class Count extends Constraint
         parent::__construct($options);
 
         if (null === $this->min && null === $this->max) {
-            throw new MissingOptionsException(sprintf(
-                'Either option "min" or "max" must be given for constraint %s',
-                __CLASS__
-            ), array('min', 'max'));
+            throw new MissingOptionsException(sprintf('Either option "min" or "max" must be given for constraint %s', __CLASS__), array('min', 'max'));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -40,7 +40,10 @@ class Length extends Constraint
         parent::__construct($options);
 
         if (null === $this->min && null === $this->max) {
-            throw new MissingOptionsException('Either option "min" or "max" must be given for constraint '.__CLASS__, array('min', 'max'));
+            throw new MissingOptionsException(sprintf(
+                'Either option "min" or "max" must be given for constraint %s',
+                __CLASS__
+            ), array('min', 'max'));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Length.php
+++ b/src/Symfony/Component/Validator/Constraints/Length.php
@@ -40,10 +40,7 @@ class Length extends Constraint
         parent::__construct($options);
 
         if (null === $this->min && null === $this->max) {
-            throw new MissingOptionsException(sprintf(
-                'Either option "min" or "max" must be given for constraint %s',
-                __CLASS__
-            ), array('min', 'max'));
+            throw new MissingOptionsException(sprintf('Either option "min" or "max" must be given for constraint %s', __CLASS__), array('min', 'max'));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -32,7 +32,10 @@ class Range extends Constraint
         parent::__construct($options);
 
         if (null === $this->min && null === $this->max) {
-            throw new MissingOptionsException('Either option "min" or "max" must be given for constraint '.__CLASS__, array('min', 'max'));
+            throw new MissingOptionsException(sprintf(
+                'Either option "min" or "max" must be given for constraint %s',
+                __CLASS__
+            ), array('min', 'max'));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Range.php
+++ b/src/Symfony/Component/Validator/Constraints/Range.php
@@ -32,10 +32,7 @@ class Range extends Constraint
         parent::__construct($options);
 
         if (null === $this->min && null === $this->max) {
-            throw new MissingOptionsException(sprintf(
-                'Either option "min" or "max" must be given for constraint %s',
-                __CLASS__
-            ), array('min', 'max'));
+            throw new MissingOptionsException(sprintf('Either option "min" or "max" must be given for constraint %s', __CLASS__), array('min', 'max'));
         }
     }
 }

--- a/src/Symfony/Component/Validator/Constraints/Valid.php
+++ b/src/Symfony/Component/Validator/Constraints/Valid.php
@@ -28,7 +28,7 @@ class Valid extends Constraint
     public function __construct($options = null)
     {
         if (is_array($options) && array_key_exists('groups', $options)) {
-            throw new ConstraintDefinitionException('The option "groups" is not supported by the constraint '.__CLASS__);
+            throw new ConstraintDefinitionException(sprintf('The option "groups" is not supported by the constraint %s', __CLASS__));
         }
 
         parent::__construct($options);

--- a/src/Symfony/Component/Validator/Mapping/ClassMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Mapping/ClassMetadataFactory.php
@@ -49,7 +49,7 @@ class ClassMetadataFactory implements MetadataFactoryInterface
     public function getMetadataFor($value)
     {
         if (!is_object($value) && !is_string($value)) {
-            throw new NoSuchMetadataException('Cannot create metadata for non-objects. Got: '.gettype($value));
+            throw new NoSuchMetadataException(sprintf('Cannot create metadata for non-objects. Got: %s', gettype($value)));
         }
 
         $class = ltrim(is_object($value) ? get_class($value) : $value, '\\');
@@ -63,7 +63,7 @@ class ClassMetadataFactory implements MetadataFactoryInterface
         }
 
         if (!class_exists($class) && !interface_exists($class)) {
-            throw new NoSuchMetadataException('The class or interface "'.$class.'" does not exist.');
+            throw new NoSuchMetadataException(sprintf('The class or interface "%s" does not exist.', $class));
         }
 
         $metadata = new ClassMetadata($class);

--- a/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
+++ b/src/Symfony/Component/Validator/Tests/Fixtures/FakeMetadataFactory.php
@@ -26,11 +26,11 @@ class FakeMetadataFactory implements MetadataFactoryInterface
         }
 
         if (!is_string($class)) {
-            throw new NoSuchMetadataException('No metadata for type '.gettype($class));
+            throw new NoSuchMetadataException(sprintf('No metadata for type %s', gettype($class)));
         }
 
         if (!isset($this->metadatas[$class])) {
-            throw new NoSuchMetadataException('No metadata for "'.$class.'"');
+            throw new NoSuchMetadataException(sprintf('No metadata for "%s"', $class));
         }
 
         return $this->metadatas[$class];


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | [yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/2483 |

Changed format of exceptions which concatenate strings as follows

```
throw new \Exception('The '.$something.' needs the '.$foobar.' parameter');
```

to

```
throw new \Exception(sprintf('The %s needs the %s parameter', $something, $foobar));
```

This follows discussion on mailing list: https://groups.google.com/forum/?fromgroups#!topic/symfony-devs/tecj3UOAueM

Unit test results are pending...
