### PR TITLE
[RFC][2.3][EventDispatcher] toward cleaner events

### DIFF
--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -25,6 +25,8 @@ namespace Symfony\Component\EventDispatcher;
  * @author  Roman Borschel <roman@code-factory.org>
  * @author  Bernhard Schussek <bschussek@gmail.com>
  *
+ * @deprecated Events objects are no longer requited to extend a base class
+ *
  * @api
  */
 class Event
@@ -68,6 +70,12 @@ class Event
      */
     public function stopPropagation()
     {
+        trigger_error(
+            'Calling stopPropagation() on the event object is deprecated. '.
+            'Throw a StopPropagationException instead.',
+            E_USER_DEPRECATED
+        );
+
         $this->propagationStopped = true;
     }
 
@@ -88,8 +96,6 @@ class Event
      *
      * @return EventDispatcherInterface
      *
-     * @deprecated The dispatcher is now the second argument passed to each listener
-     *
      * @api
      */
     public function getDispatcher()
@@ -107,8 +113,6 @@ class Event
      * Gets the event's name.
      *
      * @return string
-     *
-     * @deprecated The name is now the third argument passed to each listener
      *
      * @api
      */

--- a/src/Symfony/Component/EventDispatcher/Event.php
+++ b/src/Symfony/Component/EventDispatcher/Event.php
@@ -88,10 +88,18 @@ class Event
      *
      * @return EventDispatcherInterface
      *
+     * @deprecated The dispatcher is now the second argument passed to each listener
+     *
      * @api
      */
     public function getDispatcher()
     {
+        trigger_error(
+            'Calling getDispatcher() on the event object is deprecated. '.
+            'The dispatcher is now the second argument passed to your listener.',
+            E_USER_DEPRECATED
+        );
+
         return $this->dispatcher;
     }
 
@@ -100,10 +108,18 @@ class Event
      *
      * @return string
      *
+     * @deprecated The name is now the third argument passed to each listener
+     *
      * @api
      */
     public function getName()
     {
+        trigger_error(
+            'Calling getName() on the event object is deprecated. '.
+            'The event name is now the third argument passed to your listener.',
+            E_USER_DEPRECATED
+        );
+
         return $this->name;
     }
 

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -37,20 +37,21 @@ class EventDispatcher implements EventDispatcherInterface
      *
      * @api
      */
-    public function dispatch($eventName, Event $event = null)
+    public function dispatch($eventName, Event $event = null, EventDispatcherInterface $dispatcher = null)
     {
         if (null === $event) {
             $event = new Event();
         }
 
-        $event->setDispatcher($this);
+        // deprecated
+        $event->setDispatcher($dispatcher ?: $this);
         $event->setName($eventName);
 
         if (!isset($this->listeners[$eventName])) {
             return $event;
         }
 
-        $this->doDispatch($this->getListeners($eventName), $eventName, $event);
+        $this->doDispatch($this->getListeners($eventName), $eventName, $event, $dispatcher);
 
         return $event;
     }
@@ -158,10 +159,10 @@ class EventDispatcher implements EventDispatcherInterface
      * @param string          $eventName The name of the event to dispatch.
      * @param Event           $event     The event object to pass to the event handlers/listeners.
      */
-    protected function doDispatch($listeners, $eventName, Event $event)
+    protected function doDispatch($listeners, $eventName, Event $event, EventDispatcherInterface $dispatcher = null)
     {
         foreach ($listeners as $listener) {
-            call_user_func($listener, $event);
+            call_user_func($listener, $event, $dispatcher ?: $this, $eventName);
             if ($event->isPropagationStopped()) {
                 break;
             }

--- a/src/Symfony/Component/EventDispatcher/Exception/StopPropagationException.php
+++ b/src/Symfony/Component/EventDispatcher/Exception/StopPropagationException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\EventDispatcher\Exception;
+
+class StopPropagationException extends \Exception
+{
+}


### PR DESCRIPTION
I've quickly implemented my proposed fixes for both #6686 and #7582. We can't remove `getName()` and `getDispatcher()` from `Event` because those methods are marked `@api`, but we can deprecate them and remove them in 3.0.
