### PR TITLE
[2.3][HttpFoundation] PDO Session handling enhancements

### DIFF
--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -2,8 +2,12 @@ CHANGELOG
 =========
 
 2.3.0
+-----
 
  * `UploadedFile::isValid` now returns false if the file was not uploaded via HTTP (in a non-test mode)
+ * Improved error-handling of `\Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler`
+   to ensure the supplied PDO handler throws Exceptions on error (as the class expects). Added related test cases
+   to verify that Exceptions are properly thrown when the PDO queries fail.
 
 2.2.0
 -----

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -49,7 +49,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
             throw new \InvalidArgumentException('You must provide the "db_table" option for a PdoSessionStorage.');
         }
         if ($pdo->getAttribute(\PDO::ATTR_ERRMODE) != \PDO::ERRMODE_EXCEPTION) {
-            throw new \InvalidArgumentException("Session Handler PDO must be set to throw Exceptions on error.");
+            throw new \InvalidArgumentException(sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION))', __CLASS__));
         }
         $this->pdo = $pdo;
         $this->dbOptions = array_merge(array(

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -48,8 +48,9 @@ class PdoSessionHandler implements \SessionHandlerInterface
         if (!array_key_exists('db_table', $dbOptions)) {
             throw new \InvalidArgumentException('You must provide the "db_table" option for a PdoSessionStorage.');
         }
-
-        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        if ($pdo->getAttribute(\PDO::ATTR_ERRMODE) != \PDO::ERRMODE_EXCEPTION) {
+            throw new \InvalidArgumentException("Session Handler PDO must be set to throw Exceptions on error.");
+        }
         $this->pdo = $pdo;
         $this->dbOptions = array_merge(array(
             'db_id_col'   => 'sess_id',

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -48,7 +48,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
         if (!array_key_exists('db_table', $dbOptions)) {
             throw new \InvalidArgumentException('You must provide the "db_table" option for a PdoSessionStorage.');
         }
-        if ($pdo->getAttribute(\PDO::ATTR_ERRMODE) != \PDO::ERRMODE_EXCEPTION) {
+        if (\PDO::ERRMODE_EXCEPTION !== $pdo->getAttribute(\PDO::ATTR_ERRMODE)) {
             throw new \InvalidArgumentException(sprintf('"%s" requires PDO error mode attribute be set to throw Exceptions (i.e. $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION))', __CLASS__));
         }
         $this->pdo = $pdo;

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/Handler/PdoSessionHandler.php
@@ -49,6 +49,7 @@ class PdoSessionHandler implements \SessionHandlerInterface
             throw new \InvalidArgumentException('You must provide the "db_table" option for a PdoSessionStorage.');
         }
 
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $this->pdo = $pdo;
         $this->dbOptions = array_merge(array(
             'db_id_col'   => 'sess_id',

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -98,11 +98,7 @@ class NativeSessionStorage implements SessionStorageInterface
     public function __construct(array $options = array(), $handler = null, MetadataBag $metaBag = null)
     {
         session_cache_limiter(''); // disable by default because it's managed by HeaderBag (if used)
-        if (1 !== ini_get('session.use_cookies')) {
-             if (false === ini_set('session.use_cookies', 1)) {
-                 throw new \RuntimeException('Failed to initialize the session to use cookies');
-             }
-        }
+        ini_set('session.use_cookies', 1);
 
         if (version_compare(phpversion(), '5.4.0', '>=')) {
             session_register_shutdown();

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -97,8 +97,8 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function __construct(array $options = array(), $handler = null, MetadataBag $metaBag = null)
     {
-        ini_set('session.cache_limiter', ''); // disable by default because it's managed by HeaderBag (if used)
-        ini_set('session.use_cookies', 1);
+        session_cache_limiter('');
+        if (ini_get('session.use_cookies') != 1) ini_set('session.use_cookies', 1);
 
         if (version_compare(phpversion(), '5.4.0', '>=')) {
             session_register_shutdown();

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -98,7 +98,9 @@ class NativeSessionStorage implements SessionStorageInterface
     public function __construct(array $options = array(), $handler = null, MetadataBag $metaBag = null)
     {
         session_cache_limiter('');
-        if (ini_get('session.use_cookies') != 1) ini_set('session.use_cookies', 1);
+        if (ini_get('session.use_cookies') != 1) {
+             ini_set('session.use_cookies', 1);
+        }
 
         if (version_compare(phpversion(), '5.4.0', '>=')) {
             session_register_shutdown();

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -98,8 +98,8 @@ class NativeSessionStorage implements SessionStorageInterface
     public function __construct(array $options = array(), $handler = null, MetadataBag $metaBag = null)
     {
         session_cache_limiter(''); // disable by default because it's managed by HeaderBag (if used)
-        if (ini_get('session.use_cookies') != 1) {
-             if (ini_set('session.use_cookies', 1) === false) {
+        if (1 !== ini_get('session.use_cookies')) {
+             if (false === ini_set('session.use_cookies', 1)) {
                  throw new \RuntimeException('Failed to initialize the session to use cookies');
              }
         }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -97,9 +97,11 @@ class NativeSessionStorage implements SessionStorageInterface
      */
     public function __construct(array $options = array(), $handler = null, MetadataBag $metaBag = null)
     {
-        session_cache_limiter('');
+        session_cache_limiter(''); // disable by default because it's managed by HeaderBag (if used)
         if (ini_get('session.use_cookies') != 1) {
-             ini_set('session.use_cookies', 1);
+             if (ini_set('session.use_cookies', 1) === false) {
+                 throw new \RuntimeException('Failed to initialize the session to use cookies');
+             }
         }
 
         if (version_compare(phpversion(), '5.4.0', '>=')) {

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -29,6 +29,43 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         $this->pdo->exec($sql);
     }
 
+    public function testIncompleteOptions()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        $storage = new PdoSessionHandler($this->pdo, array(), array());
+    }
+
+    public function testWrongPdoErrMode()
+    {
+        $pdo = new \PDO("sqlite::memory:");
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_SILENT);
+        $pdo->exec("CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data TEXT, sess_time INTEGER)");
+
+        $this->setExpectedException('InvalidArgumentException');
+        $storage = new PdoSessionHandler($pdo, array('db_table' => 'sessions'), array());
+    }
+
+    public function testWrongTableOptionsWrite()
+    {
+        $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'bad_name'), array());
+        $this->setExpectedException('RuntimeException');
+        $storage->write('foo', 'bar');
+    }
+
+    public function testWrongTableOptionsRead()
+    {
+        $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'bad_name'), array());
+        $this->setExpectedException('RuntimeException');
+        $storage->read('foo', 'bar');
+    }
+
+    public function testWriteRead()
+    {
+        $storage = new PdoSessionHandler($this->pdo, array('db_table' => 'sessions'), array());
+        $storage->write('foo', 'bar');
+        $this->assertEquals('bar', $storage->read('foo'), 'written value can be read back correctly');
+    }
+
     public function testMultipleInstances()
     {
         $storage1 = new PdoSessionHandler($this->pdo, array('db_table' => 'sessions'), array());

--- a/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/Session/Storage/Handler/PdoSessionHandlerTest.php
@@ -24,6 +24,7 @@ class PdoSessionHandlerTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->pdo = new \PDO("sqlite::memory:");
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
         $sql = "CREATE TABLE sessions (sess_id VARCHAR(255) PRIMARY KEY, sess_data TEXT, sess_time INTEGER)";
         $this->pdo->exec($sql);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

`PdoSessionHandler` class assumes that the PDO object is set to throw exceptions, not errors. I added a line in the constructor to set that attribute, so configuration/query errors are able to be seen and caught a lot easier.
