### PR TITLE
[Routing][XML Loader] Add a possibility to set a default value to null

### DIFF
--- a/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/XmlFileLoader.php
@@ -141,7 +141,11 @@ class XmlFileLoader extends FileLoader
 
             switch ($node->tagName) {
                 case 'default':
-                    $defaults[(string) $node->getAttribute('key')] = trim((string) $node->nodeValue);
+                    if ($node->hasAttribute('xsi:nil') && 'true' == $node->getAttribute('xsi:nil')) {
+                        $defaults[(string) $node->getAttribute('key')] = null;
+                    } else {
+                        $defaults[(string) $node->getAttribute('key')] = trim((string) $node->nodeValue);
+                    }
                     break;
                 case 'option':
                     $options[(string) $node->getAttribute('key')] = trim((string) $node->nodeValue);

--- a/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
+++ b/src/Symfony/Component/Routing/Loader/schema/routing/routing-1.0.xsd
@@ -16,7 +16,7 @@
 
   <xsd:complexType name="route">
     <xsd:sequence>
-      <xsd:element name="default" type="element" minOccurs="0" maxOccurs="unbounded" />
+      <xsd:element name="default" nillable="true" type="element" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="requirement" type="element" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="option" type="element" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>

--- a/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/validpattern.xml
@@ -6,6 +6,7 @@
 
     <route id="blog_show" pattern="/blog/{slug}">
         <default key="_controller">MyBundle:Blog:show</default>
+        <default key="slug" xsi:nil="true" />
         <requirement key="_method">GET</requirement>
         <option key="compiler_class">RouteCompiler</option>
     </route>

--- a/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/Routing/Tests/Loader/XmlFileLoaderTest.php
@@ -47,7 +47,9 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(1, count($routes), 'One route is loaded');
         $this->assertContainsOnly('Symfony\Component\Routing\Route', $routes);
+        
         $route = $routes['blog_show'];
+        $this->assertSame(null, $route->getDefault('slug'));
         $this->assertEquals('RouteCompiler', $route->getOption('compiler_class'));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/7335 |
| License | MIT |

Example:

```
<route id="acme_user_show" pattern="/{id}">
    <default key="_controller">AcmeUserBundle:User:show</default>
    <default key="id" xsi:nil="true" />
</route>
```
