### PR TITLE
[HTTPFoundation] fixed stripped HTTP_AUTHORIZATION headers

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -236,7 +236,19 @@ class Request
      */
     public static function createFromGlobals()
     {
-        $request = new static($_GET, $_POST, array(), $_COOKIE, $_FILES, $_SERVER);
+        $server = $_SERVER;
+        if (function_exists('apache_request_headers') && apache_request_headers() !== false) {
+            $server = array_merge(
+                array_map(
+                    function($header) {
+                        return 'HTTP_' . strtoupper($header);
+                    },
+                    apache_request_headers()
+                ),
+                $server
+            );
+        }
+        $request = new static($_GET, $_POST, array(), $_COOKIE, $_FILES, $server);
 
         if (0 === strpos($request->headers->get('CONTENT_TYPE'), 'application/x-www-form-urlencoded')
             && in_array(strtoupper($request->server->get('REQUEST_METHOD', 'GET')), array('PUT', 'DELETE', 'PATCH'))


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7170 |
| License | MIT |
| Doc PR | - |

I am not 100% sure about this PR. I didn't find a way to add proper tests and I am relying on what my apache looks like and what the issue #7170 told. 
