### PR TITLE
[HTTPFoundation]  Fix download over SSL using IE < 8 and binary file response

### DIFF
--- a/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
+++ b/src/Symfony/Component/HttpFoundation/BinaryFileResponse.php
@@ -166,6 +166,8 @@ class BinaryFileResponse extends Response
             $this->setProtocolVersion('1.1');
         }
 
+        $this->ensureIEOverSSLCompatibility($request);
+
         $this->offset = 0;
         $this->maxlen = -1;
 

--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -253,15 +253,7 @@ class Response
             $this->headers->set('expires', -1);
         }
 
-        /**
-         * Check if we need to remove Cache-Control for ssl encrypted downloads when using IE < 9
-         * @link http://support.microsoft.com/kb/323308
-         */
-        if (false !== stripos($this->headers->get('Content-Disposition'), 'attachment') && preg_match('/MSIE (.*?);/i', $request->server->get('HTTP_USER_AGENT'), $match) == 1 && true === $request->isSecure()) {
-            if (intval(preg_replace("/(MSIE )(.*?);/", "$2", $match[0])) < 9) {
-                $this->headers->remove('Cache-Control');
-            }
-        }
+        $this->ensureIEOverSSLCompatibility($request);
 
         return $this;
     }
@@ -1178,5 +1170,19 @@ class Response
     public function isEmpty()
     {
         return in_array($this->statusCode, array(201, 204, 304));
+    }
+
+    /**
+     * Check if we need to remove Cache-Control for ssl encrypted downloads when using IE < 9
+     *
+     * @link http://support.microsoft.com/kb/323308
+     */
+    protected function ensureIEOverSSLCompatibility(Request $request)
+    {
+        if (false !== stripos($this->headers->get('Content-Disposition'), 'attachment') && preg_match('/MSIE (.*?);/i', $request->server->get('HTTP_USER_AGENT'), $match) == 1 && true === $request->isSecure()) {
+            if (intval(preg_replace("/(MSIE )(.*?);/", "$2", $match[0])) < 9) {
+                $this->headers->remove('Cache-Control');
+            }
+        }
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/BinaryFileResponseTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
-class BinaryFileResponseTest extends \PHPUnit_Framework_TestCase
+class BinaryFileResponseTest extends ResponseTestCase
 {
     public function testConstruction()
     {
@@ -144,5 +144,10 @@ class BinaryFileResponseTest extends \PHPUnit_Framework_TestCase
             array('/var/www/var/www/files/foo.txt', '/files/=/var/www/', '/files/var/www/files/foo.txt'),
             array('/home/foo/bar.txt', '/files/=/var/www/,/baz/=/home/foo/', '/baz/bar.txt'),
         );
+    }
+
+    protected function provideResponse()
+    {
+        return new BinaryFileResponse('README.md');
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\HttpFoundation\Tests;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class ResponseTest extends \PHPUnit_Framework_TestCase
+class ResponseTest extends ResponseTestCase
 {
     public function testCreate()
     {
@@ -324,75 +324,6 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
         $response->prepare(new Request());
 
         $this->assertEquals('text/css; charset=UTF-8', $response->headers->get('Content-Type'));
-    }
-
-    public function testNoCacheControlHeaderOnAttachmentUsingHTTPSAndMSIE()
-    {
-        // Check for HTTPS and IE 8
-        $request = new Request();
-        $request->server->set('HTTPS', true);
-        $request->server->set('HTTP_USER_AGENT', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)');
-
-        $response = new Response();
-        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
-        $response->prepare($request);
-
-        $this->assertFalse($response->headers->has('Cache-Control'));
-
-        // Check for IE 10 and HTTPS
-        $request->server->set('HTTP_USER_AGENT', 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)');
-
-        $response = new Response();
-        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
-        $response->prepare($request);
-
-        $this->assertTrue($response->headers->has('Cache-Control'));
-
-        // Check for IE 9 and HTTPS
-        $request->server->set('HTTP_USER_AGENT', 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)');
-
-        $response = new Response();
-        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
-        $response->prepare($request);
-
-        $this->assertTrue($response->headers->has('Cache-Control'));
-
-        // Check for IE 9 and HTTP
-        $request->server->set('HTTPS', false);
-
-        $response = new Response();
-        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
-        $response->prepare($request);
-
-        $this->assertTrue($response->headers->has('Cache-Control'));
-
-        // Check for IE 8 and HTTP
-        $request->server->set('HTTP_USER_AGENT', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)');
-
-        $response = new Response();
-        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
-        $response->prepare($request);
-
-        $this->assertTrue($response->headers->has('Cache-Control'));
-
-        // Check for non-IE and HTTPS
-        $request->server->set('HTTPS', true);
-        $request->server->set('HTTP_USER_AGENT', 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.60 Safari/537.17');
-
-        $response = new Response();
-        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
-        $response->prepare($request);
-
-        $this->assertTrue($response->headers->has('Cache-Control'));
-
-        // Check for non-IE and HTTP
-        $request->server->set('HTTPS', false);
-
-        $response = new Response();
-        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
-        $response->prepare($request);
-
-        $this->assertTrue($response->headers->has('Cache-Control'));
     }
 
     public function testPrepareDoesNothingIfContentTypeIsSet()
@@ -769,6 +700,11 @@ class ResponseTest extends \PHPUnit_Framework_TestCase
     protected function createDateTimeNow()
     {
         return new \DateTime();
+    }
+
+    protected function provideResponse()
+    {
+        return new Response();
     }
 }
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ResponseTestCase.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ResponseTestCase.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation\Tests;
+
+use Symfony\Component\HttpFoundation\Request;
+
+abstract class ResponseTestCase extends \PHPUnit_Framework_TestCase
+{
+    public function testNoCacheControlHeaderOnAttachmentUsingHTTPSAndMSIE()
+    {
+        // Check for HTTPS and IE 8
+        $request = new Request();
+        $request->server->set('HTTPS', true);
+        $request->server->set('HTTP_USER_AGENT', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)');
+
+        $response = $this->provideResponse();
+        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
+        $response->prepare($request);
+
+        $this->assertFalse($response->headers->has('Cache-Control'));
+
+        // Check for IE 10 and HTTPS
+        $request->server->set('HTTP_USER_AGENT', 'Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)');
+
+        $response = $this->provideResponse();
+        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
+        $response->prepare($request);
+
+        $this->assertTrue($response->headers->has('Cache-Control'));
+
+        // Check for IE 9 and HTTPS
+        $request->server->set('HTTP_USER_AGENT', 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)');
+
+        $response = $this->provideResponse();
+        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
+        $response->prepare($request);
+
+        $this->assertTrue($response->headers->has('Cache-Control'));
+
+        // Check for IE 9 and HTTP
+        $request->server->set('HTTPS', false);
+
+        $response = $this->provideResponse();
+        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
+        $response->prepare($request);
+
+        $this->assertTrue($response->headers->has('Cache-Control'));
+
+        // Check for IE 8 and HTTP
+        $request->server->set('HTTP_USER_AGENT', 'Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)');
+
+        $response = $this->provideResponse();
+        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
+        $response->prepare($request);
+
+        $this->assertTrue($response->headers->has('Cache-Control'));
+
+        // Check for non-IE and HTTPS
+        $request->server->set('HTTPS', true);
+        $request->server->set('HTTP_USER_AGENT', 'Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.60 Safari/537.17');
+
+        $response = $this->provideResponse();
+        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
+        $response->prepare($request);
+
+        $this->assertTrue($response->headers->has('Cache-Control'));
+
+        // Check for non-IE and HTTP
+        $request->server->set('HTTPS', false);
+
+        $response = $this->provideResponse();
+        $response->headers->set('Content-Disposition', 'attachment; filename="fname.ext"');
+        $response->prepare($request);
+
+        $this->assertTrue($response->headers->has('Cache-Control'));
+    }
+
+    abstract protected function provideResponse();
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

related to #7153
