### PR TITLE
[HttpKernel] Improve TraceableEventDispatcher to not call Stopwatch::stop() when not started

### DIFF
--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -385,9 +385,8 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
             case KernelEvents::VIEW:
             case KernelEvents::RESPONSE:
                 // stop only if a controller has been executed
-                try {
+                if ($this->stopwatch->isStarted('controller')) {
                     $this->stopwatch->stop('controller');
-                } catch (\LogicException $e) {
                 }
                 break;
             case KernelEvents::TERMINATE:

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -180,6 +183,43 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
             'kernel.terminate',
             'kernel.terminate.loading',
         ), array_keys($events));
+    }
+
+    public function testStopwatchCheckControllerOnRequestEvent()
+    {
+        $stopwatch = $this->getMockBuilder('Symfony\Component\Stopwatch\Stopwatch')
+            ->setMethods(['isStarted'])
+            ->getMock();
+        $stopwatch->expects($this->once())
+            ->method('isStarted')
+            ->will($this->returnValue(false));
+
+
+        $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch);
+
+        $kernel = $this->getHttpKernel($dispatcher, function () { return new Response(); });
+        $request = Request::create('/');
+        $kernel->handle($request);
+    }
+
+    public function testStopwatchStopControllerOnRequestEvent()
+    {
+        $stopwatch = $this->getMockBuilder('Symfony\Component\Stopwatch\Stopwatch')
+            ->setMethods(['isStarted', 'stop', 'stopSection'])
+            ->getMock();
+        $stopwatch->expects($this->once())
+            ->method('isStarted')
+            ->will($this->returnValue(true));
+        $stopwatch->expects($this->once())
+            ->method('stop');
+        $stopwatch->expects($this->once())
+            ->method('stopSection');
+
+        $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch);
+
+        $kernel = $this->getHttpKernel($dispatcher, function () { return new Response(); });
+        $request = Request::create('/');
+        $kernel->handle($request);
     }
 
     protected function getHttpKernel($dispatcher, $controller)

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -188,7 +188,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
     public function testStopwatchCheckControllerOnRequestEvent()
     {
         $stopwatch = $this->getMockBuilder('Symfony\Component\Stopwatch\Stopwatch')
-            ->setMethods(['isStarted'])
+            ->setMethods(array('isStarted'))
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')
@@ -205,7 +205,7 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
     public function testStopwatchStopControllerOnRequestEvent()
     {
         $stopwatch = $this->getMockBuilder('Symfony\Component\Stopwatch\Stopwatch')
-            ->setMethods(['isStarted', 'stop', 'stopSection'])
+            ->setMethods(array('isStarted', 'stop', 'stopSection'))
             ->getMock();
         $stopwatch->expects($this->once())
             ->method('isStarted')

--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -90,6 +90,18 @@ class Stopwatch
     }
 
     /**
+     * Checks if the event was started
+     *
+     * @param string $name The event name
+     *
+     * @return bool
+     */
+    public function isStarted($name)
+    {
+        return end($this->activeSections)->isEventStarted($name);
+    }
+
+    /**
      * Stops an event.
      *
      * @param string $name The event name
@@ -235,6 +247,18 @@ class Section
         }
 
         return $this->events[$name]->start();
+    }
+
+    /**
+     * Checks if the event was started
+     *
+     * @param string $name The event name
+     *
+     * @return bool
+     */
+    public function isEventStarted($name)
+    {
+        return isset($this->events[$name]);
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -29,6 +29,21 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('cat', $event->getCategory());
     }
 
+    public function testIsStarted()
+    {
+        $stopwatch = new Stopwatch();
+        $stopwatch->start('foo', 'cat');
+
+        $this->assertTrue($stopwatch->isStarted('foo'));
+    }
+
+    public function testIsNotStarted()
+    {
+        $stopwatch = new Stopwatch();
+
+        $this->assertFalse($stopwatch->isStarted('foo'));
+    }
+
     public function testStop()
     {
         $stopwatch = new Stopwatch();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7639 |
| License | MIT |
