### PR TITLE
[HttpFoundation] do not use server variable PATH_INFO 

### DIFF
--- a/src/Symfony/Component/HttpFoundation/ApacheRequest.php
+++ b/src/Symfony/Component/HttpFoundation/ApacheRequest.php
@@ -40,12 +40,4 @@ class ApacheRequest extends Request
 
         return $baseUrl;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function preparePathInfo()
-    {
-        return $this->server->get('PATH_INFO') ?: substr($this->prepareRequestUri(), strlen($this->prepareBaseUrl())) ?: '/';
-    }
 }


### PR DESCRIPTION
because it is already decoded (see http://www.ietf.org/rfc/rfc3875) and thus symfony is fragile to double encoding of the path. This is not really a security issue (in contrast to a [previous problem](http://symfony.com/blog/security-release-symfony-2-0-20-and-2-1-5-released)) but when using the apacherequest, one could access pages with double encoded characters although the path should not match.
So a double encoded `f` with path `/%2566oo` would still match route `/foo` although it should not. But as the security component would also matches this, there is no real threat.

BC break: no
tests pass: yes
