### PR TITLE
[Console] Input::__toString escaping fixes

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -321,9 +321,10 @@ class ArgvInput extends Input
     public function __toString()
     {
         $tokens = array_map(function ($token) {
-            $token = addcslashes($token, '"');
-            if (false !== strpos($token, ' ')) {
-                return '"'.$token.'"';
+            if (preg_match('{^(-[^=]+=)(.+)}', $token, $match)) {
+                return $match[1] . $this->escapeToken($match[2]);
+            } elseif ($token && $token[0] !== '-') {
+                return $this->escapeToken($token);
             }
 
             return $token;

--- a/src/Symfony/Component/Console/Input/ArrayInput.php
+++ b/src/Symfony/Component/Console/Input/ArrayInput.php
@@ -119,14 +119,10 @@ class ArrayInput extends Input
     {
         $params = array();
         foreach ($this->parameters as $param => $val) {
-            $val = addcslashes($val, '"');
-            if (false !== strpos($val, ' ')) {
-                $val = '"'.$val.'"';
-            }
             if ($param && '-' === $param[0]) {
-                $params[] = $param . ('' != $val ? ' '.$val : $val);
+                $params[] = $param . ('' != $val ? '='.$this->escapeToken($val) : '');
             } else {
-                $params[] = $val;
+                $params[] = $this->escapeToken($val);
             }
         }
 

--- a/src/Symfony/Component/Console/Input/Input.php
+++ b/src/Symfony/Component/Console/Input/Input.php
@@ -210,4 +210,14 @@ abstract class Input implements InputInterface
     {
         return $this->definition->hasOption($name);
     }
+
+    /**
+     * Escapes a token through escapeshellarg if it contains unsafe chars
+     *
+     * @return string
+     */
+    protected function escapeToken($token)
+    {
+        return preg_match('{^[\w-]+$}', $token) ? $token : escapeshellarg($token);
+    }
 }

--- a/src/Symfony/Component/Console/Input/StringInput.php
+++ b/src/Symfony/Component/Console/Input/StringInput.php
@@ -24,7 +24,7 @@ namespace Symfony\Component\Console\Input;
  */
 class StringInput extends ArgvInput
 {
-    const REGEX_STRING = '([^ ]+?)(?: |(?<!\\\\)"|(?<!\\\\)\'|$)';
+    const REGEX_STRING = '([^\s]+?)(?:\s|(?<!\\\\)"|(?<!\\\\)\'|$)';
     const REGEX_QUOTED_STRING = '(?:"([^"\\\\]*(?:\\\\.[^"\\\\]*)*)"|\'([^\'\\\\]*(?:\\\\.[^\'\\\\]*)*)\')';
 
     /**
@@ -59,14 +59,12 @@ class StringInput extends ArgvInput
      */
     private function tokenize($input)
     {
-        $input = preg_replace('/(\r\n|\r|\n|\t)/', ' ', $input);
-
         $tokens = array();
         $length = strlen($input);
         $cursor = 0;
         while ($cursor < $length) {
             if (preg_match('/\s+/A', $input, $match, null, $cursor)) {
-            } elseif (preg_match('/([^="\' ]+?)(=?)('.self::REGEX_QUOTED_STRING.'+)/A', $input, $match, null, $cursor)) {
+            } elseif (preg_match('/([^="\'\s]+?)(=?)('.self::REGEX_QUOTED_STRING.'+)/A', $input, $match, null, $cursor)) {
                 $tokens[] = $match[1].$match[2].stripcslashes(str_replace(array('"\'', '\'"', '\'\'', '""'), '', substr($match[3], 1, strlen($match[3]) - 2)));
             } elseif (preg_match('/'.self::REGEX_QUOTED_STRING.'/A', $input, $match, null, $cursor)) {
                 $tokens[] = stripcslashes(substr($match[0], 1, strlen($match[0]) - 2));

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -260,8 +260,8 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
         $input = new ArgvInput(array('cli.php', '-f', 'foo'));
         $this->assertEquals('-f foo', (string) $input);
 
-        $input = new ArgvInput(array('cli.php', '-f', '--bar=foo', 'a b c d'));
-        $this->assertEquals('-f --bar=foo "a b c d"', (string) $input);
+        $input = new ArgvInput(array('cli.php', '-f', '--bar=foo', 'a b c d', "A\nB'C"));
+        $this->assertEquals('-f --bar=foo '.escapeshellarg('a b c d').' '.escapeshellarg("A\nB'C"), (string) $input);
     }
 
     /**

--- a/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArrayInputTest.php
@@ -123,7 +123,7 @@ class ArrayInputTest extends \PHPUnit_Framework_TestCase
 
     public function testToString()
     {
-        $input = new ArrayInput(array('-f' => null, '-b' => 'bar', '--foo' => 'b a z', '--lala' => null, 'test' => 'Foo'));
-        $this->assertEquals('-f -b bar --foo "b a z" --lala Foo', (string) $input);
+        $input = new ArrayInput(array('-f' => null, '-b' => 'bar', '--foo' => 'b a z', '--lala' => null, 'test' => 'Foo', 'test2' => "A\nB'C"));
+        $this->assertEquals('-f -b=bar --foo='.escapeshellarg('b a z').' --lala Foo '.escapeshellarg("A\nB'C"), (string) $input);
     }
 }

--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -53,6 +53,8 @@ class StringInputTest extends \PHPUnit_Framework_TestCase
             array('  foo  bar  ', array('foo', 'bar'), '->tokenize() ignores whitespaces between arguments'),
             array('"quoted"', array('quoted'), '->tokenize() parses quoted arguments'),
             array("'quoted'", array('quoted'), '->tokenize() parses quoted arguments'),
+            array("'a\rb\nc\td'", array("a\rb\nc\td"), '->tokenize() parses whitespace chars in strings'),
+            array("'a'\r'b'\n'c'\t'd'", array('a','b','c','d'), '->tokenize() parses whitespace chars between args as spaces'),
             array('\"quoted\"', array('"quoted"'), '->tokenize() parses escaped-quoted arguments'),
             array("\'quoted\'", array('\'quoted\''), '->tokenize() parses escaped-quoted arguments'),
             array('-a', array('-a'), '->tokenize() parses short options'),

--- a/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/StringInputTest.php
@@ -80,9 +80,9 @@ class StringInputTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('-f foo', (string) $input);
 
         $input = new StringInput('-f --bar=foo "a b c d"');
-        $this->assertEquals('-f --bar=foo "a b c d"', (string) $input);
+        $this->assertEquals('-f --bar=foo '.escapeshellarg('a b c d'), (string) $input);
 
-        $input = new StringInput('-f --bar=foo \'a b c d\'');
-        $this->assertEquals('-f --bar=foo "a b c d"', (string) $input);
+        $input = new StringInput('-f --bar=foo \'a b c d\' '."'A\nB\\'C'");
+        $this->assertEquals('-f --bar=foo '.escapeshellarg('a b c d').' '.escapeshellarg("A\nB'C"), (string) $input);
     }
 }


### PR DESCRIPTION
Follow up to #7648, also includes a fix for StringInput to parse newlines and other whitespace chars properly instead of normalizing them all to spaces. It was kinda needed to test it properly, so I bundled both in one.
