### PR TITLE
[Form] Moved TypeTestCase to the Test namespace

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -135,6 +135,32 @@ UPGRADE FROM 2.x to 3.0
     * `Symfony\Component\HttpKernel\Exception\FatalErrorException` -> `Symfony\Component\Debug\Exception\FatalErrorException`
     * `Symfony\Component\HttpKernel\Exception\FlattenException` -> `Symfony\Component\Debug\Exception\FlattenException`
 
+### Form
+
+ * The `TypeTestCase` class was moved from the `Symfony\Component\Form\Tests\Extension\Core\Type` namespace to the `Symfony\Component\Form\Test` namespace.
+ 
+   Before:
+
+   ```
+   use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase
+
+   class MyTypeTest extends TypeTestCase
+   {
+       // ...
+   }
+   ```
+
+   After:
+
+   ```
+   use Symfony\Component\Form\Test\TypeTestCase;
+
+   class MyTypeTest extends TypeTestCase
+   {
+       // ...
+   }
+   ```
+
 ### Routing
 
  * Some route settings have been renamed:

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -161,6 +161,8 @@ UPGRADE FROM 2.x to 3.0
    }
    ```
 
+ * The `FormItegrationTestCase` and `FormPerformanceTestCase` classes were moved form the `Symfony\Component\Form\Tests` namespace to the `Symfony\Component\Form\Test` namespace.
+
 ### Routing
 
  * Some route settings have been renamed:

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypePerformanceTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bridge\Doctrine\Tests\Form\Type;
 
-use Symfony\Component\Form\Tests\FormPerformanceTestCase;
+use Symfony\Component\Form\Test\FormPerformanceTestCase;
 use Symfony\Bridge\Doctrine\Tests\Fixtures\SingleIdentEntity;
 use Doctrine\ORM\Tools\SchemaTool;
 use Symfony\Bridge\Doctrine\Tests\DoctrineOrmTestCase;

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 2.3.0
 ------
 
+ * deprecated TypeTestCase in the Symfony\Component\Form\Tests\Extension\Core\Type namespace and moved it to the Symfony\Component\Form\Test namespace.
  * changed FormRenderer::humanize() to humanize also camel cased field name
  * added FormProcessorInterface and FormInterface::process()
  * deprecated passing a Request instance to FormInterface::bind()

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -5,7 +5,8 @@ CHANGELOG
 2.3.0
 ------
 
- * deprecated TypeTestCase in the Symfony\Component\Form\Tests\Extension\Core\Type namespace and moved it to the Symfony\Component\Form\Test namespace.
+ * deprecated FormPerformanceTestCase and FormIntegrationTestCase in the Symfony\Component\Form\Tests namespace and moved them to the Symfony\Component\Form\Test namespace
+ * deprecated TypeTestCase in the Symfony\Component\Form\Tests\Extension\Core\Type namespace and moved it to the Symfony\Component\Form\Test namespace
  * changed FormRenderer::humanize() to humanize also camel cased field name
  * added FormProcessorInterface and FormInterface::process()
  * deprecated passing a Request instance to FormInterface::bind()

--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Test;
+
+use Symfony\Component\Form\Forms;
+
+/**
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Symfony\Component\Form\FormFactoryInterface
+     */
+    protected $factory;
+
+    protected function setUp()
+    {
+        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
+            $this->markTestSkipped('The "EventDispatcher" component is not available');
+        }
+
+        $this->factory = Forms::createFormFactoryBuilder()
+            ->addExtensions($this->getExtensions())
+            ->getFormFactory();
+    }
+
+    protected function getExtensions()
+    {
+        return array();
+    }
+}

--- a/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormPerformanceTestCase.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Test;
+
+/**
+ * Base class for performance tests.
+ *
+ * Copied from Doctrine 2's OrmPerformanceTestCase.
+ *
+ * @author robo
+ * @author Bernhard Schussek <bschussek@gmail.com>
+ */
+abstract class FormPerformanceTestCase extends FormIntegrationTestCase
+{
+    /**
+     * @var    integer
+     */
+    protected $maxRunningTime = 0;
+
+    /**
+     */
+    protected function runTest()
+    {
+        $s = microtime(true);
+        parent::runTest();
+        $time = microtime(true) - $s;
+
+        if ($this->maxRunningTime != 0 && $time > $this->maxRunningTime) {
+            $this->fail(
+                sprintf(
+                    'expected running time: <= %s but was: %s',
+
+                    $this->maxRunningTime,
+                    $time
+                )
+            );
+        }
+    }
+
+    /**
+     * @param  integer $maxRunningTime
+     * @throws \InvalidArgumentException
+     */
+    public function setMaxRunningTime($maxRunningTime)
+    {
+        if (is_integer($maxRunningTime) && $maxRunningTime >= 0) {
+            $this->maxRunningTime = $maxRunningTime;
+        } else {
+            throw new \InvalidArgumentException;
+        }
+    }
+
+    /**
+     * @return integer
+     * @since  Method available since Release 2.3.0
+     */
+    public function getMaxRunningTime()
+    {
+        return $this->maxRunningTime;
+    }
+}

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -12,7 +12,6 @@
 namespace Symfony\Component\Form\Test;
 
 use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Tests\FormIntegrationTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 abstract class TypeTestCase extends FormIntegrationTestCase

--- a/src/Symfony/Component/Form/Test/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Test/TypeTestCase.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien.potencier@symfony-project.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Test;
+
+use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\Tests\FormIntegrationTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+abstract class TypeTestCase extends FormIntegrationTestCase
+{
+    /**
+     * @var FormBuilder
+     */
+    protected $builder;
+
+    /**
+     * @var EventDispatcher
+     */
+    protected $dispatcher;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->builder = new FormBuilder(null, null, $this->dispatcher, $this->factory);
+    }
+
+    public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
+    {
+        self::assertEquals($expected->format('c'), $actual->format('c'));
+    }
+}

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 
-abstract class AbstractLayoutTest extends FormIntegrationTestCase
+abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormIntegrationTestCase
 {
     protected $csrfProvider;
 

--- a/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormPerformanceTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class CompoundFormPerformanceTest extends FormPerformanceTestCase
+class CompoundFormPerformanceTest extends \Symfony\Component\Form\Tests\FormPerformanceTestCase
 {
     /**
      * Create a compound form multiple times, as happens in a collection form

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/BaseTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-abstract class BaseTypeTest extends TypeTestCase
+abstract class BaseTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testPassDisabledAsOption()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\CallbackTransformer;
 
-class CheckboxTypeTest extends TypeTestCase
+class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testPassValueToView()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypePerformanceTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\Tests\FormPerformanceTestCase;
+use Symfony\Component\Form\Test\FormPerformanceTestCase;
 
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -14,7 +14,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 use Symfony\Component\Form\Extension\Core\ChoiceList\ObjectChoiceList;
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 
-class ChoiceTypeTest extends TypeTestCase
+class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     private $choices = array(
         'a' => 'Bernhard',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Form;
 
-class CollectionTypeTest extends TypeTestCase
+class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testContainsNoChildByDefault()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-class FileTypeTest extends TypeTestCase
+class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     // https://github.com/symfony/symfony/pull/5028
     public function testSetData()

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-class PasswordTypeTest extends TypeTestCase
+class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testEmptyIfNotBound()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-class RepeatedTypeTest extends TypeTestCase
+class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     protected $form;
 

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimezoneTypeTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
 
-class TimezoneTypeTest extends TypeTestCase
+class TimezoneTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
     public function testTimezonesAreSelectable()
     {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TypeTestCase.php
@@ -11,32 +11,11 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
-use Symfony\Component\Form\FormBuilder;
-use Symfony\Component\Form\Tests\FormIntegrationTestCase;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\Form\Test\TypeTestCase as BaseTypeTestCase;
 
-abstract class TypeTestCase extends FormIntegrationTestCase
+/**
+ * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use Symfony\Component\Form\Test\TypeTestCase instead.
+ */
+abstract class TypeTestCase extends BaseTypeTestCase
 {
-    /**
-     * @var FormBuilder
-     */
-    protected $builder;
-
-    /**
-     * @var EventDispatcher
-     */
-    protected $dispatcher;
-
-    protected function setUp()
-    {
-        parent::setUp();
-
-        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
-        $this->builder = new FormBuilder(null, null, $this->dispatcher, $this->factory);
-    }
-
-    public static function assertDateTimeEquals(\DateTime $expected, \DateTime $actual)
-    {
-        self::assertEquals($expected->format('c'), $actual->format('c'));
-    }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -13,8 +13,8 @@ namespace Symfony\Component\Form\Tests\Extension\Csrf\Type;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
-use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
 
 class FormTypeCsrfExtensionTest_ChildType extends AbstractType
 {

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TypeTestCase.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/TypeTestCase.php
@@ -11,10 +11,10 @@
 
 namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
 
-use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase as BaseTestCase;
+use Symfony\Component\Form\Test\TypeTestCase as BaseTypeTestCase;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension;
 
-abstract class TypeTestCase extends BaseTestCase
+abstract class TypeTestCase extends BaseTypeTestCase
 {
     protected $validator;
 

--- a/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormIntegrationTestCase.php
@@ -11,31 +11,11 @@
 
 namespace Symfony\Component\Form\Tests;
 
-use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\Test\FormIntegrationTestCase as BaseFormIntegrationTestCase;
 
 /**
- * @author Bernhard Schussek <bschussek@gmail.com>
+ * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use Symfony\Component\Form\Test\FormIntegrationTestCase instead.
  */
-abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
+abstract class FormIntegrationTestCase extends BaseFormIntegrationTestCase
 {
-    /**
-     * @var \Symfony\Component\Form\FormFactoryInterface
-     */
-    protected $factory;
-
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-
-        $this->factory = Forms::createFormFactoryBuilder()
-            ->addExtensions($this->getExtensions())
-            ->getFormFactory();
-    }
-
-    protected function getExtensions()
-    {
-        return array();
-    }
 }

--- a/src/Symfony/Component/Form/Tests/FormPerformanceTestCase.php
+++ b/src/Symfony/Component/Form/Tests/FormPerformanceTestCase.php
@@ -11,60 +11,11 @@
 
 namespace Symfony\Component\Form\Tests;
 
+use Symfony\Component\Form\Test\FormPerformanceTestCase as BaseFormPerformanceTestCase;
+
 /**
- * Base class for performance tests.
- *
- * Copied from Doctrine 2's OrmPerformanceTestCase.
- *
- * @author robo
- * @author Bernhard Schussek <bschussek@gmail.com>
+ * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use Symfony\Component\Form\Test\FormPerformanceTestCase instead.
  */
-abstract class FormPerformanceTestCase extends FormIntegrationTestCase
+abstract class FormPerformanceTestCase extends BaseFormPerformanceTestCase
 {
-    /**
-     * @var    integer
-     */
-    protected $maxRunningTime = 0;
-
-    /**
-     */
-    protected function runTest()
-    {
-        $s = microtime(true);
-        parent::runTest();
-        $time = microtime(true) - $s;
-
-        if ($this->maxRunningTime != 0 && $time > $this->maxRunningTime) {
-            $this->fail(
-                sprintf(
-                    'expected running time: <= %s but was: %s',
-
-                    $this->maxRunningTime,
-                    $time
-                )
-            );
-        }
-    }
-
-    /**
-     * @param  integer $maxRunningTime
-     * @throws \InvalidArgumentException
-     */
-    public function setMaxRunningTime($maxRunningTime)
-    {
-        if (is_integer($maxRunningTime) && $maxRunningTime >= 0) {
-            $this->maxRunningTime = $maxRunningTime;
-        } else {
-            throw new \InvalidArgumentException;
-        }
-    }
-
-    /**
-     * @return integer
-     * @since  Method available since Release 2.3.0
-     */
-    public function getMaxRunningTime()
-    {
-        return $this->maxRunningTime;
-    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #7175 |
| License | MIT |
| Doc PR | symfony/symfony-docs#2500 |

Todo:
- [x] Make a Doc PR
- [x] Update the changelog and UPGRADE-3.md files

As discussed in #7175, since this class is documented as a practise to test your form types, it's good to move it to the `Test` namespace.

I am not sure about the deprecation, I thought things deprecated in 2.3 are removed in 3.0. Also, I think we shouldn't trigger a E_USER_DEPRECATED message.
Please correct me if I'm wrong, it's my first PR for the core code.
