### PR TITLE
Disabled APC on Travis for PHP 5.5+ as it is not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - php: 5.5
 
 before_script:
-    - echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - sh -c 'if [ $(php -r "echo PHP_MINOR_VERSION;") -le 4 ]; then echo "extension = apc.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi;'
     - COMPOSER_ROOT_VERSION=2.1.x-dev composer --prefer-source --dev install
     - php src/Symfony/Component/Locale/Resources/data/build-data.php
     - export USE_INTL_ICU_DATA_VERSION=1


### PR DESCRIPTION
As APC is not available, PHP triggers a warning when trying to load the extension, which lead to many test failures.
