### PR TITLE
[WebProfilerBundle] made token shorter in WDT

### DIFF
--- a/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
+++ b/src/Symfony/Component/HttpKernel/Profiler/Profiler.php
@@ -165,7 +165,7 @@ class Profiler
             return;
         }
 
-        $profile = new Profile(sha1(uniqid(mt_rand(), true)));
+        $profile = new Profile(substr(sha1(uniqid(mt_rand(), true)), 0, 6));
         $profile->setTime(time());
         $profile->setUrl($request->getUri());
         $profile->setIp($request->getClientIp());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The length of the profiler token was increased by [this](https://github.com/symfony/symfony/commit/b9cdb9a26d2cf3ebad415b993784450aeee77ae6) commit. This PR makes the visible token shorter.

Before:
![before](https://f.cloud.github.com/assets/162986/376901/338b9684-a461-11e2-9806-fc77d5ce5039.png)
After:
![after](https://f.cloud.github.com/assets/162986/376902/338ee078-a461-11e2-88c8-78748739565c.png)
