### PR TITLE
[BrowserKit] fixed detection of secure cookies received over https

### DIFF
--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -266,7 +266,7 @@ abstract class Client
 
         $response = $this->filterResponse($this->response);
 
-        $this->cookieJar->updateFromResponse($response);
+        $this->cookieJar->updateFromResponse($response, $uri);
 
         $this->redirect = $response->getHeader('Location');
 

--- a/tests/Symfony/Tests/Component/BrowserKit/ClientTest.php
+++ b/tests/Symfony/Tests/Component/BrowserKit/ClientTest.php
@@ -205,6 +205,15 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar'), $client->getCookieJar()->allValues('http://www.example.com/foo/foobar'), '->request() updates the CookieJar');
     }
 
+    public function testRequestSecureCookies()
+    {
+        $client = new TestClient();
+        $client->setNextResponse(new Response('<html><a href="/foo">foo</a></html>', 200, array('Set-Cookie' => 'foo=bar; path=/; secure')));
+        $client->request('GET', 'https://www.example.com/foo/foobar');
+
+        $this->assertTrue($client->getCookieJar()->get('foo','/','www.example.com')->isSecure());
+    }
+
     public function testClick()
     {
         $client = new TestClient();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7666 |
| License | MIT |
| Doc PR | N/A |

As reported in symfony/symfony#7666, BrowserKit's cookie handling only recognises a secure cookie if the cookie option is set and the cookie was set over an https request. The client was not passing the url into the cookiejar update code, causing Cookie::isSecure() to always return false for every cookie.

I have corrected this behaviour and added an additional unit test to prove the bug and fix.
