### PR TITLE
[2.2][YAML] hotfix for document start and end markers

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -560,14 +560,14 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\-\-\-.*\n#ms', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\-\-\-.*?$#ms', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             //$this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;
 
             // remove end of the document marker (...)
-            $value = preg_replace('#^\.\.\..*\n#ms', '', $value);
+            $value = preg_replace('#^\.\.\..*?$#ms', '', $value);
         }
 
         return $value;

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -560,14 +560,14 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\-\-\-.*?\n#s', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\-\-\-$#ms', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;
 
             // remove end of the document marker (...)
-            $value = preg_replace('#\.\.\.\s*$#s', '', $value);
+            $value = preg_replace('#^\.\.\.$#ms', '', $value);
         }
 
         return $value;

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -560,10 +560,10 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\-\-\-.*?$#ms', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\-\-\-.*?\n#ms', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
-            //$this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
+            $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;
 
             // remove end of the document marker (...)

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -560,14 +560,14 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\-\-\-#ms', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\-\-\-.*\n#ms', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
             //$this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;
 
             // remove end of the document marker (...)
-            $value = preg_replace('#^\.\.\.#ms', '', $value);
+            $value = preg_replace('#^\.\.\..*\n#ms', '', $value);
         }
 
         return $value;

--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -560,14 +560,14 @@ class Parser
         }
 
         // remove start of the document marker (---)
-        $trimmedValue = preg_replace('#^\-\-\-$#ms', '', $value, -1, $count);
+        $trimmedValue = preg_replace('#^\-\-\-#ms', '', $value, -1, $count);
         if ($count == 1) {
             // items have been removed, update the offset
-            $this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
+            //$this->offset += substr_count($value, "\n") - substr_count($trimmedValue, "\n");
             $value = $trimmedValue;
 
             // remove end of the document marker (...)
-            $value = preg_replace('#^\.\.\.$#ms', '', $value);
+            $value = preg_replace('#^\.\.\.#ms', '', $value);
         }
 
         return $value;

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -94,10 +94,22 @@ class ParserTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testStartOfTheDocumentMarker()
+    {
+        $yaml = <<<EOF
+#comments
+--- %YAML:1.2
+foo
+...
+EOF;
+
+        $this->assertEquals('foo', $this->parser->parse($yaml));
+    }
+
     public function testEndOfTheDocumentMarker()
     {
         $yaml = <<<EOF
---- %YAML:1.0
+--- %YAML:1.2
 foo
 ...
 EOF;


### PR DESCRIPTION
According to the [YAML 1.2 specs](http://www.yaml.org/spec/1.2/spec.html) section **2.2 Structures**, the Examples 2.7 and 2.8 show that the document start `---` and end `...` can have content (such as whitespaces and comments) before and after respectively. 

The current implementation of `cleanup()` does not clean up the document start marker `---` if the marker is placed after comments. As a result, the Parser will throw an exception.

However, in this hotfix, I've changed the regular expression in the `cleanup()` process such that as long as that line contains `---` or `...` only, we remove it. 

If the markers are not used, then the usage is not affected.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | checking |
| Fixed tickets | nil |
| License | MIT |
| Doc PR | nil |

This is a minor change to the internal private API and does not affect the public API. Hence we can propose for this to come in Symfony YAML v2.2.2
