### PR TITLE
The most simple fix that could possibly work for #6686?

### DIFF
--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -43,8 +43,12 @@ class EventDispatcher implements EventDispatcherInterface
             $event = new Event();
         }
 
-        $event->setDispatcher($this);
-        $event->setName($eventName);
+        $initialDispatcher = (null == $event->getDispatcher());
+
+        if ($initialDispatcher) {
+            $event->setDispatcher($this);
+            $event->setName($eventName);
+        }
 
         if (!isset($this->listeners[$eventName])) {
             return $event;

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -43,9 +43,7 @@ class EventDispatcher implements EventDispatcherInterface
             $event = new Event();
         }
 
-        $initialDispatcher = (null == $event->getDispatcher());
-
-        if ($initialDispatcher) {
+        if (null === $event->getDispatcher()) {
             $event->setDispatcher($this);
             $event->setName($eventName);
         }

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -124,6 +124,13 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
             $event = new Event();
         }
 
+        $initialDispatcher = (null == $event->getDispatcher());
+
+        if ($initialDispatcher) {
+            $event->setDispatcher($this);
+            $event->setName($eventName);
+        }
+
         $this->id = spl_object_hash($event);
 
         $this->preDispatch($eventName, $event);

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -124,9 +124,7 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
             $event = new Event();
         }
 
-        $initialDispatcher = (null == $event->getDispatcher());
-
-        if ($initialDispatcher) {
+        if (null === $event->getDispatcher()) {
             $event->setDispatcher($this);
             $event->setName($eventName);
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -160,6 +160,8 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         });
 
         $dispatcher->dispatch('foo');
+
+        $this->assertEquals(3, $loop);
     }
 
     public function testStopwatchSections()

--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -164,6 +164,20 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(3, $loop);
     }
 
+    public function testEventObjectsContainsTheListenerThatInitiallyDispatchedTheEvent()
+    {
+        $inner = new EventDispatcher();
+        $outer = new TraceableEventDispatcher($inner, new Stopwatch());
+
+        $self = $this;
+
+        $inner->addListener('foo', $listener = function($event) use ($self, $outer) {
+            $self->assertEquals($outer, $event->getDispatcher());
+        });
+
+        $outer->dispatch('foo');
+    }
+
     public function testStopwatchSections()
     {
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch = new Stopwatch());


### PR DESCRIPTION
Please see #6686. 

If only the first dispatcher involved injects itself into the Event, then also clients obtaining the dispatcher from it will use the right instance in composition setups.

A problem might be that listeners won't get the dispatcher they are subscribed from Event::getDispatcher().
