### PR TITLE
[HttpKernel] ConfigDataCollector: Add support for new Zend OPcache accelerator

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/config.html.twig
@@ -172,6 +172,10 @@
             <td>{{ collector.hasapc ? 'enabled' : 'disabled' }}</td>
         </tr>
         <tr>
+            <th>Zend OPcache</th>
+            <td>{{ collector.haszendopcache ? 'enabled' : 'disabled' }}</td>
+        </tr>
+        <tr>
             <th>EAccelerator</th>
             <td>{{ collector.haseaccelerator ? 'enabled' : 'disabled' }}</td>
         </tr>

--- a/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
+++ b/src/Symfony/Component/HttpKernel/DataCollector/ConfigDataCollector.php
@@ -56,21 +56,22 @@ class ConfigDataCollector extends DataCollector
     public function collect(Request $request, Response $response, \Exception $exception = null)
     {
         $this->data = array(
-            'app_name'         => $this->name,
-            'app_version'      => $this->version,
-            'token'            => $response->headers->get('X-Debug-Token'),
-            'symfony_version'  => Kernel::VERSION,
-            'name'             => isset($this->kernel) ? $this->kernel->getName() : 'n/a',
-            'env'              => isset($this->kernel) ? $this->kernel->getEnvironment() : 'n/a',
-            'debug'            => isset($this->kernel) ? $this->kernel->isDebug() : 'n/a',
-            'php_version'      => PHP_VERSION,
-            'xdebug_enabled'   => extension_loaded('xdebug'),
-            'eaccel_enabled'   => extension_loaded('eaccelerator') && ini_get('eaccelerator.enable'),
-            'apc_enabled'      => extension_loaded('apc') && ini_get('apc.enabled'),
-            'xcache_enabled'   => extension_loaded('xcache') && ini_get('xcache.cacher'),
-            'wincache_enabled' => extension_loaded('wincache') && ini_get('wincache.ocenabled'),
-            'bundles'          => array(),
-            'sapi_name'        => php_sapi_name()
+            'app_name'             => $this->name,
+            'app_version'          => $this->version,
+            'token'                => $response->headers->get('X-Debug-Token'),
+            'symfony_version'      => Kernel::VERSION,
+            'name'                 => isset($this->kernel) ? $this->kernel->getName() : 'n/a',
+            'env'                  => isset($this->kernel) ? $this->kernel->getEnvironment() : 'n/a',
+            'debug'                => isset($this->kernel) ? $this->kernel->isDebug() : 'n/a',
+            'php_version'          => PHP_VERSION,
+            'xdebug_enabled'       => extension_loaded('xdebug'),
+            'eaccel_enabled'       => extension_loaded('eaccelerator') && ini_get('eaccelerator.enable'),
+            'apc_enabled'          => extension_loaded('apc') && ini_get('apc.enabled'),
+            'xcache_enabled'       => extension_loaded('xcache') && ini_get('xcache.cacher'),
+            'wincache_enabled'     => extension_loaded('wincache') && ini_get('wincache.ocenabled'),
+            'zend_opcache_enabled' => extension_loaded('Zend OPcache') && ini_get('opcache.enable'),
+            'bundles'              => array(),
+            'sapi_name'            => php_sapi_name()
         );
 
         if (isset($this->kernel)) {
@@ -181,6 +182,16 @@ class ConfigDataCollector extends DataCollector
     }
 
     /**
+     * Returns true if Zend OPcache is enabled
+     *
+     * @return Boolean true if Zend OPcache is enabled, false otherwise
+     */
+    public function hasZendOpcache()
+    {
+        return $this->data['zend_opcache_enabled'];
+    }
+
+    /**
      * Returns true if XCache is enabled.
      *
      * @return Boolean true if XCache is enabled, false otherwise
@@ -207,7 +218,7 @@ class ConfigDataCollector extends DataCollector
      */
     public function hasAccelerator()
     {
-        return $this->hasApc() || $this->hasEAccelerator() || $this->hasXCache() || $this->hasWinCache();
+        return $this->hasApc() || $this->hasZendOpcache() || $this->hasEAccelerator() || $this->hasXCache() || $this->hasWinCache();
     }
 
     public function getBundles()

--- a/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DataCollector/ConfigDataCollectorTest.php
@@ -53,6 +53,8 @@ class ConfigDataCollectorTest extends \PHPUnit_Framework_TestCase
                 ||
                 (extension_loaded('apc') && ini_get('apc.enabled'))
                 ||
+                (extension_loaded('Zend OPcache') && ini_get('opcache.enable'))
+                ||
                 (extension_loaded('xcache') && ini_get('xcache.cacher'))
                 ||
                 (extension_loaded('wincache') && ini_get('wincache.ocenabled')))) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Related: https://github.com/symfony/symfony/pull/7670

**From original pull request:**

More information: https://github.com/zend-dev/ZendOptimizerPlus

This extension is compatible with PHP 5.2-5.5. I'm using it with 5.5 and 5.4. The PHP developers plan to include this as opposed to APC in PHP 5.5 core. http://php.net/archive/2013.php#id2013-03-21-1

This does not really have to do with Zend Optimiser+. It has to do with the newly open sourced version, Zend OPcache.

I noticed a _similar_ PR here https://github.com/symfony/symfony/pull/7087 but did not like that the unit test check for accelerators was completely removed. I also do not consider it necessary to add more code just for an extension check (I would consider that 'unnecessary re-factoring'). And finally, I have no idea what the final purpose of it is. Based on its title, it seemed like at first that it was for Zend Optimizer+ (the proprietary extension: http://files.zend.com/help/Zend-Server-6/zend-server.htm#zendoptimizerplus.html) but then it sort of changed to adding support for Zend OPcache (the recently open sourced version).

This does only Zend OPcache. Tested on PHP 5.5 and PHP 5.4, including unit tests.

Based on naming scheme, I decided to name the function `hasZendOpcache` (ignoring the abbreviation as with `hasApc`) as opposed to `hasZendOpCache` or other names. Not sure if this is the 'perfect name' (it gets called in all lower-case in the twig file anyway).
