### PR TITLE
[HttpKernel] fix overwriting of request's locale if attribute _locale is missing

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -50,7 +50,7 @@ class LocaleListener implements EventSubscriberInterface
         $request = $event->getRequest();
 
         $request->setDefaultLocale($this->defaultLocale);
-        $this->setLocale($request, $request->attributes->get('_locale', $this->defaultLocale));
+        $this->setLocale($request, $request->attributes->get('_locale', $request->getLocale()));
 
         array_unshift($this->locales, $request->getLocale());
     }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -68,6 +68,17 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest($this->getEvent($request));
     }
 
+    public function testRequestLocaleIsNotOverridden()
+    {
+        $request = Request::create('/');
+        $request->setLocale('de');
+        $listener = new LocaleListener('fr');
+        $event = $this->getEvent($request);
+
+        $listener->onKernelRequest($event);
+        $this->assertEquals('de', $request->getLocale());
+    }
+
     private function getEvent(Request $request)
     {
         return new GetResponseEvent($this->getMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, HttpKernelInterface::MASTER_REQUEST);


### PR DESCRIPTION
In addition to https://github.com/symfony/symfony/pull/7516 same change for the 2.1 branch, see comments on https://github.com/lunetics/LocaleBundle/pull/59
