### PR TITLE
[Stopwatch] Fix checking started events

### DIFF
--- a/src/Symfony/Component/Stopwatch/Stopwatch.php
+++ b/src/Symfony/Component/Stopwatch/Stopwatch.php
@@ -258,7 +258,7 @@ class Section
      */
     public function isEventStarted($name)
     {
-        return isset($this->events[$name]);
+        return isset($this->events[$name]) && $this->events[$name]->isStarted();
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -107,6 +107,16 @@ class StopwatchEvent
     }
 
     /**
+     * Checks if the event was started
+     *
+     * @return bool
+     */
+    public function isStarted()
+    {
+        return (bool) count($this->started);
+    }
+
+    /**
      * Stops the current period and then starts a new one.
      *
      * @return StopwatchEvent The event

--- a/src/Symfony/Component/Stopwatch/StopwatchEvent.php
+++ b/src/Symfony/Component/Stopwatch/StopwatchEvent.php
@@ -113,7 +113,7 @@ class StopwatchEvent
      */
     public function isStarted()
     {
-        return (bool) count($this->started);
+        return !empty($this->started);
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchEventTest.php
@@ -91,6 +91,19 @@ class StopwatchEventTest extends \PHPUnit_Framework_TestCase
         $event->stop();
     }
 
+    public function testIsStarted()
+    {
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        $event->start();
+        $this->assertTrue($event->isStarted());
+    }
+
+    public function testIsNotStarted()
+    {
+        $event = new StopwatchEvent(microtime(true) * 1000);
+        $this->assertFalse($event->isStarted());
+    }
+
     public function testEnsureStopped()
     {
         // this also test overlap between two periods

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -44,6 +44,28 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($stopwatch->isStarted('foo'));
     }
 
+    public function testIsNotStartedEvent()
+    {
+        $stopwatch = new Stopwatch();
+
+        $sections = new \ReflectionProperty('Symfony\Component\Stopwatch\Stopwatch', 'sections');
+        $sections->setAccessible(true);
+        $section = $sections->getValue($stopwatch);
+
+        $events = new \ReflectionProperty('Symfony\Component\Stopwatch\Section', 'events');
+        $events->setAccessible(true);
+        $events->setValue(
+            end($section),
+            array(
+                'foo' =>
+                $this->getMockBuilder('Symfony\Component\Stopwatch\StopwatchEvent')
+                    ->setConstructorArgs([microtime(true) * 1000])
+                    ->getMock())
+        );
+
+        $this->assertFalse($stopwatch->isStarted('foo'));
+    }
+
     public function testStop()
     {
         $stopwatch = new Stopwatch();
@@ -53,7 +75,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $total = $event->getDuration();
-        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
+        $this->assertTrue($total > 10 && $total <= 29, $total . ' should be 20 (between 10 and 29)');
     }
 
     public function testLap()
@@ -67,7 +89,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $total = $event->getDuration();
-        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
+        $this->assertTrue($total > 10 && $total <= 29, $total . ' should be 20 (between 10 and 29)');
     }
 
     /**

--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -75,7 +75,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $total = $event->getDuration();
-        $this->assertTrue($total > 10 && $total <= 29, $total . ' should be 20 (between 10 and 29)');
+        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
     }
 
     public function testLap()
@@ -89,7 +89,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceof('Symfony\Component\Stopwatch\StopwatchEvent', $event);
         $total = $event->getDuration();
-        $this->assertTrue($total > 10 && $total <= 29, $total . ' should be 20 (between 10 and 29)');
+        $this->assertTrue($total > 10 && $total <= 29, $total.' should be 20 (between 10 and 29)');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7639, #7653 |
| License | MIT |

Stopwatch component return true from isStarted method, when StopwatchEvent was added but not started.
