### PR TITLE
[HttpKernel]Change the visibility of "logger" property in ControllerResolver

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ControllerResolver implements ControllerResolverInterface
 {
-    private $logger;
+    protected $logger;
 
     /**
      * Constructor.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | none |
| License | MIT |

This patch changes the _visibility_ of "logger" property in ControllerResolver.
Without this change the log is inaccessible in extending classes.
