### PR TITLE
[Stopwatch] Fix array definition from 5.4

### DIFF
--- a/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
+++ b/src/Symfony/Component/Stopwatch/Tests/StopwatchTest.php
@@ -59,7 +59,7 @@ class StopwatchTest extends \PHPUnit_Framework_TestCase
             array(
                 'foo' =>
                 $this->getMockBuilder('Symfony\Component\Stopwatch\StopwatchEvent')
-                    ->setConstructorArgs([microtime(true) * 1000])
+                    ->setConstructorArgs(array(microtime(true) * 1000))
                     ->getMock())
         );
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7639, #7653 |
| License | MIT |

I was break tests for 5.3 with my prev. PR #7691
