### PR TITLE
Upgrade DI circular reference check

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -65,10 +65,6 @@ class CheckCircularReferencesPass implements CompilerPassInterface
                 throw new ServiceCircularReferenceException($id, array_slice($this->currentPath, $searchKey));
             }
 
-            if ($this->currentId === $id) {
-                throw new ServiceCircularReferenceException($this->currentId, $this->currentPath);
-            }
-
             $this->checkOutEdges($node->getOutEdges());
             array_pop($this->currentPath);
         }

--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -56,8 +56,14 @@ class CheckCircularReferencesPass implements CompilerPassInterface
     private function checkOutEdges(array $edges)
     {
         foreach ($edges as $edge) {
-            $node = $edge->getDestNode();
-            $this->currentPath[] = $id = $node->getId();
+            $node      = $edge->getDestNode();
+            $id        = $node->getId();
+            $searchKey = array_search($id, $this->currentPath);
+            $this->currentPath[] = $id;
+
+            if (false !== $searchKey) {
+                throw new ServiceCircularReferenceException($id, array_slice($this->currentPath, $searchKey));
+            }
 
             if ($this->currentId === $id) {
                 throw new ServiceCircularReferenceException($this->currentId, $this->currentPath);

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -61,6 +61,19 @@ class CheckCircularReferencesPassTest extends \PHPUnit_Framework_TestCase
         $this->process($container);
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testDeepCircularReference()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a')->addArgument(new Reference('b'));
+        $container->register('b')->addArgument(new Reference('c'));
+        $container->register('c')->addArgument(new Reference('b'));
+
+        $this->process($container);
+    }
+
     public function testProcessIgnoresMethodCalls()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
Added a new case to circular reference check to discover a circle a in a where circular references are deeper then start node eg.: A -> B -> C -> B
