### PR TITLE
[Translator] added additional conversion for encodings other than utf-8

### DIFF
--- a/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
+++ b/src/Symfony/Component/Translation/Tests/Loader/XliffFileLoaderTest.php
@@ -50,6 +50,15 @@ class XliffFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($catalogue->has('extra', 'domain1'));
     }
 
+    public function testEncoding()
+    {
+        $loader = $this->createLoader();
+        $catalogue = $loader->load(__DIR__.'/../fixtures/encoding.xlf', 'en', 'domain1');
+
+        $this->assertEquals(utf8_decode('föö'), $catalogue->get('bar', 'domain1'));
+        $this->assertEquals(utf8_decode('bär'), $catalogue->get('foo', 'domain1'));
+    }
+
     /**
      * @expectedException \RuntimeException
      */

--- a/src/Symfony/Component/Translation/Tests/fixtures/encoding.xlf
+++ b/src/Symfony/Component/Translation/Tests/fixtures/encoding.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file source-language="en" datatype="plaintext" original="file.ext">
+    <body>
+      <trans-unit id="1" resname="foo">
+        <source>foo</source>
+        <target>bär</target>
+      </trans-unit>
+      <trans-unit id="2" resname="bar">
+        <source>bar</source> 
+        <target>föö</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Added an additional conversion if there is another encoding in the
xlf file present. Values from simple_xml are always utf-8 encoded.
Also added some tests to verify this new behaviour.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
