### PR TITLE
[DependencyInjection] Fix a DI circular reference recognition bug

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CheckCircularReferencesPass.php
@@ -56,11 +56,13 @@ class CheckCircularReferencesPass implements CompilerPassInterface
     private function checkOutEdges(array $edges)
     {
         foreach ($edges as $edge) {
-            $node = $edge->getDestNode();
-            $this->currentPath[] = $id = $node->getId();
+            $node      = $edge->getDestNode();
+            $id        = $node->getId();
+            $searchKey = array_search($id, $this->currentPath);
+            $this->currentPath[] = $id;
 
-            if ($this->currentId === $id) {
-                throw new ServiceCircularReferenceException($this->currentId, $this->currentPath);
+            if (false !== $searchKey) {
+                throw new ServiceCircularReferenceException($id, array_slice($this->currentPath, $searchKey));
             }
 
             $this->checkOutEdges($node->getOutEdges());

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CheckCircularReferencesPassTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 class CheckCircularReferencesPassTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
      */
     public function testProcess()
     {
@@ -36,7 +36,7 @@ class CheckCircularReferencesPassTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
      */
     public function testProcessWithAliases()
     {
@@ -49,7 +49,7 @@ class CheckCircularReferencesPassTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
      */
     public function testProcessDetectsIndirectCircularReference()
     {
@@ -57,6 +57,19 @@ class CheckCircularReferencesPassTest extends \PHPUnit_Framework_TestCase
         $container->register('a')->addArgument(new Reference('b'));
         $container->register('b')->addArgument(new Reference('c'));
         $container->register('c')->addArgument(new Reference('a'));
+
+        $this->process($container);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException
+     */
+    public function testDeepCircularReference()
+    {
+        $container = new ContainerBuilder();
+        $container->register('a')->addArgument(new Reference('b'));
+        $container->register('b')->addArgument(new Reference('c'));
+        $container->register('c')->addArgument(new Reference('b'));
 
         $this->process($container);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

plus add ability to detect deeper circular references eg: A -> B -> C -> B
