### PR TITLE
GH-7007: Synchronized Service alternative, backwards compatible.

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -14,7 +14,9 @@ namespace Symfony\Bridge\Twig\Tests\Extension;
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Bridge\Twig\Tests\TestCase;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
+use Symfony\Component\HttpKernel\RequestContext;
 
 class HttpKernelExtensionTest extends TestCase
 {
@@ -36,13 +38,30 @@ class HttpKernelExtensionTest extends TestCase
      */
     public function testFragmentWithError()
     {
-        $kernel = $this->getFragmentHandler($this->throwException(new \Exception('foo')));
+        $renderer = $this->getFragmentHandler($this->throwException(new \Exception('foo')));
 
-        $loader = new \Twig_Loader_Array(array('index' => '{{ fragment("foo") }}'));
-        $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
-        $twig->addExtension(new HttpKernelExtension($kernel));
+        $this->renderTemplate($renderer);
+    }
 
-        $this->renderTemplate($kernel);
+    public function testRenderFragment()
+    {
+        $renderer = $this->getFragmentHandler($this->returnValue(new Response('html')));
+
+        $response = $this->renderTemplate($renderer);
+
+        $this->assertEquals('html', $response);
+    }
+
+    public function testUnknownFragmentRenderer()
+    {
+        $context = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\RequestContext')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $renderer = new FragmentHandler($context, array());
+
+        $this->setExpectedException('InvalidArgumentException', 'The "inline" renderer does not exist.');
+        $renderer->render('/foo');
     }
 
     protected function getFragmentHandler($return)
@@ -51,8 +70,14 @@ class HttpKernelExtensionTest extends TestCase
         $strategy->expects($this->once())->method('getName')->will($this->returnValue('inline'));
         $strategy->expects($this->once())->method('render')->will($return);
 
-        $renderer = new FragmentHandler(array($strategy));
-        $renderer->setRequest(Request::create('/'));
+        $context = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\RequestContext')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $context->expects($this->any())->method('getCurrentRequest')->will($this->returnValue(Request::create('/')));
+
+        $renderer = new FragmentHandler($context, array($strategy));
 
         return $renderer;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -14,9 +14,9 @@
 
     <services>
         <service id="fragment.handler" class="%fragment.handler.class%">
+            <argument type="service" id="request_context" />
             <argument type="collection" />
             <argument>%kernel.debug%</argument>
-            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false" /></call>
         </service>
 
         <service id="fragment.renderer.inline" class="%fragment.renderer.inline.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/routing.xml
@@ -92,9 +92,9 @@
             <tag name="kernel.event_subscriber" />
             <tag name="monolog.logger" channel="request" />
             <argument type="service" id="router" />
+            <argument type="service" id="request_context" />
             <argument type="service" id="router.request_context" on-invalid="ignore" />
             <argument type="service" id="logger" on-invalid="ignore" />
-            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false" /></call>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/services.xml
@@ -12,6 +12,8 @@
         <parameter key="cache_clearer.class">Symfony\Component\HttpKernel\CacheClearer\ChainCacheClearer</parameter>
         <parameter key="file_locator.class">Symfony\Component\HttpKernel\Config\FileLocator</parameter>
         <parameter key="uri_signer.class">Symfony\Component\HttpKernel\UriSigner</parameter>
+        <parameter key="request_stack.class">Symfony\Component\HttpKernel\RequestStack</parameter>
+        <parameter key="request_context.class">Symfony\Component\HttpKernel\RequestContext</parameter>
     </parameters>
 
     <services>
@@ -23,6 +25,14 @@
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="service_container" />
             <argument type="service" id="controller_resolver" />
+            <argument type="service" id="request_stack" />
+        </service>
+
+        <service id="request_stack" class="%request_stack.class%">
+        </service>
+
+        <service id="request_context" class="%request_context.class%">
+            <argument type="service" id="request_stack" />
         </service>
 
         <service id="cache_warmer" class="%cache_warmer.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -37,8 +37,8 @@
         <service id="locale_listener" class="%locale_listener.class%">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.default_locale%</argument>
+            <argument type="service" id="request_context" />
             <argument type="service" id="router" on-invalid="ignore" />
-            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false" /></call>
         </service>
     </services>
 </container>

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\RequestStack;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -29,6 +30,7 @@ use Symfony\Component\DependencyInjection\Scope;
 class ContainerAwareHttpKernel extends HttpKernel
 {
     protected $container;
+    protected $requestStack;
 
     /**
      * Constructor.
@@ -36,12 +38,15 @@ class ContainerAwareHttpKernel extends HttpKernel
      * @param EventDispatcherInterface    $dispatcher         An EventDispatcherInterface instance
      * @param ContainerInterface          $container          A ContainerInterface instance
      * @param ControllerResolverInterface $controllerResolver A ControllerResolverInterface instance
+     * @param RequestStack                $requestStack       A stack for master/sub requests
      */
-    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver)
+    public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver, RequestStack $requestStack)
     {
         parent::__construct($dispatcher, $controllerResolver);
 
+        $this->requestStack = $requestStack;
         $this->container = $container;
+
         $container->addScope(new Scope('request'));
     }
 
@@ -50,6 +55,8 @@ class ContainerAwareHttpKernel extends HttpKernel
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
+        $this->requestStack->push($request);
+
         $request->headers->set('X-Php-Ob-Level', ob_get_level());
 
         $this->container->enterScope('request');
@@ -66,6 +73,8 @@ class ContainerAwareHttpKernel extends HttpKernel
 
         $this->container->set('request', null, 'request');
         $this->container->leaveScope('request');
+
+        $this->requestStack->pop();
 
         return $response;
     }

--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -42,9 +42,8 @@ class ContainerAwareHttpKernel extends HttpKernel
      */
     public function __construct(EventDispatcherInterface $dispatcher, ContainerInterface $container, ControllerResolverInterface $controllerResolver, RequestStack $requestStack)
     {
-        parent::__construct($dispatcher, $controllerResolver);
+        parent::__construct($dispatcher, $controllerResolver, $requestStack);
 
-        $this->requestStack = $requestStack;
         $this->container = $container;
 
         $container->addScope(new Scope('request'));
@@ -55,8 +54,6 @@ class ContainerAwareHttpKernel extends HttpKernel
      */
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
-        $this->requestStack->push($request);
-
         $request->headers->set('X-Php-Ob-Level', ob_get_level());
 
         $this->container->enterScope('request');
@@ -73,8 +70,6 @@ class ContainerAwareHttpKernel extends HttpKernel
 
         $this->container->set('request', null, 'request');
         $this->container->leaveScope('request');
-
-        $this->requestStack->pop();
 
         return $response;
     }

--- a/src/Symfony/Component/HttpKernel/Event/RequestFinishedEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/RequestFinishedEvent.php
@@ -1,7 +1,21 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel\Event;
 
+/**
+ * Triggered whenever a request is fully processed.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ */
 class RequestFinishedEvent extends KernelEvent
 {
 }

--- a/src/Symfony/Component/HttpKernel/Event/RequestFinishedEvent.php
+++ b/src/Symfony/Component/HttpKernel/Event/RequestFinishedEvent.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Event;
+
+class RequestFinishedEvent extends KernelEvent
+{
+}

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestFinishedEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\RequestContext;
 use Symfony\Component\HttpFoundation\Request;
@@ -46,7 +46,7 @@ class LocaleListener implements EventSubscriberInterface
         $this->setRouterContext($request);
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelRequestFinished(RequestFinishedEvent $event)
     {
         $this->resetRouterContext();
     }
@@ -85,8 +85,7 @@ class LocaleListener implements EventSubscriberInterface
         return array(
             // must be registered after the Router to have access to the _locale
             KernelEvents::REQUEST => array(array('onKernelRequest', 16)),
-            // should be registered very late
-            KernelEvents::RESPONSE => array(array('onKernelResponse', -255)),
+            KernelEvents::REQUEST_FINISHED => array(array('onKernelRequestFinished', 0)),
         );
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/LocaleListener.php
@@ -12,7 +12,9 @@
 namespace Symfony\Component\HttpKernel\EventListener;
 
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\RequestContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\RequestContextAwareInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -26,26 +28,13 @@ class LocaleListener implements EventSubscriberInterface
 {
     private $router;
     private $defaultLocale;
+    private $requestContext;
 
-    public function __construct($defaultLocale = 'en', RequestContextAwareInterface $router = null)
+    public function __construct($defaultLocale = 'en', RequestContext $requestContext, RequestContextAwareInterface $router = null)
     {
         $this->defaultLocale = $defaultLocale;
+        $this->requestContext = $requestContext;
         $this->router = $router;
-    }
-
-    public function setRequest(Request $request = null)
-    {
-        if (null === $request) {
-            return;
-        }
-
-        if ($locale = $request->attributes->get('_locale')) {
-            $request->setLocale($locale);
-        }
-
-        if (null !== $this->router) {
-            $this->router->getContext()->setParameter('_locale', $request->getLocale());
-        }
     }
 
     public function onKernelRequest(GetResponseEvent $event)
@@ -53,7 +42,42 @@ class LocaleListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $request->setDefaultLocale($this->defaultLocale);
 
-        $this->setRequest($request);
+        $this->setLocale($request);
+        $this->setRouterContext($request);
+    }
+
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $this->resetRouterContext();
+    }
+
+    private function resetRouterContext()
+    {
+        if ($this->requestContext === null) {
+            return;
+        }
+
+        $parentRequest = $this->requestContext->getParentRequest();
+
+        if ($parentRequest === null) {
+            return;
+        }
+
+        $this->setRouterContext($parentRequest);
+    }
+
+    private function setLocale(Request $request)
+    {
+        if ($locale = $request->attributes->get('_locale')) {
+            $request->setLocale($locale);
+        }
+    }
+
+    private function setRouterContext(Request $request)
+    {
+        if (null !== $this->router) {
+            $this->router->getContext()->setParameter('_locale', $request->getLocale());
+        }
     }
 
     public static function getSubscribedEvents()
@@ -61,6 +85,8 @@ class LocaleListener implements EventSubscriberInterface
         return array(
             // must be registered after the Router to have access to the _locale
             KernelEvents::REQUEST => array(array('onKernelRequest', 16)),
+            // should be registered very late
+            KernelEvents::RESPONSE => array(array('onKernelResponse', -255)),
         );
     }
 }

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -74,7 +74,7 @@ class RouterListener implements EventSubscriberInterface
      *
      * @param Request|null $request A Request instance
      */
-    public function setRequest(Request $request = null)
+    private function populateRoutingContext(Request $request = null)
     {
         if (null !== $request) {
             $this->context->fromRequest($request);
@@ -83,7 +83,7 @@ class RouterListener implements EventSubscriberInterface
 
     public function onKernelRequestFinished(RequestFinishedEvent $event)
     {
-        $this->setRequest($this->kernelContext->getParentRequest());
+        $this->populateRoutingContext($this->kernelContext->getParentRequest());
     }
 
     public function onKernelRequest(GetResponseEvent $event)
@@ -93,7 +93,7 @@ class RouterListener implements EventSubscriberInterface
         // initialize the context that is also used by the generator (assuming matcher and generator share the same context instance)
         // we call setRequest even if most of the time, it has already been done to keep compatibility
         // with frameworks which do not use the Symfony service container
-        $this->setRequest($request);
+        $this->populateRoutingContext($request);
 
         if ($request->attributes->has('_controller')) {
             // routing is already done

--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\HttpKernel\EventListener;
 
 use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestFinishedEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -81,7 +81,7 @@ class RouterListener implements EventSubscriberInterface
         }
     }
 
-    public function onKernelResponse(FilterResponseEvent $event)
+    public function onKernelRequestFinished(RequestFinishedEvent $event)
     {
         $this->setRequest($this->kernelContext->getParentRequest());
     }
@@ -142,7 +142,7 @@ class RouterListener implements EventSubscriberInterface
     {
         return array(
             KernelEvents::REQUEST => array(array('onKernelRequest', 32)),
-            KernelEvents::RESPONSE => array(array('onKernelResponse', -255)),
+            KernelEvents::REQUEST_FINISHED => array(array('onKernelRequestFinished', 0)),
         );
     }
 }

--- a/src/Symfony/Component/HttpKernel/HttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/HttpKernel.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\RequestFinishedEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
@@ -35,19 +36,22 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
 {
     protected $dispatcher;
     protected $resolver;
+    protected $requestStack;
 
     /**
      * Constructor
      *
-     * @param EventDispatcherInterface    $dispatcher An EventDispatcherInterface instance
-     * @param ControllerResolverInterface $resolver   A ControllerResolverInterface instance
+     * @param EventDispatcherInterface    $dispatcher   An EventDispatcherInterface instance
+     * @param ControllerResolverInterface $resolver     A ControllerResolverInterface instance
+     * @param RequestStack                $requestStack A stack for master/sub requests
      *
      * @api
      */
-    public function __construct(EventDispatcherInterface $dispatcher, ControllerResolverInterface $resolver)
+    public function __construct(EventDispatcherInterface $dispatcher, ControllerResolverInterface $resolver, RequestStack $requestStack = null)
     {
         $this->dispatcher = $dispatcher;
         $this->resolver = $resolver;
+        $this->requestStack = $requestStack ?: new RequestStack();
     }
 
     /**
@@ -105,6 +109,8 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
      */
     private function handleRaw(Request $request, $type = self::MASTER_REQUEST)
     {
+        $this->requestStack->push($request);
+
         // request
         $event = new GetResponseEvent($this, $request, $type);
         $this->dispatcher->dispatch(KernelEvents::REQUEST, $event);
@@ -167,6 +173,10 @@ class HttpKernel implements HttpKernelInterface, TerminableInterface
         $event = new FilterResponseEvent($this, $request, $type, $response);
 
         $this->dispatcher->dispatch(KernelEvents::RESPONSE, $event);
+
+        $this->requestStack->pop();
+
+        $this->dispatcher->dispatch(KernelEvents::REQUEST_FINISHED, new RequestFinishedEvent($this, $request, $type));
 
         return $event->getResponse();
     }

--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -102,4 +102,14 @@ final class KernelEvents
      * @var string
      */
     const TERMINATE = 'kernel.terminate';
+
+    /**
+     * The REQUEST_FINISHED event occurs when a response was generated for a request.
+     *
+     * This event allows you to reset the global and envioronmental state of
+     * the application, when it was changed during the request.
+     *
+     * @var string
+     */
+    const REQUEST_FINISHED = 'kernel.request_finished';
 }

--- a/src/Symfony/Component/HttpKernel/KernelEvents.php
+++ b/src/Symfony/Component/HttpKernel/KernelEvents.php
@@ -106,7 +106,7 @@ final class KernelEvents
     /**
      * The REQUEST_FINISHED event occurs when a response was generated for a request.
      *
-     * This event allows you to reset the global and envioronmental state of
+     * This event allows you to reset the global and environmental state of
      * the application, when it was changed during the request.
      *
      * @var string

--- a/src/Symfony/Component/HttpKernel/RequestContext.php
+++ b/src/Symfony/Component/HttpKernel/RequestContext.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Symfony\Component\HttpKernel;
+
+/**
+ * Registry for Requests.
+ *
+ * Facade for RequestStack that prevents modification of the stack,
+ * so that users don't accidentily push()/pop() from the stack and
+ * mess up the request cycle.
+ */
+class RequestContext
+{
+    private $stack;
+
+    public function __construct(RequestStack $stack)
+    {
+        $this->stack = $stack;
+    }
+
+    /**
+     * @return Request
+     */
+    public function getCurrentRequest()
+    {
+        return $this->stack->getCurrentRequest();
+    }
+
+    /**
+     * @return Request
+     */
+    public function getMasterRequest()
+    {
+        return $this->stack->getMasterRequest();
+    }
+
+    /**
+     * @return Request|null
+     */
+    public function getParentRequest()
+    {
+        return $this->stack->getParentRequest();
+    }
+}

--- a/src/Symfony/Component/HttpKernel/RequestContext.php
+++ b/src/Symfony/Component/HttpKernel/RequestContext.php
@@ -15,7 +15,7 @@ namespace Symfony\Component\HttpKernel;
  * Registry for Requests.
  *
  * Facade for RequestStack that prevents modification of the stack,
- * so that users don't accidentily push()/pop() from the stack and
+ * so that users don't accidentally push()/pop() from the stack and
  * mess up the request cycle.
  *
  * @author Benjamin Eberlei <kontakt@beberlei.de>

--- a/src/Symfony/Component/HttpKernel/RequestContext.php
+++ b/src/Symfony/Component/HttpKernel/RequestContext.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel;
 
 /**
@@ -8,6 +17,8 @@ namespace Symfony\Component\HttpKernel;
  * Facade for RequestStack that prevents modification of the stack,
  * so that users don't accidentily push()/pop() from the stack and
  * mess up the request cycle.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
 class RequestContext
 {

--- a/src/Symfony/Component/HttpKernel/RequestStack.php
+++ b/src/Symfony/Component/HttpKernel/RequestStack.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Component\HttpKernel;
 
 use Symfony\Component\HttpFoundation\Request;
@@ -8,6 +17,8 @@ use Symfony\Component\HttpFoundation\Request;
  * Request stack that controls the lifecycle of requests.
  *
  * Notifies services of changes in the stack.
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
  */
 class RequestStack
 {
@@ -34,18 +45,22 @@ class RequestStack
     }
 
     /**
-     * @return Request
+     * @return Request|null
      */
     public function getCurrentRequest()
     {
-        return end($this->requests);
+        return end($this->requests) ?: null;
     }
 
     /**
-     * @return Request
+     * @return Request|null
      */
     public function getMasterRequest()
     {
+        if (!$this->requests) {
+            return null;
+        }
+
         return $this->requests[0];
     }
 

--- a/src/Symfony/Component/HttpKernel/RequestStack.php
+++ b/src/Symfony/Component/HttpKernel/RequestStack.php
@@ -52,7 +52,7 @@ class RequestStack
     /**
      * Return the parent request of the current.
      *
-     * If current Request ist the master request, method returns null.
+     * If current Request is the master request, method returns null.
      *
      * @return Request
      */

--- a/src/Symfony/Component/HttpKernel/RequestStack.php
+++ b/src/Symfony/Component/HttpKernel/RequestStack.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Symfony\Component\HttpKernel;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Request stack that controls the lifecycle of requests.
+ *
+ * Notifies services of changes in the stack.
+ */
+class RequestStack
+{
+    /**
+     * @var Request[]
+     */
+    private $requests = array();
+
+    public function push(Request $request)
+    {
+        $this->requests[] = $request;
+    }
+
+    /**
+     * Pop the current request from the stack.
+     *
+     * This operation lets the current request go out of scope.
+     *
+     * @return Request
+     */
+    public function pop()
+    {
+        return array_pop($this->requests);
+    }
+
+    /**
+     * @return Request
+     */
+    public function getCurrentRequest()
+    {
+        return end($this->requests);
+    }
+
+    /**
+     * @return Request
+     */
+    public function getMasterRequest()
+    {
+        return $this->requests[0];
+    }
+
+    /**
+     * Return the parent request of the current.
+     *
+     * If current Request ist the master request, method returns null.
+     *
+     * @return Request
+     */
+    public function getParentRequest()
+    {
+        $pos = count($this->requests) - 2;
+
+        if (!isset($this->requests[$pos])) {
+            return null;
+        }
+
+        return $this->requests[$pos];
+    }
+}

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpKernel\Tests\DependencyInjection;
 
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\ContainerAwareHttpKernel;
+use Symfony\Component\HttpKernel\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -41,46 +42,22 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
         $expected = new Response();
-
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container
-            ->expects($this->once())
-            ->method('enterScope')
-            ->with($this->equalTo('request'))
-        ;
-        $container
-            ->expects($this->once())
-            ->method('leaveScope')
-            ->with($this->equalTo('request'))
-        ;
-        // first call is for addScope()
-        $container
-            ->expects($this->at(2))
-            ->method('set')
-            ->with($this->equalTo('request'), $this->equalTo($request), $this->equalTo('request'))
-        ;
-        $container
-            ->expects($this->at(3))
-            ->method('set')
-            ->with($this->equalTo('request'), $this->equalTo(null), $this->equalTo('request'))
-        ;
-
-        $dispatcher = new EventDispatcher();
-        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
-        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver);
-
         $controller = function() use ($expected) {
             return $expected;
         };
 
-        $resolver->expects($this->once())
-            ->method('getController')
-            ->with($request)
-            ->will($this->returnValue($controller));
-        $resolver->expects($this->once())
-            ->method('getArguments')
-            ->with($request, $controller)
-            ->will($this->returnValue(array()));
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this
+             ->expectsEnterScopeOnce($container)
+             ->expectsLeaveScopeOnce($container)
+             ->expectsSetRequestWithAt($container, $request, 2)
+             ->expectsSetRequestWithAt($container, null, 3)
+        ;
+
+        $dispatcher = new EventDispatcher();
+        $resolver = $this->getResolverMockFor($controller, $request);
+        $stack = new RequestStack();
+        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack);
 
         $actual = $kernel->handle($request, $type);
 
@@ -90,49 +67,50 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getProviderTypes
      */
+    public function testVerifyRequestStackPushPopDuringHandle($type)
+    {
+        $request = new Request();
+        $expected = new Response();
+        $controller = function() use ($expected) {
+            return $expected;
+        };
+
+        $stack = $this->getMock('Symfony\Component\HttpKernel\RequestStack', array('push', 'pop'));
+        $stack->expects($this->at(0))->method('push')->with($this->equalTo($request));
+        $stack->expects($this->at(1))->method('pop');
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $dispatcher = new EventDispatcher();
+        $resolver = $this->getResolverMockFor($controller, $request);
+        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack);
+
+        $kernel->handle($request, $type);
+    }
+
+    /**
+     * @dataProvider getProviderTypes
+     */
     public function testHandleRestoresThePreviousRequestOnException($type)
     {
         $request = new Request();
         $expected = new \Exception();
-
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
-        $container
-            ->expects($this->once())
-            ->method('enterScope')
-            ->with($this->equalTo('request'))
-        ;
-        $container
-            ->expects($this->once())
-            ->method('leaveScope')
-            ->with($this->equalTo('request'))
-        ;
-        $container
-            ->expects($this->at(2))
-            ->method('set')
-            ->with($this->equalTo('request'), $this->equalTo($request), $this->equalTo('request'))
-        ;
-        $container
-            ->expects($this->at(3))
-            ->method('set')
-            ->with($this->equalTo('request'), $this->equalTo(null), $this->equalTo('request'))
-        ;
-
-        $dispatcher = new EventDispatcher();
-        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
-        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver);
-
         $controller = function() use ($expected) {
             throw $expected;
         };
 
-        $resolver->expects($this->once())
-            ->method('getController')
-            ->with($request)
-            ->will($this->returnValue($controller));
-        $resolver->expects($this->once())
-            ->method('getArguments')
-            ->with($request, $controller)
-            ->will($this->returnValue(array()));
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $this
+             ->expectsEnterScopeOnce($container)
+             ->expectsLeaveScopeOnce($container)
+             ->expectsSetRequestWithAt($container, $request, 2)
+             ->expectsSetRequestWithAt($container, null, 3)
+        ;
+
+        $dispatcher = new EventDispatcher();
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
+        $resolver = $this->getResolverMockFor($controller, $request);
+        $stack = new RequestStack();
+        $kernel = new ContainerAwareHttpKernel($dispatcher, $container, $resolver, $stack);
 
         try {
             $kernel->handle($request, $type);
@@ -148,5 +126,52 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
             array(HttpKernelInterface::MASTER_REQUEST),
             array(HttpKernelInterface::SUB_REQUEST),
         );
+    }
+
+    private function getResolverMockFor($controller, $request)
+    {
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolverInterface');
+        $resolver->expects($this->once())
+            ->method('getController')
+            ->with($request)
+            ->will($this->returnValue($controller));
+        $resolver->expects($this->once())
+            ->method('getArguments')
+            ->with($request, $controller)
+            ->will($this->returnValue(array()));
+
+        return $resolver;
+    }
+
+    private function expectsSetRequestWithAt($container, $with, $at)
+    {
+        $container
+            ->expects($this->at($at))
+            ->method('set')
+            ->with($this->equalTo('request'), $this->equalTo($with), $this->equalTo('request'))
+        ;
+        return $this;
+    }
+
+    private function expectsEnterScopeOnce($container)
+    {
+        $container
+            ->expects($this->once())
+            ->method('enterScope')
+            ->with($this->equalTo('request'))
+        ;
+
+        return $this;
+    }
+
+    private function expectsLeaveScopeOnce($container)
+    {
+        $container
+            ->expects($this->once())
+            ->method('leaveScope')
+            ->with($this->equalTo('request'))
+        ;
+
+        return $this;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -73,7 +73,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelRequest($this->getEvent($request));
     }
 
-    public function testRouterResetWithParentRequestOnKernelResponse()
+    public function testRouterResetWithParentRequestOnKernelRequestFinished()
     {
         if (!class_exists('Symfony\Component\Routing\Router')) {
             $this->markTestSkipped('The "Routing" component is not available');
@@ -91,10 +91,10 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->context->expects($this->once())->method('getParentRequest')->will($this->returnValue($parentRequest));
 
-        $event = $this->getMock('Symfony\Component\HttpKernel\Event\FilterResponseEvent', array(), array(), '', false);
+        $event = $this->getMock('Symfony\Component\HttpKernel\Event\RequestFinishedEvent', array(), array(), '', false);
 
         $listener = new LocaleListener('fr', $this->context, $router);
-        $listener->onKernelResponse($event);
+        $listener->onKernelRequestFinished($event);
     }
 
     public function testRequestLocaleIsNotOverridden()

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/LocaleListenerTest.php
@@ -12,22 +12,27 @@
 namespace Symfony\Component\HttpKernel\Tests\EventListener;
 
 use Symfony\Component\HttpKernel\EventListener\LocaleListener;
+use Symfony\Component\HttpKernel\RequestContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 class LocaleListenerTest extends \PHPUnit_Framework_TestCase
 {
+    private $context;
+
     protected function setUp()
     {
         if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
             $this->markTestSkipped('The "EventDispatcher" component is not available');
         }
+
+        $this->context = $this->getMock('Symfony\Component\HttpKernel\RequestContext', array(), array(), '', false);
     }
 
     public function testDefaultLocaleWithoutSession()
     {
-        $listener = new LocaleListener('fr');
+        $listener = new LocaleListener('fr', $this->context);
         $event = $this->getEvent($request = Request::create('/'));
 
         $listener->onKernelRequest($event);
@@ -41,7 +46,7 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $request->cookies->set('foo', 'value');
 
         $request->attributes->set('_locale', 'es');
-        $listener = new LocaleListener('fr');
+        $listener = new LocaleListener('fr', $this->context);
         $event = $this->getEvent($request);
 
         $listener->onKernelRequest($event);
@@ -64,15 +69,39 @@ class LocaleListenerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
 
         $request->attributes->set('_locale', 'es');
-        $listener = new LocaleListener('fr', $router);
+        $listener = new LocaleListener('fr', $this->context, $router);
         $listener->onKernelRequest($this->getEvent($request));
+    }
+
+    public function testRouterResetWithParentRequestOnKernelResponse()
+    {
+        if (!class_exists('Symfony\Component\Routing\Router')) {
+            $this->markTestSkipped('The "Routing" component is not available');
+        }
+
+        // the request context is updated
+        $context = $this->getMock('Symfony\Component\Routing\RequestContext');
+        $context->expects($this->once())->method('setParameter')->with('_locale', 'es');
+
+        $router = $this->getMock('Symfony\Component\Routing\Router', array('getContext'), array(), '', false);
+        $router->expects($this->once())->method('getContext')->will($this->returnValue($context));
+
+        $parentRequest = Request::create('/');
+        $parentRequest->setLocale('es');
+
+        $this->context->expects($this->once())->method('getParentRequest')->will($this->returnValue($parentRequest));
+
+        $event = $this->getMock('Symfony\Component\HttpKernel\Event\FilterResponseEvent', array(), array(), '', false);
+
+        $listener = new LocaleListener('fr', $this->context, $router);
+        $listener->onKernelResponse($event);
     }
 
     public function testRequestLocaleIsNotOverridden()
     {
         $request = Request::create('/');
         $request->setLocale('de');
-        $listener = new LocaleListener('fr');
+        $listener = new LocaleListener('fr', $this->context);
         $event = $this->getEvent($request);
 
         $listener->onKernelRequest($event);

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -17,12 +17,27 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
 {
+    private $context;
+
+    public function setUp()
+    {
+        $this->context = $this->getMockBuilder('Symfony\\Component\\HttpKernel\\RequestContext')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+        $this->context
+            ->expects($this->any())
+            ->method('getCurrentRequest')
+            ->will($this->returnValue(Request::create('/')))
+        ;
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */
     public function testRenderWhenRendererDoesNotExist()
     {
-        $handler = new FragmentHandler();
+        $handler = new FragmentHandler($this->context);
         $handler->render('/', 'foo');
     }
 
@@ -72,9 +87,8 @@ class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
             call_user_func_array(array($e, 'with'), $arguments);
         }
 
-        $handler = new FragmentHandler();
+        $handler = new FragmentHandler($this->context);
         $handler->addRenderer($renderer);
-        $handler->setRequest(Request::create('/'));
 
         return $handler;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/HttpKernelTest.php
@@ -249,6 +249,20 @@ class HttpKernelTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($response, $capturedResponse);
     }
 
+    public function testVerifyRequestStackPushPopDuringHandle()
+    {
+        $request = new Request();
+
+        $stack = $this->getMock('Symfony\Component\HttpKernel\RequestStack', array('push', 'pop'));
+        $stack->expects($this->at(0))->method('push')->with($this->equalTo($request));
+        $stack->expects($this->at(1))->method('pop');
+
+        $dispatcher = new EventDispatcher();
+        $kernel = new HttpKernel($dispatcher, $this->getResolver(), $stack);
+
+        $kernel->handle($request, HttpKernelInterface::MASTER_REQUEST);
+    }
+
     protected function getResolver($controller = null)
     {
         if (null === $controller) {

--- a/src/Symfony/Component/HttpKernel/Tests/RequestStackTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/RequestStackTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpKernel\Tests;
+
+use Symfony\Component\HttpKernel\RequestStack;
+use Symfony\Component\HttpFoundation\Request;
+
+class RequestStackTest extends \PHPUnit_Framework_TestCase
+{
+    public function testPushThenPopReturnsSameRequest()
+    {
+        $request = Request::create('/');
+
+        $stack = new RequestStack();
+        $stack->push($request);
+
+        $this->assertSame($request, $stack->pop());
+        $this->assertNull($stack->pop());
+    }
+
+    public function testPopEmptyStackReturnsNull()
+    {
+        $stack = new RequestStack();
+
+        $this->assertNull($stack->pop());
+    }
+
+    public function testGetCurrentRequest()
+    {
+        $request = Request::create('/');
+        $stack = new RequestStack();
+
+        $this->assertNull($stack->getCurrentRequest());
+
+        $stack->push($request);
+
+        $this->assertSame($request, $stack->getCurrentRequest());
+        $this->assertSame($request, $stack->getCurrentRequest());
+    }
+
+    public function testGetMasterRequest()
+    {
+        $request = Request::create('/');
+        $stack = new RequestStack();
+
+        $this->assertNull($stack->getMasterRequest());
+
+        $stack->push($request);
+
+        $this->assertSame($request, $stack->getMasterRequest());
+        $this->assertSame($request, $stack->getMasterRequest());
+    }
+
+    public function testGetParentRequest()
+    {
+        $request = Request::create('/');
+        $subrequest = Request::create('/');
+
+        $stack = new RequestStack();
+        $stack->push($request);
+        $stack->push($subrequest);
+
+        $this->assertSame($request, $stack->getParentRequest());
+        $this->assertSame($subrequest, $stack->pop());
+        $this->assertSame($request, $stack->pop());
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | GH-7007 |
| License | MIT |
| Doc PR | none |

Prototype for introducing a `RequestContext` in HttpKernel.

This PR keeps the synchronized services feature, however introduces a `RequestContext` object additionally, that allows to avoid using synchronized service when injecting `request_context` instead of `request` into a service. The FrameworkBundle is modified such that it does not depend on synchronized services anymore. Users however can still depend on `request`, activating the synchronized services feature.

Features:
- Introduced `REQUEST_FINSHED` (name is up for grabs) event to handle global state and environment cleanup that should not be done in `RESPONSE`. Called in both exception or success case correctly
- Changed listeners that were synchronized before to using `onKernelRequestFinished` and `RequestContext` to reset to the parent request (RouterListener + LocaleListener).
- Changed `FragmentHandler` to use the RequestContext. Added some more tests for this class.
- `RequestStack` is injected into the `HttpKernel` to handle the request finished event and push/pop the stack with requests.

Todos:
- RequestContext name clashes with Routing components RequestContext. Keep or make unique?
- Name for Kernel Request Finished Event could be improved.
