### PR TITLE
[WIP][2.3][FrameworkBundle][Templating] Generate assets with absolute url

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/templating_php.xml
@@ -20,6 +20,7 @@
         <parameter key="templating.globals.class">Symfony\Bundle\FrameworkBundle\Templating\GlobalVariables</parameter>
         <parameter key="templating.asset.path_package.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PathPackage</parameter>
         <parameter key="templating.asset.url_package.class">Symfony\Component\Templating\Asset\UrlPackage</parameter>
+        <parameter key="templating.asset.absolute_url_package.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\AbsoluteUrlPackage</parameter>
         <parameter key="templating.asset.package_factory.class">Symfony\Bundle\FrameworkBundle\Templating\Asset\PackageFactory</parameter>
     </parameters>
 
@@ -53,6 +54,14 @@
             <argument /> <!-- version -->
             <argument /> <!-- version format -->
         </service>
+
+        <service id="templating.asset.absolute_url_package" class="%templating.asset.absolute_url_package.class%" abstract="true">
+            <argument type="service" id="router.request_context" on-invalid="ignore" />
+            <argument /> <!-- version -->
+            <argument /> <!-- version format -->
+        </service>
+        
+        <service id="absolute_url" alias="templating.asset.absolute_url_package" />
 
         <service id="templating.asset.request_aware_package" class="Symfony\Component\Templating\Asset\PackageInterface" factory-service="templating.asset.package_factory" factory-method="getPackage" abstract="true">
             <argument type="service" id="request" strict="false" />

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/AbsoluteUrlPackage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/AbsoluteUrlPackage.php
@@ -37,6 +37,35 @@ class AbsoluteUrlPackage extends Package
     
     public function getUrl($path)
     {
-        return null;
+        if (false !== strpos($path, '://') || 0 === strpos($path, '//')) {
+            return $path;
+        }
+        
+        $url = ltrim($path, '/');
+        if ($baseUrl = $this->context->getBaseUrl()) {
+            $url = trim($baseUrl, '/').'/'.$url;
+        }
+        
+        // get scheme, host and port from RequestContext
+        // based on \Symfony\Component\Routing\Generator\UrlGenerator::doGenerate()
+        $schemeAuthority = '';
+        if ($host = $this->context->getHost()) {
+            $scheme = $this->context->getScheme();
+            
+            $port = '';
+            if ('http' === $scheme && 80 != $this->context->getHttpPort()) {
+                $port = ':'.$this->context->getHttpPort();
+            } elseif ('https' === $scheme && 443 != $this->context->getHttpsPort()) {
+                $port = ':'.$this->context->getHttpsPort();
+            }
+
+            $schemeAuthority .= $scheme.'://'.$host.$port;
+        }
+
+        $url = $schemeAuthority.'/'.$url;
+        
+        $url = $this->applyVersion($url);
+        
+        return $url;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/AbsoluteUrlPackage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/AbsoluteUrlPackage.php
@@ -22,7 +22,7 @@ use Symfony\Component\Templating\Asset\Package;
 class AbsoluteUrlPackage extends Package
 {
     private $context;
-    
+
     /**
      * @param RequestContext $context Request context
      * @param string         $version The version
@@ -31,27 +31,27 @@ class AbsoluteUrlPackage extends Package
     public function __construct(RequestContext $context, $version = null, $format = null)
     {
         $this->context = $context;
-        
+
         parent::__construct($version, $format);
     }
-    
+
     public function getUrl($path)
     {
         if (false !== strpos($path, '://') || 0 === strpos($path, '//')) {
             return $path;
         }
-        
+
         $url = ltrim($path, '/');
         if ($baseUrl = $this->context->getBaseUrl()) {
             $url = trim($baseUrl, '/').'/'.$url;
         }
-        
+
         // get scheme, host and port from RequestContext
         // based on \Symfony\Component\Routing\Generator\UrlGenerator::doGenerate()
         $schemeAuthority = '';
         if ($host = $this->context->getHost()) {
             $scheme = $this->context->getScheme();
-            
+
             $port = '';
             if ('http' === $scheme && 80 != $this->context->getHttpPort()) {
                 $port = ':'.$this->context->getHttpPort();
@@ -63,9 +63,9 @@ class AbsoluteUrlPackage extends Package
         }
 
         $url = $schemeAuthority.'/'.$url;
-        
+
         $url = $this->applyVersion($url);
-        
+
         return $url;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/AbsoluteUrlPackage.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Asset/AbsoluteUrlPackage.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Templating\Asset;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Component\Templating\Asset\Package;
+
+/**
+ * This package attempts to return absolute URL for assets
+ *
+ * @author Roman Marintšenko <roman.marintsenko@knplabs.com>
+ */
+class AbsoluteUrlPackage extends Package
+{
+    private $context;
+    
+    /**
+     * @param RequestContext $context Request context
+     * @param string         $version The version
+     * @param string         $format  The version format
+     */
+    public function __construct(RequestContext $context, $version = null, $format = null)
+    {
+        $this->context = $context;
+        
+        parent::__construct($version, $format);
+    }
+    
+    public function getUrl($path)
+    {
+        return null;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Asset/AbsoluteUrlPackageTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Asset/AbsoluteUrlPackageTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bundle\FrameworkBundle\Tests\Templating\Asset;
+
+use Symfony\Component\Routing\RequestContext;
+use Symfony\Bundle\FrameworkBundle\Templating\Asset\AbsoluteUrlPackage;
+
+/**
+ * This package attempts to return absolute URL for assets
+ *
+ * @author Roman Marintšenko <roman.marintsenko@knplabs.com>
+ */
+class AbsoluteUrlPackageTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetUrl()
+    {
+        $package = new AbsoluteUrlPackage(new RequestContext());
+        $this->assertEquals('http://example.com/foo.js', $package->getUrl('http://example.com/foo.js'), '->getUrl() does nothing if an absolute URL is already given');
+        
+        $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com'));
+        $this->assertEquals('http://symfony.com/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends host and scheme to a given path');
+        $this->assertEquals('http://symfony.com/foo.js', $package->getUrl('/foo.js'), '->getUrl() prepends host and scheme to a given absolute path');
+
+        $package = new AbsoluteUrlPackage(new RequestContext('foo', 'GET', 'symfony.com'));
+        $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends base url to relative path');
+        $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('/foo.js'), '->getUrl() prepends base url to absolute path');
+        
+        $package = new AbsoluteUrlPackage(new RequestContext('/foo', 'GET', 'symfony.com'));
+        $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends base url with backslash at beginning to relative path');
+        
+        $package = new AbsoluteUrlPackage(new RequestContext('foo/', 'GET', 'symfony.com'));
+        $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends base url with backslash at end to relative path');
+
+        $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com', 'http', 8080));
+        $this->assertEquals('http://symfony.com:8080/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends port if it is different than 80');
+        
+        $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com', 'https', 80, 443));
+        $this->assertEquals('https://symfony.com/foo.js', $package->getUrl('foo.js'), '->getUrl() does not prepend 443 port if scheme is https');
+        
+        $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com', 'https', 80, 444));
+        $this->assertEquals('https://symfony.com:444/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends port if scheme is https and it is different than 443');
+
+        $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com'), 'abcd');
+        $this->assertEquals('http://symfony.com/foo.js?abcd', $package->getUrl('foo.js'), '->getUrl() appends the version if defined');
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Asset/AbsoluteUrlPackageTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/Asset/AbsoluteUrlPackageTest.php
@@ -25,7 +25,7 @@ class AbsoluteUrlPackageTest extends \PHPUnit_Framework_TestCase
     {
         $package = new AbsoluteUrlPackage(new RequestContext());
         $this->assertEquals('http://example.com/foo.js', $package->getUrl('http://example.com/foo.js'), '->getUrl() does nothing if an absolute URL is already given');
-        
+
         $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com'));
         $this->assertEquals('http://symfony.com/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends host and scheme to a given path');
         $this->assertEquals('http://symfony.com/foo.js', $package->getUrl('/foo.js'), '->getUrl() prepends host and scheme to a given absolute path');
@@ -33,19 +33,19 @@ class AbsoluteUrlPackageTest extends \PHPUnit_Framework_TestCase
         $package = new AbsoluteUrlPackage(new RequestContext('foo', 'GET', 'symfony.com'));
         $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends base url to relative path');
         $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('/foo.js'), '->getUrl() prepends base url to absolute path');
-        
+
         $package = new AbsoluteUrlPackage(new RequestContext('/foo', 'GET', 'symfony.com'));
         $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends base url with backslash at beginning to relative path');
-        
+
         $package = new AbsoluteUrlPackage(new RequestContext('foo/', 'GET', 'symfony.com'));
         $this->assertEquals('http://symfony.com/foo/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends base url with backslash at end to relative path');
 
         $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com', 'http', 8080));
         $this->assertEquals('http://symfony.com:8080/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends port if it is different than 80');
-        
+
         $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com', 'https', 80, 443));
         $this->assertEquals('https://symfony.com/foo.js', $package->getUrl('foo.js'), '->getUrl() does not prepend 443 port if scheme is https');
-        
+
         $package = new AbsoluteUrlPackage(new RequestContext('', 'GET', 'symfony.com', 'https', 80, 444));
         $this->assertEquals('https://symfony.com:444/foo.js', $package->getUrl('foo.js'), '->getUrl() prepends port if scheme is https and it is different than 443');
 

--- a/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
@@ -36,6 +36,7 @@ class AssetsExtension extends \Twig_Extension
     {
         return array(
             'asset' => new \Twig_Function_Method($this, 'getAssetUrl'),
+            'asset_url' => new \Twig_Function_Method($this, 'getAssetAbsoluteUrl'),
             'assets_version' => new \Twig_Function_Method($this, 'getAssetsVersion'),
         );
     }
@@ -53,6 +54,24 @@ class AssetsExtension extends \Twig_Extension
     public function getAssetUrl($path, $packageName = null)
     {
         return $this->container->get('templating.helper.assets')->getUrl($path, $packageName);
+    }
+    
+    /**
+     * Returns absolute URL for a given asset path
+     * Does not rely on assets_base_urls parameter, instead tries to match request scheme/host/port
+     * 
+     * If called from CLI, then relies on router.request_context.* parameters:
+     *   router.request_context.host
+     *   router.request_context.scheme
+     *   router.request_context.base_url
+     *
+     * @param string $path A public path
+     *
+     * @return string A public path which takes into account the base path and URL path
+     */
+    public function getAssetAbsoluteUrl($path)
+    {
+        return $this->getAssetUrl($path, 'absolute_url');
     }
 
     /**

--- a/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
@@ -55,11 +55,11 @@ class AssetsExtension extends \Twig_Extension
     {
         return $this->container->get('templating.helper.assets')->getUrl($path, $packageName);
     }
-    
+
     /**
      * Returns absolute URL for a given asset path
      * Does not rely on assets_base_urls parameter, instead tries to match request scheme/host/port
-     * 
+     *
      * If called from CLI, then relies on router.request_context.* parameters:
      *   router.request_context.host
      *   router.request_context.scheme


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no |
| Fixed tickets | #5322 |
| License | MIT |
| Doc PR | - |

This adds support for `asset_url` helper function, which returns asset absolute url, matching schema, host & port with server one. 

Relies on `RequestContext` class, so if request is made from CLI then `router.request_context.*` parameters are needed.

I've also added package alias called `absolute_url`, so a developer can use it inside `asset` function. 
I think it's useful when `assets_base_urls` parameter is used on production and simple absolute url is needed on dev. 
Then a twig variable can be used, defined to be `absolute_url` on dev or `null` on prod.
