### PR TITLE
Refactored tests of Request::getTrustedProxies()

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -682,7 +682,7 @@ class Request
 
         $trustedProxies = !self::$trustedProxies ? array($ip) : self::$trustedProxies;
         $ip = $clientIps[0];
-        $clientIps = array_diff($clientIps, $trustedProxies);
+        $clientIps = array_values(array_diff($clientIps, $trustedProxies));
 
         return $clientIps ? $clientIps : array($ip);
     }

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -35,8 +35,6 @@ class Request
     const HEADER_CLIENT_PROTO = 'client_proto';
     const HEADER_CLIENT_PORT  = 'client_port';
 
-    protected static $trustProxy = false;
-
     protected static $trustedProxies = array();
 
     /**
@@ -476,7 +474,6 @@ class Request
     public static function setTrustedProxies(array $proxies)
     {
         self::$trustedProxies = $proxies;
-        self::$trustProxy = $proxies ? true : false;
     }
 
     /**
@@ -672,7 +669,7 @@ class Request
     {
         $ip = $this->server->get('REMOTE_ADDR');
 
-        if (!self::$trustProxy) {
+        if (!self::$trustedProxies) {
             return array($ip);
         }
 
@@ -683,7 +680,7 @@ class Request
         $clientIps = array_map('trim', explode(',', $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_IP])));
         $clientIps[] = $ip;
 
-        $trustedProxies = self::$trustProxy && !self::$trustedProxies ? array($ip) : self::$trustedProxies;
+        $trustedProxies = !self::$trustedProxies ? array($ip) : self::$trustedProxies;
         $ip = $clientIps[0];
         $clientIps = array_diff($clientIps, $trustedProxies);
 
@@ -827,7 +824,7 @@ class Request
      */
     public function getPort()
     {
-        if (self::$trustProxy && self::$trustedHeaders[self::HEADER_CLIENT_PORT] && $port = $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_PORT])) {
+        if (self::$trustedProxies && self::$trustedHeaders[self::HEADER_CLIENT_PORT] && $port = $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_PORT])) {
             return $port;
         }
 
@@ -988,7 +985,7 @@ class Request
      */
     public function isSecure()
     {
-        if (self::$trustProxy && self::$trustedHeaders[self::HEADER_CLIENT_PROTO] && $proto = $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_PROTO])) {
+        if (self::$trustedProxies && self::$trustedHeaders[self::HEADER_CLIENT_PROTO] && $proto = $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_PROTO])) {
             return in_array(strtolower($proto), array('https', 'on', '1'));
         }
 
@@ -1014,7 +1011,7 @@ class Request
      */
     public function getHost()
     {
-        if (self::$trustProxy && self::$trustedHeaders[self::HEADER_CLIENT_HOST] && $host = $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_HOST])) {
+        if (self::$trustedProxies && self::$trustedHeaders[self::HEADER_CLIENT_HOST] && $host = $this->headers->get(self::$trustedHeaders[self::HEADER_CLIENT_HOST])) {
             $elements = explode(',', $host);
 
             $host = $elements[count($elements) - 1];

--- a/src/Symfony/Component/HttpFoundation/Request.php
+++ b/src/Symfony/Component/HttpFoundation/Request.php
@@ -661,6 +661,12 @@ class Request
     /**
      * Returns the client IP addresses.
      *
+     * The most trusted IP address is first, and the less trusted one last.
+     * The "real" client IP address is the last one, but this is also the
+     * less trusted one.
+     *
+     * Use this method carefully; you should use getClientIp() instead.
+     *
      * @return array The client IP addresses
      *
      * @see getClientIp()
@@ -684,7 +690,7 @@ class Request
         $ip = $clientIps[0];
         $clientIps = array_values(array_diff($clientIps, $trustedProxies));
 
-        return $clientIps ? $clientIps : array($ip);
+        return $clientIps ? array_reverse($clientIps) : array($ip);
     }
 
     /**
@@ -711,7 +717,7 @@ class Request
     {
         $ipAddresses = $this->getClientIps();
 
-        return array_pop($ipAddresses);
+        return $ipAddresses[0];
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -666,7 +666,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $request->initialize(array(), array(), array(), array(), array(), array('SERVER_NAME' => 'www.exemple.com', 'HTTP_HOST' => 'www.host.com'));
         $this->assertEquals('www.host.com', $request->getHost(), '->getHost() value from Host header has priority over SERVER_NAME ');
-        $this->stopTrustingProxyData();
     }
 
     /**
@@ -1275,14 +1274,6 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array('fo+o/bar', 'fo+o', 'fo+o'),
             array('fo%2Bo/bar', 'fo+o', 'fo%2Bo'),
         );
-    }
-
-    private function stopTrustingProxyData()
-    {
-        $class = new \ReflectionClass('Symfony\\Component\\HttpFoundation\\Request');
-        $property = $class->getProperty('trustProxy');
-        $property->setAccessible(true);
-        $property->setValue(false);
     }
 
     private function disableHttpMethodParameterOverride()

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -740,9 +740,9 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider testGetClientIpProvider
      */
-    public function testGetClientIp($expected, $proxy, $remoteAddr, $httpForwardedFor, $trustedProxies)
+    public function testGetClientIp($expected, $remoteAddr, $httpForwardedFor, $trustedProxies)
     {
-        $request = $this->getRequestInstanceForClientIpTests($proxy, $remoteAddr, $httpForwardedFor, $trustedProxies);
+        $request = $this->getRequestInstanceForClientIpTests($remoteAddr, $httpForwardedFor, $trustedProxies);
 
         $this->assertEquals($expected, $request->getClientIp());
 
@@ -752,27 +752,26 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testGetClientIpProvider()
     {
         return array(
-            array('88.88.88.88',              false, '88.88.88.88',  null,                                  null),
-            array('88.88.88.88',              true,  '88.88.88.88',  null,                                  null),
-            array('127.0.0.1',                false, '127.0.0.1',    null,                                  null),
-            array('::1',                      false, '::1',          null,                                  null),
-            array('127.0.0.1',                false, '127.0.0.1',    '88.88.88.88',                         null),
-            array('88.88.88.88',              true,  '127.0.0.1',    '88.88.88.88',                         null),
-            array('2620:0:1cfe:face:b00c::3', true,  '::1',          '2620:0:1cfe:face:b00c::3',            null),
-            array('88.88.88.88',              true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', null),
-            array('87.65.43.21',              true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
-            array('87.65.43.21',              false, '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
-            array('88.88.88.88',              true,  '123.45.67.89', '88.88.88.88',                         array('123.45.67.89', '88.88.88.88')),
-            array('88.88.88.88',              false, '123.45.67.89', '88.88.88.88',                         array('123.45.67.89', '88.88.88.88')),
+            //    $expected                   $remoteAddr     $httpForwardedFor                      $trustedProxies
+            array('88.88.88.88',              '88.88.88.88',  null,                                  null),
+            array('88.88.88.88',              '88.88.88.88',  null,                                  array('88.88.88.88')),
+            array('127.0.0.1',                '127.0.0.1',    null,                                  null),
+            array('::1',                      '::1',          null,                                  null),
+            array('127.0.0.1',                '127.0.0.1',    '88.88.88.88',                         null),
+            array('88.88.88.88',              '127.0.0.1',    '88.88.88.88',                         array('127.0.0.1')),
+            array('2620:0:1cfe:face:b00c::3', '::1',          '2620:0:1cfe:face:b00c::3',            array('::1')),
+            array('88.88.88.88',              '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89')),
+            array('87.65.43.21',              '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+            array('88.88.88.88',              '123.45.67.89', '88.88.88.88',                         array('123.45.67.89', '88.88.88.88')),
         );
     }
 
     /**
      * @dataProvider testGetClientIpsProvider
      */
-    public function testGetClientIps($expected, $proxy, $remoteAddr, $httpForwardedFor, $trustedProxies)
+    public function testGetClientIps($expected, $remoteAddr, $httpForwardedFor, $trustedProxies)
     {
-        $request = $this->getRequestInstanceForClientIpTests($proxy, $remoteAddr, $httpForwardedFor, $trustedProxies);
+        $request = $this->getRequestInstanceForClientIpTests($remoteAddr, $httpForwardedFor, $trustedProxies);
 
         $this->assertEquals($expected, $request->getClientIps());
 
@@ -782,15 +781,15 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     public function testGetClientIpsProvider()
     {
         return array(
-            array(array('88.88.88.88'),                             false, '88.88.88.88',  null,                                  null),
-            array(array('127.0.0.1'),                               false, '127.0.0.1',    null,                                  null),
-            array(array('::1'),                                     false, '::1',          null,                                  null),
-            array(array('127.0.0.1'),                               false, '127.0.0.1',    '88.88.88.88',                         null),
-            array(array('88.88.88.88'),                             true,  '127.0.0.1',    '88.88.88.88',                         null),
-            array(array('2620:0:1cfe:face:b00c::3'),                true,  '::1',          '2620:0:1cfe:face:b00c::3',            null),
-            array(array('127.0.0.1', '87.65.43.21', '88.88.88.88'), true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', null),
-            array(array('127.0.0.1', '87.65.43.21'),                true,  '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
-            array(array('127.0.0.1', '87.65.43.21'),                false, '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+            //    $expected                                         $remoteAddr     $httpForwardedFor                      $trustedProxies
+            array(array('88.88.88.88'),                             '88.88.88.88',  null,                                  null),
+            array(array('127.0.0.1'),                               '127.0.0.1',    null,                                  null),
+            array(array('::1'),                                     '::1',          null,                                  null),
+            array(array('127.0.0.1'),                               '127.0.0.1',    '88.88.88.88',                         null),
+            array(array('88.88.88.88'),                             '127.0.0.1',    '88.88.88.88',                         array('127.0.0.1')),
+            array(array('2620:0:1cfe:face:b00c::3'),                '::1',          '2620:0:1cfe:face:b00c::3',            array('::1')),
+            array(array('127.0.0.1', '87.65.43.21', '88.88.88.88'), '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89')),
+            array(array('127.0.0.1', '87.65.43.21'),                '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
         );
     }
 
@@ -1284,7 +1283,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
         $property->setValue(false);
     }
 
-    private function getRequestInstanceForClientIpTests($proxy, $remoteAddr, $httpForwardedFor, $trustedProxies)
+    private function getRequestInstanceForClientIpTests($remoteAddr, $httpForwardedFor, $trustedProxies)
     {
         $request = new Request();
 
@@ -1293,8 +1292,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             $server['HTTP_X_FORWARDED_FOR'] = $httpForwardedFor;
         }
 
-        if ($proxy || $trustedProxies) {
-            Request::setTrustedProxies(null === $trustedProxies ? array($remoteAddr) : $trustedProxies);
+        if ($trustedProxies) {
+            Request::setTrustedProxies($trustedProxies);
         }
 
         $request->initialize(array(), array(), array(), array(), array(), $server);

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -744,7 +744,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = $this->getRequestInstanceForClientIpTests($remoteAddr, $httpForwardedFor, $trustedProxies);
 
-        $this->assertEquals(array_pop($expected), $request->getClientIp());
+        $this->assertEquals($expected[0], $request->getClientIp());
 
         Request::setTrustedProxies(array());
     }
@@ -779,6 +779,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array(array('127.0.0.1'),                '127.0.0.1',                '88.88.88.88',               null),
             // forwarded for with remote IPv4 addr trusted
             array(array('88.88.88.88'),              '127.0.0.1',                '88.88.88.88',               array('127.0.0.1')),
+            // forwarded for with remote IPv4 and all FF addrs trusted
+            array(array('88.88.88.88'),              '127.0.0.1',                '88.88.88.88',               array('127.0.0.1', '88.88.88.88')),
 
             // forwarded for with remote IPv6 addr not trusted
             array(array('1620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3',  null),
@@ -786,18 +788,20 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             array(array('2620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3',  array('1620:0:1cfe:face:b00c::3')),
 
             // multiple forwarded for with remote IPv4 addr trusted
-            array(array('127.0.0.1', '87.65.43.21', '88.88.88.88'), '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89')),
+            array(array('88.88.88.88', '87.65.43.21', '127.0.0.1'), '123.45.67.89', '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89')),
             // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted
-            array(array('127.0.0.1', '87.65.43.21'), '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
+            array(array('87.65.43.21', '127.0.0.1'), '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '88.88.88.88')),
             // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted but in the middle
-            array(array('127.0.0.1', '88.88.88.88'), '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '87.65.43.21')),
+            array(array('88.88.88.88', '127.0.0.1'), '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '87.65.43.21')),
+            // multiple forwarded for with remote IPv4 addr and all reverse proxies trusted
+            array(array('127.0.0.1'),                '123.45.67.89',             '127.0.0.1, 87.65.43.21, 88.88.88.88', array('123.45.67.89', '87.65.43.21', '88.88.88.88', '127.0.0.1')),
 
             // multiple forwarded for with remote IPv6 addr trusted
-            array(array('3620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3')),
+            array(array('2620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3')),
             // multiple forwarded for with remote IPv6 addr and some reverse proxies trusted
             array(array('3620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3')),
             // multiple forwarded for with remote IPv4 addr and some reverse proxies trusted but in the middle
-            array(array('4620:0:1cfe:face:b00c::3', '2620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '4620:0:1cfe:face:b00c::3,3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3')),
+            array(array('2620:0:1cfe:face:b00c::3', '4620:0:1cfe:face:b00c::3'), '1620:0:1cfe:face:b00c::3', '4620:0:1cfe:face:b00c::3,3620:0:1cfe:face:b00c::3,2620:0:1cfe:face:b00c::3', array('1620:0:1cfe:face:b00c::3', '3620:0:1cfe:face:b00c::3')),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This PR reorganizes the tests for the request trusted proxies as they were unreadable. In the process, I've also removed obsolete stuff and changed the order returned by `Request::getClientIps()` (not a BC break as this method was added in 2.3 -- see #7612).
