### PR TITLE
[Form] Deprecated bind() and isBound() in favor of submit() and isSubmitted()

### DIFF
--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -20,9 +20,25 @@ UPGRADE FROM 2.x to 3.0
 
 ### Form
 
- * Passing a `Symfony\Component\HttpFoundation\Request` instance to
-   `FormInterface::bind()` was disabled. You should use
-   `FormInterface::handleRequest()` instead.
+ * The methods `Form::bind()` and `Form::isBound()` were removed. You should
+   use `Form::submit()` and `Form::isSubmitted()` instead.
+
+   Before:
+
+   ```
+   $form->bind(array(...));
+   ```
+
+   After:
+
+   ```
+   $form->submit(array(...));
+   ```
+
+ * Passing a `Symfony\Component\HttpFoundation\Request` instance, as was
+   supported by `FormInterface::bind()`, is not possible with
+   `FormInterface::submit()` anymore. You should use `FormInterface::handleRequest()`
+   instead.
 
    Before:
 
@@ -39,7 +55,7 @@ UPGRADE FROM 2.x to 3.0
    After:
 
    ```
-   $form->handleRequest();
+   $form->handleRequest($request);
 
    if ($form->isValid()) {
        // ...
@@ -47,18 +63,37 @@ UPGRADE FROM 2.x to 3.0
    ```
 
    If you want to test whether the form was submitted separately, you can use
-   the method `isBound()`:
+   the method `isSubmitted()`:
 
    ```
-   $form->handleRequest();
+   $form->handleRequest($request);
 
-   if ($form->isBound()) {
+   if ($form->isSubmitted()) {
       // ...
 
       if ($form->isValid()) {
           // ...
       }
    }
+   ```
+
+ * The events PRE_BIND, BIND and POST_BIND were renamed to PRE_SUBMIT, SUBMIT
+   and POST_SUBMIT.
+
+   Before:
+
+   ```
+   $builder->addEventListener(FormEvents::PRE_BIND, function (FormEvent $event) {
+       // ...
+   });
+   ```
+
+   After:
+
+   ```
+   $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+       // ...
+   });
    ```
 
  * The option "virtual" was renamed to "inherit_data".

--- a/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
+++ b/src/Symfony/Bridge/Doctrine/Form/EventListener/MergeDoctrineCollectionListener.php
@@ -30,7 +30,7 @@ class MergeDoctrineCollectionListener implements EventSubscriberInterface
     {
         // Higher priority than core MergeCollectionListener so that this one
         // is called before
-        return array(FormEvents::BIND => array('onBind', 10));
+        return array(FormEvents::SUBMIT => array('onBind', 10));
     }
 
     public function onBind(FormEvent $event)

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -196,7 +196,7 @@ class EntityTypeTest extends TypeTestCase
             },
         ));
 
-        $field->bind('2');
+        $field->submit('2');
     }
 
     public function testSetDataSingleNull()
@@ -248,7 +248,7 @@ class EntityTypeTest extends TypeTestCase
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
         ));
-        $field->bind(null);
+        $field->submit(null);
 
         $this->assertNull($field->getData());
         $this->assertSame(array(), $field->getViewData());
@@ -262,7 +262,7 @@ class EntityTypeTest extends TypeTestCase
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
         ));
-        $field->bind(null);
+        $field->submit(null);
 
         $this->assertNull($field->getData());
         $this->assertSame('', $field->getViewData());
@@ -275,7 +275,7 @@ class EntityTypeTest extends TypeTestCase
             'em' => 'default',
             'class' => self::SINGLE_IDENT_CLASS,
         ));
-        $field->bind(null);
+        $field->submit(null);
 
         $this->assertEquals(new ArrayCollection(), $field->getData());
         $this->assertSame(array(), $field->getViewData());
@@ -296,7 +296,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('2');
+        $field->submit('2');
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
@@ -319,7 +319,7 @@ class EntityTypeTest extends TypeTestCase
         ));
 
         // the collection key is used here
-        $field->bind('1');
+        $field->submit('1');
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
@@ -342,7 +342,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind(array('1', '3'));
+        $field->submit(array('1', '3'));
 
         $expected = new ArrayCollection(array($entity1, $entity3));
 
@@ -370,7 +370,7 @@ class EntityTypeTest extends TypeTestCase
         $existing = new ArrayCollection(array(0 => $entity2));
 
         $field->setData($existing);
-        $field->bind(array('1', '3'));
+        $field->submit(array('1', '3'));
 
         // entry with index 0 ($entity2) was replaced
         $expected = new ArrayCollection(array(0 => $entity1, 1 => $entity3));
@@ -399,7 +399,7 @@ class EntityTypeTest extends TypeTestCase
         ));
 
         // because of the composite key collection keys are used
-        $field->bind(array('0', '2'));
+        $field->submit(array('0', '2'));
 
         $expected = new ArrayCollection(array($entity1, $entity3));
 
@@ -427,7 +427,7 @@ class EntityTypeTest extends TypeTestCase
         $existing = new ArrayCollection(array(0 => $entity2));
 
         $field->setData($existing);
-        $field->bind(array('0', '2'));
+        $field->submit(array('0', '2'));
 
         // entry with index 0 ($entity2) was replaced
         $expected = new ArrayCollection(array(0 => $entity1, 1 => $entity3));
@@ -454,7 +454,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('2');
+        $field->submit('2');
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity2, $field->getData());
@@ -480,7 +480,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind(array('1', '3'));
+        $field->submit(array('1', '3'));
 
         $expected = new ArrayCollection(array($entity1, $entity3));
 
@@ -510,7 +510,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('2');
+        $field->submit('2');
 
         $this->assertEquals(array(1 => new ChoiceView($entity1, '1', 'Foo'), 2 => new ChoiceView($entity2, '2', 'Bar')), $field->createView()->vars['choices']);
         $this->assertTrue($field->isSynchronized());
@@ -535,7 +535,7 @@ class EntityTypeTest extends TypeTestCase
             'group_by' => 'groupName',
         ));
 
-        $field->bind('2');
+        $field->submit('2');
 
         $this->assertSame('2', $field->getViewData());
         $this->assertEquals(array(
@@ -599,7 +599,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('3');
+        $field->submit('3');
 
         $this->assertFalse($field->isSynchronized());
         $this->assertNull($field->getData());
@@ -620,7 +620,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('2');
+        $field->submit('2');
 
         $this->assertFalse($field->isSynchronized());
         $this->assertNull($field->getData());
@@ -644,7 +644,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('3');
+        $field->submit('3');
 
         $this->assertFalse($field->isSynchronized());
         $this->assertNull($field->getData());
@@ -668,7 +668,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('3');
+        $field->submit('3');
 
         $this->assertFalse($field->isSynchronized());
         $this->assertNull($field->getData());
@@ -692,7 +692,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('2');
+        $field->submit('2');
 
         $this->assertFalse($field->isSynchronized());
         $this->assertNull($field->getData());
@@ -712,7 +712,7 @@ class EntityTypeTest extends TypeTestCase
             'property' => 'name',
         ));
 
-        $field->bind('foo');
+        $field->submit('foo');
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity1, $field->getData());
@@ -734,7 +734,7 @@ class EntityTypeTest extends TypeTestCase
         ));
 
         // the collection key is used here
-        $field->bind('0');
+        $field->submit('0');
 
         $this->assertTrue($field->isSynchronized());
         $this->assertSame($entity1, $field->getData());

--- a/src/Symfony/Component/Form/Button.php
+++ b/src/Symfony/Component/Form/Button.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Component\Form;
 
-use Symfony\Component\Form\Exception\AlreadyBoundException;
+use Symfony\Component\Form\Exception\AlreadySubmittedException;
 use Symfony\Component\Form\Exception\BadMethodCallException;
 
 /**
@@ -34,7 +34,7 @@ class Button implements \IteratorAggregate, FormInterface
     /**
      * @var Boolean
      */
-    private $bound = false;
+    private $submitted = false;
 
     /**
      * Creates a new button from a form configuration.
@@ -258,9 +258,9 @@ class Button implements \IteratorAggregate, FormInterface
      *
      * @return Boolean true if the button was submitted.
      */
-    public function isBound()
+    public function isSubmitted()
     {
-        return $this->bound;
+        return $this->submitted;
     }
 
     /**
@@ -356,21 +356,21 @@ class Button implements \IteratorAggregate, FormInterface
     }
 
     /**
-     * Binds data to the button.
+     * Submits data to the button.
      *
      * @param null|string $submittedData The data
      *
      * @return Button The button instance
      *
-     * @throws Exception\AlreadyBoundException If the form has already been bound.
+     * @throws Exception\AlreadySubmittedException If the button has already been submitted.
      */
-    public function bind($submittedData)
+    public function submit($submittedData)
     {
-        if ($this->bound) {
-            throw new AlreadyBoundException('A form can only be bound once');
+        if ($this->submitted) {
+            throw new AlreadySubmittedException('A form can only be submitted once');
         }
 
-        $this->bound = true;
+        $this->submitted = true;
 
         return $this;
     }

--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -18,6 +18,12 @@ CHANGELOG
  * added component-level exceptions for various SPL exceptions
    changed all uses of the deprecated Exception class to use more specialized exceptions instead
    removed NotInitializedException, NotValidException, TypeDefinitionException, TypeLoaderException, CreationException
+ * added events PRE_SUBMIT, SUBMIT and POST_SUBMIT
+ * deprecated events PRE_BIND, BIND and POST_BIND
+ * [BC BREAK] renamed bind() and isBound() in FormInterface to submit() and isSubmitted()
+ * added methods submit() and isSubmitted() to Form
+ * deprecated bind() and isBound() in Form
+ * deprecated AlreadyBoundException in favor of AlreadySubmittedException
 
 2.2.0
 -----

--- a/src/Symfony/Component/Form/DataTransformerInterface.php
+++ b/src/Symfony/Component/Form/DataTransformerInterface.php
@@ -24,9 +24,9 @@ interface DataTransformerInterface
      * This method is called on two occasions inside a form field:
      *
      * 1. When the form field is initialized with the data attached from the datasource (object or array).
-     * 2. When data from a request is bound using {@link Form::bind()} to transform the new input data
-     *    back into the renderable format. For example if you have a date field and bind '2009-10-10' onto
-     *    it you might accept this value because its easily parsed, but the transformer still writes back
+     * 2. When data from a request is submitted using {@link Form::submit()} to transform the new input data
+     *    back into the renderable format. For example if you have a date field and submit '2009-10-10'
+     *    you might accept this value because its easily parsed, but the transformer still writes back
      *    "2009/10/10" onto the form field (for further displaying or other purposes).
      *
      * This method must be able to deal with empty values. Usually this will
@@ -52,7 +52,7 @@ interface DataTransformerInterface
      * Transforms a value from the transformed representation to its original
      * representation.
      *
-     * This method is called when {@link Form::bind()} is called to transform the requests tainted data
+     * This method is called when {@link Form::submit()} is called to transform the requests tainted data
      * into an acceptable format for your data processing/model layer.
      *
      * This method must be able to deal with empty values. Usually this will

--- a/src/Symfony/Component/Form/Exception/AlreadySubmittedException.php
+++ b/src/Symfony/Component/Form/Exception/AlreadySubmittedException.php
@@ -12,11 +12,11 @@
 namespace Symfony\Component\Form\Exception;
 
 /**
- * Alias of {@link AlreadySubmittedException}.
+ * Thrown when an operation is called that is not acceptable after submitting
+ * a form.
  *
- * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
- *             {@link AlreadySubmittedException} instead.
+ * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class AlreadyBoundException extends LogicException
+class AlreadySubmittedException extends AlreadyBoundException
 {
 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixCheckboxInputListener.php
@@ -36,7 +36,7 @@ class FixCheckboxInputListener implements EventSubscriberInterface
         $this->choiceList = $choiceList;
     }
 
-    public function preBind(FormEvent $event)
+    public function preSubmit(FormEvent $event)
     {
         $values = (array) $event->getData();
         $indices = $this->choiceList->getIndicesForValues($values);
@@ -44,8 +44,19 @@ class FixCheckboxInputListener implements EventSubscriberInterface
         $event->setData(count($indices) > 0 ? array_combine($indices, $values) : array());
     }
 
+    /**
+     * Alias of {@link preSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link preSubmit()} instead.
+     */
+    public function preBind(FormEvent $event)
+    {
+        $this->preSubmit($event);
+    }
+
     public static function getSubscribedEvents()
     {
-        return array(FormEvents::PRE_BIND => 'preBind');
+        return array(FormEvents::PRE_SUBMIT => 'preSubmit');
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixRadioInputListener.php
@@ -36,7 +36,7 @@ class FixRadioInputListener implements EventSubscriberInterface
         $this->choiceList = $choiceList;
     }
 
-    public function preBind(FormEvent $event)
+    public function preSubmit(FormEvent $event)
     {
         $value = $event->getData();
         $index = current($this->choiceList->getIndicesForValues(array($value)));
@@ -44,8 +44,19 @@ class FixRadioInputListener implements EventSubscriberInterface
         $event->setData(false !== $index ? array($index => $value) : array());
     }
 
+    /**
+     * Alias of {@link preSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link preSubmit()} instead.
+     */
+    public function preBind(FormEvent $event)
+    {
+        $this->preSubmit($event);
+    }
+
     public static function getSubscribedEvents()
     {
-        return array(FormEvents::PRE_BIND => 'preBind');
+        return array(FormEvents::PRE_SUBMIT => 'preSubmit');
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/FixUrlProtocolListener.php
@@ -29,7 +29,7 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         $this->defaultProtocol = $defaultProtocol;
     }
 
-    public function onBind(FormEvent $event)
+    public function onSubmit(FormEvent $event)
     {
         $data = $event->getData();
 
@@ -38,8 +38,19 @@ class FixUrlProtocolListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * Alias of {@link onSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link onSubmit()} instead.
+     */
+    public function onBind(FormEvent $event)
+    {
+        $this->onSubmit($event);
+    }
+
     public static function getSubscribedEvents()
     {
-        return array(FormEvents::BIND => 'onBind');
+        return array(FormEvents::SUBMIT => 'onSubmit');
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/MergeCollectionListener.php
@@ -50,11 +50,11 @@ class MergeCollectionListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            FormEvents::BIND => 'onBind',
+            FormEvents::SUBMIT => 'onSubmit',
         );
     }
 
-    public function onBind(FormEvent $event)
+    public function onSubmit(FormEvent $event)
     {
         $dataToMergeInto = $event->getForm()->getNormData();
         $data = $event->getData();
@@ -122,5 +122,17 @@ class MergeCollectionListener implements EventSubscriberInterface
         }
 
         $event->setData($dataToMergeInto);
+    }
+
+
+    /**
+     * Alias of {@link onSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link onSubmit()} instead.
+     */
+    public function onBind(FormEvent $event)
+    {
+        $this->onSubmit($event);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/ResizeFormListener.php
@@ -57,9 +57,9 @@ class ResizeFormListener implements EventSubscriberInterface
     {
         return array(
             FormEvents::PRE_SET_DATA => 'preSetData',
-            FormEvents::PRE_BIND => 'preBind',
+            FormEvents::PRE_SUBMIT => 'preSubmit',
             // (MergeCollectionListener, MergeDoctrineCollectionListener)
-            FormEvents::BIND => array('onBind', 50),
+            FormEvents::SUBMIT => array('onSubmit', 50),
         );
     }
 
@@ -89,7 +89,7 @@ class ResizeFormListener implements EventSubscriberInterface
         }
     }
 
-    public function preBind(FormEvent $event)
+    public function preSubmit(FormEvent $event)
     {
         $form = $event->getForm();
         $data = $event->getData();
@@ -123,7 +123,7 @@ class ResizeFormListener implements EventSubscriberInterface
         }
     }
 
-    public function onBind(FormEvent $event)
+    public function onSubmit(FormEvent $event)
     {
         $form = $event->getForm();
         $data = $event->getData();
@@ -147,5 +147,28 @@ class ResizeFormListener implements EventSubscriberInterface
         }
 
         $event->setData($data);
+    }
+
+
+    /**
+     * Alias of {@link preSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link preSubmit()} instead.
+     */
+    public function preBind(FormEvent $event)
+    {
+        $this->preSubmit($event);
+    }
+
+    /**
+     * Alias of {@link onSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link onSubmit()} instead.
+     */
+    public function onBind(FormEvent $event)
+    {
+        $this->onSubmit($event);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
+++ b/src/Symfony/Component/Form/Extension/Core/EventListener/TrimListener.php
@@ -22,7 +22,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class TrimListener implements EventSubscriberInterface
 {
-    public function preBind(FormEvent $event)
+    public function preSubmit(FormEvent $event)
     {
         $data = $event->getData();
 
@@ -37,8 +37,19 @@ class TrimListener implements EventSubscriberInterface
         }
     }
 
+    /**
+     * Alias of {@link preSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link preSubmit()} instead.
+     */
+    public function preBind(FormEvent $event)
+    {
+        $this->preSubmit($event);
+    }
+
     public static function getSubscribedEvents()
     {
-        return array(FormEvents::PRE_BIND => 'preBind');
+        return array(FormEvents::PRE_SUBMIT => 'preSubmit');
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -86,7 +86,7 @@ class FormType extends BaseType
         $view->vars = array_replace($view->vars, array(
             'read_only'  => $readOnly,
             'errors'     => $form->getErrors(),
-            'valid'      => $form->isBound() ? $form->isValid() : true,
+            'valid'      => $form->isSubmitted() ? $form->isValid() : true,
             'value'      => $form->getViewData(),
             'data'       => $form->getNormData(),
             'required'   => $form->isRequired(),

--- a/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/PasswordType.php
@@ -23,7 +23,7 @@ class PasswordType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        if ($options['always_empty'] || !$form->isBound()) {
+        if ($options['always_empty'] || !$form->isSubmitted()) {
             $view->vars['value'] = '';
         }
     }

--- a/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderInterface.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderInterface.php
@@ -22,7 +22,7 @@ namespace Symfony\Component\Form\Extension\Csrf\CsrfProvider;
  *
  * If you want to secure a form submission against CSRF attacks, you could
  * supply an "intention" string. This way you make sure that the form can only
- * be bound to pages that are designed to handle the form, that is, that use
+ * be submitted to pages that are designed to handle the form, that is, that use
  * the same intention string to validate the CSRF token with isCsrfTokenValid().
  *
  * @author Bernhard Schussek <bschussek@gmail.com>

--- a/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Csrf/EventListener/CsrfValidationListener.php
@@ -47,7 +47,7 @@ class CsrfValidationListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            FormEvents::PRE_BIND => 'preBind',
+            FormEvents::PRE_SUBMIT => 'preSubmit',
         );
     }
 
@@ -58,7 +58,7 @@ class CsrfValidationListener implements EventSubscriberInterface
         $this->intention = $intention;
     }
 
-    public function preBind(FormEvent $event)
+    public function preSubmit(FormEvent $event)
     {
         $form = $event->getForm();
         $data = $event->getData();
@@ -74,5 +74,16 @@ class CsrfValidationListener implements EventSubscriberInterface
         }
 
         $event->setData($data);
+    }
+
+    /**
+     * Alias of {@link preSubmit()}.
+     *
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link preSubmit()} instead.
+     */
+    public function preBind(FormEvent $event)
+    {
+        $this->preSubmit($event);
     }
 }

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/EventListener/BindRequestListener.php
@@ -44,7 +44,7 @@ class BindRequestListener implements EventSubscriberInterface
         }
 
         // Uncomment this as soon as the deprecation note should be shown
-        // trigger_error('Passing a Request instance to Form::bind() is deprecated since version 2.3 and will be disabled in 3.0. Call Form::process($request) instead.', E_USER_DEPRECATED);
+        // trigger_error('Passing a Request instance to Form::submit() is deprecated since version 2.3 and will be disabled in 3.0. Call Form::process($request) instead.', E_USER_DEPRECATED);
 
         $name = $form->getConfig()->getName();
         $default = $form->getConfig()->getCompound() ? array() : null;

--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -45,7 +45,7 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             if ('' === $name) {
                 $data = $request->query->all();
             } else {
-                // Don't bind GET requests if the form's name does not exist
+                // Don't submit GET requests if the form's name does not exist
                 // in the request
                 if (!$request->query->has($name)) {
                     return;
@@ -70,11 +70,11 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             }
         }
 
-        // Don't auto-bind the form unless at least one field is submitted.
+        // Don't auto-submit the form unless at least one field is present.
         if ('' === $name && count(array_intersect_key($data, $form->all())) <= 0) {
             return;
         }
 
-        $form->bind($data);
+        $form->submit($data);
     }
 }

--- a/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
+++ b/src/Symfony/Component/Form/Extension/Validator/EventListener/ValidationListener.php
@@ -32,7 +32,7 @@ class ValidationListener implements EventSubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(FormEvents::POST_BIND => 'validateForm');
+        return array(FormEvents::POST_SUBMIT => 'validateForm');
     }
 
     public function __construct(ValidatorInterface $validator, ViolationMapperInterface $violationMapper)

--- a/src/Symfony/Component/Form/FormConfigBuilderInterface.php
+++ b/src/Symfony/Component/Form/FormConfigBuilderInterface.php
@@ -122,7 +122,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setDisabled($disabled);
 
     /**
-     * Sets the data used for the client data when no value is bound.
+     * Sets the data used for the client data when no value is submitted.
      *
      * @param mixed $emptyData The empty data.
      *
@@ -140,7 +140,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
     public function setErrorBubbling($errorBubbling);
 
     /**
-     * Sets whether this field is required to be filled out when bound.
+     * Sets whether this field is required to be filled out when submitted.
      *
      * @param Boolean $required
      *
@@ -222,7 +222,7 @@ interface FormConfigBuilderInterface extends FormConfigInterface
      *
      * A form with locked data is restricted to the data passed in
      * this configuration. The data can only be modified then by
-     * binding the form.
+     * submitting the form.
      *
      * @param Boolean $locked Whether to lock the default data.
      *

--- a/src/Symfony/Component/Form/FormConfigInterface.php
+++ b/src/Symfony/Component/Form/FormConfigInterface.php
@@ -173,7 +173,7 @@ interface FormConfigInterface
      *
      * A form with locked data is restricted to the data passed in
      * this configuration. The data can only be modified then by
-     * binding the form.
+     * submitting the form.
      *
      * @return Boolean Whether the data is locked.
      */

--- a/src/Symfony/Component/Form/FormEvents.php
+++ b/src/Symfony/Component/Form/FormEvents.php
@@ -15,15 +15,33 @@ namespace Symfony\Component\Form;
  */
 final class FormEvents
 {
-    const PRE_BIND = 'form.pre_bind';
+    const PRE_SUBMIT = 'form.pre_bind';
 
-    const BIND = 'form.bind';
+    const SUBMIT = 'form.bind';
 
-    const POST_BIND = 'form.post_bind';
+    const POST_SUBMIT = 'form.post_bind';
 
     const PRE_SET_DATA = 'form.pre_set_data';
 
     const POST_SET_DATA = 'form.post_set_data';
+
+    /**
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link PRE_SUBMIT} instead.
+     */
+    const PRE_BIND = 'form.pre_bind';
+
+    /**
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link SUBMIT} instead.
+     */
+    const BIND = 'form.bind';
+
+    /**
+     * @deprecated Deprecated since version 2.3, to be removed in 3.0. Use
+     *             {@link POST_SUBMIT} instead.
+     */
+    const POST_BIND = 'form.post_bind';
 
     private function __construct()
     {

--- a/src/Symfony/Component/Form/FormInterface.php
+++ b/src/Symfony/Component/Form/FormInterface.php
@@ -25,7 +25,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadyBoundException If the form has already been bound.
+     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
      * @throws Exception\LogicException        When trying to set a parent for a form with
      *                                         an empty name.
      */
@@ -47,7 +47,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadyBoundException   If the form has already been bound.
+     * @throws Exception\AlreadySubmittedException   If the form has already been submitted.
      * @throws Exception\LogicException          When trying to add a child to a non-compound form.
      * @throws Exception\UnexpectedTypeException If $child or $type has an unexpected type.
      */
@@ -80,7 +80,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadyBoundException If the form has already been bound.
+     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
      */
     public function remove($name);
 
@@ -94,7 +94,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns all errors.
      *
-     * @return FormError[] An array of FormError instances that occurred during binding
+     * @return FormError[] An array of FormError instances that occurred during validation
      */
     public function getErrors();
 
@@ -105,7 +105,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadyBoundException If the form has already been bound.
+     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
      * @throws Exception\LogicException        If listeners try to call setData in a cycle. Or if
      *                                         the view data does not match the expected type
      *                                         according to {@link FormConfigInterface::getDataClass}.
@@ -122,8 +122,8 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the normalized data of the field.
      *
-     * @return mixed When the field is not bound, the default data is returned.
-     *               When the field is bound, the normalized bound data is
+     * @return mixed When the field is not submitted, the default data is returned.
+     *               When the field is submitted, the normalized submitted data is
      *               returned if the field is valid, null otherwise.
      */
     public function getNormData();
@@ -138,7 +138,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns the extra data.
      *
-     * @return array The bound data which do not belong to a child
+     * @return array The submitted data which do not belong to a child
      */
     public function getExtraData();
 
@@ -154,7 +154,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
      *
      * @return Boolean true if the form is submitted, false otherwise
      */
-    public function isBound();
+    public function isSubmitted();
 
     /**
      * Returns the name by which the form is identified in forms.
@@ -182,7 +182,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     /**
      * Returns whether the form and all children are valid.
      *
-     * If the form is not bound, this method always returns false.
+     * If the form is not submitted, this method always returns false.
      *
      * @return Boolean
      */
@@ -227,7 +227,7 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function isSynchronized();
 
     /**
-     * Processes the given request and binds the form if it was submitted.
+     * Processes the given request and calls {@link submit()} if it was submitted.
      *
      * Internally, the request is forwarded to a {@link RequestHandlerInterface}
      * instance. This instance determines the allowed value of the
@@ -240,15 +240,15 @@ interface FormInterface extends \ArrayAccess, \Traversable, \Countable
     public function handleRequest($request = null);
 
     /**
-     * Binds data to the form, transforms and validates it.
+     * Submits data to the form, transforms and validates it.
      *
-     * @param  null|string|array $submittedData The data
+     * @param  null|string|array $submittedData The submitted data.
      *
      * @return FormInterface The form instance
      *
-     * @throws Exception\AlreadyBoundException If the form has already been bound.
+     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
      */
-    public function bind($submittedData);
+    public function submit($submittedData);
 
     /**
      * Returns the root of the form tree.

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -55,7 +55,7 @@ class NativeRequestHandler implements RequestHandlerInterface
             if ('' === $name) {
                 $data = $_GET;
             } else {
-                // Don't bind GET requests if the form's name does not exist
+                // Don't submit GET requests if the form's name does not exist
                 // in the request
                 if (!isset($_GET[$name])) {
                     return;
@@ -85,12 +85,12 @@ class NativeRequestHandler implements RequestHandlerInterface
             }
         }
 
-        // Don't auto-bind the form unless at least one field is submitted.
+        // Don't auto-submit the form unless at least one field is present.
         if ('' === $name && count(array_intersect_key($data, $form->all())) <= 0) {
             return;
         }
 
-        $form->bind($data);
+        $form->submit($data);
     }
 
     /**

--- a/src/Symfony/Component/Form/README.md
+++ b/src/Symfony/Component/Form/README.md
@@ -1,7 +1,7 @@
 Form Component
 ==============
 
-Form provides tools for defining forms, rendering and binding request data to
+Form provides tools for defining forms, rendering and mapping request data to
 related models. Furthermore it provides integration with the Validation
 component.
 

--- a/src/Symfony/Component/Form/RequestHandlerInterface.php
+++ b/src/Symfony/Component/Form/RequestHandlerInterface.php
@@ -12,16 +12,16 @@
 namespace Symfony\Component\Form;
 
 /**
- * Binds forms from requests if they were submitted.
+ * Submits forms if they were submitted.
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
 interface RequestHandlerInterface
 {
     /**
-     * Binds a form from a request if it was submitted.
+     * Submits a form if it was submitted.
      *
-     * @param FormInterface $form    The form to bind.
+     * @param FormInterface $form    The form to submit.
      * @param mixed         $request The current request.
      */
     public function handleRequest(FormInterface $form, $request = null);

--- a/src/Symfony/Component/Form/SubmitButton.php
+++ b/src/Symfony/Component/Form/SubmitButton.php
@@ -32,17 +32,17 @@ class SubmitButton extends Button implements ClickableInterface
     }
 
     /**
-     * Binds data to the button.
+     * Submits data to the button.
      *
      * @param null|string $submittedData The data
      *
      * @return SubmitButton The button instance
      *
-     * @throws Exception\AlreadyBoundException If the form has already been bound.
+     * @throws Exception\AlreadySubmittedException If the form has already been submitted.
      */
-    public function bind($submittedData)
+    public function submit($submittedData)
     {
-        parent::bind($submittedData);
+        parent::submit($submittedData);
 
         $this->clicked = null !== $submittedData;
 

--- a/src/Symfony/Component/Form/Tests/AbstractFormTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractFormTest.php
@@ -38,7 +38,7 @@ abstract class AbstractFormTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('The "EventDispatcher" component is not available');
         }
 
-        // We need an actual dispatcher to bind the deprecated
+        // We need an actual dispatcher to use the deprecated
         // bindRequest() method
         $this->dispatcher = new EventDispatcher();
         $this->factory = $this->getMock('Symfony\Component\Form\FormFactoryInterface');

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1378,12 +1378,12 @@ abstract class AbstractLayoutTest extends \Symfony\Component\Form\Test\FormInteg
         );
     }
 
-    public function testPasswordBoundNotAlwaysEmpty()
+    public function testPasswordSubmittedWithNotAlwaysEmpty()
     {
         $form = $this->factory->createNamed('name', 'password', null, array(
             'always_empty' => false,
         ));
-        $form->bind('foo&bar');
+        $form->submit('foo&bar');
 
         $this->assertWidgetMatchesXpath($form->createView(), array(),
 '/input

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -49,7 +49,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function testBindIfNameInRequest($method)
+    public function testSubmitIfNameInRequest($method)
     {
         $form = $this->getMockForm('param1', $method);
 
@@ -58,7 +58,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('Submit')
             ->with('DATA');
 
         $this->requestHandler->handleRequest($form, $this->request);
@@ -67,7 +67,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function testDoNotBindIfWrongRequestMethod($method)
+    public function testDoNotSubmitIfWrongRequestMethod($method)
     {
         $form = $this->getMockForm('param1', $method);
 
@@ -78,7 +78,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->never())
-            ->method('bind');
+            ->method('Submit');
 
         $this->requestHandler->handleRequest($form, $this->request);
     }
@@ -86,7 +86,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodExceptGetProvider
      */
-    public function testBindSimpleFormWithNullIfNameNotInRequestAndNotGetRequest($method)
+    public function testSubmitSimpleFormWithNullIfNameNotInRequestAndNotGetRequest($method)
     {
         $form = $this->getMockForm('param1', $method, false);
 
@@ -95,7 +95,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('Submit')
             ->with($this->identicalTo(null));
 
         $this->requestHandler->handleRequest($form, $this->request);
@@ -104,7 +104,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodExceptGetProvider
      */
-    public function testBindCompoundFormWithArrayIfNameNotInRequestAndNotGetRequest($method)
+    public function testSubmitCompoundFormWithArrayIfNameNotInRequestAndNotGetRequest($method)
     {
         $form = $this->getMockForm('param1', $method, true);
 
@@ -113,13 +113,13 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('Submit')
             ->with($this->identicalTo(array()));
 
         $this->requestHandler->handleRequest($form, $this->request);
     }
 
-    public function testDoNotBindIfNameNotInRequestAndGetRequest()
+    public function testDoNotSubmitIfNameNotInRequestAndGetRequest()
     {
         $form = $this->getMockForm('param1', 'GET');
 
@@ -128,7 +128,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->never())
-            ->method('bind');
+            ->method('Submit');
 
         $this->requestHandler->handleRequest($form, $this->request);
     }
@@ -136,7 +136,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function testBindFormWithEmptyNameIfAtLeastOneFieldInRequest($method)
+    public function testSubmitFormWithEmptyNameIfAtLeastOneFieldInRequest($method)
     {
         $form = $this->getMockForm('', $method);
         $form->expects($this->any())
@@ -152,7 +152,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('Submit')
             ->with($requestData);
 
         $this->requestHandler->handleRequest($form, $this->request);
@@ -161,7 +161,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodProvider
      */
-    public function testDoNotBindFormWithEmptyNameIfNoFieldInRequest($method)
+    public function testDoNotSubmitFormWithEmptyNameIfNoFieldInRequest($method)
     {
         $form = $this->getMockForm('', $method);
         $form->expects($this->any())
@@ -176,7 +176,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->never())
-            ->method('bind');
+            ->method('Submit');
 
         $this->requestHandler->handleRequest($form, $this->request);
     }
@@ -200,7 +200,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('Submit')
             ->with(array(
                 'field1' => 'DATA',
                 'field2' => $file,
@@ -224,7 +224,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('Submit')
             ->with('DATA');
 
         $this->requestHandler->handleRequest($form, $this->request);
@@ -233,7 +233,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodExceptGetProvider
      */
-    public function testBindFileIfNoParam($method)
+    public function testSubmitFileIfNoParam($method)
     {
         $form = $this->getMockForm('param1', $method);
         $file = $this->getMockFile();
@@ -245,7 +245,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('Submit')
             ->with($file);
 
         $this->requestHandler->handleRequest($form, $this->request);

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -24,7 +24,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->form->add($this->getValidForm('firstName'));
         $this->form->add($this->getValidForm('lastName'));
 
-        $this->form->bind(array(
+        $this->form->submit(array(
             'firstName' => 'Bernhard',
             'lastName' => 'Schussek',
         ));
@@ -37,7 +37,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->form->add($this->getValidForm('firstName'));
         $this->form->add($this->getInvalidForm('lastName'));
 
-        $this->form->bind(array(
+        $this->form->submit(array(
             'firstName' => 'Bernhard',
             'lastName' => 'Schussek',
         ));
@@ -45,17 +45,17 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertFalse($this->form->isValid());
     }
 
-    public function testBindForwardsNullIfValueIsMissing()
+    public function testSubmitForwardsNullIfValueIsMissing()
     {
         $child = $this->getMockForm('firstName');
 
         $this->form->add($child);
 
         $child->expects($this->once())
-            ->method('bind')
+            ->method('submit')
             ->with($this->equalTo(null));
 
-        $this->form->bind(array());
+        $this->form->submit(array());
     }
 
     public function testCloneChildren()
@@ -82,7 +82,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertFalse($this->form->isEmpty());
     }
 
-    public function testValidIfBoundAndDisabledWithChildren()
+    public function testValidIfSubmittedAndDisabledWithChildren()
     {
         $this->factory->expects($this->once())
             ->method('createNamedBuilder')
@@ -95,7 +95,7 @@ class CompoundFormTest extends AbstractFormTest
             ->setDataMapper($this->getDataMapper())
             ->add('name', 'text')
             ->getForm();
-        $form->bind(array('name' => 'Jacques Doe'));
+        $form->submit(array('name' => 'Jacques Doe'));
 
         $this->assertTrue($form->isValid());
     }
@@ -108,7 +108,7 @@ class CompoundFormTest extends AbstractFormTest
             ->will($this->returnValue(false));
 
         $this->form->add($child);
-        $this->form->bind(array());
+        $this->form->submit(array());
 
         $this->assertFalse($this->form->isValid());
     }
@@ -199,11 +199,11 @@ class CompoundFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadyBoundException
+     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
      */
-    public function testAddThrowsExceptionIfAlreadyBound()
+    public function testAddThrowsExceptionIfAlreadySubmitted()
     {
-        $this->form->bind(array());
+        $this->form->submit(array());
         $this->form->add($this->getBuilder('foo')->getForm());
     }
 
@@ -218,12 +218,12 @@ class CompoundFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadyBoundException
+     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
      */
-    public function testRemoveThrowsExceptionIfAlreadyBound()
+    public function testRemoveThrowsExceptionIfAlreadySubmitted()
     {
         $this->form->add($this->getBuilder('foo')->setCompound(false)->getForm());
-        $this->form->bind(array('foo' => 'bar'));
+        $this->form->submit(array('foo' => 'bar'));
         $this->form->remove('foo');
     }
 
@@ -331,7 +331,7 @@ class CompoundFormTest extends AbstractFormTest
         $form->setData('foo');
     }
 
-    public function testBindMapsBoundChildrenOntoExistingViewData()
+    public function testSubmitMapsSubmittedChildrenOntoExistingViewData()
     {
         $test = $this;
         $mapper = $this->getDataMapper();
@@ -358,7 +358,7 @@ class CompoundFormTest extends AbstractFormTest
                 $test->assertEquals('Schussek', $child2->getData());
             }));
 
-        $form->bind(array(
+        $form->submit(array(
             'firstName' => 'Bernhard',
             'lastName' => 'Schussek',
         ));
@@ -383,7 +383,7 @@ class CompoundFormTest extends AbstractFormTest
         $mapper->expects($this->never())
             ->method('mapFormsToData');
 
-        $form->bind(array(
+        $form->submit(array(
             'firstName' => 'Bernhard',
             'lastName' => 'Schussek',
         ));
@@ -392,7 +392,7 @@ class CompoundFormTest extends AbstractFormTest
     /*
      * https://github.com/symfony/symfony/issues/4480
      */
-    public function testBindRestoresViewDataIfCompoundAndEmpty()
+    public function testSubmitRestoresViewDataIfCompoundAndEmpty()
     {
         $mapper = $this->getDataMapper();
         $object = new \stdClass();
@@ -402,12 +402,12 @@ class CompoundFormTest extends AbstractFormTest
             ->setData($object)
             ->getForm();
 
-        $form->bind(array());
+        $form->submit(array());
 
         $this->assertSame($object, $form->getData());
     }
 
-    public function testBindMapsBoundChildrenOntoEmptyData()
+    public function testSubmitMapsSubmittedChildrenOntoEmptyData()
     {
         $test = $this;
         $mapper = $this->getDataMapper();
@@ -429,7 +429,7 @@ class CompoundFormTest extends AbstractFormTest
                 $test->assertSame(array('name' => $child), iterator_to_array($iterator));
             }));
 
-        $form->bind(array(
+        $form->submit(array(
             'name' => 'Bernhard',
         ));
     }
@@ -447,7 +447,7 @@ class CompoundFormTest extends AbstractFormTest
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindPostOrPutRequest($method)
+    public function testSubmitPostOrPutRequest($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -499,7 +499,7 @@ class CompoundFormTest extends AbstractFormTest
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindPostOrPutRequestWithEmptyRootFormName($method)
+    public function testSubmitPostOrPutRequestWithEmptyRootFormName($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -550,7 +550,7 @@ class CompoundFormTest extends AbstractFormTest
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindPostOrPutRequestWithSingleChildForm($method)
+    public function testSubmitPostOrPutRequestWithSingleChildForm($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -590,7 +590,7 @@ class CompoundFormTest extends AbstractFormTest
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindPostOrPutRequestWithSingleChildFormUploadedFile($method)
+    public function testSubmitPostOrPutRequestWithSingleChildFormUploadedFile($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -619,7 +619,7 @@ class CompoundFormTest extends AbstractFormTest
         unlink($path);
     }
 
-    public function testBindGetRequest()
+    public function testSubmitGetRequest()
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -651,7 +651,7 @@ class CompoundFormTest extends AbstractFormTest
         $this->assertEquals('Schussek', $form['lastName']->getData());
     }
 
-    public function testBindGetRequestWithEmptyRootFormName()
+    public function testSubmitGetRequestWithEmptyRootFormName()
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixRadioInputListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixRadioInputListenerTest.php
@@ -44,7 +44,7 @@ class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
         $event = new FormEvent($form, $data);
 
-        $this->listener->preBind($event);
+        $this->listener->preSubmit($event);
 
         $this->assertEquals(array(1 => '1'), $event->getData());
     }
@@ -55,7 +55,7 @@ class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
         $event = new FormEvent($form, $data);
 
-        $this->listener->preBind($event);
+        $this->listener->preSubmit($event);
 
         $this->assertEquals(array(0 => '0'), $event->getData());
     }
@@ -66,7 +66,7 @@ class FixRadioInputListenerTest extends \PHPUnit_Framework_TestCase
         $form = $this->getMock('Symfony\Component\Form\Test\FormInterface');
         $event = new FormEvent($form, $data);
 
-        $this->listener->preBind($event);
+        $this->listener->preSubmit($event);
 
         $this->assertEquals(array(), $event->getData());
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/FixUrlProtocolListenerTest.php
@@ -30,7 +30,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
-        $filter->onBind($event);
+        $filter->onSubmit($event);
 
         $this->assertEquals('http://www.symfony.com', $event->getData());
     }
@@ -42,7 +42,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
-        $filter->onBind($event);
+        $filter->onSubmit($event);
 
         $this->assertEquals('http://www.symfony.com', $event->getData());
     }
@@ -54,7 +54,7 @@ class FixUrlProtocolListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($form, $data);
 
         $filter = new FixUrlProtocolListener('http');
-        $filter->onBind($event);
+        $filter->onSubmit($event);
 
         $this->assertEquals('ftp://www.symfony.com', $event->getData());
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/MergeCollectionListenerTest.php
@@ -85,7 +85,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         // The original object was modified
         if (is_object($originalData)) {
@@ -109,7 +109,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         // The original object was modified
         if (is_object($originalData)) {
@@ -134,7 +134,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         // We still have the original object
         if (is_object($originalData)) {
@@ -158,7 +158,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         // The original object was modified
         if (is_object($originalData)) {
@@ -183,7 +183,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         // We still have the original object
         if (is_object($originalData)) {
@@ -203,7 +203,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $newData = 'no array or traversable';
         $event = new FormEvent($this->form, $newData);
         $listener = new MergeCollectionListener($allowAdd, $allowDelete);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
     }
 
     public function testDealWithNullData()
@@ -216,7 +216,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         $this->assertSame($originalData, $event->getData());
     }
@@ -234,7 +234,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         $this->assertSame($newData, $event->getData());
     }
@@ -252,7 +252,7 @@ abstract class MergeCollectionListenerTest extends \PHPUnit_Framework_TestCase
         $this->form->setData($originalData);
 
         $event = new FormEvent($this->form, $newData);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         $this->assertNull($event->getData());
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/ResizeFormListenerTest.php
@@ -110,7 +110,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $listener->preSetData($event);
     }
 
-    public function testPreBindResizesUpIfAllowAdd()
+    public function testPreSubmitResizesUpIfAllowAdd()
     {
         $this->form->add($this->getForm('0'));
 
@@ -122,13 +122,13 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $data = array(0 => 'string', 1 => 'string');
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array('max_length' => 10), true, false);
-        $listener->preBind($event);
+        $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
         $this->assertTrue($this->form->has('1'));
     }
 
-    public function testPreBindResizesDownIfAllowDelete()
+    public function testPreSubmitResizesDownIfAllowDelete()
     {
         $this->form->add($this->getForm('0'));
         $this->form->add($this->getForm('1'));
@@ -136,26 +136,26 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $data = array(0 => 'string');
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
-        $listener->preBind($event);
+        $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
         $this->assertFalse($this->form->has('1'));
     }
 
     // fix for https://github.com/symfony/symfony/pull/493
-    public function testPreBindRemovesZeroKeys()
+    public function testPreSubmitRemovesZeroKeys()
     {
         $this->form->add($this->getForm('0'));
 
         $data = array();
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
-        $listener->preBind($event);
+        $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('0'));
     }
 
-    public function testPreBindDoesNothingIfNotAllowAddNorAllowDelete()
+    public function testPreSubmitDoesNothingIfNotAllowAddNorAllowDelete()
     {
         $this->form->add($this->getForm('0'));
         $this->form->add($this->getForm('1'));
@@ -163,7 +163,7 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
         $data = array(0 => 'string', 2 => 'string');
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
-        $listener->preBind($event);
+        $listener->preSubmit($event);
 
         $this->assertTrue($this->form->has('0'));
         $this->assertTrue($this->form->has('1'));
@@ -173,59 +173,59 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
      */
-    public function testPreBindRequiresArrayOrTraversable()
+    public function testPreSubmitRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
-        $listener->preBind($event);
+        $listener->preSubmit($event);
     }
 
-    public function testPreBindDealsWithNullData()
+    public function testPreSubmitDealsWithNullData()
     {
         $this->form->add($this->getForm('1'));
 
         $data = null;
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
-        $listener->preBind($event);
+        $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
     }
 
     // fixes https://github.com/symfony/symfony/pull/40
-    public function testPreBindDealsWithEmptyData()
+    public function testPreSubmitDealsWithEmptyData()
     {
         $this->form->add($this->getForm('1'));
 
         $data = '';
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
-        $listener->preBind($event);
+        $listener->preSubmit($event);
 
         $this->assertFalse($this->form->has('1'));
     }
 
-    public function testOnBindNormDataRemovesEntriesMissingInTheFormIfAllowDelete()
+    public function testOnSubmitNormDataRemovesEntriesMissingInTheFormIfAllowDelete()
     {
         $this->form->add($this->getForm('1'));
 
         $data = array(0 => 'first', 1 => 'second', 2 => 'third');
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         $this->assertEquals(array(1 => 'second'), $event->getData());
     }
 
-    public function testOnBindNormDataDoesNothingIfNotAllowDelete()
+    public function testOnSubmitNormDataDoesNothingIfNotAllowDelete()
     {
         $this->form->add($this->getForm('1'));
 
         $data = array(0 => 'first', 1 => 'second', 2 => 'third');
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         $this->assertEquals($data, $event->getData());
     }
@@ -233,22 +233,22 @@ class ResizeFormListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
      */
-    public function testOnBindNormDataRequiresArrayOrTraversable()
+    public function testOnSubmitNormDataRequiresArrayOrTraversable()
     {
         $data = 'no array or traversable';
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, false);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
     }
 
-    public function testOnBindNormDataDealsWithNullData()
+    public function testOnSubmitNormDataDealsWithNullData()
     {
         $this->form->add($this->getForm('1'));
 
         $data = null;
         $event = new FormEvent($this->form, $data);
         $listener = new ResizeFormListener('text', array(), false, true);
-        $listener->onBind($event);
+        $listener->onSubmit($event);
 
         $this->assertEquals(array(), $event->getData());
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/EventListener/TrimListenerTest.php
@@ -30,7 +30,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($form, $data);
 
         $filter = new TrimListener();
-        $filter->preBind($event);
+        $filter->preSubmit($event);
 
         $this->assertEquals('Foo!', $event->getData());
     }
@@ -42,7 +42,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($form, $data);
 
         $filter = new TrimListener();
-        $filter->preBind($event);
+        $filter->preSubmit($event);
 
         $this->assertSame(1234, $event->getData());
     }
@@ -63,7 +63,7 @@ class TrimListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($form, $data);
 
         $filter = new TrimListener();
-        $filter->preBind($event);
+        $filter->preSubmit($event);
 
         $this->assertSame("ab\ncd", $event->getData(), 'TrimListener should trim character(s): '.implode(', ', $chars));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CheckboxTypeTest.php
@@ -50,56 +50,56 @@ class CheckboxTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertFalse($view->vars['checked']);
     }
 
-    public function testBindWithValueChecked()
+    public function testSubmitWithValueChecked()
     {
         $form = $this->factory->create('checkbox', null, array(
             'value' => 'foobar',
         ));
-        $form->bind('foobar');
+        $form->submit('foobar');
 
         $this->assertTrue($form->getData());
         $this->assertEquals('foobar', $form->getViewData());
     }
 
-    public function testBindWithRandomValueChecked()
+    public function testSubmitWithRandomValueChecked()
     {
         $form = $this->factory->create('checkbox', null, array(
             'value' => 'foobar',
         ));
-        $form->bind('krixikraxi');
+        $form->submit('krixikraxi');
 
         $this->assertTrue($form->getData());
         $this->assertEquals('foobar', $form->getViewData());
     }
 
-    public function testBindWithValueUnchecked()
+    public function testSubmitWithValueUnchecked()
     {
         $form = $this->factory->create('checkbox', null, array(
             'value' => 'foobar',
         ));
-        $form->bind(null);
+        $form->submit(null);
 
         $this->assertFalse($form->getData());
         $this->assertNull($form->getViewData());
     }
 
-    public function testBindWithEmptyValueChecked()
+    public function testSubmitWithEmptyValueChecked()
     {
         $form = $this->factory->create('checkbox', null, array(
             'value' => '',
         ));
-        $form->bind('');
+        $form->submit('');
 
         $this->assertTrue($form->getData());
         $this->assertSame('', $form->getViewData());
     }
 
-    public function testBindWithEmptyValueUnchecked()
+    public function testSubmitWithEmptyValueUnchecked()
     {
         $form = $this->factory->create('checkbox', null, array(
             'value' => '',
         ));
-        $form->bind(null);
+        $form->submit(null);
 
         $this->assertFalse($form->getData());
         $this->assertNull($form->getViewData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/ChoiceTypeTest.php
@@ -163,7 +163,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         }
     }
 
-    public function testBindSingleNonExpanded()
+    public function testSubmitSingleNonExpanded()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -171,13 +171,13 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->choices,
         ));
 
-        $form->bind('b');
+        $form->submit('b');
 
         $this->assertEquals('b', $form->getData());
         $this->assertEquals('b', $form->getViewData());
     }
 
-    public function testBindSingleNonExpandedObjectChoices()
+    public function testSubmitSingleNonExpandedObjectChoices()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -194,13 +194,13 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         ));
 
         // "id" value of the second entry
-        $form->bind('2');
+        $form->submit('2');
 
         $this->assertEquals($this->objectChoices[1], $form->getData());
         $this->assertEquals('2', $form->getViewData());
     }
 
-    public function testBindMultipleNonExpanded()
+    public function testSubmitMultipleNonExpanded()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => true,
@@ -208,13 +208,13 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->choices,
         ));
 
-        $form->bind(array('a', 'b'));
+        $form->submit(array('a', 'b'));
 
         $this->assertEquals(array('a', 'b'), $form->getData());
         $this->assertEquals(array('a', 'b'), $form->getViewData());
     }
 
-    public function testBindMultipleNonExpandedObjectChoices()
+    public function testSubmitMultipleNonExpandedObjectChoices()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => true,
@@ -230,13 +230,13 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             ),
         ));
 
-        $form->bind(array('2', '3'));
+        $form->submit(array('2', '3'));
 
         $this->assertEquals(array($this->objectChoices[1], $this->objectChoices[2]), $form->getData());
         $this->assertEquals(array('2', '3'), $form->getViewData());
     }
 
-    public function testBindSingleExpanded()
+    public function testSubmitSingleExpanded()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -244,7 +244,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->choices,
         ));
 
-        $form->bind('b');
+        $form->submit('b');
 
         $this->assertSame('b', $form->getData());
         $this->assertFalse($form[0]->getData());
@@ -259,7 +259,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
-    public function testBindSingleExpandedNothingChecked()
+    public function testSubmitSingleExpandedNothingChecked()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -267,7 +267,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->choices,
         ));
 
-        $form->bind(null);
+        $form->submit(null);
 
         $this->assertNull($form->getData());
         $this->assertFalse($form[0]->getData());
@@ -282,7 +282,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
-    public function testBindSingleExpandedWithFalseDoesNotHaveExtraChildren()
+    public function testSubmitSingleExpandedWithFalseDoesNotHaveExtraChildren()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -290,13 +290,13 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->choices,
         ));
 
-        $form->bind(false);
+        $form->submit(false);
 
         $this->assertEmpty($form->getExtraData());
         $this->assertNull($form->getData());
     }
 
-    public function testBindSingleExpandedWithEmptyChild()
+    public function testSubmitSingleExpandedWithEmptyChild()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -307,7 +307,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             ),
         ));
 
-        $form->bind('');
+        $form->submit('');
 
         $this->assertNull($form->getData());
         $this->assertTrue($form[0]->getData());
@@ -316,7 +316,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[1]->getViewData());
     }
 
-    public function testBindSingleExpandedObjectChoices()
+    public function testSubmitSingleExpandedObjectChoices()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -332,7 +332,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             ),
         ));
 
-        $form->bind('2');
+        $form->submit('2');
 
         $this->assertSame($this->objectChoices[1], $form->getData());
         $this->assertFalse($form[0]->getData());
@@ -347,7 +347,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
-    public function testBindSingleExpandedNumericChoices()
+    public function testSubmitSingleExpandedNumericChoices()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => false,
@@ -355,7 +355,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->numericChoices,
         ));
 
-        $form->bind('1');
+        $form->submit('1');
 
         $this->assertSame(1, $form->getData());
         $this->assertFalse($form[0]->getData());
@@ -370,7 +370,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
-    public function testBindMultipleExpanded()
+    public function testSubmitMultipleExpanded()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => true,
@@ -378,7 +378,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->choices,
         ));
 
-        $form->bind(array('a', 'c'));
+        $form->submit(array('a', 'c'));
 
         $this->assertSame(array('a', 'c'), $form->getData());
         $this->assertTrue($form[0]->getData());
@@ -393,7 +393,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
-    public function testBindMultipleExpandedEmpty()
+    public function testSubmitMultipleExpandedEmpty()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => true,
@@ -401,7 +401,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->choices,
         ));
 
-        $form->bind(array());
+        $form->submit(array());
 
         $this->assertSame(array(), $form->getData());
         $this->assertFalse($form[0]->getData());
@@ -416,7 +416,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
-    public function testBindMultipleExpandedWithEmptyChild()
+    public function testSubmitMultipleExpandedWithEmptyChild()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => true,
@@ -428,7 +428,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             )
         ));
 
-        $form->bind(array('', '2'));
+        $form->submit(array('', '2'));
 
         $this->assertSame(array('', 2), $form->getData());
         $this->assertTrue($form[0]->getData());
@@ -439,7 +439,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('2', $form[2]->getViewData());
     }
 
-    public function testBindMultipleExpandedObjectChoices()
+    public function testSubmitMultipleExpandedObjectChoices()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => true,
@@ -455,7 +455,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             ),
         ));
 
-        $form->bind(array('1', '2'));
+        $form->submit(array('1', '2'));
 
         $this->assertSame(array($this->objectChoices[0], $this->objectChoices[1]), $form->getData());
         $this->assertTrue($form[0]->getData());
@@ -470,7 +470,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertNull($form[4]->getViewData());
     }
 
-    public function testBindMultipleExpandedNumericChoices()
+    public function testSubmitMultipleExpandedNumericChoices()
     {
         $form = $this->factory->create('choice', null, array(
             'multiple' => true,
@@ -478,7 +478,7 @@ class ChoiceTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
             'choices' => $this->numericChoices,
         ));
 
-        $form->bind(array('1', '2'));
+        $form->submit(array('1', '2'));
 
         $this->assertSame(array(1, 2), $form->getData());
         $this->assertFalse($form[0]->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/CollectionTypeTest.php
@@ -59,13 +59,13 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $form->setData(new \stdClass());
     }
 
-    public function testNotResizedIfBoundWithMissingData()
+    public function testNotResizedIfSubmittedWithMissingData()
     {
         $form = $this->factory->create('collection', null, array(
             'type' => 'text',
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
-        $form->bind(array('foo@bar.com'));
+        $form->submit(array('foo@bar.com'));
 
         $this->assertTrue($form->has('0'));
         $this->assertTrue($form->has('1'));
@@ -73,14 +73,14 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals('', $form[1]->getData());
     }
 
-    public function testResizedDownIfBoundWithMissingDataAndAllowDelete()
+    public function testResizedDownIfSubmittedWithMissingDataAndAllowDelete()
     {
         $form = $this->factory->create('collection', null, array(
             'type' => 'text',
             'allow_delete' => true,
         ));
         $form->setData(array('foo@foo.com', 'bar@bar.com'));
-        $form->bind(array('foo@foo.com'));
+        $form->submit(array('foo@foo.com'));
 
         $this->assertTrue($form->has('0'));
         $this->assertFalse($form->has('1'));
@@ -88,27 +88,27 @@ class CollectionTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertEquals(array('foo@foo.com'), $form->getData());
     }
 
-    public function testNotResizedIfBoundWithExtraData()
+    public function testNotResizedIfSubmittedWithExtraData()
     {
         $form = $this->factory->create('collection', null, array(
             'type' => 'text',
         ));
         $form->setData(array('foo@bar.com'));
-        $form->bind(array('foo@foo.com', 'bar@bar.com'));
+        $form->submit(array('foo@foo.com', 'bar@bar.com'));
 
         $this->assertTrue($form->has('0'));
         $this->assertFalse($form->has('1'));
         $this->assertEquals('foo@foo.com', $form[0]->getData());
     }
 
-    public function testResizedUpIfBoundWithExtraDataAndAllowAdd()
+    public function testResizedUpIfSubmittedWithExtraDataAndAllowAdd()
     {
         $form = $this->factory->create('collection', null, array(
             'type' => 'text',
             'allow_add' => true,
         ));
         $form->setData(array('foo@bar.com'));
-        $form->bind(array('foo@bar.com', 'bar@bar.com'));
+        $form->submit(array('foo@bar.com', 'bar@bar.com'));
 
         $this->assertTrue($form->has('0'));
         $this->assertTrue($form->has('1'));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -33,7 +33,7 @@ class DateTimeTypeTest extends TypeTestCase
             'input' => 'datetime',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'date' => array(
                 'day' => '2',
                 'month' => '6',
@@ -60,7 +60,7 @@ class DateTimeTypeTest extends TypeTestCase
             'time_widget' => 'choice',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'date' => array(
                 'day' => '2',
                 'month' => '6',
@@ -85,7 +85,7 @@ class DateTimeTypeTest extends TypeTestCase
             'time_widget' => 'choice',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'date' => array(
                 'day' => '2',
                 'month' => '6',
@@ -126,7 +126,7 @@ class DateTimeTypeTest extends TypeTestCase
             ),
         );
 
-        $form->bind($input);
+        $form->submit($input);
 
         $this->assertDateTimeEquals(new \DateTime('2010-06-02 03:00:00 UTC'), $form->getData());
     }
@@ -157,7 +157,7 @@ class DateTimeTypeTest extends TypeTestCase
             ),
         );
 
-        $form->bind($input);
+        $form->submit($input);
 
         $this->assertDateTimeEquals(new \DateTime('2010-06-02 03:04:05 UTC'), $form->getData());
     }
@@ -175,7 +175,7 @@ class DateTimeTypeTest extends TypeTestCase
 
         $dateTime = new \DateTime('2010-06-02 03:04:05 Pacific/Tahiti');
 
-        $form->bind(array(
+        $form->submit(array(
             'date' => array(
                 'day' => (int) $dateTime->format('d'),
                 'month' => (int) $dateTime->format('m'),
@@ -204,7 +204,7 @@ class DateTimeTypeTest extends TypeTestCase
 
         $outputTime = new \DateTime('2010-06-02 03:04:00 Pacific/Tahiti');
 
-        $form->bind('2010-06-02T03:04:00-10:00');
+        $form->submit('2010-06-02T03:04:00-10:00');
 
         $outputTime->setTimezone(new \DateTimeZone('America/New_York'));
 
@@ -221,7 +221,7 @@ class DateTimeTypeTest extends TypeTestCase
             'widget' => 'single_text',
         ));
 
-        $form->bind('2010-06-02T03:04:00Z');
+        $form->submit('2010-06-02T03:04:00Z');
 
         $this->assertEquals('2010-06-02 03:04:00', $form->getData());
         $this->assertEquals('2010-06-02T03:04:00Z', $form->getViewData());
@@ -237,7 +237,7 @@ class DateTimeTypeTest extends TypeTestCase
             'with_seconds' => true,
         ));
 
-        $form->bind('2010-06-02T03:04:05Z');
+        $form->submit('2010-06-02T03:04:05Z');
 
         $this->assertEquals('2010-06-02 03:04:05', $form->getData());
         $this->assertEquals('2010-06-02T03:04:05Z', $form->getViewData());
@@ -254,7 +254,7 @@ class DateTimeTypeTest extends TypeTestCase
 
         $dateTime = new \DateTime('2010-06-02 03:04');
 
-        $form->bind(array(
+        $form->submit(array(
             'date' => '06*2010*02',
             'time' => '03:04',
         ));

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -56,7 +56,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'datetime',
         ));
 
-        $form->bind('2010-06-02');
+        $form->submit('2010-06-02');
 
         $this->assertDateTimeEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('2010-06-02', $form->getViewData());
@@ -72,7 +72,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'datetime',
         ));
 
-        $form->bind('2.6.2010');
+        $form->submit('2.6.2010');
 
         $this->assertDateTimeEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('02.06.2010', $form->getViewData());
@@ -88,7 +88,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'string',
         ));
 
-        $form->bind('2.6.2010');
+        $form->submit('2.6.2010');
 
         $this->assertEquals('2010-06-02', $form->getData());
         $this->assertEquals('02.06.2010', $form->getViewData());
@@ -104,7 +104,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'timestamp',
         ));
 
-        $form->bind('2.6.2010');
+        $form->submit('2.6.2010');
 
         $dateTime = new \DateTime('2010-06-02 UTC');
 
@@ -122,7 +122,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'array',
         ));
 
-        $form->bind('2.6.2010');
+        $form->submit('2.6.2010');
 
         $output = array(
             'day' => '2',
@@ -148,7 +148,7 @@ class DateTypeTest extends TypeTestCase
             'year' => '2010',
         );
 
-        $form->bind($text);
+        $form->submit($text);
 
         $dateTime = new \DateTime('2010-06-02 UTC');
 
@@ -170,7 +170,7 @@ class DateTypeTest extends TypeTestCase
             'year' => '2010',
         );
 
-        $form->bind($text);
+        $form->submit($text);
 
         $dateTime = new \DateTime('2010-06-02 UTC');
 
@@ -193,7 +193,7 @@ class DateTypeTest extends TypeTestCase
             'year' => '',
         );
 
-        $form->bind($text);
+        $form->submit($text);
 
         $this->assertNull($form->getData());
         $this->assertEquals($text, $form->getViewData());
@@ -209,7 +209,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'datetime',
         ));
 
-        $form->bind('06*2010*02');
+        $form->submit('06*2010*02');
 
         $this->assertDateTimeEquals(new \DateTime('2010-06-02 UTC'), $form->getData());
         $this->assertEquals('06*2010*02', $form->getViewData());
@@ -225,7 +225,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'string',
         ));
 
-        $form->bind('06*2010*02');
+        $form->submit('06*2010*02');
 
         $this->assertEquals('2010-06-02', $form->getData());
         $this->assertEquals('06*2010*02', $form->getViewData());
@@ -241,7 +241,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'timestamp',
         ));
 
-        $form->bind('06*2010*02');
+        $form->submit('06*2010*02');
 
         $dateTime = new \DateTime('2010-06-02 UTC');
 
@@ -259,7 +259,7 @@ class DateTypeTest extends TypeTestCase
             'input' => 'array',
         ));
 
-        $form->bind('06*2010*02');
+        $form->submit('06*2010*02');
 
         $output = array(
             'day' => '2',
@@ -447,7 +447,7 @@ class DateTypeTest extends TypeTestCase
             'widget' => 'single_text',
         ));
 
-        $form->bind('7.6.2010');
+        $form->submit('7.6.2010');
 
         $this->assertFalse($form->isPartiallyFilled());
     }
@@ -462,7 +462,7 @@ class DateTypeTest extends TypeTestCase
             'widget' => 'choice',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'day' => '',
             'month' => '',
             'year' => '',
@@ -481,7 +481,7 @@ class DateTypeTest extends TypeTestCase
             'widget' => 'choice',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'day' => '2',
             'month' => '6',
             'year' => '2010',
@@ -500,7 +500,7 @@ class DateTypeTest extends TypeTestCase
             'widget' => 'choice',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'day' => '',
             'month' => '6',
             'year' => '2010',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FileTypeTest.php
@@ -24,22 +24,22 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame($data, $form->getData());
     }
 
-    public function testBind()
+    public function testSubmit()
     {
         $form = $this->factory->createBuilder('file')->getForm();
         $data = $this->createUploadedFileMock('abcdef', 'original.jpg', true);
 
-        $form->bind($data);
+        $form->submit($data);
 
         $this->assertSame($data, $form->getData());
     }
 
     // https://github.com/symfony/symfony/issues/6134
-    public function testBindEmpty()
+    public function testSubmitEmpty()
     {
         $form = $this->factory->createBuilder('file')->getForm();
 
-        $form->bind(null);
+        $form->submit(null);
 
         $this->assertNull($form->getData());
     }
@@ -47,7 +47,7 @@ class FileTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testDontPassValueToView()
     {
         $form = $this->factory->create('file');
-        $form->bind(array(
+        $form->submit(array(
             'file' => $this->createUploadedFileMock('abcdef', 'original.jpg', true),
         ));
         $view = $form->createView();

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -68,7 +68,7 @@ class FormTypeTest extends BaseTypeTest
         $this->assertTrue($form->isRequired());
     }
 
-    public function testBoundDataIsTrimmedBeforeTransforming()
+    public function testSubmittedDataIsTrimmedBeforeTransforming()
     {
         $form = $this->factory->createBuilder('form')
             ->addViewTransformer(new FixedDataTransformer(array(
@@ -78,13 +78,13 @@ class FormTypeTest extends BaseTypeTest
             ->setCompound(false)
             ->getForm();
 
-        $form->bind(' a ');
+        $form->submit(' a ');
 
         $this->assertEquals('a', $form->getViewData());
         $this->assertEquals('reverse[a]', $form->getData());
     }
 
-    public function testBoundDataIsNotTrimmedBeforeTransformingIfNoTrimming()
+    public function testSubmittedDataIsNotTrimmedBeforeTransformingIfNoTrimming()
     {
         $form = $this->factory->createBuilder('form', null, array('trim' => false))
             ->addViewTransformer(new FixedDataTransformer(array(
@@ -94,7 +94,7 @@ class FormTypeTest extends BaseTypeTest
             ->setCompound(false)
             ->getForm();
 
-        $form->bind(' a ');
+        $form->submit(' a ');
 
         $this->assertEquals(' a ', $form->getViewData());
         $this->assertEquals('reverse[ a ]', $form->getData());
@@ -135,7 +135,7 @@ class FormTypeTest extends BaseTypeTest
         $this->assertSame(10, $view->vars['max_length']);
     }
 
-    public function testBindWithEmptyDataCreatesObjectIfClassAvailable()
+    public function testSubmitWithEmptyDataCreatesObjectIfClassAvailable()
     {
         $form = $this->factory->create('form', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
@@ -146,7 +146,7 @@ class FormTypeTest extends BaseTypeTest
 
         $form->setData(null);
         // partially empty, still an object is created
-        $form->bind(array('firstName' => 'Bernhard', 'lastName' => ''));
+        $form->submit(array('firstName' => 'Bernhard', 'lastName' => ''));
 
         $author = new Author();
         $author->firstName = 'Bernhard';
@@ -155,7 +155,7 @@ class FormTypeTest extends BaseTypeTest
         $this->assertEquals($author, $form->getData());
     }
 
-    public function testBindWithEmptyDataCreatesObjectIfInitiallyBoundWithObject()
+    public function testSubmitWithEmptyDataCreatesObjectIfInitiallySubmittedWithObject()
     {
         $form = $this->factory->create('form', null, array(
             // data class is inferred from the passed object
@@ -167,7 +167,7 @@ class FormTypeTest extends BaseTypeTest
 
         $form->setData(null);
         // partially empty, still an object is created
-        $form->bind(array('firstName' => 'Bernhard', 'lastName' => ''));
+        $form->submit(array('firstName' => 'Bernhard', 'lastName' => ''));
 
         $author = new Author();
         $author->firstName = 'Bernhard';
@@ -176,7 +176,7 @@ class FormTypeTest extends BaseTypeTest
         $this->assertEquals($author, $form->getData());
     }
 
-    public function testBindWithEmptyDataCreatesArrayIfDataClassIsNull()
+    public function testSubmitWithEmptyDataCreatesArrayIfDataClassIsNull()
     {
         $form = $this->factory->create('form', null, array(
             'data_class' => null,
@@ -185,12 +185,12 @@ class FormTypeTest extends BaseTypeTest
         $form->add($this->factory->createNamed('firstName', 'text'));
 
         $form->setData(null);
-        $form->bind(array('firstName' => 'Bernhard'));
+        $form->submit(array('firstName' => 'Bernhard'));
 
         $this->assertSame(array('firstName' => 'Bernhard'), $form->getData());
     }
 
-    public function testBindEmptyWithEmptyDataCreatesNoObjectIfNotRequired()
+    public function testSubmitEmptyWithEmptyDataCreatesNoObjectIfNotRequired()
     {
         $form = $this->factory->create('form', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
@@ -200,12 +200,12 @@ class FormTypeTest extends BaseTypeTest
         $form->add($this->factory->createNamed('lastName', 'text'));
 
         $form->setData(null);
-        $form->bind(array('firstName' => '', 'lastName' => ''));
+        $form->submit(array('firstName' => '', 'lastName' => ''));
 
         $this->assertNull($form->getData());
     }
 
-    public function testBindEmptyWithEmptyDataCreatesObjectIfRequired()
+    public function testSubmitEmptyWithEmptyDataCreatesObjectIfRequired()
     {
         $form = $this->factory->create('form', null, array(
             'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
@@ -215,7 +215,7 @@ class FormTypeTest extends BaseTypeTest
         $form->add($this->factory->createNamed('lastName', 'text'));
 
         $form->setData(null);
-        $form->bind(array('firstName' => '', 'lastName' => ''));
+        $form->submit(array('firstName' => '', 'lastName' => ''));
 
         $this->assertEquals(new Author(), $form->getData());
     }
@@ -223,35 +223,35 @@ class FormTypeTest extends BaseTypeTest
     /*
      * We need something to write the field values into
      */
-    public function testBindWithEmptyDataStoresArrayIfNoClassAvailable()
+    public function testSubmitWithEmptyDataStoresArrayIfNoClassAvailable()
     {
         $form = $this->factory->create('form');
         $form->add($this->factory->createNamed('firstName', 'text'));
 
         $form->setData(null);
-        $form->bind(array('firstName' => 'Bernhard'));
+        $form->submit(array('firstName' => 'Bernhard'));
 
         $this->assertSame(array('firstName' => 'Bernhard'), $form->getData());
     }
 
-    public function testBindWithEmptyDataPassesEmptyStringToTransformerIfNotCompound()
+    public function testSubmitWithEmptyDataPassesEmptyStringToTransformerIfNotCompound()
     {
         $form = $this->factory->createBuilder('form')
             ->addViewTransformer(new FixedDataTransformer(array(
                 // required for the initial, internal setData(null)
                 null => 'null',
-                // required to test that bind(null) is converted to ''
+                // required to test that submit(null) is converted to ''
                 'empty' => '',
             )))
             ->setCompound(false)
             ->getForm();
 
-        $form->bind(null);
+        $form->submit(null);
 
         $this->assertSame('empty', $form->getData());
     }
 
-    public function testBindWithEmptyDataUsesEmptyDataOption()
+    public function testSubmitWithEmptyDataUsesEmptyDataOption()
     {
         $author = new Author();
 
@@ -261,7 +261,7 @@ class FormTypeTest extends BaseTypeTest
         ));
         $form->add($this->factory->createNamed('firstName', 'text'));
 
-        $form->bind(array('firstName' => 'Bernhard'));
+        $form->submit(array('firstName' => 'Bernhard'));
 
         $this->assertSame($author, $form->getData());
         $this->assertEquals('Bernhard', $author->firstName);
@@ -320,7 +320,7 @@ class FormTypeTest extends BaseTypeTest
         $builder->get('reference')->add('firstName', 'text');
         $form = $builder->getForm();
 
-        $form->bind(array(
+        $form->submit(array(
             // reference has a getter, but not setter
             'reference' => array(
                 'firstName' => 'Foo',
@@ -345,7 +345,7 @@ class FormTypeTest extends BaseTypeTest
 
         $form['referenceCopy']->setData($newReference); // new author object
 
-        $form->bind(array(
+        $form->submit(array(
         // referenceCopy has a getter that returns a copy
             'referenceCopy' => array(
                 'firstName' => 'Foo',
@@ -367,7 +367,7 @@ class FormTypeTest extends BaseTypeTest
         $builder->get('referenceCopy')->add('firstName', 'text');
         $form = $builder->getForm();
 
-        $form->bind(array(
+        $form->submit(array(
             // referenceCopy has a getter that returns a copy
             'referenceCopy' => array(
                 'firstName' => 'Foo',
@@ -393,7 +393,7 @@ class FormTypeTest extends BaseTypeTest
         ));
         $form = $builder->getForm();
 
-        $form->bind(array(
+        $form->submit(array(
             'referenceCopy' => array(), // doesn't matter actually
         ));
 
@@ -419,7 +419,7 @@ class FormTypeTest extends BaseTypeTest
         ));
         $form = $builder->getForm();
 
-        $form->bind(array(
+        $form->submit(array(
             'referenceCopy' => array('a' => 'b'), // doesn't matter actually
         ));
 
@@ -506,17 +506,17 @@ class FormTypeTest extends BaseTypeTest
         $this->assertFalse($form->getConfig()->getMapped());
     }
 
-    public function testViewValidUnbound()
+    public function testViewValidNotSubmitted()
     {
         $form = $this->factory->create('form');
         $view = $form->createView();
         $this->assertTrue($view->vars['valid']);
     }
 
-    public function testViewNotValidBound()
+    public function testViewNotValidSubmitted()
     {
         $form = $this->factory->create('form');
-        $form->bind(array());
+        $form->submit(array());
         $form->addError(new FormError('An error'));
         $view = $form->createView();
         $this->assertFalse($view->vars['valid']);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/IntegerTypeTest.php
@@ -26,7 +26,7 @@ class IntegerTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('integer');
 
-        $form->bind('1.678');
+        $form->submit('1.678');
 
         $this->assertSame(1, $form->getData());
         $this->assertSame('1', $form->getViewData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/PasswordTypeTest.php
@@ -13,7 +13,7 @@ namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
 {
-    public function testEmptyIfNotBound()
+    public function testEmptyIfNotSubmitted()
     {
         $form = $this->factory->create('password');
         $form->setData('pAs5w0rd');
@@ -22,19 +22,19 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
         $this->assertSame('', $view->vars['value']);
     }
 
-    public function testEmptyIfBound()
+    public function testEmptyIfSubmitted()
     {
         $form = $this->factory->create('password');
-        $form->bind('pAs5w0rd');
+        $form->submit('pAs5w0rd');
         $view = $form->createView();
 
         $this->assertSame('', $view->vars['value']);
     }
 
-    public function testNotEmptyIfBoundAndNotAlwaysEmpty()
+    public function testNotEmptyIfSubmittedAndNotAlwaysEmpty()
     {
         $form = $this->factory->create('password', null, array('always_empty' => false));
-        $form->bind('pAs5w0rd');
+        $form->submit('pAs5w0rd');
         $view = $form->createView();
 
         $this->assertSame('pAs5w0rd', $view->vars['value']);
@@ -43,7 +43,7 @@ class PasswordTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     public function testNotTrimmed()
     {
         $form = $this->factory->create('password', null);
-        $form->bind(' pAs5w0rd ');
+        $form->submit(' pAs5w0rd ');
         $data = $form->getData();
 
         $this->assertSame(' pAs5w0rd ', $data);

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/RepeatedTypeTest.php
@@ -125,7 +125,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $input = array('first' => 'foo', 'second' => 'bar');
 
-        $this->form->bind($input);
+        $this->form->submit($input);
 
         $this->assertEquals('foo', $this->form['first']->getViewData());
         $this->assertEquals('bar', $this->form['second']->getViewData());
@@ -138,7 +138,7 @@ class RepeatedTypeTest extends \Symfony\Component\Form\Test\TypeTestCase
     {
         $input = array('first' => 'foo', 'second' => 'foo');
 
-        $this->form->bind($input);
+        $this->form->submit($input);
 
         $this->assertEquals('foo', $this->form['first']->getViewData());
         $this->assertEquals('foo', $this->form['second']->getViewData());

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
@@ -28,26 +28,26 @@ class SubmitTypeTest extends TypeTestCase
         $this->assertFalse($button->isClicked());
     }
 
-    public function testNotClickedIfBoundWithNull()
+    public function testNotClickedIfSubmittedWithNull()
     {
         $button = $this->factory->create('submit');
-        $button->bind(null);
+        $button->submit(null);
 
         $this->assertFalse($button->isClicked());
     }
 
-    public function testClickedIfBoundWithEmptyString()
+    public function testClickedIfSubmittedWithEmptyString()
     {
         $button = $this->factory->create('submit');
-        $button->bind('');
+        $button->submit('');
 
         $this->assertTrue($button->isClicked());
     }
 
-    public function testClickedIfBoundWithUnemptyString()
+    public function testClickedIfSubmittedWithUnemptyString()
     {
         $button = $this->factory->create('submit');
-        $button->bind('foo');
+        $button->submit('foo');
 
         $this->assertTrue($button->isClicked());
     }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -37,7 +37,7 @@ class TimeTypeTest extends TypeTestCase
             'minute' => '4',
         );
 
-        $form->bind($input);
+        $form->submit($input);
 
         $dateTime = new \DateTime('1970-01-01 03:04:00 UTC');
 
@@ -58,7 +58,7 @@ class TimeTypeTest extends TypeTestCase
             'minute' => '4',
         );
 
-        $form->bind($input);
+        $form->submit($input);
 
         $this->assertEquals('03:04:00', $form->getData());
         $this->assertEquals($input, $form->getViewData());
@@ -77,7 +77,7 @@ class TimeTypeTest extends TypeTestCase
             'minute' => '4',
         );
 
-        $form->bind($input);
+        $form->submit($input);
 
         $dateTime = new \DateTime('1970-01-01 03:04:00 UTC');
 
@@ -98,7 +98,7 @@ class TimeTypeTest extends TypeTestCase
             'minute' => '4',
         );
 
-        $form->bind($input);
+        $form->submit($input);
 
         $this->assertEquals($input, $form->getData());
         $this->assertEquals($input, $form->getViewData());
@@ -113,7 +113,7 @@ class TimeTypeTest extends TypeTestCase
             'widget' => 'single_text',
         ));
 
-        $form->bind('03:04');
+        $form->submit('03:04');
 
         $this->assertEquals(new \DateTime('1970-01-01 03:04:00 UTC'), $form->getData());
         $this->assertEquals('03:04', $form->getViewData());
@@ -129,7 +129,7 @@ class TimeTypeTest extends TypeTestCase
             'with_minutes' => false,
         ));
 
-        $form->bind('03');
+        $form->submit('03');
 
         $this->assertEquals(new \DateTime('1970-01-01 03:00:00 UTC'), $form->getData());
         $this->assertEquals('03', $form->getViewData());
@@ -149,7 +149,7 @@ class TimeTypeTest extends TypeTestCase
             'minute' => '4',
         );
 
-        $form->bind('03:04');
+        $form->submit('03:04');
 
         $this->assertEquals($data, $form->getData());
         $this->assertEquals('03:04', $form->getViewData());
@@ -169,7 +169,7 @@ class TimeTypeTest extends TypeTestCase
             'hour' => '3',
         );
 
-        $form->bind('03');
+        $form->submit('03');
 
         $this->assertEquals($data, $form->getData());
         $this->assertEquals('03', $form->getViewData());
@@ -191,7 +191,7 @@ class TimeTypeTest extends TypeTestCase
             'second' => '5',
         );
 
-        $form->bind('03:04:05');
+        $form->submit('03:04:05');
 
         $this->assertEquals($data, $form->getData());
         $this->assertEquals('03:04:05', $form->getViewData());
@@ -206,7 +206,7 @@ class TimeTypeTest extends TypeTestCase
             'widget' => 'single_text',
         ));
 
-        $form->bind('03:04');
+        $form->submit('03:04');
 
         $this->assertEquals('03:04:00', $form->getData());
         $this->assertEquals('03:04', $form->getViewData());
@@ -222,7 +222,7 @@ class TimeTypeTest extends TypeTestCase
             'with_minutes' => false,
         ));
 
-        $form->bind('03');
+        $form->submit('03');
 
         $this->assertEquals('03:00:00', $form->getData());
         $this->assertEquals('03', $form->getViewData());
@@ -360,7 +360,7 @@ class TimeTypeTest extends TypeTestCase
             'widget' => 'choice',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'hour' => '',
             'minute' => '',
         ));
@@ -377,7 +377,7 @@ class TimeTypeTest extends TypeTestCase
             'with_seconds' => true,
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'hour' => '',
             'minute' => '',
             'second' => '',
@@ -394,7 +394,7 @@ class TimeTypeTest extends TypeTestCase
             'widget' => 'choice',
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'hour' => '0',
             'minute' => '0',
         ));
@@ -411,7 +411,7 @@ class TimeTypeTest extends TypeTestCase
             'with_seconds' => true,
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'hour' => '0',
             'minute' => '0',
             'second' => '0',
@@ -429,7 +429,7 @@ class TimeTypeTest extends TypeTestCase
             'with_seconds' => true,
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'hour' => '',
             'minute' => '0',
             'second' => '0',
@@ -447,7 +447,7 @@ class TimeTypeTest extends TypeTestCase
             'with_seconds' => true,
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'hour' => '0',
             'minute' => '',
             'second' => '0',
@@ -465,7 +465,7 @@ class TimeTypeTest extends TypeTestCase
             'with_seconds' => true,
         ));
 
-        $form->bind(array(
+        $form->submit(array(
             'hour' => '0',
             'minute' => '0',
             'second' => '',

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/UrlTypeTest.php
@@ -17,7 +17,7 @@ class UrlTypeTest extends TypeTestCase
     {
         $form = $this->factory->create('url', 'name');
 
-        $form->bind('www.domain.com');
+        $form->submit('www.domain.com');
 
         $this->assertSame('http://www.domain.com', $form->getData());
         $this->assertSame('http://www.domain.com', $form->getViewData());
@@ -29,7 +29,7 @@ class UrlTypeTest extends TypeTestCase
             'default_protocol' => 'http',
         ));
 
-        $form->bind('ftp://www.domain.com');
+        $form->submit('ftp://www.domain.com');
 
         $this->assertSame('ftp://www.domain.com', $form->getData());
         $this->assertSame('ftp://www.domain.com', $form->getViewData());
@@ -41,7 +41,7 @@ class UrlTypeTest extends TypeTestCase
             'default_protocol' => 'http',
         ));
 
-        $form->bind('');
+        $form->submit('');
 
         $this->assertNull($form->getData());
         $this->assertSame('', $form->getViewData());
@@ -53,7 +53,7 @@ class UrlTypeTest extends TypeTestCase
             'default_protocol' => null,
         ));
 
-        $form->bind('www.domain.com');
+        $form->submit('www.domain.com');
 
         $this->assertSame('www.domain.com', $form->getData());
         $this->assertSame('www.domain.com', $form->getViewData());

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/EventListener/CsrfValidationListenerTest.php
@@ -70,7 +70,7 @@ class CsrfValidationListenerTest extends \PHPUnit_Framework_TestCase
         $event = new FormEvent($this->form, $data);
 
         $validation = new CsrfValidationListener('csrf', $this->csrfProvider, 'unknown');
-        $validation->preBind($event);
+        $validation->preSubmit($event);
 
         // Validate accordingly
         $this->assertSame($data, $event->getData());

--- a/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Csrf/Type/FormTypeCsrfExtensionTest.php
@@ -140,7 +140,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
     /**
      * @dataProvider provideBoolean
      */
-    public function testValidateTokenOnBindIfRootAndCompound($valid)
+    public function testValidateTokenOnSubmitIfRootAndCompound($valid)
     {
         $this->csrfProvider->expects($this->once())
             ->method('isCsrfTokenValid')
@@ -157,7 +157,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->add('child', 'text')
             ->getForm();
 
-        $form->bind(array(
+        $form->submit(array(
             'child' => 'foobar',
             'csrf' => 'token',
         ));
@@ -184,7 +184,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->add('child', 'text')
             ->getForm();
 
-        $form->bind(array(
+        $form->submit(array(
             'child' => 'foobar',
             // token is missing
         ));
@@ -214,7 +214,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
             ->getForm()
             ->get('form');
 
-        $form->bind(array(
+        $form->submit(array(
             'child' => 'foobar',
             'csrf' => 'token',
         ));
@@ -233,7 +233,7 @@ class FormTypeCsrfExtensionTest extends TypeTestCase
                 'compound' => false,
             ));
 
-        $form->bind(array(
+        $form->submit(array(
             'csrf' => 'token',
         ));
     }

--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/EventListener/BindRequestListenerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/EventListener/BindRequestListenerTest.php
@@ -84,7 +84,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindRequest($method)
+    public function testSubmitRequest($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -113,7 +113,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindRequestWithEmptyName($method)
+    public function testSubmitRequestWithEmptyName($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -140,7 +140,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindEmptyRequestToCompoundForm($method)
+    public function testSubmitEmptyRequestToCompoundForm($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -167,7 +167,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider requestMethodProvider
      */
-    public function testBindEmptyRequestToSimpleForm($method)
+    public function testSubmitEmptyRequestToSimpleForm($method)
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -190,7 +190,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($event->getData());
     }
 
-    public function testBindGetRequest()
+    public function testSubmitGetRequest()
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -215,7 +215,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         ), $event->getData());
     }
 
-    public function testBindGetRequestWithEmptyName()
+    public function testSubmitGetRequestWithEmptyName()
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -239,7 +239,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         ), $event->getData());
     }
 
-    public function testBindEmptyGetRequestToCompoundForm()
+    public function testSubmitEmptyGetRequestToCompoundForm()
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');
@@ -262,7 +262,7 @@ class BindRequestListenerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $event->getData());
     }
 
-    public function testBindEmptyGetRequestToSimpleForm()
+    public function testSubmitEmptyGetRequestToSimpleForm()
     {
         if (!class_exists('Symfony\Component\HttpFoundation\Request')) {
             $this->markTestSkipped('The "HttpFoundation" component is not available');

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -206,7 +206,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->getForm();
 
         // Launch transformer
-        $form->bind(array());
+        $form->submit(array());
 
         $context->expects($this->never())
             ->method('validate');
@@ -235,7 +235,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->getForm();
 
         // Launch transformer
-        $form->bind('foo');
+        $form->submit('foo');
 
         $context->expects($this->never())
             ->method('validate');
@@ -275,7 +275,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->getForm();
 
         // Launch transformer
-        $form->bind('foo');
+        $form->submit('foo');
 
         $context->expects($this->never())
             ->method('validate');
@@ -314,7 +314,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->getForm();
 
         // Launch transformer
-        $form->bind(array());
+        $form->submit(array());
 
         $context->expects($this->never())
             ->method('validate');
@@ -346,7 +346,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->getForm();
 
         // Launch transformer
-        $form->bind(array('child' => 'foo'));
+        $form->submit(array('child' => 'foo'));
 
         $context->expects($this->never())
             ->method('addViolation');
@@ -582,7 +582,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
             ->add($this->getBuilder('child'))
             ->getForm();
 
-        $form->bind(array('foo' => 'bar'));
+        $form->submit(array('foo' => 'bar'));
 
         $context->expects($this->once())
             ->method('addViolation')
@@ -717,7 +717,7 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
 
     private function getClickedSubmitButton($name = 'name', array $options = array())
     {
-        return $this->getSubmitButton($name, $options)->bind('');
+        return $this->getSubmitButton($name, $options)->submit('');
     }
 
     /**

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/FormTypeValidatorExtensionTest.php
@@ -67,7 +67,7 @@ class FormTypeValidatorExtensionTest extends TypeTestCase
         $this->assertTrue(is_callable($form->getConfig()->getOption('validation_groups')));
     }
 
-    public function testBindValidatesData()
+    public function testSubmitValidatesData()
     {
         $builder = $this->factory->createBuilder('form', null, array(
             'validation_groups' => 'group',
@@ -80,6 +80,6 @@ class FormTypeValidatorExtensionTest extends TypeTestCase
             ->with($this->equalTo($form));
 
         // specific data is irrelevant
-        $form->bind(array());
+        $form->submit(array());
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/ViolationMapper/ViolationMapperTest.php
@@ -173,8 +173,8 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $parent->add($child);
         $child->add($grandChild);
 
-        // bind to invoke the transformer and mark the form unsynchronized
-        $parent->bind(array());
+        // submit to invoke the transformer and mark the form unsynchronized
+        $parent->submit(array());
 
         $this->mapper->mapViolation($violation, $parent);
 
@@ -197,8 +197,8 @@ class ViolationMapperTest extends \PHPUnit_Framework_TestCase
         $parent->add($child);
         $child->add($grandChild);
 
-        // bind to invoke the transformer and mark the form unsynchronized
-        $parent->bind(array());
+        // submit to invoke the transformer and mark the form unsynchronized
+        $parent->submit(array());
 
         $this->mapper->mapViolation($violation, $parent);
 

--- a/src/Symfony/Component/Form/Tests/Fixtures/FixedFilterListener.php
+++ b/src/Symfony/Component/Form/Tests/Fixtures/FixedFilterListener.php
@@ -22,27 +22,27 @@ class FixedFilterListener implements EventSubscriberInterface
     public function __construct(array $mapping)
     {
         $this->mapping = array_merge(array(
-            'preBind' => array(),
-            'onBind' => array(),
+            'preSubmit' => array(),
+            'onSubmit' => array(),
             'preSetData' => array(),
         ), $mapping);
     }
 
-    public function preBind(FormEvent $event)
+    public function preSubmit(FormEvent $event)
     {
         $data = $event->getData();
 
-        if (isset($this->mapping['preBind'][$data])) {
-            $event->setData($this->mapping['preBind'][$data]);
+        if (isset($this->mapping['preSubmit'][$data])) {
+            $event->setData($this->mapping['preSubmit'][$data]);
         }
     }
 
-    public function onBind(FormEvent $event)
+    public function onSubmit(FormEvent $event)
     {
         $data = $event->getData();
 
-        if (isset($this->mapping['onBind'][$data])) {
-            $event->setData($this->mapping['onBind'][$data]);
+        if (isset($this->mapping['onSubmit'][$data])) {
+            $event->setData($this->mapping['onSubmit'][$data]);
         }
     }
 
@@ -58,8 +58,8 @@ class FixedFilterListener implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            FormEvents::PRE_BIND => 'preBind',
-            FormEvents::BIND => 'onBind',
+            FormEvents::PRE_SUBMIT => 'preSubmit',
+            FormEvents::SUBMIT => 'onSubmit',
             FormEvents::PRE_SET_DATA => 'preSetData',
         );
     }

--- a/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/NativeRequestHandlerTest.php
@@ -67,7 +67,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('submit')
             ->with('DATA');
 
         $this->requestHandler->handleRequest($form, $this->request);
@@ -86,7 +86,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         )));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('submit')
             ->with($this->identicalTo(null));
 
         $this->requestHandler->handleRequest($form, $this->request);
@@ -115,7 +115,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         )));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('submit')
             ->with(array(
                 'field' => array(
                     'name' => 'upload.txt',
@@ -152,7 +152,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         )));
 
         $form->expects($this->once())
-            ->method('bind')
+            ->method('submit')
             ->with(array(
                 'field' => array(
                     'subfield' => array(
@@ -179,7 +179,7 @@ class NativeRequestHandlerTest extends AbstractRequestHandlerTest
         $_SERVER['HTTP_X_HTTP_METHOD_OVERRIDE'] = 'PUT';
 
         $form->expects($this->never())
-            ->method('bind');
+            ->method('submit');
 
         $this->requestHandler->handleRequest($form, $this->request);
     }

--- a/src/Symfony/Component/Form/Tests/SimpleFormTest.php
+++ b/src/Symfony/Component/Form/Tests/SimpleFormTest.php
@@ -75,47 +75,47 @@ class SimpleFormTest extends AbstractFormTest
     }
 
     // https://github.com/symfony/symfony/commit/d4f4038f6daf7cf88ca7c7ab089473cce5ebf7d8#commitcomment-1632879
-    public function testDataIsInitializedFromBind()
+    public function testDataIsInitializedFromSubmit()
     {
         $mock = $this->getMockBuilder('\stdClass')
-            ->setMethods(array('preSetData', 'preBind'))
+            ->setMethods(array('preSetData', 'preSubmit'))
             ->getMock();
         $mock->expects($this->at(0))
             ->method('preSetData');
         $mock->expects($this->at(1))
-            ->method('preBind');
+            ->method('preSubmit');
 
         $config = new FormConfigBuilder('name', null, $this->dispatcher);
         $config->addEventListener(FormEvents::PRE_SET_DATA, array($mock, 'preSetData'));
-        $config->addEventListener(FormEvents::PRE_BIND, array($mock, 'preBind'));
+        $config->addEventListener(FormEvents::PRE_SUBMIT, array($mock, 'preSubmit'));
         $form = new Form($config);
 
         // no call to setData() or similar where the object would be
         // initialized otherwise
 
-        $form->bind('foobar');
+        $form->submit('foobar');
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadyBoundException
+     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
      */
-    public function testBindThrowsExceptionIfAlreadyBound()
+    public function testSubmitThrowsExceptionIfAlreadySubmitted()
     {
-        $this->form->bind(array());
-        $this->form->bind(array());
+        $this->form->submit(array());
+        $this->form->submit(array());
     }
 
-    public function testBindIsIgnoredIfDisabled()
+    public function testSubmitIsIgnoredIfDisabled()
     {
         $form = $this->getBuilder()
             ->setDisabled(true)
             ->setData('initial')
             ->getForm();
 
-        $form->bind('new');
+        $form->submit('new');
 
         $this->assertEquals('initial', $form->getData());
-        $this->assertTrue($form->isBound());
+        $this->assertTrue($form->isSubmitted());
     }
 
     public function testNeverRequiredIfParentNotRequired()
@@ -259,23 +259,23 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertFalse($this->form->isEmpty());
     }
 
-    public function testValidIfBound()
+    public function testValidIfSubmitted()
     {
         $form = $this->getBuilder()->getForm();
-        $form->bind('foobar');
+        $form->submit('foobar');
 
         $this->assertTrue($form->isValid());
     }
 
-    public function testValidIfBoundAndDisabled()
+    public function testValidIfSubmittedAndDisabled()
     {
         $form = $this->getBuilder()->setDisabled(true)->getForm();
-        $form->bind('foobar');
+        $form->submit('foobar');
 
         $this->assertTrue($form->isValid());
     }
 
-    public function testNotValidIfNotBound()
+    public function testNotValidIfNotSubmitted()
     {
         $this->assertFalse($this->form->isValid());
     }
@@ -283,7 +283,7 @@ class SimpleFormTest extends AbstractFormTest
     public function testNotValidIfErrors()
     {
         $form = $this->getBuilder()->getForm();
-        $form->bind('foobar');
+        $form->submit('foobar');
         $form->addError(new FormError('Error!'));
 
         $this->assertFalse($form->isValid());
@@ -302,33 +302,33 @@ class SimpleFormTest extends AbstractFormTest
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadyBoundException
+     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
      */
-    public function testSetParentThrowsExceptionIfAlreadyBound()
+    public function testSetParentThrowsExceptionIfAlreadySubmitted()
     {
-        $this->form->bind(array());
+        $this->form->submit(array());
         $this->form->setParent($this->getBuilder('parent')->getForm());
     }
 
-    public function testBound()
+    public function testSubmitted()
     {
         $form = $this->getBuilder()->getForm();
-        $form->bind('foobar');
+        $form->submit('foobar');
 
-        $this->assertTrue($form->isBound());
+        $this->assertTrue($form->isSubmitted());
     }
 
-    public function testNotBound()
+    public function testNotSubmitted()
     {
-        $this->assertFalse($this->form->isBound());
+        $this->assertFalse($this->form->isSubmitted());
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\AlreadyBoundException
+     * @expectedException \Symfony\Component\Form\Exception\AlreadySubmittedException
      */
-    public function testSetDataThrowsExceptionIfAlreadyBound()
+    public function testSetDataThrowsExceptionIfAlreadySubmitted()
     {
-        $this->form->bind(array());
+        $this->form->submit(array());
         $this->form->setData(null);
     }
 
@@ -356,18 +356,18 @@ class SimpleFormTest extends AbstractFormTest
         // use real event dispatcher now
         $form = $this->getBuilder('name', new EventDispatcher())
             ->addEventSubscriber(new FixedFilterListener(array(
-            'preSetData' => array(
-                'app' => 'filtered',
-            ),
-        )))
+                'preSetData' => array(
+                    'app' => 'filtered',
+                ),
+            )))
             ->addModelTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'filtered' => 'norm',
-        )))
+                '' => '',
+                'filtered' => 'norm',
+            )))
             ->addViewTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'norm' => 'client',
-        )))
+                '' => '',
+                'norm' => 'client',
+            )))
             ->getForm();
 
         $form->setData('app');
@@ -381,13 +381,13 @@ class SimpleFormTest extends AbstractFormTest
     {
         $form = $this->getBuilder()
             ->addViewTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'first' => 'second',
-        )))
+                '' => '',
+                'first' => 'second',
+            )))
             ->addViewTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'second' => 'third',
-        )))
+                '' => '',
+                'second' => 'third',
+            )))
             ->getForm();
 
         $form->setData('first');
@@ -399,13 +399,13 @@ class SimpleFormTest extends AbstractFormTest
     {
         $form = $this->getBuilder()
             ->addModelTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'second' => 'third',
-        )))
+                '' => '',
+                'second' => 'third',
+            )))
             ->addModelTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'first' => 'second',
-        )))
+                '' => '',
+                'first' => 'second',
+            )))
             ->getForm();
 
         $form->setData('first');
@@ -475,81 +475,81 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertSame('default', $form->getData());
     }
 
-    public function testBindConvertsEmptyToNullIfNoTransformer()
+    public function testSubmitConvertsEmptyToNullIfNoTransformer()
     {
         $form = $this->getBuilder()->getForm();
 
-        $form->bind('');
+        $form->submit('');
 
         $this->assertNull($form->getData());
         $this->assertNull($form->getNormData());
         $this->assertSame('', $form->getViewData());
     }
 
-    public function testBindExecutesTransformationChain()
+    public function testSubmitExecutesTransformationChain()
     {
         // use real event dispatcher now
         $form = $this->getBuilder('name', new EventDispatcher())
             ->addEventSubscriber(new FixedFilterListener(array(
-            'preBind' => array(
-                'client' => 'filteredclient',
-            ),
-            'onBind' => array(
-                'norm' => 'filterednorm',
-            ),
-        )))
+                'preSubmit' => array(
+                    'client' => 'filteredclient',
+                ),
+                'onSubmit' => array(
+                    'norm' => 'filterednorm',
+                ),
+            )))
             ->addViewTransformer(new FixedDataTransformer(array(
-            '' => '',
-            // direction is reversed!
-            'norm' => 'filteredclient',
-            'filterednorm' => 'cleanedclient'
-        )))
+                '' => '',
+                // direction is reversed!
+                'norm' => 'filteredclient',
+                'filterednorm' => 'cleanedclient'
+            )))
             ->addModelTransformer(new FixedDataTransformer(array(
-            '' => '',
-            // direction is reversed!
-            'app' => 'filterednorm',
-        )))
+                '' => '',
+                // direction is reversed!
+                'app' => 'filterednorm',
+            )))
             ->getForm();
 
-        $form->bind('client');
+        $form->submit('client');
 
         $this->assertEquals('app', $form->getData());
         $this->assertEquals('filterednorm', $form->getNormData());
         $this->assertEquals('cleanedclient', $form->getViewData());
     }
 
-    public function testBindExecutesViewTransformersInReverseOrder()
+    public function testSubmitExecutesViewTransformersInReverseOrder()
     {
         $form = $this->getBuilder()
             ->addViewTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'third' => 'second',
-        )))
+                '' => '',
+                'third' => 'second',
+            )))
             ->addViewTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'second' => 'first',
-        )))
+                '' => '',
+                'second' => 'first',
+            )))
             ->getForm();
 
-        $form->bind('first');
+        $form->submit('first');
 
         $this->assertEquals('third', $form->getNormData());
     }
 
-    public function testBindExecutesModelTransformersInOrder()
+    public function testSubmitExecutesModelTransformersInOrder()
     {
         $form = $this->getBuilder()
             ->addModelTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'second' => 'first',
-        )))
+                '' => '',
+                'second' => 'first',
+            )))
             ->addModelTransformer(new FixedDataTransformer(array(
-            '' => '',
-            'third' => 'second',
-        )))
+                '' => '',
+                'third' => 'second',
+            )))
             ->getForm();
 
-        $form->bind('first');
+        $form->submit('first');
 
         $this->assertEquals('third', $form->getData());
     }
@@ -559,9 +559,9 @@ class SimpleFormTest extends AbstractFormTest
         $this->assertTrue($this->form->isSynchronized());
     }
 
-    public function testSynchronizedAfterBinding()
+    public function testSynchronizedAfterSubmission()
     {
-        $this->form->bind('foobar');
+        $this->form->submit('foobar');
 
         $this->assertTrue($this->form->isSynchronized());
     }
@@ -577,7 +577,7 @@ class SimpleFormTest extends AbstractFormTest
             ->addViewTransformer($transformer)
             ->getForm();
 
-        $form->bind('foobar');
+        $form->submit('foobar');
 
         $this->assertFalse($form->isSynchronized());
     }
@@ -593,7 +593,7 @@ class SimpleFormTest extends AbstractFormTest
             ->addModelTransformer($transformer)
             ->getForm();
 
-        $form->bind('foobar');
+        $form->submit('foobar');
 
         $this->assertFalse($form->isSynchronized());
     }
@@ -609,7 +609,7 @@ class SimpleFormTest extends AbstractFormTest
         )))
             ->getForm();
 
-        $form->bind('');
+        $form->submit('');
 
         $this->assertEquals('bar', $form->getData());
     }
@@ -632,15 +632,15 @@ class SimpleFormTest extends AbstractFormTest
         )))
             ->getForm();
 
-        $form->bind('');
+        $form->submit('');
 
         $this->assertEquals('bar', $form->getData());
     }
 
-    public function testBindResetsErrors()
+    public function testSubmitResetsErrors()
     {
         $this->form->addError(new FormError('Error!'));
-        $this->form->bind('foobar');
+        $this->form->submit('foobar');
 
         $this->assertSame(array(), $this->form->getErrors());
     }
@@ -859,13 +859,13 @@ class SimpleFormTest extends AbstractFormTest
         $form->setData('foo');
     }
 
-    public function testBindingWrongDataIsIgnored()
+    public function testSubmittingWrongDataIsIgnored()
     {
         $test = $this;
 
         $child = $this->getBuilder('child', $this->dispatcher);
-        $child->addEventListener(FormEvents::PRE_BIND, function (FormEvent $event) use ($test) {
-            // child form doesn't receive the wrong data that is bound on parent
+        $child->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) use ($test) {
+            // child form doesn't receive the wrong data that is submitted on parent
             $test->assertNull($event->getData());
         });
 
@@ -875,7 +875,7 @@ class SimpleFormTest extends AbstractFormTest
             ->add($child)
             ->getForm();
 
-        $parent->bind('not-an-array');
+        $parent->submit('not-an-array');
     }
 
     public function testHandleRequestForwardsToRequestHandler()
@@ -964,30 +964,30 @@ class SimpleFormTest extends AbstractFormTest
         $form->getViewData();
     }
 
-    public function testPostBindDataIsNullIfInheritData()
+    public function testPostSubmitDataIsNullIfInheritData()
     {
         $test = $this;
         $form = $this->getBuilder()
-            ->addEventListener(FormEvents::POST_BIND, function (FormEvent $event) use ($test) {
+            ->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($test) {
                 $test->assertNull($event->getData());
             })
             ->setInheritData(true)
             ->getForm();
 
-        $form->bind('foo');
+        $form->submit('foo');
     }
 
-    public function testBindIsNeverFiredIfInheritData()
+    public function testSubmitIsNeverFiredIfInheritData()
     {
         $test = $this;
         $form = $this->getBuilder()
-            ->addEventListener(FormEvents::BIND, function (FormEvent $event) use ($test) {
-                $test->fail('The BIND event should not be fired');
+            ->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) use ($test) {
+                $test->fail('The SUBMIT event should not be fired');
             })
             ->setInheritData(true)
             ->getForm();
 
-        $form->bind('foo');
+        $form->submit('foo');
     }
 
     protected function createForm()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes (*) |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets | #5493 |
| License | MIT |
| Doc PR | TODO |

This change was discussed for a while in #5493. **(*)** It breaks BC _only for people who implemented_ `FormInterface` _manually_ (not a lot, so I hope). These can fix the problem by simply renaming `bind()` and `isBound()` in their implementation to `submit()` and `isSubmitted()`.

The main rationale is that with the request handlers introduced in #6522, people won't be confronted with the term "binding" anymore. As such, `isBound()` will be a very strange name to new users that have never used `bind()` manually.

See this code sample as example:

``` php
$form = $this->createForm(...);
$form->handleRequest($request);

// Imagine you have never heard about bind() or binding. What does this mean?
if ($form->isBound()) {
    // ...
}
```

In reality, `bind()` submits a form. Where-ever I renamed "bind" to "submit" in the comments, "submit" made actually much more sense. So it does in the code sample above:

``` php
$form = $this->createForm(...);
$form->handleRequest($request);

// Aha!
if ($form->isSubmitted()) {
    // ...
}
```

Also when using `submit()` directly, the code makes much more sense now:

``` php
$text = $this->createForm('text');
$text->submit('New Value');
```

For current users, the current naming will be supported until 3.0.
