### PR TITLE
Added html method into Crawler class

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -481,6 +481,28 @@ class Crawler extends \SplObjectStorage
     }
 
     /**
+     * Returns the html of the first node of the list.
+     *
+     * @return string The node html
+     *
+     * @throws \InvalidArgumentException When current node is empty
+     */
+    public function html()
+    {
+        if (!count($this)) {
+            throw new \InvalidArgumentException('The current node list is empty.');
+        }
+
+        $html = '';
+        foreach ($this->getNode(0)->childNodes as $child) {
+
+            $html .= $child->ownerDocument->saveXML($child);
+        }
+
+        return str_replace('&#13;', '', $html);
+    }
+
+    /**
      * Extracts information from the list of nodes.
      *
      * You can extract attributes or/and the node value (_text).

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -319,6 +319,18 @@ EOF
         }
     }
 
+    public function testHtml()
+    {
+        $this->assertEquals('<img alt="Bar"/>', $this->createTestCrawler()->filterXPath('//a[5]')->html(), '->html() returns the html of the first element of the node list');
+
+        try {
+            $this->createTestCrawler()->filterXPath('//ol')->html();
+            $this->fail('->html() throws an \InvalidArgumentException if the node list is empty');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertTrue(true, '->html() throws an \InvalidArgumentException if the node list is empty');
+        }
+    }
+
     public function testExtract()
     {
         $crawler = $this->createTestCrawler()->filterXPath('//ul[1]/li');


### PR DESCRIPTION
This PR was submitted on the symfony/DomCrawler read-only repository and moved automatically to the main Symfony repository (closes symfony/DomCrawler#11).

A pull request is waiting for aproval, but is not tested
- This method allow to get html inside desired element
- New method is tested
