### PR TITLE
Method each return an instance of Crawler instead DOMElement

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -7,6 +7,8 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
+ *
+ * Minor change to test
  */
 
 namespace Symfony\Component\DomCrawler;

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -7,8 +7,6 @@
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
- *
- * Minor change to test
  */
 
 namespace Symfony\Component\DomCrawler;

--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -277,7 +277,7 @@ class Crawler extends \SplObjectStorage
      *
      *     $crawler->filter('h1')->each(function ($node, $i)
      *     {
-     *       return $node->nodeValue;
+     *       return $node->text();
      *     });
      *
      * @param \Closure $closure An anonymous function
@@ -290,6 +290,7 @@ class Crawler extends \SplObjectStorage
     {
         $data = array();
         foreach ($this as $i => $node) {
+            $node = new static($node, $this->uri);
             $data[] = $closure($node, $i);
         }
 

--- a/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
+++ b/src/Symfony/Component/DomCrawler/Tests/CrawlerTest.php
@@ -276,8 +276,8 @@ EOF
 
     public function testEach()
     {
-        $data = $this->createTestCrawler()->filterXPath('//ul[1]/li')->each(function ($node, $i) {
-            return $i.'-'.$node->nodeValue;
+        $data = $this->createTestCrawler()->filter('ul:first-child li')->each(function ($node, $i) {
+            return $i.'-'.$node->text();
         });
 
         $this->assertEquals(array('0-One', '1-Two', '2-Three'), $data, '->each() executes an anonymous function on each node of the list');


### PR DESCRIPTION
This PR was submitted on the symfony/DomCrawler read-only repository and moved automatically to the main Symfony repository (closes symfony/DomCrawler#9).

Method each return an instance of Crawler instead DOMElement
