### PR TITLE
Filesystem::touch() not working with different owners (utime/atime issue)

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -101,7 +101,8 @@ class Filesystem
     public function touch($files, $time = null, $atime = null)
     {
         foreach ($this->toIterator($files) as $file) {
-            if (true !== @touch($file, $time, $atime)) {
+            $touch = $time ? @touch($file, $time, $atime) : @touch($file);
+            if (true !== $touch) {
                 throw new IOException(sprintf('Failed to touch %s', $file));
             }
         }

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -100,10 +100,6 @@ class Filesystem
      */
     public function touch($files, $time = null, $atime = null)
     {
-        if (null === $time) {
-            $time = time();
-        }
-
         foreach ($this->toIterator($files) as $file) {
             if (true !== @touch($file, $time, $atime)) {
                 throw new IOException(sprintf('Failed to touch %s', $file));


### PR DESCRIPTION
This PR was submitted on the symfony/Filesystem read-only repository and moved automatically to the main Symfony repository (closes symfony/Filesystem#3).

Case: I have 2 users, www-data and myself. I have a command script that makes a lock file in /var/lock/.../ something. This command is called from a post request by FOS and ran in the background.  Whever one of the 2 methods (web/cli manually) is used, the other user won't have permissions to use the Filesystem::touch(). The reason this won't work is the second parameter.

What touch() does:
$touch param: The touch time. If time is not supplied, the current system time is used.
$atime param: If present, the access time of the given filename is set to the value of atime. Otherwise, it is set to the value passed to the time parameter. If neither are present, the current system time is used.

So the current code is basically copying this. However, if the second parameter is null it is still present and will cause the same problem. Note that all files and folders related are set to 0777 and have the owner of www-data. I'm accessing them under my own account here:

Interactive shell

php > var_dump(touch('/var/lock/tripolis/ontw/dev/2140191804.lock', null));
PHP Warning:  touch(): Utime failed: Operation not permitted in php shell code on line 1

Warning: touch(): Utime failed: Operation not permitted in php shell code on line 1
bool(false)
php > var_dump(touch('/var/lock/tripolis/ontw/dev/2140191804.lock'));
bool(true)

If I were to pass it without second parameter, let it be time() or null (Filesystem uses time() by default if not present), it DOES work. However, Filesystem::touch() ALWAYS gives a parameter to touch. This parameter is exactly the same value as what the function itself would do in php. Let it be that in my case there is an issue with the atime. I'm not exactly sure how it works but it's not tracked or usable in my case. Because parameter 2 exists, parameter 3 is set. Parameter 3 is not allowed and therefore causes Filesystem::touch() to throw an exception.
