### PR TITLE
fix DateTimeToLocalizedStringTransformer issue #7561

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformer.php
@@ -130,8 +130,12 @@ class DateTimeToLocalizedStringTransformer extends BaseDateTimeTransformer
             throw new TransformationFailedException(intl_get_error_message());
         }
 
-        // read timestamp into DateTime object - the formatter delivers in UTC
-        $dateTime = new \DateTime(sprintf('@%s UTC', $timestamp));
+        try {
+            // read timestamp into DateTime object - the formatter delivers in UTC
+            $dateTime = new \DateTime(sprintf('@%s UTC', $timestamp));
+        } catch (\Exception $e) {
+            throw new TransformationFailedException($e->getMessage(), $e->getCode(), $e);
+        }
 
         if ('UTC' !== $this->inputTimezone) {
             try {

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToLocalizedStringTransformerTest.php
@@ -263,4 +263,13 @@ class DateTimeToLocalizedStringTransformerTest extends DateTimeTestCase
 
         $this->assertDateTimeEquals($this->dateTimeWithoutSeconds, $transformer->reverseTransform('31.04.10 04:05'));
     }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\TransformationFailedException
+     */
+    public function testReverseTransformOutOfTimestampRange()
+    {
+        $transformer = new DateTimeToLocalizedStringTransformer('UTC', 'UTC');
+        $transformer->reverseTransform('1789-07-14');
+    }
 }


### PR DESCRIPTION
this PR fix #7561 issue:

This fix possible issue with new `\DateTime` throwing `Exception` not handled by the transformer.
