### PR TITLE
[Validator] added missing estonian translation of messages

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.et.xlf
@@ -126,6 +126,14 @@
                 <source>The file could not be uploaded.</source>
                 <target>Faili ei saa üles laadida.</target>
              </trans-unit>
+            <trans-unit id="57">
+                <source>Invalid card number.</source>
+                <target>Vigane kaardi number.</target>
+            </trans-unit>
+            <trans-unit id="58">
+                <source>Unsupported card type or invalid card number.</source>
+                <target>Kaardi tüüpi ei toetata või kaardi number on vigane.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | - |
| License | MIT |

This commit adds missing Estonian translation of messages introduced in 2.2. It's a follow-up to #7769.
