### PR TITLE
Refactor behaviour triggered by a flag into separate classes.

### DIFF
--- a/src/Symfony/Component/Config/NonvalidatingCache.php
+++ b/src/Symfony/Component/Config/NonvalidatingCache.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * A cache that never expires once it has been written.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Matthias Pigulla <mp@webfactory.de>
+ */
+class NonvalidatingCache
+{
+    protected $file;
+
+    /**
+     * Constructor.
+     *
+     * @param string  $file  The absolute cache path
+     */
+    public function __construct($file)
+    {
+        $this->file = $file;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return $this->file;
+    }
+
+    /**
+     * By design, this method always returns true once the cache
+     * has been initialized.
+     *
+     * {@inheritdoc}
+     */
+    public function isFresh()
+    {
+        if (!is_file($this->file)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * This implementation ignores the metadata.
+     * {@inheritdoc}
+     */
+    public function write($content, array $metadata = null)
+    {
+        $filesystem = new Filesystem();
+        $filesystem->dumpFile($this->file, $content, 0666 & ~umask());
+    }
+}

--- a/src/Symfony/Component/Config/ResourceValidatingCache.php
+++ b/src/Symfony/Component/Config/ResourceValidatingCache.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Config;
+
+use Symfony\Component\Config\Resource\ResourceInterface;
+use Symfony\Component\Filesystem\Filesystem;
+
+/**
+ * ConfigCache manages PHP cache files.
+ *
+ * When debug is enabled, it knows when to flush the cache
+ * thanks to an array of ResourceInterface instances.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ResourceValidatingCache extends NonvalidatingCache
+{
+
+    /**
+     * Checks if the cache is still fresh.
+     *
+     * This method evaluates the resources/metadata passed to the
+     * write() method.
+     *
+     * @return Boolean true if the cache is fresh, false otherwise
+     */
+    public function isFresh()
+    {
+        if (!parent::isFresh()) {
+            return false;
+        }
+
+        $metadata = $this->getMetaFile();
+        if (!is_file($metadata)) {
+            return false;
+        }
+
+        $time = filemtime($this->file);
+        $meta = unserialize(file_get_contents($metadata));
+        foreach ($meta as $resource) {
+            if (!$resource->isFresh($time)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Writes cache.
+     *
+     * @param string              $content  The content to write in the cache
+     * @param ResourceInterface[] $metadata An array of ResourceInterface instances
+     *
+     * @throws \RuntimeException When cache file can't be wrote
+     */
+    public function write($content, array $metadata = null)
+    {
+        if (null !== $metadata) {
+            $filesystem = new Filesystem();
+            $filesystem->dumpFile($this->getMetaFile(), serialize($metadata), 0666 & ~umask());
+        }
+
+        parent::write($content);
+    }
+
+    /**
+     * Gets the meta file path.
+     *
+     * @return string The meta file path
+     */
+    private function getMetaFile()
+    {
+        return $this->file.'.meta';
+    }
+
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes (refactoring) |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | we'll see :-) |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

The ConfigCache class has two modes of behavior, toggled by the "debug" [flag](http://martinfowler.com/bliki/FlagArgument.html).

Refactoring that into two different classes may seem pointless or overkill at the moment, but gets more interesting once resource checking/validation gets more intricate. Peek at [this](https://github.com/webfactory/symfony/blob/2957057017259ff315c58e22637605963e303c11/src/Symfony/Component/Config/ResourceValidatingCache.php) if you're curious :-).

It's a pick off #7230.

NB. With the changes from #7781, you probably don't want to use `ConfigCache` anymore but instead have the factory create the right implementation and use it directly.
