### PR TITLE
[Component] [Security] [Acl] [Domain] Role security identity fix

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * A SecurityIdentity implementation for roles
@@ -30,11 +30,11 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function __construct($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
 
-        $this->role = (string) $role;
+        $this->role = $role;
     }
 
     /**

--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -34,7 +34,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
             $role = $role->getRole();
         }
 
-        $this->role = $role;
+        $this->role = (string) $role;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Casting the role property in the constructor is necessary to let the equals function binary  comparison work properly while using a custom role entity.

The security identity retrieval strategy getSecurityIdentities function instantiates the role security identity class passing an object. The constructor will assign this object to $this->role in case it's not an instance of Role. Binary safe comparison will fail even though gettype returns "string". The custom role entity requires a __toString magic method in this case.
