### PR TITLE
[Filesystem] Added a missing test case for Filesystem::dumpFile()

### DIFF
--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -883,6 +883,17 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testDumpFile()
+    {
+        $filename = $this->workspace.DIRECTORY_SEPARATOR.'foo'.DIRECTORY_SEPARATOR.'baz.txt';
+
+        $this->filesystem->dumpFile($filename, 'bar', 0753);
+
+        $this->assertFileExists($filename);
+        $this->assertSame('bar', file_get_contents($filename));
+        $this->assertEquals(753, $this->getFilePermissions($filename));
+    }
+
     /**
      * Returns file permissions as three digits (i.e. 755)
      *


### PR DESCRIPTION
This PR adds a test case for the `Filesystem::dumpFile()` method (introduced in #7753).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | [![Build Status](https://travis-ci.org/jakzal/symfony.png?branch=dumpfile-tests)](https://travis-ci.org/jakzal/symfony) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
