### PR TITLE
[Validator] Rename requireHyphens to requireHyphen for Issn constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Issn.php
+++ b/src/Symfony/Component/Validator/Constraints/Issn.php
@@ -22,5 +22,5 @@ class Issn extends Constraint
 {
     public $invalidMessage = 'This value is not a valid ISSN.';
     public $caseSensitive = false;
-    public $requireHyphens = false;
+    public $requireHyphen = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/IssnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IssnValidator.php
@@ -38,7 +38,7 @@ class IssnValidator extends ConstraintValidator
         }
 
         // Compose regex pattern
-        $digitsPattern = $constraint->requireHyphens ? '\d{4}-\d{3}' : '\d{4}-?\d{3}';
+        $digitsPattern = $constraint->requireHyphen ? '\d{4}-\d{3}' : '\d{4}-?\d{3}';
         $checksumPattern = $constraint->caseSensitive ? '[\d|X]' : '[\d|X|x]';
         $pattern = "/^".$digitsPattern.$checksumPattern."$/";
 

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -153,9 +153,9 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getValidNonHyphenatedIssn
      */
-    public function testRequireHyphensIssns($issn)
+    public function testRequireHyphenIssns($issn)
     {
-        $constraint = new Issn(array('requireHyphens' => true));
+        $constraint = new Issn(array('requireHyphen' => true));
         $this->context
             ->expects($this->once())
             ->method('addViolation')


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

While writing the documentation for the new Issn validator submitted yesterday at https://github.com/symfony/symfony/pull/7756, I've realized that the option `requireHyphens` should be renamed to `requireHyphen` because only one hyphen is allowed in the ISSN value.
