### PR TITLE
[FrameworkBundle] Improved TemplateNameParser performance

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/TemplateNameParser.php
@@ -56,19 +56,11 @@ class TemplateNameParser implements TemplateNameParserInterface
             throw new \RuntimeException(sprintf('Template name "%s" contains invalid characters.', $name));
         }
 
-        $parts = explode(':', $name);
-        if (3 !== count($parts)) {
+        if (!preg_match('/^([^:]*):([^:]*):(.+)\.([^\.]+)\.([^\.]+)$/', $name, $matches)) {
             throw new \InvalidArgumentException(sprintf('Template name "%s" is not valid (format is "bundle:section:template.format.engine").', $name));
         }
 
-        $elements = explode('.', $parts[2]);
-        if (3 > count($elements)) {
-            throw new \InvalidArgumentException(sprintf('Template name "%s" is not valid (format is "bundle:section:template.format.engine").', $name));
-        }
-        $engine = array_pop($elements);
-        $format = array_pop($elements);
-
-        $template = new TemplateReference($parts[0], $parts[1], implode('.', $elements), $format, $engine);
+        $template = new TemplateReference($matches[1], $matches[2], $matches[3], $matches[4], $matches[5]);
 
         if ($template->get('bundle')) {
             try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Performance test in symfony-standard:

``` php
<?php

use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;

require __DIR__.'/vendor/autoload.php';
require __DIR__.'/app/AppKernel.php';

$kernel = new AppKernel('dev', true);
$kernel->boot();
$parser = new TemplateNameParser($kernel);

$time = microtime(true);

for ($i = 0; $i < 50; ++$i) {
    $parser->parse("AcmeDemoBundle:Foo:bar$i.html.twig");
}

echo "Time:   " . (microtime(true) - $time)*1000 . "ms\n";
echo "Memory: " . memory_get_peak_usage(true)/(1024*1024) . "MB\n";
```

Before:

```
Time:   3.80706787109ms
Memory: 1.5MB
```

After:

```
Time:   3.13401222229ms
Memory: 1.5MB
```
