### PR TITLE
[FrameworkBundle] Made TemplateNameParser able to parse templates in the @-notation (#5660)

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Templating/TemplateNameParserTest.php
@@ -44,25 +44,37 @@ class TemplateNameParserTest extends TestCase
     /**
      * @dataProvider getLogicalNameToTemplateProvider
      */
-    public function testParse($name, $ref)
+    public function testParseLogicalName($logicalName, $atName, $ref)
     {
-        $template = $this->parser->parse($name);
+        $template = $this->parser->parse($logicalName);
 
-        $this->assertEquals($template->getLogicalName(), $ref->getLogicalName());
-        $this->assertEquals($template->getLogicalName(), $name);
+        $this->assertEquals($logicalName, $template->getLogicalName());
+        $this->assertEquals($logicalName, $ref->getLogicalName());
+    }
+
+    /**
+     * @dataProvider getLogicalNameToTemplateProvider
+     */
+    public function testParseAtName($logicalName, $atName, $ref)
+    {
+        $template = $this->parser->parse($atName);
+
+        $this->assertEquals($logicalName, $template->getLogicalName());
+        $this->assertEquals($logicalName, $ref->getLogicalName());
     }
 
     public function getLogicalNameToTemplateProvider()
     {
         return array(
-            array('FooBundle:Post:index.html.php', new TemplateReference('FooBundle', 'Post', 'index', 'html', 'php')),
-            array('FooBundle:Post:index.html.twig', new TemplateReference('FooBundle', 'Post', 'index', 'html', 'twig')),
-            array('FooBundle:Post:index.xml.php', new TemplateReference('FooBundle', 'Post', 'index', 'xml', 'php')),
-            array('SensioFooBundle:Post:index.html.php', new TemplateReference('SensioFooBundle', 'Post', 'index', 'html', 'php')),
-            array('SensioCmsFooBundle:Post:index.html.php', new TemplateReference('SensioCmsFooBundle', 'Post', 'index', 'html', 'php')),
-            array(':Post:index.html.php', new TemplateReference('', 'Post', 'index', 'html', 'php')),
-            array('::index.html.php', new TemplateReference('', '', 'index', 'html', 'php')),
-            array('FooBundle:Post:foo.bar.index.html.php', new TemplateReference('FooBundle', 'Post', 'foo.bar.index', 'html', 'php')),
+            array('FooBundle:Post:index.html.php', '@Foo/Post/index.html.php', new TemplateReference('FooBundle', 'Post', 'index', 'html', 'php')),
+            array('FooBundle:Post:index.html.twig', '@Foo/Post/index.html.twig', new TemplateReference('FooBundle', 'Post', 'index', 'html', 'twig')),
+            array('FooBundle:Post:index.xml.php', '@Foo/Post/index.xml.php', new TemplateReference('FooBundle', 'Post', 'index', 'xml', 'php')),
+            array('SensioFooBundle:Post:index.html.php', '@SensioFoo/Post/index.html.php', new TemplateReference('SensioFooBundle', 'Post', 'index', 'html', 'php')),
+            array('SensioCmsFooBundle:Post:index.html.php', '@SensioCmsFoo/Post/index.html.php', new TemplateReference('SensioCmsFooBundle', 'Post', 'index', 'html', 'php')),
+            array('FooBundle::index.html.php', '@Foo/index.html.php', new TemplateReference('FooBundle', '', 'index', 'html', 'php')),
+            array(':Post:index.html.php', 'Post/index.html.php', new TemplateReference('', 'Post', 'index', 'html', 'php')),
+            array('::index.html.php', 'index.html.php', new TemplateReference('', '', 'index', 'html', 'php')),
+            array('FooBundle:Post:foo.bar.index.html.php', '@Foo/Post/foo.bar.index.html.php', new TemplateReference('FooBundle', 'Post', 'foo.bar.index', 'html', 'php')),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6918 |
| License | MIT |
| Doc PR | TODO |

This PR adds the ability to handle Twig's new template name syntax (see fabpot/Twig#772 and #5660) to the `TemplateNameParser` class. Before, the syntax could only be used in Twig's own functionality, such as the `extend` or `include` statements. Now, the syntax can be used anywhere in a Symfony application, such as when returning from a Controller, the `@Template` annotation or with PHP Templating. The old syntax "bundle:controller:template" is still supported, but can be completely replaced*.

Examples:

| New Syntax | Old Syntax (still supported) |
| --- | --- |
| `index.html.twig` | `::index.html.twig` |
| `Foo/bar.html.php` | `:Foo:bar.html.php` |
| `@AcmeDemo/test.html.twig` | `AcmeDemoBundle::test.html.twig` |
| `@AcmeDemo/Post/create.html.php` | `AcmeDemoBundle:Post:create.html.php` |

\* The support for bundle inheritance is still missing for Twig: #6918
###### Benchmarks

Performance benchmark:

|  | Old paths | New paths (leading @) | New paths (no leading @) |
| --- | --- | --- | --- |
| Before | ~3.20ms | - | - |
| After | ~3.20ms | ~3.25ms | ~2.90ms |

Scripts:

benchmark-old.php

``` php
<?php

use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;

require __DIR__.'/vendor/autoload.php';
require __DIR__.'/app/AppKernel.php';

$kernel = new AppKernel('dev', true);
$kernel->boot();
$parser = new TemplateNameParser($kernel);


$time = microtime(true);

for ($i = 0; $i < 50; ++$i) {
    $parser->parse("AcmeDemoBundle:Foo:bar$i.html.twig");
}

echo "Time:   " . (microtime(true)-$time)*1000 . "ms\n";
echo "Memory: " . memory_get_peak_usage(true)/(1024*1024) . "MB\n";
```

benchmark-new.php

``` php
<?php

use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;

require __DIR__.'/vendor/autoload.php';
require __DIR__.'/app/AppKernel.php';

$kernel = new AppKernel('dev', true);
$kernel->boot();
$parser = new TemplateNameParser($kernel);


$time = microtime(true);

for ($i = 0; $i < 50; ++$i) {
    $parser->parse("@AcmeDemo/Foo/bar$i.html.twig");
}

echo "Time:   " . (microtime(true)-$time)*1000 . "ms\n";
echo "Memory: " . memory_get_peak_usage(true)/(1024*1024) . "MB\n";
```

benchmark-new2.php

``` php
<?php

use Symfony\Bundle\FrameworkBundle\Templating\TemplateNameParser;

require __DIR__.'/vendor/autoload.php';
require __DIR__.'/app/AppKernel.php';

$kernel = new AppKernel('dev', true);
$kernel->boot();
$parser = new TemplateNameParser($kernel);


$time = microtime(true);

for ($i = 0; $i < 50; ++$i) {
    $parser->parse("AcmeDemoBundle/Foo/bar$i.html.twig");
}

echo "Time:   " . (microtime(true)-$time)*1000 . "ms\n";
echo "Memory: " . memory_get_peak_usage(true)/(1024*1024) . "MB\n";
```
###### Remaining Concerns
- [ ] Drop the "Bundle" suffix or not?

My remaining concern is about the convention to drop the bundle suffix in the new syntax. I dislike it for three reasons:
- it is inconsistent with the resource import syntax (`@AcmeDemo/index.html.twig` vs. `@AcmeDemoBundle/Resources/config/routing.yml`)
- the paths for templates from a bundle vs. globally overridden templates are inconsistent (`@AcmeDemo/index.html.twig` vs. `AcmeDemoBundle/index.html.twig`)
- when an author creates both a library and some bundle to integrate it, he can't easily add namespaces for both of them (e.g. library "Monolog" and bundle "MonologBundle" - the namespace for the first would be `@Monolog/template.html.twig` but for the second as well, creating a conflict)

@fabpot stated in #5660 that an advantage of dropping the "Bundle" suffix is making the namespaces

> more agnostic for when the templates are used outside of the full-stack framework

I disagree. When I load MonologBundle into my non-Symfony application, it makes sense that the namespace is "MonologBundle".
- [ ] Adapt getLogicalName() or not?

The second question we have to solve is whether we change the logical template name (`TemplateReference::getLogicalName()`) to the new syntax as well. I left it at the old syntax for now because I don't know what the BC implications would be.
