### PR TITLE
[Filesystem] Made sure Filesystem::dumpFile() overwrites an existing file

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -224,16 +224,17 @@ class Filesystem
     /**
      * Renames a file.
      *
-     * @param string $origin The origin filename
-     * @param string $target The new filename
+     * @param string  $origin    The origin filename
+     * @param string  $target    The new filename
+     * @param Boolean $overwrite Whether to overwrite the target if it already exists
      *
      * @throws IOException When target file already exists
      * @throws IOException When origin cannot be renamed
      */
-    public function rename($origin, $target)
+    public function rename($origin, $target, $overwrite = false)
     {
         // we check that target does not exist
-        if (is_readable($target)) {
+        if (!$overwrite && is_readable($target)) {
             throw new IOException(sprintf('Cannot rename because the target "%s" already exist.', $target));
         }
 
@@ -452,7 +453,7 @@ class Filesystem
             throw new IOException(sprintf('Failed to write file "%s".', $filename));
         }
 
-        $this->rename($tmpFile, $filename);
+        $this->rename($tmpFile, $filename, true);
         $this->chmod($filename, $mode);
     }
 }

--- a/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
+++ b/src/Symfony/Component/Filesystem/Tests/FilesystemTest.php
@@ -639,6 +639,20 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->filesystem->rename($file, $newPath);
     }
 
+    public function testRenameOverwritesTheTargetIfItAlreadyExists()
+    {
+        $file = $this->workspace.DIRECTORY_SEPARATOR.'file';
+        $newPath = $this->workspace.DIRECTORY_SEPARATOR.'new_file';
+
+        touch($file);
+        touch($newPath);
+
+        $this->filesystem->rename($file, $newPath, true);
+
+        $this->assertFileNotExists($file);
+        $this->assertFileExists($newPath);
+    }
+
     /**
      * @expectedException \Symfony\Component\Filesystem\Exception\IOException
      */
@@ -892,6 +906,17 @@ class FilesystemTest extends \PHPUnit_Framework_TestCase
         $this->assertFileExists($filename);
         $this->assertSame('bar', file_get_contents($filename));
         $this->assertEquals(753, $this->getFilePermissions($filename));
+    }
+
+    public function testDumpFileOverwritesAnExistingFile()
+    {
+        $filename = $this->workspace.DIRECTORY_SEPARATOR.'foo.txt';
+        file_put_contents($filename, 'FOO BAR');
+
+        $this->filesystem->dumpFile($filename, 'bar');
+
+        $this->assertFileExists($filename);
+        $this->assertSame('bar', file_get_contents($filename));
     }
 
     /**


### PR DESCRIPTION
#7753 introduced a change in behaviour. Before, ConfigCache simply used the `rename()` function to save a file. It was replaced by `Filesystem::dumpFile()` which internally uses `Filesystem::rename()`. The later checks if file already exists and throws an exception if it exists.

This PR makes sure that `Filesystem::dumpFile()` removes the file before creating a new one.

Alternatively, we could introduce a third parameter to the `Filesystem::rename()` which would allow to overwrite the target file.

Before #7752: 
- [CompilerDebugDumpPass](https://github.com/symfony/symfony/blob/d100ffaf761b46acdb2440c04602378b87b0d610/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CompilerDebugDumpPass.php#L23) uses ConfigCache
- [ConfigCache](https://github.com/symfony/symfony/blob/d100ffaf761b46acdb2440c04602378b87b0d610/src/Symfony/Component/Config/ConfigCache.php#L103) uses the [rename()](http://uk1.php.net/rename) function (which overwrites a file if it exists)

After #7752: 
- [CompilerDebugDumpPass](https://github.com/symfony/symfony/blob/ad47bc47380188041b7889f40e380ad3766a0110/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Compiler/CompilerDebugDumpPass.php#L23) uses the `Filesystem::dumpFile()`
- [Filesystem::dumpFile()](https://github.com/webfactory/symfony/blob/ad47bc47380188041b7889f40e380ad3766a0110/src/Symfony/Component/Filesystem/Filesystem.php#L458) uses the [Filesystem::rename()](https://github.com/webfactory/symfony/blob/ad47bc47380188041b7889f40e380ad3766a0110/src/Symfony/Component/Filesystem/Filesystem.php#L239) (which throws an exception if file exists)

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7816 |
| License | MIT |
| Doc PR | ~ |
