### PR TITLE
[Form] make prototype_name available in twig template

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -32,7 +32,7 @@
 {% block collection_widget %}
 {% spaceless %}
     {% if prototype is defined %}
-        {% set attr = attr|merge({'data-prototype': form_row(prototype) }) %}
+        {% set attr = attr|merge({'data-prototype': form_row(prototype), 'data-prototype-name': prototype.vars.name }) %}
     {% endif %}
     {{ block('form_widget') }}
 {% endspaceless %}

--- a/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractLayoutTest.php
@@ -1735,7 +1735,7 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
     public function testCollectionPrototype()
     {
         $form = $this->factory->createNamedBuilder('name', 'form', array('items' => array('one', 'two', 'three')))
-            ->add('items', 'collection', array('allow_add' => true))
+            ->add('items', 'collection', array('allow_add' => true, 'prototype_name' => '__item__'))
             ->getForm()
             ->createView();
 
@@ -1745,6 +1745,14 @@ abstract class AbstractLayoutTest extends FormIntegrationTestCase
             '//div[@id="name_items"][@data-prototype]
             |
              //table[@id="name_items"][@data-prototype]
+
+'
+        );
+
+        $this->assertMatchesXpath($html,
+            '//div[@id="name_items"][@data-prototype-name="__item__"]
+            |
+             //table[@id="name_items"][@data-prototype-name="__item__"]
 
 '
         );


### PR DESCRIPTION
When using several collection types on the same page you might wan't to use different prototype names. Having the name in the template allows for a clean javascript to replace the prototype name in the prototype (see adjusted sample in the Doc PR). 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n.a |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/2544 |
