### PR TITLE
[RFC][WIP][Form] Rewrite boolean attributes to match HTML spec

### DIFF
--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -370,15 +370,41 @@
 
 {% block widget_attributes %}
 {% spaceless %}
-    id="{{ id }}" name="{{ full_name }}"{% if read_only %} readonly="readonly"{% endif %}{% if disabled %} disabled="disabled"{% endif %}{% if required %} required="required"{% endif %}{% if max_length %} maxlength="{{ max_length }}"{% endif %}{% if pattern %} pattern="{{ pattern }}"{% endif %}
-    {% for attrname, attrvalue in attr %}{% if attrname in ['placeholder', 'title'] %}{{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}" {% else %}{{ attrname }}="{{ attrvalue }}" {% endif %}{% endfor %}
+    id="{{ id }}"
+    name="{{ full_name }}"
+    {% if read_only %} readonly="readonly"{% endif %}
+    {% if disabled %} disabled="disabled"{% endif %}
+    {% if required %} required="required"{% endif %}
+    {% if max_length %} maxlength="{{ max_length }}"{% endif %}
+    {% if pattern %} pattern="{{ pattern }}"{% endif %}
+    {% for attrname, attrvalue in attr %}
+        {% if attrname in ['placeholder', 'title'] %}
+            {{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}"
+        {% else %}
+            {% if attrvalue is sameas(true) %}
+                {{ attrname }}="{{ attrname }}"
+            {% elseif attrvalue is not sameas(false) %}
+                {{ attrname }}="{{ attrvalue }}"
+            {% endif %}
+        {% endif %}
+    {% endfor %}
 {% endspaceless %}
 {% endblock widget_attributes %}
 
 {% block widget_container_attributes %}
 {% spaceless %}
     {% if id is not empty %}id="{{ id }}" {% endif %}
-    {% for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}
+    {% for attrname, attrvalue in attr %}
+        {% if attrname in ['placeholder', 'title'] %}
+            {{ attrname }}="{{ attrvalue|trans({}, translation_domain) }}"
+        {% else %}
+            {% if attrvalue is sameas(true) %}
+                {{ attrname }}="{{ attrname }}"
+            {% elseif attrvalue is not sameas(false) %}
+                {{ attrname }}="{{ attrvalue }}"
+            {% endif %}
+        {% endif %}
+    {% endfor %}
 {% endspaceless %}
 {% endblock widget_container_attributes %}
 


### PR DESCRIPTION
> 'The presence of a boolean attribute on an element represents the true value, and the absence of the attribute represents the false value.' - http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#boolean-attribute

This commit modifies widget_container_attributes and widget_attributes so that:
- `true` values render as the attribute name with the attribute name repeated as the value
- `false` values are not rendered

The comparison is strict using sames() in twig.

Previously `false` values would have been rendered as `some-attribute=""` which according to the spec would actually make them a boolean attribute and therefore equal to true.

Todo:
- [ ] Write tests
- [ ] Update docs
- [ ] Update PHP templates
