### PR TITLE
[Validator] Add digit constraint

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Digit.php
+++ b/src/Symfony/Component/Validator/Constraints/Digit.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ *
+ * @author Steve Müller <st.mueller@dzh-online.de>
+ *
+ * @api
+ */
+class Digit extends Constraint
+{
+    public $message = 'This value does not consist of numeric characters only.';
+}

--- a/src/Symfony/Component/Validator/Constraints/DigitValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DigitValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author Steve Müller <st.mueller@dzh-online.de>
+ *
+ * @api
+ */
+class DigitValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!ctype_digit(is_int($value) ? (string) $value : $value)) {
+            $this->context->addViolation($constraint->message, array('{{ value }}' => $value));
+        }
+    }
+}

--- a/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.de.xlf
@@ -246,6 +246,10 @@
                 <source>This value is not a valid currency.</source>
                 <target>Dieser Wert ist keine gültige Währung.</target>
             </trans-unit>
+            <trans-unit id="64">
+                <source>This value does not consist of numeric characters only.</source>
+                <target>Dieser Wert besteht nicht ausschließlich aus Ziffern.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.en.xlf
@@ -246,6 +246,10 @@
                 <source>This value is not a valid currency.</source>
                 <target>This value is not a valid currency.</target>
             </trans-unit>
+            <trans-unit id="65">
+                <source>This value does not consist of numeric characters only.</source>
+                <target>This value does not consist of numeric characters only.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/src/Symfony/Component/Validator/Tests/Constraints/DigitValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DigitValidatorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Constraints;
+
+use Symfony\Component\Validator\Constraints\Digit;
+use Symfony\Component\Validator\Constraints\DigitValidator;
+
+class DigitValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    protected $context;
+    protected $validator;
+
+    protected function setUp()
+    {
+        $this->context = $this->getMock('Symfony\Component\Validator\ExecutionContext', array(), array(), '', false);
+        $this->validator = new DigitValidator();
+        $this->validator->initialize($this->context);
+    }
+
+    protected function tearDown()
+    {
+        $this->context = null;
+        $this->validator = null;
+    }
+
+    public function testNullIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate(null, new Digit());
+    }
+
+    public function testEmptyStringIsValid()
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate('', new Digit());
+    }
+
+    /**
+     * @dataProvider getValidValues
+     */
+    public function testValidValues($value)
+    {
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($value, new Digit());
+    }
+
+    public function getValidValues()
+    {
+        return array(
+            array(0),
+            array('0'),
+            array('012345'),
+            array(666),
+            array('666'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     */
+    public function testInvalidValues($value)
+    {
+        $constraint = new Digit(array(
+            'message' => 'myMessage'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $value,
+            ));
+
+        $this->validator->validate($value, $constraint);
+    }
+
+    public function getInvalidValues()
+    {
+        return array(
+            array('foobar'),
+            array(1.1),
+            array('1.1'),
+            array(-1),
+            array('-1'),
+            array(false),
+            array(true),
+            array(new \stdClass()),
+            array(array()),
+        );
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | symfony/symfony-docs#2566 |

This PR adds a constraint for validating that a value consists of numeric characters only. Also added german translation.

This is my first contribution to the Symfony2 repository. I hope I have not forgotten anything, otherwise please tell me =)
