### PR TITLE
Place hasArgument() check at the beginning of getArgument() method 

### DIFF
--- a/src/Symfony/Component/Console/Input/InputDefinition.php
+++ b/src/Symfony/Component/Console/Input/InputDefinition.php
@@ -153,11 +153,11 @@ class InputDefinition
      */
     public function getArgument($name)
     {
-        $arguments = is_int($name) ? array_values($this->arguments) : $this->arguments;
-
         if (!$this->hasArgument($name)) {
             throw new \InvalidArgumentException(sprintf('The "%s" argument does not exist.', $name));
         }
+
+        $arguments = is_int($name) ? array_values($this->arguments) : $this->arguments;
 
         return $arguments[$name];
     }


### PR DESCRIPTION
If input definition doesn't have specified argument, then unnecessary operations will be executed ($arguments = is_int($name) ? array_values($this->arguments) : $this->arguments;)
