### PR TITLE
Fix http-kernel dep in symfony/security

### DIFF
--- a/src/Symfony/Component/Security/composer.json
+++ b/src/Symfony/Component/Security/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.3",
         "symfony/event-dispatcher": "~2.1",
         "symfony/http-foundation": ">=2.1,<2.4-dev",
-        "symfony/http-kernel": ">=2.1,<=2.3-dev"
+        "symfony/http-kernel": ">=2.1,<2.4-dev"
     },
     "require-dev": {
         "symfony/form": "~2.0",


### PR DESCRIPTION
The current constraint will not match 2.3.x-dev and cause edge cases
where either:
- composer falls back to symfony/symfony because it cannot find a match
- composer installs 2.2 versions of http-kernel and http-foundation
