### PR TITLE
[Validator] Rename issn constraint message option.

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Issn.php
+++ b/src/Symfony/Component/Validator/Constraints/Issn.php
@@ -20,7 +20,7 @@ use Symfony\Component\Validator\Constraint;
  */
 class Issn extends Constraint
 {
-    public $invalidMessage = 'This value is not a valid ISSN.';
+    public $message = 'This value is not a valid ISSN.';
     public $caseSensitive = false;
     public $requireHyphen = false;
 }

--- a/src/Symfony/Component/Validator/Constraints/IssnValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/IssnValidator.php
@@ -43,7 +43,7 @@ class IssnValidator extends ConstraintValidator
         $pattern = "/^".$digitsPattern.$checksumPattern."$/";
 
         if (!preg_match($pattern, $value)) {
-            $this->context->addViolation($constraint->invalidMessage);
+            $this->context->addViolation($constraint->message);
         } else {
             $digits = str_split(strtoupper(str_replace('-', '', $value)));
 
@@ -55,7 +55,7 @@ class IssnValidator extends ConstraintValidator
             $checksum = 'X' == reset($digits) ? 10 : (int) reset($digits);
 
             if (0 != ($sum + $checksum) % 11) {
-                $this->context->addViolation($constraint->invalidMessage);
+                $this->context->addViolation($constraint->message);
             }
         }
     }

--- a/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/IssnValidatorTest.php
@@ -145,7 +145,7 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context
             ->expects($this->once())
             ->method('addViolation')
-            ->with($constraint->invalidMessage);
+            ->with($constraint->message);
 
         $this->validator->validate($issn, $constraint);
     }
@@ -159,7 +159,7 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context
             ->expects($this->once())
             ->method('addViolation')
-            ->with($constraint->invalidMessage);
+            ->with($constraint->message);
 
         $this->validator->validate($issn, $constraint);
     }
@@ -186,7 +186,7 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context
             ->expects($this->once())
             ->method('addViolation')
-            ->with($constraint->invalidMessage);
+            ->with($constraint->message);
 
         $this->validator->validate($issn, $constraint);
     }
@@ -200,7 +200,7 @@ class IssnValidatorTest extends \PHPUnit_Framework_TestCase
         $this->context
             ->expects($this->once())
             ->method('addViolation')
-            ->with($constraint->invalidMessage);
+            ->with($constraint->message);
 
         $this->validator->validate($issn, $constraint);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Rename issn constraint message option to be consistent with all constraints having a single message option as suggested by @stof at https://github.com/symfony/symfony/commit/a4abfb95509437153bee13f1a49ae74a63408806#L0R23
