### PR TITLE
[OutputFormatterStyleTest] Added additional tests for OutputFormatterStyle Component

### DIFF
--- a/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterStyleTest.php
+++ b/tests/Symfony/Tests/Component/Console/Formatter/OutputFormatterStyleTest.php
@@ -73,5 +73,21 @@ class OutputFormatterStyleTest extends \PHPUnit_Framework_TestCase
 
         $style->setOptions(array('bold'));
         $this->assertEquals("\033[1mfoo\033[0m", $style->apply('foo'));
+
+        try {
+            $style->setOption('foo');
+            $this->fail('->setOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->setOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+            $this->assertContains('Invalid option specified: "foo"', $e->getMessage(), '->setOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+        }
+
+        try {
+            $style->unsetOption('foo');
+            $this->fail('->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+        } catch (\Exception $e) {
+            $this->assertInstanceOf('\InvalidArgumentException', $e, '->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+            $this->assertContains('Invalid option specified: "foo"', $e->getMessage(), '->unsetOption() throws an \InvalidArgumentException when the option does not exist in the available options');
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Added two additional tests to cover instances where an InvalidArgumentException should be thrown (setting/unsetting option that does not appear in the available options list).
