### PR TITLE
[Console] Code Enhancement: place $command->isEnabled() check at the beginning of Application:add() method

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -417,13 +417,11 @@ class Application
      */
     public function add(Command $command)
     {
-        $command->setApplication($this);
-
         if (!$command->isEnabled()) {
-            $command->setApplication(null);
-
             return;
         }
+
+        $command->setApplication($this);
 
         $this->commands[$command->getName()] = $command;
 


### PR DESCRIPTION
We don't need to set application to command if command is not enabled.
