### PR TITLE
Re-add travis build status icon - reverts @d2885adf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status - master branch](https://travis-ci.org/symfony/symfony.png?branch=master)](https://travis-ci.org/symfony/symfony)
+
 README
 ======
 


### PR DESCRIPTION
Instead of removing the build status icon, builds in the matrix such as `5.3.3` should be moved to allowed failures.

The build status icon is relevant to frequent contributors that may look into what is going on, it's not about advertising anything :)
