### PR TITLE
[DependencyInjection] Add Generic CompilerPass to collect tagged services

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Compiler/CollectSimpleTaggedServicesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CollectSimpleTaggedServicesPass.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Closure;
+
+/**
+ * Simplify collecting and registering tagged services.
+ *
+ * Adds convenience functionality to register tagged services
+ * with a parent service inside Bundle#build(ContainerBuilder $container).
+ *
+ * @author Benjamin Eberlei <kontakt@beberlei.de>
+ *
+ * @example
+ *
+ * Collect all services tagged with 'my_tag_name' and inject them
+ * into 'my_parent_service' using the 'addListener' method. Using
+ * one argument only and injecting the service:
+ *
+ *      $container->addCompilerPass(new CollectSimpleTaggedServicesPass(
+ *          'my_tag_name', 'my_parent_service', 'addListener'
+ *      ));
+ *
+ * Collect all services and work with additional arguments:
+ *
+ *      $container->addCompilerPass(new CollectSimpleTaggedServicesPass(
+ *          'my_tag_name', 'my_parent_service', 'addListener',
+ *          function ($id, $arguments) {
+ *              return array(new Reference($id), $arguments['foo']);
+ *          }
+ *      ));
+ */
+class CollectSimpleTaggedServicesPass implements CompilerPassInterface
+{
+    private $tagName;
+    private $service;
+    private $collectMethodName;
+    private $argumentWrangler;
+
+    /**
+     * @param string $tagName
+     * @param string $service
+     * @param string $collectMethodName
+     * @param Closure|null $argumentWrangler
+     */
+    public function __construct($tagName, $service, $collectMethodName, Closure $argumentWrangler = null)
+    {
+        $this->tagName = $tagName;
+        $this->service = $service;
+        $this->collectMethodName = $collectMethodName;
+
+        $this->argumentWrangler = $argumentWrangler ?: function ($id, $arguments) {
+            return array(new Reference($id));
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has($this->service)) {
+            return;
+        }
+
+        $taggedServiceIds = $container->findTaggedServiceIds($this->tagName);
+        $definition = $container->findDefinition($this->service);
+        $wrangler = $this->argumentWrangler;
+
+        foreach ($taggedServiceIds as $id => $tags) {
+            foreach ($tags as $arguments) {
+                $definition->addMethodCall(
+                    $this->collectMethodName,
+                    $wrangler($id, $arguments)
+                );
+            }
+        }
+    }
+}
+

--- a/src/Symfony/Component/DependencyInjection/Compiler/CollectSimpleTaggedServicesPass.php
+++ b/src/Symfony/Component/DependencyInjection/Compiler/CollectSimpleTaggedServicesPass.php
@@ -25,7 +25,7 @@ use Symfony\Component\DependencyInjection\Reference;
  * @example
  *
  * Collect all services tagged with 'my_tag_name' and inject them
- * into 'my_parent_service' using the 'addListener' method. Using
+ * into 'my_aggregating_service' using the 'addListener' method. Using
  * one argument only and injecting the service:
  *
  *      $container->addCompilerPass(new CollectSimpleTaggedServicesPass(

--- a/src/Symfony/Component/DependencyInjection/Tests/Compiler/CollectSimpleTaggedServicesPassTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Compiler/CollectSimpleTaggedServicesPassTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Tests\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CollectSimpleTaggedServicesPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class CollectSimpleTaggedServicesPassTest extends \PHPUnit_Framework_TestCase
+{
+    public function testProcess()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+        ;
+        $container
+            ->register('bar1')
+            ->addTag('bar', array())
+        ;
+        $container
+            ->register('bar2')
+            ->addTag('bar', array())
+        ;
+
+        $pass = new CollectSimpleTaggedServicesPass('bar', 'foo', 'setBar');
+        $pass->process($container);
+
+        $this->assertEquals(array(
+                array('setBar', array(new Reference('bar1'))),
+                array('setBar', array(new Reference('bar2'))),
+            ), $container->findDefinition('foo')->getMethodCalls());
+    }
+
+    public function testProcessWithArgumentWrangling()
+    {
+        $container = new ContainerBuilder();
+        $container
+            ->register('foo')
+        ;
+        $container
+            ->register('bar1')
+            ->addTag('bar', array('foo' => 'bar'))
+        ;
+
+        $pass = new CollectSimpleTaggedServicesPass('bar', 'foo', 'setBar', function ($id, $arguments) {
+            return array(new Reference($id), $arguments['foo']);
+        });
+        $pass->process($container);
+
+        $this->assertEquals(array(
+                array('setBar', array(new Reference('bar1'), 'bar')),
+            ), $container->findDefinition('foo')->getMethodCalls());
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

I often see developers either not knowing, or having difficulties with implementing tagged services and their collection. The problem is generically solvable and we should so, because it tremendously helps developers implement decoupled and reusable code.

Usage of the CompilerPass is described in the doc block class comment. I can add this as a documentation as well. This affects the following cookbook entry: http://symfony.com/doc/master/components/dependency_injection/tags.html
