### PR TITLE
[Form] Fixed: String validation groups are never interpreted as callbacks

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Constraints/FormValidator.php
@@ -181,7 +181,7 @@ class FormValidator extends ConstraintValidator
             $groups = $form->getConfig()->getOption('validation_groups');
 
             if (null !== $groups) {
-                if (is_callable($groups)) {
+                if (!is_string($groups) && is_callable($groups)) {
                     $groups = call_user_func($groups, $form);
                 }
 

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -302,6 +302,24 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate($form, new Form());
     }
 
+    public function testDontExecuteFunctionNames()
+    {
+        $context = $this->getExecutionContext();
+        $graphWalker = $context->getGraphWalker();
+        $object = $this->getMock('\stdClass');
+        $options = array('validation_groups' => 'header');
+        $form = $this->getBuilder('name', '\stdClass', $options)
+            ->setData($object)
+            ->getForm();
+
+        $graphWalker->expects($this->once())
+            ->method('walkReference')
+            ->with($object, 'header', 'data', true);
+
+        $this->validator->initialize($context);
+        $this->validator->validate($form, new Form());
+    }
+
     public function testHandleClosureValidationGroups()
     {
         $context = $this->getExecutionContext();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7371 |
| License | MIT |
| Doc PR | - |
