### PR TITLE
[FrameworkBundle] [Routing] added option to generate route names using underscores

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -176,6 +176,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('type')->end()
                         ->scalarNode('http_port')->defaultValue(80)->end()
                         ->scalarNode('https_port')->defaultValue(443)->end()
+                        ->scalarNode('naming_strategy')->defaultNull()->end()
                         ->scalarNode('strict_requirements')
                             ->info(
                                 "set to true to throw an exception when a parameter does not match the requirements\n".

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -279,6 +279,7 @@ class FrameworkExtension extends Extension
     {
         $loader->load('routing.xml');
 
+        $container->setParameter('router.naming_strategy', $config['naming_strategy']);
         $container->setParameter('router.resource', $config['resource']);
         $container->setParameter('router.cache_class_prefix', $container->getParameter('kernel.name').ucfirst($container->getParameter('kernel.environment')));
         $router = $container->findDefinition('router.default');

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -111,7 +111,7 @@ class Router implements RouterInterface
             'matcher_dumper_class'   => 'Symfony\\Component\\Routing\\Matcher\\Dumper\\PhpMatcherDumper',
             'matcher_cache_class'    => 'ProjectUrlMatcher',
             'resource_type'          => null,
-            'strict_requirements'    => true,
+            'strict_requirements'    => true
         );
 
         // check option names and live merge, if errors are encountered Exception will be thrown


### PR DESCRIPTION
This allows generated route names to be separated by underscore instead of just converting them to lowercase.

Example:
StemerdinkIt\CamelCasedBundle

Would now be:
stemerdink_it_camel_cased_...
Instead of:
stemerdinkit_camelcased_...

To keep it backwards compatible it is not enabled by default. It can be enabled via config.yml:

framework:
    router:
        naming_strategy: underscore

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This change also depends on a change in the SensioFrameworkExtraBundle: StemerdinkIT/SensioFrameworkExtraBundle@836cafd69addac9e6a82b81a42b5e06bac5f22a1
