### PR TITLE
WIP [HttpFoundation] fix AcceptHeader::__toString() that did not sort the items

### DIFF
--- a/src/Symfony/Component/HttpFoundation/AcceptHeader.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeader.php
@@ -69,6 +69,8 @@ class AcceptHeader
      */
     public function __toString()
     {
+        $this->sort();
+
         return implode(',', $this->items);
     }
 
@@ -160,6 +162,10 @@ class AcceptHeader
                 $qB = $b->getQuality();
 
                 if ($qA === $qB) {
+                    if ($a->getIndex() === $b->getIndex()) {
+                        return 0;
+                    }
+
                     return $a->getIndex() > $b->getIndex() ? 1 : -1;
                 }
 

--- a/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
@@ -131,7 +131,7 @@ class AcceptHeaderItem
      */
     public function setQuality($quality)
     {
-        $this->quality = $quality;
+        $this->quality = (float) $quality;
 
         return $this;
     }
@@ -155,7 +155,7 @@ class AcceptHeaderItem
      */
     public function setIndex($index)
     {
-        $this->index = $index;
+        $this->index = (int) $index;
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/AcceptHeaderTest.php
@@ -20,6 +20,9 @@ class AcceptHeaderTest extends \PHPUnit_Framework_TestCase
     {
         $header = AcceptHeader::fromString('text/plain; q=0.5, text/html, text/x-dvi; q=0.8, text/x-c');
         $this->assertSame('text/html', $header->first()->getValue());
+
+        $header = new AcceptHeader($header->all());
+        $this->assertSame('text/html', $header->first()->getValue());
     }
 
     /**


### PR DESCRIPTION
WIP

The items should be sorted otherwise the string representation would depend on the order of method calls, e.g. if you called all() before __toString() or not.

When doing so I figured the sort algorithm does not work for items that have the same quality and index (as a test makes use of). Unfortunately it's not easily possible to fix as phps uasort() does not retain the array order even when returning 0.

@jfsimon cc
