### PR TITLE
[DependencyInjection] Make service names case sensitive

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -250,8 +250,6 @@ class Container implements IntrospectableContainerInterface
      */
     public function get($id, $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE)
     {
-        $id = strtolower($id);
-
         if (array_key_exists($id, $this->services)) {
             return $this->services[$id];
         }


### PR DESCRIPTION
This skips a call that IMO is unnecessary, but obviously it is strictly speaking a BC break. I just have no idea if anyone relies on service names being case insensitive or not.
