### PR TITLE
Dependency check should be on ProxyManager directly - fixes #7945

### DIFF
--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -688,7 +688,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     {
         $container = new ContainerBuilder(new ParameterBag($this->getKernelParameters()));
 
-        if (class_exists('Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator')) {
+        if (class_exists('ProxyManager\Configuration')) {
             $container->setProxyInstantiator(new RuntimeInstantiator());
         }
 
@@ -708,7 +708,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
         // cache the container
         $dumper = new PhpDumper($container);
 
-        if (class_exists('Symfony\Bridge\ProxyManager\LazyProxy\Instantiator\RuntimeInstantiator')) {
+        if (class_exists('ProxyManager\Configuration')) {
             $dumper->setProxyDumper(new ProxyDumper());
         }
 


### PR DESCRIPTION
Hotfix for #7945 and symfony/symfony-standard#542

Yes yes, I know, the headers - coming after meeting time
