### PR TITLE
[Templating] Allows "template" and "parameters" as parameter name (replaces #7908)

### DIFF
--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -42,6 +42,9 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected $globals;
     protected $parser;
 
+    private $evalTemplate;
+    private $evalParameters;
+
     /**
      * Constructor.
      *
@@ -156,31 +159,28 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      */
     protected function evaluate(Storage $template, array $parameters = array())
     {
-        $__template__   = $template;
-        $__parameters__ = $parameters;
+        $this->evalTemplate   = $template;
+        $this->evalParameters = $parameters;
 
-        if (isset($__parameters__['__template__'])) {
-            throw new \InvalidArgumentException('Invalid parameter (__template__)');
+        if (isset($this->evalParameters['this'])) {
+            throw new \InvalidArgumentException('Invalid parameter (this)');
         }
-        if (isset($__parameters__['__parameters__'])) {
-            throw new \InvalidArgumentException('Invalid parameter (__parameters__)');
-        }
-        if (isset($__parameters__['view'])) {
+        if (isset($this->evalParameters['view'])) {
             throw new \InvalidArgumentException('Invalid parameter (view)');
         }
 
-        if ($__template__ instanceof FileStorage) {
-            extract($__parameters__, EXTR_OVERWRITE);
+        if ($this->evalTemplate instanceof FileStorage) {
+            extract($this->evalParameters, EXTR_OVERWRITE);
             $view = $this;
             ob_start();
-            require $__template__;
+            require $this->evalTemplate;
 
             return ob_get_clean();
-        } elseif ($__template__ instanceof StringStorage) {
-            extract($__parameters__, EXTR_OVERWRITE);
+        } elseif ($this->evalTemplate instanceof StringStorage) {
+            extract($this->evalParameters, EXTR_OVERWRITE);
             $view = $this;
             ob_start();
-            eval('; ?>'.$__template__.'<?php ;');
+            eval('; ?>'.$this->evalTemplate.'<?php ;');
 
             return ob_get_clean();
         }

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -161,6 +161,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     {
         $this->evalTemplate = $template;
         $this->evalParameters = $parameters;
+        unset($template, $parameters);
 
         if (isset($this->evalParameters['this'])) {
             throw new \InvalidArgumentException('Invalid parameter (this)');
@@ -169,19 +170,25 @@ class PhpEngine implements EngineInterface, \ArrayAccess
             throw new \InvalidArgumentException('Invalid parameter (view)');
         }
 
-        extract($this->evalParameters, EXTR_OVERWRITE);
-        $this->evalTemplate = null;
-        $this->evalParameters = null;
         $view = $this;
-
         if ($this->evalTemplate instanceof FileStorage) {
+            extract($this->evalParameters, EXTR_SKIP);
+            $this->evalParameters = null;
+
             ob_start();
             require $this->evalTemplate;
 
+            $this->evalTemplate = null;
+
             return ob_get_clean();
         } elseif ($this->evalTemplate instanceof StringStorage) {
+            extract($this->evalParameters, EXTR_SKIP);
+            $this->evalParameters = null;
+
             ob_start();
             eval('; ?>'.$this->evalTemplate.'<?php ;');
+
+            $this->evalTemplate = null;
 
             return ob_get_clean();
         }

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -166,6 +166,9 @@ class PhpEngine implements EngineInterface, \ArrayAccess
         if (isset($__parameters__['__parameters__'])) {
             throw new \InvalidArgumentException('Invalid parameter (__parameters__)');
         }
+        if (isset($__parameters__['view'])) {
+            throw new \InvalidArgumentException('Invalid parameter (view)');
+        }
 
         if ($__template__ instanceof FileStorage) {
             extract($__parameters__, EXTR_SKIP);

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -157,9 +157,13 @@ class PhpEngine implements EngineInterface, \ArrayAccess
     protected function evaluate(Storage $template, array $parameters = array())
     {
         $__template__ = $template;
+        unset($template);
 
         if (isset($parameters['__template__'])) {
             throw new \InvalidArgumentException('Invalid parameter (__template__)');
+        }
+        if (isset($parameters['parameters'])) {
+            throw new \InvalidArgumentException('Invalid parameter (parameters)');
         }
 
         if ($__template__ instanceof FileStorage) {

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -159,7 +159,7 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      */
     protected function evaluate(Storage $template, array $parameters = array())
     {
-        $this->evalTemplate   = $template;
+        $this->evalTemplate = $template;
         $this->evalParameters = $parameters;
 
         if (isset($this->evalParameters['this'])) {
@@ -169,16 +169,17 @@ class PhpEngine implements EngineInterface, \ArrayAccess
             throw new \InvalidArgumentException('Invalid parameter (view)');
         }
 
+        extract($this->evalParameters, EXTR_OVERWRITE);
+        $this->evalTemplate = null;
+        $this->evalParameters = null;
+        $view = $this;
+
         if ($this->evalTemplate instanceof FileStorage) {
-            extract($this->evalParameters, EXTR_OVERWRITE);
-            $view = $this;
             ob_start();
             require $this->evalTemplate;
 
             return ob_get_clean();
         } elseif ($this->evalTemplate instanceof StringStorage) {
-            extract($this->evalParameters, EXTR_OVERWRITE);
-            $view = $this;
             ob_start();
             eval('; ?>'.$this->evalTemplate.'<?php ;');
 

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -156,25 +156,26 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      */
     protected function evaluate(Storage $template, array $parameters = array())
     {
-        $__template__ = $template;
-        unset($template);
+        $__template__   = &$template;
+        $__parameters__ = &$parameters;
+        unset($template, $parameters);
 
-        if (isset($parameters['__template__'])) {
+        if (isset($__parameters__['__template__'])) {
             throw new \InvalidArgumentException('Invalid parameter (__template__)');
         }
-        if (isset($parameters['parameters'])) {
-            throw new \InvalidArgumentException('Invalid parameter (parameters)');
+        if (isset($__parameters__['__parameters__'])) {
+            throw new \InvalidArgumentException('Invalid parameter (__parameters__)');
         }
 
         if ($__template__ instanceof FileStorage) {
-            extract($parameters, EXTR_SKIP);
+            extract($__parameters__, EXTR_SKIP);
             $view = $this;
             ob_start();
             require $__template__;
 
             return ob_get_clean();
         } elseif ($__template__ instanceof StringStorage) {
-            extract($parameters, EXTR_SKIP);
+            extract($__parameters__, EXTR_SKIP);
             $view = $this;
             ob_start();
             eval('; ?>'.$__template__.'<?php ;');

--- a/src/Symfony/Component/Templating/PhpEngine.php
+++ b/src/Symfony/Component/Templating/PhpEngine.php
@@ -156,9 +156,8 @@ class PhpEngine implements EngineInterface, \ArrayAccess
      */
     protected function evaluate(Storage $template, array $parameters = array())
     {
-        $__template__   = &$template;
-        $__parameters__ = &$parameters;
-        unset($template, $parameters);
+        $__template__   = $template;
+        $__parameters__ = $parameters;
 
         if (isset($__parameters__['__template__'])) {
             throw new \InvalidArgumentException('Invalid parameter (__template__)');
@@ -171,14 +170,14 @@ class PhpEngine implements EngineInterface, \ArrayAccess
         }
 
         if ($__template__ instanceof FileStorage) {
-            extract($__parameters__, EXTR_SKIP);
+            extract($__parameters__, EXTR_OVERWRITE);
             $view = $this;
             ob_start();
             require $__template__;
 
             return ob_get_clean();
         } elseif ($__template__ instanceof StringStorage) {
-            extract($__parameters__, EXTR_SKIP);
+            extract($__parameters__, EXTR_OVERWRITE);
             $view = $this;
             ob_start();
             eval('; ?>'.$__template__.'<?php ;');

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -137,8 +137,7 @@ class PhpEngineTest extends \PHPUnit_Framework_TestCase
     public function forbiddenParameterNames()
     {
         return array(
-            array('__template__'),
-            array('__parameters__'),
+            array('this'),
             array('view'),
         );
     }

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -116,6 +116,32 @@ class PhpEngineTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar-foo-', $engine->render('foo.php', array('foo' => 'foo', 'bar' => 'bar')), '->render() supports render() calls in templates');
     }
 
+    public function testRenderParameter()
+    {
+        $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader);
+        $this->loader->setTemplate('foo.php', '<?php echo $template . $parameters[\'template\'] ?>');
+        $this->assertEquals('foofoo', $engine->render('foo.php', array('template' => 'foo')), '->render() extract variables');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @dataProvider forbiddenParameterNames
+     */
+    public function testRenderForbiddenParameter($name)
+    {
+        $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader);
+        $this->loader->setTemplate('foo.php', 'bar');
+        $engine->render('foo.php', array($name => 'foo'));
+    }
+
+    public function forbiddenParameterNames()
+    {
+        return array(
+            array('__template__'),
+            array('parameters'),
+        );
+    }
+
     public function testEscape()
     {
         $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader);

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -139,6 +139,7 @@ class PhpEngineTest extends \PHPUnit_Framework_TestCase
         return array(
             array('__template__'),
             array('__parameters__'),
+            array('view'),
         );
     }
 

--- a/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
+++ b/src/Symfony/Component/Templating/Tests/PhpEngineTest.php
@@ -119,8 +119,8 @@ class PhpEngineTest extends \PHPUnit_Framework_TestCase
     public function testRenderParameter()
     {
         $engine = new ProjectTemplateEngine(new TemplateNameParser(), $this->loader);
-        $this->loader->setTemplate('foo.php', '<?php echo $template . $parameters[\'template\'] ?>');
-        $this->assertEquals('foofoo', $engine->render('foo.php', array('template' => 'foo')), '->render() extract variables');
+        $this->loader->setTemplate('foo.php', '<?php echo $template . $parameters ?>');
+        $this->assertEquals('foobar', $engine->render('foo.php', array('template' => 'foo', 'parameters' => 'bar')), '->render() extract variables');
     }
 
     /**
@@ -138,7 +138,7 @@ class PhpEngineTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('__template__'),
-            array('parameters'),
+            array('__parameters__'),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | n/a |

Allows "template" and "parameters" as parameter name.
**BC break:** These variables were previously declared on every template with respectively the Templating\Storage instance and the array of parameters.
