### PR TITLE
[HttpKernel] Prevent setting something into frozen container.

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ContainerAwareHttpKernel.php
@@ -51,21 +51,25 @@ class ContainerAwareHttpKernel extends HttpKernel
     public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
     {
         $request->headers->set('X-Php-Ob-Level', ob_get_level());
-
-        $this->container->enterScope('request');
-        $this->container->set('request', $request, 'request');
+        if (!$this->container->isFrozen()) {
+            $this->container->enterScope('request');
+            $this->container->set('request', $request, 'request');
+        }
 
         try {
             $response = parent::handle($request, $type, $catch);
         } catch (\Exception $e) {
-            $this->container->set('request', null, 'request');
-            $this->container->leaveScope('request');
+            if (!$this->container->isFrozen()) {
+                $this->container->set('request', null, 'request');
+                $this->container->leaveScope('request');
+            }
 
             throw $e;
         }
-
-        $this->container->set('request', null, 'request');
-        $this->container->leaveScope('request');
+        if (!$this->container->isFrozen()) {
+            $this->container->set('request', null, 'request');
+            $this->container->leaveScope('request');
+        }
 
         return $response;
     }

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -42,11 +42,16 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $expected = new Response();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface', array('enterScope', 'leaveScope', 'set', 'isFrozen'));
+        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', array('enterScope', 'leaveScope', 'set', 'isFrozen'));
         $container
             ->expects($this->once())
             ->method('enterScope')
             ->with($this->equalTo('request'))
+        ;
+        $container
+            ->expects($this->once())
+            ->method('isFrozen')
+            ->will($this->returnValue(true))
         ;
         $container
             ->expects($this->once())
@@ -95,11 +100,16 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $expected = new \Exception();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface', array('enterScope', 'leaveScope', 'set', 'isFrozen'));
+        $container = $this->getMock('Symfony\Component\DependencyInjection\Container', array('enterScope', 'leaveScope', 'set', 'isFrozen'));
         $container
             ->expects($this->once())
             ->method('enterScope')
             ->with($this->equalTo('request'))
+        ;
+        $container
+            ->expects($this->once())
+            ->method('isFrozen')
+            ->will($this->returnValue(true))
         ;
         $container
             ->expects($this->once())

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -42,7 +42,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $expected = new Response();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface', array('enterScope', 'leaveScope', 'set', 'isFrozen'));
         $container
             ->expects($this->once())
             ->method('enterScope')
@@ -95,7 +95,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $request = new Request();
         $expected = new \Exception();
 
-        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface', array('enterScope', 'leaveScope', 'set', 'isFrozen'));
         $container
             ->expects($this->once())
             ->method('enterScope')

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -60,7 +60,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         ;
         // first call is for addScope()
         $container
-            ->expects($this->at(3))
+            ->expects($this->at(2))
             ->method('set')
             ->with($this->equalTo('request'), $this->equalTo($request), $this->equalTo('request'))
         ;
@@ -117,7 +117,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('request'))
         ;
         $container
-            ->expects($this->at(3))
+            ->expects($this->at(2))
             ->method('set')
             ->with($this->equalTo('request'), $this->equalTo($request), $this->equalTo('request'))
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -60,12 +60,12 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         ;
         // first call is for addScope()
         $container
-            ->expects($this->at(2))
+            ->expects($this->at(3))
             ->method('set')
             ->with($this->equalTo('request'), $this->equalTo($request), $this->equalTo('request'))
         ;
         $container
-            ->expects($this->at(3))
+            ->expects($this->at(4))
             ->method('set')
             ->with($this->equalTo('request'), $this->equalTo(null), $this->equalTo('request'))
         ;
@@ -117,12 +117,12 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('request'))
         ;
         $container
-            ->expects($this->at(2))
+            ->expects($this->at(3))
             ->method('set')
             ->with($this->equalTo('request'), $this->equalTo($request), $this->equalTo('request'))
         ;
         $container
-            ->expects($this->at(3))
+            ->expects($this->at(4))
             ->method('set')
             ->with($this->equalTo('request'), $this->equalTo(null), $this->equalTo('request'))
         ;

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -51,7 +51,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $container
             ->expects($this->once())
             ->method('isFrozen')
-            ->will($this->returnValue(true))
+            ->will($this->returnValue(false))
         ;
         $container
             ->expects($this->once())
@@ -109,7 +109,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
         $container
             ->expects($this->once())
             ->method('isFrozen')
-            ->will($this->returnValue(true))
+            ->will($this->returnValue(false))
         ;
         $container
             ->expects($this->once())

--- a/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/DependencyInjection/ContainerAwareHttpKernelTest.php
@@ -49,7 +49,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('request'))
         ;
         $container
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('isFrozen')
             ->will($this->returnValue(false))
         ;
@@ -107,7 +107,7 @@ class ContainerAwareHttpKernelTest extends \PHPUnit_Framework_TestCase
             ->with($this->equalTo('request'))
         ;
         $container
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('isFrozen')
             ->will($this->returnValue(false))
         ;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no3 |

I have a problem with profiler. Symfony tries set `request` into already frozen container. 
Here is my question on mailing list (with full error message): https://groups.google.com/forum/?fromgroups=#!topic/symfony2/UyqdwD7BAh0
