### PR TITLE
[HttpFoundation] enable ParameterBag's set/has/remove to also handle deep parameters

### DIFF
--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -65,7 +65,7 @@ class FrozenParameterBag extends ParameterBag
      *
      * @api
      */
-    public function set($name, $value)
+    public function set($name, $value, $deep = false)
     {
         throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
     }

--- a/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
+++ b/src/Symfony/Component/DependencyInjection/ParameterBag/FrozenParameterBag.php
@@ -65,7 +65,7 @@ class FrozenParameterBag extends ParameterBag
      *
      * @api
      */
-    public function set($name, $value, $deep = false)
+    public function set($name, $value)
     {
         throw new LogicException('Impossible to call set() on a frozen ParameterBag.');
     }

--- a/src/Symfony/Component/HttpFoundation/CHANGELOG.md
+++ b/src/Symfony/Component/HttpFoundation/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 2.3.0
 -----
 
+ * enable ParameterBag's set/has/remove to also handle deep parameters
  * added support for ranges of IPs in trusted proxies
  * `UploadedFile::isValid` now returns false if the file was not uploaded via HTTP (in a non-test mode)
  * Improved error-handling of `\Symfony\Component\HttpFoundation\Session\Storage\Handler\PdoSessionHandler`

--- a/src/Symfony/Component/HttpFoundation/FileBag.php
+++ b/src/Symfony/Component/HttpFoundation/FileBag.php
@@ -53,13 +53,13 @@ class FileBag extends ParameterBag
      *
      * @api
      */
-    public function set($key, $value)
+    public function set($key, $value, $deep = false)
     {
         if (!is_array($value) && !$value instanceof UploadedFile) {
             throw new \InvalidArgumentException('An uploaded file must be an array or an instance of UploadedFile.');
         }
 
-        parent::set($key, $this->convertFileInformation($value));
+        parent::set($key, $this->convertFileInformation($value), $deep);
     }
 
     /**

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -294,14 +294,14 @@ class ParameterBag implements \IteratorAggregate, \Countable
     /**
      * Allows to find the last parent and key for a given path within the parameters.
      *
-     * @param string      $path       A path like foo[bar]
-     * @param null|array  $lastParent A call-by-reference parameter for the last parent
-     * @param null|string $lastKey    A call-by-reference parameter for the last key
+     * @param string      $path           A path like foo[bar]
+     * @param \Closure    $foundCallback  Is called with parent level, key and value, if found 
+     * @param Boolean     $createPath     If true, create missing levels on path
      *
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      *
-     * @return boolean True if the path was found, false otherwise
+     * @return Boolean True if the path was found, false otherwise
      */
     private function getParentAndKeyByPath($path, \Closure $foundCallback = null, $createPath = false)
     {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -107,9 +107,10 @@ class ParameterBag implements \IteratorAggregate, \Countable
         }
 
         $result = null;
-        if (!$this->getParentAndKeyByPath($path, function($lastParent, $lastKey, $value) use (&$result) {
+        $callback = function($lastParent, $lastKey, $value) use (&$result) {
             $result = $value;
-        })) {
+        };
+        if (!$this->getParentAndKeyByPath($path, $callback)) {
             return $default;
         }
 

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -102,7 +102,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function get($path, $default = null, $deep = false)
     {
-        if (!$deep) {
+        if (!$deep || false === strpos($path, '[')) {
             return array_key_exists($path, $this->parameters) ? $this->parameters[$path] : $default;
         }
 
@@ -130,7 +130,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function set($path, $value, $deep = false)
     {
-        if (!$deep) {
+        if (!$deep || false === strpos($path, '[')) {
             $this->parameters[$path] = $value;
         } else {
             $this->getParentAndKeyByPath($path, function(&$lastParent, $lastKey, $value) use ($value) {
@@ -151,7 +151,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function has($path, $deep = false)
     {
-        if (!$deep) {
+        if (!$deep || false === strpos($path, '[')) {
             return array_key_exists($path, $this->parameters);
         }
 
@@ -168,7 +168,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      */
     public function remove($path, $deep = false)
     {
-        if (!$deep) {
+        if (!$deep || false === strpos($path, '[')) {
             unset($this->parameters[$path]);
         } else {
             $this->getParentAndKeyByPath($path, function(&$lastParent, &$lastKey, $value) {

--- a/src/Symfony/Component/HttpFoundation/ParameterBag.php
+++ b/src/Symfony/Component/HttpFoundation/ParameterBag.php
@@ -303,7 +303,7 @@ class ParameterBag implements \IteratorAggregate, \Countable
      *
      * @return boolean True if the path was found, false otherwise
      */
-    protected function getParentAndKeyByPath($path, \Closure $foundCallback = null, $createPath = false)
+    private function getParentAndKeyByPath($path, \Closure $foundCallback = null, $createPath = false)
     {
         $parameters = $this->parameters;
 

--- a/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/ParameterBagTest.php
@@ -125,6 +125,14 @@ class ParameterBagTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('default', $bag->get('bar[moo][foo]', 'default', true));
     }
 
+    public function testGetWithUtf8Key()
+    {
+        $bag = new ParameterBag(array('foö' => 'bar', 'bäz' => array('büz' => 'boo')));
+
+        $this->assertEquals('bar', $bag->get('foö'));
+        $this->assertEquals('boo', $bag->get('bäz[büz]', null, true));
+    }
+
     /**
      * @covers Symfony\Component\HttpFoundation\ParameterBag::set
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5040 |
| License | MIT |
- [ ] Doc PR

Allows the methods to handle deep parameters.
They now offer an additional boolean parameter to allow parsing of an array-syntax in the key.
The same behavior was already available for the get method.
