### PR TITLE
[TwigBundle] Fixed 2 namespaces

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Compiler/TwigLoaderPassTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace symfony\src\Symfony\Bundle\TwigBundle\Tests\DependencyInjection\Compiler;
+namespace Symfony\Bundle\TwigBundle\Tests\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;

--- a/src/Symfony/Bundle/TwigBundle/Tests/TokenParser/RenderTokenParserTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/TokenParser/RenderTokenParserTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Symfony\Bridge\Twig\Tests\Node;
+namespace Symfony\Bundle\TwigBundle\Tests\TokenParser;
 
 use Symfony\Bundle\TwigBundle\Tests\TestCase;
 use Symfony\Bundle\TwigBundle\TokenParser\RenderTokenParser;


### PR DESCRIPTION
Something went wrong with the namespaces in the test directory in 2.2
