### PR TITLE
[Finder] Fixed filter size on directory

### DIFF
--- a/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
+++ b/src/Symfony/Component/Finder/Iterator/SizeRangeFilterIterator.php
@@ -41,7 +41,7 @@ class SizeRangeFilterIterator extends FilterIterator
     public function accept()
     {
         $fileinfo = $this->current();
-        if (!$fileinfo->isFile()) {
+        if (!$fileinfo->isFile() && !$fileinfo->isDir() ) {
             return true;
         }
 

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -112,6 +112,13 @@ class FinderTest extends Iterator\RealIteratorTestCase
         $this->assertIterator($this->toAbsolute(array('test.php')), $finder->in(self::$tmpDir)->getIterator());
     }
 
+    public function testSizeWithDirectory()
+    {
+        $finder = new Finder();
+        $this->assertSame($finder, $finder->directories()->size('< 100'));
+        $this->assertIterator($this->toAbsolute(array('toto')), $finder->in(self::$tmpDir)->getIterator());
+    }
+
     public function testDate()
     {
         $finder = new Finder();

--- a/src/Symfony/Component/Finder/Tests/Iterator/SizeRangeFilterIteratorTest.php
+++ b/src/Symfony/Component/Finder/Tests/Iterator/SizeRangeFilterIteratorTest.php
@@ -31,7 +31,7 @@ class SizeRangeFilterIteratorTest extends RealIteratorTestCase
     public function getAcceptData()
     {
         return array(
-            array(array(new NumberComparator('< 1K'), new NumberComparator('> 0.5K')), array(sys_get_temp_dir().'/symfony2_finder/.foo', sys_get_temp_dir().'/symfony2_finder/.git', sys_get_temp_dir().'/symfony2_finder/foo', sys_get_temp_dir().'/symfony2_finder/test.php', sys_get_temp_dir().'/symfony2_finder/toto')),
+            array(array(new NumberComparator('< 1K'), new NumberComparator('> 0.5K')), array(sys_get_temp_dir().'/symfony2_finder/test.php')),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | not sure |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | itself |
| License | MIT |
| Doc PR | n/a |

Right now Finder composant returns all directories even is a size() is set and should filter out some.

Before the fix : 

``` php
$finder->directories()->size('< 500') 
// => return all folders even those bigger then 500 octets
```

After 

``` php
$finder->directories()->size('< 500') 
// => only returns folders smaller than 500 octets
```

Not sure if it can break BC, need your feedbacks
