### PR TITLE
[Serializer] Fatal error in denormalizeObject for Normalizers that do not implement DenormalizerInterface

### DIFF
--- a/src/Symfony/Component/Serializer/Serializer.php
+++ b/src/Symfony/Component/Serializer/Serializer.php
@@ -239,7 +239,8 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         }
 
         foreach ($this->normalizers as $normalizer) {
-            if ($normalizer->supportsNormalization($object, $format)) {
+            if ($normalizer instanceof NormalizerInterface
+                && $normalizer->supportsNormalization($object, $format)) {
                 $this->normalizerCache[$class][$format] = $normalizer;
 
                 return $normalizer->normalize($object, $format, $context);
@@ -273,7 +274,8 @@ class Serializer implements SerializerInterface, NormalizerInterface, Denormaliz
         }
 
         foreach ($this->normalizers as $normalizer) {
-            if ($normalizer->supportsDenormalization($data, $class, $format)) {
+            if ($normalizer instanceof DenormalizerInterface
+                && $normalizer->supportsDenormalization($data, $class, $format)) {
                 $this->denormalizerCache[$class][$format] = $normalizer;
 
                 return $normalizer->denormalize($data, $class, $format, $context);

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestDenormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * Provides a test Normalizer which only implements the DenormalizerInterface.
+ *
+ * @author Lin Clark <lin@lin-clark.com>
+ */
+class TestDenormalizer implements DenormalizerInterface
+{
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = null, array $context = array())
+  {
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsDenormalization($data, $type, $format = null)
+  {
+    return TRUE;
+  }
+}

--- a/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
+++ b/src/Symfony/Component/Serializer/Tests/Normalizer/TestNormalizer.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Serializer\Tests\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Provides a test Normalizer which only implements the NormalizerInterface.
+ *
+ * @author Lin Clark <lin@lin-clark.com>
+ */
+class TestNormalizer implements NormalizerInterface
+{
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = null, array $context = array())
+  {
+    
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsNormalization($data, $format = null)
+  {
+    return TRUE;
+  }
+}

--- a/src/Symfony/Component/Serializer/Tests/SerializerTest.php
+++ b/src/Symfony/Component/Serializer/Tests/SerializerTest.php
@@ -17,6 +17,8 @@ use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 use Symfony\Component\Serializer\Tests\Fixtures\TraversableDummy;
 use Symfony\Component\Serializer\Tests\Fixtures\NormalizableTraversableDummy;
+use Symfony\Component\Serializer\Tests\Normalizer\TestNormalizer;
+use Symfony\Component\Serializer\Tests\Normalizer\TestDenormalizer;
 
 class SerializerTest extends \PHPUnit_Framework_TestCase
 {
@@ -46,10 +48,29 @@ class SerializerTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
      */
+    public function testNormalizeOnDenormalizer()
+    {
+      $this->serializer = new Serializer(array(new TestDenormalizer()), array());
+      $this->assertTrue($this->serializer->normalize(new \stdClass, 'json'));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     */
     public function testDenormalizeNoMatch()
     {
         $this->serializer = new Serializer(array($this->getMock('Symfony\Component\Serializer\Normalizer\CustomNormalizer')));
         $this->serializer->denormalize('foo', 'stdClass');
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Serializer\Exception\UnexpectedValueException
+     */
+    public function testDenormalizeOnNormalizer()
+    {
+      $this->serializer = new Serializer(array(new TestNormalizer()), array());
+      $data = array('title' => 'foo', 'numbers' => array(5, 3));
+      $this->assertTrue($this->serializer->denormalize(json_encode($data), 'stdClass', 'json'));
     }
 
     public function testSerialize()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | 7971 |
| License | MIT |
| Doc PR |  |

If there is a list of Normalizers, and only some of them implement DenormalizerInterface, then a call to deserialize() can result in a fatal error. 

This is because denormalizeObject does not check that the Normalizer implements DenormalizerInterface before calling supportsDenormalization on it.
