### PR TITLE
[Form] getErrorsAsArray for Form class

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -758,6 +758,27 @@ class Form implements \IteratorAggregate, FormInterface
     }
 
     /**
+     * Returns an array representation of all form errors (including children errors).
+     *
+     * @return array An array representation of all errors in a tree structure with field names as array keys
+     */
+    public function getErrorsAsArray()
+    {
+        $errors = array();
+        foreach ($this->errors as $error) {
+            $errors[] = $error->getMessage();
+        }
+
+        foreach ($this->children as $key => $child) {
+            if ($err = $child->getErrorsAsArray()) {
+                $errors[$key] = $err;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function all()


### PR DESCRIPTION
With this new handy method Form class is now able to provide all validation errors of a form  (and its child forms) in a beautiful associative array tree that can, for example, easily be serialized to JSON for API responses and such. It seems quite a few people (including me) have had problems with the lack of this feature. At least this is the impression I had while browsing through questions in stackoverflow etc.

Implementation is similar to existing helper method `getErrorsAsString` so this one should behave however it behaves.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes (...I think. There were errors/fails but not caused by my code) |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

So... Any future for this?
