### PR TITLE
[FrameworkBundle] add configuration for the Property Accessor 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -100,6 +100,13 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('field_name')->defaultValue('_token')->end()
                     ->end()
                 ->end()
+                ->arrayNode('property_accessor')
+                    ->info('property accessor configuration')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('magic_call')->defaultFalse()->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -165,6 +165,7 @@ class FrameworkExtension extends Extension
         } else {
             $container->setParameter('form.type_extension.csrf.enabled', false);
         }
+        $container->setParameter('property_accessor.magic_call.enabled', $config['property_accessor']['magic_call']);
     }
 
     /**

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -55,7 +55,9 @@
         </service>
 
         <!-- PropertyAccessor -->
-        <service id="property_accessor" class="%property_accessor.class%" />
+        <service id="property_accessor" class="%property_accessor.class%">
+            <argument>%property_accessor.magic_call.enabled%</argument>
+        </service>
 
         <!-- CoreExtension -->
         <service id="form.type.field" class="Symfony\Component\Form\Extension\Core\Type\FieldType">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -94,6 +94,9 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             'ide'                 => null,
             'default_locale'      => 'en',
             'form'                => array('enabled' => false),
+            'property_accessor'   => array(
+                'magic_call' => false,
+            ),
             'csrf_protection'     => array(
                 'enabled'    => true,
                 'field_name' => '_token',
@@ -128,7 +131,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                 'debug'          => '%kernel.debug%',
             ),
             'serializer'          => array(
-                'enabled' => false           
+                'enabled' => false
             )
         );
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -4,6 +4,9 @@ $container->loadFromExtension('framework', array(
     'secret' => 's3cr3t',
     'default_locale' => 'fr',
     'form' => null,
+    'property_accessor' => array(
+        'magic_call' => false
+    ),
     'http_method_override' => false,
     'trusted_proxies' => array('127.0.0.1', '10.0.0.1'),
     'csrf_protection' => array(

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -2,6 +2,8 @@ framework:
     secret: s3cr3t
     default_locale: fr
     form: ~
+    property_accessor:
+        magic_call: false
     http_method_override: false
     trusted_proxies: ['127.0.0.1', '10.0.0.1']
     csrf_protection:

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -272,6 +272,13 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertStringEndsWith('TestBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'validation.xml', $xmlArgs[1]);
     }
 
+    public function testPropertyAccessor()
+    {
+        $container = $this->createContainerFromFile('full');
+
+        $this->assertFalse($container->getParameter('property_accessor.magic_call.enabled'));
+    }
+
     protected function createContainer(array $data = array())
     {
         return new ContainerBuilder(new ParameterBag(array_merge(array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | none |
| License | MIT |
| Doc PR | not yet done |

This allow to configure the property accessor to enable magic `__call` feature

``` yml
# config.yml
framework:
    property_accessor:
        magic_call: true #default is false
```

@bschussek 
