### PR TITLE
[Config][Loader] missing type parameter on import

### DIFF
--- a/src/Symfony/Component/Config/Loader/Loader.php
+++ b/src/Symfony/Component/Config/Loader/Loader.php
@@ -52,7 +52,7 @@ abstract class Loader implements LoaderInterface
      */
     public function import($resource, $type = null)
     {
-        return $this->resolve($resource)->load($resource, $type);
+        return $this->resolve($resource, $type)->load($resource, $type);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | idontknow |
| Fixed tickets | #7965 |
| License | MIT |
| Doc PR | - |

$type was missing inside the import() resolver call.
