### PR TITLE
[HttpFoundation][File][UploadedFile] Fix guessClientExtension() method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\HttpFoundation\File;
 
 use Symfony\Component\HttpFoundation\File\Exception\FileException;
 use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+use Symfony\Component\HttpFoundation\File\MimeType\ExtensionGuesser;
 
 /**
  * A file uploaded through a form.

--- a/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
+++ b/src/Symfony/Component/HttpFoundation/File/UploadedFile.php
@@ -171,7 +171,7 @@ class UploadedFile extends File
      */
     public function guessClientExtension()
     {
-        $type = $this->getMimeType();
+        $type = $this->getClientMimeType();
         $guesser = ExtensionGuesser::getInstance();
 
         return $guesser->guess($type);

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -73,7 +73,7 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             null
         );
 
-        $this->assertEquals('gif',$file->guessClientExtension());
+        $this->assertEquals('gif', $file->guessClientExtension());
     }
 
     public function testGuessClientExtensionWithIncorrectMimeType()
@@ -86,7 +86,7 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
             null
         );
 
-        $this->assertEquals('jpeg',$file->guessClientExtension());
+        $this->assertEquals('jpeg', $file->guessClientExtension());
     }
 
     public function testErrorIsOkByDefault()

--- a/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/File/UploadedFileTest.php
@@ -63,6 +63,32 @@ class UploadedFileTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('application/octet-stream', $file->getClientMimeType());
     }
 
+    public function testGuessClientExtension()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/gif',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null
+        );
+
+        $this->assertEquals('gif',$file->guessClientExtension());
+    }
+
+    public function testGuessClientExtensionWithIncorrectMimeType()
+    {
+        $file = new UploadedFile(
+            __DIR__.'/Fixtures/test.gif',
+            'original.gif',
+            'image/jpeg',
+            filesize(__DIR__.'/Fixtures/test.gif'),
+            null
+        );
+
+        $this->assertEquals('jpeg',$file->guessClientExtension());
+    }
+
     public function testErrorIsOkByDefault()
     {
         $file = new UploadedFile(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

1) Change getMimeType() by getClientMimeType() (we are guessing extension based on client information after all)
2) Add use of missing namespace (ExtensionGuesser)
3) Add tests for getClientExtension() method
