### PR TITLE
[Process] Moved process information retrieval into protected method.

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1121,6 +1121,16 @@ class Process
     }
 
     /**
+     * Retrieves the process information array from the process.
+     *
+     * @return array Process information
+     */
+    protected function getProcessInformation()
+    {
+        return proc_get_status($this->process);
+    }
+
+    /**
      * Builds up the callback used by wait().
      *
      * The callbacks adds all occurred output to the specific buffer and calls
@@ -1159,7 +1169,8 @@ class Process
             return;
         }
 
-        $this->processInformation = proc_get_status($this->process);
+        $this->processInformation = $this->getProcessInformation();
+
         if (!$this->processInformation['running']) {
             $this->status = self::STATUS_TERMINATED;
             if (-1 !== $this->processInformation['exitcode']) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This is a simple move the of the `proc_get_status` call into a protected method so that it may potentially be overridden in derivative classes.  Without this call isolated an override of any method accessing the private member `processInformation` would need to be overridden as well.

No documentation seems to cover this so I did not include a documentation pull request.  If this is in error, I will happily update the relevant documentation.
