### PR TITLE
Change the log level for 4xx HttpExceptions?

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -12,6 +12,8 @@ CHANGELOG
  * added the collect of data if a controller is a Closure in the Request collector
  * pass exceptions from the ExceptionListener to the logger using the logging context to allow for more
    detailed messages
+ * in `Symfony\Component\HttpKernel\EventListener\ExceptionListener`, reduced the logging level for HttpExceptions with
+   4xx status codes from "error" to "notice"
 
 2.2.0
 -----

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -100,7 +100,7 @@ class ExceptionListener implements EventSubscriberInterface
             if ($isCritical) {
                 $this->logger->critical($message, $context);
             } else {
-                $this->logger->error($message, $context);
+                $this->logger->notice($message, $context);
             }
         } elseif (!$original || $isCritical) {
             error_log($message);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | unsure |
| New feature? | unsure |
| BC breaks? | possibly, as folks might have to change config to get same results as before |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | n/a |

(Updated at 2013-05-10 13:15 UTC)

The initial motivation was in #7972 which I closed in favor of this one as we've got a much more valuable discussion here. Other changes nobody objected to have already been merged as #8000.

My POV is that HttpExceptions with 4xx status codes (and 404 in particular) are pretty normal events in webapps. Dynamic content comes and goes, people mistype URLs, browsers look for favicons, spiders want the robots.txt... 

[RFC2616](http://www.ietf.org/rfc/rfc2616.txt) uses 4xx "for cases in which the client seems to have erred". The application detects that, handles it gracefully by telling the client and showing a nice error page - and all is well from a user experience perspective.

Having such exceptions at the `error` level means a lot of clutter in log files unless you use the FingersCrossedHandler at a level _above_ that - which in turn would miss other `warning` level things.

For me, the `app` log channel is for application-level events, to record states and conditions in my application. In order to track "popular" 404s and user experience (for example, a page many folks suddenly miss), we're using the webserver access log files.

I chose the `notice` level to leave a bit more of options below so you don't get _all_ the info if you want to get the HttpExceptions.

But as the following discussion shows, clearly there are good reasons why higher log levels might be appropriate as well.
