### PR TITLE
Fixed failing 2.2 tests

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Constraints/FormValidatorTest.php
@@ -293,17 +293,16 @@ class FormValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testDontExecuteFunctionNames()
     {
-        $context = $this->getExecutionContext();
-        $graphWalker = $context->getGraphWalker();
+        $context = $this->getMockExecutionContext();
         $object = $this->getMock('\stdClass');
         $options = array('validation_groups' => 'header');
         $form = $this->getBuilder('name', '\stdClass', $options)
             ->setData($object)
             ->getForm();
 
-        $graphWalker->expects($this->once())
-            ->method('walkReference')
-            ->with($object, 'header', 'data', true);
+        $context->expects($this->once())
+            ->method('validate')
+            ->with($object, 'data', 'header', true);
 
         $this->validator->initialize($context);
         $this->validator->validate($form, new Form());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

1858b96b7dc473fcab09533b17ace9a24b8d3d86 introduced a mocked context and therefore `getExecutionContext()` is was renamed to `getMockExectionContext()`.
