### PR TITLE
Fixed parsing of leading blank lines in folded scalars.

### DIFF
--- a/src/Symfony/Component/Yaml/Parser.php
+++ b/src/Symfony/Component/Yaml/Parser.php
@@ -419,6 +419,18 @@ class Parser
             return '';
         }
 
+        $isCurrentLineBlank = $this->isCurrentLineBlank();
+        $text = '';
+
+        // leading blank lines are consumed before determining indentation
+        while ($notEOF && $isCurrentLineBlank) {
+            // newline only if not EOF
+            if ($notEOF = $this->moveToNextLine()) {
+                $text .= "\n";
+                $isCurrentLineBlank = $this->isCurrentLineBlank();
+            }
+        }
+
         // determine indentation if not specified
         if (0 === $indentation) {
             if (preg_match('/^ +/', $this->currentLine, $matches)) {
@@ -426,11 +438,9 @@ class Parser
             }
         }
 
-        $text = '';
         if ($indentation > 0) {
             $pattern = sprintf('/^ {%d}(.*)$/', $indentation);
 
-            $isCurrentLineBlank = $this->isCurrentLineBlank();
             while (
                 $notEOF && (
                     $isCurrentLineBlank ||

--- a/src/Symfony/Component/Yaml/Tests/ParserTest.php
+++ b/src/Symfony/Component/Yaml/Tests/ParserTest.php
@@ -396,6 +396,27 @@ EOF;
         $this->assertSame($expected, $this->parser->parse($yaml));
     }
 
+    /**
+     * Regression test for issue #7989.
+     *
+     * @see https://github.com/symfony/symfony/issues/7989
+     */
+    public function testBlockLiteralWithLeadingNewlines()
+    {
+        $yaml = <<<'EOF'
+foo: |-
+
+
+    bar
+
+EOF;
+        $expected = array(
+            'foo' => "\n\nbar"
+        );
+
+        $this->assertSame($expected, $this->parser->parse($yaml));
+    }
+
     public function testObjectSupportEnabled()
     {
         $input = <<<EOF


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7989 |
| License | MIT |
| Doc PR | n/a |

Fixed the issue raised in #7989. The cause was in the way the parser determined the indentation level of block scalars. When the indentation is not manually specified, the parser now determines the indentation from the first _non-empty_ line as per section [8.1.1.1.](http://www.yaml.org/spec/1.2/spec.html#id2793979) of the spec.
