### PR TITLE
Pass exceptions from the ExceptionListener to Monolog

### DIFF
--- a/src/Symfony/Component/HttpKernel/CHANGELOG.md
+++ b/src/Symfony/Component/HttpKernel/CHANGELOG.md
@@ -10,6 +10,8 @@ CHANGELOG
  * deprecated `Symfony\Component\HttpKernel\Kernel::init()``
  * added the possibility to specify an id an extra attributes to hinclude tags
  * added the collect of data if a controller is a Closure in the Request collector
+ * pass exceptions from the ExceptionListener to the logger using the logging context to allow for more
+   detailed messages
 
 2.2.0
 -----

--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -95,11 +95,12 @@ class ExceptionListener implements EventSubscriberInterface
     protected function logException(\Exception $exception, $message, $original = true)
     {
         $isCritical = !$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500;
+        $context = array('exception' => $exception);
         if (null !== $this->logger) {
             if ($isCritical) {
-                $this->logger->critical($message);
+                $this->logger->critical($message, $context);
             } else {
-                $this->logger->error($message);
+                $this->logger->error($message, $context);
             }
         } elseif (!$original || $isCritical) {
             error_log($message);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | rather yes |
| New feature? | rather no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7973, #7976 |
| License | MIT |
| Doc PR | n/a |

Pass exceptions caught by the ExceptionListener to Monolog, using the log message context. As of Monolog 1.5, exceptions passed that way will at least be logged with the line they were thrown in, also including any previous exceptions. 

Getting full stack traces (as suggested in #7976) becomes a possible change at the Monolog level (see seldaek/monolog#192) or users can add their own Monolog Formatter for that.

This PR is based on master. I'd be glad to provide similar ones for 2.1/2.2 if you'd pick them. Due to recent changes in the ExceptionListener I don't think a single patch on the older branches can easily be pulled to master anyway.
