### PR TITLE
[WIP][FrameworkBundle] Use new table helper in container:debug command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerDebugCommand.php
@@ -169,10 +169,7 @@ EOF
 
         $output->writeln($this->getHelper('formatter')->formatSection('container', $label));
 
-        // loop through to get space needed and filter private services
-        $maxName = 4;
-        $maxScope = 6;
-        $maxTags = array();
+        $headerTags = array();
         foreach ($serviceIds as $key => $serviceId) {
             $definition = $this->resolveServiceDefinition($serviceId);
 
@@ -183,77 +180,52 @@ EOF
                     continue;
                 }
 
-                if (strlen($definition->getScope()) > $maxScope) {
-                    $maxScope = strlen($definition->getScope());
-                }
-
                 if (null !== $showTagAttributes) {
                     $tags = $definition->getTag($showTagAttributes);
                     foreach ($tags as $tag) {
-                        foreach ($tag as $key => $value) {
-                            if (!isset($maxTags[$key])) {
-                                $maxTags[$key] = strlen($key);
-                            }
-                            if (strlen($value) > $maxTags[$key]) {
-                                $maxTags[$key] = strlen($value);
+                        foreach (array_keys($tag) as $key) {
+                            if (!in_array($key, $headerTags, true)) {
+                                $headerTags[] = $key;
                             }
                         }
                     }
                 }
             }
-
-            if (strlen($serviceId) > $maxName) {
-                $maxName = strlen($serviceId);
-            }
         }
-        $format = '%-'.$maxName.'s ';
-        $format .= implode("", array_map(function($length) { return "%-{$length}s "; }, $maxTags));
-        $format .= '%-'.$maxScope.'s %s';
 
-        // the title field needs extra space to make up for comment tags
-        $format1 = '%-'.($maxName + 19).'s ';
-        $format1 .= implode("", array_map(function($length) { return '%-'.($length + 19).'s '; }, $maxTags));
-        $format1 .= '%-'.($maxScope + 19).'s %s';
-
-        $tags = array();
-        foreach ($maxTags as $tagName => $length) {
-            $tags[] = '<comment>'.$tagName.'</comment>';
-        }
-        $output->writeln(vsprintf($format1, $this->buildArgumentsArray('<comment>Service Id</comment>', '<comment>Scope</comment>', '<comment>Class Name</comment>', $tags)));
+        $table = $this->getHelperSet()->get('table');
+        $table->setHeaders($this->buildArgumentsArray('Service Id', 'Scope', 'Class Name', $headerTags));
 
         foreach ($serviceIds as $serviceId) {
             $definition = $this->resolveServiceDefinition($serviceId);
 
             if ($definition instanceof Definition) {
-                $lines = array();
                 if (null !== $showTagAttributes) {
                     foreach ($definition->getTag($showTagAttributes) as $key => $tag) {
                         $tagValues = array();
-                        foreach (array_keys($maxTags) as $tagName) {
+                        foreach ($headerTags as $tagName) {
                             $tagValues[] = isset($tag[$tagName]) ? $tag[$tagName] : "";
                         }
                         if (0 === $key) {
-                            $lines[] = $this->buildArgumentsArray($serviceId, $definition->getScope(), $definition->getClass(), $tagValues);
+                            $table->addRow($this->buildArgumentsArray($serviceId, $definition->getScope(), $definition->getClass(), $tagValues));
                         } else {
-                            $lines[] = $this->buildArgumentsArray('  "', '', '', $tagValues);
+                            $table->addRow($this->buildArgumentsArray('  "', '', '', $tagValues));
                         }
                     }
                 } else {
-                    $lines[] = $this->buildArgumentsArray($serviceId, $definition->getScope(), $definition->getClass());
-                }
-
-                foreach ($lines as $arguments) {
-                    $output->writeln(vsprintf($format, $arguments));
+                    $table->addRow($this->buildArgumentsArray($serviceId, $definition->getScope(), $definition->getClass()));
                 }
             } elseif ($definition instanceof Alias) {
                 $alias = $definition;
-                $output->writeln(vsprintf($format, $this->buildArgumentsArray($serviceId, 'n/a', sprintf('<comment>alias for</comment> <info>%s</info>', (string) $alias), count($maxTags) ? array_fill(0, count($maxTags), "") : array())));
+                $table->addRow($this->buildArgumentsArray($serviceId, 'n/a', sprintf('alias for %s', (string) $alias), count($headerTags) ? array_fill(0, count($headerTags), "") : array()));
             } else {
                 // we have no information (happens with "service_container")
                 $service = $definition;
-                $output->writeln(vsprintf($format, $this->buildArgumentsArray($serviceId, '', get_class($service), count($maxTags) ? array_fill(0, count($maxTags), "") : array())));
+                $table->addRow($this->buildArgumentsArray($this->buildArgumentsArray($serviceId, '', get_class($service), count($headerTags) ? array_fill(0, count($headerTags), "") : array())));
             }
         }
+
+        $table->render($output);
     }
 
     protected function buildArgumentsArray($serviceId, $scope, $className, array $tagAttributes = array())


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This PR updates the container:debug command in order to make use of the new Table output helper. This should make the code cleaner and easer to maintain in the future. There are some issues which probably should be discussed before continuing/merging:
- [ ] The layout breaks badly if the table doesn't fit into the console. For the normal services dump this won't occur so quickly, but when I tried to apply this on the --parameters command, it became unreadable
- [ ] The layout breaks if you use <comment> (or other) tags. The helper will take the chars in account, while they are not rendered. I stripped them for now
- [ ] I wanted to apply the helper on the service information view, but i think it won't be applicable... E.g. `app/console container:debug data_collector.router`.

Let me know what you think about the issues
