### PR TITLE
[HttpFoundation][NamespacedAttributeBag] Refactoring of resolveKey() method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Attribute/NamespacedAttributeBag.php
@@ -149,8 +149,8 @@ class NamespacedAttributeBag extends AttributeBag
      */
     protected function resolveKey($name)
     {
-        if (strpos($name, $this->namespaceCharacter) !== false) {
-            $name = substr($name, strrpos($name, $this->namespaceCharacter)+1, strlen($name));
+        if (false !== $pos = strrpos($name, $this->namespaceCharacter)) {
+            $name = substr($name, $pos+1);
         }
 
         return $name;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Just code enhancement. Low priority.

1) We don't need to call strlen($name) as last argument of substr() function
2) We don't need to call strrpos (or strpos) two times.
