### PR TITLE
[Security] Disabled the BCryptPasswordEncoder tests for PHP < 5.3.7

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -46,7 +46,17 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
     }
 
     /**
-     * {@inheritdoc}
+     * Encodes the raw password.
+     *
+     * It doesn't work with PHP versions lower than 5.3.7, since
+     * the password compat library uses CRYPT_BLOWFISH hash type with
+     * the "$2y$" salt prefix (which is not available in the early PHP versions).
+     * @see https://github.com/ircmaxell/password_compat/issues/10#issuecomment-11203833
+     *
+     * @param string $raw  The password to encode
+     * @param string $salt The salt
+     *
+     * @return string The encoded password
      */
     public function encodePassword($raw, $salt)
     {

--- a/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
+++ b/src/Symfony/Component/Security/Tests/Core/Encoder/BCryptPasswordEncoderTest.php
@@ -47,6 +47,8 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testResultLength()
     {
+        $this->skipIfPhpVersionIsNotSupported();
+
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertEquals(60, strlen($result));
@@ -54,9 +56,18 @@ class BCryptPasswordEncoderTest extends \PHPUnit_Framework_TestCase
 
     public function testValidation()
     {
+        $this->skipIfPhpVersionIsNotSupported();
+
         $encoder = new BCryptPasswordEncoder(self::VALID_COST);
         $result = $encoder->encodePassword(self::PASSWORD, null);
         $this->assertTrue($encoder->isPasswordValid($result, self::PASSWORD, null));
         $this->assertFalse($encoder->isPasswordValid($result, 'anotherPassword', null));
+    }
+
+    private function skipIfPhpVersionIsNotSupported()
+    {
+        if (version_compare(phpversion(), '5.3.7', '<')) {
+            $this->markTestSkipped('Requires PHP >= 5.3.7');
+        }
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (segfault) |
| Fixed tickets | #7994 |
| License | MIT |
| Doc PR | - |

See https://github.com/ircmaxell/password_compat/issues/10#issuecomment-11203833.
