### PR TITLE
[DomCrawler] Fixed the Crawler::html() method for early PHP versions

### DIFF
--- a/src/Symfony/Component/DomCrawler/Crawler.php
+++ b/src/Symfony/Component/DomCrawler/Crawler.php
@@ -499,7 +499,15 @@ class Crawler extends \SplObjectStorage
 
         $html = '';
         foreach ($this->getNode(0)->childNodes as $child) {
-            $html .= $child->ownerDocument->saveHTML($child);
+            if (version_compare(PHP_VERSION, '5.3.6', '>=')) {
+                // node parameter was added to the saveHTML() method in PHP 5.3.6
+                // @see http://php.net/manual/en/domdocument.savehtml.php
+                $html .= $child->ownerDocument->saveHTML($child);
+            } else {
+                $document = new \DOMDocument('1.0', 'UTF-8');
+                $document->appendChild($document->importNode($child, true));
+                $html .= rtrim($document->saveHTML());
+            }
         }
 
         return $html;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes, but not on travis (segfault) |
| Fixed tickets | #7963 |
| License | MIT |
| Doc PR | - |

Node argument was added to the [`DOMDocument::saveHTML()`](http://php.net/manual/en/domdocument.savehtml.php) in PHP 5.3.6. See http://php.net/manual/en/domdocument.savehtml.php.

It's not a nice looking solution, but seems to be the only option. Condition should be removed once PHP dependency goes over 5.3.6.
