### PR TITLE
[Form] allow binding JSON requests

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/HttpFoundation/HttpFoundationRequestHandlerTest.php
@@ -51,4 +51,15 @@ class HttpFoundationRequestHandlerTest extends AbstractRequestHandlerTest
             ->disableOriginalConstructor()
             ->getMock();
     }
+
+    public function testProcessorHandlesJSON()
+    {
+        $data = array('test_field1' => 'value1', 'test_field2' => 'value2');
+        $this->request = Request::create('http://localhost', 'POST', array(), array(), array(), array('CONTENT_TYPE' => 'application/json'), json_encode(array('test_form' => $data)));
+        $form = $this->getMockForm('testForm', 'POST', false);
+
+        $form->expects($this->once())->method('submit')->with(array('testField1' => 'value1', 'testField2' => 'value2'));
+
+        $this->requestHandler->handleRequest($form, $this->request);
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Since we made a move to Angular for our frontend experience, we are forced to throw data around in JSON format more and more. This PR solves a problem we were forced to solve in our controllers in many occasions.

Also, since JMS serializer bundle by default converts camel case properties to underscore case keys, the reverse had to be supplied at some point. I chose to do this in the PHP side of things.

This all allows me to use the Form component without actually using the FormView (in fact, I'd even vote for splitting the Form and FormView into two components at some point)

This PR of course opens the door for other formats, like XML.
