### PR TITLE
[2.4][Console] Added status code to CommandTester and ApplicationTester

### DIFF
--- a/src/Symfony/Component/Console/Tester/ApplicationTester.php
+++ b/src/Symfony/Component/Console/Tester/ApplicationTester.php
@@ -32,6 +32,7 @@ class ApplicationTester
     private $application;
     private $input;
     private $output;
+    private $statusCode;
 
     /**
      * Constructor.
@@ -72,7 +73,7 @@ class ApplicationTester
             $this->output->setVerbosity($options['verbosity']);
         }
 
-        return $this->application->run($this->input, $this->output);
+        return $this->statusCode = $this->application->run($this->input, $this->output);
     }
 
     /**
@@ -113,5 +114,15 @@ class ApplicationTester
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * Gets the status code returned by the last execution of the application.
+     *
+     * @return integer The status code
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
     }
 }

--- a/src/Symfony/Component/Console/Tester/CommandTester.php
+++ b/src/Symfony/Component/Console/Tester/CommandTester.php
@@ -25,6 +25,7 @@ class CommandTester
     private $command;
     private $input;
     private $output;
+    private $statusCode;
 
     /**
      * Constructor.
@@ -65,7 +66,7 @@ class CommandTester
             $this->output->setVerbosity($options['verbosity']);
         }
 
-        return $this->command->run($this->input, $this->output);
+        return $this->statusCode = $this->command->run($this->input, $this->output);
     }
 
     /**
@@ -106,5 +107,15 @@ class CommandTester
     public function getOutput()
     {
         return $this->output;
+    }
+
+    /**
+     * Gets the status code returned by the last execution of the application.
+     *
+     * @return integer The status code
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
     }
 }

--- a/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/ApplicationTesterTest.php
@@ -61,4 +61,9 @@ class ApplicationTesterTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('foo'.PHP_EOL, $this->tester->getDisplay(), '->getDisplay() returns the display of the last execution');
     }
+
+    public function testGetStatusCode()
+    {
+        $this->assertSame(0, $this->tester->getStatusCode(), '->getStatusCode() returns the status code');
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
+++ b/src/Symfony/Component/Console/Tests/Tester/CommandTesterTest.php
@@ -59,4 +59,9 @@ class CommandTesterTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('foo'.PHP_EOL, $this->tester->getDisplay(), '->getDisplay() returns the display of the last execution');
     }
+
+    public function testGetStatusCode()
+    {
+        $this->assertSame(0, $this->tester->getStatusCode(), '->getStatusCode() returns the status code');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes, but not on travis (segfault) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Theses classes are already statefull. They contain the input and the
output data. So we can safely add the last status code to the class.
