### PR TITLE
[BrowserKit] should not follow redirects if status code is not 30x

### DIFF
--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -263,3 +263,19 @@ Console
    ```
    if (OutputInterface::VERBOSITY_VERBOSE <= $output->getVerbosity()) { ... }
    ```
+
+BrowserKit
+----------
+
+ * If you are receiving responses with non-30x Status Code and Location header
+   please be aware that you won't be able to use auto-redirects on these kind
+   of responses. To force redirection even if the response is not HTTP 30x,
+   call `Client::followRedirect(true)` to force-redirect if `Location` header
+   is present.
+
+   If you are correctly passing 30x Status Code with Location header, you
+   don't have to worry about the change.
+
+   If you were using responses with Location header and non-30x Status Code,
+   you have to update your code to forcely follow the redirect with
+   `Client::followRedirect(true)`.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -269,13 +269,11 @@ BrowserKit
 
  * If you are receiving responses with non-30x Status Code and Location header
    please be aware that you won't be able to use auto-redirects on these kind
-   of responses. To force redirection even if the response is not HTTP 30x,
-   call `Client::followRedirect(true)` to force-redirect if `Location` header
-   is present.
+   of responses.
 
    If you are correctly passing 30x Status Code with Location header, you
    don't have to worry about the change.
 
    If you were using responses with Location header and non-30x Status Code,
-   you have to update your code to forcely follow the redirect with
-   `Client::followRedirect(true)`.
+   you have to update your code to manually create another request to URL
+   grabbed from the Location header.

--- a/UPGRADE-2.3.md
+++ b/UPGRADE-2.3.md
@@ -267,13 +267,13 @@ Console
 BrowserKit
 ----------
 
- * If you are receiving responses with non-30x Status Code and Location header
+ * If you are receiving responses with non-3xx Status Code and Location header
    please be aware that you won't be able to use auto-redirects on these kind
    of responses.
 
-   If you are correctly passing 30x Status Code with Location header, you
+   If you are correctly passing 3xx Status Code with Location header, you
    don't have to worry about the change.
 
-   If you were using responses with Location header and non-30x Status Code,
+   If you were using responses with Location header and non-3xx Status Code,
    you have to update your code to manually create another request to URL
    grabbed from the Location header.

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 -----
 
  * [BC BREAK] `Client::followRedirect()` won't redirect responses with
-   a non-30x Status Code and `Location` header anymore, as per 
+   a non-3xx Status Code and `Location` header anymore, as per 
    http://tools.ietf.org/html/rfc2616#section-14.30
 
  * added `Client::getInternalRequest()` and `Client::getInternalResponse()` to

--- a/src/Symfony/Component/BrowserKit/CHANGELOG.md
+++ b/src/Symfony/Component/BrowserKit/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 2.3.0
 -----
 
+ * [BC BREAK] `Client::followRedirect()` won't redirect responses with
+   a non-30x Status Code and `Location` header anymore, as per 
+   http://tools.ietf.org/html/rfc2616#section-14.30
+
  * added `Client::getInternalRequest()` and `Client::getInternalResponse()` to
    have access to the BrowserKit internal request and response objects
 

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -329,9 +329,12 @@ abstract class Client
         $this->cookieJar->updateFromResponse($this->internalResponse, $uri);
 
         $status = $this->internalResponse->getStatus();
-        $location = $this->internalResponse->getHeader('Location');
-
-        $this->redirect = $status >= 300 && $status < 400 ? $location : null;
+        
+        if ($status >= 300 && $status < 400) {
+            $this->redirect = $this->internalResponse->getHeader('Location');
+        } else {
+            $this->redirect = null;
+        }
 
         if ($this->followRedirects && $this->redirect) {
             return $this->crawler = $this->followRedirect();

--- a/src/Symfony/Component/BrowserKit/Client.php
+++ b/src/Symfony/Component/BrowserKit/Client.php
@@ -473,15 +473,13 @@ abstract class Client
      *
      * @return Crawler
      *
-     * @param boolean $force Do not check Status Code and follow if Location header present (default: false)
-     *
      * @throws \LogicException If request was not a redirect
      *
      * @api
      */
-    public function followRedirect($force = false)
+    public function followRedirect()
     {
-        if (!$force && empty($this->redirect)) {
+        if (empty($this->redirect)) {
             throw new \LogicException('The request was not redirected.');
         }
 
@@ -493,10 +491,7 @@ abstract class Client
 
         $this->isMainRequest = false;
 
-        $response = $this->request('get', $force 
-            ? $this->internalResponse->getHeader('Location') 
-            : $this->redirect
-        );
+        $response = $this->request('get', $this->redirect);
 
         $this->isMainRequest = true;
 

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -348,6 +348,30 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $client->request('GET', 'http://www.example.com/foo/foobar');
 
         $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect() automatically follows redirects if followRedirects is true');
+
+        $client = new TestClient();
+        $client->setNextResponse(new Response('', 201, array('Location' => 'http://www.example.com/redirected')));
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        $this->assertEquals('http://www.example.com/foo/foobar', $client->getRequest()->getUri(), '->followRedirect() does not follow redirect if HTTP Code is not 30x');
+
+        $client = new TestClient();
+        $client->setNextResponse(new Response('', 201, array('Location' => 'http://www.example.com/redirected')));
+        $client->followRedirects(false);
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+
+        try {
+            $client->followRedirect();
+            $this->fail('->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
+        } catch (\Exception $e) {
+            $this->assertInstanceof('LogicException', $e, '->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
+        }
+
+        $client->setNextResponse(new Response('', 201, array('Location' => 'http://www.example.com/redirected')));
+        $client->request('GET', 'http://www.example.com/foo/foobar');
+        $client->followRedirect(true);
+
+        $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect(true) follows a redirect even if HTTP Code differs from 30x');
     }
     
     public function testFollowRedirectWithMaxRedirects()

--- a/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
+++ b/src/Symfony/Component/BrowserKit/Tests/ClientTest.php
@@ -366,12 +366,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         } catch (\Exception $e) {
             $this->assertInstanceof('LogicException', $e, '->followRedirect() throws a \LogicException if the request did not respond with 30x HTTP Code');
         }
-
-        $client->setNextResponse(new Response('', 201, array('Location' => 'http://www.example.com/redirected')));
-        $client->request('GET', 'http://www.example.com/foo/foobar');
-        $client->followRedirect(true);
-
-        $this->assertEquals('http://www.example.com/redirected', $client->getRequest()->getUri(), '->followRedirect(true) follows a redirect even if HTTP Code differs from 30x');
     }
     
     public function testFollowRedirectWithMaxRedirects()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Currently, BrowserKit operates incorrectly. It follows "redirect" when `Location` header is present, but having just the header is not enough to perform redirection. [RFC-2616](http://tools.ietf.org/html/rfc2616#section-14.30) precisely says that the redirection should be performed only with `30x` status codes.

This PR fixes the incorrect behaviour of BrowserKit and make it consist with both the RFC document and with other clients, used for example with Behat.

I've found the issue while testing my application with Behat. I was returning `Location` header with `HTTP 201/Created` status code and was surprised that BrowserKit follows the redirection.

This PR is for 2.3 version (master) of Symfony.
