### PR TITLE
[HttpKernel] Fixed typo

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ExceptionListener.php
@@ -89,7 +89,7 @@ class ExceptionListener implements EventSubscriberInterface
             // set handling to false otherwise it wont be able to handle further more
             $handling = false;
 
-            // re-throw the exception from within HttpKernel as this is a catch-all
+            // avoid hidding exceptions set in exception listeners (see the Security ExceptionListener for some examples)
             return;
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | did not changed code |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This is just a quick patch.

But I think we have a "big" issue here. If something wrong happen during the exception handling, the last exception is hidden. Of course, the last exception is logged, But IMHO, this not very handly.

I try to isolate the bug in this simple gist https://gist.github.com/lyrixx/5570964#file-index-php .
Here the debug is a nightmare for new comers. I let you try and see ;)
IMHO, the last exception should not be hidden, but display.
