### PR TITLE
[RFC][WIP][FrameworkBundle/Console] add possibility to print log messages to command output

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/ContainerAwareCommand.php
@@ -11,9 +11,13 @@
 
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Output\StreamOutput;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Command.
@@ -45,5 +49,41 @@ abstract class ContainerAwareCommand extends Command implements ContainerAwareIn
     public function setContainer(ContainerInterface $container = null)
     {
         $this->container = $container;
+    }
+
+    /**
+     * Enables printing of logged messages to the command output depending on the verbosity settings.
+     *
+     * @param OutputInterface $output        Command output
+     * @param string          $loggerService The logger service whose messages should be echoed
+     */
+    protected function enableLogToOutput(OutputInterface $output, $loggerService = 'logger')
+    {
+        if (OutputInterface::VERBOSITY_QUIET === $output->getVerbosity()) {
+            return;
+        }
+
+        $logger = $this->getContainer()->get($loggerService, ContainerInterface::NULL_ON_INVALID_REFERENCE);
+        if ($logger instanceof Logger) {
+            switch ($output->getVerbosity()) {
+                case OutputInterface::VERBOSITY_NORMAL:
+                    $level = Logger::WARNING;
+                    break;
+                case OutputInterface::VERBOSITY_VERBOSE:
+                    $level = Logger::NOTICE;
+                    break;
+                case OutputInterface::VERBOSITY_VERY_VERBOSE:
+                    $level = Logger::INFO;
+                    break;
+                default:
+                    $level = Logger::DEBUG;
+                    break;
+            }
+
+            // use a custom handler that uses ConsoleOutput::getErrorOutput ('php://stderr') for errors?
+            // probably also use a custom formatter that colors the output depending on log level
+            $stream = $output instanceof StreamOutput ? $output->getStream() : 'php://output';
+            $logger->pushHandler(new StreamHandler($stream, $level));
+        }
     }
 }


### PR DESCRIPTION
This PR adds the possibility to print log messages to command output depending on verbosity settings. For example: You have a command that uses a service which also logs some messages. Now you can easily also see the logged messages in the console.
You can configure the the level of information with the verbosity settings. So when this feature is enabled in your command with

```
protected function execute(InputInterface $input, OutputInterface $output)
{
    $this->enableLogToOutput($output, 'logger');
    ...
```
- `app/console mycommand` will show all `WARNING` and higher logs
- `app/console mycommand -v` will show all `NOTICE` and higher logs
- `app/console mycommand -vv` will show all `INFO` and higher logs
- `app/console mycommand -vvv` will show all `DEBUG` and higher logs

I think it's a nice feature because the verbosity settings and logs are highly related and thus integration should be available.

I made the `$loggerService` configurable so that a user can use a different logger service (e.g. one that uses a custom channel).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | [todo] |

Todo:
- [ ] find a good name for the method
- [ ] add a method to also disable this behavior
- [ ] use a custom handler that uses ConsoleOutput::getErrorOutput ('php://stderr') for errors?
- [ ] probably also use a custom formatter that colors the output depending on log level
- [ ] make it possible to enable this feature by default via config
- [ ] add tests
