### PR TITLE
[Form][Validator] Extended Date Validator with before/after options

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -22,5 +22,50 @@ use Symfony\Component\Validator\Constraint;
  */
 class Date extends Constraint
 {
-    public $message = 'This value is not a valid date.';
+    public $message               = 'This value is not a valid date.';
+    public $messageBeforeDate     = 'The date should be before {{ before }}.';
+    public $messageAfterDate      = 'The date should be after {{ after }}.';
+    public $dateFormatMessages    = 'yyyy-MM-dd'; // see http://userguide.icu-project.org/formatparse/datetime
+    public $dateFormatter;
+
+    public $before;
+    public $after;
+
+    public function __construct($options = null)
+    {
+        if (isset($options['after']) && !$options['after'] instanceof \DateTime) {
+            $options['after'] = new \DateTime($options['after']);
+        }
+
+        if (isset($options['before']) && !$options['before'] instanceof \DateTime) {
+            $options['before'] = new \DateTime($options['before']);
+        }
+
+        if (isset($options['before']) && isset($options['after'])) {
+            if ($options['before'] == $options['after']) {
+                throw new InvalidOptionsException('The options "after" and "before" may not have the same value. ' . __CLASS__, array('after', 'before'));
+            }
+            if ($options['before'] < $options['after']) {
+                throw new InvalidOptionsException('The value of "before" must be a date later than the value of "after". ' . __CLASS__, array('after', 'before'));
+            }
+        }
+
+        if (isset($options['dateFormatter'])) {
+            if (!$options['dateFormatter'] instanceof \IntlDateFormatter) {
+                throw new InvalidOptionsException('The option "dateFormatter" must be an instance of \IntlDateFormatter.' . __CLASS__, array('dateFormatter'));
+            }
+        } else {
+            $options['dateFormatter']  = new \IntlDateFormatter('en_US', \IntlDateFormatter::SHORT, \IntlDateFormatter::NONE);
+        }
+
+        if (isset($options['dateFormatMessages'])) {
+            if (!$options['dateFormatter']->setPattern($options['dateFormatMessages'])) {
+                throw new InvalidOptionsException('The value of the option "dateFormatMessages" is invalid. ' . __CLASS__, array('dateFormatMessages'));
+            }
+        } else {
+            $options['dateFormatter']->setPattern($this->dateFormatMessages);
+        }
+
+        parent::__construct($options);
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -78,6 +78,7 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
     public function getValidDates()
     {
         return array(
+            array(''),
             array('2010-01-01'),
             array('1955-12-12'),
             array('2030-05-31'),
@@ -111,6 +112,230 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
             array('2010-13-01'),
             array('2010-04-32'),
             array('2010-02-29'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidBeforeDates
+     */
+    public function testValidBeforeDates($date)
+    {
+        $constraint = new Date(array(
+            'before' => '2015-01-01'
+        ));
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getValidBeforeDates()
+    {
+        return array(
+            array('2014-12-31'),
+            array('2000-01-01'),
+            array('1980-01-01'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidBeforeDates
+     */
+    public function testInvalidBeforeDates($date)
+    {
+        $constraint = new Date(array(
+            'messageBeforeDate' => 'myMessage',
+            'before' => '2015-01-01'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}'  => $date,
+                '{{ before }}' => '2015-01-01',
+            ));
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getInvalidBeforeDates()
+    {
+        return array(
+            array('2015-01-01'),
+            array('2018-12-20'),
+            array('2016-02-29'),
+        );
+    }
+
+    /**
+     * @dataProvider getValidAfterDates
+     */
+    public function testValidAfterDates($date)
+    {
+        $constraint = new Date(array(
+            'after' => '2015-01-01'
+        ));
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getValidAfterDates()
+    {
+        return array(
+            array('2015-01-02'),
+            array('2016-02-29'),
+            array('2100-12-31'),
+        );
+    }
+
+    /**
+     * @dataProvider getInvalidAfterDates
+     */
+    public function testInvalidAfterDates($date)
+    {
+        $constraint = new Date(array(
+            'messageAfterDate' => 'myMessage',
+            'after' => '2015-01-01'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $date,
+                '{{ after }}' => '2015-01-01',
+            ));
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getInvalidAfterDates()
+    {
+        return array(
+            array('2015-01-01'),
+            array('2014-12-31'),
+            array('1980-01-01'),
+        );
+    }
+
+
+    /**
+     * @dataProvider getValidInBetweenDates
+     */
+    public function testValidInBetweenDates($date)
+    {
+        $constraint = new Date(array(
+            'after'  => '2014-12-31',
+            'before' => '2017-01-01'
+        ));
+
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getValidInBetweenDates()
+    {
+        return array(
+            array('2015-01-01'),
+            array('2015-12-31'),
+            array('2016-12-31'),
+        );
+    }
+
+    /**
+     * @dataProvider getTooLateInBetweenDates
+     */
+    public function testTooLateInBetweenDates($date)
+    {
+        $constraint = new Date(array(
+            'messageAfterDate'  => 'myMessage',
+            'messageBeforeDate' => 'myMessage',
+            'after'  => '2014-12-31',
+            'before' => '2017-01-01'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $date,
+                '{{ before }}' => '2017-01-01',
+            ));
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getTooLateInBetweenDates()
+    {
+        return array(
+            array('2017-01-01'),
+            array('2020-06-06'),
+        );
+    }
+
+    /**
+     * @dataProvider getTooEarlyInBetweenDates
+     */
+    public function testTooEarlyInBetweenDates($date)
+    {
+        $constraint = new Date(array(
+            'messageAfterDate'  => 'myMessage',
+            'messageBeforeDate' => 'myMessage',
+            'after'  => '2014-12-31',
+            'before' => '2017-01-01'
+        ));
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $date,
+                '{{ after }}' => '2014-12-31',
+            ));
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getTooEarlyInBetweenDates()
+    {
+        return array(
+            array('2014-12-31'),
+            array('2000-06-06'),
+        );
+    }
+
+    /**
+     * @dataProvider getDateFormatMessages
+     */
+    public function testDateFormatMessagesFormatter($format, $expected)
+    {
+        $constraint = new Date(array(
+            'messageAfterDate'   => 'myMessage',
+            'after'              => '2014-12-31',
+            'dateFormatMessages' => $format,
+        ));
+
+        $date = '2000-01-01';
+
+        $this->context->expects($this->once())
+            ->method('addViolation')
+            ->with('myMessage', array(
+                '{{ value }}' => $date,
+                '{{ after }}' => $expected,
+            ));
+
+        $this->validator->validate($date, $constraint);
+    }
+
+    public function getDateFormatMessages()
+    {
+        return array(
+            array('dd/MM/yy',   '31/12/14'),
+            array('yyyy-MM-dd', '2014-12-31'),
+            array('yyyyMMdd HH:mm:ss', '20141231 00:00:00'),
         );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #3640 |
| License | MIT |

Due to personal use I extended the DateValidator to handle `after` and `before` options. The existing validation of the value being an actual date is still there.

Example:

```
// only dates within the year 2014 will be valid.
new Assert\Date(array( 
    'after'   => '2013-12-31'
    'before'  => '2015-01-01'
)),
```

It is possible to change the date format in error messages.
In the example below, an error message for the value '2016-01-01' would look like `The date should be before 01.01.2015`

```
new Assert\Date(array( 
    'after'   => '2013-12-31'
    'before'  => '2015-01-01'
    'message' => 'This value is not a valid date',
    'messageAfterDate'  => 'The date should be after {{ after }}',
    'messageBeforeDate' => 'The date should be before {{ before }}',
    'dateFormatMessages' => 'dd.MM.yyyy'
)),
```

If needed, the DateFormatter can be exchanged completely:

```
new Assert\Date(array( 
    'after'   => '2013-12-31'
    'messageAfterDate'  => 'The date should be after {{ after }}',
    'dateFormatter' =>  new \IntlDateFormatter('de_DE', \IntlDateFormatter::MEDIUM, \IntlDateFormatter::NONE)
)),
```
