### PR TITLE
force the Content-Type to html in the profiler controller

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ProfilerController.php
@@ -61,7 +61,7 @@ class ProfilerController
     {
         $this->profiler->disable();
 
-        return new RedirectResponse($this->generator->generate('_profiler_search_results', array('token' => 'empty', 'limit' => 10)));
+        return new RedirectResponse($this->generator->generate('_profiler_search_results', array('token' => 'empty', 'limit' => 10)), 302, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -82,7 +82,7 @@ class ProfilerController
         $page = $request->query->get('page', 'home');
 
         if (!$profile = $this->profiler->loadProfile($token)) {
-            return new Response($this->twig->render('@WebProfiler/Profiler/info.html.twig', array('about' => 'no_token', 'token' => $token)));
+            return new Response($this->twig->render('@WebProfiler/Profiler/info.html.twig', array('about' => 'no_token', 'token' => $token)), 200, array('Content-Type' => 'text/html'));
         }
 
         if (!$profile->hasCollector($panel)) {
@@ -98,7 +98,7 @@ class ProfilerController
             'request'   => $request,
             'templates' => $this->getTemplateManager()->getTemplates($profile),
             'is_ajax'   => $request->isXmlHttpRequest(),
-        )));
+        )), 200, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -134,7 +134,7 @@ class ProfilerController
         $this->profiler->disable();
         $this->profiler->purge();
 
-        return new RedirectResponse($this->generator->generate('_profiler_info', array('about' => 'purge')));
+        return new RedirectResponse($this->generator->generate('_profiler_info', array('about' => 'purge')), 302, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -151,14 +151,14 @@ class ProfilerController
         $file = $request->files->get('file');
 
         if (empty($file) || !$file->isValid()) {
-            return new RedirectResponse($this->generator->generate('_profiler_info', array('about' => 'upload_error')));
+            return new RedirectResponse($this->generator->generate('_profiler_info', array('about' => 'upload_error')), 302, array('Content-Type' => 'text/html'));
         }
 
         if (!$profile = $this->profiler->import(file_get_contents($file->getPathname()))) {
-            return new RedirectResponse($this->generator->generate('_profiler_info', array('about' => 'already_exists')));
+            return new RedirectResponse($this->generator->generate('_profiler_info', array('about' => 'already_exists')), 302, array('Content-Type' => 'text/html'));
         }
 
-        return new RedirectResponse($this->generator->generate('_profiler', array('token' => $profile->getToken())));
+        return new RedirectResponse($this->generator->generate('_profiler', array('token' => $profile->getToken())), 302, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -174,7 +174,7 @@ class ProfilerController
 
         return new Response($this->twig->render('@WebProfiler/Profiler/info.html.twig', array(
             'about' => $about
-        )));
+        )), 200, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -195,13 +195,13 @@ class ProfilerController
         }
 
         if (null === $token) {
-            return new Response();
+            return new Response('', 200, array('Content-Type' => 'text/html'));
         }
 
         $this->profiler->disable();
 
         if (!$profile = $this->profiler->loadProfile($token)) {
-            return new Response();
+            return new Response('', 200, array('Content-Type' => 'text/html'));
         }
 
         // the toolbar position (top, bottom, normal, or null -- use the configuration)
@@ -222,7 +222,7 @@ class ProfilerController
             'templates'    => $this->getTemplateManager()->getTemplates($profile),
             'profiler_url' => $url,
             'token'        => $token,
-        )));
+        )), 200, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -262,7 +262,7 @@ class ProfilerController
             'start'  => $start,
             'end'    => $end,
             'limit'  => $limit,
-        )));
+        )), 200, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -297,7 +297,7 @@ class ProfilerController
             'end'       => $end,
             'limit'     => $limit,
             'panel'     => null,
-        )));
+        )), 200, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -330,7 +330,7 @@ class ProfilerController
         }
 
         if (!empty($token)) {
-            return new RedirectResponse($this->generator->generate('_profiler', array('token' => $token)));
+            return new RedirectResponse($this->generator->generate('_profiler', array('token' => $token)), 302, array('Content-Type' => 'text/html'));
         }
 
         $tokens = $this->profiler->find($ip, $url, $limit, $method, $start, $end);
@@ -343,7 +343,7 @@ class ProfilerController
             'start'  => $start,
             'end'    => $end,
             'limit'  => $limit,
-        )));
+        )), 302, array('Content-Type' => 'text/html'));
     }
 
     /**
@@ -359,7 +359,7 @@ class ProfilerController
         phpinfo();
         $phpinfo = ob_get_clean();
 
-        return new Response($phpinfo);
+        return new Response($phpinfo, 200, array('Content-Type' => 'text/html'));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This just forces the Content-Type to match what will be returned, otherwise if the request format happens to be something else than HTML (which can be the case when building an app that only does JSON/XML with FOSRestBundle) it can happen that the Response class automatically sets a different Content-Type.

The approach taken here matches https://github.com/nelmio/NelmioApiDocBundle/blob/master/Controller/ApiDocController.php#L24
