### PR TITLE
[Console] Add clear() to ProgressHelper.

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -290,6 +290,18 @@ class ProgressHelper extends Helper
     }
 
     /**
+     * Removes the progress bar from the current line.
+     *
+     * This is useful if you wish to write some output
+     * while a progress bar is running.
+     * Call display() to show the progress bar again.
+     */
+    public function clear()
+    {
+        $this->overwrite($this->output, '');
+    }
+
+    /**
      * Finishes the progress output.
      */
     public function finish()

--- a/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/ProgressHelperTest.php
@@ -151,6 +151,20 @@ class ProgressHelperTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($this->generateOutput('    3 [■■■>------------------------]'), stream_get_contents($output->getStream()));
     }
 
+    public function testClear()
+    {
+        $progress = new ProgressHelper();
+        $progress->start($output = $this->getOutputStream(), 50);
+        $progress->setCurrent(25);
+        $progress->clear();
+
+        rewind($output->getStream());
+        $this->assertEquals(
+            $this->generateOutput(' 25/50 [==============>-------------]  50%') . $this->generateOutput(''),
+            stream_get_contents($output->getStream())
+        );
+    }
+
     protected function getOutputStream()
     {
         return new StreamOutput(fopen('php://memory', 'r+', false));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR | symfony/symfony-docs#2642 |

One may want to print something else while the progress bar is running.
The output will be messy if the progress bar is not removed first.

One may also want to remove the progress bar after the work is complete.
