### PR TITLE
Use strstr instead of strpos in ClassLoader (4% perf improvement)

### DIFF
--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -177,7 +177,7 @@ class ClassLoader
         $classPath .= str_replace('_', DIRECTORY_SEPARATOR, $className).'.php';
 
         foreach ($this->prefixes as $prefix => $dirs) {
-            if (0 === strpos($class, $prefix)) {
+            if ($class == strstr($class, $prefix)) {
                 foreach ($dirs as $dir) {
                     if (file_exists($dir.DIRECTORY_SEPARATOR.$classPath)) {
                         return $dir.DIRECTORY_SEPARATOR.$classPath;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [ |
| License | MIT |
| Doc PR |  |

Using ClassLoader in Drupal 8, using strstr instead of strpos nets 4% perf improvement.
XHPROF diff https://dl.dropboxusercontent.com/u/10201421/diff.html
