### PR TITLE
[HttpFoundation] Fix unexpected status code for FastCGI interface

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Response.php
+++ b/src/Symfony/Component/HttpFoundation/Response.php
@@ -281,6 +281,11 @@ class Response
         // status
         header(sprintf('HTTP/%s %s %s', $this->version, $this->statusCode, $this->statusText));
 
+        // Fix status for FastCGI server
+        if ('cgi-fcgi' === php_sapi_name() && false == ini_get('cgi.rfc2616_headers')) {
+            $this->headers->set('Status', sprintf('%s %s', $this->statusCode, $this->statusText));
+        }
+
         // headers
         foreach ($this->headers->all() as $name => $values) {
             foreach ($values as $value) {


### PR DESCRIPTION
| Q | A |
| --: | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8085 |
| License | MIT |
- [x] Add tests if possible. Edit: Apparently not (This works for my server but it is not sufficient as a test).
- [x] Add FastCGI server detection for set the header only if needed 

The header `HTTP/` cannot set properly the status code on a FastCGI server. [source](http://php.net/manual/function.header.php)

1) Try to overwrite the status code from an existing file.

``` php
<?php // index.php
header("HTTP/1.1 404 Not Found");
```

<table>
  <tr>
    <th>Call</th><th>status code</th>
  </tr>
  <tr>
    <td>index.php</td><td>HTTP/1.1 404 OK</td>
  </tr>
</table>


2) Try to overwrite the status code with calling to a not existing file

```
# .htaccess
ErrorDocument 404 <path to the 404.php file>
```

``` php
<?php // 404.php
header("HTTP/1.1 200 OK");
```

<table>
  <tr>
    <th>Call</th><th>status code</th>
  </tr>
  <tr>
    <td>notfound.php</td><td>HTTP/1.1 404 Not Found</td>
  </tr>
</table>


For both cases urlrewriting is not used.

Edit:
This PR follow the PHP behaviour and nothing more. For bad configuration of the PHP directive `cgi.rfc2616_headers`. See http://php.net/manual/en/ini.core.php#ini.cgi.rfc2616-headers

I just offers a solution to this unusual problem. I believe that merge is not the most important because this code snippet can be put to other place.
