### PR TITLE
[Config] Including exception message to clarify the underlying issue

### DIFF
--- a/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
+++ b/src/Symfony/Component/Config/Exception/FileLoaderLoadException.php
@@ -37,6 +37,9 @@ class FileLoaderLoadException extends \Exception
             $parts = explode(DIRECTORY_SEPARATOR, $resource);
             $bundle = substr($parts[0], 1);
             $message .= ' '.sprintf('Make sure the "%s" bundle is correctly registered and loaded in the application kernel class.', $bundle);
+        } elseif ($previous) {
+            // include the previous exception, to help the user see what might be the underlying cause
+            $message .= ' '.sprintf('(%s)', $previous->getMessage());
         }
 
         parent::__construct($message, $code, $previous);


### PR DESCRIPTION
Hi guys!

In the framework if you, for example, make a syntax error in YAML, then the true, clear message (e.g. Unable to parse at line 5 (near "framework") is nested, and harder to visually see. This includes that message in the main exception so that users can debug more easily.

I see this quite a bit, it's a choke point for newcomers :).

Before: Cannot import resource "/path/to/app/config/config.yml" from "/path/to/app/config/config_dev.yml".

After: Cannot import resource "/path/to/app/config/config.yml" from "/path/to/app/config/config_dev.yml". (Unable to parse at line 5 (near "framework").)

Corrections and comments warmly appreciated.

Thanks!

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | n/a |
