### PR TITLE
[DoctrineBridge] Only load event managers if tagged event subscribers / ...

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/DependencyInjection/CompilerPass/RegisterEventListenersAndSubscribersPassTest.php
@@ -109,6 +109,17 @@ class RegisterEventListenersAndSubscribersPassTest extends \PHPUnit_Framework_Te
         $this->assertEquals(array('c', 'd', 'e', 'b', 'a'), $this->getServiceOrder($container, 'addEventSubscriber'));
     }
 
+    public function testProcessNoTaggedServices()
+    {
+        $container = $this->createBuilder(true);
+
+        $this->process($container);
+
+        $this->assertEquals(array(), $container->getDefinition('doctrine.dbal.default_connection.event_manager')->getMethodCalls());
+
+        $this->assertEquals(array(), $container->getDefinition('doctrine.dbal.second_connection.event_manager')->getMethodCalls());
+    }
+
     private function process(ContainerBuilder $container)
     {
         $pass = new RegisterEventListenersAndSubscribersPass('doctrine.connections', 'doctrine.dbal.%s_connection.event_manager', 'doctrine');


### PR DESCRIPTION
...listeners are found

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |

This PR only wraps the code that adds event subscribers / listeners in the Doctrine compiler pass RegisterEventListenersAndSubscribersPass so it doesn't run if no tagged services are found. So in general it doesn't change anything besides not running a few lines of code if it's not necessary. The reason I want this change is that it will allow DoctrinePHPCRBundle to be installed without Doctrine2 PHPCR ODM (I just want the PHPCR session..I don't need the ODM). This doesn't work currently as it tries to load the entity managers resulting in an error (Error: The service definition "doctrine_phpcr.odm.default_session.event_manager" does not exist.).
