### PR TITLE
[HttpKernel] Fixed two bugs in HttpCache

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -192,8 +192,6 @@ class HttpCache implements HttpKernelInterface
             $response = $this->lookup($request, $catch);
         }
 
-        $response->isNotModified($request);
-
         $this->restoreResponseBody($request, $response);
 
         $response->setDate(new \DateTime(null, new \DateTimeZone('UTC')));
@@ -211,6 +209,8 @@ class HttpCache implements HttpKernelInterface
         }
 
         $response->prepare();
+
+        $response->isNotModified($request);
 
         return $response;
     }
@@ -248,6 +248,15 @@ class HttpCache implements HttpKernelInterface
         if ($response->isSuccessful() || $response->isRedirect()) {
             try {
                 $this->store->invalidate($request, $catch);
+
+                // As per the RFC, invalidate Location and Content-Location URLs if present
+                foreach (array('Location', 'Content-Location') as $header) {
+                    if ($uri = $response->headers->get($header)) {
+                        $subRequest = $request::create($uri, 'get', array(), array(), array(), $request->server->all());
+
+                        $this->store->invalidate($subRequest);
+                    }
+                }
 
                 $this->record($request, 'invalidate');
             } catch (\Exception $e) {

--- a/src/Symfony/Component/HttpKernel/HttpCache/Store.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/Store.php
@@ -219,15 +219,6 @@ class Store implements StoreInterface
                 throw new \RuntimeException('Unable to store the metadata.');
             }
         }
-
-        // As per the RFC, invalidate Location and Content-Location URLs if present
-        foreach (array('Location', 'Content-Location') as $header) {
-            if ($uri = $request->headers->get($header)) {
-                $subRequest = Request::create($uri, 'get', array(), array(), array(), $request->server->all());
-
-                $this->invalidate($subRequest);
-            }
-        }
     }
 
     /**

--- a/tests/Symfony/Tests/Component/HttpKernel/HttpCache/HttpCacheTest.php
+++ b/tests/Symfony/Tests/Component/HttpKernel/HttpCache/HttpCacheTest.php
@@ -100,7 +100,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
         $this->assertHttpKernelIsCalled();
         $this->assertEquals(304, $this->response->getStatusCode());
-        $this->assertEquals('text/html; charset=UTF-8', $this->response->headers->get('Content-Type'));
+        $this->assertEquals('', $this->response->headers->get('Content-Type'));
         $this->assertEmpty($this->response->getContent());
         $this->assertTraceContains('miss');
         $this->assertTraceContains('store');
@@ -113,7 +113,7 @@ class HttpCacheTest extends HttpCacheTestCase
 
         $this->assertHttpKernelIsCalled();
         $this->assertEquals(304, $this->response->getStatusCode());
-        $this->assertEquals('text/html; charset=UTF-8', $this->response->headers->get('Content-Type'));
+        $this->assertEquals('', $this->response->headers->get('Content-Type'));
         $this->assertTrue($this->response->headers->has('ETag'));
         $this->assertEmpty($this->response->getContent());
         $this->assertTraceContains('miss');
@@ -800,7 +800,7 @@ class HttpCacheTest extends HttpCacheTestCase
         $this->assertTraceContains('fresh');
 
         // now POST to same URL
-        $this->request('POST', '/');
+        $this->request('POST', '/helloworld');
         $this->assertHttpKernelIsCalled();
         $this->assertEquals('/', $this->response->headers->get('Location'));
         $this->assertTraceContains('invalidate');


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8097 |
| License | MIT |
| Doc PR |  |
1. 304 responses always send "Content-Type: text/html; charset=UTF-8"
   header
   I discovered that the HttpCache::handle method calls Response::prepare
   after calling Response::isModified.  Response::isModified removes the
   Content-Type header as it should, but Response::handle adds in the
   default Content-Type header when none is set.  If the default
   Content-Type is not the correct Content-Type, then the Content-Type in
   the cache gets clobered.  I solved this problem by moving the
   Response::isModified call after the Response::prepare call.  I updated
   the testRespondsWith304WhenIfModifiedSinceMatchesLastModified and
   testRespondsWith304WhenIfNoneMatchMatchesETag tests to verify that the
   Content-Type header was not being sent for 304 responses.
2. Failure to invalidate cached entities referred to by the Location
   header
   I discovered that the Store::invalidate method was looking for Location
   and Content-Location headers to invalidate, but it was looking in the
   request headers instead of the response headers.  Because the
   Store::invalidate method doesn't take a response, I decided it was
   better to move this logic to the HttpCache::invalidate method instead.
   I updated the testInvalidatesCachedResponsesOnPost test to verify that
   Location headers are getting invalidated correctly.
