### PR TITLE
[WIP][2.4][Form] Add option "widget" to ChoiceType

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Bridge\Doctrine\Form\Type;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Symfony\Component\Form\Exception\LogicException;
 use Symfony\Component\Form\Exception\RuntimeException;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -50,6 +51,9 @@ abstract class DoctrineType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        if ('text' === $options['widget'] && !$options['property']) {
+            throw new LogicException('When using a text widget, the "property" option must be defined.');
+        }
         if ($options['multiple']) {
             $builder
                 ->addEventSubscriber(new MergeDoctrineCollectionListener())
@@ -116,7 +120,8 @@ abstract class DoctrineType extends AbstractType
                 $loaderHash,
                 $choiceHashes,
                 $preferredChoiceHashes,
-                $groupByHash
+                $groupByHash,
+                'text' === $options['widget']
             )));
 
             if (!isset($choiceListCache[$hash])) {
@@ -128,7 +133,8 @@ abstract class DoctrineType extends AbstractType
                     $options['choices'],
                     $options['preferred_choices'],
                     $options['group_by'],
-                    $propertyAccessor
+                    $propertyAccessor,
+                    'text' === $options['widget']
                 );
             }
 

--- a/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
+++ b/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig
@@ -46,10 +46,12 @@
 
 {% block choice_widget %}
 {% spaceless %}
-    {% if expanded %}
+    {% if widget == 'checkbox' or widget == 'radio' %}
         {{ block('choice_widget_expanded') }}
+    {% elseif widget == 'select' %}
+        {{ block('choice_widget_select') }}
     {% else %}
-        {{ block('choice_widget_collapsed') }}
+        {{ block('form_widget_simple') }}
     {% endif %}
 {% endspaceless %}
 {% endblock choice_widget %}
@@ -65,7 +67,7 @@
 {% endspaceless %}
 {% endblock choice_widget_expanded %}
 
-{% block choice_widget_collapsed %}
+{% block choice_widget_select %}
 {% spaceless %}
     <select {{ block('widget_attributes') }}{% if multiple %} multiple="multiple"{% endif %}>
         {% if empty_value is not none %}
@@ -82,7 +84,7 @@
         {{ block('choice_widget_options') }}
     </select>
 {% endspaceless %}
-{% endblock choice_widget_collapsed %}
+{% endblock choice_widget_select %}
 
 {% block choice_widget_options %}
 {% spaceless %}
@@ -388,3 +390,7 @@
     {% for attrname, attrvalue in attr %}{{ attrname }}="{{ attrvalue }}" {% endfor %}
 {% endspaceless %}
 {% endblock button_attributes %}
+
+{# Deprecated in Symfony 2.4, to be removed in 3.0 #}
+
+{% block choice_widget_collapsed %}{{ block('choice_widget_select') }}{% endblock %}

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValuesToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValuesToStringTransformer.php
@@ -17,8 +17,8 @@ use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
 /**
- * Converts a string with multiple values separated by a delimiter to an array of values.
- * 
+ * Converts an array of values to a string with multiple values separated by a delimiter.
+ *
  * @author Bilal Amarni <bilal.amarni@gmail.com>
  */
 class ValuesToStringTransformer implements DataTransformerInterface
@@ -57,8 +57,7 @@ class ValuesToStringTransformer implements DataTransformerInterface
      *
      * @return array
      *
-     * @throws UnexpectedTypeException       if the given value is not a string
-     * @throws TransformationFailedException if could not find all matching choices for the given labels
+     * @throws UnexpectedTypeException if the given value is not a string
      */
     public function reverseTransform($string)
     {

--- a/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValuesToStringTransformer.php
+++ b/src/Symfony/Component/Form/Extension/Core/DataTransformer/ValuesToStringTransformer.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Extension\Core\DataTransformer;
+
+use Symfony\Component\Form\Exception\TransformationFailedException;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+/**
+ * Converts a string with multiple values separated by a delimiter to an array of values.
+ * 
+ * @author Bilal Amarni <bilal.amarni@gmail.com>
+ */
+class ValuesToStringTransformer implements DataTransformerInterface
+{
+    private $delimiter;
+    private $trim;
+
+    public function __construct($delimiter, $trim)
+    {
+        $this->delimiter = $delimiter;
+        $this->trim = $trim;
+    }
+
+    /**
+     * @param array $array
+     *
+     * @return string
+     *
+     * @throws UnexpectedTypeException if the given value is not an array
+     */
+    public function transform($array)
+    {
+        if (null === $array) {
+            return array();
+        }
+
+        if (!is_array($array)) {
+            throw new UnexpectedTypeException($array, 'array');
+        }
+
+        return implode($this->delimiter, $array);
+    }
+
+    /**
+     * @param string $string
+     *
+     * @return array
+     *
+     * @throws UnexpectedTypeException       if the given value is not a string
+     * @throws TransformationFailedException if could not find all matching choices for the given labels
+     */
+    public function reverseTransform($string)
+    {
+        if (empty($string)) {
+            return array();
+        }
+
+        if (!is_string($string)) {
+            throw new UnexpectedTypeException($string, 'string');
+        }
+
+        $values = explode($this->delimiter, $string);
+
+        if ($this->trim) {
+            $values = array_map('trim', $values);
+        }
+
+        return $values;
+    }
+}

--- a/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ChoiceType.php
@@ -99,7 +99,6 @@ class ChoiceType extends AbstractType
      */
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
-        var_dump($options['multiple']);
         $view->vars = array_replace($view->vars, array(
             'widget'            => $options['widget'],
             'multiple'          => $options['multiple'],


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | yes |
| Tests pass? | no |
| Fixed tickets | #6602 |
| License | MIT |
| Doc PR | not yet |
- [ ] add / fix tests / CS / PHPDocs
- [ ] submit changes to the documentation
- [ ] update php templates and twig table layout

I've implemented the behavior described in #6602.
### Choice
- Also, does `choice_widget_select` now fit better than `choice_widget_collapsed`?
### Doctrine
- For the original entity_id use case, it'd simply mean setting the `property` option to `id`.

``` php
<?php

$builder->add('field', 'entity', array(
    'class' => 'MyBundle:Product',
    'widget' => 'text',
    'property' => 'id',
));
```

Then the choice list won't be loaded in advance but validated on the fly.

What do you think about the approach?  cc @bschussek
