### PR TITLE
[Console] Add namespace support back in to list command

### DIFF
--- a/src/Symfony/Component/Console/Command/ListCommand.php
+++ b/src/Symfony/Component/Console/Command/ListCommand.php
@@ -73,7 +73,7 @@ EOF
         }
 
         $helper = new DescriptorHelper();
-        $helper->describe($output, $this->getApplication(), $input->getOption('format'), $input->getOption('raw'));
+        $helper->describe($output, $this->getApplication(), $input->getOption('format'), $input->getOption('raw'), $input->getArgument('namespace'));
     }
 
     /**

--- a/src/Symfony/Component/Console/Helper/DescriptorHelper.php
+++ b/src/Symfony/Component/Console/Helper/DescriptorHelper.php
@@ -56,9 +56,9 @@ class DescriptorHelper extends Helper
      * @param string          $format
      * @param boolean         $raw
      */
-    public function describe(OutputInterface $output, $object, $format = null, $raw = false)
+    public function describe(OutputInterface $output, $object, $format = null, $raw = false, $namespace = null)
     {
-        $options = array('raw_text' => $raw, 'format' => $format ?: 'txt');
+        $options = array('raw_text' => $raw, 'format' => $format ?: 'txt', 'namespace' => $namespace);
         $type = !$raw && 'txt' === $options['format'] ? OutputInterface::OUTPUT_NORMAL : OutputInterface::OUTPUT_RAW;
 
         if (!isset($this->descriptors[$options['format']])) {

--- a/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/ListCommandTest.php
@@ -46,4 +46,20 @@ EOF;
 
         $this->assertEquals($output, $commandTester->getDisplay(true));
     }
+
+    public function testExecuteListsCommandsWithNamespaceArgument()
+    {
+
+        require_once(realpath(__DIR__.'/../Fixtures/FooCommand.php'));
+        $application = new Application();
+        $application->add(new \FooCommand());
+        $commandTester = new CommandTester($command = $application->get('list'));
+        $commandTester->execute(array('command' => $command->getName(), 'namespace' => 'foo', '--raw' => true));
+        $output = <<<EOF
+foo:bar   The foo:bar command
+
+EOF;
+
+        $this->assertEquals($output, $commandTester->getDisplay(true));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | Couldn't spot this issue in the list |
| License | MIT |
| Doc PR | NA |

Added a test to prevent this happening again.
