### PR TITLE
[Console] add exceptions for incorrect Command inheritance

### DIFF
--- a/src/Symfony/Component/Console/Tests/Command/CommandTest.php
+++ b/src/Symfony/Component/Console/Tests/Command/CommandTest.php
@@ -335,4 +335,22 @@ class CommandTest extends \PHPUnit_Framework_TestCase
         $tester->execute(array('command' => $command->getName()));
         $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/command_asxml.txt', $command->asXml(), '->asXml() returns an XML representation of the command');
     }
+
+    public function testGetNameExceptionWhenNameNotSet()
+    {
+        $this->setExpectedException('\LogicException', 'Command name not found. You must call parent::__construct($name) in Foo5Command constructor');
+        $this->createFixtureCommand()->getName();
+    }
+
+    public function testGetDefinitionExceptionWhenNameNotSet()
+    {
+        $this->setExpectedException('\LogicException', 'InputDefinition not found. You must call parent::__construct($name) in Foo5Command constructor');
+        $this->createFixtureCommand()->getDefinition();
+    }
+
+    protected function createFixtureCommand()
+    {
+        require_once self::$fixturesPath.'/Foo5Command.php';
+        return new \Foo5Command;
+    }
 }

--- a/src/Symfony/Component/Console/Tests/Fixtures/Foo5Command.php
+++ b/src/Symfony/Component/Console/Tests/Fixtures/Foo5Command.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Console\Command\Command;
+
+class Foo5Command extends Command
+{
+    public function __construct()
+    {
+
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | possibly |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Hello,

I use console commands with constructor dependency injection. I overrided Command constructor and forgot call parent::__construct(). When I ran app/console, I saw:

```
Warning: Invalid argument supplied for foreach() in /vendor_dir/symfony/console/Symfony/Component/Console/Application.php on line 411
```

I added $this->setAliases(array()) to constructor. After that warning disappeared, but I not found my new command in available commands, because configure method not called in my new constructor.

This PR simplify debugging this situation.
