### PR TITLE
[FrameworkBundle] removed deprecated method from cache:clear command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/CacheClearCommand.php
@@ -142,14 +142,6 @@ EOF
     }
 
     /**
-     * @deprecated to be removed in 2.3
-     */
-    protected function getTempSuffix()
-    {
-        return '';
-    }
-
-    /**
      * @param KernelInterface $parent
      * @param string          $namespace
      * @param string          $parentClass


### PR DESCRIPTION
bc break: no
test pass: yes
