### PR TITLE
FIX [Form][FormTypeGuesserChain] Replace reading of private property on 'getter' method call. Realize 'getter' method

### DIFF
--- a/src/Symfony/Component/Form/FormTypeGuesserChain.php
+++ b/src/Symfony/Component/Form/FormTypeGuesserChain.php
@@ -33,11 +33,21 @@ class FormTypeGuesserChain implements FormTypeGuesserInterface
             }
 
             if ($guesser instanceof self) {
-                $this->guessers = array_merge($this->guessers, $guesser->guessers);
+                $this->guessers = array_merge($this->guessers, $guesser->getGuessers());
             } else {
                 $this->guessers[] = $guesser;
             }
         }
+    }
+    
+    /**
+     * Gets the form type guessers.
+     * 
+     * @return FormTypeGuesserInterface[] Guessers
+     **/
+    public function getGuessers()
+    {
+        return $this->guessers;
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
