### PR TITLE
[Console] renamed ConsoleForExceptionEvent into ConsoleExceptionEvent

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\ProgressHelper;
 use Symfony\Component\Console\Helper\TableHelper;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Event\ConsoleForExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -901,7 +901,7 @@ class Application
             $event = new ConsoleTerminateEvent($command, $input, $output, $e->getCode());
             $this->dispatcher->dispatch(ConsoleEvents::TERMINATE, $event);
 
-            $event = new ConsoleForExceptionEvent($command, $input, $output, $e, $event->getExitCode());
+            $event = new ConsoleExceptionEvent($command, $input, $output, $e, $event->getExitCode());
             $this->dispatcher->dispatch(ConsoleEvents::EXCEPTION, $event);
 
             throw $event->getException();

--- a/src/Symfony/Component/Console/ConsoleEvents.php
+++ b/src/Symfony/Component/Console/ConsoleEvents.php
@@ -46,7 +46,7 @@ final class ConsoleEvents
      *
      * This event allows you to deal with the exception or
      * to modify the thrown exception. The event listener method receives
-     * a Symfony\Component\Console\Event\ConsoleForExceptionEvent
+     * a Symfony\Component\Console\Event\ConsoleExceptionEvent
      * instance.
      *
      * @var string

--- a/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
+++ b/src/Symfony/Component/Console/Event/ConsoleExceptionEvent.php
@@ -20,7 +20,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ConsoleForExceptionEvent extends ConsoleEvent
+class ConsoleExceptionEvent extends ConsoleEvent
 {
     private $exception;
     private $exitCode;

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\ApplicationTester;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
-use Symfony\Component\Console\Event\ConsoleForExceptionEvent;
+use Symfony\Component\Console\Event\ConsoleExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -788,7 +788,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
             $event->setExitCode(128);
         });
-        $dispatcher->addListener('console.exception', function (ConsoleForExceptionEvent $event) {
+        $dispatcher->addListener('console.exception', function (ConsoleExceptionEvent $event) {
             $event->getOutput()->writeln('caught.');
 
             $event->setException(new \LogicException('caught.', $event->getExitCode(), $event->getException()));


### PR DESCRIPTION
I wondered about the name and now I figured the problem was already raised in the PR: https://github.com/symfony/symfony/pull/7466#discussion-diff-3503539

So I think it should be fixed for LTS.

BC break: yes
test pass: yes
