### PR TITLE
[Finder] Fixed a path in a test

### DIFF
--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -761,7 +761,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         $locations = array(
             __DIR__.'/Fixtures/one',
-            self::$files[8],
+            self::$tmpDir.DIRECTORY_SEPARATOR.'toto',
         );
 
         $finder = new Finder();


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Test case was introduced in 45b68e02bd5838c0288db360ce117b714f9ceaca.

It's probably better to be explicit rather than to rely on a path position in the array. Position in 2.1 was different than in the other branches.
