### PR TITLE
[FrameworkBundle] set the dispatcher in the console application 

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -67,6 +67,8 @@ class Application extends BaseApplication
     {
         $this->registerCommands();
 
+        $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
+
         if (true === $input->hasParameterOption(array('--shell', '-s'))) {
             $shell = new Shell($this);
             $shell->setProcessIsolation($input->hasParameterOption(array('--process-isolation')));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Console/ApplicationTest.php
@@ -20,7 +20,7 @@ class ApplicationTest extends TestCase
 {
     public function testBundleInterfaceImplementation()
     {
-        $bundle = $this->getMock("Symfony\Component\HttpKernel\Bundle\BundleInterface");
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\BundleInterface');
 
         $kernel = $this->getKernel(array($bundle));
 
@@ -30,7 +30,7 @@ class ApplicationTest extends TestCase
 
     public function testBundleCommandsAreRegistered()
     {
-        $bundle = $this->getMock("Symfony\Component\HttpKernel\Bundle\Bundle");
+        $bundle = $this->getMock('Symfony\Component\HttpKernel\Bundle\Bundle');
         $bundle->expects($this->once())->method('registerCommands');
 
         $kernel = $this->getKernel(array($bundle));
@@ -41,11 +41,30 @@ class ApplicationTest extends TestCase
 
     private function getKernel(array $bundles)
     {
-        $kernel = $this->getMock("Symfony\Component\HttpKernel\KernelInterface");
+        $dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $dispatcher
+            ->expects($this->atLeastOnce())
+            ->method('dispatch')
+        ;
+
+        $container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
+        $container
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('event_dispatcher'))
+            ->will($this->returnValue($dispatcher))
+        ;
+
+        $kernel = $this->getMock('Symfony\Component\HttpKernel\KernelInterface');
         $kernel
             ->expects($this->any())
             ->method('getBundles')
             ->will($this->returnValue($bundles))
+        ;
+        $kernel
+            ->expects($this->any())
+            ->method('getContainer')
+            ->will($this->returnValue($container))
         ;
 
         return $kernel;

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -33,7 +33,7 @@ use Symfony\Component\Console\Helper\TableHelper;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Event\ConsoleForExceptionEvent;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * An Application is the container for a collection of commands.
@@ -88,7 +88,7 @@ class Application
         }
     }
 
-    public function setDispatcher(EventDispatcher $dispatcher)
+    public function setDispatcher(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }


### PR DESCRIPTION
BC break: no
test pass: yes

Otherwise events are not dispatched in symfony frameworkbundle.
The first commit fixes a related typehint in the console.
