### PR TITLE
[FrameworkBundle] Removed reference to FieldType in form.xml

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml
@@ -58,9 +58,6 @@
         <service id="property_accessor" class="%property_accessor.class%" />
 
         <!-- CoreExtension -->
-        <service id="form.type.field" class="Symfony\Component\Form\Extension\Core\Type\FieldType">
-            <tag name="form.type" alias="field" />
-        </service>
         <service id="form.type.form" class="Symfony\Component\Form\Extension\Core\Type\FormType">
             <argument type="service" id="property_accessor"/>
             <tag name="form.type" alias="form" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [yes] |
| New feature? | [no] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Removed reference of deprecated FieldType class in FrameworkBundle form.xml configuragion.
