### PR TITLE
[HttpFoundation] Enforce UTF-8 header in JSON responses.

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -111,7 +111,7 @@ class JsonResponse extends Response
         // Only set the header when there is none or when it equals 'text/javascript' (from a previous update with callback)
         // in order to not overwrite a custom definition.
         if (!$this->headers->has('Content-Type') || 'text/javascript' === $this->headers->get('Content-Type')) {
-            $this->headers->set('Content-Type', 'application/json');
+            $this->headers->set('Content-Type', 'application/json; charset=utf-8');
         }
 
         return $this->setContent($this->data);

--- a/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/JsonResponseTest.php
@@ -57,13 +57,13 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
     public function testConstructorAddsContentTypeHeader()
     {
         $response = new JsonResponse();
-        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('application/json; charset=utf-8', $response->headers->get('Content-Type'));
     }
 
     public function testConstructorWithCustomHeaders()
     {
         $response = new JsonResponse(array(), 200, array('ETag' => 'foo'));
-        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('application/json; charset=utf-8', $response->headers->get('Content-Type'));
         $this->assertSame('foo', $response->headers->get('ETag'));
     }
 
@@ -133,13 +133,13 @@ class JsonResponseTest extends \PHPUnit_Framework_TestCase
     public function testStaticCreateAddsContentTypeHeader()
     {
         $response = JsonResponse::create();
-        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('application/json; charset=utf-8', $response->headers->get('Content-Type'));
     }
 
     public function testStaticCreateWithCustomHeaders()
     {
         $response = JsonResponse::create(array(), 200, array('ETag' => 'foo'));
-        $this->assertSame('application/json', $response->headers->get('Content-Type'));
+        $this->assertSame('application/json; charset=utf-8', $response->headers->get('Content-Type'));
         $this->assertSame('foo', $response->headers->get('ETag'));
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This makes sure JSON responses are always explitly sent as UTF-8.
The RFC says that JSON "SHOULD" be sent as UTF-8, so that makes sense.

For reference, see [this old Laravel ticket](https://github.com/laravel/laravel/pull/910).
