### PR TITLE
ErrorHandler and $context fixes

### DIFF
--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -90,7 +90,7 @@ class ErrorHandler
     }
 
     /**
-     * @throws \ContextErrorException When error_reporting returns error
+     * @throws ContextErrorException When error_reporting returns error
      */
     public function handle($level, $message, $file = 'unknown', $line = 0, $context = array())
     {

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Debug;
 
 use Symfony\Component\Debug\Exception\FatalErrorException;
+use Symfony\Component\Debug\Exception\ContextErrorException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -89,9 +90,9 @@ class ErrorHandler
     }
 
     /**
-     * @throws \ErrorException When error_reporting returns error
+     * @throws \ContextErrorException When error_reporting returns error
      */
-    public function handle($level, $message, $file, $line, $context)
+    public function handle($level, $message, $file='unknown', $line=0, $context=array())
     {
         if (0 === $this->level) {
             return false;
@@ -118,7 +119,7 @@ class ErrorHandler
         }
 
         if ($this->displayErrors && error_reporting() & $level && $this->level & $level) {
-            throw new \ErrorException(sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line), 0, $level, $file, $line);
+            throw new \ContextErrorException(sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line), 0, $level, $file, $line, $context);
         }
 
         return false;

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -92,7 +92,7 @@ class ErrorHandler
     /**
      * @throws \ContextErrorException When error_reporting returns error
      */
-    public function handle($level, $message, $file='unknown', $line=0, $context=array())
+    public function handle($level, $message, $file = 'unknown', $line = 0, $context = array())
     {
         if (0 === $this->level) {
             return false;
@@ -119,7 +119,7 @@ class ErrorHandler
         }
 
         if ($this->displayErrors && error_reporting() & $level && $this->level & $level) {
-            throw new \ContextErrorException(sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line), 0, $level, $file, $line, $context);
+            throw new ContextErrorException(sprintf('%s: %s in %s line %d', isset($this->levels[$level]) ? $this->levels[$level] : $level, $message, $file, $line), 0, $level, $file, $line, $context);
         }
 
         return false;

--- a/src/Symfony/Component/Debug/Exception/ContextErrorException.php
+++ b/src/Symfony/Component/Debug/Exception/ContextErrorException.php
@@ -20,15 +20,14 @@ class ContextErrorException extends \ErrorException
 {
     private $context = array();
     
-    public function __construct($message, $code, $severity, $filename, $lineno, $context=array())
+    public function __construct($message, $code, $severity, $filename, $lineno, $context = array())
     {
         $this->context = $context;
         parent::__construct($message, $code, $severity, $filename, $lineno);
     }
     
     /**
-     * Returns an array of variables that existed when the exception occurred.
-     * @return array Array of variable name=>value pairs.
+     * @return array Array of variables that existed when the exception occured
      */
     public function getContext(){
         return $this->context;

--- a/src/Symfony/Component/Debug/Exception/ContextErrorException.php
+++ b/src/Symfony/Component/Debug/Exception/ContextErrorException.php
@@ -22,14 +22,15 @@ class ContextErrorException extends \ErrorException
     
     public function __construct($message, $code, $severity, $filename, $lineno, $context = array())
     {
-        $this->context = $context;
         parent::__construct($message, $code, $severity, $filename, $lineno);
+        $this->context = $context;
     }
     
     /**
      * @return array Array of variables that existed when the exception occured
      */
-    public function getContext(){
+    public function getContext()
+    {
         return $this->context;
     }		
 }

--- a/src/Symfony/Component/Debug/Exception/ContextErrorException.php
+++ b/src/Symfony/Component/Debug/Exception/ContextErrorException.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Exception;
+
+/**
+ * Error Exception with Variable Context.
+ *
+ * @author Christian Sciberras <uuf6429@gmail.com>
+ */
+class ContextErrorException extends \ErrorException
+{
+    private $context = array();
+    
+    public function __construct($message, $code, $severity, $filename, $lineno, $context=array())
+    {
+        $this->context = $context;
+        parent::__construct($message, $code, $severity, $filename, $lineno);
+    }
+    
+    /**
+     * Returns an array of variables that existed when the exception occurred.
+     * @return array Array of variable name=>value pairs.
+     */
+    public function getContext(){
+        return $this->context;
+    }		
+}


### PR DESCRIPTION
Fixes a minor issue with optional parameters not being optional and added support for `ContextErrorException` class as detailed here: https://github.com/fabpot/Silex/issues/717
