### PR TITLE
[2.3][Process] Add possibility to use array prefixes

### DIFF
--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -28,7 +28,7 @@ class ProcessBuilder
     private $timeout;
     private $options;
     private $inheritEnv;
-    private $prefix;
+    private $prefix = array();
 
     public function __construct(array $arguments = array())
     {
@@ -64,13 +64,13 @@ class ProcessBuilder
      *
      * The prefix is preserved when reseting arguments.
      *
-     * @param string $prefix A command prefix
+     * @param string|array $prefix A command prefix or an array of command prefixes
      *
      * @return ProcessBuilder
      */
     public function setPrefix($prefix)
     {
-        $this->prefix = $prefix;
+        $this->prefix = is_array($prefix) ? $prefix : array($prefix);
 
         return $this;
     }
@@ -154,13 +154,13 @@ class ProcessBuilder
 
     public function getProcess()
     {
-        if (!$this->prefix && !count($this->arguments)) {
+        if (0 === count($this->prefix) && 0 === count($this->arguments)) {
             throw new LogicException('You must add() command arguments before calling getProcess().');
         }
 
         $options = $this->options;
 
-        $arguments = $this->prefix ? array_merge(array($this->prefix), $this->arguments) : $this->arguments;
+        $arguments = array_merge($this->prefix, $this->arguments);
         $script = implode(' ', array_map(array(__NAMESPACE__.'\\ProcessUtils', 'escapeArgument'), $arguments));
 
         if ($this->inheritEnv) {

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -124,6 +124,26 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testArrayPrefixesArePrependedToAllGeneratedProcess()
+    {
+        $pb = new ProcessBuilder();
+        $pb->setPrefix(array('/usr/bin/php', 'composer.phar'));
+
+        $proc = $pb->setArguments(array('-v'))->getProcess();
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->assertEquals('"/usr/bin/php" "composer.phar" "-v"', $proc->getCommandLine());
+        } else {
+            $this->assertEquals("'/usr/bin/php' 'composer.phar' '-v'", $proc->getCommandLine());
+        }
+
+        $proc = $pb->setArguments(array('-i'))->getProcess();
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->assertEquals('"/usr/bin/php" "composer.phar" "-i"', $proc->getCommandLine());
+        } else {
+            $this->assertEquals("'/usr/bin/php' 'composer.phar' '-i'", $proc->getCommandLine());
+        }
+    }
+
     public function testShouldEscapeArguments()
     {
         $pb = new ProcessBuilder(array('%path%', 'foo " bar'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | no |
| License | MIT |
| Doc PR | no |

This can be useful to use `'/opt/custom-php/bin/php' 'composer.phar'` as a prefix, it is not possible with the current implementation.

I submit the patch on 2.3 as `ProcessBuilder::setPrefix` method has been added for release 2.3. If it's too late for such modification, let me know, I'll open the PR against master.
