### PR TITLE
[HttpKernel] instantiate valid commands only

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -189,7 +189,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
                 $ns .= '\\'.strtr($relativePath, '/', '\\');
             }
             $r = new \ReflectionClass($ns.'\\'.$file->getBasename('.php'));
-            if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract()) {
+            if ($r->isSubclassOf('Symfony\\Component\\Console\\Command\\Command') && !$r->isAbstract() && !$r->getConstructor()->getNumberOfRequiredParameters()) {
                 $application->add($r->newInstance());
             }
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtensionPresentBundle/Command/BarCommand.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fixtures/ExtensionPresentBundle/Command/BarCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symfony\Component\HttpKernel\Tests\Fixtures\ExtensionPresentBundle\Command;
+
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * This command has a required parameter on the constructor and will be ignored by the default Bundle implementation.
+ *
+ * @see Symfony\Component\HttpKernel\Bundle\Bundle::registerCommands
+ */
+class BarCommand extends Command
+{
+    public function __construct($example, $name = 'bar')
+    {
+
+    }
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | debatable .. |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This skips the default behavior to instantiate `Command` that cannot simply be instantiated. The respective commands have to be registered by other means.
