### PR TITLE
[HttpFoundation] Request->getPort() should prefer HTTP_HOST over SERVER_PORT

### DIFF
--- a/src/Symfony/Component/HttpFoundation/HostHeader.php
+++ b/src/Symfony/Component/HttpFoundation/HostHeader.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation;
+
+/**
+ * Represents a Host header.
+ *
+ * A host header specifies the host and port of the
+ * resource being requested.
+ *
+ * @author Dennis Hotson <dennis.hotson@gmail.com>
+ */
+class HostHeader
+{
+    /**
+     * @var string
+     */
+    private $host;
+
+    /**
+     * @var string
+     */
+    private $port;
+
+    public function __construct($host, $port)
+    {
+        $this->host = $host;
+        $this->port = $port;
+    }
+
+    /**
+     * Returns the host name.
+     *
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+
+    /**
+     * Returns the port
+     *
+     * @return string (null if not specified)
+     */
+    public function getPort()
+    {
+        return $this->port;
+    }
+
+    /**
+     * Builds an HostHeader instance from a string.
+     *
+     * @param string $headerValue
+     *
+     * @return HostHeader
+     */
+    public static function fromString($headerValue)
+    {
+        if (preg_match(self::_pattern(), $headerValue, $matches)) {
+            $port = isset($matches['port']) ? $matches['port'] : null;
+            return new self($matches['host'], $port);
+        } else {
+            throw new \UnexpectedValueException('Invalid Host header value: '.$headerValue);
+        }
+    }
+
+    private static $_pattern;
+
+    /**
+     * Builds a regex pattern to parse a HTTP Host header
+     * according to RFC3986 http://tools.ietf.org/html/rfc3986.html
+     *
+     * @return string
+     */
+    private static function _pattern()
+    {
+        if (isset(self::$_pattern))
+            return self::$_pattern;
+
+        $h16 = '[[:xdigit:]]{1,4}';
+        $h16c = "(?: $h16 : )"; // A h16 followed by a colon
+        $unreserved = '[-._~[:alpha:][:digit:]]';
+        $pctEncoded = '(?: % [[:xdigit]]{2} )';
+        $subDelims = "[!$&'()*+,;=]";
+        $decOctet = <<<EOS
+            (?:
+                  [0-9]
+                | (?: [1-9][0-9] )
+                | (?: 1 [0-9][0-9] )
+                | (?: 2 [0-4][0-9] )
+                | (?: 25 [0-5] )
+            )
+EOS;
+
+        $regName = <<<EOS
+            (?:
+                  $unreserved
+                | $pctEncoded
+                | $subDelims
+            )*
+EOS;
+
+        $ipv4Address = <<<EOS
+            (?:
+                $decOctet \. $decOctet \. $decOctet \. $decOctet
+            )
+EOS;
+
+        $ls32 = <<<EOS
+            (?:
+                (?: $h16 : $h16) | $ipv4Address
+            )
+EOS;
+
+        $ipv6Address = <<<EOS
+            (?:
+                  (?:                           $h16c{6} $ls32 )
+                | (?:                        :: $h16c{5} $ls32 )
+                | (?: (?:            $h16 )? :: $h16c{4} $ls32 )
+                | (?: (?: $h16c{0,1} $h16 )? :: $h16c{3} $ls32 )
+                | (?: (?: $h16c{0,2} $h16 )? :: $h16c{2} $ls32 )
+                | (?: (?: $h16c{0,3} $h16 )? :: $h16c    $ls32 )
+                | (?: (?: $h16c{0,4} $h16 )? ::          $ls32 )
+                | (?: (?: $h16c{0,5} $h16 )? ::          $h16  )
+                | (?: (?: $h16c{0,6} $h16 )? ::                )
+            )
+EOS;
+
+        $ipvFuture = <<<EOS
+            (?:
+                v [[:xdigit:]]+ \. (?: $unreserved | $subDelims | : )+
+            )
+EOS;
+
+        $ipLiteral = <<<EOS
+            (?: \[ (?: $ipv6Address | $ipvFuture ) \] )
+EOS;
+
+        $host = "(?P<host> $ipLiteral | $ipv4Address | $regName )";
+        $port = '(?: : (?P<port> [0-9]* ) )?';
+        $pattern = "/ \A $host $port \Z /x";
+
+        return self::$_pattern = $pattern;
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/HostHeader.php
+++ b/src/Symfony/Component/HttpFoundation/HostHeader.php
@@ -31,6 +31,12 @@ class HostHeader
      */
     private $port;
 
+    /**
+     * Pattern to validate Host header value
+     * @var string
+     */
+    private static $pattern;
+
     public function __construct($host, $port)
     {
         $this->host = $host;
@@ -66,7 +72,7 @@ class HostHeader
      */
     public static function fromString($headerValue)
     {
-        if (preg_match(self::_pattern(), $headerValue, $matches)) {
+        if (preg_match(self::pattern(), $headerValue, $matches)) {
             $port = isset($matches['port']) ? $matches['port'] : null;
             return new self($matches['host'], $port);
         } else {
@@ -74,7 +80,6 @@ class HostHeader
         }
     }
 
-    private static $_pattern;
 
     /**
      * Builds a regex pattern to parse a HTTP Host header
@@ -82,10 +87,10 @@ class HostHeader
      *
      * @return string
      */
-    private static function _pattern()
+    private static function pattern()
     {
-        if (isset(self::$_pattern))
-            return self::$_pattern;
+        if (isset(self::$pattern))
+            return self::$pattern;
 
         $h16 = '[[:xdigit:]]{1,4}';
         $h16c = "(?: $h16 : )"; // A h16 followed by a colon
@@ -150,6 +155,6 @@ EOS;
         $port = '(?: : (?P<port> [0-9]* ) )?';
         $pattern = "/ \A $host $port \Z /x";
 
-        return self::$_pattern = $pattern;
+        return self::$pattern = $pattern;
     }
 }

--- a/src/Symfony/Component/HttpFoundation/Tests/HostHeaderTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/HostHeaderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpFoundation\Tests;
+
+use Symfony\Component\HttpFoundation\HostHeader;
+
+class HostHeaderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideFromValidStringData
+     */
+    public function testFromValidString($string, array $hostAndPort)
+    {
+        $header = HostHeader::fromString($string);
+        list($host, $port) = $hostAndPort;
+        $this->assertEquals($host, $header->getHost());
+        $this->assertEquals($port, $header->getPort());
+    }
+
+    public function provideFromValidStringData()
+    {
+        return array(
+            array('example.org', array('example.org', null)),
+            array('example.org:90', array('example.org', 90)),
+            array('sub.example.org', array('sub.example.org', null)),
+            array('sub.example.org:8080', array('sub.example.org', 8080)),
+            array('192.168.1.1', array('192.168.1.1', null)),
+            array('127.0.0.1:90', array('127.0.0.1', 90)),
+            array('[::1]:90', array('[::1]', 90)),
+            array('[2607:f0d0:1002:0051:0000:0000:0000:0004]:90', array('[2607:f0d0:1002:0051:0000:0000:0000:0004]', 90)),
+            array('', array('', null)),
+            array(':90', array('', 90)),
+        );
+    }
+
+    /**
+     * @dataProvider invalidHostProvider
+     */
+    public function testFromInvalidString($string)
+    {
+        $this->setExpectedException('\UnexpectedValueException');
+        $header = HostHeader::fromString($string);
+    }
+
+    public function invalidHostProvider()
+    {
+        return array(
+            array('example.org:blah'),
+            array('whitespace not valid'),
+            array('asdf:asdf:90'),
+            array('1.1.1.1.1   '),
+            array('<script>alert(1);</script>'),
+            array("asdf\nHost: example.org"),
+            array('   example.org:90'),
+        );
+    }
+}

--- a/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RequestTest.php
@@ -335,7 +335,7 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $server['HTTP_HOST'] = 'host:8080';
         $server['SERVER_NAME'] = 'servername';
-        $server['SERVER_PORT'] = '8080';
+        $server['SERVER_PORT'] = '8888'; // Port in HTTP_HOST takes preference
 
         $server['QUERY_STRING'] = 'query=string';
         $server['REQUEST_URI'] = '/index.php/path/info?query=string';
@@ -578,22 +578,21 @@ class RequestTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
 
-        $server['SERVER_NAME'] = 'servername';
-        $server['SERVER_PORT'] = '90';
+        $server['HTTP_HOST'] = 'host:90';
         $request->initialize(array(), array(), array(), array(), array(), $server);
-        $this->assertEquals('http://servername:90', $request->getSchemeAndHttpHost());
+        $this->assertEquals('http://host:90', $request->getSchemeAndHttpHost());
 
         $server['PHP_AUTH_USER'] = 'fabien';
         $request->initialize(array(), array(), array(), array(), array(), $server);
-        $this->assertEquals('http://servername:90', $request->getSchemeAndHttpHost());
+        $this->assertEquals('http://host:90', $request->getSchemeAndHttpHost());
 
         $server['PHP_AUTH_USER'] = '0';
         $request->initialize(array(), array(), array(), array(), array(), $server);
-        $this->assertEquals('http://servername:90', $request->getSchemeAndHttpHost());
+        $this->assertEquals('http://host:90', $request->getSchemeAndHttpHost());
 
         $server['PHP_AUTH_PW'] = '0';
         $request->initialize(array(), array(), array(), array(), array(), $server);
-        $this->assertEquals('http://servername:90', $request->getSchemeAndHttpHost());
+        $this->assertEquals('http://host:90', $request->getSchemeAndHttpHost());
     }
 
     /**
@@ -701,6 +700,13 @@ class RequestTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(80, $port, 'If X_FORWARDED_PROTO is set to http return 80.');
         Request::setTrustedProxies(array());
+
+        $request = Request::create('http://example.com:90', 'GET', array(), array(), array(), array(
+            'SERVER_PORT' => 1234
+        ));
+        $port = $request->getPort();
+
+        $this->assertEquals(90, $port, 'If server is running on a different port (eg load balancer) prefer port in HTTP_HOST');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | https://github.com/symfony/symfony/issues/3420 |
| License | MIT |
| Doc PR | none |
## What is this?

This fixes the semantics of the `Request#getPort()` method to prefer the HTTP_HOST header over SERVER_PORT.

This is relevant in situations where the web server is running on a different port to the public facing website. e.g. load balancers, proxies, port forwarding.

Since the HTTP_HOST is user input it cannot be trusted. That's why I've introduced a `HostHeader` class to validate the value of HTTP_HOST according to [rfc3986](http://tools.ietf.org/html/rfc3986.html), which describes valid syntax for URIs.

The implementation builds a regular expression based on the grammar in the rfc, so the code may look a little bit gnarly. Feedback welcome. :)
On the plus side, it should be very strict about what it accepts.
## Consistency

This change makes Symfony more consistent with other popular web frameworks.

Preferring HTTP_HOST over SERVER_NAME and SERVER_PORT is the strategy used by Ruby's Rack and Python's Django.

Python has a PEP that describes how to reconstruct URLs:
http://www.python.org/dev/peps/pep-0333/#url-reconstruction

https://github.com/rack/rack/blob/b6290a184cead2ffd731647d0836c5ebd3c21e7a/lib/rack/request.rb#L92
## Additional security issues

Validating that the Host header is in a valid format isn't quite enough, you should also make sure the Host is something you expect it to be. Otherwise you can be vulnerable to attacks such as [cache poisoning via Host header injection](http://seclists.org/fulldisclosure/2008/Jun/169).

Django has a method to set allowed hosts:
https://docs.djangoproject.com/en/dev/ref/settings/#allowed-hosts

Rails has some configuration to set the default url host:
http://edgeguides.rubyonrails.org/action_controller_overview.html#default-url-options

Symfony should probably adopt a similar approach to prevent these types of attacks.
This isn't a new issue though. I believe Symfony apps are already susceptible to this.
