### PR TITLE
[DoctrineBridgeBundle] Support of non default entity manager for EntityUserProvider

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
+++ b/src/Symfony/Bridge/Doctrine/Security/User/EntityUserProvider.php
@@ -34,7 +34,10 @@ class EntityUserProvider implements UserProviderInterface
 
     public function __construct(ManagerRegistry $registry, $class, $property = null, $managerName = null)
     {
-        $em = $registry->getManager($managerName);
+        $em = null === $managerName 
+            ? $registry->getManagerForClass($class) 
+            : $registry->getManager($managerName);
+
         $this->class = $class;
         $this->metadata = $em->getClassMetadata($class);
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | na |
| Fixed tickets | doctrine/DoctrineBundle#188 |
| License | MIT |

this is reference to doctrine/DoctrineBundle#188

TLDR The EntityUserProvider found in DoctrineBridgeBundle only assumes entity to use default EntityManager.
