### PR TITLE
[Security] Use HMAC construction for remember me cookie hashes

### DIFF
--- a/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
+++ b/src/Symfony/Component/Security/Http/RememberMe/TokenBasedRememberMeServices.php
@@ -147,6 +147,6 @@ class TokenBasedRememberMeServices extends AbstractRememberMeServices
      */
     protected function generateCookieHash($class, $username, $expires, $password)
     {
-        return hash('sha256', $class.$username.$expires.$password.$this->getKey());
+        return hash_hmac('sha256', $class.$username.$expires.$password, $this->getKey());
     }
 }


### PR DESCRIPTION
[Security] Use HMAC construction for remember me cookie hashes

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

HMAC is a more secure construction for MACs than the secret suffix method that is currently being used by the remember me cookies, see http://rdist.root.org/2009/10/29/stop-using-unsafe-keyed-hashes-use-hmac/.

Changing the MAC scheme means that current cookies will be invalidated and users will have to login again. Though there are no API BC issues.
