### PR TITLE
[Console] Throw exception if value is passed to VALUE_NONE input optin, long syntax

### DIFF
--- a/src/Symfony/Component/Console/Input/ArgvInput.php
+++ b/src/Symfony/Component/Console/Input/ArgvInput.php
@@ -134,7 +134,7 @@ class ArgvInput extends Input
 
                 break;
             } else {
-                $this->addLongOption($option->getName(), true);
+                $this->addLongOption($option->getName(), null);
             }
         }
     }
@@ -218,6 +218,10 @@ class ArgvInput extends Input
         // Convert false values (from a previous call to substr()) to null
         if (false === $value) {
             $value = null;
+        }
+
+        if (null !== $value && !$option->acceptValue()) {
+            throw new \RuntimeException(sprintf('The "--%s" option does not accept a value.', $name, $value));
         }
 
         if (null === $value && $option->acceptValue() && count($this->parsed)) {

--- a/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
+++ b/src/Symfony/Component/Console/Tests/Input/ArgvInputTest.php
@@ -176,6 +176,11 @@ class ArgvInputTest extends \PHPUnit_Framework_TestCase
                 'The "-o" option does not exist.'
             ),
             array(
+                array('cli.php', '--foo=bar'),
+                new InputDefinition(array(new InputOption('foo', 'f', InputOption::VALUE_NONE))),
+                'The "--foo" option does not accept a value.'
+            ),
+            array(
                 array('cli.php', 'foo', 'bar'),
                 new InputDefinition(),
                 'Too many arguments.'


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8135 |
| License | MIT |

Input options with InputOption::VALUE_NONE accept values in both short and long syntaxes:
- When using the long syntax, no exception is thrown;
- When using short, a "The %s option does not exist" exception is thrown.

This PR only addresses the long syntax case. The short syntax case would require considerable refactoring of the parse code, which I believe should be discussed.

I included a test that illustrates the above mentioned problem for the long syntax scenario.
