### PR TITLE
[Console] fix status and exit code

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -113,9 +113,16 @@ class Application
             } else {
                 $this->renderException($e, $output);
             }
-            $statusCode = $e->getCode();
 
-            $statusCode = is_numeric($statusCode) && $statusCode ? (int) $statusCode : 1;
+            $statusCode = $e->getCode();
+            if (is_numeric($statusCode)) {
+                $statusCode = (int) $statusCode;
+                if (0 === $statusCode) {
+                    $statusCode = 1;
+                }
+            } else {
+                $statusCode = 1;
+            }
         }
 
         if ($this->autoExit) {

--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -126,11 +126,9 @@ class Application
         }
 
         if ($this->autoExit) {
-            if ($statusCode > 255) {
-                $statusCode = 255;
-            }
+            // ensure exit code is between 0-254 (255 is reserved by PHP and should not be used)
             // @codeCoverageIgnoreStart
-            exit($statusCode);
+            exit(max(0, min(254, $statusCode)));
             // @codeCoverageIgnoreEnd
         }
 


### PR DESCRIPTION
Fix https://github.com/symfony/symfony/pull/8183#discussion_r4525267
and
http://www.php.net/manual/en/function.exit.php

> Exit statuses should be in the range 0 to 254, the exit status 255 is reserved by PHP and shall not be used. The status 0 is used to terminate the program successfully.
