### PR TITLE
[PropelBridge] make PropelLogger implement LoggerInterface

### DIFF
--- a/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
+++ b/src/Symfony/Bridge/Propel1/DataCollector/PropelDataCollector.php
@@ -26,7 +26,7 @@ class PropelDataCollector extends DataCollector
     /**
      * Propel logger
      *
-     * @var \Symfony\Bridge\Propel1\Logger\PropelLogger
+     * @var PropelLogger
      */
     private $logger;
 

--- a/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
+++ b/src/Symfony/Bridge/Propel1/Logger/PropelLogger.php
@@ -19,56 +19,75 @@ use Psr\Log\LoggerInterface;
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author William Durand <william.durand1@gmail.com>
+ * @author Tobias Schultze <http://tobion.de>
  */
-class PropelLogger
+class PropelLogger implements LoggerInterface
 {
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface|null
      */
     protected $logger;
 
     /**
      * @var array
      */
-    protected $queries;
+    protected $queries = array();
 
     /**
-     * @var Stopwatch
+     * @var Stopwatch|null
      */
     protected $stopwatch;
 
-    private $isPrepared;
+    private $isPrepared = false;
 
     /**
      * Constructor.
      *
-     * @param LoggerInterface $logger    A LoggerInterface instance
-     * @param Stopwatch       $stopwatch A Stopwatch instance
+     * @param LoggerInterface|null $logger    An optional LoggerInterface instance
+     * @param Stopwatch|null       $stopwatch An optional Stopwatch instance
      */
     public function __construct(LoggerInterface $logger = null, Stopwatch $stopwatch = null)
     {
         $this->logger    = $logger;
-        $this->queries   = array();
         $this->stopwatch = $stopwatch;
-        $this->isPrepared = false;
     }
 
     /**
-     * A convenience function for logging an alert event.
-     *
-     * @param mixed $message the message to log.
+     * {@inheritdoc}
      */
-    public function alert($message)
+    public function emergency($message, array $context = array())
     {
         if (null !== $this->logger) {
-            $this->logger->alert($message);
+            $this->logger->emergency($message, $context);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function alert($message, array $context = array())
+    {
+        if (null !== $this->logger) {
+            $this->logger->alert($message, $context);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function critical($message, array $context = array())
+    {
+        if (null !== $this->logger) {
+            $this->logger->critical($message, $context);
         }
     }
 
     /**
      * A convenience function for logging a critical event.
      *
-     * @param mixed $message the message to log.
+     * @param string $message the message to log.
+     *
+     * @deprecated Deprecated since version 2.4, to be removed in 3.0. Use critical() instead.
      */
     public function crit($message)
     {
@@ -78,9 +97,21 @@ class PropelLogger
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function error($message, array $context = array())
+    {
+        if (null !== $this->logger) {
+            $this->logger->error($message, $context);
+        }
+    }
+
+    /**
      * A convenience function for logging an error event.
      *
-     * @param mixed $message the message to log.
+     * @param string $message the message to log.
+     *
+     * @deprecated Deprecated since version 2.4, to be removed in 3.0. Use error() instead.
      */
     public function err($message)
     {
@@ -90,47 +121,39 @@ class PropelLogger
     }
 
     /**
-     * A convenience function for logging a warning event.
-     *
-     * @param mixed $message the message to log.
+     * {@inheritdoc}
      */
-    public function warning($message)
+    public function warning($message, array $context = array())
     {
         if (null !== $this->logger) {
-            $this->logger->warning($message);
+            $this->logger->warning($message, $context);
         }
     }
 
     /**
-     * A convenience function for logging an critical event.
-     *
-     * @param mixed $message the message to log.
+     * {@inheritdoc}
      */
-    public function notice($message)
+    public function notice($message, array $context = array())
     {
         if (null !== $this->logger) {
-            $this->logger->notice($message);
+            $this->logger->notice($message, $context);
         }
     }
 
     /**
-     * A convenience function for logging an critical event.
-     *
-     * @param mixed $message the message to log.
+     * {@inheritdoc}
      */
-    public function info($message)
+    public function info($message, array $context = array())
     {
         if (null !== $this->logger) {
-            $this->logger->info($message);
+            $this->logger->info($message, $context);
         }
     }
 
     /**
-     * A convenience function for logging a debug event.
-     *
-     * @param mixed $message the message to log.
+     * {@inheritdoc}
      */
-    public function debug($message)
+    public function debug($message, array $context = array())
     {
         $add = true;
 
@@ -153,8 +176,18 @@ class PropelLogger
         if ($add) {
             $this->queries[] = $message;
             if (null !== $this->logger) {
-                $this->logger->debug($message);
+                $this->logger->debug($message, $context);
             }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function log($level, $message, array $context = array())
+    {
+        if (null !== $this->logger) {
+            $this->logger->log($level, $message, $context);
         }
     }
 


### PR DESCRIPTION
bc break: no
deprecations: PropelLogger::err() and PropelLogger::crit()
test pass: yes

As the PropelLogger is a logger and a wrapper around another logger, it should implement LoggerInterface as well. Anotherwise the logger cant be used as a replacement for other loggers.
