### PR TITLE
[Security] Fix BCryptPasswordEncoder to encode password using salt

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -60,7 +60,7 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
      */
     public function encodePassword($raw, $salt)
     {
-        return password_hash($raw, PASSWORD_BCRYPT, array('cost' => $this->cost));
+        return password_hash($raw, PASSWORD_BCRYPT, array('cost' => $this->cost, 'salt' => $salt));
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

After changing the bcrypt logic from Symfony to `ircmaxell/password-compat` in b2e553a the salt was never passed to the password_hash method. 

This actually still occurs in 9d089ef as well:

``` php
if (function_exists('password_hash')) {
   return password_hash($raw, PASSWORD_BCRYPT, array('cost' => $this->cost));
}
```

I don't know if there wasn't salt support previously which is why it was never implemented before. Since a lot of the logic was changed in the 2.3 branch in the class BCryptPasswordEncoder i thought it would be better to issue a pull request here. 
