### PR TITLE
[Form] Fixed SubmitTypeValidatorExtension not correctly extending BaseValidatorExtension

### DIFF
--- a/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\Form\Extension\Validator\Type;
 
-use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Validator\ViolationMapper\ViolationMapper;
 use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;

--- a/src/Symfony/Component/Form/Extension/Validator/Type/SubmitTypeValidatorExtension.php
+++ b/src/Symfony/Component/Form/Extension/Validator/Type/SubmitTypeValidatorExtension.php
@@ -11,12 +11,10 @@
 
 namespace Symfony\Component\Form\Extension\Validator\Type;
 
-use Symfony\Component\Form\AbstractTypeExtension;
-
 /**
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class SubmitTypeValidatorExtension extends AbstractTypeExtension
+class SubmitTypeValidatorExtension extends BaseValidatorExtension
 {
     /**
      * {@inheritdoc}

--- a/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Validator/Type/SubmitTypeValidatorExtensionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Form\Tests\Extension\Validator\Type;
+
+use Symfony\Component\Form\FormInterface;
+
+class SubmitTypeValidatorExtensionTest extends TypeTestCase
+{
+    public function testValidationGroupNullByDefault()
+    {
+        $form =  $this->factory->create('submit');
+
+        $this->assertNull($form->getConfig()->getOption('validation_groups'));
+    }
+
+    public function testValidationGroupsTransformedToArray()
+    {
+        $form = $this->factory->create('submit', null, array(
+            'validation_groups' => 'group',
+        ));
+
+        $this->assertEquals(array('group'), $form->getConfig()->getOption('validation_groups'));
+    }
+
+    public function testValidationGroupsCanBeSetToArray()
+    {
+        $form = $this->factory->create('submit', null, array(
+            'validation_groups' => array('group1', 'group2'),
+        ));
+
+        $this->assertEquals(array('group1', 'group2'), $form->getConfig()->getOption('validation_groups'));
+    }
+
+    public function testValidationGroupsCanBeSetToFalse()
+    {
+        $form = $this->factory->create('submit', null, array(
+                'validation_groups' => false,
+            ));
+
+        $this->assertEquals(array(), $form->getConfig()->getOption('validation_groups'));
+    }
+
+    public function testValidationGroupsCanBeSetToCallback()
+    {
+        $form = $this->factory->create('submit', null, array(
+            'validation_groups' => array($this, 'testValidationGroupsCanBeSetToCallback'),
+        ));
+
+        $this->assertTrue(is_callable($form->getConfig()->getOption('validation_groups')));
+    }
+
+    public function testValidationGroupsCanBeSetToClosure()
+    {
+        $form = $this->factory->create('submit', null, array(
+            'validation_groups' => function(FormInterface $form){ return null; },
+        ));
+
+        $this->assertTrue(is_callable($form->getConfig()->getOption('validation_groups')));
+    }
+
+}


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8209 |
| License | MIT |
| Doc PR |  |

Although stated in the documentation is was not actually possible to use "validation_groups" config on a submit form type. Turns out that although a BaseValidatorExtension had be created with the required functionality SubmitTypeValidatorExtension was not yet extending from it.

This pull request corrects this issue, adds tests for SubmitTypeValidatorExtension and as a bonus removes an unused import in FormTypeValidatorExtension.
