### PR TITLE
[Console] Ensure proper exit code on Exception

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -113,15 +113,11 @@ class Application
             } else {
                 $this->renderException($e, $output);
             }
-            $statusCode = $e->getCode();
 
-            $statusCode = is_numeric($statusCode) && $statusCode ? (int) $statusCode : 1;
+            $statusCode = max(1, min(254, intval($e->getCode())));
         }
 
         if ($this->autoExit) {
-            if ($statusCode > 255) {
-                $statusCode = 255;
-            }
             // @codeCoverageIgnoreStart
             exit($statusCode);
             // @codeCoverageIgnoreEnd

--- a/src/Symfony/Component/Console/Tests/ApplicationTest.php
+++ b/src/Symfony/Component/Console/Tests/ApplicationTest.php
@@ -531,6 +531,51 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(1, $exitCode, '->run() returns exit code 1 when exception code is 0');
     }
 
+    public function testRunReturnsExitCodeOneForExceptionCodeNegative()
+    {
+        $exception = new \Exception('', -20);
+
+        $application = $this->getMock('Symfony\Component\Console\Application', array('doRun'));
+        $application->setAutoExit(false);
+        $application->expects($this->once())
+             ->method('doRun')
+             ->will($this->throwException($exception));
+
+        $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
+
+        $this->assertSame(1, $exitCode, '->run() returns exit code 1 when exception code is negative');
+    }
+
+    public function testRunReturnsExitCodeOneForExceptionCodeNonInteger()
+    {
+        $exception = new \Exception('', false);
+
+        $application = $this->getMock('Symfony\Component\Console\Application', array('doRun'));
+        $application->setAutoExit(false);
+        $application->expects($this->once())
+             ->method('doRun')
+             ->will($this->throwException($exception));
+
+        $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
+
+        $this->assertSame(1, $exitCode, '->run() returns exit code 1 when exception code is not integer');
+    }
+
+    public function testRunReturnsExitCode254ForExceptionCodeHigher254()
+    {
+        $exception = new \Exception('', 404);
+
+        $application = $this->getMock('Symfony\Component\Console\Application', array('doRun'));
+        $application->setAutoExit(false);
+        $application->expects($this->once())
+             ->method('doRun')
+             ->will($this->throwException($exception));
+
+        $exitCode = $application->run(new ArrayInput(array()), new NullOutput());
+
+        $this->assertSame(254, $exitCode, '->run() returns exit code 254 when exception code is 254+');
+    }
+
     /**
      * @expectedException \LogicException
      * @dataProvider getAddingAlreadySetDefinitionElementData


### PR DESCRIPTION
Fixes broken exit codes for console component.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| New test cases? | yes |
| Tests pass? | yes |
| Fixed tickets | 8183, 8202 |
| License | MIT |
- Prevent negative and 0 exit code from being used on exception
- Prevent 255+ exit code from being used
