### PR TITLE
Add the referer information that could help you findout where's the link comes from

### DIFF
--- a/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/RouterListener.php
@@ -87,7 +87,7 @@ class RouterListener implements EventSubscriberInterface
             unset($parameters['_controller']);
             $request->attributes->set('_route_params', $parameters);
         } catch (ResourceNotFoundException $e) {
-            $message = sprintf('No route found for "%s %s"', $request->getMethod(), $request->getPathInfo());
+            $message = sprintf('No route found for "%s %s" (from %s)', $request->getMethod(), $request->getPathInfo(), $request->headers->get('referer'));
 
             throw new NotFoundHttpException($message, $e);
         } catch (MethodNotAllowedException $e) {


### PR DESCRIPTION
It's very difficult to find out where's the bad link coming from. So It's better to add the referer infomation on not found page.
