### PR TITLE
[Process] fix issue where $_ENV contains array vals

### DIFF
--- a/src/Symfony/Component/Process/ProcessBuilder.php
+++ b/src/Symfony/Component/Process/ProcessBuilder.php
@@ -169,6 +169,9 @@ class ProcessBuilder
             $env = $this->env;
         }
 
+        // Process can not handle env values that are arrays
+        $env = $env ? array_filter($env, function ($value) { if (!is_array($value)) { return true; } }) : $env;
+
         return new Process($script, $this->cwd, $env, $this->stdin, $this->timeout, $options);
     }
 }

--- a/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessBuilderTest.php
@@ -45,6 +45,22 @@ class ProcessBuilderTest extends \PHPUnit_Framework_TestCase
         $_ENV = $snapshot;
     }
 
+    public function testProcessBuilderShouldNotPassEnvArrays()
+    {
+        $snapshot = $_ENV;
+        $_ENV = array('a' => array('b', 'c'), 'd' => 'e', 'f' => 'g');
+        $expected = array('d' => 'e', 'f' => 'g');
+
+        $pb = new ProcessBuilder();
+        $pb->add('a')->inheritEnvironmentVariables()
+            ->setEnv('d', 'e');
+        $proc = $pb->getProcess();
+
+        $this->assertEquals($expected, $proc->getEnv(), '->inheritEnvironmentVariables() removes array values from $_ENV');
+
+        $_ENV = $snapshot;
+    }
+
     public function testInheritEnvironmentVarsByDefault()
     {
         $pb = new ProcessBuilder();


### PR DESCRIPTION
There are cases where $env or $_ENV can contain a value that is an array
This will cause Process to throw an Array to String conversion exception
Initially I submitted a patch of Process.php, however Fabien indicated
that it shouldn't be fixed there (see below pull request).

Before recently, a simple work around would be in php.ini to set:

  register_argc_argv = On

However with recent changes, this seems to no longer work.

Original pull request: https://github.com/symfony/symfony/pull/7354

See ticket https://github.com/symfony/symfony/issues/7196

```
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 7196
| License       | MIT
| Doc PR        | none
```
