### PR TITLE
[WIP][HttpKernel] Add missing ttl configuration into HttpCache::validate()

### DIFF
--- a/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
+++ b/src/Symfony/Component/HttpKernel/HttpCache/HttpCache.php
@@ -394,6 +394,12 @@ class HttpCache implements HttpKernelInterface, TerminableInterface
             $this->record($request, 'invalid');
         }
 
+        if ($this->isPrivateRequest($request) && !$response->headers->hasCacheControlDirective('public')) {
+            $response->setPrivate(true);
+        } elseif ($this->options['default_ttl'] > 0 && null === $response->getTtl() && !$response->headers->getCacheControlDirective('must-revalidate')) {
+            $response->setTtl($this->options['default_ttl']);
+        }
+
         if ($response->isCacheable()) {
             $this->store($request, $response);
         }


### PR DESCRIPTION
| Q | A |
| --: | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
- [ ] Add unit tests

The TTL configuration was lost after HTTP validation
