### PR TITLE
[FrameworkBundle][Command] print registered event-listeners + event-subscribers

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -21,12 +21,6 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
             ->setDescription('Displays current event-listeners and event-subscribers for an application');
     }
 
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @return void
-     * @throws \InvalidArgumentException if the event does not exists
-     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $containerBuilder = $this->getContainerBuilder();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
 /**
- * A console command for retrieving information about services
+ * A console command for retrieving information about events
  *
  * @author Florian Semm <floriansemm@googlemail.com>
  */
@@ -78,9 +78,7 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
         $table = $this->getHelperSet()->get('table');
         $table
             ->setHeaders(array('Class', 'Event'))
-            ->setCrossingChar('')
-            ->setVerticalBorderChar('')
-            ->setHorizontalBorderChar('');
+            ->setLayout(TableHelper::LAYOUT_BORDERLESS);
 
         return $table;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Symfony\Bundle\FrameworkBundle\Command;
+
+use Symfony\Component\Console\Helper\TableHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\Config\FileLocator;
+
+class EventDispatcherDebugCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('event_dispatcher:debug')
+            ->addArgument('event', InputArgument::OPTIONAL, 'Show listeners for a event', '')
+            ->setDescription('Displays current event-listeners and event-subscribers for an application');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $containerBuilder = $this->getContainerBuilder();
+
+        $listeners = $this->getListeners($containerBuilder);
+        $listeners = $this->getEventSubscriber($containerBuilder, $listeners);
+
+        $event = $input->getArgument('event');
+        if ($event != '') {
+            if (!isset($listeners[$event])) {
+                throw new \InvalidArgumentException(sprintf('The event %s does not exist', $event));
+            }
+
+            $listeners = $listeners[$event];
+
+            $output->writeln(sprintf('<info>[event_dispatcher]</info> Information for event <info>%s</info>', $event));
+        } else {
+            ksort($listeners);
+            $listeners = array_reduce($listeners, function($result, $elements){
+                foreach ($elements as $element) {
+                    $result[] = $element;
+                }
+
+                return $result;
+            });
+
+            $output->writeln('<info>[event_dispatcher]</info> Listeners');
+        }
+
+        $table = $this->setupTableNoBorders();
+        $table
+            ->setRows($listeners)
+            ->render($output);
+    }
+
+    /**
+     * @return TableHelper
+     */
+    private function setupTableNoBorders()
+    {
+        $table = $this->getHelperSet()->get('table');
+        $table
+            ->setHeaders(array('Class', 'Event'))
+            ->setCrossingChar('')
+            ->setVerticalBorderChar('')
+            ->setHorizontalBorderChar('');
+
+        return $table;
+    }
+
+    /**
+     * @param ContainerBuilder $containerBuilder
+     * @return array
+     */
+    private function getListeners(ContainerBuilder $containerBuilder)
+    {
+        $definitions = $containerBuilder->findTaggedServiceIds('kernel.event_listener');
+
+        $listeners = array();
+        foreach ($definitions as $id => $definition) {
+            $event = $definition[0]['event'];
+
+            $class = $containerBuilder->getDefinition($id)->getClass();
+
+            $listeners[$event][] = array($class, $event);
+        }
+
+        return $listeners;
+    }
+
+    /**
+     * @param ContainerBuilder $containerBuilder
+     * @return array
+     */
+    private function getEventSubscriber(ContainerBuilder $containerBuilder, array $listeners)
+    {
+        foreach ($containerBuilder->findTaggedServiceIds('kernel.event_subscriber') as $id => $attributes) {
+            $class = $containerBuilder->getDefinition($id)->getClass();
+
+            $refClass = new \ReflectionClass($class);
+            $interface = 'Symfony\Component\EventDispatcher\EventSubscriberInterface';
+
+            if (!$refClass->implementsInterface($interface)) {
+                continue;
+            }
+
+            $subscribedEvents = $class::getSubscribedEvents();
+            $events = array_keys($subscribedEvents);
+
+            foreach ($events as $event) {
+                $listeners[$event][] = array($class, $event);
+            }
+        }
+
+        return $listeners;
+    }
+
+    /**
+     * Loads the ContainerBuilder from the cache.
+     *
+     * @return ContainerBuilder
+     */
+    protected function getContainerBuilder()
+    {
+        if (!$this->getApplication()->getKernel()->isDebug()) {
+            throw new \LogicException(sprintf('Debug information about the EventDispatcher is only available in debug mode.'));
+        }
+
+        if (!is_file($cachedFile = $this->getContainer()->getParameter('debug.container.dump'))) {
+            throw new \LogicException(sprintf('Debug information about the EventDispatcher could not be found. Please clear the cache and try again.'));
+        }
+
+        $container = new ContainerBuilder();
+
+        $loader = new XmlFileLoader($container, new FileLocator());
+        $loader->load($cachedFile);
+
+        return $container;
+    }
+}

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -64,23 +64,12 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
             $output->writeln('<info>[event_dispatcher]</info> Listeners');
         }
 
-        $table = $this->setupTableNoBorders();
-        $table
-            ->setRows($listeners)
-            ->render($output);
-    }
-
-    /**
-     * @return TableHelper
-     */
-    private function setupTableNoBorders()
-    {
         $table = $this->getHelperSet()->get('table');
         $table
             ->setHeaders(array('Class', 'Event'))
-            ->setLayout(TableHelper::LAYOUT_BORDERLESS);
-
-        return $table;
+            ->setLayout(TableHelper::LAYOUT_BORDERLESS)
+            ->setRows($listeners)
+            ->render($output);
     }
 
     /**
@@ -109,12 +98,11 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
      */
     private function getEventSubscriber(ContainerBuilder $containerBuilder, array $listeners)
     {
+        $interface = 'Symfony\Component\EventDispatcher\EventSubscriberInterface';
         foreach ($containerBuilder->findTaggedServiceIds('kernel.event_subscriber') as $id => $attributes) {
             $class = $containerBuilder->getDefinition($id)->getClass();
 
             $refClass = new \ReflectionClass($class);
-            $interface = 'Symfony\Component\EventDispatcher\EventSubscriberInterface';
-
             if (!$refClass->implementsInterface($interface)) {
                 continue;
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -21,6 +21,12 @@ class EventDispatcherDebugCommand extends ContainerAwareCommand
             ->setDescription('Displays current event-listeners and event-subscribers for an application');
     }
 
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return void
+     * @throws \InvalidArgumentException if the event does not exists
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $containerBuilder = $this->getContainerBuilder();

--- a/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/EventDispatcherDebugCommand.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Helper\TableHelper;
@@ -11,6 +20,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\Config\FileLocator;
 
+/**
+ * A console command for retrieving information about services
+ *
+ * @author Florian Semm <floriansemm@googlemail.com>
+ */
 class EventDispatcherDebugCommand extends ContainerAwareCommand
 {
     protected function configure()


### PR DESCRIPTION
| Q | A |
| --: | :-: |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixedtickets |  |
| License | MIT |

New console-command for the event-dispatcher. The command prints a table like the `container:debug` command with all registered events and their event-listeners. 
The list is sorted by events.
There is an additional argument `event`. If this parameter is set, the command prints the listener for the event.
