### PR TITLE
[FrameworkBundle] do not re-register commands each time a Console\Application is run

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -27,6 +27,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 class Application extends BaseApplication
 {
     private $kernel;
+    private $commandsRegistered = false;
 
     /**
      * Constructor.
@@ -65,7 +66,9 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        $this->registerCommands();
+        if(!$this->commandsRegistered){
+            $this->registerCommands();
+        }
 
         $this->setDispatcher($this->kernel->getContainer()->get('event_dispatcher'));
 
@@ -89,5 +92,7 @@ class Application extends BaseApplication
                 $bundle->registerCommands($this);
             }
         }
+
+        $this->commandsRegistered = true;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Console/Application.php
@@ -66,7 +66,7 @@ class Application extends BaseApplication
      */
     public function doRun(InputInterface $input, OutputInterface $output)
     {
-        if(!$this->commandsRegistered){
+        if (!$this->commandsRegistered) {
             $this->registerCommands();
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I have been experimenting with using the Symfony console application inside of a React event loop which works quite well.

In this scenario, I re-use an instances of a Console\Application to run multiple tasks. This works well apart from unnecessarily reloading the command classes from all included bundles each time doRun() is called (https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Console/Application.php#L68). This can also lead to running out of file descriptors under heavy load as bootstrap.php.cache uses a RecursiveDirectoryIterator to load the command.
