### PR TITLE
[Finder] Fix SplFileInfo::getContents isn't working with ssh2 protocol

### DIFF
--- a/src/Symfony/Component/Finder/SplFileInfo.php
+++ b/src/Symfony/Component/Finder/SplFileInfo.php
@@ -65,7 +65,7 @@ class SplFileInfo extends \SplFileInfo
     public function getContents()
     {
         $level = error_reporting(0);
-        $content = file_get_contents($this->getRealpath());
+        $content = file_get_contents($this->getPathname());
         error_reporting($level);
         if (false === $content) {
             $error = error_get_last();


### PR DESCRIPTION
| Q | A |
| --: | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8219 |
| License | MIT |
