### PR TITLE
[Form][BUG]Button missing getErrorsAsString() fixes #8084

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -747,7 +747,7 @@ class Form implements \IteratorAggregate, FormInterface
 
         foreach ($this->children as $key => $child) {
             $errors .= str_repeat(' ', $level).$key.":\n";
-            if ($err = $child->getErrorsAsString($level + 4)) {
+            if ($child instanceof self && $err = $child->getErrorsAsString($level + 4)) {
                 $errors .= $err;
             } else {
                 $errors .= str_repeat(' ', $level + 4)."No errors\n";

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/FormTypeTest.php
@@ -571,6 +571,20 @@ class FormTypeTest extends BaseTypeTest
         $this->assertSame('0', $view->vars['label']);
     }
 
+    public function testCanGetErrorsWhenButtonInForm()
+    {
+        $builder = $this->factory->createBuilder('form', null, array(
+            'data_class' => 'Symfony\Component\Form\Tests\Fixtures\Author',
+            'required' => false,
+        ));
+        $builder->add('foo', 'text');
+        $builder->add('submit', 'submit');
+        $form = $builder->getForm();
+
+        //This method should not throw a Fatal Error Exception.
+        $form->getErrorsAsString();
+    }
+
     protected function getTestedType()
     {
         return 'form';


### PR DESCRIPTION
Debug: Not calling undefined method anymore.
If the form contained a submit button the call would fail and the debug of the form wasn't possible.
Now it will work in all cases.
This fixes #8084 

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8084 |
| License | MIT |
