### PR TITLE
Container check alias in has method

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -88,6 +88,7 @@ class Container implements IntrospectableContainerInterface
         $this->parameterBag = null === $parameterBag ? new ParameterBag() : $parameterBag;
 
         $this->services       = array();
+        $this->aliases        = array();
         $this->scopes         = array();
         $this->scopeChildren  = array();
         $this->scopedServices = array();
@@ -228,7 +229,10 @@ class Container implements IntrospectableContainerInterface
     {
         $id = strtolower($id);
 
-        return array_key_exists($id, $this->services) || method_exists($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service');
+        return array_key_exists($id, $this->services)
+            || array_key_exists($id, $this->aliases)
+            || method_exists($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service')
+        ;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -477,6 +477,14 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         return $reflection->getValue($obj);
     }
+
+    public function testAlias()
+    {
+        $c = new ProjectServiceContainer();
+
+        $this->assertTrue($c->has('alias'));
+        $this->assertSame($c->get('alias'), $c->get('bar'));
+    }
 }
 
 class ProjectServiceContainer extends Container
@@ -490,6 +498,7 @@ class ProjectServiceContainer extends Container
         $this->__bar = new \stdClass();
         $this->__foo_bar = new \stdClass();
         $this->__foo_baz = new \stdClass();
+        $this->aliases = array('alias' => 'bar');
     }
 
     protected function getScopedService()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | [![Build Status](https://travis-ci.org/lsmith77/symfony.png?branch=container_check_alias_in_has_method)](https://travis-ci.org/lsmith77/symfony) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This bug might also be in 2.2 but we encountered it in 2.3 and the relevant code was changed slightly from 2.2 to 2.3. We noticed this issue here:
https://github.com/symfony-cmf/RoutingBundle/issues/109

The issue is caused by the `$container->has->('router')` check in the Router related commands:
https://github.com/symfony/FrameworkBundle/blob/master/Command/RouterDebugCommand.php#L32

As with the CMF we use a chain router service that is aliased to `router`, the commands do not get registered.

One could classify this as a BC break, but imho its a bug fix.
