### PR TITLE
fix-progressbar-start

### DIFF
--- a/src/Symfony/Component/Console/Helper/ProgressHelper.php
+++ b/src/Symfony/Component/Console/Helper/ProgressHelper.php
@@ -186,6 +186,8 @@ class ProgressHelper extends Helper
         $this->current   = 0;
         $this->max       = (int) $max;
         $this->output    = $output;
+        $this->lastMessagesLength = 0;
+        $this->barCharOriginal = '';
 
         if (null === $this->format) {
             switch ($output->getVerbosity()) {


### PR DESCRIPTION
lastMessagesLength and barCharOriginal should be reset if you want to use 2 or more Progress Bars in the same command flow
