### PR TITLE
Explicitly disallowing serialization of objects as controller attributes...

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -47,7 +47,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $reference = null;
         if ($uri instanceof ControllerReference) {
             $reference = $uri;
-            $uri = $this->generateFragmentUri($uri, $request);
+            $uri = $this->generateFragmentUri($uri, $request, false);
         }
 
         $subRequest = $this->createSubRequest($uri, $request);

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -39,21 +39,33 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
     /**
      * Generates a fragment URI for a given controller.
      *
-     * @param ControllerReference  $reference A ControllerReference instance
-     * @param Request              $request    A Request instance
+     * @param ControllerReference  $reference         A ControllerReference instance
+     * @param Request              $request           A Request instance
+     * @param bool                 $includeAttributes whether to include reference attributes into the URI
      *
      * @return string A fragment URI
      */
-    protected function generateFragmentUri(ControllerReference $reference, Request $request)
+    protected function generateFragmentUri(ControllerReference $reference, Request $request, $includeAttributes = true)
     {
+        // work with copies of query and attributes data
+        $renderedAttributes = array('_controller' => $reference->controller);
+
         if (!isset($reference->attributes['_format'])) {
-            $reference->attributes['_format'] = $request->getRequestFormat();
+            $renderedAttributes['_format'] = $request->getRequestFormat();
         }
 
-        $reference->attributes['_controller'] = $reference->controller;
+        if ($includeAttributes) {
+            $renderedAttributes = array_merge($renderedAttributes, $reference->attributes);
+        }
 
-        $reference->query['_path'] = http_build_query($reference->attributes, '', '&');
+        $renderedQuery = array_merge($reference->query, array('_path' => http_build_query($renderedAttributes, '', '&')));
 
-        return $request->getUriForPath($this->fragmentPath.'?'.http_build_query($reference->query, '', '&'));
+        // make sure that logic entities do not end up haphazardly serialized
+        parse_str($renderedQuery['_path'], $serializedAttributes);
+        if ($serializedAttributes != $renderedAttributes) {
+            throw new \LogicException('controller attributes with objects are not supported');
+        }
+
+        return $request->getUriForPath($this->fragmentPath.'?'.http_build_query($renderedQuery, '', '&'));
     }
 }


### PR DESCRIPTION
... in non-inline fragment renderer strategies.

Right now, the fragment renderer accepts a controller reference with a set of attributes/parameters. When rendering inline, any attributes that are objects get passed directly to the subrequest. When rendering as a URL (e.g. for ESI or HInclude), those objects are serialized by the http_build_query function. This change makes URL rendering steps explicitly reject any object values instead of letting http_build_query serialize them.

Why? Consider the case where we are passing a DB entity as controller param to be rendered using the ESI or HInclude strategy. Either way, the developer has to pass an ID instead of DB entity itself for this to work - http_build_query lacks intelligence to automatically convert the DB entity into just its ID value.

This change does not add the intelligence to convert entities into IDs, but still explicitly reminds the developer to not pass the object directly when non-inline strategies are used, thus reducing silent bug-causing behaviour.
