### PR TITLE
[WIP] Explicitly disallowing serialization of objects as controller attributes...

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -47,7 +47,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $reference = null;
         if ($uri instanceof ControllerReference) {
             $reference = $uri;
-            $uri = $this->generateFragmentUri($uri, $request);
+            $uri = $this->generateFragmentUri($uri, $request, false);
         }
 
         $subRequest = $this->createSubRequest($uri, $request);
@@ -55,6 +55,8 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         // override Request attributes as they can be objects (which are not supported by the generated URI)
         if (null !== $reference) {
             $subRequest->attributes->add($reference->attributes);
+            $subRequest->attributes->set('_format', isset($reference->attributes['_format']) ? $reference->attributes['_format'] : $request->getRequestFormat());
+            $subRequest->attributes->set('_controller', $reference->controller);
         }
 
         $level = ob_get_level();

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -60,7 +60,9 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
         $renderedQuery = array_merge($reference->query, array('_path' => http_build_query($renderedAttributes, '', '&')));
 
         // make sure that logic entities do not end up haphazardly serialized
+        // using non-strict comparison to allow stringified integers to still match
         parse_str($renderedQuery['_path'], $serializedAttributes);
+
         if ($serializedAttributes != $renderedAttributes) {
             throw new \LogicException('controller attributes with objects are not supported');
         }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
@@ -45,6 +45,15 @@ class RoutableFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('http://localhost/_fragment?_path=_format%3Djson%26_controller%3Dcontroller', $this->getRenderer()->doGenerateFragmentUri($controller, $request));
     }
 
+    public function testFailGenerateFragmentUriWithObject()
+    {
+        $object     = new \SplObjectStorage(); // using any non-anonymous instance
+        $controller = new ControllerReference('controller', array('foo' => $object), array());
+
+        $this->setExpectedException('LogicException');
+        $this->getRenderer()->doGenerateFragmentUri($controller, Request::create('/'));
+    }
+
     private function getRenderer()
     {
         return new Renderer();


### PR DESCRIPTION
... in non-inline fragment renderers

| Q | A |
| --- | --- |
| Bug fix? | possibly |
| New feature? | no |
| BC breaks? | possibly |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7124 |
| License | MIT |
| Doc PR | none |

Right now, the fragment renderer accepts a controller reference with a set of attributes/parameters. When rendering inline, any attributes that are objects get passed directly to the subrequest. When rendering as a URL (e.g. for ESI or HInclude), those objects are serialized by the http_build_query function. This change makes URL rendering steps explicitly reject any object values instead of letting http_build_query serialize them.

Why? Consider the case where we are passing a DB entity as controller param to be rendered using the ESI or HInclude strategy. Either way, the developer has to pass an ID instead of DB entity itself for this to work - http_build_query lacks intelligence to automatically convert the DB entity into just its ID value.

This change does not add the intelligence to convert entities into IDs, but still explicitly reminds the developer to not pass the object directly when non-inline strategies are used, thus reducing silent bug-causing behaviour.

NOTE: this needs discussion regarding BC breaks. In theory, nothing should break. In practice, others' code may have relied on quirks of serializing/unserializing params via http_build_query. Non-inline fragment renders should be least susceptible to breakage; inline fragment renders are more susceptible - e.g. integer params used to be forced into strings through the query encoding step, and some comparisons may start breaking because of that.
