### PR TITLE
[Security] fixed usage of the salt for the bcrypt encoder (refs #8210)

### DIFF
--- a/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
+++ b/src/Symfony/Component/Security/Core/Encoder/BCryptPasswordEncoder.php
@@ -53,14 +53,24 @@ class BCryptPasswordEncoder extends BasePasswordEncoder
      * the "$2y$" salt prefix (which is not available in the early PHP versions).
      * @see https://github.com/ircmaxell/password_compat/issues/10#issuecomment-11203833
      *
+     * It is almost best to **not** pass a salt and let PHP generate one for you.
+     *
      * @param string $raw  The password to encode
      * @param string $salt The salt
      *
      * @return string The encoded password
+     *
+     * @link http://lxr.php.net/xref/PHP_5_5/ext/standard/password.c#111
      */
     public function encodePassword($raw, $salt)
     {
-        return password_hash($raw, PASSWORD_BCRYPT, array('cost' => $this->cost));
+        $options = array('cost' => $this->cost);
+
+        if ($salt) {
+            $options['salt'] = $salt;
+        }
+
+        return password_hash($raw, PASSWORD_BCRYPT, $options);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8210 |
| License | MIT |
| Doc PR | n/a |

see #8210
