### PR TITLE
[FORM]Add custom Type, TypeExtension and TypeGessers in FormIntegrationTestCase

### DIFF
--- a/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
+++ b/src/Symfony/Component/Form/Test/FormIntegrationTestCase.php
@@ -31,10 +31,28 @@ abstract class FormIntegrationTestCase extends \PHPUnit_Framework_TestCase
 
         $this->factory = Forms::createFormFactoryBuilder()
             ->addExtensions($this->getExtensions())
+            ->addTypes($this->getTypes())
+            ->addTypeExtensions($this->getTypeExtensions())
+            ->addTypeGuessers($this->getTypeGuessers())
             ->getFormFactory();
     }
 
     protected function getExtensions()
+    {
+        return array();
+    }
+    
+    protected function getTypes()
+    {
+        return array();
+    }
+
+    protected function getTypeExtensions()
+    {
+        return array();
+    }
+
+    protected function getTypeGuessers()
     {
         return array();
     }


### PR DESCRIPTION
since 2.3 it's no longer possible to add Type to the Factory when using Symfony\Component\Form\Test\TypeTestCase as base class for tests. I porpose to add Types, TypeExtension and TypeGuessers during use of FormFactoryBuilder like it's already possible with Extensions.
I don't see another way to add custom Type (in my use case).
