### PR TITLE
[2.3][CssSelector] Added test to highlight a regression

### DIFF
--- a/src/Symfony/Component/CssSelector/Tests/CssSelectorTest.php
+++ b/src/Symfony/Component/CssSelector/Tests/CssSelectorTest.php
@@ -19,6 +19,7 @@ class CssSelectorTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals('descendant-or-self::*', CssSelector::toXPath(''));
         $this->assertEquals('descendant-or-self::h1', CssSelector::toXPath('h1'));
+        $this->assertEquals('descendant-or-self::Project', CssSelector::toXPath('Project'));
         $this->assertEquals("descendant-or-self::h1[@id = 'foo']", CssSelector::toXPath('h1#foo'));
         $this->assertEquals("descendant-or-self::h1[@class and contains(concat(' ', normalize-space(@class), ' '), ' foo ')]", CssSelector::toXPath('h1.foo'));
         $this->assertEquals('descendant-or-self::foo:h1', CssSelector::toXPath('foo|h1'));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (that's the point) |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Hello.

I tried to use latest Symfony2 version in fapot/sismo, and sismo tests fail because of a regression in CssSelector Component.

You can easily reproduce it by cloning sismo, run a `composer update`, then `phpunit`.

I tried to debug it, but DomDocument and XPath don't like me.

ping @jfsimon
