### PR TITLE
[CssSelector] added a node about HTML extension in readme

### DIFF
--- a/src/Symfony/Component/CssSelector/README.md
+++ b/src/Symfony/Component/CssSelector/README.md
@@ -10,6 +10,28 @@ equivalents:
 
     print CssSelector::toXPath('div.item > h4 > a');
 
+HTML and XML are different
+--------------------------
+
+- The `CssSelector` component comes with an `HTML` extension which is enabled by default.
+- If you need to use this component with `XML` documents, you have to disable `HTML` extension.
+- `HTML` tag & attribute names are always lower-cased, with `XML` they are case-sensistive.
+
+Disable & enable `HTML` extension:
+
+    // disable `HTML` extension:
+    CssSelector::disableHtmlExtension();
+    // re-enable `HTML` extension:
+    CssSelector::enableHtmlExtension();
+
+What brings `HTML` extension?
+- Tag names are lower-cased
+- Attribute names are lower-cased
+- Adds following pseudo-classes:
+    - `checked`, `link`, `disabled`, `enabled`, `selected`: used with form tags
+    - `invalid`, `hover`, `visited`: always select nothing
+- Adds `lang()` function
+
 Resources
 ---------
 


### PR DESCRIPTION
It's a common mistake to use `CssSelector` with XML without knowing that `HTML` extension must be disbaled first (see #8286). This PR adds a note about that in the component's readme file.
