### PR TITLE
[Process] Added support for stdout and stderr flush (Issue #7884)

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -546,33 +546,6 @@ class Process
     }
 
     /**
-     * Returns the current output of the process and clears it
-     *
-     * @return string The process output
-     */
-    public function getAndFlushOutput()
-    {
-        $data = $this->getOutput();
-        $this->flushOutput();
-
-        return $data;
-    }
-
-    /**
-     * Returns the current output of the process and clears it
-     *
-     * @return string The process output since the last call.
-     */
-    public function getAndFlushIncrementalOutput()
-    {
-        $data = $this->getIncrementalOutput();
-        $this->flushOutput();
-
-        return $data;
-    }
-
-
-    /**
      * Returns the current error output of the process (STDERR).
      *
      * @return string The process error output
@@ -616,32 +589,6 @@ class Process
         $this->incrementalErrorOutputOffset = 0;
 
         return $this;
-    }
-
-    /**
-     * Returns the current output of the process and clears it
-     *
-     * @return string The process output
-     */
-    public function getAndFlushErrorOutput()
-    {
-        $data = $this->getErrorOutput();
-        $this->flushErrorOutput();
-
-        return $data;
-    }
-
-    /**
-     * Returns the current output of the process and clears it
-     *
-     * @return string The process output since the last call.
-     */
-    public function getAndFlushIncrementalErrorOutput()
-    {
-        $data = $this->getIncrementalErrorOutput();
-        $this->flushErrorOutput();
-
-        return $data;
     }
 
     /**

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -533,6 +533,46 @@ class Process
     }
 
     /**
+     * Clears the process output.
+     *
+     * @return Process
+     */
+    public function flushOutput()
+    {
+        $this->stdout = '';
+        $this->incrementalOutputOffset = 0;
+
+        return $this;
+    }
+
+    /**
+     * Returns the current output of the process and clears it
+     *
+     * @return string The process output
+     */
+    public function getAndFlushOutput()
+    {
+        $data = $this->getOutput();
+        $this->flushOutput();
+
+        return $data;
+    }
+
+    /**
+     * Returns the current output of the process and clears it
+     *
+     * @return string The process output since the last call.
+     */
+    public function getAndFlushIncrementalOutput()
+    {
+        $data = $this->getIncrementalOutput();
+        $this->flushOutput();
+
+        return $data;
+    }
+
+
+    /**
      * Returns the current error output of the process (STDERR).
      *
      * @return string The process error output
@@ -563,6 +603,45 @@ class Process
         $this->incrementalErrorOutputOffset = strlen($data);
 
         return $latest;
+    }
+
+    /**
+     * Clears the process output.
+     *
+     * @return Process
+     */
+    public function flushErrorOutput()
+    {
+        $this->stderr = '';
+        $this->incrementalErrorOutputOffset = 0;
+
+        return $this;
+    }
+
+    /**
+     * Returns the current output of the process and clears it
+     *
+     * @return string The process output
+     */
+    public function getAndFlushErrorOutput()
+    {
+        $data = $this->getErrorOutput();
+        $this->flushErrorOutput();
+
+        return $data;
+    }
+
+    /**
+     * Returns the current output of the process and clears it
+     *
+     * @return string The process output since the last call.
+     */
+    public function getAndFlushIncrementalErrorOutput()
+    {
+        $data = $this->getIncrementalErrorOutput();
+        $this->flushErrorOutput();
+
+        return $data;
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -162,29 +162,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $p->run();
         $p->flushErrorOutput();
-        $this->assertEquals('', $p->getErrorOutput());
-    }
-
-    public function testGetAndFlushErrorOutput()
-    {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }')));
-
-        $p->run();
-        $this->assertEquals(3, preg_match_all('/ERROR/', $p->getAndFlushErrorOutput(), $matches));
-        $this->assertEquals('', $p->getErrorOutput());
-    }
-
-    public function testGetAndFlushIncrementalErrorOutput()
-    {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { usleep(50000); file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }')));
-
-        $p->start();
-        while ($p->isRunning()) {
-            $this->assertLessThanOrEqual(1, preg_match_all('/ERROR/', $p->getandFlushIncrementalErrorOutput(), $matches));
-            usleep(20000);
-        }
-        $this->assertLessThanOrEqual(1, preg_match_all('/ERROR/', $p->getandFlushIncrementalErrorOutput(), $matches));
-        $this->assertEquals('', $p->getErrorOutput());
+        $this->assertEmpty($p->getErrorOutput());
     }
 
     public function testGetOutput()
@@ -212,29 +190,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $p->run();
         $p->flushOutput();
-        $this->assertEquals('', $p->getOutput());
-    }
-
-    public function testGetAndFlushOutput()
-    {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('$n=0;while ($n<3) {echo \' foo \';$n++;}')));
-
-        $p->run();
-        $this->assertEquals(3, preg_match_all('/foo/', $p->getAndFlushOutput(), $matches));
-        $this->assertEquals('', $p->getOutput());
-    }
-
-    public function testGetAndFlushIncrementalOutput()
-    {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('$n=0;while ($n<3) { echo \' foo \'; usleep(50000); $n++; }')));
-
-        $p->start();
-        while ($p->isRunning()) {
-            $this->assertLessThanOrEqual(1, preg_match_all('/foo/', $p->getAndFlushIncrementalOutput(), $matches));
-            usleep(20000);
-        }
-        $this->assertLessThanOrEqual(1, preg_match_all('/foo/', $p->getAndFlushIncrementalOutput(), $matches));
-        $this->assertEquals('', $p->getOutput());
+        $this->assertEmpty($p->getOutput());
     }
 
     public function testExitCodeCommandFailed()

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -181,9 +181,10 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $p->start();
         while ($p->isRunning()) {
             $this->assertLessThanOrEqual(1, preg_match_all('/ERROR/', $p->getandFlushIncrementalErrorOutput(), $matches));
-            $this->assertEquals('', $p->getErrorOutput());
             usleep(20000);
         }
+        $this->assertLessThanOrEqual(1, preg_match_all('/ERROR/', $p->getandFlushIncrementalErrorOutput(), $matches));
+        $this->assertEquals('', $p->getErrorOutput());
     }
 
     public function testGetOutput()
@@ -230,9 +231,10 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $p->start();
         while ($p->isRunning()) {
             $this->assertLessThanOrEqual(1, preg_match_all('/foo/', $p->getAndFlushIncrementalOutput(), $matches));
-            $this->assertEquals('', $p->getOutput());
             usleep(20000);
         }
+        $this->assertLessThanOrEqual(1, preg_match_all('/foo/', $p->getAndFlushIncrementalOutput(), $matches));
+        $this->assertEquals('', $p->getOutput());
     }
 
     public function testExitCodeCommandFailed()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7884 |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/2728 |

**To-do**
- [x] Submit changes to the documentation.
- [x] Fix a test broken on travis.
- [x] Fix mistakes on the documentation.
- [x] Removed flush + get methods.
- [x] Changed tests assert calls.

This PR introduces flushing methods for both stdout and stderr on Process class. The new methods are:
- flushOutput(): clears the output buffer.
- flushErrorOutput(): clears the error output buffer.

Tests for new methods are included on the PR.
