### PR TITLE
[Form] Add allow_html5 option to date and time FormType to disable HTML5 input type

### DIFF
--- a/src/Symfony/Component/Form/CHANGELOG.md
+++ b/src/Symfony/Component/Form/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+2.6.0
+-----
+* added allow_html5 option to Date, Time and DateTimeFormType to disable HTML5 input date when widget option is single_text
+
 2.5.0
 ------
 

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateTimeType.php
@@ -117,6 +117,7 @@ class DateTimeType extends AbstractType
                 'empty_value',
                 'required',
                 'translation_domain',
+                'allow_html5',
             )));
 
             $timeOptions = array_intersect_key($options, array_flip(array(
@@ -128,6 +129,7 @@ class DateTimeType extends AbstractType
                 'empty_value',
                 'required',
                 'translation_domain',
+                'allow_html5',
             )));
 
             if (null !== $options['date_widget']) {
@@ -180,10 +182,11 @@ class DateTimeType extends AbstractType
     {
         $view->vars['widget'] = $options['widget'];
 
-        // Change the input to a HTML5 date input if
+        // Change the input to a HTML5 datetime input if
         //  * the widget is set to "single_text"
         //  * the format matches the one expected by HTML5
-        if ('single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
+        //  * the allow_html5 is set to true
+        if ($options['allow_html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
             $view->vars['type'] = 'datetime';
         }
     }
@@ -218,6 +221,7 @@ class DateTimeType extends AbstractType
             'time_widget'    => $timeWidget,
             'with_minutes'   => true,
             'with_seconds'   => false,
+            'allow_html5'    => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,

--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -130,7 +130,8 @@ class DateType extends AbstractType
         // Change the input to a HTML5 date input if
         //  * the widget is set to "single_text"
         //  * the format matches the one expected by HTML5
-        if ('single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
+        //  * the allow_html5 is set to true
+        if ($options['allow_html5'] && 'single_text' === $options['widget'] && self::HTML5_FORMAT === $options['format']) {
             $view->vars['type'] = 'date';
         }
 
@@ -199,6 +200,7 @@ class DateType extends AbstractType
             'model_timezone' => null,
             'view_timezone'  => null,
             'empty_value'    => $emptyValue,
+            'allow_html5'   => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,

--- a/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/TimeType.php
@@ -138,7 +138,10 @@ class TimeType extends AbstractType
             'with_seconds' => $options['with_seconds'],
         ));
 
-        if ('single_text' === $options['widget']) {
+        // Change the input to a HTML5 time input if
+        //  * the widget is set to "single_text"
+        //  * the allow_html5 is set to true
+        if ($options['allow_html5'] && 'single_text' === $options['widget']) {
             $view->vars['type'] = 'time';
 
             // we need to force the browser to display the seconds by
@@ -192,6 +195,7 @@ class TimeType extends AbstractType
             'model_timezone' => null,
             'view_timezone'  => null,
             'empty_value'    => $emptyValue,
+            'allow_html5'   => true,
             // Don't modify \DateTime classes by reference, we treat
             // them like immutable value objects
             'by_reference'   => false,

--- a/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/DataTransformer/DateTimeToRfc3339TransformerTest.php
@@ -32,7 +32,7 @@ class DateTimeToRfc3339TransformerTest extends DateTimeTestCase
         $this->dateTimeWithoutSeconds = null;
     }
 
-    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = FALSE, $ignoreCase = FALSE)
+    public static function assertEquals($expected, $actual, $message = '', $delta = 0, $maxDepth = 10, $canonicalize = false, $ignoreCase = false)
     {
         if ($expected instanceof \DateTime && $actual instanceof \DateTime) {
             $expected = $expected->format('c');

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTimeTypeTest.php
@@ -405,6 +405,17 @@ class DateTimeTypeTest extends TypeTestCase
         $this->assertSame('datetime', $view->vars['type']);
     }
 
+    public function testDontPassHtml5TypeIfHtml5NotAllowed()
+    {
+        $form = $this->factory->create('datetime', null, array(
+            'widget' => 'single_text',
+            'allow_html5' => false,
+        ));
+
+        $view = $form->createView();
+        $this->assertFalse(isset($view->vars['type']));
+    }
+
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
         $form = $this->factory->create('datetime', null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/DateTypeTest.php
@@ -705,6 +705,17 @@ class DateTypeTest extends TypeTestCase
         $this->assertSame('date', $view->vars['type']);
     }
 
+    public function testDontPassHtml5TypeIfHtml5NotAllowed()
+    {
+        $form = $this->factory->create('date', null, array(
+            'widget' => 'single_text',
+            'allow_html5' => false,
+        ));
+
+        $view = $form->createView();
+        $this->assertFalse(isset($view->vars['type']));
+    }
+
     public function testDontPassHtml5TypeIfNotHtml5Format()
     {
         $form = $this->factory->create('date', null, array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/TimeTypeTest.php
@@ -519,6 +519,17 @@ class TimeTypeTest extends TypeTestCase
         $this->assertEquals(30, $view->vars['attr']['step']);
     }
 
+    public function testDontPassHtml5TypeIfHtml5NotAllowed()
+    {
+        $form = $this->factory->create('time', null, array(
+            'widget' => 'single_text',
+            'allow_html5' => false,
+        ));
+
+        $view = $form->createView();
+        $this->assertFalse(isset($view->vars['type']));
+    }
+
     public function testPassDefaultEmptyValueToViewIfNotRequired()
     {
         $form = $this->factory->create('time', null, array(


### PR DESCRIPTION
[Form] added allow_html5 option to date and time FormType to disable HTML5 input type when widget is set to single_text

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6927 #7123 |
| License | MIT |
| Doc PR |  |

With this little patch we can have a single text widget without HTML5 date input type which is required when using some javascript date or time picker .
