### PR TITLE
[DependencyInjection] Replaced try/catch block with an @expectedException annotation

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/IniFileLoaderTest.php
@@ -50,31 +50,25 @@ class IniFileLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::__construct
      * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::load
+     *
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The file "foo.ini" does not exist (in:
      */
     public function testExceptionIsRaisedWhenIniFileDoesNotExist()
     {
-        try {
-            $this->loader->load('foo.ini');
-            $this->fail('->load() throws an InvalidArgumentException if the loaded file does not exist');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('\InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if the loaded file does not exist');
-            $this->assertStringStartsWith('The file "foo.ini" does not exist (in: ', $e->getMessage(), '->load() throws an InvalidArgumentException if the loaded file does not exist');
-        }
+        $this->loader->load('foo.ini');
     }
 
     /**
      * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::__construct
      * @covers Symfony\Component\DependencyInjection\Loader\IniFileLoader::load
+     *
+     * @expectedException        \InvalidArgumentException
+     * @expectedExceptionMessage The "nonvalid.ini" file is not valid.
      */
     public function testExceptionIsRaisedWhenIniFileCannotBeParsed()
     {
-        try {
-            @$this->loader->load('nonvalid.ini');
-            $this->fail('->load() throws an InvalidArgumentException if the loaded file is not parseable');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('\InvalidArgumentException', $e, '->load() throws an InvalidArgumentException if the loaded file is not parseable');
-            $this->assertEquals('The "nonvalid.ini" file is not valid.', $e->getMessage(), '->load() throws an InvalidArgumentException if the loaded file is not parseable');
-        }
+        @$this->loader->load('nonvalid.ini');
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

This fix doesn't seem like changing anything but thanks to it, PHP 5.3.3 stops segfaulting. 

Tests started failing after merging #8285. However, it's not the change which made them failing (the change is totally unrelated to the segfaulting test case). I suspect it has something to do with memory management in the early PHP 5.3 versions. We've had this kind of failures in the past.
