### PR TITLE
[Validator] added before and after options to Date constraints

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Date.php
+++ b/src/Symfony/Component/Validator/Constraints/Date.php
@@ -23,4 +23,6 @@ use Symfony\Component\Validator\Constraint;
 class Date extends Constraint
 {
     public $message = 'This value is not a valid date.';
+    public $after;
+    public $before;
 }

--- a/src/Symfony/Component/Validator/Constraints/DateTime.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTime.php
@@ -23,4 +23,6 @@ use Symfony\Component\Validator\Constraint;
 class DateTime extends Constraint
 {
     public $message = 'This value is not a valid datetime.';
+    public $after;
+    public $before;
 }

--- a/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/DateTimeValidator.php
@@ -18,5 +18,6 @@ namespace Symfony\Component\Validator\Constraints;
  */
 class DateTimeValidator extends DateValidator
 {
+    const FORMAT = 'Y-m-d H:i:s';
     const PATTERN = '/^(\d{4})-(\d{2})-(\d{2}) (0[0-9]|1[0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/';
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateTimeValidatorTest.php
@@ -117,4 +117,33 @@ class DateTimeValidatorTest extends \PHPUnit_Framework_TestCase
             array('2010-01-01 00:00:60'),
         );
     }
+
+    /**
+     * @dataProvider getBeforeAndAfter
+     */
+    public function testBeforeAndAfter($date, $before, $after, $valid)
+    {
+        $this->context->expects($valid ? $this->never() : $this->once())
+            ->method('addViolation');
+
+        $this->validator->validate($date, new DateTime(array(
+            'before' => $before,
+            'after' => $after,
+        )));
+    }
+
+    public function getBeforeAndAfter()
+    {
+        return array(
+            array('2010-01-02 15:00:33', '2010-01-02 16:30:00', '2010-01-01', true),
+            array('2008-01-02 12:00:00', '2012-02-02', '2010-01-01', false),
+            array('2010-01-02 00:00:00', '2012-02-02', null, true),
+            array('2013-01-02 01:02:03', '2012-02-02', null, false),
+            array('2010-01-02 10:10:10', null, '2012-02-02', false),
+            array('2013-01-02 15:12:00', null, '2012-02-02', true),
+            array(date('Y-m-d H:i:s', strtotime('+1 day')), null, 'now', true),
+            array(new \DateTime('-1 hour'), 'now', null, true),
+            array(new \DateTime('-5 minutes'), 'now', '-3 minutes', false),
+        );
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/DateValidatorTest.php
@@ -113,4 +113,33 @@ class DateValidatorTest extends \PHPUnit_Framework_TestCase
             array('2010-02-29'),
         );
     }
+
+    /**
+     * @dataProvider getBeforeAndAfter
+     */
+    public function testBeforeAndAfter($date, $before, $after, $valid)
+    {
+        $this->context->expects($valid ? $this->never() : $this->once())
+            ->method('addViolation');
+
+        $this->validator->validate($date, new Date(array(
+            'before' => $before,
+            'after' => $after,
+        )));
+    }
+
+    public function getBeforeAndAfter()
+    {
+        return array(
+            array('2010-01-02', '2012-02-02', '2010-01-01', true),
+            array('2008-01-02', '2012-02-02', '2010-01-01', false),
+            array('2010-01-02', '2012-02-02', null, true),
+            array('2013-01-02', '2012-02-02', null, false),
+            array('2010-01-02', null, '2012-02-02', false),
+            array('2013-01-02', null, '2012-02-02', true),
+            array(date('Y-m-d', strtotime('+1 day')), null, 'now', true),
+            array(new \DateTime('-1 day'), 'now', null, true),
+            array(new \DateTime('-5 days'), 'now', '-3 days', false),
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | [no] |
| New feature? | [yes] |
| BC breaks? | [no] |
| Deprecations? | [no] |
| Tests pass? | [yes] |
| License | MIT |
| Doc PR | [todo] |

I've added an after and before options to Date and DateTime constraints. It uses the strtotime function so it's user friendly, values like "now", "+1 week" can be used.

I think it can be very useful, some examples : 
- an appointment can't be scheduled before 10 days
- a user must be more than 16 years old (checking the birthday)
- a date must be in the future

What do you think?
