### PR TITLE
[Config] Allow to get parent of BaseNode

### DIFF
--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -281,6 +281,16 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
+     * Returns parent node for this node
+     *
+     * @return NodeInterface
+     */
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
      * Finalizes a value, applying all finalization closures.
      *
      * @param mixed $value The value to finalize

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -283,7 +283,7 @@ abstract class BaseNode implements NodeInterface
     /**
      * Returns parent node for this node
      *
-     * @return NodeInterface
+     * @return NodeInterface|null
      */
     public function getParent()
     {

--- a/src/Symfony/Component/Config/Definition/BaseNode.php
+++ b/src/Symfony/Component/Config/Definition/BaseNode.php
@@ -281,7 +281,7 @@ abstract class BaseNode implements NodeInterface
     }
 
     /**
-     * Returns parent node for this node
+     * Returns parent node for this node.
      *
      * @return NodeInterface|null
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no (improvement) |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Like an ArrayNode have method `getChildren`, I might to be good idea for having method `getParent` of all nodes.
