### PR TITLE
Sorting files while extracting translation messages from a twig templates

### DIFF
--- a/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
+++ b/src/Symfony/Bridge/Twig/Translation/TwigExtractor.php
@@ -56,7 +56,7 @@ class TwigExtractor implements ExtractorInterface
     {
         // load any existing translation files
         $finder = new Finder();
-        $files = $finder->files()->name('*.twig')->in($directory);
+        $files = $finder->files()->name('*.twig')->sortByName()->in($directory);
         foreach ($files as $file) {
             $this->extractTemplate(file_get_contents($file->getPathname()), $catalogue);
         }


### PR DESCRIPTION
Hello
When we generate a translations via command:

``` php
app\console translation:update
```

is nice if order of found items don't change over the time (inside the file).
So we need to sort the *.twig files to prevent changes in output lang files.

This very simple fix do this.

Please consider this in your code :)

Thanks
