### PR TITLE
Added MutableAclProvider::deleteSecurityIdentity

### DIFF
--- a/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
+++ b/src/Symfony/Component/Security/Acl/Dbal/MutableAclProvider.php
@@ -109,6 +109,18 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     }
 
     /**
+     * Deletes the security identity from the database.
+     * ACL entries have the CASCADE option on their foreign key so they will also get deleted
+     *
+     * @param SecurityIdentityInterface $sid
+     * @throws \InvalidArgumentException
+     */
+    public function deleteSecurityIdentity(SecurityIdentityInterface $sid)
+    {
+        $this->connection->executeQuery($this->getDeleteSecurityIdentityIdSql($sid));
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function findAcls(array $oids, array $sids = array())
@@ -593,6 +605,21 @@ QUERY;
             $this->connection->quote($identifier),
             $this->connection->getDatabasePlatform()->convertBooleans($username)
         );
+    }
+
+    /**
+     * Constructs the SQL to delete a security identity.
+     *
+     * @param SecurityIdentityInterface $sid
+     * @throws \InvalidArgumentException
+     * @return string
+     */
+    protected function getDeleteSecurityIdentityIdSql(SecurityIdentityInterface $sid)
+    {
+        $select = $this->getSelectSecurityIdentityIdSql($sid);
+        $delete = preg_replace('/^SELECT id FROM/', 'DELETE FROM', $select);
+
+        return $delete;
     }
 
     /**


### PR DESCRIPTION
This provides a very simple function to enable the deletion of a SecurityIdentity.

Developers can add a listener on the delete of a user and remove all the related ACLs.
Foreign keys already ensure that the ACEs are properly deleted.

Among the problems of not deleting the SecurityIdentity:
- Inconsistent database, referring to a non-existent user.
- If a user is deleted and another is created with the same name, it will inherit all the old user’s ACEs

Not addressed by this PR: Changing a user’s username breaks the related ACLs. See #5787

See also: https://groups.google.com/forum/#!topic/symfony2/mGTXlTWiMs8/discussion
