### PR TITLE
[FrameworkBundle] Fixed variable name used in translation cache

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Translation/TranslatorTest.php
@@ -45,13 +45,15 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
     {
         $translator = $this->getTranslator($this->getLoader());
         $translator->setLocale('fr');
-        $translator->setFallbackLocales(array('en', 'es'));
+        $translator->setFallbackLocales(array('en', 'es', 'pt-PT', 'pt_BR'));
 
         $this->assertEquals('foo (FR)', $translator->trans('foo'));
         $this->assertEquals('bar (EN)', $translator->trans('bar'));
         $this->assertEquals('foobar (ES)', $translator->trans('foobar'));
         $this->assertEquals('choice 0 (EN)', $translator->transChoice('choice', 0));
         $this->assertEquals('no translation', $translator->trans('no translation'));
+        $this->assertEquals('foobarfoo (PT-PT)', $translator->trans('foobarfoo'));
+        $this->assertEquals('other choice 1 (PT-BR)', $translator->transChoice('other choice', 1));
     }
 
     public function testTransWithCaching()
@@ -59,25 +61,29 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         // prime the cache
         $translator = $this->getTranslator($this->getLoader(), array('cache_dir' => $this->tmpDir));
         $translator->setLocale('fr');
-        $translator->setFallbackLocales(array('en', 'es'));
+        $translator->setFallbackLocales(array('en', 'es', 'pt-PT', 'pt_BR'));
 
         $this->assertEquals('foo (FR)', $translator->trans('foo'));
         $this->assertEquals('bar (EN)', $translator->trans('bar'));
         $this->assertEquals('foobar (ES)', $translator->trans('foobar'));
         $this->assertEquals('choice 0 (EN)', $translator->transChoice('choice', 0));
         $this->assertEquals('no translation', $translator->trans('no translation'));
+        $this->assertEquals('foobarfoo (PT-PT)', $translator->trans('foobarfoo'));
+        $this->assertEquals('other choice 1 (PT-BR)', $translator->transChoice('other choice', 1));
 
         // do it another time as the cache is primed now
         $loader = $this->getMock('Symfony\Component\Translation\Loader\LoaderInterface');
         $translator = $this->getTranslator($loader, array('cache_dir' => $this->tmpDir));
         $translator->setLocale('fr');
-        $translator->setFallbackLocales(array('en', 'es'));
+        $translator->setFallbackLocales(array('en', 'es', 'pt-PT', 'pt_BR'));
 
         $this->assertEquals('foo (FR)', $translator->trans('foo'));
         $this->assertEquals('bar (EN)', $translator->trans('bar'));
         $this->assertEquals('foobar (ES)', $translator->trans('foobar'));
         $this->assertEquals('choice 0 (EN)', $translator->transChoice('choice', 0));
         $this->assertEquals('no translation', $translator->trans('no translation'));
+        $this->assertEquals('foobarfoo (PT-PT)', $translator->trans('foobarfoo'));
+        $this->assertEquals('other choice 1 (PT-BR)', $translator->transChoice('other choice', 1));
     }
 
     public function testGetLocale()
@@ -155,6 +161,20 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
                 'foobar' => 'foobar (ES)',
             ))))
         ;
+        $loader
+            ->expects($this->at(3))
+            ->method('load')
+            ->will($this->returnValue($this->getCatalogue('pt-PT', array(
+                'foobarfoo' => 'foobarfoo (PT-PT)',
+            ))))
+        ;
+        $loader
+            ->expects($this->at(4))
+            ->method('load')
+            ->will($this->returnValue($this->getCatalogue('pt_BR', array(
+                'other choice' => '{0} other choice 0 (PT-BR)|{1} other choice 1 (PT-BR)|]1,Inf] other choice inf (PT-BR)',
+            ))))
+        ;
 
         return $loader;
     }
@@ -183,6 +203,8 @@ class TranslatorTest extends \PHPUnit_Framework_TestCase
         $translator->addResource('loader', 'foo', 'fr');
         $translator->addResource('loader', 'foo', 'en');
         $translator->addResource('loader', 'foo', 'es');
+        $translator->addResource('loader', 'foo', 'pt-PT'); // European Portuguese
+        $translator->addResource('loader', 'foo', 'pt_BR'); // Brazilian Portuguese
 
         return $translator;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -98,6 +98,8 @@ class Translator extends BaseTranslator
             $fallbackContent = '';
             $current = '';
             foreach ($this->computeFallbackLocales($locale) as $fallback) {
+                $fallbackSuffix = $this->getCatalogueSuffix($fallback);
+
                 $fallbackContent .= sprintf(<<<EOF
 \$catalogue%s = new MessageCatalogue('%s', %s);
 \$catalogue%s->addFallbackCatalogue(\$catalogue%s);
@@ -105,11 +107,11 @@ class Translator extends BaseTranslator
 
 EOF
                     ,
-                    ucfirst($fallback),
+                    $fallbackSuffix,
                     $fallback,
                     var_export($this->catalogues[$fallback]->all(), true),
-                    ucfirst($current),
-                    ucfirst($fallback)
+                    $this->getCatalogueSuffix($current),
+                    $fallbackSuffix
                 );
                 $current = $fallback;
             }
@@ -146,5 +148,21 @@ EOF
                 $this->addLoader($alias, $this->container->get($id));
             }
         }
+    }
+
+    /**
+     * Returns a catalogue suffix from the given locale for variables used in cache.
+     *
+     * @param string $locale
+     *
+     * @return string
+     */
+    private function getCatalogueSuffix($locale)
+    {
+        $suffix = str_replace(array('-', '_'), ' ', $locale);
+        $suffix = mb_convert_case($suffix, MB_CASE_TITLE);
+        $suffix = str_replace(' ', '', $suffix);
+
+        return $suffix;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -98,7 +98,7 @@ class Translator extends BaseTranslator
             $fallbackContent = '';
             $current = '';
             foreach ($this->computeFallbackLocales($locale) as $fallback) {
-                $fallbackSuffix = $this->getCatalogueSuffix($fallback);
+                $fallbackSuffix = ucfirst(str_replace('-', '_', $fallback));
 
                 $fallbackContent .= sprintf(<<<EOF
 \$catalogue%s = new MessageCatalogue('%s', %s);
@@ -110,7 +110,7 @@ EOF
                     $fallbackSuffix,
                     $fallback,
                     var_export($this->catalogues[$fallback]->all(), true),
-                    $this->getCatalogueSuffix($current),
+                    ucfirst(str_replace('-', '_', $current)),
                     $fallbackSuffix
                 );
                 $current = $fallback;
@@ -148,21 +148,5 @@ EOF
                 $this->addLoader($alias, $this->container->get($id));
             }
         }
-    }
-
-    /**
-     * Returns a catalogue suffix from the given locale for variables used in cache.
-     *
-     * @param string $locale
-     *
-     * @return string
-     */
-    private function getCatalogueSuffix($locale)
-    {
-        $suffix = str_replace(array('-', '_'), ' ', $locale);
-        $suffix = ucwords(strtolower($suffix));
-        $suffix = str_replace(' ', '', $suffix);
-
-        return $suffix;
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php
@@ -160,7 +160,7 @@ EOF
     private function getCatalogueSuffix($locale)
     {
         $suffix = str_replace(array('-', '_'), ' ', $locale);
-        $suffix = mb_convert_case($suffix, MB_CASE_TITLE);
+        $suffix = ucwords(strtolower($suffix));
         $suffix = str_replace(' ', '', $suffix);
 
         return $suffix;


### PR DESCRIPTION
This simply fixes the `$catalogueXXX` variable name used in the translation cache files in case the user use locales such as `en-US`, the generated variable's name was `$catalogueEn-Us`, with this fix it will be `$catalogueEnUs`.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7824 |
| License | MIT |
| Doc PR | - |
