### PR TITLE
[Security] RoleSecurityIdentity checks for instances of RoleInterface to allow custom Role implementation

### DIFF
--- a/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
+++ b/src/Symfony/Component/Security/Acl/Domain/RoleSecurityIdentity.php
@@ -12,7 +12,7 @@
 namespace Symfony\Component\Security\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Model\SecurityIdentityInterface;
-use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 
 /**
  * A SecurityIdentity implementation for roles
@@ -30,7 +30,7 @@ final class RoleSecurityIdentity implements SecurityIdentityInterface
      */
     public function __construct($role)
     {
-        if ($role instanceof Role) {
+        if ($role instanceof RoleInterface) {
             $role = $role->getRole();
         }
 

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/RoleSecurityIdentityTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/RoleSecurityIdentityTest.php
@@ -51,7 +51,6 @@ class RoleSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             array(new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity(new Role('ROLE_FOO')), true),
             array(new RoleSecurityIdentity('ROLE_USER'), new RoleSecurityIdentity('ROLE_FOO'), false),
             array(new RoleSecurityIdentity('ROLE_FOO'), new UserSecurityIdentity('ROLE_FOO', 'Foo'), false),
-            array(new RoleSecurityIdentity('ROLE_FOO'), new UserSecurityIdentity('ROLE_FOO', 'Foo'), false),
             array(new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity(new MyRole('ROLE_FOO')), true),
             array(new RoleSecurityIdentity('ROLE_USER'), new RoleSecurityIdentity(new MyRole('ROLE_FOO')), false),
         );

--- a/src/Symfony/Component/Security/Tests/Acl/Domain/RoleSecurityIdentityTest.php
+++ b/src/Symfony/Component/Security/Tests/Acl/Domain/RoleSecurityIdentityTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Security\Tests\Acl\Domain;
 
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Core\Role\Role;
+use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Acl\Domain\RoleSecurityIdentity;
 
 class RoleSecurityIdentityTest extends \PHPUnit_Framework_TestCase
@@ -50,6 +51,32 @@ class RoleSecurityIdentityTest extends \PHPUnit_Framework_TestCase
             array(new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity(new Role('ROLE_FOO')), true),
             array(new RoleSecurityIdentity('ROLE_USER'), new RoleSecurityIdentity('ROLE_FOO'), false),
             array(new RoleSecurityIdentity('ROLE_FOO'), new UserSecurityIdentity('ROLE_FOO', 'Foo'), false),
+            array(new RoleSecurityIdentity('ROLE_FOO'), new UserSecurityIdentity('ROLE_FOO', 'Foo'), false),
+            array(new RoleSecurityIdentity('ROLE_FOO'), new RoleSecurityIdentity(new MyRole('ROLE_FOO')), true),
+            array(new RoleSecurityIdentity('ROLE_USER'), new RoleSecurityIdentity(new MyRole('ROLE_FOO')), false),
         );
+    }
+}
+
+class MyRole implements RoleInterface
+{
+    private $role;
+
+    /**
+     * Constructor.
+     *
+     * @param string $role The role name
+     */
+    public function __construct($role)
+    {
+        $this->role = (string) $role;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRole()
+    {
+        return $this->role;
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1538 #1673 #1748 #2541 #4309 #5026 #5076 #5171 #5303 #5909 #6012 #7791 |
| License | MIT |
| Doc PR | no |

Hi,

We are using a **custom** `Role` entity that's implementing the `RoleInterface`, but when we tried to apply ACL on the application, some `SecurityContext->isGranted` calls were denying access when they should actually allow.

After checking database, our code, Symfony code, we got to the dead end where the following triple comparison was returning false:

```
$this->role === $sid->getRole()
```

One `$this->role` was holding our custom object that implements the RoleInterface the other `$sid->getRole()` was holding a string, the strict comparison would obviously fail.

After updating the constructor and tests, everything looks great.

Thanks,
