### PR TITLE
[Validator] Add ConstraintViolationList::toArray method

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -52,6 +52,53 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
     }
 
     /**
+     * Converts the violation list into an associative array as follow:
+     * <code>
+     *     array(
+     *         'root1' => array (
+     *                        'property1.1' => array('message1.1', 'message1.2'),
+     *                        'property1.2' => array('message2')
+     *                    ),
+     *         ........
+     *     )
+     * </code>
+     * with the possibility to filter a given root or a given property.
+     *
+     * @param string $property The name of the property to filter
+     * @param string $root The name of the root to filter
+     *
+     * @return array
+     */
+    public function toArray($property = null, $root = null)
+    {
+        $output = array();
+
+        foreach ($this->violations as $violation) {
+            $output[$violation->getRoot()][$violation->getPropertyPath()][] = $violation->getMessage();
+        }
+
+        if (null !== $root) {
+            if (array_key_exists($root, $output)) {
+                $output = array_intersect_key($output, array($root => 0));
+            } else {
+                return array();
+            }
+        }
+
+        if (null !== $property) {
+            foreach ($output as $key => $value) {
+                if (array_key_exists($property, $value)) {
+                    $output[$key] = array_intersect_key($output[$key], array($property => 0));
+                } else {
+                    unset($output[$key]);
+                }
+            }
+        }
+
+        return $output;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function add(ConstraintViolationInterface $violation)

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -127,6 +127,45 @@ EOF;
         $this->assertEquals($expected, (string) $this->list);
     }
 
+    public function testToArray()
+    {
+        $this->list = new ConstraintViolationList(array(
+            $this->getViolation('Error 1', 'Root', 'foo'),
+            $this->getViolation('Error 2', 'Root', 'foo'),
+            $this->getViolation('Error 3', 'Root', 'bar'),
+            $this->getViolation('Error 4', 'Root 2', 'foo'),
+            $this->getViolation('Error 5', 'Root 3', 'baz'),
+        ));
+
+        $expectedNoFilters = array(
+            'Root'   => array('foo' => array('Error 1', 'Error 2'), 'bar' => array('Error 3')),
+            'Root 2' => array('foo' => array('Error 4')),
+            'Root 3' => array('baz' => array('Error 5'))
+        );
+        $this->assertEquals($expectedNoFilters, $this->list->toArray());
+
+        $expectedFilterRoot = array(
+            'Root'   => array('foo' => array('Error 1', 'Error 2'), 'bar' => array('Error 3')),
+        );
+        $this->assertEquals($expectedFilterRoot, $this->list->toArray(null, 'Root'));
+
+        $expectedFilterProperty = array(
+            'Root'   => array('foo' => array('Error 1', 'Error 2')),
+            'Root 2' => array('foo' => array('Error 4')),
+        );
+        $this->assertEquals($expectedFilterProperty, $this->list->toArray('foo'));
+
+        $expectedFilterBoth = array('Root' => array('foo' => array('Error 1', 'Error 2')));
+        $this->assertEquals($expectedFilterBoth, $this->list->toArray('foo', 'Root'));
+
+        //Wrong values causes to return empty array
+        $this->assertEquals(array(), $this->list->toArray(null, 'wrong'));
+        $this->assertEquals(array(), $this->list->toArray('bar', 'wrong'));
+        $this->assertEquals(array(), $this->list->toArray('wrong', null));
+        $this->assertEquals(array(), $this->list->toArray('wrong', 'Root'));
+        $this->assertEquals(array(), $this->list->toArray('wrong', 'wrong'));
+    }
+
     protected function getViolation($message, $root = null, $propertyPath = null)
     {
         return new ConstraintViolation($message, $message, array(), $root, $propertyPath, null);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Add `toArray` method to `ConstraintViolationListClass`.

This method returns the violations, included in the list, as an associative array:

``` php
$violationsArray = array(
    'Root 1' => array(
        'Property1.1' => array('Error message 1'), 
        'Property2.1' => array('Error message 2', .... , 'Error message n'),
         .........
    ),
    'Root 2' => array(
        'Property2.1' => array('Error message 3', 'Error message 4', ........),
        ........
    )
);
```

As you certainly know, Propel2 validation sub-system is based on Symfony Validator Component.
Some Propel users asked us for this feature (See https://github.com/propelorm/Propel2/issues/413 and the discussion here https://github.com/propelorm/Propel2/pull/414) so we decided first to submit this PR, in case you consider this feature useful also for Symfony community.
