### PR TITLE
Added Spanish NIF validation feature

### DIFF
--- a/src/Symfony/Component/Validator/Constraints/Nif.php
+++ b/src/Symfony/Component/Validator/Constraints/Nif.php
@@ -1,15 +1,22 @@
 <?php
 
-namespace Symfony\Component\Validator\Constraints;
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
+namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 /**
-* @Annotation
-*/
-class Nif extends Constraint
-{
-
-public $message = 'This DNI/NIF doesn´t seem to be valid.';
-
+ * @Annotation
+ *
+ * @api
+ */
+class Nif extends Constraint{
+    public $message = 'This DNI/NIF doesn´t seem to be valid.';
 }

--- a/src/Symfony/Component/Validator/Constraints/Nif.php
+++ b/src/Symfony/Component/Validator/Constraints/Nif.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+* @Annotation
+*/
+class Nif extends Constraint
+{
+
+public $message = 'This DNI/NIF doesn´t seem to be valid.';
+
+}

--- a/src/Symfony/Component/Validator/Constraints/NifValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NifValidator.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+
+/**
+ * @author Marcos Gómez
+ *
+ * @api
+ */
+class NifValidator extends ConstraintValidator {
+  /**
+	 * {@inheritDoc}
+	 */
+	public function validate($value, Constraint $constraint) {
+        $letters = 'TRWAGMYFPDXBNJZSQVHLCKE';
+        $letter = strtoupper(substr($value,8,1));
+        $nif = strotoupper(substr($value,0,8));
+        $nif = str_replace('X','0',$nif);
+        $nif = str_replace('Y','1',$nif);
+        $nif = str_replace('Z','2',$nif);
+        $nif -= intval($nif/23) * 23;
+		if ($letters{$nif} != $letter) {
+			$this->context
+					->addViolation($constraint->message,
+                             array('%string%' => $value));
+		}
+
+	}
+
+}

--- a/src/Symfony/Component/Validator/Constraints/NifValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NifValidator.php
@@ -1,20 +1,36 @@
 <?php
 
-namespace Symfony\Component\Validator\Constraints;
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
+namespace Symfony\Component\Validator\Constraints;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
- * @author Marcos Gómez
+ * Validates that DNI/NIF spanish have specified scheme.
  *
- * @api
+ * @see http://es.wikipedia.org/wiki/NIF
+ * @author Marcos Gómez Vilches <marcos@gesdinet.com>
  */
 class NifValidator extends ConstraintValidator {
-  /**
-	 * {@inheritDoc}
+	
+	/**
+ 	 * Validates that DNI/NIF spanish have specified scheme.
+	 *
+	 * @param mixed $value
+	 * @param Constraint $constraint
 	 */
 	public function validate($value, Constraint $constraint) {
+        if (null === $value || '' === $value) {
+            return;
+        }
         $letters = 'TRWAGMYFPDXBNJZSQVHLCKE';
         $letter = strtoupper(substr($value,8,1));
         $nif = strotoupper(substr($value,0,8));
@@ -22,12 +38,10 @@ class NifValidator extends ConstraintValidator {
         $nif = str_replace('Y','1',$nif);
         $nif = str_replace('Z','2',$nif);
         $nif -= intval($nif/23) * 23;
-		if ($letters{$nif} != $letter) {
-			$this->context
-					->addViolation($constraint->message,
-                             array('%string%' => $value));
-		}
-
+	if ($letters{$nif} != $letter) {
+		$this->context->addViolation($constraint->message);
+	}
+	
 	}
 
 }

--- a/src/Symfony/Component/Validator/Constraints/NifValidator.php
+++ b/src/Symfony/Component/Validator/Constraints/NifValidator.php
@@ -28,19 +28,19 @@ class NifValidator extends ConstraintValidator {
 	 * @param Constraint $constraint
 	 */
 	public function validate($value, Constraint $constraint) {
-        if (null === $value || '' === $value) {
-            return;
-        }
-        $letters = 'TRWAGMYFPDXBNJZSQVHLCKE';
-        $letter = strtoupper(substr($value,8,1));
-        $nif = strotoupper(substr($value,0,8));
-        $nif = str_replace('X','0',$nif);
-        $nif = str_replace('Y','1',$nif);
-        $nif = str_replace('Z','2',$nif);
-        $nif -= intval($nif/23) * 23;
-	if ($letters{$nif} != $letter) {
-		$this->context->addViolation($constraint->message);
-	}
+	        if (null === $value || '' === $value) {
+	            return;
+	        }
+	        $letters = 'TRWAGMYFPDXBNJZSQVHLCKE';
+	        $letter = strtoupper(substr($value,8,1));
+	        $nif = strotoupper(substr($value,0,8));
+	        $nif = str_replace('X','0',$nif);
+	        $nif = str_replace('Y','1',$nif);
+	        $nif = str_replace('Z','2',$nif);
+	        $nif -= intval($nif/23) * 23;
+		if ($letters{$nif} != $letter) {
+			$this->context->addViolation($constraint->message);
+		}
 	
 	}
 


### PR DESCRIPTION
Added Spanish NIF validation feature

To use:

```
// src/Acme/DemoBundle/Entity/AcmeEntity.php
use Symfony\Component\Validator\Constraints as Assert;

class AcmeEntity
{
    // ...

    /**
     * @Assert\Nif
     */
    protected $nif;

    // ...
}
```
