### PR TITLE
[Routing] Add an extension-point for DI into the Matcher/Generator Dumpers

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -233,7 +233,7 @@ class Router implements RouterInterface
         $class = $this->options['matcher_cache_class'];
         $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
         if (!$cache->isFresh($class)) {
-            $dumper = $this->getMatcherDumperInstance($this->options['matcher_dumper_class']);
+            $dumper = $this->getMatcherDumperInstance();
 
             $options = array(
                 'class'      => $class,
@@ -265,7 +265,7 @@ class Router implements RouterInterface
             $class = $this->options['generator_cache_class'];
             $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
             if (!$cache->isFresh($class)) {
-                $dumper = $this->getGeneratorDumperInstance($this->options['generator_dumper_class']);
+                $dumper = $this->getGeneratorDumperInstance();
 
                 $options = array(
                     'class'      => $class,
@@ -288,22 +288,18 @@ class Router implements RouterInterface
     }
 
     /**
-     * @param string $generatorDumperClass The generator dumper class
-     *
      * @return \Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface
      */
-    protected function getGeneratorDumperInstance($generatorDumperClass)
+    protected function getGeneratorDumperInstance()
     {
-        return new $generatorDumperClass($this->getRouteCollection());
+        return new $this->options['generator_dumper_class']($this->getRouteCollection());
     }
 
     /**
-     * @param string $matcherDumperClass The matcher dumper class
-     *
      * @return \Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface
      */
-    protected function getMatcherDumperInstance($matcherDumperClass)
+    protected function getMatcherDumperInstance()
     {
-        return new $matcherDumperClass($this->getRouteCollection());
+        return new $this->options['matcher_dumper_class']($this->getRouteCollection());
     }
 }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -233,7 +233,7 @@ class Router implements RouterInterface
         $class = $this->options['matcher_cache_class'];
         $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
         if (!$cache->isFresh($class)) {
-            $dumper = new $this->options['matcher_dumper_class']($this->getRouteCollection());
+            $dumper = $this->getMatcherDumperInstance($this->options['matcher_dumper_class']);
 
             $options = array(
                 'class'      => $class,
@@ -265,7 +265,7 @@ class Router implements RouterInterface
             $class = $this->options['generator_cache_class'];
             $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
             if (!$cache->isFresh($class)) {
-                $dumper = new $this->options['generator_dumper_class']($this->getRouteCollection());
+                $dumper = $this->getGeneratorDumperInstance($this->options['generator_dumper_class']);
 
                 $options = array(
                     'class'      => $class,
@@ -285,5 +285,25 @@ class Router implements RouterInterface
         }
 
         return $this->generator;
+    }
+
+    /**
+     * @param string $generatorDumperClass The generator dumper class
+     *
+     * @return \Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface
+     */
+    public function getGeneratorDumperInstance($generatorDumperClass)
+    {
+        return new $generatorDumperClass($this->getRouteCollection());
+    }
+
+    /**
+     * @param string $matcherDumperClass The matcher dumper class
+     *
+     * @return \Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface
+     */
+    public function getMatcherDumperInstance($matcherDumperClass)
+    {
+        return new $matcherDumperClass($this->getRouteCollection());
     }
 }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -292,7 +292,7 @@ class Router implements RouterInterface
      *
      * @return \Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface
      */
-    public function getGeneratorDumperInstance($generatorDumperClass)
+    protected function getGeneratorDumperInstance($generatorDumperClass)
     {
         return new $generatorDumperClass($this->getRouteCollection());
     }
@@ -302,7 +302,7 @@ class Router implements RouterInterface
      *
      * @return \Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface
      */
-    public function getMatcherDumperInstance($matcherDumperClass)
+    protected function getMatcherDumperInstance($matcherDumperClass)
     {
         return new $matcherDumperClass($this->getRouteCollection());
     }

--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -16,7 +16,9 @@ use Symfony\Component\Config\ConfigCache;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface;
 use Symfony\Component\Routing\Matcher\UrlMatcherInterface;
+use Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface;
 
 /**
  * The Router class is an example of the integration of all pieces of the
@@ -288,7 +290,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * @return \Symfony\Component\Routing\Generator\Dumper\GeneratorDumperInterface
+     * @return GeneratorDumperInterface
      */
     protected function getGeneratorDumperInstance()
     {
@@ -296,7 +298,7 @@ class Router implements RouterInterface
     }
 
     /**
-     * @return \Symfony\Component\Routing\Matcher\Dumper\MatcherDumperInterface
+     * @return MatcherDumperInterface
      */
     protected function getMatcherDumperInstance()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

The Routing's MatcherDumper and GeneratorDumper classes are instantiated very deeply into the `Router::getGenerator()` and `Router::getMatcher()` methods.

This pull requests aims to : 
1. separate the instances creation
2. ease overriding (lesser risks of changes at framework updates)
3. ease dependencies injection for these classes (as we can't inject dependencies in another way, be it service definition, compiler pass or whatever I'm aware of).

An example of usage would be the following : https://gist.github.com/gnutix/5844630
It's a real case I'm having in my company's current project.
