### PR TITLE
[Form] Moved auto_initialize option to the BaseType

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/BaseType.php
@@ -33,6 +33,7 @@ abstract class BaseType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->setDisabled($options['disabled']);
+        $builder->setAutoInitialize($options['auto_initialize']);
     }
 
     /**
@@ -112,6 +113,7 @@ abstract class BaseType extends AbstractType
             'label'              => null,
             'attr'               => array(),
             'translation_domain' => null,
+            'auto_initialize'    => true,
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/ButtonType.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Extension\Core\Type;
 
 use Symfony\Component\Form\ButtonTypeInterface;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
  * A form button.
@@ -34,5 +35,17 @@ class ButtonType extends BaseType implements ButtonTypeInterface
     public function getName()
     {
         return 'button';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+
+        $resolver->setDefaults(array(
+            'auto_initialize' => false,
+        ));
     }
 }

--- a/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/FormType.php
@@ -55,7 +55,6 @@ class FormType extends BaseType
             ->setDataMapper($options['compound'] ? new PropertyPathMapper($this->propertyAccessor) : null)
             ->setMethod($options['method'])
             ->setAction($options['action'])
-            ->setAutoInitialize($options['auto_initialize'])
         ;
 
         if ($options['trim']) {
@@ -189,7 +188,6 @@ class FormType extends BaseType
             // According to RFC 2396 (http://www.ietf.org/rfc/rfc2396.txt)
             // section 4.2., empty URIs are considered same-document references
             'action'             => '',
-            'auto_initialize'    => true,
         ));
 
         $resolver->setAllowedTypes(array(

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/SubmitTypeTest.php
@@ -51,4 +51,13 @@ class SubmitTypeTest extends TypeTestCase
 
         $this->assertTrue($button->isClicked());
     }
+
+    public function testSubmitCanBeAddedToForm()
+    {
+        $form = $this->factory
+            ->createBuilder('form')
+            ->getForm();
+
+        $this->assertSame($form, $form->add('send', 'submit'));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8162 |
| License | MIT |
| Doc PR | - |

I'm not fully confident in this change, so let someone review it before mergin please. My thinking was - since "auto_initialized" option is always passed to a form factory, it should be required by the base type.
