### PR TITLE
Passed the config when building the Configuration in ConfigurableExtension

### DIFF
--- a/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php
+++ b/src/Symfony/Component/HttpKernel/DependencyInjection/ConfigurableExtension.php
@@ -32,7 +32,7 @@ abstract class ConfigurableExtension extends Extension
      */
     final public function load(array $configs, ContainerBuilder $container)
     {
-        $this->loadInternal($this->processConfiguration($this->getConfiguration(array(), $container), $configs), $container);
+        $this->loadInternal($this->processConfiguration($this->getConfiguration($configs, $container), $configs), $container);
     }
 
     /**


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This passes the config to `getConfiguration` instead of passing an empty array in ConfigurableExtension. This makes the class usable for bundle overwriting the `getConfiguration` method to use the config instead of using the default logic (which does not need the config).
