### PR TITLE
[HttpFoundation] Enable LSB feature for AcceptHeader and AcceptHeaderItem

### DIFF
--- a/src/Symfony/Component/HttpFoundation/AcceptHeader.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeader.php
@@ -54,7 +54,7 @@ class AcceptHeader
     {
         $index = 0;
 
-        return new self(array_map(function ($itemValue) use (&$index) {
+        return new static(array_map(function ($itemValue) use (&$index) {
             $item = AcceptHeaderItem::fromString($itemValue);
             $item->setIndex($index++);
 
@@ -132,7 +132,7 @@ class AcceptHeader
      */
     public function filter($pattern)
     {
-        return new self(array_filter($this->items, function (AcceptHeaderItem $item) use ($pattern) {
+        return new static(array_filter($this->items, function (AcceptHeaderItem $item) use ($pattern) {
             return preg_match($pattern, $item->getValue());
         }));
     }

--- a/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
+++ b/src/Symfony/Component/HttpFoundation/AcceptHeaderItem.php
@@ -78,7 +78,7 @@ class AcceptHeaderItem
             }
         }
 
-        return new self(($start = substr($value, 0, 1)) === ($end = substr($value, -1)) && ($start === '"' || $start === '\'') ? substr($value, 1, -1) : $value, $attributes);
+        return new static(($start = substr($value, 0, 1)) === ($end = substr($value, -1)) && ($start === '"' || $start === '\'') ? substr($value, 1, -1) : $value, $attributes);
     }
 
     /**


### PR DESCRIPTION
This PR allows to use static binding in methods for creation of concrete children classes for testing/extending.
