### PR TITLE
[OptionsResolver] Allow giving a callback as an allowedValue to OptionsResolver

### DIFF
--- a/src/Symfony/Component/OptionsResolver/OptionsResolver.php
+++ b/src/Symfony/Component/OptionsResolver/OptionsResolver.php
@@ -294,8 +294,14 @@ class OptionsResolver implements OptionsResolverInterface
     private function validateOptionValues(array $options)
     {
         foreach ($this->allowedValues as $option => $allowedValues) {
-            if (isset($options[$option]) && !in_array($options[$option], $allowedValues, true)) {
-                throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", but is expected to be one of "%s"', $option, $options[$option], implode('", "', $allowedValues)));
+            if (isset($options[$option])) {
+                if (is_array($allowedValues) && !in_array($options[$option], $allowedValues, true)) {
+                    throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", but is expected to be one of "%s"', $option, $options[$option], implode('", "', $allowedValues)));
+                }
+
+                if (is_callable($allowedValues) && !call_user_func($allowedValues, $options[$option])) {
+                    throw new InvalidOptionsException(sprintf('The option "%s" has the value "%s", which it is not valid', $option, $options[$option]));
+                }
             }
         }
     }

--- a/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
+++ b/src/Symfony/Component/OptionsResolver/Tests/OptionsResolverTest.php
@@ -658,6 +658,45 @@ class OptionsResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($options, $this->resolver->resolve($options));
     }
 
+    public function testResolveSucceedsIfValueAllowedCallbackReturnsTrue()
+    {
+        $this->resolver->setRequired(array(
+            'test',
+        ));
+        $this->resolver->setAllowedValues(array(
+            'test' => function ($value) {
+                return true;
+            },
+        ));
+
+        $options = array(
+            'test' => true,
+        );
+
+        $this->assertEquals($options, $this->resolver->resolve($options));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\OptionsResolver\Exception\InvalidOptionsException
+     */
+    public function testResolveFailsIfValueAllowedCallbackReturnsFalse()
+    {
+        $this->resolver->setRequired(array(
+            'test',
+        ));
+        $this->resolver->setAllowedValues(array(
+            'test' => function ($value) {
+                return false;
+            },
+        ));
+
+        $options = array(
+            'test' => true,
+        );
+
+        $this->assertEquals($options, $this->resolver->resolve($options));
+    }
+
     public function testClone()
     {
         $this->resolver->setDefaults(array('one' => '1'));


### PR DESCRIPTION
I recently had to use an option which was an array and could contain some one or multiple values from a list. As it could contain all possible combinations, it was not possible to validate it with a list of allowed values.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | -- |
| License | MIT |
| Doc PR | https://github.com/symfony/symfony-docs/pull/3437 |
