### PR TITLE
Added Query Hints support to Entity form type that use query builder

### DIFF
--- a/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/DoctrineType.php
@@ -67,7 +67,7 @@ abstract class DoctrineType extends AbstractType
 
         $loader = function (Options $options) use ($type) {
             if (null !== $options['query_builder']) {
-                return $type->getLoader($options['em'], $options['query_builder'], $options['class']);
+                return $type->getLoader($options['em'], $options['query_builder'], $options['class'], $options['query_hints']);
             }
 
             return null;
@@ -158,6 +158,7 @@ abstract class DoctrineType extends AbstractType
             'em'                => null,
             'property'          => null,
             'query_builder'     => null,
+            'query_hints'       => array(),
             'loader'            => $loader,
             'choices'           => null,
             'choice_list'       => $choiceList,
@@ -184,7 +185,7 @@ abstract class DoctrineType extends AbstractType
      *
      * @return EntityLoaderInterface
      */
-    abstract public function getLoader(ObjectManager $manager, $queryBuilder, $class);
+    abstract public function getLoader(ObjectManager $manager, $queryBuilder, $class, $hints);
 
     public function getParent()
     {

--- a/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
+++ b/src/Symfony/Bridge/Doctrine/Form/Type/EntityType.php
@@ -24,12 +24,13 @@ class EntityType extends DoctrineType
      * @param string        $class
      * @return ORMQueryBuilderLoader
      */
-    public function getLoader(ObjectManager $manager, $queryBuilder, $class)
+    public function getLoader(ObjectManager $manager, $queryBuilder, $class, $hints)
     {
         return new ORMQueryBuilderLoader(
             $queryBuilder,
             $manager,
-            $class
+            $class,
+            $hints
         );
     }
 

--- a/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
+++ b/src/Symfony/Bridge/Doctrine/Tests/Form/Type/EntityTypeTest.php
@@ -199,6 +199,29 @@ class EntityTypeTest extends TypeTestCase
         $field->submit('2');
     }
 
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\UnexpectedTypeException
+     */
+    public function testConfigureQueryBuilderWithNonArrayHints()
+    {
+        $entity1 = new SingleIdentEntity(1, 'Foo');
+        $entity2 = new SingleIdentEntity(2, 'Bar');
+
+        $this->persist(array($entity1, $entity2));
+        $qb = $this->em->createQueryBuilder()->select('e')->from(self::SINGLE_IDENT_CLASS, 'e');
+
+        $field = $this->factory->createNamed('name', 'entity', null, array(
+            'em' => 'default',
+            'class' => self::SINGLE_IDENT_CLASS,
+            'required' => false,
+            'property' => 'name',
+            'query_builder' => $qb,
+            'query_hints' => 'foo'
+        ));
+        
+        $field->submit('2');
+    }
+
     public function testSetDataSingleNull()
     {
         $field = $this->factory->createNamed('name', 'entity', null, array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | [none] |
| License | MIT |
| Doc PR | [will add later on] |

Adds an optional "query_hints" array to be passed to "entity" form types, to be used when generating the Query object to retrieve objects from storage.

I've added a basic test, that just validates the scenario where the input type for the "query_hints" is incorrect. I wanted to add a test to validate the working scenario, but my phpunit/doctrine knowledge only goes so far, so if anyone could give me a help with it, I'd really appreciate.
