### PR TITLE
[Form][RFC] added failing test for 'en_GB' locale and missing `ja_JP`

### DIFF
--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\Form\Tests\Extension\Core\Type;
 
 use Symfony\Component\Form\Extension\Core\View\ChoiceView;
+use Symfony\Component\Intl\Intl;
 use Symfony\Component\Intl\Util\IntlTestHelper;
 
 class LocaleTypeTest extends TypeTestCase
@@ -23,8 +24,13 @@ class LocaleTypeTest extends TypeTestCase
         parent::setUp();
     }
 
-    public function testLocalesAreSelectable()
+    /**
+     * @dataProvider localeProvider
+     */
+    public function testLocalesAreSelectable($locale)
     {
+        \Locale::setDefault($locale);
+
         $form = $this->factory->create('locale');
         $view = $form->createView();
         $choices = $view->vars['choices'];
@@ -32,5 +38,15 @@ class LocaleTypeTest extends TypeTestCase
         $this->assertContains(new ChoiceView('en', 'en', 'English'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'English (United Kingdom)'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'Chinese (Traditional, Macau SAR China)'), $choices, '', false, false);
+    }
+
+    public function localeProvider()
+    {
+        return array(
+            array('en'),
+            array('en_US'),
+            array('en_CA'),
+            array('en_GB')
+        );
     }
 }

--- a/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
+++ b/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php
@@ -38,6 +38,8 @@ class LocaleTypeTest extends TypeTestCase
         $this->assertContains(new ChoiceView('en', 'en', 'English'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('en_GB', 'en_GB', 'English (United Kingdom)'), $choices, '', false, false);
         $this->assertContains(new ChoiceView('zh_Hant_MO', 'zh_Hant_MO', 'Chinese (Traditional, Macau SAR China)'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('ja', 'ja', 'Japanese'), $choices, '', false, false);
+        $this->assertContains(new ChoiceView('ja_JP', 'ja_JP', 'Japanese (Japan)'), $choices, '', false, false);
     }
 
     public function localeProvider()


### PR DESCRIPTION
I was having some trouble with the list of locales available via the `LocaleType`.  When the default locale is `en_US` or `en_CA` it works as expected, but for `en_GB` the list has just one entry:

``` php
array('tzm' => 'Central Morocco Tamazight')
```

Further, for `fr`, the list is correct, but for `fr_CA` it is not:

``` php
array(
    'si' => 'singhalais',
    'to' => 'tongan'
)
```

Also, it appears the `ja_JP` locale is missing entirely.

I have wrote a some failing tests based on this issue.

```
There were 4 failures:

1) Symfony\Component\Form\Tests\Extension\Core\Type\LocaleTypeTest::testLocalesAreSelectable with data set #0 ('en')
Failed asserting that an array contains Symfony\Component\Form\Extension\Core\View\ChoiceView Object (
    'data' => 'ja_JP'
    'value' => 'ja_JP'
    'label' => 'Japanese (Japan)'
).

/home/kbond/www/symfony/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php:42

2) Symfony\Component\Form\Tests\Extension\Core\Type\LocaleTypeTest::testLocalesAreSelectable with data set #1 ('en_US')
Failed asserting that an array contains Symfony\Component\Form\Extension\Core\View\ChoiceView Object (
    'data' => 'ja_JP'
    'value' => 'ja_JP'
    'label' => 'Japanese (Japan)'
).

/home/kbond/www/symfony/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php:42

3) Symfony\Component\Form\Tests\Extension\Core\Type\LocaleTypeTest::testLocalesAreSelectable with data set #2 ('en_CA')
Failed asserting that an array contains Symfony\Component\Form\Extension\Core\View\ChoiceView Object (
    'data' => 'ja_JP'
    'value' => 'ja_JP'
    'label' => 'Japanese (Japan)'
).

/home/kbond/www/symfony/src/Symfony/Component/Form/Tests/Extension/Core/Type/LocaleTypeTest.php:42

4) Symfony\Component\Form\Tests\Extension\Core\Type\LocaleTypeTest::testLocalesAreSelectable with data set #3 ('en_GB')
Failed asserting that an array contains Symfony\Component\Form\Extension\Core\View\ChoiceView Object (
    'data' => 'en'
    'value' => 'en'
    'label' => 'English'
)
```
