### PR TITLE
[Console] Avoided an unnecessary check if a stream is an interactive terminal

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -859,9 +859,7 @@ class Application
 
         if (true === $input->hasParameterOption(array('--no-interaction', '-n'))) {
             $input->setInteractive(false);
-        }
-
-        if (function_exists('posix_isatty') && $this->getHelperSet()->has('dialog')) {
+        } elseif (function_exists('posix_isatty') && $this->getHelperSet()->has('dialog')) {
             $inputStream = $this->getHelperSet()->get('dialog')->getInputStream();
             if (!posix_isatty($inputStream)) {
                 $input->setInteractive(false);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

It only makes sense to do the second check, if the first one evaluates to false (so the `--no-interaction` option was not passed).

Running `posix_isatty()` raises a warning with some stream types (like in-memory stream). With this patch, warning could be avoided by passing the `--no-interaction option` (which is what we want with an in-memory stream).

The warning I'm getting is:

```
PHP Warning:  posix_isatty(): could not use stream of type 'MEMORY' in vendor/symfony/console/Symfony/Component/Console/Application.php on line 866
```
