### PR TITLE
[2.3] Return BC compatibility for DI Container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Container.php
+++ b/src/Symfony/Component/DependencyInjection/Container.php
@@ -229,8 +229,8 @@ class Container implements IntrospectableContainerInterface
     {
         $id = strtolower($id);
 
-        return array_key_exists($id, $this->services)
-            || array_key_exists($id, $this->aliases)
+        return isset($this->services[$id])
+            || isset($this->aliases[$id])
             || method_exists($this, 'get'.strtr($id, array('_' => '', '.' => '_')).'Service')
         ;
     }
@@ -303,7 +303,7 @@ class Container implements IntrospectableContainerInterface
         } catch (\Exception $e) {
             unset($this->loading[$id]);
 
-            if (array_key_exists($id, $this->services)) {
+            if (isset($this->services[$id])) {
                 unset($this->services[$id]);
             }
 
@@ -328,7 +328,7 @@ class Container implements IntrospectableContainerInterface
      */
     public function initialized($id)
     {
-        return array_key_exists(strtolower($id), $this->services);
+        return isset($this->services[strtolower($id)]);
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/ContainerTest.php
@@ -193,7 +193,6 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
     public function testGetCircularReference()
     {
-
         $sc = new ProjectServiceContainer();
         try {
             $sc->get('circular');
@@ -210,7 +209,13 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testGetReturnsNullOnInactiveScope()
     {
         $sc = new ProjectServiceContainer();
-        $this->assertNull($sc->get('inactive', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        $this->assertNull($sc->get('inactive', ContainerInterface::NULL_ON_INVALID_REFERENCE), '->get() returns null if service not exists and ContainerInterface::NULL_ON_INVALID_REFERENCE is used');
+
+        $sc->set('foo', $foo = new \stdClass());
+        $this->assertEquals($foo, $sc->get('foo'), '->get() returns the service for the given id if it exists');
+
+        $sc->set('foo', null);
+        $this->assertNull($sc->get('foo', ContainerInterface::NULL_ON_INVALID_REFERENCE), '->get() returns null if service is null and ContainerInterface::NULL_ON_INVALID_REFERENCE is used');
     }
 
     /**
@@ -220,11 +225,16 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     {
         $sc = new ProjectServiceContainer();
         $sc->set('foo', new \stdClass());
+        $sc->set('foo2', new \stdClass());
         $this->assertFalse($sc->has('foo1'), '->has() returns false if the service does not exist');
+        $this->assertTrue($sc->has('foo2'), '->has() returns true if the service exists');
         $this->assertTrue($sc->has('foo'), '->has() returns true if the service exists');
         $this->assertTrue($sc->has('bar'), '->has() returns true if a get*Method() is defined');
         $this->assertTrue($sc->has('foo_bar'), '->has() returns true if a get*Method() is defined');
         $this->assertTrue($sc->has('foo.baz'), '->has() returns true if a get*Method() is defined');
+
+        $sc->set('foo', null);
+        $this->assertFalse($sc->has('foo'), '->has() returns false if the service was set to null');
     }
 
     /**
@@ -237,6 +247,9 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($sc->initialized('foo'), '->initialized() returns true if service is loaded');
         $this->assertFalse($sc->initialized('foo1'), '->initialized() returns false if service is not loaded');
         $this->assertFalse($sc->initialized('bar'), '->initialized() returns false if a service is defined, but not currently loaded');
+
+        $sc->set('foo', null);
+        $this->assertFalse($sc->initialized('foo'), '->initialized() returns false if the service was set to null');
     }
 
     public function testEnterLeaveCurrentScope()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8347 |
| License | MIT |

When setting service to `null` it's considered as existing instead of removed/reset state which is BC break, more in #8347.
