### PR TITLE
Replace romaji period characters with Japanese style zenkaku period char...

### DIFF
--- a/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
+++ b/src/Symfony/Component/Validator/Resources/translations/validators.ja.xlf
@@ -24,11 +24,11 @@
             </trans-unit>
             <trans-unit id="6">
                 <source>You must select at least {{ limit }} choice.|You must select at least {{ limit }} choices.</source>
-                <target>{{ limit }}個以上選択してください.</target>
+                <target>{{ limit }}個以上選択してください。</target>
             </trans-unit>
             <trans-unit id="7">
                 <source>You must select at most {{ limit }} choice.|You must select at most {{ limit }} choices.</source>
-                <target>{{ limit }}個以内で選択してください.</target>
+                <target>{{ limit }}個以内で選択してください。</target>
             </trans-unit>
             <trans-unit id="8">
                 <source>One or more of the given values is invalid.</source>
@@ -76,7 +76,7 @@
             </trans-unit>
             <trans-unit id="19">
                 <source>This value is too long. It should have {{ limit }} character or less.|This value is too long. It should have {{ limit }} characters or less.</source>
-                <target>値が長すぎます。{{ limit }}文字以内でなければなりません.</target>
+                <target>値が長すぎます。{{ limit }}文字以内でなければなりません。</target>
             </trans-unit>
             <trans-unit id="20">
                 <source>This value should be {{ limit }} or more.</source>
@@ -84,7 +84,7 @@
             </trans-unit>
             <trans-unit id="21">
                 <source>This value is too short. It should have {{ limit }} character or more.|This value is too short. It should have {{ limit }} characters or more.</source>
-                <target>値が短すぎます。{{ limit }}文字以上でなければなりません.</target>
+                <target>値が短すぎます。{{ limit }}文字以上でなければなりません。</target>
             </trans-unit>
             <trans-unit id="22">
                 <source>This value should not be blank.</source>


### PR DESCRIPTION
...acters

Found 4 of the Japanese translations inconsistently used romaji style periods. Replaced with zenkaku periods.
