### PR TITLE
[HttpKernel] [EventDispatcher] TraceableEventDispatcher kills event priorities

### DIFF
--- a/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ContainerAwareEventDispatcher.php
@@ -96,7 +96,7 @@ class ContainerAwareEventDispatcher extends EventDispatcher
             }
         }
 
-        parent::removeListener($eventName, $listener);
+        return parent::removeListener($eventName, $listener);
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -108,6 +108,7 @@ class EventDispatcher implements EventDispatcherInterface
         foreach ($this->listeners[$eventName] as $priority => $listeners) {
             if (false !== ($key = array_search($listener, $listeners, true))) {
                 unset($this->listeners[$eventName][$priority][$key], $this->sorted[$eventName]);
+                return $priority;
             }
         }
     }

--- a/src/Symfony/Component/EventDispatcher/EventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcher.php
@@ -108,9 +108,25 @@ class EventDispatcher implements EventDispatcherInterface
         foreach ($this->listeners[$eventName] as $priority => $listeners) {
             if (false !== ($key = array_search($listener, $listeners, true))) {
                 unset($this->listeners[$eventName][$priority][$key], $this->sorted[$eventName]);
+            }
+        }
+    }
+
+    /**
+     * @see EventDispatcherInterface::getListenerPriority
+     */
+     public function getListenerPriority($eventName, $listener) {
+        if (!isset($this->listeners[$eventName])) {
+            return null;
+        }
+
+        foreach ($this->listeners[$eventName] as $priority => $listeners) {
+            if (false !== ($key = array_search($listener, $listeners, true))) {
                 return $priority;
             }
         }
+
+        return null;
     }
 
     /**

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -66,6 +66,8 @@ interface EventDispatcherInterface
      *
      * @param string|array $eventName The event(s) to remove a listener from
      * @param callable     $listener  The listener to remove
+     *
+     * @return integer The listener's priority value
      */
     public function removeListener($eventName, $listener);
 

--- a/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
+++ b/src/Symfony/Component/EventDispatcher/EventDispatcherInterface.php
@@ -66,8 +66,6 @@ interface EventDispatcherInterface
      *
      * @param string|array $eventName The event(s) to remove a listener from
      * @param callable     $listener  The listener to remove
-     *
-     * @return integer The listener's priority value
      */
     public function removeListener($eventName, $listener);
 
@@ -95,4 +93,14 @@ interface EventDispatcherInterface
      * @return Boolean true if the specified event has any listeners, false otherwise
      */
     public function hasListeners($eventName = null);
+
+    /**
+     * Returns the priority of the given listener.
+     *
+     * @param string   $eventName The event to get the listener's priority
+     * @param callable $listener  The listener for which the priority is returned
+     *
+     * @return integer|null The listener's priority value, null if the listener wasn't found
+     */
+    public function getListenerPriority($eventName, $listener);
 }

--- a/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
+++ b/src/Symfony/Component/EventDispatcher/ImmutableEventDispatcher.php
@@ -89,4 +89,12 @@ class ImmutableEventDispatcher implements EventDispatcherInterface
     {
         return $this->dispatcher->hasListeners($eventName);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->dispatcher->getListenerPriority($eventName, $listener);
+    }
 }

--- a/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
+++ b/src/Symfony/Component/EventDispatcher/Tests/EventDispatcherTest.php
@@ -163,6 +163,19 @@ class EventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('3', '2', '1'), $invoked);
     }
 
+    public function testGetListenerPriorty()
+    {
+        $listener1 = new TestEventListener();
+        $listener2 = new TestEventListener();
+        $listener3 = new TestEventListener();
+        $this->dispatcher->addListener('pre.foo', $listener1, -10);
+        $this->dispatcher->addListener('pre.foo', $listener2);
+        $this->assertEquals(-10, $this->dispatcher->getListenerPriority('pre.foo', $listener1));
+        $this->assertEquals(0, $this->dispatcher->getListenerPriority('pre.foo', $listener2));
+        $this->assertNull($this->dispatcher->getListenerPriority('pre.bar', $listener1));
+        $this->assertNull($this->dispatcher->getListenerPriority('pre.foo', $listener3));
+    }
+
     public function testRemoveListener()
     {
         $this->dispatcher->addListener('pre.bar', $this->listener);

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -118,6 +118,14 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
     /**
      * {@inheritdoc}
      */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->dispatcher->getListenerPriority($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function dispatch($eventName, Event $event = null)
     {
         if (null === $event) {
@@ -372,7 +380,8 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
         $listeners = $this->dispatcher->getListeners($eventName);
 
         foreach ($listeners as $listener) {
-            $priority = $this->dispatcher->removeListener($eventName, $listener);
+            $priority = $this->dispatcher->getListenerPriority($eventName, $listener);
+            $this->dispatcher->removeListener($eventName, $listener);
             $wrapped = $this->wrapListener($eventName, $listener);
             $this->wrappedListeners[$this->id][$wrapped] = $listener;
             $this->dispatcher->addListener($eventName, $wrapped, $priority);
@@ -433,7 +442,8 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
         }
 
         foreach ($this->wrappedListeners[$this->id] as $wrapped) {
-            $priority = $this->dispatcher->removeListener($eventName, $wrapped);
+            $priority = $this->dispatcher->getListenerPriority($eventName, $wrapped);
+            $this->dispatcher->removeListener($eventName, $wrapped);
             $this->dispatcher->addListener($eventName, $this->wrappedListeners[$this->id][$wrapped], $priority);
         }
 

--- a/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
+++ b/src/Symfony/Component/HttpKernel/Debug/TraceableEventDispatcher.php
@@ -372,10 +372,10 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
         $listeners = $this->dispatcher->getListeners($eventName);
 
         foreach ($listeners as $listener) {
-            $this->dispatcher->removeListener($eventName, $listener);
+            $priority = $this->dispatcher->removeListener($eventName, $listener);
             $wrapped = $this->wrapListener($eventName, $listener);
             $this->wrappedListeners[$this->id][$wrapped] = $listener;
-            $this->dispatcher->addListener($eventName, $wrapped);
+            $this->dispatcher->addListener($eventName, $wrapped, $priority);
         }
 
         switch ($eventName) {
@@ -433,8 +433,8 @@ class TraceableEventDispatcher implements EventDispatcherInterface, TraceableEve
         }
 
         foreach ($this->wrappedListeners[$this->id] as $wrapped) {
-            $this->dispatcher->removeListener($eventName, $wrapped);
-            $this->dispatcher->addListener($eventName, $this->wrappedListeners[$this->id][$wrapped]);
+            $priority = $this->dispatcher->removeListener($eventName, $wrapped);
+            $this->dispatcher->addListener($eventName, $this->wrappedListeners[$this->id][$wrapped], $priority);
         }
 
         unset($this->wrappedListeners[$this->id]);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Fix a bug where the TraceableEventDispatcher sets all event priorities to 0 when wrapping the events.

I stumpled across this problem when running multiple consecutive BrowserKit requests from a single functional test case.
Sometimes the ContextListener's kernel.response event handler was called after the TestSessionListener's handler, which leads to a started session after finishing the request.
This causes a "Cannot set session ID after the session has started." error on the subsequent request.

I fixed this by introducing a new return value to the EventDispatcher's removeListener method: it now returns the priority of the Event removed so it's easy for the TraceableEventDispatcher to add a wrapped event with the same priority.
