### PR TITLE
[Validator] fixed ConstraintViolation::$propertyPath incorrect when nested

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
+++ b/src/Symfony/Component/Validator/ConstraintValidatorFactory.php
@@ -32,7 +32,7 @@ class ConstraintValidatorFactory implements ConstraintValidatorFactoryInterface
     {
         $className = $constraint->validatedBy();
 
-        if (!isset($this->validators[$className])) {
+        if (!isset($this->validators[$className]) || $className === 'Symfony\Component\Validator\Constraints\CollectionValidator') {
             $this->validators[$className] = new $className();
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8351 |
| License | MIT |

In nested constraints, the property path will be overwritten in the context (as there would be a recursive call to CollectionValidotor when nested). Reason is, in ConstraintValidatorFactory object is loaded from memory if exists and context is initialized with the new context. So, other constraints after the nested constraints PropertyPath would be wrong. 

So I think better create a new object for CollectionValidator always. 

see this https://gist.github.com/alexkappa/5851274
It shows [name][email] even though the email is not under the name node.
