### PR TITLE
[Serializer] Add the missing context support inside the XmlEncoder

### DIFF
--- a/src/Symfony/Component/Serializer/CHANGELOG.md
+++ b/src/Symfony/Component/Serializer/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+ * added `$context` support for XMLEncoder.
+
 2.3.0
 -----
 

--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -24,6 +24,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
 {
     private $dom;
     private $format;
+    private $context;
     private $rootNodeName = 'response';
 
     /**
@@ -49,6 +50,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
 
         $this->dom = new \DOMDocument();
         $this->format = $format;
+        $this->context = $context;
 
         if (null !== $data && !is_scalar($data)) {
             $root = $this->dom->createElement($xmlRootNodeName);
@@ -325,7 +327,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         }
 
         if (is_object($data)) {
-            $data = $this->serializer->normalize($data, $this->format);
+            $data = $this->serializer->normalize($data, $this->format, $this->context);
             if (null !== $data && !is_scalar($data)) {
                 return $this->buildXml($parentNode, $data, $xmlRootNodeName);
             }
@@ -399,7 +401,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
         } elseif ($val instanceof \Traversable) {
             $this->buildXml($node, $val);
         } elseif (is_object($val)) {
-            return $this->buildXml($node, $this->serializer->normalize($val, $this->format));
+            return $this->buildXml($node, $this->serializer->normalize($val, $this->format, $this->context));
         } elseif (is_numeric($val)) {
             return $this->appendText($node, (string) $val);
         } elseif (is_string($val) && $this->needsCdataWrapping($val)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

$context variable was added in symfony 2.3 but not inside this encoder
