### PR TITLE
[Validator] Constaint Violation List add isEmpty()

### DIFF
--- a/src/Symfony/Component/Validator/ConstraintViolationList.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationList.php
@@ -108,6 +108,14 @@ class ConstraintViolationList implements \IteratorAggregate, ConstraintViolation
     /**
      * {@inheritDoc}
      */
+    public function isEmpty()
+    {
+        return $this->violations == array();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function getIterator()
     {
         return new \ArrayIterator($this->violations);

--- a/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
+++ b/src/Symfony/Component/Validator/ConstraintViolationListInterface.php
@@ -80,4 +80,13 @@ interface ConstraintViolationListInterface extends \Traversable, \Countable, \Ar
      * @api
      */
     public function remove($offset);
+
+    /**
+     * Returns whether the violation list is empty.
+     *
+     * @return Boolean True if violation list is empty otherwise false.
+     *
+     * @api
+     */
+    public function isEmpty();
 }

--- a/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
+++ b/src/Symfony/Component/Validator/Tests/ConstraintViolationListTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\Validator\ConstraintViolationList;
 
 class ConstraintViolationListTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var ConstraintViolationList
+     */
     protected $list;
 
     protected function setUp()
@@ -66,6 +69,20 @@ class ConstraintViolationListTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($violations[10], $this->list[0]);
         $this->assertSame($violations[20], $this->list[1]);
         $this->assertSame($violations[30], $this->list[2]);
+    }
+
+    public function testIsEmpty()
+    {
+        $this->assertTrue($this->list->isEmpty());
+
+        $violation = $this->getViolation('Error');
+        $this->list = new ConstraintViolationList(array($violation));
+
+        $this->assertFalse($this->list->isEmpty());
+
+        unset($this->list[0]);
+
+        $this->assertTrue($this->list->isEmpty());
     }
 
     public function testIterator()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

At http://symfony.com/doc/current/book/validation.html

``` php
$validator = $this->get('validator');
$errors = $validator->validate($author);

if (count($errors) > 0) {
    return new Response(print_r($errors, true));
} else {
    return new Response('The author is valid! Yes!');
}
```

While doing this code several times, to me doing a count every time doesn't look good, I would prefer to have a isEmpty()

``` php
$validator = $this->get('validator');
$violations = $validator->validate($author);

if ($violations->isEmpty()) {
    return new Response('The author is valid! Yes!');
}

return new Response(print_r($errors, true));
```

The isEmpty() just compare against array dropping the count.

**If this PR is accepted and is wanted I can make a PR to change the doc**
