### PR TITLE
[BrowserKit] At Cookie fromString() remove some strtolower

### DIFF
--- a/src/Symfony/Component/BrowserKit/Cookie.php
+++ b/src/Symfony/Component/BrowserKit/Cookie.php
@@ -154,8 +154,9 @@ class Cookie
 
         foreach ($parts as $part) {
             $part = trim($part);
+            $lowercasePart = strtolower($part);
 
-            if ('secure' === strtolower($part)) {
+            if ('secure' === $lowercasePart) {
                 // Ignore the secure flag if the original URI is not given or is not HTTPS
                 if (!$url || !isset($urlParts['scheme']) || 'https' != $urlParts['scheme']) {
                     continue;
@@ -166,18 +167,17 @@ class Cookie
                 continue;
             }
 
-            if ('httponly' === strtolower($part)) {
+            if ('httponly' === $lowercasePart) {
                 $values['httponly'] = true;
 
                 continue;
             }
 
             if (2 === count($elements = explode('=', $part, 2))) {
-                if ('expires' === strtolower($elements[0])) {
-                    $elements[1] = self::parseDate($elements[1]);
-                }
-
-                $values[strtolower($elements[0])] = $elements[1];
+                $lowercaseFirstElement = strtolower($elements[0]);
+                $values[$lowercaseFirstElement] = 'expires' === $lowercaseFirstElement
+                    ? self::parseDate($elements[1])
+                    : $elements[1];
             }
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

I can revert the change to ternary operator if someone don't like it

I thinked in move the if ('httponly' to before if ('secure' just as a minor performance optimization, but I don't have  any data to support it
