### PR TITLE
[Form] Abstract extension, on getType() call hasType()

### DIFF
--- a/src/Symfony/Component/Form/AbstractExtension.php
+++ b/src/Symfony/Component/Form/AbstractExtension.php
@@ -48,11 +48,7 @@ abstract class AbstractExtension implements FormExtensionInterface
      */
     public function getType($name)
     {
-        if (null === $this->types) {
-            $this->initTypes();
-        }
-
-        if (!isset($this->types[$name])) {
+        if (!$this->hasType($name)) {
             throw new InvalidArgumentException(sprintf('The type "%s" can not be loaded by this extension', $name));
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

If not calling hasType and duplicate code is due to performance, **at least a comment should be added**. And is this code called so many times that worth duplicate code?
