### PR TITLE
[DI] Fixed bug requesting non existing service from dumped frozen container

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -849,7 +849,11 @@ EOF;
     private function addAliases()
     {
         if (!$aliases = $this->container->getAliases()) {
-            return '';
+            if ($this->container->isFrozen()) {
+                return "\n        \$this->aliases = array();\n";
+            } else {
+                return '';
+            }
         }
 
         $code = "        \$this->aliases = array(\n";

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -134,6 +134,18 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($foo, $container->get('alias_for_alias'));
     }
 
+    public function testFrozenContainerWithoutAliases()
+    {
+        $container = new ContainerBuilder();
+        $container->compile();
+
+        $dumper = new PhpDumper($container);
+        eval('?>'.$dumper->dump(array('class' => 'Symfony_DI_PhpDumper_Test_Frozen_No_Aliases')));
+
+        $container = new \Symfony_DI_PhpDumper_Test_Frozen_No_Aliases();
+        $this->assertFalse($container->has('foo'));
+    }
+
     public function testOverrideServiceWhenUsingADumpedContainer()
     {
         require_once self::$fixturesPath.'/php/services9.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services10.php
@@ -36,6 +36,8 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'test' => 'getTestService',
         );
+
+        $this->aliases = array();
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services11.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services11.php
@@ -34,6 +34,8 @@ class ProjectServiceContainer extends Container
         $this->methodMap = array(
             'foo' => 'getFooService',
         );
+
+        $this->aliases = array();
     }
 
     /**


### PR DESCRIPTION
When dumping a frozen container without aliases, the method `Container::has()` will throw a _"Warning: array_key_exists() expects parameter 2 to be array, null given"_ warning. It's because `PhpDumper::addAliases` returns `''` if no aliases are given. This will work for a normal constructor, because it calls the `Container::__construct` method, but the frozen constructor doesn't do that. So it requires a `$this->aliases = array();` in the constructor.

This PR fixes this bug (and adds the test). Bug is introduced in #8252 and 63367a3d5615ff65251ccee4f73223107275f65f

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
