### PR TITLE
[HttpKernel] changed the fragment handler to explicitely disallow non-scalar in generated URIs (refs #8263)

### DIFF
--- a/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/InlineFragmentRenderer.php
@@ -52,7 +52,7 @@ class InlineFragmentRenderer extends RoutableFragmentRenderer
         $reference = null;
         if ($uri instanceof ControllerReference) {
             $reference = $uri;
-            $uri = $this->generateFragmentUri($uri, $request);
+            $uri = $this->generateFragmentUri($uri, $request, false);
         }
 
         $subRequest = $this->createSubRequest($uri, $request);

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -64,13 +64,11 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
 
     private function checkNonScalar($values)
     {
-        foreach ($values as $value) {
+        foreach ($values as $key => $value) {
             if (is_array($value)) {
                 $this->checkNonScalar($value);
-            }
-
-            if (!is_scalar($value)) {
-                throw new \LogicException('Controller attributes cannot contain non-scalar values.');
+            } elseif (!is_scalar($value)) {
+                throw new \LogicException(sprintf('Controller attributes cannot contain non-scalar values (value for key "%s" is not a scalar).', $key));
             }
         }
     }

--- a/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/RoutableFragmentRenderer.php
@@ -40,12 +40,17 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
      * Generates a fragment URI for a given controller.
      *
      * @param ControllerReference  $reference A ControllerReference instance
-     * @param Request              $request    A Request instance
+     * @param Request              $request   A Request instance
+     * @param Boolean              $strict    Whether to allow non-scalar attributes or not
      *
      * @return string A fragment URI
      */
-    protected function generateFragmentUri(ControllerReference $reference, Request $request)
+    protected function generateFragmentUri(ControllerReference $reference, Request $request, $strict = true)
     {
+        if ($strict) {
+            $this->checkNonScalar($reference->attributes);
+        }
+
         if (!isset($reference->attributes['_format'])) {
             $reference->attributes['_format'] = $request->getRequestFormat();
         }
@@ -55,5 +60,18 @@ abstract class RoutableFragmentRenderer implements FragmentRendererInterface
         $reference->query['_path'] = http_build_query($reference->attributes, '', '&');
 
         return $request->getUriForPath($this->fragmentPath.'?'.http_build_query($reference->query, '', '&'));
+    }
+
+    private function checkNonScalar($values)
+    {
+        foreach ($values as $value) {
+            if (is_array($value)) {
+                $this->checkNonScalar($value);
+            }
+
+            if (!is_scalar($value)) {
+                throw new \LogicException('Controller attributes cannot contain non-scalar values.');
+            }
+        }
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/InlineFragmentRendererTest.php
@@ -71,6 +71,24 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $strategy->render(new ControllerReference('main_controller', array('object' => $object), array()), Request::create('/'));
     }
 
+    public function testRenderWithObjectsAsAttributesPassedAsObjectsInTheController()
+    {
+        $resolver = $this->getMock('Symfony\\Component\\HttpKernel\\Controller\\ControllerResolver', array('getController'));
+        $resolver
+            ->expects($this->once())
+            ->method('getController')
+            ->will($this->returnValue(function (\stdClass $object, Bar $object1) {
+                return new Response($object1->getBar());
+            }))
+        ;
+
+        $kernel = new HttpKernel(new EventDispatcher(), $resolver);
+        $renderer = new InlineFragmentRenderer($kernel);
+
+        $response = $renderer->render(new ControllerReference('main_controller', array('object' => new \stdClass(), 'object1' => new Bar()), array()), Request::create('/'));
+        $this->assertEquals('bar', $response->getContent());
+    }
+
     /**
      * @expectedException \RuntimeException
      */
@@ -166,5 +184,14 @@ class InlineFragmentRendererTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/');
         $request->headers->set('Surrogate-Capability', 'abc="ESI/1.0"');
         $strategy->render('/', $request);
+    }
+}
+
+class Bar {
+    public $bar = 'bar';
+
+    public function getBar()
+    {
+        return $this->bar;
     }
 }

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/RoutableFragmentRendererTest.php
@@ -47,12 +47,19 @@ class RoutableFragmentRendererTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException LogicException
+     * @dataProvider      getGenerateFragmentUriDataWithNonScalar
      */
-    public function testGenerateFragmentUriWithObject()
+    public function testGenerateFragmentUriWithNonScalar($controller)
     {
-        $controller = new ControllerReference('controller', array('foo' => new Foo(), 'bar' => 'bar'), array());
-
         $this->callGenerateFragmentUriMethod($controller, Request::create('/'));
+    }
+
+    public function getGenerateFragmentUriDataWithNonScalar()
+    {
+        return array(
+            array(new ControllerReference('controller', array('foo' => new Foo(), 'bar' => 'bar'), array())),
+            array(new ControllerReference('controller', array('foo' => array('foo' => 'foo'), 'bar' => array('bar' => new Foo())), array())),
+        );
     }
 
     private function callGenerateFragmentUriMethod(ControllerReference $reference, Request $request)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8263 |
| License | MIT |
| Doc PR | n/a |

When using the `render()` function in Twig with a `controller()` reference, the attributes can contain non-scalar. That's fine for the inline strategy, but it cannot work for other strategies as it then involves a proper HTTP request.

So, this PR properly throw an exception in such situations to avoid difficult to find bugs.
