### PR TITLE
[WebProfiler] Can't consult the exception panel when there is an exception

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Controller/ExceptionController.php
@@ -96,7 +96,7 @@ class ExceptionController
             return new Response($handler->getStylesheet($exception));
         }
 
-        return new Response($this->twig->render('@WebProfiler/Collector/exception.css.twig'), 200, 'text/css');
+        return new Response($this->twig->render('@WebProfiler/Collector/exception.css.twig'), 200, array('Content-Type' => 'text/css'));
     }
 
     protected function getTemplate()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no (not yet) |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | not reported yet AFAIK |
| License | MIT |
| Doc PR | none |

When consulting the Exception Panel of the Web Profiler, there was an exception stating that the ResponseHeaderBag expects an array as a typehint, and it has a string instead

```
An exception has been thrown during the rendering of a template ("Catchable Fatal Error: Argument 1 passed to Symfony\Component\HttpFoundation\ResponseHeaderBag::__construct() must be of the type array, string given
```

This was induced in the commit 6d2135b.

The thing is, as I already discussed on IRC with @lsmith77, I think it is strange that the `Response`'s constructor does not have a typehint on the `$headers` parameter, as it is directly fed to the `ResponseHeaderBag`, on the very first instruction of the mentionned controller, which provokes the mentionned error. So either we can add the typehint on the Response, or we can also typehint the parameter :

``` php
<?php

class Response
{
    // ...
    public function __construct($content = '', $status = 200, $headers = array())
    {
        $this->headers = new ResponseHeaderBag((array) $headers);
    }

    // ...
}
```

Though I think it is not as neat as the typehint directly on the parameter, but  I heard that it was a no-go to add a typehint on object's constructor, as this could be a potential BC Break. Is it still the case ? Even though this call are here for at least 2 years now...

Cheers.
