### PR TITLE
[Console] Make DialogHelper respect interaction settings

### DIFF
--- a/src/Symfony/Component/Console/Application.php
+++ b/src/Symfony/Component/Console/Application.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputAwareInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -895,6 +896,12 @@ class Application
      */
     protected function doRunCommand(Command $command, InputInterface $input, OutputInterface $output)
     {
+        foreach ($command->getHelperSet() as $helper) {
+            if ($helper instanceof InputAwareInterface) {
+                $helper->setInput($input);
+            }
+        }
+
         if (null === $this->dispatcher) {
             return $command->run($input, $output);
         }

--- a/src/Symfony/Component/Console/Helper/DialogHelper.php
+++ b/src/Symfony/Component/Console/Helper/DialogHelper.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Formatter\OutputFormatterStyle;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class DialogHelper extends Helper
+class DialogHelper extends InputAwareHelper
 {
     private $inputStream;
     private static $shell;
@@ -98,6 +98,10 @@ class DialogHelper extends Helper
      */
     public function ask(OutputInterface $output, $question, $default = null, array $autocomplete = null)
     {
+        if ($this->input && !$this->input->isInteractive()) {
+            return $default;
+        }
+
         $output->write($question);
 
         $inputStream = $this->inputStream ?: STDIN;

--- a/src/Symfony/Component/Console/Helper/HelperSet.php
+++ b/src/Symfony/Component/Console/Helper/HelperSet.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Command\Command;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class HelperSet
+class HelperSet implements \IteratorAggregate
 {
     private $helpers;
     private $command;
@@ -100,5 +100,10 @@ class HelperSet
     public function getCommand()
     {
         return $this->command;
+    }
+
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->helpers);
     }
 }

--- a/src/Symfony/Component/Console/Helper/InputAwareHelper.php
+++ b/src/Symfony/Component/Console/Helper/InputAwareHelper.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Helper;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputAwareInterface;
+
+/**
+ * An implementation of InputAwareInterface for Helpers.
+ *
+ * @author Wouter J <waldio.webdesign@gmail.com>
+ */
+abstract class InputAwareHelper extends Helper implements InputAwareInterface
+{
+    protected $input;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setInput(InputInterface $input)
+    {
+        $this->input = $input;
+    }
+}

--- a/src/Symfony/Component/Console/Input/InputAwareInterface.php
+++ b/src/Symfony/Component/Console/Input/InputAwareInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Console\Input;
+
+/**
+ * InputAwareInterface should be implemented by classes that depends on the 
+ * Console Input.
+ *
+ * @author Wouter J <waldio.webdesign@gmail.com>
+ */
+interface InputAwareInterface
+{
+    /**
+     * Sets the Console Input.
+     *
+     * @param InputInterface
+     */
+    public function setInput(InputInterface $input);
+}

--- a/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/DialogHelperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\Console\Tests\Helper;
 
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Helper\DialogHelper;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Helper\FormatterHelper;
@@ -151,6 +152,18 @@ class DialogHelperTest extends \PHPUnit_Framework_TestCase
         } catch (\InvalidArgumentException $e) {
             $this->assertEquals($error, $e->getMessage());
         }
+    }
+
+    public function testNoInteration()
+    {
+        $dialog = new DialogHelper();
+
+        $input = new ArrayInput(array());
+        $input->setInteractive(false);
+
+        $dialog->setInput($input);
+
+        $this->assertEquals('not yet', $dialog->ask($this->getOutputStream(), 'Do you have a job?', 'not yet'));
     }
 
     protected function getInputStream($input)

--- a/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
+++ b/src/Symfony/Component/Console/Tests/Helper/HelperSetTest.php
@@ -111,6 +111,23 @@ class HelperSetTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($cmd, $helperset->getCommand(), '->getCommand() retrieves stored command');
     }
 
+    /**
+     * @covers \Symfony\Component\Console\Helper\HelperSet::getIterator
+     */
+    public function testIteration()
+    {
+        $helperset = new HelperSet();
+        $helperset->set($this->getGenericMockHelper('fake_helper_01', $helperset));
+        $helperset->set($this->getGenericMockHelper('fake_helper_02', $helperset));
+
+        $helpers = array('fake_helper_01', 'fake_helper_02');
+        $i = 0;
+
+        foreach ($helperset as $helper) {
+            $this->assertEquals($helpers[$i++], $helper->getName());
+        }
+    }
+
    /**
      * Create a generic mock for the helper interface. Optionally check for a call to setHelperSet with a specific
      * helperset instance.


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8079 |
| License | MIT |
| Doc PR | - |

This is based on @cordoval's #8366, but it tries to not break BC and to be a little more userfriendly.

@stof I can't seem to follow the infinite loop you talked about in #8366 . `DialogHelper::ask` will return the default, which is `null`, that breaks the while loop and it returns the default.
