### PR TITLE
[Process] Fixed #8455: PhpExecutableFinder::find() does not always return the correct binary

### DIFF
--- a/src/Symfony/Component/Process/PhpExecutableFinder.php
+++ b/src/Symfony/Component/Process/PhpExecutableFinder.php
@@ -34,7 +34,7 @@ class PhpExecutableFinder
     public function find()
     {
         // PHP_BINARY return the current sapi executable
-        if (defined('PHP_BINARY') && PHP_BINARY && ('cli' === PHP_SAPI)) {
+        if (defined('PHP_BINARY') && PHP_BINARY && ('cli' === PHP_SAPI) && is_file(PHP_BINARY)) {
             return PHP_BINARY;
         }
 


### PR DESCRIPTION
Since `PHP_BINARY` is the very first approach considered, there is no way to use a workaround like setting the `PHP_PATH`.

Checking `PHP_PATH` could potentially be put before checking `PHP_BINARY`: that would avoid an extra function call (and system call), at the price of a small BC_BREAK, but I think it's better in this case to have a solution that doesn't force people to set the `PHP_PATH` environment variable.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8455 |
| License | MIT |
| Doc PR | none |
