### PR TITLE
[Config] Fixed error messages of min/max validation methods

### DIFF
--- a/src/Symfony/Component/Config/Definition/NumericNode.php
+++ b/src/Symfony/Component/Config/Definition/NumericNode.php
@@ -39,10 +39,10 @@ class NumericNode extends ScalarNode
 
         $errorMsg = null;
         if (isset($this->min) && $value < $this->min) {
-            $errorMsg = sprintf('The value %s is too small for path "%s". Should be greater than: %s', $value, $this->getPath(), $this->min);
+            $errorMsg = sprintf('The value %s is too small for path "%s". Should be greater than or equal to %s', $value, $this->getPath(), $this->min);
         }
         if (isset($this->max) && $value > $this->max) {
-            $errorMsg = sprintf('The value %s is too big for path "%s". Should be less than: %s', $value, $this->getPath(), $this->max);
+            $errorMsg = sprintf('The value %s is too big for path "%s". Should be less than or equal to %s', $value, $this->getPath(), $this->max);
         }
         if (isset($errorMsg)) {
             $ex = new InvalidConfigurationException($errorMsg);

--- a/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
+++ b/src/Symfony/Component/Config/Tests/Definition/Builder/NumericNodeDefinitionTest.php
@@ -39,7 +39,7 @@ class NumericNodeDefinitionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 4 is too small for path "foo". Should be greater than: 5
+     * @expectedExceptionMessage The value 4 is too small for path "foo". Should be greater than or equal to 5
      */
     public function testIntegerMinAssertion()
     {
@@ -49,7 +49,7 @@ class NumericNodeDefinitionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 4 is too big for path "foo". Should be less than: 3
+     * @expectedExceptionMessage The value 4 is too big for path "foo". Should be less than or equal to 3
      */
     public function testIntegerMaxAssertion()
     {
@@ -66,7 +66,7 @@ class NumericNodeDefinitionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 400 is too small for path "foo". Should be greater than: 500
+     * @expectedExceptionMessage The value 400 is too small for path "foo". Should be greater than or equal to 500
      */
     public function testFloatMinAssertion()
     {
@@ -76,7 +76,7 @@ class NumericNodeDefinitionTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage The value 4.3 is too big for path "foo". Should be less than: 0.3
+     * @expectedExceptionMessage The value 4.3 is too big for path "foo". Should be less than or equal to 0.3
      */
     public function testFloatMaxAssertion()
     {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This PR fixes the error messages of the configuration validation methods `min` and `max`. The error message was "Should be greater/less than: <value>" but should be "Should be greater/less than or equal to <value>".
