### PR TITLE
Reverts recent change that added type coercion for JSON responses

### DIFF
--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -89,7 +89,7 @@ class JsonResponse extends Response
     public function setData($data = array())
     {
         // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
-        $this->data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT | JSON_NUMERIC_CHECK);
+        $this->data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT );
 
         return $this->update();
     }


### PR DESCRIPTION
We shouldn't be coercing primitive in the array provided to setData.
