### PR TITLE
 	[HttpFoundation] Fixed NativeSessionStorage:regenerate when does not exists

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -211,9 +211,13 @@ class NativeSessionStorage implements SessionStorageInterface
 
         // workaround for https://bugs.php.net/bug.php?id=61470 as suggested by David Grudl
         session_write_close();
-        $backup = $_SESSION;
-        session_start();
-        $_SESSION = $backup;
+        if (isset($_SESSION)) {
+            $backup = $_SESSION;
+            session_start();
+            $_SESSION = $backup;
+        } else {
+            session_start();
+        }
 
         return $ret;
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8460 |
| License | MIT |
| Doc PR | - |

**warning** I did not try to reproduce this bug, so I am not sure it fixes the issue. I just open a PR with the suggested patch. Tests for http foundation are OK. I am not sur it's the best way to fix this issue as I do not understand why symfony reach this code if $_SESSION is not set. 
