### PR TITLE
[Bridge][Twig] Pass locale to the ControllerReference - Fixes #6932

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -38,7 +38,7 @@ class HttpKernelExtension extends \Twig_Extension
         return array(
             'render'     => new \Twig_Function_Method($this, 'renderFragment', array('is_safe' => array('html'))),
             'render_*'   => new \Twig_Function_Method($this, 'renderFragmentStrategy', array('is_safe' => array('html'))),
-            'controller' => new \Twig_Function_Method($this, 'controller'),
+            'controller' => new \Twig_Function_Method($this, 'controller', array('needs_context' => true)),
         );
     }
 
@@ -76,8 +76,12 @@ class HttpKernelExtension extends \Twig_Extension
         return $this->handler->render($uri, $strategy, $options);
     }
 
-    public function controller($controller, $attributes = array(), $query = array())
+    public function controller(array $context, $controller, $attributes = array(), $query = array())
     {
+        if (isset($context['app'])) {
+            $attributes['_locale'] = $context['app']->getRequest()->getLocale();
+        }
+
         return new ControllerReference($controller, $attributes, $query);
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #6932 |
| License | MIT |
| Doc PR | - |

The fix consists in passing the locale in the controller reference,
by making the controller twig function aware of the current context.
There are a few additional checks for the request scope, in order
not to break compatibility when using the console.
