### PR TITLE
[Translation] added translation domain cascading functionnality

### DIFF
--- a/src/Symfony/Component/Translation/MessageCatalogue.php
+++ b/src/Symfony/Component/Translation/MessageCatalogue.php
@@ -94,8 +94,12 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function has($id, $domain = 'messages')
     {
-        if (isset($this->messages[$domain][$id])) {
-            return true;
+        $domains = is_array($domain) ? $domain : array($domain);
+
+        foreach ($domains as $domain) {
+            if (isset($this->messages[$domain][$id])) {
+                return true;
+            }
         }
 
         if (null !== $this->fallbackCatalogue) {
@@ -110,7 +114,15 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function defines($id, $domain = 'messages')
     {
-        return isset($this->messages[$domain][$id]);
+        $domains = is_array($domain) ? $domain : array($domain);
+
+        foreach ($domains as $domain) {
+            if (isset($this->messages[$domain][$id])) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -120,12 +132,17 @@ class MessageCatalogue implements MessageCatalogueInterface, MetadataAwareInterf
      */
     public function get($id, $domain = 'messages')
     {
-        if (isset($this->messages[$domain][$id])) {
-            return $this->messages[$domain][$id];
+        $domains = is_array($domain) ? $domain : array($domain);
+
+        foreach ($domains as $domain) {
+            if (isset($this->messages[$domain][$id])) {
+                return $this->messages[$domain][$id];
+            }
+
         }
 
         if (null !== $this->fallbackCatalogue) {
-            return $this->fallbackCatalogue->get($id, $domain);
+            return $this->fallbackCatalogue->get($id, $domains);
         }
 
         return $id;

--- a/src/Symfony/Component/Translation/MessageCatalogueInterface.php
+++ b/src/Symfony/Component/Translation/MessageCatalogueInterface.php
@@ -68,7 +68,7 @@ interface MessageCatalogueInterface
      * Checks if a message has a translation.
      *
      * @param string $id     The message id
-     * @param string $domain The domain name
+     * @param string $domain The domain name, or an array of domain names
      *
      * @return Boolean true if the message has a translation, false otherwise
      *
@@ -80,7 +80,7 @@ interface MessageCatalogueInterface
      * Checks if a message has a translation (it does not take into account the fallback mechanism).
      *
      * @param string $id     The message id
-     * @param string $domain The domain name
+     * @param string $domain The domain name, or an array of domain names
      *
      * @return Boolean true if the message has a translation, false otherwise
      *
@@ -91,8 +91,8 @@ interface MessageCatalogueInterface
     /**
      * Gets a message translation.
      *
-     * @param string $id     The message id
-     * @param string $domain The domain name
+     * @param string       $id     The message id
+     * @param array|string $domain The domain name, or an array of domain names
      *
      * @return string The message translation
      *

--- a/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
+++ b/src/Symfony/Component/Translation/Tests/MessageCatalogueTest.php
@@ -44,7 +44,10 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($catalogue->has('foo', 'domain1'));
         $this->assertFalse($catalogue->has('bar', 'domain1'));
+        $this->assertTrue($catalogue->has('bar', array('domain1', 'domain2')));
+        $this->assertFalse($catalogue->has('baz', array('domain1', 'domain2')));
         $this->assertFalse($catalogue->has('foo', 'domain88'));
+        $this->assertFalse($catalogue->has('foo', array('domain69', 'domain88')));
     }
 
     public function testGetSet()
@@ -54,6 +57,7 @@ class MessageCatalogueTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('foo', $catalogue->get('foo', 'domain1'));
         $this->assertEquals('foo1', $catalogue->get('foo1', 'domain1'));
+        $this->assertEquals('foo1', $catalogue->get('foo1', array('domain2', 'domain1')));
     }
 
     public function testAdd()

--- a/src/Symfony/Component/Translation/TranslatorInterface.php
+++ b/src/Symfony/Component/Translation/TranslatorInterface.php
@@ -23,10 +23,10 @@ interface TranslatorInterface
     /**
      * Translates the given message.
      *
-     * @param string $id         The message id (may also be an object that can be cast to string)
-     * @param array  $parameters An array of parameters for the message
-     * @param string $domain     The domain for the message
-     * @param string $locale     The locale
+     * @param string       $id         The message id (may also be an object that can be cast to string)
+     * @param array        $parameters An array of parameters for the message
+     * @param array|string $domain     The domain for the message or an array of domains for cascading lookup
+     * @param string       $locale     The locale
      *
      * @return string The translated string
      *
@@ -37,11 +37,11 @@ interface TranslatorInterface
     /**
      * Translates the given choice message by choosing a translation according to a number.
      *
-     * @param string  $id         The message id (may also be an object that can be cast to string)
-     * @param integer $number     The number to use to find the indice of the message
-     * @param array   $parameters An array of parameters for the message
-     * @param string  $domain     The domain for the message
-     * @param string  $locale     The locale
+     * @param string       $id         The message id (may also be an object that can be cast to string)
+     * @param integer      $number     The number to use to find the indice of the message
+     * @param array        $parameters An array of parameters for the message
+     * @param array|string $domain     The domain for the message or an array of domains for cascading lookup
+     * @param string       $locale     The locale
      *
      * @return string The translated string
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
| Doc PR | symfony/symfony-docs#2825 |

With this PR, you can optionally pass an array of domains instead of a simple string to `Translator::trans()` or `Translator::transChoice`, allowing for multi-level fallbacks.

Added new tests specifics to this feature.
