### PR TITLE
[Router] added static requirement optimization to php matcher dumper

### DIFF
--- a/src/Symfony/Component/Routing/Tests/Fixtures/dumper/optimized_route_matcher.php
+++ b/src/Symfony/Component/Routing/Tests/Fixtures/dumper/optimized_route_matcher.php
@@ -1,0 +1,35 @@
+<?php
+
+use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\Routing\Exception\ResourceNotFoundException;
+use Symfony\Component\Routing\RequestContext;
+
+/**
+ * ProjectUrlMatcher
+ *
+ * This class has been auto-generated
+ * by the Symfony Routing Component.
+ */
+class ProjectUrlMatcher extends Symfony\Component\Routing\Matcher\UrlMatcher
+{
+    /**
+     * Constructor.
+     */
+    public function __construct(RequestContext $context)
+    {
+        $this->context = $context;
+    }
+
+    public function match($pathinfo)
+    {
+        $allow = array();
+        $pathinfo = rawurldecode($pathinfo);
+
+        // name
+        if ($pathinfo === '/test/static') {
+            return array (  'param' => 'static',  '_route' => 'name',);
+        }
+
+        throw 0 < count($allow) ? new MethodNotAllowedException(array_unique($allow)) : new ResourceNotFoundException();
+    }
+}

--- a/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
+++ b/src/Symfony/Component/Routing/Tests/Matcher/Dumper/PhpMatcherDumperTest.php
@@ -258,4 +258,14 @@ class PhpMatcherDumperTest extends \PHPUnit_Framework_TestCase
            array($rootprefixCollection, 'url_matcher3.php', array())
         );
     }
+
+    public function testOptimizedRouteDump()
+    {
+        $collection = new RouteCollection();
+        $collection->add('name', new Route('/test/{param}', array(), array('param' => 'static')));
+        $dumper = new PhpMatcherDumper($collection);
+        $fixture = __DIR__.'/../../Fixtures/dumper/optimized_route_matcher.php';
+
+        $this->assertStringEqualsFile($fixture, $dumper->dump());
+    }
 }


### PR DESCRIPTION
This PR attempts to apply #6838 suggestion.
@Tobion could you please take a look and tell me what you think?

This comment should be taken in account https://github.com/symfony/symfony/issues/6838#issuecomment-21033208, this optimization could be performed by the `RouteCompiler` but it would require #5410 to be fixed (which may never happen).

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
