### PR TITLE
[bridge] [propel1] [ModelChoiceList] fix issue #8499 call getPrimaryKey on a non object

### DIFF
--- a/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
+++ b/src/Symfony/Bridge/Propel1/Form/ChoiceList/ModelChoiceList.php
@@ -289,7 +289,7 @@ class ModelChoiceList extends ObjectChoiceList
         $choices = $this->fixChoices($models);
         foreach ($this->getChoices() as $i => $choice) {
             foreach ($choices as $j => $givenChoice) {
-                if ($this->getIdentifierValues($choice) === $this->getIdentifierValues($givenChoice)) {
+                if (null !== $givenChoice && $this->getIdentifierValues($choice) === $this->getIdentifierValues($givenChoice)) {
                     $indices[] = $i;
                     unset($choices[$j]);
 
@@ -414,6 +414,10 @@ class ModelChoiceList extends ObjectChoiceList
         // readonly="true" models do not implement Persistent.
         if ($model instanceof BaseObject && method_exists($model, 'getPrimaryKey')) {
             return array($model->getPrimaryKey());
+        }
+
+        if (null === $model) {
+            return array();
         }
 
         return $model->getPrimaryKeys();

--- a/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/ModelChoiceListTest.php
+++ b/src/Symfony/Bridge/Propel1/Tests/Form/ChoiceList/ModelChoiceListTest.php
@@ -199,4 +199,16 @@ class ModelChoiceListTest extends Propel1TestCase
 
         $this->assertEquals(array(1), $choiceList->getIndicesForChoices(array($choosenItem)));
     }
+
+    public function testGetIndicesForNullChoices()
+    {
+        $item = new Item(1, 'Foo');
+        $choiceList = new ModelChoiceList(
+            self::ITEM_CLASS,
+            'value',
+            array($item)
+        );
+
+        $this->assertEquals(array(), $choiceList->getIndicesForChoices(array(null)));
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8499 |
| License | MIT |
| Doc PR | no |

This fix an issue #8499 introduced by the PR #8223

CC @willdurand @havvg
