### PR TITLE
[Serializer] Added XML attributes support in XmlEncoder

### DIFF
--- a/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
+++ b/src/Symfony/Component/Serializer/Encoder/XmlEncoder.php
@@ -47,7 +47,7 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
 
         $xmlRootNodeName = $this->resolveXmlRootName($context);
 
-        $this->dom = new \DOMDocument();
+        $this->dom = $this->createDomDocument($context);
         $this->format = $format;
 
         if (null !== $data && !is_scalar($data)) {
@@ -426,4 +426,32 @@ class XmlEncoder extends SerializerAwareEncoder implements EncoderInterface, Dec
             : $this->rootNodeName;
     }
 
+    /**
+     * Create a DOM document, taking serializer options into account.
+     *
+     * @param array $context options that the encoder has access to.
+     *
+     * @return \DOMDocument
+     */
+    private function createDomDocument(array $context)
+    {
+        $document = new \DOMDocument();
+
+        // Set an attribute on the DOM document specifying, as part of the XML declaration,
+        $xmlOptions = array(
+            // the version number of the document
+            'xml_version' => 'xmlVersion',
+            // the encoding of the document
+            'xml_encoding' => 'encoding',
+            // whether the document is standalone
+            'xml_standalone' => 'xmlStandalone',
+        );
+        foreach ($xmlOptions as $xmlOption => $documentProperty) {
+            if (isset($context[$xmlOption])) {
+                $document->$documentProperty = $context[$xmlOption];
+            }
+        }
+
+        return $document;
+    }
 }

--- a/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
+++ b/src/Symfony/Component/Serializer/Tests/Encoder/XmlEncoderTest.php
@@ -118,6 +118,23 @@ class XmlEncoderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $this->encoder->encode($array, 'xml'));
     }
 
+    public function testEncodeXmlAttributes()
+    {
+        $xml = simplexml_load_string('<firstname>Peter</firstname>');
+        $array = array('person' => $xml);
+
+        $expected = '<?xml version="1.1" encoding="utf-8" standalone="yes"?>'."\n".
+            '<response><person><firstname>Peter</firstname></person></response>'."\n";
+
+        $context = array(
+            'xml_version' => '1.1',
+            'xml_encoding' => 'utf-8',
+            'xml_standalone' => true,
+        );
+
+        $this->assertSame($expected, $this->encoder->encode($array, 'xml', $context));
+    }
+
     public function testEncodeScalarRootAttributes()
     {
         $array = array(


### PR DESCRIPTION
This is a rebase and refactoring of #8424.

---

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8424 |
| License | MIT |
| Doc PR | - |

---

| New Code | Result |
| --- | --- |
| Code coverage | 100% |
| PSR-2 | No violations |
| PHP-CS-Fixer | No changes |

---
### TODO
- [ ] **Q**: I looked through `symfony-docs` for any mention of `xml_root_node_name` which is already implemented, but failed to find any. How to best document those new additions?
