### PR TITLE
[HttpKernel] [FrameworkBundle] Introduce Rails-like default response headers to control browser-side security features

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -82,6 +82,7 @@ class Configuration implements ConfigurationInterface
         $this->addValidationSection($rootNode);
         $this->addAnnotationsSection($rootNode);
         $this->addSerializerSection($rootNode);
+        $this->addResponseSection($rootNode);
 
         return $treeBuilder;
     }
@@ -410,6 +411,42 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('serializer')
                     ->info('serializer configuration')
                     ->canBeEnabled()
+                ->end()
+            ->end()
+        ;
+    }
+
+    private function addResponseSection(ArrayNodeDefinition $rootNode)
+    {
+        $default = array(
+            'X-Content-Type-Options' => 'nosniff',
+        );
+
+        $example = array(
+            'X-Content-Type-Options' => 'nosniff',
+            'X-XSS-Protection'       => '1; mode=block',
+            'X-Frame-Options'        => 'SAMEORIGIN',
+        );
+
+        $rootNode
+            ->children()
+                ->arrayNode('response')
+                    ->info('response configuration')
+                    ->addDefaultsIfNotSet()
+                    ->fixXmlConfig('default_header')
+                    ->children()
+                        ->arrayNode('default_headers')
+                            ->normalizeKeys(false)
+                            ->useAttributeAsKey('name')
+                            ->example($example)
+                            ->defaultValue($default)
+                            ->beforeNormalization()
+                                ->ifNull()
+                                ->then(function($v) use ($default) { return $default; })
+                            ->end()
+                            ->prototype('scalar')->end()
+                        ->end()
+                    ->end()
                 ->end()
             ->end()
         ;

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -73,6 +73,10 @@ class FrameworkExtension extends Extension
         $container->setParameter('kernel.trusted_proxies', $config['trusted_proxies']);
         $container->setParameter('kernel.default_locale', $config['default_locale']);
 
+        if (isset($config['response'])) {
+            $container->setParameter('kernel.default_response_headers', $config['response']['default_headers']);
+        }
+
         if (!empty($config['test'])) {
             $loader->load('test.xml');
         }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -20,6 +20,7 @@
             <xsd:element name="translator" type="translator" minOccurs="0" maxOccurs="1" />
             <xsd:element name="validation" type="validation" minOccurs="0" maxOccurs="1" />
             <xsd:element name="annotations" type="annotations" minOccurs="0" maxOccurs="1" />
+            <xsd:element name="response" type="response" minOccurs="0" maxOccurs="1" />
         </xsd:all>
 
         <xsd:attribute name="http-method-override" type="xsd:boolean" />
@@ -28,6 +29,16 @@
         <xsd:attribute name="secret" type="xsd:string" />
         <xsd:attribute name="default-locale" type="xsd:string" />
         <xsd:attribute name="test" type="xsd:boolean" />
+    </xsd:complexType>
+
+    <xsd:complexType name="response">
+        <xsd:sequence>
+            <xsd:element name="default-header" type="default-header" minOccurs="0" maxOccurs="unbounded" />
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <xsd:complexType name="default-header" mixed="true">
+        <xsd:attribute name="name" type="xsd:string" />
     </xsd:complexType>
 
     <xsd:complexType name="form">

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/web.xml
@@ -28,6 +28,7 @@
         <service id="response_listener" class="%response_listener.class%">
             <tag name="kernel.event_subscriber" />
             <argument>%kernel.charset%</argument>
+            <argument>%kernel.default_response_headers%</argument>
         </service>
 
         <service id="streamed_response_listener" class="%streamed_response_listener.class%">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/ConfigurationTest.php
@@ -129,7 +129,12 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             ),
             'serializer'          => array(
                 'enabled' => false
-            )
+            ),
+            'response'            => array(
+                'default_headers' => array(
+                    'X-Content-Type-Options' => 'nosniff',
+                ),
+            ),
         );
     }
 }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -70,5 +70,11 @@ $container->loadFromExtension('framework', array(
         'debug' => true,
         'file_cache_dir' => '%kernel.cache_dir%/annotations',
     ),
-    'ide' => 'file%%link%%format'
+    'ide' => 'file%%link%%format',
+    'response' => array(
+        'default_headers' => array(
+            'X-Foo' => 'Bar',
+            'X-Bar' => 'Foo',
+        ),
+    ),
 ));

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -36,5 +36,9 @@
         <framework:translator enabled="true" fallback="fr" />
         <framework:validation enabled="true" cache="apc" />
         <framework:annotations cache="file" debug="true" file-cache-dir="%kernel.cache_dir%/annotations" />
+        <framework:response>
+            <framework:default-header name="X-Foo">Bar</framework:default-header>
+            <framework:default-header name="X-Bar">Foo</framework:default-header>
+        </framework:response>
     </framework:config>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -55,3 +55,7 @@ framework:
         debug:   true
         file_cache_dir: %kernel.cache_dir%/annotations
     ide: file%%link%%format
+    response:
+        default_headers:
+            "X-Foo" : "Bar"
+            "X-Bar" : "Foo"

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/FrameworkExtensionTest.php
@@ -284,6 +284,17 @@ abstract class FrameworkExtensionTest extends TestCase
         $this->assertStringEndsWith('TestBundle'.DIRECTORY_SEPARATOR.'Resources'.DIRECTORY_SEPARATOR.'config'.DIRECTORY_SEPARATOR.'validation.xml', $xmlArgs[1]);
     }
 
+    public function testDefaultResponseHeader()
+    {
+        $container = $this->createContainerFromFile('full');
+
+        $this->assertTrue($container->hasParameter('kernel.default_response_headers'), '->registerValidationConfiguration() loads validator.xml');
+        $this->assertEquals(array(
+            'X-Foo' => 'Bar',
+            'X-Bar' => 'Foo',
+        ), $container->getParameter('kernel.default_response_headers'), '->registerValidationConfiguration() loads validator.xml');
+    }
+
     protected function createContainer(array $data = array())
     {
         return new ContainerBuilder(new ParameterBag(array_merge(array(

--- a/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
+++ b/src/Symfony/Component/HttpKernel/EventListener/ResponseListener.php
@@ -25,9 +25,12 @@ class ResponseListener implements EventSubscriberInterface
 {
     private $charset;
 
-    public function __construct($charset)
+    private $defaultHeaders = array();
+
+    public function __construct($charset, $defaultHeaders = array())
     {
         $this->charset = $charset;
+        $this->defaultHeaders = $defaultHeaders;
     }
 
     /**
@@ -42,6 +45,9 @@ class ResponseListener implements EventSubscriberInterface
         }
 
         $response = $event->getResponse();
+        foreach ($this->defaultHeaders as $key => $value) {
+            $response->headers->set($key, $value, false);
+        }
 
         if (null === $response->getCharset()) {
             $response->setCharset($this->charset);

--- a/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/EventListener/ResponseListenerTest.php
@@ -96,4 +96,23 @@ class ResponseListenerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('ISO-8859-15', $response->getCharset());
     }
+
+    public function testFiltersSetsDefaultHeaders()
+    {
+        $listener = new ResponseListener('UTF-8', array(
+            'X-Add'     => 'default-value',
+            'X-Not-Add' => 'default-value',
+        ));
+        $this->dispatcher->addListener(KernelEvents::RESPONSE, array($listener, 'onKernelResponse'), 1);
+
+        $response = new Response();
+        $response->headers->set('X-Not-Add', 'user-value');
+
+        $request = Request::create('/');
+        $event = new FilterResponseEvent($this->kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $this->dispatcher->dispatch(KernelEvents::RESPONSE, $event);
+
+        $this->assertEquals('default-value', $response->headers->get('X-Add'));
+        $this->assertEquals('user-value', $response->headers->get('X-Not-Add'));
+    }
 }


### PR DESCRIPTION
Rails 4 provides new `default_headers` to send some security headers by default. Such headers control browser-side security features.

It is also good for Symfony because it provides transparent security to users like output escaping and CSRF protection.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | not yet |
## TODO
- [ ] submit changes to the documentation
- [ ] gather feedback for my changes

(NOTE: adding this feature is finished, I think, but we should consider about default configurations as I discuss later)
## Security headers?

Modern web browsers provide some security features (to mitigate effects of frequent vulnerabilities, or to avoid new attack methods e.g. Clickjacking). To use them, setting via response headers like the followings:
- [X-Content-Type-Options](http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx): disable [MIME-sniffing](http://mimesniff.spec.whatwg.org/), sometimes this feature brings some vulnerabilities like XSS, and make refer the response as a certain MIME type specified in the Content-Type header
- [X-XSS-Protection](http://blogs.msdn.com/b/ie/archive/2008/07/02/ie8-security-part-iv-the-xss-filter.aspx): control browser-side XSS filter mode (disable / stop-rendering if attack detected (default) / block-rendering if attack detected)
- [X-Frame-Options](http://tools.ietf.org/html/draft-ietf-websec-x-frame-options-00): deny rendering within a frame to prevent from [Clickjacking](https://www.owasp.org/index.php/Clickjacking)
- [Content-Security-Policy, X-Content-Security-Policy, X-WebKit-CSP](https://www.owasp.org/index.php/Content_Security_Policy): configure Content Security Policy to add some restriction (e.g. deny inline JavaScript)
- [Strict-Transport-Security](http://tools.ietf.org/html/rfc6797): enables HTTP-Strict-Transport-Security (HSTS) to indicate "always load via HTTPS" message to the browser
- [X-UA-Compatible](http://msdn.microsoft.com/en-us//library/cc288325%28v=vs.85%29.aspx): force rendering mode in IE
- [Access-Control-Allow-Origin](https://developer.mozilla.org/en-US/docs/HTTP/Access_control_CORS): change [Same-Origin Policy (SOP)](http://tools.ietf.org/html/rfc6454) restriction to enable [Cross-Origin Resource Sharing (CORS)](http://www.w3.org/TR/cors/)

About browser support situations, you can get information from http://www.browserscope.org/?category=security
## Configuration

User can configure default response header like the following:

```
framework:
    response:
        default_headers:
            "X-Content-Type-Options": "nosniff"
            "X-XSS-Protection": "1; mode=block"
            "X-Frame-Options": "SAMEORIGIN"
            "X-Foo": "Bar"
```
## Default Configuration

I think about the default configuration is very important and we need to discuss since it may affect existing projects. (Currently, only `X-Content-Type-Options: sniff` is defined as default header)

`X-Content-Type-Options: sniff` is almost essential because Symfony always sends a valid Content-Type so it keeps current behaviours.

And also `X-XSS-Protection: 1; mode=block` does not break anything, but in false-negative situation, the end-user will see a white-screen-of-death (by block-mode of XSS filter) instead of corrupt HTML string (by default-mode).

`X-Frame-Options` is the missing protection against Clickjacking but it damages iframe-embed page so we cannot adopt this as default but we should recommend use this.

Content Security Policy is a very powerful feature but it might be difficult for many users to control.

A preferred value of`Strict-Transport-Security`, `X-UA-Compatible` and `Access-Control-Allow-Origin` cannot be decided without user's judgment.

FYI, here is the default configuration of Rails 4:

```
config.action_dispatch.default_headers = {
  'X-Frame-Options' => 'SAMEORIGIN',
  'X-XSS-Protection' => '1; mode=block',
  'X-Content-Type-Options' => 'nosniff'
}
```
## References
- https://github.com/rails/rails/pull/7302 (Rails discussion)
- https://www.owasp.org/index.php/List_of_useful_HTTP_headers
- http://recxltd.blogspot.com/2012/03/seven-web-server-http-headers-that.html
- http://homakov.blogspot.com/2012/06/saferweb-with-new-features-come-new.html
