### PR TITLE
[DependencyInjection][2.3] Add exception for service name not dumpable in PHP

### DIFF
--- a/CHANGELOG-2.2.md
+++ b/CHANGELOG-2.2.md
@@ -7,6 +7,20 @@ in 2.2 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.2.0...v2.2.1
 
+* 2.2.4 (2013-07-15)
+
+ * 52e530d: Fixed NativeSessionStorage:regenerate when does not exists
+ * bb59f40: Reverts JSON_NUMERIC_CHECK
+ * 9c5f8c6: [Yaml] removed wrong comment removal inside a string block
+ * 2dc1ee0: [HtppKernel] fixed inline fragment renderer
+ * 06b69b8: fixed inline fragment renderer
+ * 91bb757: ProgressHelper shows percentage complete.
+ * 9d1004b: fix handling of a default 'template' as a string
+ * 82dbaee: [HttpKernel] fixed the inline renderer when passing objects as attributes (closes #7124)
+ * 6dbd1e1: [WebProfiler] fix content-type parameter
+ * a830001: Passed the config when building the Configuration in ConfigurableExtension
+ * c875d0a: [Form] fixed INF usage which does not work on Solaris (closes #8246)
+
 * 2.2.3 (2013-06-19)
 
  * c0da3ae: [Process] Disable exception on stream_select timeout

--- a/CHANGELOG-2.3.md
+++ b/CHANGELOG-2.3.md
@@ -7,6 +7,36 @@ in 2.3 minor versions.
 To get the diff for a specific change, go to https://github.com/symfony/symfony/commit/XXX where XXX is the change hash
 To get the diff between two versions, go to https://github.com/symfony/symfony/compare/v2.3.0...v2.3.1
 
+* 2.3.2 (2013-07-17)
+
+ * bb59f40: Reverts JSON_NUMERIC_CHECK
+ * 9c5f8c6: [Yaml] removed wrong comment removal inside a string block
+ * 2dc1ee0: [HtppKernel] fixed inline fragment renderer
+ * 06b69b8: fixed inline fragment renderer
+ * 91bb757: ProgressHelper shows percentage complete.
+ * 9d1004b: fix handling of a default 'template' as a string
+ * 82dbaee: [HttpKernel] fixed the inline renderer when passing objects as attributes (closes #7124)
+ * 8bb4e4d: [DI] Fixed bug requesting non existing service from dumped frozen container
+ * 6dbd1e1: [WebProfiler] fix content-type parameter
+ * a830001: Passed the config when building the Configuration in ConfigurableExtension
+ * c875d0a: [Form] fixed INF usage which does not work on Solaris (closes #8246)
+ * ab1439e: [Console] Fixed the table rendering with multi-byte strings.
+ * c0da3ae: [Process] Disable exception on stream_select timeout
+ * 77f2aa8: [HttpFoundation] fixed issue with session_regenerate_id (closes #7380)
+ * bcbbb28: Throw exception if value is passed to VALUE_NONE input, long syntax
+ * 6b71513: fixed date type format pattern regex
+ * b5ded81: [Security] fixed usage of the salt for the bcrypt encoder (refs #8210)
+ * 842f3fa: do not re-register commands each time a Console\Application is run
+ * 0991cd0: [Process] moved env check to the Process class (refs #8227)
+ * 8764944: fix issue where $_ENV contains array vals
+ * 4139936: [DomCrawler] Fix handling file:// without a host
+ * e65723c: fix-progressbar-start
+ * aa79393: also consider alias in Container::has()
+ * de289d2: [Form] corrected interface bind() method defined against in deprecation notice
+ * 0c0a3e9: [Console] fixed regression when calling a command foo:bar if there is another one like foo:bar:baz (closes #8245)
+ * 849f3ed: [Finder] Fix SplFileInfo::getContents isn't working with ssh2 protocol
+ * 6d2135b: force the Content-Type to html in the web profiler controllers
+
 * 2.3.1 (2013-06-11)
 
  * 25e3abd: fix many-to-many Propel1 ModelChoiceList

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,12 +19,12 @@ Symfony2 is the result of the work of many people who made the code better
  - Joseph Bielawski (stloyd)
  - Jeremy Mikola (jmikola)
  - Igor Wiedler (igorw)
- - Benjamin Eberlei (beberlei)
  - Jean-François Simon (jfsimon)
+ - Benjamin Eberlei (beberlei)
+ - Jakub Zalas (jakubzalas)
  - Hugo Hamon (hhamon)
  - Eriksen Costa (eriksencosta)
  - Martin Hasoň (hason)
- - Jakub Zalas (jakubzalas)
  - Jonathan Wage (jwage)
  - William Durand (couac)
  - Alexandre Salomé (alexandresalome)
@@ -57,8 +57,8 @@ Symfony2 is the result of the work of many people who made the code better
  - Daniel Holmes (dholmes)
  - Brikou Carré (brikou)
  - John Wards (johnwards)
- - Antoine Hérault (herzult)
  - Bart van den Burg (burgov)
+ - Antoine Hérault (herzult)
  - Toni Uebernickel (havvg)
  - Tim Nagel (merk)
  - Włodzimierz Gajda (gajdaw)
@@ -70,8 +70,8 @@ Symfony2 is the result of the work of many people who made the code better
  - Fabien Pennequin (fabienpennequin)
  - excelwebzone
  - woodspire
- - Mario A. Alvarez Garcia (nomack84)
  - Douglas Greenshields (shieldo)
+ - Mario A. Alvarez Garcia (nomack84)
  - Kevin Bond (kbond)
  - Richard Miller (mr_r_miller)
  - Jacob Dreesen (jdreesen)
@@ -105,6 +105,8 @@ Symfony2 is the result of the work of many people who made the code better
  - Benjamin Dulau (dbenjamin)
  - Andreas Hucks (meandmymonkey)
  - Noel Guilbert (noel)
+ - Dmitrii Chekaliuk (lazyhammer)
+ - Dorian Villet (gnutix)
  - Guilherme Blanco (guilhermeblanco)
  - Martin Schuhfuß (usefulthink)
  - Thomas Rabaix (rande)
@@ -120,12 +122,11 @@ Symfony2 is the result of the work of many people who made the code better
  - Dustin Whittle (dustinwhittle)
  - jeff
  - Clemens Tolboom
+ - Wouter De Jong (wouterj)
  - Justin Hileman (bobthecow)
  - Sven Paulus (subsven)
- - Dmitrii Chekaliuk (lazyhammer)
  - Xavier Perez
  - Rui Marinho (ruimarinho)
- - Dorian Villet (gnutix)
  - Ray
  - Joseph Rouff (rouffj)
  - Francois Zaninotto
@@ -149,7 +150,6 @@ Symfony2 is the result of the work of many people who made the code better
  - Elnur Abdurrakhimov (elnur)
  - Matthew Lewinski (lewinski)
  - Kim Hemsø Rasmussen
- - Wouter De Jong (wouterj)
  - Dirk Pahl (dirkaholic)
  - Wouter Van Hecke
  - Gyula Sallai (salla)
@@ -186,6 +186,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Erin Millard
  - Manuel Reinhard (sprain)
  - Francesco Levorato
+ - Vitaliy Zakharov (zakharovvi)
  - Michele Orselli (orso)
  - Tom Van Looy (tvlooy)
  - Brouznouf
@@ -219,10 +220,12 @@ Symfony2 is the result of the work of many people who made the code better
  - janschoenherr
  - Emanuele Gaspari (inmarelibero)
  - Brian King
+ - Marco Pivetta (ocramius)
  - Jan Schumann
  - Ruben Gonzalez (rubenrua)
  - Antonio J. García Lagar (ajgarlag)
  - Olivier Dolbeau (odolbeau)
+ - alquerci
  - Robert Kiss (kepten)
  - Asier Illarramendi (doup)
  - Javier López (loalf)
@@ -258,12 +261,12 @@ Symfony2 is the result of the work of many people who made the code better
  - alexpods
  - Erik Trapman (eriktrapman)
  - De Cock Xavier (xdecock)
- - Vitaliy Zakharov (zakharovvi)
  - Matthijs van den Bos
  - Joel Wurtz
  - Nils Adermann (naderman)
  - Gábor Fási
  - Leevi Graham
+ - Luis Cordova (cordoval)
  - Michaël Perrin (michael.perrin)
  - sasezaki
  - Loïc Chardonnet (gnusat)
@@ -285,13 +288,13 @@ Symfony2 is the result of the work of many people who made the code better
  - Karoly Negyesi (chx)
  - jamogon
  - Miha Vrhovnik
+ - Moritz Borgmann
  - Geoffrey Tran (geoff)
  - Florian Rey (nervo)
  - Maks
  - Christian Schaefer (caefer)
  - Elliot Anderson (elliot)
  - Patrick Kaufmann
- - Marco Pivetta (ocramius)
  - Ben Ramsey (ramsey)
  - Christian Jul Jensen
  - Chris Jones (leek)
@@ -301,7 +304,6 @@ Symfony2 is the result of the work of many people who made the code better
  - Max Rath (drak3)
  - Sinan Eldem
  - DerManoMann
- - alquerci
  - Nahuel Cuesta (ncuesta)
  - Chris Boden (cboden)
  - Roumen Damianoff (roumen)
@@ -359,6 +361,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Andrew Udvare
  - Xavier Lacot (xavier)
  - Olivier Maisonneuve
+ - Eduardo Oliveira (entering)
  - Iwan van Staveren (istaveren)
  - cgonzalez
  - matt foster
@@ -370,9 +373,9 @@ Symfony2 is the result of the work of many people who made the code better
  - Gunther Konig
  - Christopher Hall (mythmakr)
  - Paul Kamer (pkamer)
+ - Reen Lokum
  - Pierre Vanliefland (pvanliefland)
  - Martin Parsiegla (spea)
- - Luis Cordova (cordoval)
  - Philipp Kräutli (pkraeutli)
  - Stefano Sala (stefano.sala)
  - frost-nzcr4
@@ -413,7 +416,6 @@ Symfony2 is the result of the work of many people who made the code better
  - Adán Lobato (adanlobato)
  - Mikhail Yurasov
  - Sam Williams
- - Moritz Borgmann
  - Daniel Cestari
  - Magnus Nordlander (magnusnordlander)
  - Adam Monsen (meonkeys)
@@ -508,6 +510,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Quique Porta
  - Aharon Perkel
  - Malaney J. Hill
+ - Cédric Girard (enk_)
  - Andy Cox (ringo)
  - Sebastian Göttschkes (sgoettschkes)
  - erikaheidi
@@ -534,13 +537,13 @@ Symfony2 is the result of the work of many people who made the code better
  - Evan Kaufman
  - Romain Geissler
  - Marcus Stöhr (dafish)
- - Eduardo Oliveira (entering)
  - Carsten Nielsen (phreaknerd)
  - Jay Severson
  - René Kerner
  - Adrien Samson (adriensamson)
  - Samuel Gordalina (gordalina)
  - Timothy Anido (xanido)
+ - Rick Prent
  - Martin Eckhardt
  - Michael Dowling (mtdowling)
  - Robert Queck
@@ -548,6 +551,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Fabian Steiner (fabstei)
  - Thomas Chmielowiec (chmielot)
  - Jānis Lukss
+ - Matthew J Mucklo
  - fdgdfg (psampaz)
  - Maxwell Vandervelde
  - kaywalker
@@ -569,6 +573,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Nicolas Badey (nico-b)
  - Gunnar Lium
  - povilas
+ - Tiago Garcia (tiagojsag)
  - Lars Strojny
  - Bouke Haarsma
  - Harm van Tilborg
@@ -584,13 +589,16 @@ Symfony2 is the result of the work of many people who made the code better
  - Josef Cech
  - Andrey Esaulov (andremaha)
  - hicham ELGUAROUANI (hiiimoo)
+ - Paul Seiffert (seiffert)
  - Stefan Koopmanschap (skoop)
  - Ivan Kurnosov
  - stloyd
  - Andrew Coulton
  - Chris Tickner (tickner)
  - Luis Muñoz
+ - Strate
  - Thomas Chmielowiec
+ - František Bereň
  - Christoph Nissle (derstoffel)
  - Benjamin Zikarsky
  - Romain Dorgueil
@@ -600,6 +608,7 @@ Symfony2 is the result of the work of many people who made the code better
  - alefranz
  - alsar
  - Mike Meier
+ - Warwick
  - efeen
  - Bob den Otter (bopp)
  - Simone Fumagalli (hpatoio)
@@ -637,6 +646,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Linnik Sergey
  - David Christmann
  - root
+ - Tom Maguire
  - Pierre Rineau
  - Ari Pringle (apringle)
  - Dan Ordille (dordille)
@@ -713,6 +723,7 @@ Symfony2 is the result of the work of many people who made the code better
  - jc
  - BenjaminBeck
  - Christian Eikermann
+ - Antonio Angelino
  - Vladimir Sazhin
  - Vyacheslav Slinko
  - Johannes
@@ -730,6 +741,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Tammy D
  - Ondrej Slinták
  - vlechemin
+ - Brian Corrigan
  - Skorney
  - André Neves
  - Pierre-Louis LAUNAY
@@ -738,6 +750,8 @@ Symfony2 is the result of the work of many people who made the code better
  - Abdulkadir N. A.
  - Sema
  - Thorsten Hallwas
+ - Michael Squires
+ - pauluz
  - Vincent
  - Chris Smith
  - kwiateusz
@@ -771,6 +785,7 @@ Symfony2 is the result of the work of many people who made the code better
  - Daniel Londero (dlondero)
  - Adel ELHAIBA (eadel)
  - Fabien Dosse (fabd)
+ - Sorin Gitlan (forapathy)
  - Yohan Giarelli (frequence-web)
  - Massimiliano Arione (garak)
  - Vladislav Krupenkin (ideea)

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -490,7 +490,6 @@ class PhpDumper extends Dumper
      */
     private function addService($id, $definition)
     {
-        $name = Container::camelize($id);
         $this->definitionVariables = new \SplObjectStorage();
         $this->referenceVariables = array();
         $this->variableCount = 0;
@@ -555,7 +554,7 @@ EOF;
      *$lazyInitializationDoc
      * $return
      */
-    {$visibility} function get{$name}Service($lazyInitialization)
+    {$visibility} function get{$this->camelize($id)}Service($lazyInitialization)
     {
 
 EOF;
@@ -656,14 +655,12 @@ EOF;
             return;
         }
 
-        $name = Container::camelize($id);
-
         return <<<EOF
 
     /**
      * Updates the '$id' service.
      */
-    protected function synchronize{$name}Service()
+    protected function synchronize{$this->camelize($id)}Service()
     {
 $code    }
 
@@ -835,7 +832,7 @@ EOF;
         $code = "        \$this->methodMap = array(\n";
         ksort($definitions);
         foreach ($definitions as $id => $definition) {
-            $code .= '            '.var_export($id, true).' => '.var_export('get'.Container::camelize($id).'Service', true).",\n";
+            $code .= '            '.var_export($id, true).' => '.var_export('get'.$this->camelize($id).'Service', true).",\n";
         }
 
         return $code . "        );\n";
@@ -1258,6 +1255,26 @@ EOF;
 
             return sprintf('$this->get(\'%s\')', $id);
         }
+    }
+
+    /**
+     * Convert a service id to a valid PHP method name.
+     *
+     * @param string $id
+     *
+     * @return string
+     *
+     * @throws InvalidArgumentException
+     */
+    private function camelize($id)
+    {
+        $name = Container::camelize($id);
+
+        if (!preg_match('/^[a-zA-Z0-9_\x7f-\xff]+$/', $name)) {
+            throw new InvalidArgumentException(sprintf('Service id "%s" cannot be converted to a valid PHP method name.', $id));
+        }
+
+        return $name;
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -120,6 +120,18 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Service id "bar$" cannot be converted to a valid PHP method name.
+     */
+    public function testAddServiceInvalidServiceId()
+    {
+        $container = new ContainerBuilder();
+        $container->register('bar$', 'FooClass');
+        $dumper = new PhpDumper($container);
+        $dumper->dump();
+    }
+
     public function testAliases()
     {
         $container = include self::$fixturesPath.'/containers/container9.php';

--- a/src/Symfony/Component/HttpFoundation/JsonResponse.php
+++ b/src/Symfony/Component/HttpFoundation/JsonResponse.php
@@ -83,7 +83,7 @@ class JsonResponse extends Response
     public function setData($data = array())
     {
         // Encode <, >, ', &, and " for RFC4627-compliant JSON, which may also be embedded into HTML.
-        $this->data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT );
+        $this->data = json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_AMP | JSON_HEX_QUOT);
 
         return $this->update();
     }

--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -209,9 +209,13 @@ class NativeSessionStorage implements SessionStorageInterface
 
         // workaround for https://bugs.php.net/bug.php?id=61470 as suggested by David Grudl
         session_write_close();
-        $backup = $_SESSION;
-        session_start();
-        $_SESSION = $backup;
+        if (isset($_SESSION)) {
+            $backup = $_SESSION;
+            session_start();
+            $_SESSION = $backup;
+        } else {
+            session_start();
+        }
 
         return $ret;
     }

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -61,12 +61,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $classes;
     protected $loadClassCache;
 
-    const VERSION         = '2.3.2';
-    const VERSION_ID      = '20302';
+    const VERSION         = '2.3.3-DEV';
+    const VERSION_ID      = '20303';
     const MAJOR_VERSION   = '2';
     const MINOR_VERSION   = '3';
-    const RELEASE_VERSION = '2';
-    const EXTRA_VERSION   = '';
+    const RELEASE_VERSION = '3';
+    const EXTRA_VERSION   = 'DEV';
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -61,12 +61,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $classes;
     protected $loadClassCache;
 
-    const VERSION         = '2.3.2-DEV';
+    const VERSION         = '2.3.2';
     const VERSION_ID      = '20302';
     const MAJOR_VERSION   = '2';
     const MINOR_VERSION   = '3';
     const RELEASE_VERSION = '2';
-    const EXTRA_VERSION   = 'DEV';
+    const EXTRA_VERSION   = '';
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -67,7 +67,7 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     const MAJOR_VERSION   = '2';
     const MINOR_VERSION   = '2';
     const RELEASE_VERSION = '5';
-    const EXTRA_VERSION   = 'DDEV';
+    const EXTRA_VERSION   = 'DEV';
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -62,12 +62,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $classes;
     protected $errorReportingLevel;
 
-    const VERSION         = '2.2.4';
-    const VERSION_ID      = '20204';
+    const VERSION         = '2.2.5-DEV';
+    const VERSION_ID      = '20205';
     const MAJOR_VERSION   = '2';
     const MINOR_VERSION   = '2';
-    const RELEASE_VERSION = '4';
-    const EXTRA_VERSION   = '';
+    const RELEASE_VERSION = '5';
+    const EXTRA_VERSION   = 'DDEV';
 
     /**
      * Constructor.

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -62,12 +62,12 @@ abstract class Kernel implements KernelInterface, TerminableInterface
     protected $classes;
     protected $errorReportingLevel;
 
-    const VERSION         = '2.2.4-DEV';
+    const VERSION         = '2.2.4';
     const VERSION_ID      = '20204';
     const MAJOR_VERSION   = '2';
     const MINOR_VERSION   = '2';
     const RELEASE_VERSION = '4';
-    const EXTRA_VERSION   = 'DEV';
+    const EXTRA_VERSION   = '';
 
     /**
      * Constructor.


### PR DESCRIPTION
Same as #8494 for branch 2.3 since the DI component has been refactored (bb797ee75591f8461dbcc6fdc8a50b5d3aa8fe5a, f1c2ab78af69d5cfa1db2c244dbf22e0303036f2)

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8485 #8030 |
| License | MIT |
| Doc PR | n/a |

Throws an exception when the DIC is dumped to PHP, before generating invalid PHP.
The regex comes from the PHP doc: http://www.php.net/manual/en/language.oop5.basic.php
