### PR TITLE
[SwiftmailerBridge] Marked MessageDataCollector as deprecated

### DIFF
--- a/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
+++ b/src/Symfony/Bridge/Swiftmailer/DataCollector/MessageDataCollector.php
@@ -21,6 +21,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Clément JOBEILI <clement.jobeili@gmail.com>
+ *
+ * @deprecated Deprecated since version 2.4, to be removed in 3.0. Use
+ *             MessageDataCollector of SwiftmailerBundle instead.
  */
 class MessageDataCollector extends DataCollector
 {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes |
| Deprecations? | yes |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

Now you can configure several mailers.

Linked to the following PR:
- [ ] https://github.com/symfony/SwiftmailerBundle/pull/34
