### PR TITLE
security acl dbal schema: inject the schema instead of the whole container

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/EventListener/AclSchemaListener.php
+++ b/src/Symfony/Bundle/SecurityBundle/EventListener/AclSchemaListener.php
@@ -11,7 +11,7 @@
 
 namespace Symfony\Bundle\SecurityBundle\EventListener;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\Security\Acl\Dbal\Schema;
 use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
 
 /**
@@ -21,16 +21,16 @@ use Doctrine\ORM\Tools\Event\GenerateSchemaEventArgs;
  */
 class AclSchemaListener
 {
-    private $container;
+    private $schema;
 
-    public function __construct(ContainerInterface $container)
+    public function __construct(Schema $schema)
     {
-        $this->container = $container;
+        $this->schema = $schema;
     }
 
     public function postGenerateSchema(GenerateSchemaEventArgs $args)
     {
         $schema = $args->getSchema();
-        $this->container->get('security.acl.dbal.schema')->addToSchema($schema);
+        $this->schema->addToSchema($schema);
     }
 }

--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/security_acl_dbal.xml
@@ -37,7 +37,7 @@
             <argument type="service" id="security.acl.dbal.connection" />
         </service>
         <service id="security.acl.dbal.schema_listener" class="%security.acl.dbal.schema_listener.class%" public="false">
-            <argument type="service" id="service_container" />
+            <argument type="service" id="security.acl.dbal.schema" />
         </service>
 
         <service id="security.acl.provider" alias="security.acl.dbal.provider" />


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

following a discussion with @Stof on https://github.com/doctrine/DoctrinePHPCRBundle/pull/78 i thought to clean up the code i used as template as well.
