### PR TITLE
Add tests for supporting query parameters on the controller resolver.

### DIFF
--- a/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
+++ b/src/Symfony/Component/HttpKernel/Controller/ControllerResolver.php
@@ -114,10 +114,13 @@ class ControllerResolver implements ControllerResolverInterface
     protected function doGetArguments(Request $request, $controller, array $parameters)
     {
         $attributes = $request->attributes->all();
+        $query = $request->query->all();
         $arguments = array();
         foreach ($parameters as $param) {
             if (array_key_exists($param->name, $attributes)) {
                 $arguments[] = $attributes[$param->name];
+            } elseif (array_key_exists($param->name, $query)) {
+                $arguments[] = $query[$param->name];
             } elseif ($param->getClass() && $param->getClass()->isInstance($request)) {
                 $arguments[] = $request;
             } elseif ($param->isDefaultValueAvailable()) {

--- a/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Controller/ControllerResolverTest.php
@@ -99,6 +99,17 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo'), $resolver->getArguments($request, $controller), '->getArguments() returns an array of arguments for the controller method');
 
         $request = Request::create('/');
+        $request->query->set('foo', 'foo');
+        $controller = array(new self(), 'controllerMethod1');
+        $this->assertEquals(array('foo'), $resolver->getArguments($request, $controller), '->getArguments() uses query parameters if just the parameter on query is specified.');
+
+        $request = Request::create('/');
+        $request->query->set('foo', 'bar');
+        $request->attributes->set('foo', 'foo');
+        $controller = array(new self(), 'controllerMethod1');
+        $this->assertEquals(array('foo'), $resolver->getArguments($request, $controller), '->getArguments() uses attributes if the parameter on both query and attributes are specified.');
+
+        $request = Request::create('/');
         $request->attributes->set('foo', 'foo');
         $controller = array(new self(), 'controllerMethod2');
         $this->assertEquals(array('foo', null), $resolver->getArguments($request, $controller), '->getArguments() uses default values if present');


### PR DESCRIPTION
There are many usescase where you not only want to have inject request attributes but also request query parameters.

one example: In Drupal a pager looks like that: foo?page=1

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |
