### PR TITLE
[2.2][HttpFoundation][RedirectResponse] Added refresh timeout support

### DIFF
--- a/src/Symfony/Component/HttpFoundation/RedirectResponse.php
+++ b/src/Symfony/Component/HttpFoundation/RedirectResponse.php
@@ -21,6 +21,7 @@ namespace Symfony\Component\HttpFoundation;
 class RedirectResponse extends Response
 {
     protected $targetUrl;
+    protected $refreshTimeout;
 
     /**
      * Creates a redirect response so that it conforms to the rules defined for a redirect status code.
@@ -28,6 +29,7 @@ class RedirectResponse extends Response
      * @param string  $url     The URL to redirect to
      * @param integer $status  The status code (302 by default)
      * @param array   $headers The headers (Location is always set to the given url)
+     * @param integer $timeout Refresh timeout (1 by default)
      *
      * @throws \InvalidArgumentException
      *
@@ -35,7 +37,7 @@ class RedirectResponse extends Response
      *
      * @api
      */
-    public function __construct($url, $status = 302, $headers = array())
+    public function __construct($url, $status = 302, $headers = array(), $timeout = 1)
     {
         if (empty($url)) {
             throw new \InvalidArgumentException('Cannot redirect to an empty URL.');
@@ -43,6 +45,7 @@ class RedirectResponse extends Response
 
         parent::__construct('', $status, $headers);
 
+        $this->setRefreshTimeout($timeout);
         $this->setTargetUrl($url);
 
         if (!$this->isRedirect()) {
@@ -53,9 +56,9 @@ class RedirectResponse extends Response
     /**
      * {@inheritDoc}
      */
-    public static function create($url = '', $status = 302, $headers = array())
+    public static function create($url = '', $status = 302, $headers = array(), $timeout = 1)
     {
-        return new static($url, $status, $headers);
+        return new static($url, $status, $headers, $timeout);
     }
 
     /**
@@ -71,7 +74,7 @@ class RedirectResponse extends Response
     /**
      * Sets the redirect target of this response.
      *
-     * @param string  $url     The URL to redirect to
+     * @param string $url The URL to redirect to
      *
      * @return RedirectResponse The current response.
      *
@@ -90,16 +93,40 @@ class RedirectResponse extends Response
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <meta http-equiv="refresh" content="1;url=%1$s" />
+        <meta http-equiv="refresh" content="%2$d;url=%1$s" />
 
         <title>Redirecting to %1$s</title>
     </head>
     <body>
         Redirecting to <a href="%1$s">%1$s</a>.
     </body>
-</html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8')));
+</html>', htmlspecialchars($url, ENT_QUOTES, 'UTF-8'), $this->getRefreshTimeout()));
 
         $this->headers->set('Location', $url);
+
+        return $this;
+    }
+
+    /**
+     * Returns the refresh timeout.
+     *
+     * @return integer refresh timeout
+     */
+    public function getRefreshTimeout()
+    {
+        return $this->refreshTimeout;
+    }
+
+    /**
+     * Sets the redirect refresh timeout of this response.
+     *
+     * @param integer $timeout Refresh timeout (1 by default)
+     *
+     * @return RedirectResponse The current response.
+     */
+    public function setRefreshTimeout($timeout)
+    {
+        $this->refreshTimeout = max(1, (int) $timeout);
 
         return $this;
     }

--- a/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
+++ b/src/Symfony/Component/HttpFoundation/Tests/RedirectResponseTest.php
@@ -80,4 +80,43 @@ class RedirectResponseTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\RedirectResponse', $response);
         $this->assertEquals(301, $response->getStatusCode());
     }
+
+    public function testRefreshTimeoutCanBeSetViaConstructor()
+    {
+        $response = new RedirectResponse('/foo', 301, array(), 3);
+
+        $this->assertEquals(3, $response->getRefreshTimeout());
+        $this->assertContains('<meta http-equiv="refresh" content="3;url=/foo" />', $response->getContent());
+    }
+
+    public function testRefreshTimeoutCanBeSetViaSetter()
+    {
+        $response = new RedirectResponse('foo');
+        $response->setRefreshTimeout(5);
+
+        $this->assertEquals(5, $response->getRefreshTimeout());
+    }
+
+    /**
+     * @dataProvider provideRefreshTimeoutValues
+     */
+    public function testRefreshTimeoutShouldBeAPositiveInteger($given, $expected)
+    {
+        $response = new RedirectResponse('foo');
+        $response->setRefreshTimeout($given);
+
+        $this->assertEquals($expected, $response->getRefreshTimeout());
+    }
+
+    public function provideRefreshTimeoutValues()
+    {
+        return array(
+            array(-1, 1),
+            array(0, 1),
+            array(5, 5),
+            array(null, 1),
+            array('baz', 1),
+            array('77', 77)
+        );
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This little patch give the ability to specify a latency before the redirect.
It's a minor feature that affects only browser's behavior, but helps in some simple situations (e.g. refresh the same page after 10s) without using JavaScript.

This patch can also be safely applied both on master and 2.3 branch.

If needed I can provide English and Italian documentation.
