### PR TITLE
[DependencyInjection] call synchronize{$id} from get{$id}Service method

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -420,6 +420,18 @@ class PhpDumper extends Dumper
         return $code;
     }
 
+    private function addServiceSynchronizeCall($id, $definition)
+    {
+        if (!$definition->isSynchronized()) {
+            return '';
+        }
+
+        $name = 'synchronize'.$this->camelize($id).'Service';
+        $code = sprintf("\n        \$this->%s();\n", $name);
+
+        return $code;
+    }
+
     /**
      * Generates the inline definition setup.
      *
@@ -585,6 +597,7 @@ EOF;
                 $this->addServiceMethodCalls($id, $definition).
                 $this->addServiceProperties($id, $definition).
                 $this->addServiceConfigurator($id, $definition).
+                $this->addServiceSynchronizeCall($id, $definition).
                 $this->addServiceReturn($id, $definition)
             ;
         }

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -420,7 +420,7 @@ class PhpDumper extends Dumper
         return $code;
     }
 
-    private function addServiceSynchronizeCall($id, $definition)
+    private function addServiceSynchronizeCall($id, Definition $definition)
     {
         if (!$definition->isSynchronized()) {
             return '';

--- a/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/PhpDumper.php
@@ -378,7 +378,7 @@ class PhpDumper extends Dumper
                 continue;
             }
 
-            if ($sDefinition->getMethodCalls() || $sDefinition->getProperties() || $sDefinition->getConfigurator()) {
+            if ($sDefinition->getMethodCalls() || $sDefinition->getProperties() || $sDefinition->getConfigurator() || $sDefinition->isSynchronized()) {
                 return false;
             }
         }
@@ -427,7 +427,7 @@ class PhpDumper extends Dumper
         }
 
         $name = 'synchronize'.$this->camelize($id).'Service';
-        $code = sprintf("\n        \$this->%s();\n", $name);
+        $code = sprintf("        \$this->%s();\n", $name);
 
         return $code;
     }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -189,11 +189,11 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         require_once self::$fixturesPath.'/php/services15.php';
 
         $container = new \AnotherProjectServiceContainer();
-        $dependentService = $container->get('dependsOnSynchronized');
+        $dependentService = $container->get('depends_on_synchronized');
         $this->assertNull($dependentService->bar);
 
         $container->enterScope('request');
-        $synchronizedService = $container->get('synchronizedService');
+        $synchronizedService = $container->get('synchronized_service');
 
         $this->assertEquals($dependentService->bar, $synchronizedService);
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -11,6 +11,7 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -180,5 +181,21 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $container->set('bar', $bar = new \stdClass());
 
         $this->assertSame($bar, $container->get('foo')->bar, '->set() overrides an already defined service');
+    }
+
+    public function testSynchronizedServiceUpdatesDependencies() {
+        require_once self::$fixturesPath.'/includes/foo.php';
+        require_once self::$fixturesPath.'/includes/classes.php';
+        require_once self::$fixturesPath.'/php/services15.php';
+
+        $container = new \AnotherProjectServiceContainer();
+        $dependentService = $container->get('dependsOnSynchronized');
+        $this->assertNull($dependentService->bar);
+
+        $container->enterScope('request');
+        $synchronizedService = $container->get('synchronizedService');
+
+        $this->assertEquals($dependentService->bar, $synchronizedService);
+
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/PhpDumperTest.php
@@ -11,7 +11,6 @@
 
 namespace Symfony\Component\DependencyInjection\Tests\Dumper;
 
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -183,7 +182,8 @@ class PhpDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($bar, $container->get('foo')->bar, '->set() overrides an already defined service');
     }
 
-    public function testSynchronizedServiceUpdatesDependencies() {
+    public function testSynchronizedServiceUpdatesDependencies()
+    {
         require_once self::$fixturesPath.'/includes/foo.php';
         require_once self::$fixturesPath.'/includes/classes.php';
         require_once self::$fixturesPath.'/php/services15.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container15.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container15.php
@@ -10,13 +10,13 @@ use Symfony\Component\DependencyInjection\Parameter;
 $container = new ContainerBuilder();
 $container->addScope(new \Symfony\Component\DependencyInjection\Scope('request'));
 $container
-    ->register('synchronizedService', 'BarClass')
+    ->register('synchronized_service', 'BarClass')
     ->setSynchronized(true)
     ->setScope('request')
 ;
 $container
-    ->register('dependsOnSynchronized', 'FooClass')
-    ->addMethodCall('setBar', array(new Reference('synchronizedService', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)))
+    ->register('depends_on_synchronized', 'FooClass')
+    ->addMethodCall('setBar', array(new Reference('synchronized_service', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)))
 ;
 
 return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container15.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container15.php
@@ -1,0 +1,22 @@
+<?php
+
+require_once __DIR__.'/../includes/classes.php';
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Parameter;
+
+$container = new ContainerBuilder();
+$container->addScope(new \Symfony\Component\DependencyInjection\Scope('request'));
+$container
+    ->register('synchronizedService', 'BarClass')
+    ->setSynchronized(true)
+    ->setScope('request')
+;
+$container
+    ->register('dependsOnSynchronized', 'FooClass')
+    ->addMethodCall('setBar', array(new Reference('synchronizedService', ContainerInterface::NULL_ON_INVALID_REFERENCE, false)))
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services15.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services15.php
@@ -32,8 +32,8 @@ class AnotherProjectServiceContainer extends Container
         $this->scopes = array('request' => 'container');
         $this->scopeChildren = array('request' => array());
         $this->methodMap = array(
-            'dependsonsynchronized' => 'getDependsonsynchronizedService',
-            'synchronizedservice' => 'getSynchronizedserviceService',
+            'depends_on_synchronized' => 'getDependsonsynchronizedService',
+            'synchronized_service' => 'getSynchronizedserviceService',
         );
 
         $this->aliases = array();
@@ -49,9 +49,9 @@ class AnotherProjectServiceContainer extends Container
      */
     protected function getDependsonsynchronizedService()
     {
-        $this->services['dependsonsynchronized'] = $instance = new \FooClass();
+        $this->services['depends_on_synchronized'] = $instance = new \FooClass();
 
-        $instance->setBar($this->get('synchronizedservice', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        $instance->setBar($this->get('synchronized_service', ContainerInterface::NULL_ON_INVALID_REFERENCE));
 
         return $instance;
     }
@@ -69,10 +69,10 @@ class AnotherProjectServiceContainer extends Container
     protected function getSynchronizedserviceService()
     {
         if (!isset($this->scopedServices['request'])) {
-            throw new InactiveScopeException('synchronizedservice', 'request');
+            throw new InactiveScopeException('synchronized_service', 'request');
         }
 
-        $this->services['synchronizedservice'] = $this->scopedServices['request']['synchronizedservice'] = $instance = new \BarClass();
+        $this->services['synchronized_service'] = $this->scopedServices['request']['synchronized_service'] = $instance = new \BarClass();
 
         $this->synchronizeSynchronizedserviceService();
 
@@ -84,8 +84,8 @@ class AnotherProjectServiceContainer extends Container
      */
     protected function synchronizeSynchronizedserviceService()
     {
-        if ($this->initialized('dependsonsynchronized')) {
-            $this->get('dependsonsynchronized')->setBar($this->get('synchronizedservice', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        if ($this->initialized('depends_on_synchronized')) {
+            $this->get('depends_on_synchronized')->setBar($this->get('synchronized_service', ContainerInterface::NULL_ON_INVALID_REFERENCE));
         }
     }
 }

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services15.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/php/services15.php
@@ -1,0 +1,91 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\Exception\InactiveScopeException;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Parameter;
+use Symfony\Component\DependencyInjection\ParameterBag\FrozenParameterBag;
+
+/**
+ * AnotherProjectServiceContainer
+ *
+ * This class has been auto-generated
+ * by the Symfony Dependency Injection Component.
+ */
+class AnotherProjectServiceContainer extends Container
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->services =
+        $this->scopedServices =
+        $this->scopeStacks = array();
+
+        $this->set('service_container', $this);
+
+        $this->scopes = array('request' => 'container');
+        $this->scopeChildren = array('request' => array());
+        $this->methodMap = array(
+            'dependsonsynchronized' => 'getDependsonsynchronizedService',
+            'synchronizedservice' => 'getSynchronizedserviceService',
+        );
+
+        $this->aliases = array();
+    }
+
+    /**
+     * Gets the 'dependsonsynchronized' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return FooClass A FooClass instance.
+     */
+    protected function getDependsonsynchronizedService()
+    {
+        $this->services['dependsonsynchronized'] = $instance = new \FooClass();
+
+        $instance->setBar($this->get('synchronizedservice', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+
+        return $instance;
+    }
+
+    /**
+     * Gets the 'synchronizedservice' service.
+     *
+     * This service is shared.
+     * This method always returns the same instance of the service.
+     *
+     * @return BarClass A BarClass instance.
+     * 
+     * @throws InactiveScopeException when the 'synchronizedservice' service is requested while the 'request' scope is not active
+     */
+    protected function getSynchronizedserviceService()
+    {
+        if (!isset($this->scopedServices['request'])) {
+            throw new InactiveScopeException('synchronizedservice', 'request');
+        }
+
+        $this->services['synchronizedservice'] = $this->scopedServices['request']['synchronizedservice'] = $instance = new \BarClass();
+
+        $this->synchronizeSynchronizedserviceService();
+
+        return $instance;
+    }
+
+    /**
+     * Updates the 'synchronizedservice' service.
+     */
+    protected function synchronizeSynchronizedserviceService()
+    {
+        if ($this->initialized('dependsonsynchronized')) {
+            $this->get('dependsonsynchronized')->setBar($this->get('synchronizedservice', ContainerInterface::NULL_ON_INVALID_REFERENCE));
+        }
+    }
+}


### PR DESCRIPTION
this calls the synchronize method for services that are marked as synchronized but are not synthetic.

when the scope of the requested service is not active, the container won't create the instance nor call the synchronize method.
when the scope gets entered and the service is fetched from container afterwards, the synchronize{$id}Service method is called to update all dependent services.
