### PR TITLE
[HttpKernel][Bundle] Bundle multiple Inheritance

### DIFF
--- a/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/Bundle.php
@@ -135,7 +135,7 @@ abstract class Bundle extends ContainerAware implements BundleInterface
     /**
      * Returns the bundle parent name.
      *
-     * @return string The Bundle parent name it overrides or null if no parent
+     * @return string|array The Bundle parent name it overrides or null if no parent; Use array of parent name if bundle override more than one parent
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
+++ b/src/Symfony/Component/HttpKernel/Bundle/BundleInterface.php
@@ -65,7 +65,7 @@ interface BundleInterface extends ContainerAwareInterface
      * between the bundles, just a way to extend and override an existing
      * bundle.
      *
-     * @return string The Bundle name it overrides or null if no parent
+     * @return string|array The Bundle parent name it overrides or null if no parent; Use array of parent name if bundle override more than one parent
      *
      * @api
      */

--- a/src/Symfony/Component/HttpKernel/Kernel.php
+++ b/src/Symfony/Component/HttpKernel/Kernel.php
@@ -485,14 +485,22 @@ abstract class Kernel implements KernelInterface, TerminableInterface
             }
             $this->bundles[$name] = $bundle;
 
-            if ($parentName = $bundle->getParent()) {
-                if (isset($directChildren[$parentName])) {
-                    throw new \LogicException(sprintf('Bundle "%s" is directly extended by two bundles "%s" and "%s".', $parentName, $name, $directChildren[$parentName]));
+            if ($parentNames = $bundle->getParent()) {
+
+                if (!is_array($parentNames)) {
+                    $parentNames = array($parentNames);
                 }
-                if ($parentName == $name) {
-                    throw new \LogicException(sprintf('Bundle "%s" can not extend itself.', $name));
+
+                foreach ($parentNames as $parentName) {
+
+                    if (isset($directChildren[$parentName])) {
+                        throw new \LogicException(sprintf('Bundle "%s" is directly extended by two bundles "%s" and "%s".', $parentName, $name, $directChildren[$parentName]));
+                    }
+                    if ($parentName == $name) {
+                        throw new \LogicException(sprintf('Bundle "%s" can not extend itself.', $name));
+                    }
+                    $directChildren[$parentName] = $name;
                 }
-                $directChildren[$parentName] = $name;
             } else {
                 $topMostBundles[$name] = $bundle;
             }


### PR DESCRIPTION
add support of array for Bundle::getParent so bundle could override multiple parents

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | yes (as Stof note it : returning an array breaks any bundle relying on this method currently) |
| Deprecations? | no |
| Tests pass? | yes (same error on 5.3.3 travis build as master repository) |
| Fixed tickets | #8071 |
| License | MIT |
| Doc PR | - |
- [ ] submit changes to the documentation
- [ ] submit changes to the sension/framework-extra-bundle to allow Sensio\Bundle\FrameworkExtraBundle\Templating\TemplateGuesser::guessTemplateName to work with array returned by Bundle::getParent
