### PR TITLE
[Routing] Allow easy extension of YamlFileLoader

### DIFF
--- a/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/Routing/Loader/YamlFileLoader.php
@@ -27,9 +27,6 @@ use Symfony\Component\Config\Loader\FileLoader;
  */
 class YamlFileLoader extends FileLoader
 {
-    private static $availableKeys = array(
-        'resource', 'type', 'prefix', 'pattern', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options',
-    );
     private $yamlParser;
 
     /**
@@ -184,10 +181,11 @@ class YamlFileLoader extends FileLoader
         if (!is_array($config)) {
             throw new \InvalidArgumentException(sprintf('The definition of "%s" in "%s" must be a YAML array.', $name, $path));
         }
-        if ($extraKeys = array_diff(array_keys($config), self::$availableKeys)) {
+        $availableKeys = $this->getAvailableKeys();
+        if ($extraKeys = array_diff(array_keys($config), $availableKeys)) {
             throw new \InvalidArgumentException(sprintf(
                 'The routing file "%s" contains unsupported keys for "%s": "%s". Expected one of: "%s".',
-                $path, $name, implode('", "', $extraKeys), implode('", "', self::$availableKeys)
+                $path, $name, implode('", "', $extraKeys), implode('", "', $availableKeys)
             ));
         }
         if (isset($config['resource']) && isset($config['path'])) {
@@ -208,5 +206,17 @@ class YamlFileLoader extends FileLoader
                 $name, $path
             ));
         }
+    }
+
+    /**
+     * Returns valid keys for yaml
+     *
+     * @return array
+     */
+    protected function getAvailableKeys()
+    {
+        return array(
+            'resource', 'type', 'prefix', 'pattern', 'path', 'host', 'schemes', 'methods', 'defaults', 'requirements', 'options',
+        );
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | N/A |
| License | MIT |
| Doc PR | N/A |

I often found myself extending `YamlFileLoader` to add custom routing options, and I think it's quite hard to avoid duplicating the whole class. Validation of routes is a must, and I'd like to extend the default one with more keys, but this can't be done because declaration is `private static` and static binding is used. I think it would be nice to have an easy way to extend from this class.

Some solutions come to mind:
- Change `$availableKeys` visibility to `protected` and use late static binding instead of `self::$availableKeys`.
  This way is easier to replace with new keys, but harder to add to current ones.
- Extract keys to a protected method, say `getAvailableKeys`.
  Allows for easy replacement and extension, by calling `parent::getAvailableKeys` and mix with the new ones.
- Create a `Symfony/Config` object in a protected method, and let derived classes to extend it.
  This brings even more power (validation and conversion) but couples `Routing` to `Config` components for a little profit.

I attach the code for the second solution (extraction to protected method).
This is an easy patch, but I would love to hear some opinions in the subject.
