### PR TITLE
[Debug] Developer friendly Class Not Found and Undefined Function errors

### DIFF
--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -40,6 +40,16 @@ class DebugClassLoader
     }
 
     /**
+     * Gets the wrapped class loader.
+     *
+     * @return object a class loader instance
+     */
+    public function getClassLoader()
+    {
+        return $this->classFinder;
+    }
+
+    /**
      * Replaces all autoloaders implementing a findFile method by a DebugClassLoader wrapper.
      */
     public static function enable()

--- a/src/Symfony/Component/Debug/CHANGELOG.md
+++ b/src/Symfony/Component/Debug/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+ * improved error messages for not found classes and functions
+
 2.3.0
 -----
 

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -16,6 +16,7 @@ use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\Debug\FatalErrorHandler\UndefinedFunctionFatalErrorHandler;
 use Symfony\Component\Debug\FatalErrorHandler\ClassNotFoundFatalErrorHandler;
+use Symfony\Component\Debug\FatalErrorHandler\FatalErrorHandlerInterface;
 
 /**
  * ErrorHandler.
@@ -57,7 +58,7 @@ class ErrorHandler
     /**
      * Registers the error handler.
      *
-     * @param integer $level The level at which the conversion to Exception is done (null to use the error_reporting() value and 0 to disable)
+     * @param integer $level         The level at which the conversion to Exception is done (null to use the error_reporting() value and 0 to disable)
      * @param Boolean $displayErrors Display errors (for dev environment) or just log they (production usage)
      *
      * @return The registered error handler
@@ -76,16 +77,32 @@ class ErrorHandler
         return $handler;
     }
 
+    /**
+     * Sets the level at which the conversion to Exception is done.
+     *
+     * @param integer|null $level The level (null to use the error_reporting() value and 0 to disable)
+     */
     public function setLevel($level)
     {
         $this->level = null === $level ? error_reporting() : $level;
     }
 
+    /**
+     * Sets the display_errors flag value.
+     *
+     * @param integer $displayErrors The display_errors flag value
+     */
     public function setDisplayErrors($displayErrors)
     {
         $this->displayErrors = $displayErrors;
     }
 
+    /**
+     * Sets a logger for the given channel.
+     *
+     * @param LoggerInterface $logger  A logger interface
+     * @param string          $channel The channel associated with the logger (deprecation or emergency)
+     */
     public static function setLogger(LoggerInterface $logger, $channel = 'deprecation')
     {
         self::$loggers[$channel] = $logger;
@@ -163,7 +180,14 @@ class ErrorHandler
         }
     }
 
-    public function getFatalErrorHandlers()
+    /**
+     * Gets the fatal error handlers.
+     *
+     * Override this method if you want to define more fatal error handlers.
+     *
+     * @return FatalErrorHandlerInterface[] An array of FatalErrorHandlerInterface
+     */
+    protected function getFatalErrorHandlers()
     {
         return array(
             new UndefinedFunctionFatalErrorHandler(),

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -154,7 +154,13 @@ class ErrorHandler
             return;
         }
 
-        $this->handleFatalError($error);
+        // get current exception handler
+        $exceptionHandler = set_exception_handler(function() {});
+        restore_exception_handler();
+
+        if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandler) {
+            $this->handleFatalError($exceptionHandler[0], $error);
+        }
     }
 
     public function getFatalErrorHandlers()
@@ -165,22 +171,18 @@ class ErrorHandler
         );
     }
 
-    private function handleFatalError($error)
+    private function handleFatalError(ExceptionHandler $exceptionHandler, array $error)
     {
-        // get current exception handler
-        $exceptionHandler = set_exception_handler(function() {});
-        restore_exception_handler();
+        $level = isset($this->levels[$error['type']]) ? $this->levels[$error['type']] : $error['type'];
+        $message = sprintf('%s: %s in %s line %d', $level, $error['message'], $error['file'], $error['line']);
+        $exception = new FatalErrorException($message, 0, $error['type'], $error['file'], $error['line']);
 
-        if (is_array($exceptionHandler) && $exceptionHandler[0] instanceof ExceptionHandler) {
-            $level = isset($this->levels[$error['type']]) ? $this->levels[$error['type']] : $error['type'];
-            $message = sprintf('%s: %s in %s line %d', $level, $error['message'], $error['file'], $error['line']);
-            $exception = new FatalErrorException($message, 0, $error['type'], $error['file'], $error['line']);
-
-            foreach ($this->getFatalErrorHandlers() as $handler) {
-                if ($ex = $handler->handleError($error, $exception)) {
-                    return $exceptionHandler[0]->handle($ex);
-                }
+        foreach ($this->getFatalErrorHandlers() as $handler) {
+            if ($ex = $handler->handleError($error, $exception)) {
+                return $exceptionHandler->handle($ex);
             }
         }
+
+        $exceptionHandler->handle($exception);
     }
 }

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -12,13 +12,10 @@
 namespace Symfony\Component\Debug;
 
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Debug\Exception\ClassNotFoundException;
 use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\Debug\Exception\FatalErrorException;
-use Symfony\Component\Debug\Exception\UndefinedFunctionException;
-use Composer\Autoload\ClassLoader as ComposerClassLoader;
-use Symfony\Component\ClassLoader as SymfonyClassLoader;
-use Symfony\Component\ClassLoader\DebugClassLoader;
+use Symfony\Component\Debug\FatalErrorHandler\UndefinedFunctionFatalErrorHandler;
+use Symfony\Component\Debug\FatalErrorHandler\ClassNotFoundFatalErrorHandler;
 
 /**
  * ErrorHandler.
@@ -160,6 +157,14 @@ class ErrorHandler
         $this->handleFatalError($error);
     }
 
+    public function getFatalErrorHandlers()
+    {
+        return array(
+            new UndefinedFunctionFatalErrorHandler(),
+            new ClassNotFoundFatalErrorHandler(),
+        );
+    }
+
     private function handleFatalError($error)
     {
         // get current exception handler
@@ -171,210 +176,11 @@ class ErrorHandler
             $message = sprintf('%s: %s in %s line %d', $level, $error['message'], $error['file'], $error['line']);
             $exception = new FatalErrorException($message, 0, $error['type'], $error['file'], $error['line']);
 
-            if ($ex = $this->handleUndefinedFunctionError($error, $exception)) {
-                return $exceptionHandler[0]->handle($ex);
-            }
-
-            if ($ex = $this->handleClassNotFoundError($error, $exception)) {
-                return $exceptionHandler[0]->handle($ex);
-            }
-
-            $exceptionHandler[0]->handle($exception);
-        }
-    }
-
-    private function handleUndefinedFunctionError($error, $exception)
-    {
-        $messageLen = strlen($error['message']);
-        $notFoundSuffix = '()';
-        $notFoundSuffixLen = strlen($notFoundSuffix);
-        if ($notFoundSuffixLen > $messageLen) {
-            return;
-        }
-
-        if (0 !== substr_compare($error['message'], $notFoundSuffix, -$notFoundSuffixLen)) {
-            return;
-        }
-
-        $prefix = 'Call to undefined function ';
-        $prefixLen = strlen($prefix);
-        if (0 !== strpos($error['message'], $prefix)) {
-            return;
-        }
-
-        $fullyQualifiedFunctionName = substr($error['message'], $prefixLen, -$notFoundSuffixLen);
-        if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedFunctionName, '\\')) {
-            $functionName = substr($fullyQualifiedFunctionName, $namespaceSeparatorIndex + 1);
-            $namespacePrefix = substr($fullyQualifiedFunctionName, 0, $namespaceSeparatorIndex);
-            $message = sprintf(
-                'Attempted to call function "%s" from namespace "%s" in %s line %d.',
-                $functionName,
-                $namespacePrefix,
-                $error['file'],
-                $error['line']
-            );
-        } else {
-            $functionName = $fullyQualifiedFunctionName;
-            $message = sprintf(
-                'Attempted to call function "%s" from the global namespace in %s line %d.',
-                $functionName,
-                $error['file'],
-                $error['line']
-            );
-        }
-
-        $candidates = array();
-        foreach (get_defined_functions() as $type => $definedFunctionNames) {
-            foreach ($definedFunctionNames as $definedFunctionName) {
-                if (false !== $namespaceSeparatorIndex = strrpos($definedFunctionName, '\\')) {
-                    $definedFunctionNameBasename = substr($definedFunctionName, $namespaceSeparatorIndex + 1);
-                } else {
-                    $definedFunctionNameBasename = $definedFunctionName;
-                }
-
-                if ($definedFunctionNameBasename === $functionName) {
-                    $candidates[] = '\\'.$definedFunctionName;
+            foreach ($this->getFatalErrorHandlers() as $handler) {
+                if ($ex = $handler->handleError($error, $exception)) {
+                    return $exceptionHandler[0]->handle($ex);
                 }
             }
-        }
-
-        if ($candidates) {
-            $message .= ' Did you mean to call: '.implode(', ', array_map(function ($val) {
-                return '"'.$val.'"';
-            }, $candidates)).'?';
-        }
-
-        return new UndefinedFunctionException($message, $exception);
-    }
-
-    private function handleClassNotFoundError($error, $exception)
-    {
-        $messageLen = strlen($error['message']);
-        $notFoundSuffix = '" not found';
-        $notFoundSuffixLen = strlen($notFoundSuffix);
-        if ($notFoundSuffixLen > $messageLen) {
-            return;
-        }
-
-        if (0 !== substr_compare($error['message'], $notFoundSuffix, -$notFoundSuffixLen)) {
-            return;
-        }
-
-        foreach (array('class', 'interface', 'trait') as $typeName) {
-            $prefix = ucfirst($typeName).' "';
-            $prefixLen = strlen($prefix);
-            if (0 !== strpos($error['message'], $prefix)) {
-                continue;
-            }
-
-            $fullyQualifiedClassName = substr($error['message'], $prefixLen, -$notFoundSuffixLen);
-            if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedClassName, '\\')) {
-                $className = substr($fullyQualifiedClassName, $namespaceSeparatorIndex + 1);
-                $namespacePrefix = substr($fullyQualifiedClassName, 0, $namespaceSeparatorIndex);
-                $message = sprintf(
-                    'Attempted to load %s "%s" from namespace "%s" in %s line %d. Do you need to "use" it from another namespace?',
-                    $typeName,
-                    $className,
-                    $namespacePrefix,
-                    $error['file'],
-                    $error['line']
-                );
-            } else {
-                $className = $fullyQualifiedClassName;
-                $message = sprintf(
-                    'Attempted to load %s "%s" from the global namespace in %s line %d. Did you forget a use statement for this %s?',
-                    $typeName,
-                    $className,
-                    $error['file'],
-                    $error['line'],
-                    $typeName
-                );
-            }
-
-            if ($classes = $this->getClassCandidates($className)) {
-                $message .= sprintf(' Perhaps you need to add a use statement for one of the following class: %s.', implode(', ', $classes));
-            }
-
-            return new ClassNotFoundException($message, $exception);
-        }
-    }
-
-    /**
-     * Tries to guess the full namespace for a given class name.
-     *
-     * By default, it looks for PSR-0 classes registered via a Symfony or a Composer
-     * autoloader (that should cover all common cases).
-     *
-     * @param string $class A class name (without its namespace)
-     *
-     * @return array An array of possible fully qualified class names
-     */
-    private function getClassCandidates($class)
-    {
-        if (!is_array($functions = spl_autoload_functions())) {
-            return array();
-        }
-
-        // find Symfony and Composer autoloaders
-        $classes = array();
-        foreach ($functions as $function) {
-            if (!is_array($function)) {
-                continue;
-            }
-
-            // get class loaders wrapped by DebugClassLoader
-            if ($function[0] instanceof DebugClassLoader && method_exists($function[0], 'getClassLoader')) {
-                $function[0] = $function[0]->getClassLoader();
-            }
-
-            if ($function[0] instanceof ComposerClassLoader || $function[0] instanceof SymfonyClassLoader) {
-                foreach ($function[0]->getPrefixes() as $paths) {
-                    foreach ($paths as $path) {
-                        $classes = array_merge($classes, $this->findClassInPath($function[0], $path, $class));
-                    }
-                }
-            }
-        }
-
-        return $classes;
-    }
-
-    private function findClassInPath($loader, $path, $class)
-    {
-        if (!$path = realpath($path)) {
-            continue;
-        }
-
-        $classes = array();
-        $filename = $class.'.php';
-        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
-            if ($filename == $file->getFileName() && $class = $this->convertFileToClass($loader, $path, $file->getPathName())) {
-                $classes[] = $class;
-            }
-        }
-
-        return $classes;
-    }
-
-    private function convertFileToClass($loader, $path, $file)
-    {
-        // We cannot use the autoloader here as most of them use require; but if the class
-        // is not found, the new autoloader call will require the file again leading to a
-        // "cannot redeclare class" error.
-        require_once $file;
-
-        $file = str_replace(array($path.'/', '.php'), array('', ''), $file);
-
-        // is it a namespaced class?
-        $class = str_replace('/', '\\', $file);
-        if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false))) {
-            return $class;
-        }
-
-        // is it a PEAR-like class name instead?
-        $class = str_replace('/', '_', $file);
-        if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false))) {
-            return $class;
         }
     }
 }

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -16,6 +16,9 @@ use Symfony\Component\Debug\Exception\ClassNotFoundException;
 use Symfony\Component\Debug\Exception\ContextErrorException;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use Symfony\Component\Debug\Exception\UndefinedFunctionException;
+use Composer\Autoload\ClassLoader as ComposerClassLoader;
+use Symfony\Component\ClassLoader as SymfonyClassLoader;
+use Symfony\Component\ClassLoader\DebugClassLoader;
 
 /**
  * ErrorHandler.
@@ -288,7 +291,7 @@ class ErrorHandler
                 );
             }
 
-            if ($classes = $this->getUseStatementSuggestions($className)) {
+            if ($classes = $this->getClassCandidates($className)) {
                 $message .= sprintf(' Perhaps you need to add a use statement for one of the following class: %s.', implode(', ', $classes));
             }
 
@@ -296,15 +299,82 @@ class ErrorHandler
         }
     }
 
-    protected function getUseStatementSuggestions($class)
+    /**
+     * Tries to guess the full namespace for a given class name.
+     *
+     * By default, it looks for PSR-0 classes registered via a Symfony or a Composer
+     * autoloader (that should cover all common cases).
+     *
+     * @param string $class A class name (without its namespace)
+     *
+     * @return array An array of possible fully qualified class names
+     */
+    private function getClassCandidates($class)
     {
-        $classNameToUseStatementSuggestions = array(
-            'Request'  => array('Symfony\Component\HttpFoundation\Request'),
-            'Response' => array('Symfony\Component\HttpFoundation\Response'),
-        );
+        if (!is_array($functions = spl_autoload_functions())) {
+            return array();
+        }
 
-        if (isset($classNameToUseStatementSuggestions[$class])) {
-            return $classNameToUseStatementSuggestions[$class];
+        // find Symfony and Composer autoloaders
+        $classes = array();
+        foreach ($functions as $function) {
+            if (!is_array($function)) {
+                continue;
+            }
+
+            // get class loaders wrapped by DebugClassLoader
+            if ($function[0] instanceof DebugClassLoader && method_exists($function[0], 'getClassLoader')) {
+                $function[0] = $function[0]->getClassLoader();
+            }
+
+            if ($function[0] instanceof ComposerClassLoader || $function[0] instanceof SymfonyClassLoader) {
+                foreach ($function[0]->getPrefixes() as $paths) {
+                    foreach ($paths as $path) {
+                        $classes = array_merge($classes, $this->findClassInPath($function[0], $path, $class));
+                    }
+                }
+            }
+        }
+
+        return $classes;
+    }
+
+    private function findClassInPath($loader, $path, $class)
+    {
+        if (!$path = realpath($path)) {
+            continue;
+        }
+
+        $classes = array();
+        $filename = $class.'.php';
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+            if ($filename == $file->getFileName() && $class = $this->convertFileToClass($loader, $path, $file->getPathName())) {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }
+
+    private function convertFileToClass($loader, $path, $file)
+    {
+        // We cannot use the autoloader here as most of them use require; but if the class
+        // is not found, the new autoloader call will require the file again leading to a
+        // "cannot redeclare class" error.
+        require_once $file;
+
+        $file = str_replace(array($path.'/', '.php'), array('', ''), $file);
+
+        // is it a namespaced class?
+        $class = str_replace('/', '\\', $file);
+        if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false))) {
+            return $class;
+        }
+
+        // is it a PEAR-like class name instead?
+        $class = str_replace('/', '_', $file);
+        if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false))) {
+            return $class;
         }
     }
 }

--- a/src/Symfony/Component/Debug/ErrorHandler.php
+++ b/src/Symfony/Component/Debug/ErrorHandler.php
@@ -43,11 +43,6 @@ class ErrorHandler
         E_PARSE             => 'Parse',
     );
 
-    private $classNameToUseStatementSuggestions = array(
-        'Request' => 'Symfony\Component\HttpFoundation\Request',
-        'Response' => 'Symfony\Component\HttpFoundation\Response',
-    );
-
     private $level;
 
     private $reservedMemory;
@@ -293,11 +288,23 @@ class ErrorHandler
                 );
             }
 
-            if (isset($this->classNameToUseStatementSuggestions[$className])) {
-                $message .= sprintf(' Perhaps you need to add "use %s" at the top of this file?', $this->classNameToUseStatementSuggestions[$className]);
+            if ($classes = $this->getUseStatementSuggestions($className)) {
+                $message .= sprintf(' Perhaps you need to add a use statement for one of the following class: %s.', implode(', ', $classes));
             }
 
             return new ClassNotFoundException($message, $exception);
+        }
+    }
+
+    protected function getUseStatementSuggestions($class)
+    {
+        $classNameToUseStatementSuggestions = array(
+            'Request'  => array('Symfony\Component\HttpFoundation\Request'),
+            'Response' => array('Symfony\Component\HttpFoundation\Response'),
+        );
+
+        if (isset($classNameToUseStatementSuggestions[$class])) {
+            return $classNameToUseStatementSuggestions[$class];
         }
     }
 }

--- a/src/Symfony/Component/Debug/Exception/ClassNotFoundException.php
+++ b/src/Symfony/Component/Debug/Exception/ClassNotFoundException.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Debug\Exception;
  *
  * @author Konstanton Myakshin <koc-dp@yandex.ru>
  */
-class ClassNotFoundException extends \ErrorException
+class ClassNotFoundException extends FatalErrorException
 {
     public function __construct($message, \ErrorException $previous)
     {

--- a/src/Symfony/Component/Debug/Exception/ClassNotFoundException.php
+++ b/src/Symfony/Component/Debug/Exception/ClassNotFoundException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Exception;
+
+/**
+ * Class (or Trait or Interface) Not Found Exception.
+ *
+ * @author Konstanton Myakshin <koc-dp@yandex.ru>
+ */
+class ClassNotFoundException extends \ErrorException
+{
+    public function __construct($message, \ErrorException $previous)
+    {
+        parent::__construct(
+            $message,
+            $previous->getCode(),
+            $previous->getSeverity(),
+            $previous->getFile(),
+            $previous->getLine(),
+            $previous->getPrevious()
+        );
+    }
+}

--- a/src/Symfony/Component/Debug/Exception/UndefinedFunctionException.php
+++ b/src/Symfony/Component/Debug/Exception/UndefinedFunctionException.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Exception;
+
+/**
+ * Undefined Function Exception.
+ *
+ * @author Konstanton Myakshin <koc-dp@yandex.ru>
+ */
+class UndefinedFunctionException extends \ErrorException
+{
+    public function __construct($message, \ErrorException $previous)
+    {
+        parent::__construct(
+            $message,
+            $previous->getCode(),
+            $previous->getSeverity(),
+            $previous->getFile(),
+            $previous->getLine(),
+            $previous->getPrevious()
+        );
+    }
+}

--- a/src/Symfony/Component/Debug/Exception/UndefinedFunctionException.php
+++ b/src/Symfony/Component/Debug/Exception/UndefinedFunctionException.php
@@ -16,7 +16,7 @@ namespace Symfony\Component\Debug\Exception;
  *
  * @author Konstanton Myakshin <koc-dp@yandex.ru>
  */
-class UndefinedFunctionException extends \ErrorException
+class UndefinedFunctionException extends FatalErrorException
 {
     public function __construct($message, \ErrorException $previous)
     {

--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\FatalErrorHandler;
+
+use Symfony\Component\Debug\Exception\ClassNotFoundException;
+use Symfony\Component\Debug\Exception\FatalErrorException;
+use Composer\Autoload\ClassLoader as ComposerClassLoader;
+use Symfony\Component\ClassLoader as SymfonyClassLoader;
+use Symfony\Component\ClassLoader\DebugClassLoader;
+
+/**
+ * ErrorHandler for classes that do not exist.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handleError(array $error, FatalErrorException $exception)
+    {
+        $messageLen = strlen($error['message']);
+        $notFoundSuffix = '" not found';
+        $notFoundSuffixLen = strlen($notFoundSuffix);
+        if ($notFoundSuffixLen > $messageLen) {
+            return;
+        }
+
+        if (0 !== substr_compare($error['message'], $notFoundSuffix, -$notFoundSuffixLen)) {
+            return;
+        }
+
+        foreach (array('class', 'interface', 'trait') as $typeName) {
+            $prefix = ucfirst($typeName).' "';
+            $prefixLen = strlen($prefix);
+            if (0 !== strpos($error['message'], $prefix)) {
+                continue;
+            }
+
+            $fullyQualifiedClassName = substr($error['message'], $prefixLen, -$notFoundSuffixLen);
+            if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedClassName, '\\')) {
+                $className = substr($fullyQualifiedClassName, $namespaceSeparatorIndex + 1);
+                $namespacePrefix = substr($fullyQualifiedClassName, 0, $namespaceSeparatorIndex);
+                $message = sprintf(
+                    'Attempted to load %s "%s" from namespace "%s" in %s line %d. Do you need to "use" it from another namespace?',
+                    $typeName,
+                    $className,
+                    $namespacePrefix,
+                    $error['file'],
+                    $error['line']
+                );
+            } else {
+                $className = $fullyQualifiedClassName;
+                $message = sprintf(
+                    'Attempted to load %s "%s" from the global namespace in %s line %d. Did you forget a use statement for this %s?',
+                    $typeName,
+                    $className,
+                    $error['file'],
+                    $error['line'],
+                    $typeName
+                );
+            }
+
+            if ($classes = $this->getClassCandidates($className)) {
+                $message .= sprintf(' Perhaps you need to add a use statement for one of the following class: %s.', implode(', ', $classes));
+            }
+
+            return new ClassNotFoundException($message, $exception);
+        }
+    }
+
+    /**
+     * Tries to guess the full namespace for a given class name.
+     *
+     * By default, it looks for PSR-0 classes registered via a Symfony or a Composer
+     * autoloader (that should cover all common cases).
+     *
+     * @param string $class A class name (without its namespace)
+     *
+     * @return array An array of possible fully qualified class names
+     */
+    private function getClassCandidates($class)
+    {
+        if (!is_array($functions = spl_autoload_functions())) {
+            return array();
+        }
+
+        // find Symfony and Composer autoloaders
+        $classes = array();
+        foreach ($functions as $function) {
+            if (!is_array($function)) {
+                continue;
+            }
+
+            // get class loaders wrapped by DebugClassLoader
+            if ($function[0] instanceof DebugClassLoader && method_exists($function[0], 'getClassLoader')) {
+                $function[0] = $function[0]->getClassLoader();
+            }
+
+            if ($function[0] instanceof ComposerClassLoader || $function[0] instanceof SymfonyClassLoader) {
+                foreach ($function[0]->getPrefixes() as $paths) {
+                    foreach ($paths as $path) {
+                        $classes = array_merge($classes, $this->findClassInPath($function[0], $path, $class));
+                    }
+                }
+            }
+        }
+
+        return $classes;
+    }
+
+    private function findClassInPath($loader, $path, $class)
+    {
+        if (!$path = realpath($path)) {
+            continue;
+        }
+
+        $classes = array();
+        $filename = $class.'.php';
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($path), \RecursiveIteratorIterator::LEAVES_ONLY) as $file) {
+            if ($filename == $file->getFileName() && $class = $this->convertFileToClass($loader, $path, $file->getPathName())) {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }
+
+    private function convertFileToClass($loader, $path, $file)
+    {
+        // We cannot use the autoloader here as most of them use require; but if the class
+        // is not found, the new autoloader call will require the file again leading to a
+        // "cannot redeclare class" error.
+        require_once $file;
+
+        $file = str_replace(array($path.'/', '.php'), array('', ''), $file);
+
+        // is it a namespaced class?
+        $class = str_replace('/', '\\', $file);
+        if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false))) {
+            return $class;
+        }
+
+        // is it a PEAR-like class name instead?
+        $class = str_replace('/', '_', $file);
+        if (class_exists($class, false) || interface_exists($class, false) || (function_exists('trait_exists') && trait_exists($class, false))) {
+            return $class;
+        }
+    }
+}

--- a/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/ClassNotFoundFatalErrorHandler.php
@@ -72,7 +72,7 @@ class ClassNotFoundFatalErrorHandler implements FatalErrorHandlerInterface
             }
 
             if ($classes = $this->getClassCandidates($className)) {
-                $message .= sprintf(' Perhaps you need to add a use statement for one of the following class: %s.', implode(', ', $classes));
+                $message .= sprintf(' Perhaps you need to add a use statement for one of the following: %s.', implode(', ', $classes));
             }
 
             return new ClassNotFoundException($message, $exception);

--- a/src/Symfony/Component/Debug/FatalErrorHandler/FatalErrorHandlerInterface.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/FatalErrorHandlerInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\FatalErrorHandler;
+
+use Symfony\Component\Debug\Exception\FatalErrorException;
+
+/**
+ * Attempts to convert fatal errors to exceptions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+interface FatalErrorHandlerInterface
+{
+    /**
+     * Attempts to convert an error into an exception.
+     *
+     * @param array               $error     An array as returned by error_get_last()
+     * @param FatalErrorException $exception A FatalErrorException instance
+     *
+     * @return FatalErrorException|null A FatalErrorException instance if the class is able to convert the error, null otherwise
+     */
+    public function handleError(array $error, FatalErrorException $exception);
+}

--- a/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedFunctionFatalErrorHandler.php
+++ b/src/Symfony/Component/Debug/FatalErrorHandler/UndefinedFunctionFatalErrorHandler.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\FatalErrorHandler;
+
+use Symfony\Component\Debug\Exception\UndefinedFunctionException;
+use Symfony\Component\Debug\Exception\FatalErrorException;
+
+/**
+ * ErrorHandler for undefined functions.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class UndefinedFunctionFatalErrorHandler implements FatalErrorHandlerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function handleError(array $error, FatalErrorException $exception)
+    {
+        $messageLen = strlen($error['message']);
+        $notFoundSuffix = '()';
+        $notFoundSuffixLen = strlen($notFoundSuffix);
+        if ($notFoundSuffixLen > $messageLen) {
+            return;
+        }
+
+        if (0 !== substr_compare($error['message'], $notFoundSuffix, -$notFoundSuffixLen)) {
+            return;
+        }
+
+        $prefix = 'Call to undefined function ';
+        $prefixLen = strlen($prefix);
+        if (0 !== strpos($error['message'], $prefix)) {
+            return;
+        }
+
+        $fullyQualifiedFunctionName = substr($error['message'], $prefixLen, -$notFoundSuffixLen);
+        if (false !== $namespaceSeparatorIndex = strrpos($fullyQualifiedFunctionName, '\\')) {
+            $functionName = substr($fullyQualifiedFunctionName, $namespaceSeparatorIndex + 1);
+            $namespacePrefix = substr($fullyQualifiedFunctionName, 0, $namespaceSeparatorIndex);
+            $message = sprintf(
+                'Attempted to call function "%s" from namespace "%s" in %s line %d.',
+                $functionName,
+                $namespacePrefix,
+                $error['file'],
+                $error['line']
+            );
+        } else {
+            $functionName = $fullyQualifiedFunctionName;
+            $message = sprintf(
+                'Attempted to call function "%s" from the global namespace in %s line %d.',
+                $functionName,
+                $error['file'],
+                $error['line']
+            );
+        }
+
+        $candidates = array();
+        foreach (get_defined_functions() as $type => $definedFunctionNames) {
+            foreach ($definedFunctionNames as $definedFunctionName) {
+                if (false !== $namespaceSeparatorIndex = strrpos($definedFunctionName, '\\')) {
+                    $definedFunctionNameBasename = substr($definedFunctionName, $namespaceSeparatorIndex + 1);
+                } else {
+                    $definedFunctionNameBasename = $definedFunctionName;
+                }
+
+                if ($definedFunctionNameBasename === $functionName) {
+                    $candidates[] = '\\'.$definedFunctionName;
+                }
+            }
+        }
+
+        if ($candidates) {
+            $message .= ' Did you mean to call: '.implode(', ', array_map(function ($val) {
+                return '"'.$val.'"';
+            }, $candidates)).'?';
+        }
+
+        return new UndefinedFunctionException($message, $exception);
+    }
+}

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Debug\Tests;
 
 use Symfony\Component\Debug\ErrorHandler;
+use Symfony\Component\Debug\Exception\ClassNotFoundException;
+use Symfony\Component\Debug\ExceptionHandler;
 
 /**
  * ErrorHandlerTest
@@ -90,4 +92,154 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
 
         restore_error_handler();
     }
+
+    public function provideClassNotFoundData()
+    {
+        return array(
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Class 'WhizBangFactory' not found",
+                ),
+                "Attempted to load class 'WhizBangFactory' from the global namespace in foo.php line 12. Did you forget a use statement for this class?",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Class 'Foo\\Bar\\WhizBangFactory' not found",
+                ),
+                "Attempted to load class 'WhizBangFactory' from namespace 'Foo\\Bar' in foo.php line 12. Do you need to 'use' it from another namespace?",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Class 'Request' not found",
+                ),
+                "Attempted to load class 'Request' from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Request' at the top of this file?",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Class 'Foo\\Bar\\Request' not found",
+                ),
+                "Attempted to load class 'Request' from namespace 'Foo\\Bar' in foo.php line 12. Do you need to 'use' it from another namespace? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Request' at the top of this file?",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Class 'Response' not found",
+                ),
+                "Attempted to load class 'Response' from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Response' at the top of this file?",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Class 'Foo\\Bar\\Response' not found",
+                ),
+                "Attempted to load class 'Response' from namespace 'Foo\\Bar' in foo.php line 12. Do you need to 'use' it from another namespace? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Response' at the top of this file?",
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideClassNotFoundData
+     */
+    public function testClassNotFound($error, $translatedMessage)
+    {
+        $handler = ErrorHandler::register(3);
+
+        $exceptionHandler = new MockExceptionHandler;
+        set_exception_handler(array($exceptionHandler, 'handle'));
+
+        $handler->handleFatalError($error);
+
+        $this->assertNotNull($exceptionHandler->e);
+        $this->assertSame($translatedMessage, $exceptionHandler->e->getMessage());
+        $this->assertSame($error['type'], $exceptionHandler->e->getSeverity());
+        $this->assertSame($error['file'], $exceptionHandler->e->getFile());
+        $this->assertSame($error['line'], $exceptionHandler->e->getLine());
+
+        restore_exception_handler();
+        restore_error_handler();
+    }
+
+    public function provideUndefinedFunctionData()
+    {
+        return array(
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Call to undefined function test_namespaced_function()",
+                ),
+                "Attempted to call function 'test_namespaced_function' from the global namespace in foo.php line 12. Did you mean to call: '\\symfony\\component\\debug\\tests\\test_namespaced_function'?",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Call to undefined function Foo\\Bar\\Baz\\test_namespaced_function()",
+                ),
+                "Attempted to call function 'test_namespaced_function' from namespace 'Foo\\Bar\\Baz' in foo.php line 12. Did you mean to call: '\\symfony\\component\\debug\\tests\\test_namespaced_function'?",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Call to undefined function foo()",
+                ),
+                "Attempted to call function 'foo' from the global namespace in foo.php line 12.",
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => "Call to undefined function Foo\\Bar\\Baz\\foo()",
+                ),
+                "Attempted to call function 'foo' from namespace 'Foo\Bar\Baz' in foo.php line 12.",
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideUndefinedFunctionData
+     */
+    public function testUndefinedFunction($error, $translatedMessage)
+    {
+        $handler = ErrorHandler::register(3);
+
+        $exceptionHandler = new MockExceptionHandler;
+        set_exception_handler(array($exceptionHandler, 'handle'));
+
+        $handler->handleFatalError($error);
+
+        $this->assertNotNull($exceptionHandler->e);
+        $this->assertSame($translatedMessage, $exceptionHandler->e->getMessage());
+        $this->assertSame($error['type'], $exceptionHandler->e->getSeverity());
+        $this->assertSame($error['file'], $exceptionHandler->e->getFile());
+        $this->assertSame($error['line'], $exceptionHandler->e->getLine());
+
+        restore_exception_handler();
+        restore_error_handler();
+    }
+}
+
+function test_namespaced_function()
+{
 }

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -101,54 +101,36 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Class 'WhizBangFactory' not found",
+                    'message' => 'Class "WhizBangFactory" not found',
                 ),
-                "Attempted to load class 'WhizBangFactory' from the global namespace in foo.php line 12. Did you forget a use statement for this class?",
+                'Attempted to load class "WhizBangFactory" from the global namespace in foo.php line 12. Did you forget a use statement for this class?',
             ),
             array(
                 array(
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Class 'Foo\\Bar\\WhizBangFactory' not found",
+                    'message' => 'Class "Foo\\Bar\\WhizBangFactory" not found',
                 ),
-                "Attempted to load class 'WhizBangFactory' from namespace 'Foo\\Bar' in foo.php line 12. Do you need to 'use' it from another namespace?",
+                'Attempted to load class "WhizBangFactory" from namespace "Foo\\Bar" in foo.php line 12. Do you need to "use" it from another namespace?',
             ),
             array(
                 array(
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Class 'Request' not found",
+                    'message' => 'Class "Request" not found',
                 ),
-                "Attempted to load class 'Request' from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Request' at the top of this file?",
+                'Attempted to load class "Request" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add "use Symfony\\Component\\HttpFoundation\\Request" at the top of this file?',
             ),
             array(
                 array(
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Class 'Foo\\Bar\\Request' not found",
+                    'message' => 'Class "Foo\\Bar\\Request" not found',
                 ),
-                "Attempted to load class 'Request' from namespace 'Foo\\Bar' in foo.php line 12. Do you need to 'use' it from another namespace? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Request' at the top of this file?",
-            ),
-            array(
-                array(
-                    'type' => 1,
-                    'line' => 12,
-                    'file' => 'foo.php',
-                    'message' => "Class 'Response' not found",
-                ),
-                "Attempted to load class 'Response' from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Response' at the top of this file?",
-            ),
-            array(
-                array(
-                    'type' => 1,
-                    'line' => 12,
-                    'file' => 'foo.php',
-                    'message' => "Class 'Foo\\Bar\\Response' not found",
-                ),
-                "Attempted to load class 'Response' from namespace 'Foo\\Bar' in foo.php line 12. Do you need to 'use' it from another namespace? Perhaps you need to add 'use Symfony\\Component\\HttpFoundation\\Response' at the top of this file?",
+                'Attempted to load class "Request" from namespace "Foo\\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add "use Symfony\\Component\\HttpFoundation\\Request" at the top of this file?',
             ),
         );
     }
@@ -159,11 +141,13 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testClassNotFound($error, $translatedMessage)
     {
         $handler = ErrorHandler::register(3);
+        $m = new \ReflectionMethod($handler, 'handleFatalError');
+        $m->setAccessible(true);
 
         $exceptionHandler = new MockExceptionHandler;
         set_exception_handler(array($exceptionHandler, 'handle'));
 
-        $handler->handleFatalError($error);
+        $m->invoke($handler, $error);
 
         $this->assertNotNull($exceptionHandler->e);
         $this->assertSame($translatedMessage, $exceptionHandler->e->getMessage());
@@ -183,36 +167,36 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Call to undefined function test_namespaced_function()",
+                    'message' => 'Call to undefined function test_namespaced_function()',
                 ),
-                "Attempted to call function 'test_namespaced_function' from the global namespace in foo.php line 12. Did you mean to call: '\\symfony\\component\\debug\\tests\\test_namespaced_function'?",
+                'Attempted to call function "test_namespaced_function" from the global namespace in foo.php line 12. Did you mean to call: "\\symfony\\component\\debug\\tests\\test_namespaced_function"?',
             ),
             array(
                 array(
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Call to undefined function Foo\\Bar\\Baz\\test_namespaced_function()",
+                    'message' => 'Call to undefined function Foo\\Bar\\Baz\\test_namespaced_function()',
                 ),
-                "Attempted to call function 'test_namespaced_function' from namespace 'Foo\\Bar\\Baz' in foo.php line 12. Did you mean to call: '\\symfony\\component\\debug\\tests\\test_namespaced_function'?",
+                'Attempted to call function "test_namespaced_function" from namespace "Foo\\Bar\\Baz" in foo.php line 12. Did you mean to call: "\\symfony\\component\\debug\\tests\\test_namespaced_function"?',
             ),
             array(
                 array(
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Call to undefined function foo()",
+                    'message' => 'Call to undefined function foo()',
                 ),
-                "Attempted to call function 'foo' from the global namespace in foo.php line 12.",
+                'Attempted to call function "foo" from the global namespace in foo.php line 12.',
             ),
             array(
                 array(
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => "Call to undefined function Foo\\Bar\\Baz\\foo()",
+                    'message' => 'Call to undefined function Foo\\Bar\\Baz\\foo()',
                 ),
-                "Attempted to call function 'foo' from namespace 'Foo\Bar\Baz' in foo.php line 12.",
+                'Attempted to call function "foo" from namespace "Foo\Bar\Baz" in foo.php line 12.',
             ),
         );
     }
@@ -223,11 +207,13 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     public function testUndefinedFunction($error, $translatedMessage)
     {
         $handler = ErrorHandler::register(3);
+        $m = new \ReflectionMethod($handler, 'handleFatalError');
+        $m->setAccessible(true);
 
         $exceptionHandler = new MockExceptionHandler;
         set_exception_handler(array($exceptionHandler, 'handle'));
 
-        $handler->handleFatalError($error);
+        $m->invoke($handler, $error);
 
         $this->assertNotNull($exceptionHandler->e);
         $this->assertSame($translatedMessage, $exceptionHandler->e->getMessage());

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -121,7 +121,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class "Request" not found',
                 ),
-                'Attempted to load class "Request" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add "use Symfony\\Component\\HttpFoundation\\Request" at the top of this file?',
+                'Attempted to load class "Request" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony\Component\HttpFoundation\Request.',
             ),
             array(
                 array(
@@ -130,7 +130,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class "Foo\\Bar\\Request" not found',
                 ),
-                'Attempted to load class "Request" from namespace "Foo\\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add "use Symfony\\Component\\HttpFoundation\\Request" at the top of this file?',
+                'Attempted to load class "Request" from namespace "Foo\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add a use statement for one of the following class: Symfony\Component\HttpFoundation\Request.',
             ),
         );
     }

--- a/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/ErrorHandlerTest.php
@@ -119,18 +119,27 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => 'Class "Request" not found',
+                    'message' => 'Class "UndefinedFunctionException" not found',
                 ),
-                'Attempted to load class "Request" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony\Component\HttpFoundation\Request.',
+                'Attempted to load class "UndefinedFunctionException" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
             ),
             array(
                 array(
                     'type' => 1,
                     'line' => 12,
                     'file' => 'foo.php',
-                    'message' => 'Class "Foo\\Bar\\Request" not found',
+                    'message' => 'Class "PEARClass" not found',
                 ),
-                'Attempted to load class "Request" from namespace "Foo\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add a use statement for one of the following class: Symfony\Component\HttpFoundation\Request.',
+                'Attempted to load class "PEARClass" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony_Component_Debug_Tests_Fixtures_PEARClass.',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Class "Foo\\Bar\\UndefinedFunctionException" not found',
+                ),
+                'Attempted to load class "UndefinedFunctionException" from namespace "Foo\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add a use statement for one of the following class: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
             ),
         );
     }

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -60,7 +60,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class "UndefinedFunctionException" not found',
                 ),
-                'Attempted to load class "UndefinedFunctionException" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
+                'Attempted to load class "UndefinedFunctionException" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
             ),
             array(
                 array(
@@ -69,7 +69,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class "PEARClass" not found',
                 ),
-                'Attempted to load class "PEARClass" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony_Component_Debug_Tests_Fixtures_PEARClass.',
+                'Attempted to load class "PEARClass" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following: Symfony_Component_Debug_Tests_Fixtures_PEARClass.',
             ),
             array(
                 array(
@@ -78,7 +78,7 @@ class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
                     'file' => 'foo.php',
                     'message' => 'Class "Foo\\Bar\\UndefinedFunctionException" not found',
                 ),
-                'Attempted to load class "UndefinedFunctionException" from namespace "Foo\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add a use statement for one of the following class: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
+                'Attempted to load class "UndefinedFunctionException" from namespace "Foo\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add a use statement for one of the following: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
             ),
         );
     }

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/ClassNotFoundFatalErrorHandlerTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Tests\FatalErrorHandler;
+
+use Symfony\Component\Debug\ErrorHandler;
+use Symfony\Component\Debug\Exception\FatalErrorException;
+use Symfony\Component\Debug\FatalErrorHandler\ClassNotFoundFatalErrorHandler;
+
+class ClassNotFoundFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideClassNotFoundData
+     */
+    public function testClassNotFound($error, $translatedMessage)
+    {
+        $handler = new ClassNotFoundFatalErrorHandler();
+        $exception = $handler->handleError($error, new FatalErrorException('', 0, $error['type'], $error['file'], $error['line']));
+
+        $this->assertInstanceof('Symfony\Component\Debug\Exception\ClassNotFoundException', $exception);
+        $this->assertSame($translatedMessage, $exception->getMessage());
+        $this->assertSame($error['type'], $exception->getSeverity());
+        $this->assertSame($error['file'], $exception->getFile());
+        $this->assertSame($error['line'], $exception->getLine());
+    }
+
+    public function provideClassNotFoundData()
+    {
+        return array(
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Class "WhizBangFactory" not found',
+                ),
+                'Attempted to load class "WhizBangFactory" from the global namespace in foo.php line 12. Did you forget a use statement for this class?',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Class "Foo\\Bar\\WhizBangFactory" not found',
+                ),
+                'Attempted to load class "WhizBangFactory" from namespace "Foo\\Bar" in foo.php line 12. Do you need to "use" it from another namespace?',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Class "UndefinedFunctionException" not found',
+                ),
+                'Attempted to load class "UndefinedFunctionException" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Class "PEARClass" not found',
+                ),
+                'Attempted to load class "PEARClass" from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add a use statement for one of the following class: Symfony_Component_Debug_Tests_Fixtures_PEARClass.',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Class "Foo\\Bar\\UndefinedFunctionException" not found',
+                ),
+                'Attempted to load class "UndefinedFunctionException" from namespace "Foo\Bar" in foo.php line 12. Do you need to "use" it from another namespace? Perhaps you need to add a use statement for one of the following class: Symfony\Component\Debug\Exception\UndefinedFunctionException.',
+            ),
+        );
+    }
+}

--- a/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedFunctionFatalErrorHandlerTest.php
+++ b/src/Symfony/Component/Debug/Tests/FatalErrorHandler/UndefinedFunctionFatalErrorHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Tests\FatalErrorHandler;
+
+use Symfony\Component\Debug\ErrorHandler;
+use Symfony\Component\Debug\Exception\FatalErrorException;
+use Symfony\Component\Debug\FatalErrorHandler\UndefinedFunctionFatalErrorHandler;
+
+class UndefinedFunctionFatalErrorHandlerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider provideUndefinedFunctionData
+     */
+    public function testUndefinedFunction($error, $translatedMessage)
+    {
+        $handler = new UndefinedFunctionFatalErrorHandler();
+        $exception = $handler->handleError($error, new FatalErrorException('', 0, $error['type'], $error['file'], $error['line']));
+
+        $this->assertInstanceof('Symfony\Component\Debug\Exception\UndefinedFunctionException', $exception);
+        $this->assertSame($translatedMessage, $exception->getMessage());
+        $this->assertSame($error['type'], $exception->getSeverity());
+        $this->assertSame($error['file'], $exception->getFile());
+        $this->assertSame($error['line'], $exception->getLine());
+    }
+
+    public function provideUndefinedFunctionData()
+    {
+        return array(
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Call to undefined function test_namespaced_function()',
+                ),
+                'Attempted to call function "test_namespaced_function" from the global namespace in foo.php line 12. Did you mean to call: "\\symfony\\component\\debug\\tests\\fatalerrorhandler\\test_namespaced_function"?',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Call to undefined function Foo\\Bar\\Baz\\test_namespaced_function()',
+                ),
+                'Attempted to call function "test_namespaced_function" from namespace "Foo\\Bar\\Baz" in foo.php line 12. Did you mean to call: "\\symfony\\component\\debug\\tests\\fatalerrorhandler\\test_namespaced_function"?',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Call to undefined function foo()',
+                ),
+                'Attempted to call function "foo" from the global namespace in foo.php line 12.',
+            ),
+            array(
+                array(
+                    'type' => 1,
+                    'line' => 12,
+                    'file' => 'foo.php',
+                    'message' => 'Call to undefined function Foo\\Bar\\Baz\\foo()',
+                ),
+                'Attempted to call function "foo" from namespace "Foo\Bar\Baz" in foo.php line 12.',
+            ),
+        );
+    }
+}
+
+function test_namespaced_function()
+{
+}

--- a/src/Symfony/Component/Debug/Tests/Fixtures/PEARClass.php
+++ b/src/Symfony/Component/Debug/Tests/Fixtures/PEARClass.php
@@ -1,0 +1,5 @@
+<?php
+
+class Symfony_Component_Debug_Tests_Fixtures_PEARClass
+{
+}

--- a/src/Symfony/Component/Debug/Tests/MockExceptionHandler.php
+++ b/src/Symfony/Component/Debug/Tests/MockExceptionHandler.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Debug\Tests;
+
+use Symfony\Component\Debug\ExceptionHandler;
+
+class MockExceptionHandler extends Exceptionhandler
+{
+    public $e;
+
+    public function handle(\Exception $e)
+    {
+        $this->e = $e;
+    }
+}


### PR DESCRIPTION
This is a followup of #8156

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8156 |
| License | MIT |
| Doc PR | n/a |

Here is the original description from #8156:

Per a discussion with @weaverryan and others, I took a crack at enhancing the exception display for class not found errors and undefined function errors. It is not the cleanest solution but this is a work in progress to see whether or not following this path makes sense.
# Class Names
## Class Not Found: Unknown Class (Global Namespace)

``` php
<?php
new WhizBangFactory();
```

> Attempted to load class 'WhizBangFactory' from the global namespace in foo.php line 12. Did you forget a use statement for this class?
## Class Not Found: Unknown Class (Full Namespace)

``` php
<?php
namespace Foo\Bar;
new WhizBangFactory();
```

> Attempted to load class 'WhizBangFactory' from namespace 'Foo\Bar' in foo.php line 12. Do you need to 'use' it from another namespace?
## Class Not Found: Well Known Class (Global Namespace)

``` php
<?php
new Request();
```

> Attempted to load class 'Request' from the global namespace in foo.php line 12. Did you forget a use statement for this class? Perhaps you need to add 'use Symfony\Component\HttpFoundation\Request' at the top of this file?
## Class Not Found: Well Known Class (Full Namespace)

``` php
<?php
namespace Foo\Bar;
new Request();
```

> Attempted to load class 'Request' from namespace 'Foo\Bar' in foo.php line 12. Do you need to 'use' it from another namespace? Perhaps you need to add 'use Symfony\Component\HttpFoundation\Request' at the top of this file?
# Functions
## Undefined Function (Global Namespace)

``` php
<?php
// example.php:
// namespace Acme\Example;
// function test_namespaced_function()
// {
// }
include "example.php";

test_namespaced_function()
```

> Attempted to call function 'test_namespaced_function' from the global namespace in foo.php line 12. Did you mean to call: '\acme\example\test_namespaced_function'?
## Undefined Function (Full Namespace)

``` php
<?php
namespace Foo\Bar\Baz;

// example.php:
// namespace Acme\Example;
// function test_namespaced_function()
// {
// }
include "example.php";

test_namespaced_function()
```

> Attempted to call function 'test_namespaced_function' from namespace 'Foo\Bar\Baz' in foo.php line 12. Did you mean to call: '\acme\example\test_namespaced_function'?
## Undefined Function: Unknown Function (Global Namespace)

``` php
<?php
test_namespaced_function()
```

> Attempted to call function 'test_namespaced_function' from the global namespace in foo.php line 12.
## Undefined Function: Unknown Function (Full Namespace)

``` php
<?php
namespace Foo\Bar\Baz;

test_namespaced_function()
```

> Attempted to call function 'test_namespaced_function' from namespace 'Foo\Bar\Baz' in foo.php line 12.
