### PR TITLE
[FrameworkBundle] RedirectCotroller: The ignoreAttributes parameter should be ignored

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php
@@ -49,7 +49,7 @@ class RedirectController extends ContainerAware
         $attributes = array();
         if (false === $ignoreAttributes || is_array($ignoreAttributes)) {
             $attributes = $request->attributes->get('_route_params');
-            unset($attributes['route'], $attributes['permanent']);
+            unset($attributes['route'], $attributes['permanent'], $attributes['ignoreAttributes']);
             if ($ignoreAttributes) {
                 $attributes = array_diff_key($attributes, array_flip($ignoreAttributes));
             }

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/Controller/RedirectControllerTest.php
@@ -53,6 +53,7 @@ class RedirectControllerTest extends TestCase
                 'route' => $route,
                 'permanent' => $permanent,
                 'additional-parameter' => 'value',
+                'ignoreAttributes' => $ignoreAttributes
             ),
         );
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

As discussed in PR #7590, when pointing a route to FrameworkBundle's `RedirectController` the attribute `ignoreAttributes` is added to the new route's attributes, if specified as array. As @lsmith77 wrote in a comment to that PR, this should not be the intended behavior. A valid workaround is to add `ignoreAttributes` itself to this array.

The problem remained undiscovered by the unit test, as `ignoreAttribues` was not included in the `_route_params` of the faked `Request` object. This PR should fix both, the unit test and the `RedirectController` itself, so the workaround mentioned above is not necessary anymore. Additionally, my fix should not break any routing configuration that is using the workaround.
