### PR TITLE
[Intl] made RegionBundle merge fallback data if using a country-specific locale

### DIFF
--- a/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/LanguageBundle.php
@@ -27,7 +27,7 @@ class LanguageBundle extends AbstractBundle implements LanguageBundleInterface
             $locale = \Locale::getDefault();
         }
 
-        if (null === ($languages = $this->readEntry($locale, array('Languages')))) {
+        if (null === ($languages = $this->readEntry($locale, array('Languages'), true))) {
             return null;
         }
 
@@ -49,7 +49,7 @@ class LanguageBundle extends AbstractBundle implements LanguageBundleInterface
             $locale = \Locale::getDefault();
         }
 
-        if (null === ($languages = $this->readEntry($locale, array('Languages')))) {
+        if (null === ($languages = $this->readEntry($locale, array('Languages'), true))) {
             return array();
         }
 
@@ -102,7 +102,7 @@ class LanguageBundle extends AbstractBundle implements LanguageBundleInterface
             $locale = \Locale::getDefault();
         }
 
-        if (null === ($scripts = $this->readEntry($locale, array('Scripts')))) {
+        if (null === ($scripts = $this->readEntry($locale, array('Scripts'), true))) {
             return array();
         }
 

--- a/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
+++ b/src/Symfony/Component/Intl/ResourceBundle/RegionBundle.php
@@ -27,7 +27,7 @@ class RegionBundle extends AbstractBundle implements RegionBundleInterface
             $locale = \Locale::getDefault();
         }
 
-        return $this->readEntry($locale, array('Countries', $country));
+        return $this->readEntry($locale, array('Countries', $country), true);
     }
 
     /**
@@ -39,7 +39,7 @@ class RegionBundle extends AbstractBundle implements RegionBundleInterface
             $locale = \Locale::getDefault();
         }
 
-        if (null === ($countries = $this->readEntry($locale, array('Countries')))) {
+        if (null === ($countries = $this->readEntry($locale, array('Countries'), true))) {
             return array();
         }
 

--- a/src/Symfony/Component/Intl/Tests/ResourceBundle/RegionBundleTest.php
+++ b/src/Symfony/Component/Intl/Tests/ResourceBundle/RegionBundleTest.php
@@ -40,7 +40,7 @@ class RegionBundleTest extends \PHPUnit_Framework_TestCase
     {
         $this->reader->expects($this->once())
             ->method('readEntry')
-            ->with(self::RES_DIR, 'en', array('Countries', 'AT'))
+            ->with(self::RES_DIR, 'en', array('Countries', 'AT'), true)
             ->will($this->returnValue('Austria'));
 
         $this->assertSame('Austria', $this->bundle->getCountryName('AT', 'en'));
@@ -55,7 +55,7 @@ class RegionBundleTest extends \PHPUnit_Framework_TestCase
 
         $this->reader->expects($this->once())
             ->method('readEntry')
-            ->with(self::RES_DIR, 'en', array('Countries'))
+            ->with(self::RES_DIR, 'en', array('Countries'), true)
             ->will($this->returnValue($sortedCountries));
 
         $this->assertSame($sortedCountries, $this->bundle->getCountryNames('en'));

--- a/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/CountryValidatorTest.php
@@ -104,4 +104,14 @@ class CountryValidatorTest extends \PHPUnit_Framework_TestCase
             array('EN'),
         );
     }
+
+    public function testValidateUsingCountrySpecificLocale()
+    {
+        \Locale::setDefault('en_GB');
+        $existingCountry = 'GB';
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($existingCountry, new Country());
+    }
 }

--- a/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
+++ b/src/Symfony/Component/Validator/Tests/Constraints/LanguageValidatorTest.php
@@ -104,4 +104,16 @@ class LanguageValidatorTest extends \PHPUnit_Framework_TestCase
             array('foobar'),
         );
     }
+
+    public function testValidateUsingCountrySpecificLocale()
+    {
+        \Locale::setDefault('fr_FR');
+        $existingLanguage = 'en';
+        $this->context->expects($this->never())
+            ->method('addViolation');
+
+        $this->validator->validate($existingLanguage, new Language(array(
+            'message' => 'aMessage'
+        )));
+    }
 }


### PR DESCRIPTION
See #8442 and symfony/Icu#2.

Essentially, country data fetches from the Intl component do not currently work when using a locale with a country specifier, e.g. `fr_FR`.  This change forces a merge on the data against the root language locale, thus making country data available for such locales.
