### PR TITLE
[Form] fixes empty file-inputs get treated as extra field 

### DIFF
--- a/src/Symfony/Component/Form/Form.php
+++ b/src/Symfony/Component/Form/Form.php
@@ -546,7 +546,7 @@ class Form implements \IteratorAggregate, FormInterface
 
             foreach ($this->children as $name => $child) {
                 $fieldValue = null;
-                if (isset($submittedData[$name])) {
+                if (array_key_exists($name, $submittedData)) {
                     $fieldValue = $submittedData[$name];
                     unset($submittedData[$name]);
                 }

--- a/src/Symfony/Component/Form/Tests/CompoundFormTest.php
+++ b/src/Symfony/Component/Form/Tests/CompoundFormTest.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Form\Tests;
 
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationRequestHandler;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\Forms;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Symfony\Component\Form\Tests\Fixtures\FixedDataTransformer;
@@ -71,6 +72,19 @@ class CompoundFormTest extends AbstractFormTest
             ->method('setData');
 
         $this->form->submit(array(), false);
+    }
+
+    public function testSubmitDoesNotAddExtraFieldForNullValues()
+    {
+        $factory = Forms::createFormFactoryBuilder()
+            ->getFormFactory();
+
+        $child = $factory->create('file', null, array('auto_initialize' => false));
+
+        $this->form->add($child);
+        $this->form->submit(array('file' => null));
+
+        $this->assertCount(0, $this->form->getExtraData());
     }
 
     public function testClearMissingFlagIsForwarded()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8548, #8566 |
| License | MIT |
