### PR TITLE
[Filesystem] fixed exception message when not a able to write to a directory

### DIFF
--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -456,7 +456,7 @@ class Filesystem
         if (!is_dir($dir)) {
             $this->mkdir($dir);
         } elseif (!is_writable($dir)) {
-            throw new IOException(sprintf('Unable to write in the %s directory\n', $dir));
+            throw new IOException(sprintf('Unable to write to directory "%s".', $dir));
         }
 
         $tmpFile = tempnam($dir, basename($filename));

--- a/src/Symfony/Component/Filesystem/Filesystem.php
+++ b/src/Symfony/Component/Filesystem/Filesystem.php
@@ -456,7 +456,7 @@ class Filesystem
         if (!is_dir($dir)) {
             $this->mkdir($dir);
         } elseif (!is_writable($dir)) {
-            throw new IOException(sprintf('Unable to write to directory "%s".', $dir));
+            throw new IOException(sprintf('Unable to write to the "%s" directory.', $dir));
         }
 
         $tmpFile = tempnam($dir, basename($filename));


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

This simply fixes an exception message in the Filesystem Component when a directory is not writable while dumping a file via `dumpFile()`.
