### PR TITLE
[DependencyInjection] Dump and Load Scopes

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/XmlDumper.php
@@ -52,6 +52,7 @@ class XmlDumper extends Dumper
         $container->setAttribute('xsi:schemaLocation', 'http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd');
 
         $this->addParameters($container);
+        $this->addScopes($container);
         $this->addServices($container);
 
         $this->document->appendChild($container);
@@ -81,6 +82,34 @@ class XmlDumper extends Dumper
         $parent->appendChild($parameters);
         $this->convertParameters($data, 'parameter', $parameters);
     }
+
+    /**
+     * Adds Scopes.
+     *
+     * @param \DOMElement $parent
+     */
+    private function addScopes(\DOMElement $parent)
+    {
+        $data = $this->container->getScopes();
+        if (!$data) {
+            return;
+        }
+
+        if ($this->container->isFrozen()) {
+            $data = $this->escape($data);
+        }
+
+        $scopes = $this->document->createElement('scopes');
+        $parent->appendChild($scopes);
+        foreach ($data as $name => $parent) {
+            $scope = $this->document->createElement('scope');
+            $scope->setAttribute('name', $name);
+            $scope->setAttribute('parent', $parent);
+            $scopes->appendChild($scope);
+        }
+    }
+
+
 
     /**
      * Adds method calls.

--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -56,7 +56,7 @@ class YamlDumper extends Dumper
      */
     public function dump(array $options = array())
     {
-        return $this->addParameters()."\n".$this->addServices();
+        return $this->addParameters()."\n".$this->addScopes().$this->addServices();
     }
 
     /**
@@ -207,6 +207,23 @@ class YamlDumper extends Dumper
         $parameters = $this->prepareParameters($this->container->getParameterBag()->all(), $this->container->isFrozen());
 
         return $this->dumper->dump(array('parameters' => $parameters), 2);
+    }
+
+    /**
+     * Adds Scopes
+     *
+     * @return string
+     */
+    private function addScopes()
+    {
+        $scopes = $this->container->getScopes();
+        if (empty($scopes)) {
+            return '';
+        }
+
+        $parameters = $this->prepareParameters($scopes, false);
+
+        return $this->dumper->dump(array('scopes' => $parameters), 2)."\n";
     }
 
     /**

--- a/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
+++ b/src/Symfony/Component/DependencyInjection/Loader/YamlFileLoader.php
@@ -113,10 +113,10 @@ class YamlFileLoader extends FileLoader
         }
 
         foreach ($content['scopes'] as $name => $parent) {
-        $parentName = !empty($parent) ? $parent : ContainerInterface::SCOPE_CONTAINER;
-        if (!$this->container->hasScope($name)) {
-            $this->container->addScope(new Scope($name, $parentName));
-        }
+            if (!$this->container->hasScope($name)) {
+                $parentName = !empty($parent) ? $parent : ContainerInterface::SCOPE_CONTAINER;
+                $this->container->addScope(new Scope($name, $parentName));
+            }
         }
 
     }

--- a/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
+++ b/src/Symfony/Component/DependencyInjection/Loader/schema/dic/services/services-1.0.xsd
@@ -27,6 +27,7 @@
       <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
       <xsd:element name="imports" type="imports" minOccurs="0" maxOccurs="1" />
       <xsd:element name="parameters" type="parameters" minOccurs="0" maxOccurs="1" />
+      <xsd:element name="scopes" type="scopes" minOccurs="0" maxOccurs="1" />
       <xsd:element name="services" type="services" minOccurs="0" maxOccurs="1" />
       <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
     </xsd:sequence>
@@ -149,6 +150,17 @@
       <xsd:element name="service" type="service" />
     </xsd:choice>
     <xsd:attribute name="method" type="xsd:string" />
+  </xsd:complexType>
+
+  <xsd:complexType name="scopes" mixed="true">
+      <xsd:choice minOccurs="1" maxOccurs="unbounded">
+          <xsd:element name="scope" type="scope" />
+      </xsd:choice>
+  </xsd:complexType>
+
+  <xsd:complexType name="scope">
+    <xsd:attribute name="name" type="xsd:string" use="required" />
+    <xsd:attribute name="parent" type="xsd:string" />
   </xsd:complexType>
 
   <xsd:simpleType name="parameter_type">

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/XmlDumperTest.php
@@ -40,11 +40,11 @@ class XmlDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/xml/services8.xml', $dumper->dump(), '->dump() dumps parameters');
     }
 
-    public function testAddParameters()
+    public function testAddScopes()
     {
-        $container = include self::$fixturesPath.'//containers/container8.php';
+        $container = include self::$fixturesPath.'//containers/container16.php';
         $dumper = new XmlDumper($container);
-        $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/xml/services8.xml', $dumper->dump(), '->dump() dumps parameters');
+        $this->assertXmlStringEqualsXmlFile(self::$fixturesPath.'/xml/services16.xml', $dumper->dump(), '->dump() dumps parameters');
     }
 
     public function testAddService()

--- a/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Dumper/YamlDumperTest.php
@@ -47,6 +47,13 @@ class YamlDumperTest extends \PHPUnit_Framework_TestCase
         $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services8.yml', $dumper->dump(), '->dump() dumps parameters');
     }
 
+    public function testAddScopes()
+    {
+        $container = include self::$fixturesPath.'/containers/container16.php';
+        $dumper = new YamlDumper($container);
+        $this->assertStringEqualsFile(self::$fixturesPath.'/yaml/services16.yml', $dumper->dump(), '->dump() dumps parameters');
+    }
+
     public function testAddService()
     {
         $container = include self::$fixturesPath.'/containers/container9.php';

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container16.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/containers/container16.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Scope;
+
+$container = new ContainerBuilder();
+$container->
+    addScope(new Scope("request"))
+;
+
+return $container;

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services16.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services16.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <scopes>
+    <scope name="request" parent="container"/>
+  </scopes>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services16_double_scope.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services16_double_scope.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <scopes>
+      <scope name="request" parent="container"/>
+      <scope name="request" parent="container"/>
+  </scopes>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services16.yml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/yaml/services16.yml
@@ -1,0 +1,4 @@
+
+scopes:
+    request: container
+

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -104,6 +104,30 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($expected, $actual, '->load() converts XML values to PHP ones');
     }
 
+    public function testLoadScopes()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services16.xml');
+
+        $actual = $container->getScopes();
+        $expected = array('request' => 'container');
+
+        $this->assertEquals($expected, $actual, '->load() adds Scopes to Container');
+    }
+
+    public function testLoadScopesWithoutDuplicates()
+    {
+        $container = new ContainerBuilder();
+        $loader = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader->load('services16_double_scope.xml');
+
+        $actual = $container->getScopes();
+        $expected = array('request' => 'container');
+
+        $this->assertEquals($expected, $actual, '->load() adds Scopes only once to Container');
+    }
+
     public function testLoadImports()
     {
         if (!class_exists('Symfony\Component\Yaml\Yaml')) {

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/YamlFileLoaderTest.php
@@ -87,6 +87,14 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo' => 'bar', 'mixedcase' => array('MixedCaseKey' => 'value'), 'values' => array(true, false, 0, 1000.3), 'bar' => 'foo', 'escape' => '@escapeme', 'foo_bar' => new Reference('foo_bar')), $container->getParameterBag()->all(), '->load() converts YAML keys to lowercase');
     }
 
+    public function testLoadScopes()
+    {
+        $container = new ContainerBuilder();
+        $loader = new YamlFileLoader($container, new FileLocator(self::$fixturesPath.'/yaml'));
+        $loader->load('services16.yml');
+        $this->assertEquals(array('request' => 'container'), $container->getScopes(), '->load() adds Scopes to Container');
+    }
+
     public function testLoadImports()
     {
         $container = new ContainerBuilder();


### PR DESCRIPTION
fixes #8539, see problem description over there.

If a ContainerBuilder Instance has Scopes defined, they are now dumped to XML and YML Files. The PhpDumper already does the same.
The Loaders now also load Scopes from file and registers them at the ContainerBuilder. 
