### PR TITLE
[Validator] Fixed StaticMethodLoader does not try to invoke methods of abstract classes anymore

### DIFF
--- a/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
+++ b/src/Symfony/Component/Validator/Mapping/Loader/StaticMethodLoader.php
@@ -31,7 +31,7 @@ class StaticMethodLoader implements LoaderInterface
         /** @var \ReflectionClass $reflClass */
         $reflClass = $metadata->getReflectionClass();
 
-        if (!$reflClass->isInterface() && $reflClass->hasMethod($this->methodName)) {
+        if (!$reflClass->isInterface() && !$reflClass->isAbstract() && $reflClass->hasMethod($this->methodName)) {
             $reflMethod = $reflClass->getMethod($this->methodName);
 
             if (!$reflMethod->isStatic()) {

--- a/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
+++ b/src/Symfony/Component/Validator/Tests/Mapping/Loader/StaticMethodLoaderTest.php
@@ -48,12 +48,12 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
         $loader = new StaticMethodLoader('loadMetadata');
         $metadata = new ClassMetadata(__NAMESPACE__.'\StaticLoaderDocument');
         $loader->loadClassMetadata($metadata);
-        $this->assertSame(0, count($metadata->getConstraints()));
+        $this->assertCount(0, $metadata->getConstraints());
 
         $loader = new StaticMethodLoader('loadMetadata');
         $metadata = new ClassMetadata(__NAMESPACE__.'\BaseStaticLoaderDocument');
         $loader->loadClassMetadata($metadata);
-        $this->assertSame(1, count($metadata->getConstraints()));
+        $this->assertCount(1, $metadata->getConstraints());
     }
 
     public function testLoadClassMetadataIgnoresInterfaces()
@@ -63,13 +63,30 @@ class StaticMethodLoaderTest extends \PHPUnit_Framework_TestCase
 
         $loader->loadClassMetadata($metadata);
 
-        $this->assertSame(0, count($metadata->getConstraints()));
+        $this->assertCount(0, $metadata->getConstraints());
+    }
+
+    public function testLoadClassMetadataIgnoresAbstractClasses()
+    {
+        $loader = new StaticMethodLoader('loadMetadata');
+        $metadata = new ClassMetadata(__NAMESPACE__.'\AbstractStaticLoader');
+
+        $loader->loadClassMetadata($metadata);
+
+        $this->assertCount(0, $metadata->getConstraints());
     }
 }
 
 interface StaticLoaderInterface
 {
     public static function loadMetadata(ClassMetadata $metadata);
+}
+
+abstract class AbstractStaticLoader
+{
+    public static function loadMetadata(ClassMetadata $metadata)
+    {
+    }
 }
 
 class StaticLoaderEntity


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8589 |
| License | MIT |
| Doc PR | n/a |
