### PR TITLE
[2.3] [HttpKernel] TraceableEventDispatcher loses event priorities try to fix #8426

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -159,6 +159,30 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher->dispatch('foo');
     }
 
+     public function testDispatchByPriority()
+     {
+         $invoked = array();
+         $listener1 = function () use (&$invoked) {
+             $invoked[] = '1';
+         };
+         $listener2 = function () use (&$invoked) {
+             $invoked[] = '2';
+         };
+         $listener3 = function () use (&$invoked) {
+             $invoked[] = '3';
+         };
+         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());
+         $dispatcher->addListener('pre.foo', $listener1, -10);
+         $dispatcher->addListener('pre.foo', $listener2);
+         $dispatcher->dispatch('pre.foo');
+         $this->assertEquals(array('2', '1'), $invoked);
+         
+         $invoked = array();
+         $dispatcher->addListener('pre.foo', $listener3, -5);
+         $dispatcher->dispatch(('pre.foo'));
+         $this->assertEquals(array('2', '3', '1'), $invoked);
+     }
+
     public function testStopwatchSections()
     {
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), $stopwatch = new Stopwatch());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8426 |
| License | MIT |
| Doc PR | n/a |
### I found four options:
- Use `ReflectionProperty` to get the priority parameter of a listener from `EventDispatcher`
- Get the priority parameter of a listener from `\Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher::addListener`
- Do not wrap a `EventDispatcherInterface`, reimplement one.
- Do not wrap a `EventDispatcherInterface`, extend one to access the priority parameter of a listener .
- Add PriorityAwareEventDispatcherInterface on EventDispatcher.
### This PR try first option.
