### PR TITLE
[HttpFoundation] deprecates FlashBag::getIterator() method

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Flash/FlashBag.php
@@ -14,6 +14,8 @@ namespace Symfony\Component\HttpFoundation\Session\Flash;
 /**
  * FlashBag flash message container.
  *
+ * \IteratorAggregate implementation is deprecated and will be removed in 3.0.
+ *
  * @author Drak <drak@zikula.org>
  */
 class FlashBag implements FlashBagInterface, \IteratorAggregate
@@ -166,6 +168,8 @@ class FlashBag implements FlashBagInterface, \IteratorAggregate
 
     /**
      * Returns an iterator for flashes.
+     *
+     * @deprecated Will be removed in 3.0.
      *
      * @return \ArrayIterator An \ArrayIterator instance
      */


### PR DESCRIPTION
This PR does not fix #8294 but this issue is not fixable. The `FlashBag::getIterator()` method actualy does not make any sense and is confusing. It should be removed. I just added a `@deprecated` tag and `Will be removed in 3.0.` message because removing it now would introduce a BC break. I guess issue #8294 can be closed after merge as it make not more sense than the incriminated method.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8294 |
