### PR TITLE
[WebProfilerBundle] make toolbar listener instantiation conditional

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/DependencyInjection/WebProfilerExtension.php
@@ -44,18 +44,13 @@ class WebProfilerExtension extends Extension
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('profiler.xml');
-        $loader->load('toolbar.xml');
-
-        $container->setParameter('web_profiler.debug_toolbar.intercept_redirects', $config['intercept_redirects']);
-
-        if (!$config['toolbar']) {
-            $mode = WebDebugToolbarListener::DISABLED;
-        } else {
-            $mode = WebDebugToolbarListener::ENABLED;
-        }
-
-        $container->setParameter('web_profiler.debug_toolbar.mode', $mode);
         $container->setParameter('web_profiler.debug_toolbar.position', $config['position']);
+
+        if ($config['toolbar'] || $config['intercept_redirects']) {
+            $loader->load('toolbar.xml');
+            $container->setParameter('web_profiler.debug_toolbar.intercept_redirects', $config['intercept_redirects']);
+            $container->setParameter('web_profiler.debug_toolbar.mode', $config['toolbar'] ? WebDebugToolbarListener::ENABLED : WebDebugToolbarListener::DISABLED);
+        }
     }
 
     /**

--- a/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Tests/DependencyInjection/WebProfilerExtensionTest.php
@@ -86,7 +86,7 @@ class WebProfilerExtensionTest extends TestCase
         $extension = new WebProfilerExtension();
         $extension->load(array(array()), $this->container);
 
-        $this->assertFalse($this->container->get('web_profiler.debug_toolbar')->isEnabled());
+        $this->assertFalse($this->container->has('web_profiler.debug_toolbar'));
 
         $this->assertSaneContainer($this->getDumpedContainer());
     }
@@ -94,12 +94,16 @@ class WebProfilerExtensionTest extends TestCase
     /**
      * @dataProvider getDebugModes
      */
-    public function testToolbarConfig($enabled)
+    public function testToolbarConfig($toolbarEnabled, $interceptRedirects, $listenerInjected, $listenerEnabled)
     {
         $extension = new WebProfilerExtension();
-        $extension->load(array(array('toolbar' => $enabled)), $this->container);
+        $extension->load(array(array('toolbar' => $toolbarEnabled, 'intercept_redirects' => $interceptRedirects)), $this->container);
 
-        $this->assertSame($enabled, $this->container->get('web_profiler.debug_toolbar')->isEnabled());
+        $this->assertSame($listenerInjected, $this->container->has('web_profiler.debug_toolbar'));
+
+        if ($listenerInjected) {
+            $this->assertSame($listenerEnabled, $this->container->get('web_profiler.debug_toolbar')->isEnabled());
+        }
 
         $this->assertSaneContainer($this->getDumpedContainer());
     }
@@ -107,8 +111,10 @@ class WebProfilerExtensionTest extends TestCase
     public function getDebugModes()
     {
         return array(
-            array(true),
-            array(false),
+            array(false, false, false, false),
+            array(true,  false, true,  true),
+            array(false, true,  true,  false),
+            array(true,  true,  true,  true),
         );
     }
 


### PR DESCRIPTION
In the `WebProfilerBundle`, if `intercept_redirects` and `toolbar` options are both `false`, the `toolbar.xml` config file should not be loaded as the listener becomes useless.

| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8130 |
