### PR TITLE
[Form] Fixed: If a form is not present in a request, it is not automatically submitted 

### DIFF
--- a/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
+++ b/src/Symfony/Component/Form/Extension/HttpFoundation/HttpFoundationRequestHandler.php
@@ -56,10 +56,13 @@ class HttpFoundationRequestHandler implements RequestHandlerInterface
             if ('' === $name) {
                 $params = $request->request->all();
                 $files = $request->files->all();
-            } else {
+            } elseif ($request->request->has($name) || $request->files->has($name)) {
                 $default = $form->getConfig()->getCompound() ? array() : null;
                 $params = $request->request->get($name, $default);
                 $files = $request->files->get($name, $default);
+            } else {
+                // Don't submit the form if it is not present in the request
+                return;
             }
 
             if (is_array($params) && is_array($files)) {

--- a/src/Symfony/Component/Form/NativeRequestHandler.php
+++ b/src/Symfony/Component/Form/NativeRequestHandler.php
@@ -72,10 +72,13 @@ class NativeRequestHandler implements RequestHandlerInterface
             if ('' === $name) {
                 $params = $_POST;
                 $files = $fixedFiles;
-            } else {
+            } elseif (array_key_exists($name, $_POST) || array_key_exists($name, $fixedFiles)) {
                 $default = $form->getConfig()->getCompound() ? array() : null;
-                $params = isset($_POST[$name]) ? $_POST[$name] : $default;
-                $files = isset($fixedFiles[$name]) ? $fixedFiles[$name] : $default;
+                $params = array_key_exists($name, $_POST) ? $_POST[$name] : $default;
+                $files = array_key_exists($name, $fixedFiles) ? $fixedFiles[$name] : $default;
+            } else {
+                // Don't submit the form if it is not present in the request
+                return;
             }
 
             if (is_array($params) && is_array($files)) {

--- a/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
+++ b/src/Symfony/Component/Form/Tests/AbstractRequestHandlerTest.php
@@ -86,7 +86,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodExceptGetProvider
      */
-    public function testSubmitSimpleFormWithNullIfNameNotInRequestAndNotGetRequest($method)
+    public function testDoNoSubmitSimpleFormIfNameNotInRequestAndNotGetRequest($method)
     {
         $form = $this->getMockForm('param1', $method, false);
 
@@ -94,9 +94,8 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
             'paramx' => array(),
         ));
 
-        $form->expects($this->once())
-            ->method('submit')
-            ->with($this->identicalTo(null), 'PATCH' !== $method);
+        $form->expects($this->never())
+            ->method('submit');
 
         $this->requestHandler->handleRequest($form, $this->request);
     }
@@ -104,7 +103,7 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider methodExceptGetProvider
      */
-    public function testSubmitCompoundFormWithArrayIfNameNotInRequestAndNotGetRequest($method)
+    public function testDoNotSubmitCompoundFormIfNameNotInRequestAndNotGetRequest($method)
     {
         $form = $this->getMockForm('param1', $method, true);
 
@@ -112,9 +111,8 @@ abstract class AbstractRequestHandlerTest extends \PHPUnit_Framework_TestCase
             'paramx' => array(),
         ));
 
-        $form->expects($this->once())
-            ->method('submit')
-            ->with($this->identicalTo(array()), 'PATCH' !== $method);
+        $form->expects($this->never())
+            ->method('submit');
 
         $this->requestHandler->handleRequest($form, $this->request);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8385 |
| License | MIT |
| Doc PR | - |

This PR changes the following behavior of `handleRequest()`:

Current behavior:

``` php
$_POST = array('foo' => 'bar');
$form = $factory->createNamed('myform', 'mytype');

// "myform" is not present in the request
$form->handleRequest();

assert(true === $form->isSubmitted());
```

Behavior after PR:

``` php
$_POST = array('foo' => 'bar');
$form = $factory->createNamed('myform', 'mytype');

// "myform" is not present in the request
$form->handleRequest();

assert(false === $form->isSubmitted());
```

As #8385 pointed out, the latter behavior is expected, so I consider the current behavior a bug.
