### PR TITLE
[DoctrineBridge] [ORM] Use custom cache namespace option if it is specified

### DIFF
--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -363,12 +363,12 @@ abstract class AbstractDoctrineExtension extends Extension
 
         $cacheDef->setPublic(false);
 
-        if (!isset($objectManager['namespace'])) {
+        if (!isset($cacheDriver['namespace'])) {
             // generate a unique namespace for the given application
-            $objectManager['namespace'] = 'sf2'.$this->getMappingResourceExtension().'_'.$objectManager['name'].'_'.md5($container->getParameter('kernel.root_dir').$container->getParameter('kernel.environment'));
+            $cacheDriver['namespace'] = 'sf2'.$this->getMappingResourceExtension().'_'.$objectManager['name'].'_'.md5($container->getParameter('kernel.root_dir').$container->getParameter('kernel.environment'));
         }
 
-        $cacheDef->addMethodCall('setNamespace', array($objectManager['namespace']));
+        $cacheDef->addMethodCall('setNamespace', array($cacheDriver['namespace']));
 
         $container->setDefinition($cacheDriverService, $cacheDef);
     }

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -295,8 +295,8 @@ abstract class AbstractDoctrineExtension extends Extension
     /**
      * Loads a configured object manager metadata, query or result cache driver.
      *
-     * @param array            $objectManager  A configured object manager.
-     * @param ContainerBuilder $container      A ContainerBuilder instance.
+     * @param array            $objectManager A configured object manager.
+     * @param ContainerBuilder $container     A ContainerBuilder instance.
      * @param string           $cacheName
      *
      * @throws \InvalidArgumentException In case of unknown driver type.

--- a/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
+++ b/src/Symfony/Bridge/Doctrine/DependencyInjection/AbstractDoctrineExtension.php
@@ -295,8 +295,8 @@ abstract class AbstractDoctrineExtension extends Extension
     /**
      * Loads a configured object manager metadata, query or result cache driver.
      *
-     * @param array            $objectManager A configured object manager.
-     * @param ContainerBuilder $container     A ContainerBuilder instance.
+     * @param array            $objectManager  A configured object manager.
+     * @param ContainerBuilder $container      A ContainerBuilder instance.
      * @param string           $cacheName
      *
      * @throws \InvalidArgumentException In case of unknown driver type.
@@ -362,9 +362,13 @@ abstract class AbstractDoctrineExtension extends Extension
         }
 
         $cacheDef->setPublic(false);
-        // generate a unique namespace for the given application
-        $namespace = 'sf2'.$this->getMappingResourceExtension().'_'.$objectManager['name'].'_'.md5($container->getParameter('kernel.root_dir').$container->getParameter('kernel.environment'));
-        $cacheDef->addMethodCall('setNamespace', array($namespace));
+
+        if (!isset($objectManager['namespace'])) {
+            // generate a unique namespace for the given application
+            $objectManager['namespace'] = 'sf2'.$this->getMappingResourceExtension().'_'.$objectManager['name'].'_'.md5($container->getParameter('kernel.root_dir').$container->getParameter('kernel.environment'));
+        }
+
+        $cacheDef->addMethodCall('setNamespace', array($objectManager['namespace']));
 
         $container->setDefinition($cacheDriverService, $cacheDef);
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |

This allows an option `namespace` to be used instead of having Symfony generate the hash. If the option is not set, the original behaviour will occur.

While this code will execute on the current version, this change depends on https://github.com/doctrine/DoctrineBundle/pull/198 to fully work.
