### PR TITLE
[Form] Fix issue with \DateTimeZone::UTC / 'UTC' for PHP < 5.5

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -250,7 +250,7 @@ class DateType extends AbstractType
         if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
             $formatter->setTimeZone(\DateTimeZone::UTC);
         } else {
-            $formatter->setTimeZoneId(\DateTimeZone::UTC);
+            $formatter->setTimeZoneId('UTC');
         }
 
         if (preg_match($regex, $pattern, $matches)) {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

On PHP 5.4.x and 5.3.x, `setTimeZoneId()` requires the parameter to be a string, but the constant `\DateTimeZone::UTC` is (int) 1024. 

See: http://www.php.net/manual/en/intldateformatter.settimezoneid.php

This caused an issue for us when using Date formfields, giving this error:

```
"DateTimeZone::__construct(): Unknown or bad timezone (1024)"
```
