### PR TITLE
Correct DateTimZone object for IntlDateFormatter::setTimeZone() using PHP5.5

### DIFF
--- a/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
+++ b/src/Symfony/Component/Form/Extension/Core/Type/DateType.php
@@ -248,7 +248,7 @@ class DateType extends AbstractType
         $timezone = $formatter->getTimezoneId();
 
         if (version_compare(\PHP_VERSION, '5.5.0-dev', '>=')) {
-            $formatter->setTimeZone(\DateTimeZone::UTC);
+            $formatter->setTimeZone(new \DateTimeZone('UTC'));
         } else {
             $formatter->setTimeZoneId(\DateTimeZone::UTC);
         }


### PR DESCRIPTION
A timezone object should be passed when using the new setTimeZone() function. DateTimeZone::UTC will return the TimeZoneId, so this is not suitable and will throw errors. A DateTimeZone object should be created and be passed.
