### PR TITLE
[Security][Acl] Add MutableAclProvider::updateUserSecurityIdentity

### DIFF
--- a/src/Symfony/Component/Security/Acl/Tests/Dbal/MutableAclProviderTest.php
+++ b/src/Symfony/Component/Security/Acl/Tests/Dbal/MutableAclProviderTest.php
@@ -407,6 +407,36 @@ class MutableAclProviderTest extends \PHPUnit_Framework_TestCase
         $provider->updateAcl($acl);
     }
 
+    public function testUpdateUserSecurityIdentity()
+    {
+        $provider = $this->getProvider();
+        $acl = $provider->createAcl(new ObjectIdentity(1, 'Foo'));
+        $sid = new UserSecurityIdentity('johannes', 'FooClass');
+        $acl->setEntriesInheriting(!$acl->isEntriesInheriting());
+
+        $acl->insertObjectAce($sid, 1);
+        $acl->insertClassAce($sid, 5, 0, false);
+        $acl->insertObjectAce($sid, 2, 1, true);
+        $acl->insertClassFieldAce('field', $sid, 2, 0, true);
+        $provider->updateAcl($acl);
+
+        $newSid = new UserSecurityIdentity('mathieu', 'FooClass');
+        $provider->updateUserSecurityIdentity($newSid, 'johannes');
+
+        $reloadProvider = $this->getProvider();
+        $reloadedAcl = $reloadProvider->findAcl(new ObjectIdentity(1, 'Foo'));
+
+        $this->assertNotSame($acl, $reloadedAcl);
+        $this->assertSame($acl->isEntriesInheriting(), $reloadedAcl->isEntriesInheriting());
+
+        $aces = $acl->getObjectAces();
+        $reloadedAces = $reloadedAcl->getObjectAces();
+        $this->assertEquals(count($aces), count($reloadedAces));
+        foreach ($reloadedAces as $ace) {
+            $this->assertTrue($ace->getSecurityIdentity()->equals($newSid));
+        }
+    }
+
     /**
      * Data must have the following format:
      * array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #5787 |
| License | MIT |
| Doc PR | symfony/symfony-docs#3319 |

This provides a very simple function to enable the update of a User's username while keeping its associated ACEs (by updating its corresponding UserSecurityIdentity)

Developers can add a listener on the preUpdate of a user and remove all the related ACLs:

``` php
if ($args->hasChangedField('username')) {
    $aclProvider = $this->container->get('security.acl.provider');

    $oldUsername = $args->getOldValue ('username');
    $user        = $args->getEntity();

    $aclProvider->updateUserSecurityIdentity(UserSecurityIdentity::fromAccount($user) , $oldUsername);
}
```

Among the problems of not updating the UserSecurityIdentity:
- Inconsistent database, referring to a non-existent user.
- The user loses all its associated permissions
- If another user is created with the old username, it will inherit all the first user’s ACEs

This PR intends to fix Issue #5787 and is similar to and inspired from PR #8305.
This will also be heavily impacted by the outcome of #8848
