### PR TITLE
adds ability to define an idle timeout

### DIFF
--- a/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessTimedOutException.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Exception;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Exception that is thrown when a process times out.
+ *
+ * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+ */
+class ProcessTimedOutException extends RuntimeException
+{
+    const TYPE_GENERAL = 1;
+    const TYPE_IDLE = 2;
+
+    private $process;
+    private $timeoutType;
+
+    public function __construct(Process $process, $timeoutType)
+    {
+        $this->process = $process;
+        $this->timeoutType = $timeoutType;
+
+        parent::__construct(sprintf(
+            'The process "%s" exceeded the timeout of %s seconds.',
+            $process->getCommandLine(),
+            $this->getExceededTimeout()
+        ));
+    }
+
+    public function getProcess()
+    {
+        return $this->process;
+    }
+
+    public function isGeneralTimeout()
+    {
+        return $this->timeoutType === self::TYPE_GENERAL;
+    }
+
+    public function isIdleTimeout()
+    {
+        return $this->timeoutType === self::TYPE_IDLE;
+    }
+
+    public function getExceededTimeout()
+    {
+        switch ($this->timeoutType) {
+            case self::TYPE_GENERAL:
+                return $this->process->getTimeout();
+
+            case self::TYPE_IDLE:
+                return $this->process->getIdleTimeout();
+
+            default:
+                throw new \LogicException(sprintf('Unknown timeout type "%d".', $this->timeoutType));
+        }
+    }
+}


### PR DESCRIPTION
This adds the ability to define an idle timeout which in contrast to the current timeout considers only the time since the last output was produced by a process.

It also adds a special exception for timeout cases.
