### PR TITLE
Adds PTY mode & convenience method mustRun()

### DIFF
--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -6,6 +6,7 @@ CHANGELOG
 
  * added the ability to define an idle timeout
  * added support for PTY mode
+ * added the convenience method "mustRun"
 
 2.3.0
 -----

--- a/src/Symfony/Component/Process/CHANGELOG.md
+++ b/src/Symfony/Component/Process/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 -----
 
  * added the ability to define an idle timeout
+ * added support for PTY mode
 
 2.3.0
 -----

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -62,6 +62,7 @@ class Process
     private $incrementalOutputOffset;
     private $incrementalErrorOutputOffset;
     private $tty;
+    private $pty;
 
     private $fileHandles;
     private $readBytes;
@@ -156,6 +157,7 @@ class Process
         }
         $this->stdin = $stdin;
         $this->setTimeout($timeout);
+        $this->pty = false;
         $this->enhanceWindowsCompatibility = true;
         $this->enhanceSigchildCompatibility = !defined('PHP_WINDOWS_VERSION_BUILD') && $this->isSigchildEnabled();
         $this->options = array_replace(array('suppress_errors' => true, 'binary_pipes' => true), $options);
@@ -916,6 +918,30 @@ class Process
     }
 
     /**
+     * Sets PTY mode.
+     *
+     * @param Boolean $bool
+     *
+     * @return self
+     */
+    public function setPty($bool)
+    {
+        $this->pty = (Boolean) $bool;
+
+        return $this;
+    }
+
+    /**
+     * Returns PTY state.
+     *
+     * @return Boolean
+     */
+    public function isPty()
+    {
+        return $this->pty;
+    }
+
+    /**
      * Gets the working directory.
      *
      * @return string The current working directory
@@ -1136,6 +1162,12 @@ class Process
                 array('file', '/dev/tty', 'r'),
                 array('file', '/dev/tty', 'w'),
                 array('file', '/dev/tty', 'w'),
+            );
+        } elseif ($this->pty) {
+            $descriptors = array(
+                array('pty'),
+                array('pty'),
+                array('pty'),
             );
         } else {
            $descriptors = array(

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -121,6 +121,27 @@ class Process
     );
 
     /**
+     * Returns whether PTY is supported on the current operating system.
+     *
+     * @return Boolean
+     */
+    public static function isPtySupported()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            return false;
+        }
+
+        $proc = @proc_open('echo 1', array(array('pty'), array('pty'), array('pty')), $pipes);
+        if (is_resource($proc)) {
+            proc_close($proc);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Constructor.
      *
      * @param string  $commandline The command line to run
@@ -1183,7 +1204,7 @@ class Process
                 array('file', '/dev/tty', 'w'),
                 array('file', '/dev/tty', 'w'),
             );
-        } elseif ($this->pty) {
+        } elseif ($this->pty && self::isPtySupported()) {
             $descriptors = array(
                 array('pty'),
                 array('pty'),

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -13,6 +13,7 @@ namespace Symfony\Component\Process;
 
 use Symfony\Component\Process\Exception\InvalidArgumentException;
 use Symfony\Component\Process\Exception\LogicException;
+use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Exception\ProcessTimedOutException;
 use Symfony\Component\Process\Exception\RuntimeException;
 
@@ -207,6 +208,25 @@ class Process
         $this->start($callback);
 
         return $this->wait($callback);
+    }
+
+    /**
+     * Runs the process.
+     *
+     * This is identical to run() except that an exception is thrown if the process
+     * exits with a non-zero exit code.
+     *
+     * @param callable|null $callback
+     *
+     * @return self
+     */
+    public function mustRun($callback = null)
+    {
+        if (0 !== $this->run($callback)) {
+            throw new ProcessFailedException($this);
+        }
+
+        return $this;
     }
 
     /**

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -127,18 +127,24 @@ class Process
      */
     public static function isPtySupported()
     {
+        static $result;
+
+        if (null !== $result) {
+            return $result;
+        }
+
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            return false;
+            return $result = false;
         }
 
         $proc = @proc_open('echo 1', array(array('pty'), array('pty'), array('pty')), $pipes);
         if (is_resource($proc)) {
             proc_close($proc);
 
-            return true;
+            return $result = true;
         }
 
-        return false;
+        return $result = false;
     }
 
     /**

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -200,6 +200,23 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(Process::STATUS_TERMINATED, $process->getStatus());
     }
 
+    /**
+     * @group pty
+     */
+    public function testPTYCommand()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not have PTY support.');
+        }
+
+        $process = $this->getProcess('echo "foo"');
+        $process->setPty(true);
+        $process->run();
+
+        $this->assertSame(Process::STATUS_TERMINATED, $process->getStatus());
+        $this->assertEquals("foo\r\n", $process->getOutput());
+    }
+
     public function testExitCodeText()
     {
         $process = $this->getProcess('');

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -205,8 +205,8 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
      */
     public function testPTYCommand()
     {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not have PTY support.');
+        if ( ! Process::isPtySupported()) {
+            $this->markTestSkipped('PTY is not supported on this operating system.');
         }
 
         $process = $this->getProcess('echo "foo"');

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -217,6 +217,28 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals("foo\r\n", $process->getOutput());
     }
 
+    /**
+     * @group mustRun
+     */
+    public function testMustRun()
+    {
+        $process = $this->getProcess('echo "foo"');
+
+        $this->assertSame($process, $process->mustRun());
+        $this->assertEquals("foo\n", $process->getOutput());
+        $this->assertEquals(0, $process->getExitCode());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\ProcessFailedException
+     * @group mustRun
+     */
+    public function testMustRunThrowsException()
+    {
+        $process = $this->getProcess('exit 1');
+        $process->mustRun();
+    }
+
     public function testExitCodeText()
     {
         $process = $this->getProcess('');

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -31,6 +31,24 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
 
     /**
      * @expectedException \Symfony\Component\Process\Exception\RuntimeException
+     * @group mustRun
+     */
+    public function testMustRun()
+    {
+        parent::testMustRun();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
+     * @group mustRun
+     */
+    public function testMustRunThrowsException()
+    {
+        parent::testMustRunThrowsException();
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\RuntimeException
      */
     public function testProcessIsSignaledIfStopped()
     {


### PR DESCRIPTION
This makes two additions. I've split them into separate commits so that you can pull them separately if required.
1. Adds PTY mode. 
   In contrast to the existing TTY mode, the proc_open call becomes the master not the process currently executing.
2. Adds a `mustRun` method
   This is merely for convenience:

``` php
# Before
$proc = new Process($cmd);
if (0 !== $proc->run()) {
    throw new ProcessFailedException($proc);
}

$proc = new Process($cmd);
if (0 !== $proc->run()) {
    throw new ProcessFailedException($proc);
}

# After
(new Process($cmd))->mustRun();
(new Process($cmd))->mustRun();
```
