### PR TITLE
Added option to show controllers optionally in the router:debug command

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -129,7 +129,7 @@ EOF
                     $controller = 'Closure';
                 } else {
                     if (is_object($controller)) {
-                        get_class($controller);
+                        $controller = get_class($controller);
                     }
                 }
                 $output->writeln(sprintf($format, $name, $method, $scheme, $host, $route->getPath(), $controller), OutputInterface::OUTPUT_RAW);

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -13,6 +13,7 @@ namespace Symfony\Bundle\FrameworkBundle\Command;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -49,6 +50,7 @@ class RouterDebugCommand extends ContainerAwareCommand
             ->setName('router:debug')
             ->setDefinition(array(
                 new InputArgument('name', InputArgument::OPTIONAL, 'A route name'),
+                new InputOption('show-controllers', null,  InputOption::VALUE_NONE, 'Show assigned controllers in overview')
             ))
             ->setDescription('Displays current routes for an application')
             ->setHelp(<<<EOF
@@ -72,11 +74,11 @@ EOF
         if ($name) {
             $this->outputRoute($output, $name);
         } else {
-            $this->outputRoutes($output);
+            $this->outputRoutes($output, null, $input->getOption('show-controllers'));
         }
     }
 
-    protected function outputRoutes(OutputInterface $output, $routes = null)
+    protected function outputRoutes(OutputInterface $output, $routes = null, $showControllers = false)
     {
         if (null === $routes) {
             $routes = $this->getContainer()->get('router')->getRouteCollection()->all();
@@ -88,26 +90,44 @@ EOF
         $maxMethod = strlen('method');
         $maxScheme = strlen('scheme');
         $maxHost = strlen('host');
+        $maxPath = strlen('path');
 
         foreach ($routes as $name => $route) {
             $method = $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY';
             $scheme = $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY';
             $host = '' !== $route->getHost() ? $route->getHost() : 'ANY';
+            $path = $route->getPath();
             $maxName = max($maxName, strlen($name));
             $maxMethod = max($maxMethod, strlen($method));
             $maxScheme = max($maxScheme, strlen($scheme));
             $maxHost = max($maxHost, strlen($host));
+            $maxPath = max($maxPath, strlen($path));
         }
 
         $format  = '%-'.$maxName.'s %-'.$maxMethod.'s %-'.$maxScheme.'s %-'.$maxHost.'s %s';
-        $formatHeader  = '%-'.($maxName + 19).'s %-'.($maxMethod + 19).'s %-'.($maxScheme + 19).'s %-'.($maxHost + 19).'s %s';
-        $output->writeln(sprintf($formatHeader, '<comment>Name</comment>', '<comment>Method</comment>',  '<comment>Scheme</comment>', '<comment>Host</comment>', '<comment>Path</comment>'));
+        $formatHeader  = '%-'.($maxName + 19).'s %-'.($maxMethod + 19).'s %-'.($maxScheme + 19).'s %-'.($maxHost + 19).'s %-'.($maxPath + 19).'s';
+
+        if ($showControllers) {
+            $format = str_replace('s %s', 's %-'.$maxPath.'s %s', $format);
+            $formatHeader = $formatHeader . ' %s';
+        }
+
+        if ($showControllers) {
+            $output->writeln(sprintf($formatHeader, '<comment>Name</comment>', '<comment>Method</comment>',  '<comment>Scheme</comment>', '<comment>Host</comment>', '<comment>Path</comment>', '<comment>Controller</comment>'));
+        } else {
+            $output->writeln(sprintf($formatHeader, '<comment>Name</comment>', '<comment>Method</comment>',  '<comment>Scheme</comment>', '<comment>Host</comment>', '<comment>Path</comment>'));
+        }
 
         foreach ($routes as $name => $route) {
             $method = $route->getMethods() ? implode('|', $route->getMethods()) : 'ANY';
             $scheme = $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY';
             $host = '' !== $route->getHost() ? $route->getHost() : 'ANY';
-            $output->writeln(sprintf($format, $name, $method, $scheme, $host, $route->getPath()), OutputInterface::OUTPUT_RAW);
+            if ($showControllers) {
+                $controller = $route->getDefaults()['_controller'] ? $route->getDefaults()['_controller'] : '';
+                $output->writeln(sprintf($format, $name, $method, $scheme, $host, $route->getPath(), $controller), OutputInterface::OUTPUT_RAW);
+            } else {
+                $output->writeln(sprintf($format, $name, $method, $scheme, $host, $route->getPath()), OutputInterface::OUTPUT_RAW);
+            }
         }
     }
 

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -124,9 +124,13 @@ EOF
             $host = '' !== $route->getHost() ? $route->getHost() : 'ANY';
             if ($showControllers) {
                 $defaultData = $route->getDefaults();
-                $controller = $defaultData['controller'] ? $defaultData['controller'] : '';
-                if (is_callable($controller)) {
+                $controller = $defaultData['_controller'] ? $defaultData['_controller'] : '';
+                if ($controller instanceof \Closure) {
                     $controller = 'Closure';
+                } else {
+                    if (is_object($controller)) {
+                        get_class($controller);
+                    }
                 }
                 $output->writeln(sprintf($format, $name, $method, $scheme, $host, $route->getPath(), $controller), OutputInterface::OUTPUT_RAW);
             } else {

--- a/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Command/RouterDebugCommand.php
@@ -123,7 +123,11 @@ EOF
             $scheme = $route->getSchemes() ? implode('|', $route->getSchemes()) : 'ANY';
             $host = '' !== $route->getHost() ? $route->getHost() : 'ANY';
             if ($showControllers) {
-                $controller = $route->getDefaults()['_controller'] ? $route->getDefaults()['_controller'] : '';
+                $defaultData = $route->getDefaults();
+                $controller = $defaultData['controller'] ? $defaultData['controller'] : '';
+                if (is_callable($controller)) {
+                    $controller = 'Closure';
+                }
                 $output->writeln(sprintf($format, $name, $method, $scheme, $host, $route->getPath(), $controller), OutputInterface::OUTPUT_RAW);
             } else {
                 $output->writeln(sprintf($format, $name, $method, $scheme, $host, $route->getPath()), OutputInterface::OUTPUT_RAW);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

Added option to show controllers in the router debug command as a convenience function.

```
app/console router:debug --show-controllers
```
