### PR TITLE
[DependencyInjection] Trim constants

### DIFF
--- a/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
+++ b/src/Symfony/Component/DependencyInjection/SimpleXMLElement.php
@@ -84,7 +84,7 @@ class SimpleXMLElement extends \SimpleXMLElement
                     $arguments[$key] = (string) $arg;
                     break;
                 case 'constant':
-                    $arguments[$key] = constant((string) $arg);
+                    $arguments[$key] = constant(trim((string) $arg));
                     break;
                 default:
                     $arguments[$key] = self::phpize($arg);

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/constants.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/constants.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+  <parameters>
+    <parameter key="simple_constant" type="constant">PHP_EOL</parameter>
+  </parameters>
+</container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/constants.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/constants.xml
@@ -5,5 +5,8 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
   <parameters>
     <parameter key="simple_constant" type="constant">PHP_EOL</parameter>
+    <parameter key="indented_constant" type="constant">
+        PHP_EOL
+    </parameter>
   </parameters>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -383,6 +383,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $actual = $container->getParameterBag()->all();
         $expected = array(
             'simple_constant' => PHP_EOL,
+            'indented_constant' => PHP_EOL,
         );
 
         $this->assertEquals($expected, $actual, '->load() parses PHP constants');

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -372,4 +372,19 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertSame('Document types are not allowed.', $e->getMessage(), '->load() throws an InvalidArgumentException if the configuration contains a document type');
         }
     }
+
+    public function testConstants()
+    {
+        $container = new ContainerBuilder();
+
+        $loader1 = new XmlFileLoader($container, new FileLocator(self::$fixturesPath.'/xml'));
+        $loader1->load('constants.xml');
+
+        $actual = $container->getParameterBag()->all();
+        $expected = array(
+            'simple_constant' => PHP_EOL,
+        );
+
+        $this->assertEquals($expected, $actual, '->load() parses PHP constants');
+    }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | **yes** |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | **yes** |
| License | MIT |

When indenting constant parameters in XML configuration files, an exception is throwed.
This PR simply adds:
- a test for simple constant support in XML configuration files
- a test for indented constant support in XML configuration files (proving the issue)
- a fix by trimming constants
## Example to reproduce the bug

Configuration sample:

``` XML
<?xml version="1.0" ?>

<container xmlns="http://symfony.com/schema/dic/services"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
  <parameters>
    <parameter key="simple_constant" type="constant">PHP_EOL</parameter>
    <parameter key="indented_constant" type="constant">
        PHP_EOL
    </parameter>
  </parameters>
</container>
```

Code sample:

``` PHP
<?php
$container = new ContainerBuilder();

$loader = new XmlFileLoader($container, new FileLocator(__DIR__);
$loader->load('indented_constant.xml');

$container->getParameterBag()->all();
```

Result:

```
constant(): Couldn't find constant 
        PHP_EOL

```

Notice the fact that the error message is not:

```
constant(): Couldn't find constant PHP_EOL
```
