### PR TITLE
[DependencyInjection] Test constants

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services2.xml
+++ b/src/Symfony/Component/DependencyInjection/Tests/Fixtures/xml/services2.xml
@@ -27,5 +27,6 @@
     <parameter key="MixedCase" type="collection"> <!-- Should be lower cased -->
       <parameter key="MixedCaseKey">value</parameter> <!-- Should stay mixed case -->
     </parameter>
+    <parameter key="constant" type="constant">PHP_EOL</parameter>
   </parameters>
 </container>

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -114,7 +114,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
                 'float' => 1.3,
                 1000.3,
                 'a string',
-                array('foo', 'bar',)
+                array('foo', 'bar'),
             ),
             'foo_bar' => new Reference('foo_bar'),
             'mixedcase' => array('MixedCaseKey' => 'value'),
@@ -155,7 +155,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
                 'float' => 1.3,
                 1000.3,
                 'a string',
-                array('foo', 'bar',)
+                array('foo', 'bar'),
             ),
             'foo_bar' => new Reference('foo_bar'),
             'mixedcase' => array('MixedCaseKey' => 'value'),

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -99,7 +99,26 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services2.xml');
 
         $actual = $container->getParameterBag()->all();
-        $expected = array('a string', 'foo' => 'bar', 'values' => array(0, 'integer' => 4, 100 => null, 'true', true, false, 'on', 'off', 'float' => 1.3, 1000.3, 'a string', array('foo', 'bar')), 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'));
+        $expected = array(
+            'a string',
+            'foo' => 'bar',
+            'values' => array(
+                0,
+                'integer' => 4,
+                100 => null,
+                'true',
+                true,
+                false,
+                'on',
+                'off',
+                'float' => 1.3,
+                1000.3,
+                'a string',
+                array('foo', 'bar')
+            ),
+            'foo_bar' => new Reference('foo_bar'),
+            'mixedcase' => array('MixedCaseKey' => 'value'),
+        );
 
         $this->assertEquals($expected, $actual, '->load() converts XML values to PHP ones');
     }
@@ -120,7 +139,29 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $loader->load('services4.xml');
 
         $actual = $container->getParameterBag()->all();
-        $expected = array('a string', 'foo' => 'bar', 'values' => array(true, false), 'foo_bar' => new Reference('foo_bar'), 'mixedcase' => array('MixedCaseKey' => 'value'), 'bar' => '%foo%', 'imported_from_ini' => true, 'imported_from_yaml' => true);
+        $expected = array(
+            'a string',
+            'foo' => 'bar',
+            'values' => array(
+                0,
+                'integer' => 4,
+                100 => null,
+                'true',
+                true,
+                false,
+                'on',
+                'off',
+                'float' => 1.3,
+                1000.3,
+                'a string',
+                array('foo', 'bar')
+            ),
+            'foo_bar' => new Reference('foo_bar'),
+            'mixedcase' => array('MixedCaseKey' => 'value'),
+            'bar' => '%foo%',
+            'imported_from_ini' => true,
+            'imported_from_yaml' => true
+        );
 
         $this->assertEquals(array_keys($expected), array_keys($actual), '->load() imports and merges imported files');
 

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -114,7 +114,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
                 'float' => 1.3,
                 1000.3,
                 'a string',
-                array('foo', 'bar')
+                array('foo', 'bar',)
             ),
             'foo_bar' => new Reference('foo_bar'),
             'mixedcase' => array('MixedCaseKey' => 'value'),
@@ -155,7 +155,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
                 'float' => 1.3,
                 1000.3,
                 'a string',
-                array('foo', 'bar')
+                array('foo', 'bar',)
             ),
             'foo_bar' => new Reference('foo_bar'),
             'mixedcase' => array('MixedCaseKey' => 'value'),

--- a/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
+++ b/src/Symfony/Component/DependencyInjection/Tests/Loader/XmlFileLoaderTest.php
@@ -118,6 +118,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
             ),
             'foo_bar' => new Reference('foo_bar'),
             'mixedcase' => array('MixedCaseKey' => 'value'),
+            'constant' => PHP_EOL,
         );
 
         $this->assertEquals($expected, $actual, '->load() converts XML values to PHP ones');
@@ -158,6 +159,7 @@ class XmlFileLoaderTest extends \PHPUnit_Framework_TestCase
             ),
             'foo_bar' => new Reference('foo_bar'),
             'mixedcase' => array('MixedCaseKey' => 'value'),
+            'constant' => PHP_EOL,
             'bar' => '%foo%',
             'imported_from_ini' => true,
             'imported_from_yaml' => true


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | **yes** |
| License | MIT |

Added a test for constant support in XML configuration files.
Related PR: #8661
