### PR TITLE
Adapt security collector template name to webprofiler conventions

### DIFF
--- a/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
+++ b/src/Symfony/Bundle/SecurityBundle/Resources/config/collectors.xml
@@ -10,7 +10,7 @@
 
     <services>
         <service id="data_collector.security" class="%data_collector.security.class%" public="false">
-            <tag name="data_collector" template="SecurityBundle:Collector:security" id="security" />
+            <tag name="data_collector" template="@Security/Collector/security.html.twig" id="security" />
             <argument type="service" id="security.context" on-invalid="ignore" />
         </service>
     </services>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | fabpot/Twig#1156 |
| License | MIT |

Debugging the issue I noticed that the @WebProfiler templates use a different convention than the @SecurityBundle collector template.

This is a quick fix for symfony.

To allow the conventions most bundles use the Twig_Loader_Filesystem needs to be updated instead.
