### PR TITLE
Allow TemplateManager to fallback to SF TemplateNameParser & TemplateLocator

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
+++ b/src/Symfony/Bundle/WebProfilerBundle/Profiler/TemplateManager.php
@@ -121,8 +121,8 @@ class TemplateManager
     protected function templateExists($template)
     {
         $loader = $this->twig->getLoader();
-        if ($loader instanceof \Twig_ExistsLoaderInterface) {
-            return $loader->exists($template);
+        if ($loader instanceof \Twig_ExistsLoaderInterface && $loader->exists($template)) {
+            return true;
         }
 
         try {


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | _no_ |
| Fixed tickets | fabpot/Twig#1156, #8665 |
| License | MIT |

The `exist` method of the `Symfony\Bundle\TwigBundle\Loader\FilesystemLoader` (inherited from `Twig_Loader_Filesystem`) doesn’t fallback to Symfony’s TemplateNameParser & TemplateLocator and therefore fails on template names following the Bundle syntax like `SecurityBundle:Collector:security`.

This is option 1 how to fix this. However, I prefer option 2..see #8266.
