### PR TITLE
Overwrite exist method of Twig FilesystemLoader

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -41,6 +41,25 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function exists($name)
+    {
+        // for BC
+        if ($this->doFindTemplate($name)) {
+            return true;
+        }
+
+        try {
+            $this->findTemplate($name);
+
+            return true;
+        } catch (\Twig_Error_Loader $e) {
+            return false;
+        }
+    }
+
+    /**
      * Returns the path to the template file.
      *
      * The file locator is used to locate the template when the naming convention


### PR DESCRIPTION
- Implement exist method for the Symfony\Bundle\TwigBundle\Loader\FilesystemLoader to allow bundle syntax for templates

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | fabpot/Twig#1156, #8665 |
| License | MIT |

This is option 2 and preferred.
