### PR TITLE
replaced deprecated Twig features

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -46,14 +46,14 @@ class CodeExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'abbr_class'            => new \Twig_Filter_Method($this, 'abbrClass', array('is_safe' => array('html'))),
-            'abbr_method'           => new \Twig_Filter_Method($this, 'abbrMethod', array('is_safe' => array('html'))),
-            'format_args'           => new \Twig_Filter_Method($this, 'formatArgs', array('is_safe' => array('html'))),
-            'format_args_as_text'   => new \Twig_Filter_Method($this, 'formatArgsAsText'),
-            'file_excerpt'          => new \Twig_Filter_Method($this, 'fileExcerpt', array('is_safe' => array('html'))),
-            'format_file'           => new \Twig_Filter_Method($this, 'formatFile', array('is_safe' => array('html'))),
-            'format_file_from_text' => new \Twig_Filter_Method($this, 'formatFileFromText', array('is_safe' => array('html'))),
-            'file_link'             => new \Twig_Filter_Method($this, 'getFileLink', array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('abbr_class', array($this, 'abbrClass'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('abbr_method', array($this, 'abbrMethod'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('format_args', array($this, 'formatArgs'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('format_args_as_text', array($this, 'formatArgsAsText')),
+            new \Twig_SimpleFilter('file_excerpt', array($this, 'fileExcerpt'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('format_file', array($this, 'formatFile'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('format_file_from_text', array($this, 'formatFileFromText'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFilter('file_link', array($this, 'getFileLink'), array('is_safe' => array('html'))),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/FormExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/FormExtension.php
@@ -61,13 +61,13 @@ class FormExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'form_enctype' => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
-            'form_widget'  => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
-            'form_errors'  => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
-            'form_label'   => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
-            'form_row'     => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
-            'form_rest'    => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
-            'csrf_token'   => new \Twig_Function_Method($this, 'renderer->renderCsrfToken'),
+            new \Twig_SimpleFunction('form_enctype', null, array('node_class' => 'Symfony\Bridge\Twig\Node\FormEnctypeNode', 'is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_widget', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_errors', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_label', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_row', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new \Twig_SimpleFunction('form_rest', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
+            new \Twig_SimpleFunction('csrf_token', array($this->renderer, 'renderCsrfToken')),
         );
     }
 
@@ -77,7 +77,7 @@ class FormExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'humanize' => new \Twig_Filter_Method($this, 'renderer->humanize'),
+            new \Twig_SimpleFilter('humanize', array($this->renderer, 'humanize')),
         );
     }
 
@@ -87,7 +87,7 @@ class FormExtension extends \Twig_Extension
     public function getTests()
     {
         return array(
-            'selectedchoice' => new \Twig_Test_Method($this, 'isSelectedChoice'),
+            new \Twig_SimpleTest('selectedchoice', array($this, 'isSelectedChoice')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/HttpKernelExtension.php
@@ -36,9 +36,9 @@ class HttpKernelExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'render'     => new \Twig_Function_Method($this, 'renderFragment', array('is_safe' => array('html'))),
-            'render_*'   => new \Twig_Function_Method($this, 'renderFragmentStrategy', array('is_safe' => array('html'))),
-            'controller' => new \Twig_Function_Method($this, 'controller'),
+            new \Twig_SimpleFunction('render',array($this, 'renderFragment'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('render_*', array($this, 'renderFragmentStrategy'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('controller', array($this, 'controller')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/RoutingExtension.php
@@ -35,8 +35,8 @@ class RoutingExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'url'  => new \Twig_Function_Method($this, 'getUrl'),
-            'path' => new \Twig_Function_Method($this, 'getPath'),
+            new \Twig_SimpleFunction('url', array($this, 'getUrl')),
+            new \Twig_SimpleFunction('path', array($this, 'getPath')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/SecurityExtension.php
@@ -47,7 +47,7 @@ class SecurityExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'is_granted' => new \Twig_Function_Method($this, 'isGranted'),
+            new \Twig_SimpleFunction('is_granted', array($this, 'isGranted')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/TranslationExtension.php
@@ -45,8 +45,8 @@ class TranslationExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'trans' => new \Twig_Filter_Method($this, 'trans'),
-            'transchoice' => new \Twig_Filter_Method($this, 'transchoice'),
+            new \Twig_SimpleFilter('trans', array($this, 'trans')),
+            new \Twig_SimpleFilter('transchoice', array($this, 'transchoice')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/YamlExtension.php
@@ -26,8 +26,8 @@ class YamlExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'yaml_encode' => new \Twig_Filter_Method($this, 'encode'),
-            'yaml_dump'   => new \Twig_Filter_Method($this, 'dump'),
+            new \Twig_SimpleFilter('yaml_encode', array($this, 'encode')),
+            new \Twig_SimpleFilter('yaml_dump', array($this, 'dump')),
         );
     }
 

--- a/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
+++ b/src/Symfony/Bundle/SecurityBundle/Twig/Extension/LogoutUrlExtension.php
@@ -38,8 +38,8 @@ class LogoutUrlExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'logout_url'  => new \Twig_Function_Method($this, 'getLogoutUrl'),
-            'logout_path' => new \Twig_Function_Method($this, 'getLogoutPath'),
+            new \Twig_SimpleFunction('logout_url', array($this, 'getLogoutUrl')),
+            new \Twig_SimpleFunction('logout_path', array($this, 'getLogoutPath')),
         );
     }
 

--- a/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
+++ b/src/Symfony/Bundle/TwigBundle/Extension/AssetsExtension.php
@@ -35,8 +35,8 @@ class AssetsExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'asset' => new \Twig_Function_Method($this, 'getAssetUrl'),
-            'assets_version' => new \Twig_Function_Method($this, 'getAssetsVersion'),
+            new \Twig_SimpleFunction('asset', array($this, 'getAssetUrl')),
+            new \Twig_SimpleFunction('assets_version', array($this, 'getAssetsVersion')),
         );
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

As Symfony depends on Twig 1.11+, removing the usage of deprecated features will allow Symfony 2.2+ to work with Twig 2.0.
