### PR TITLE
Added parameter to setRendered(). Now rendered could already set to false and prototypes could be rendered multiple times.

### DIFF
--- a/src/Symfony/Component/Form/FormView.php
+++ b/src/Symfony/Component/Form/FormView.php
@@ -84,11 +84,13 @@ class FormView implements \ArrayAccess, \IteratorAggregate, \Countable
     /**
      * Marks the view as rendered.
      *
+     * @param string $rendered The rendered mark
+     * 
      * @return FormView The view object.
      */
-    public function setRendered()
+    public function setRendered($rendered = true)
     {
-        $this->rendered = true;
+        $this->rendered = $rendered;
 
         return $this;
     }


### PR DESCRIPTION
I need this because i had my own field type which is generated dynamically and i wan't to render the protoype for this field type multiple times.

{{ form_widget(form.vars.prototype, {'groups': groups}) | e }}

If i can't reset the rendered value i can't generate the prototype multiple times with dynamic values. I have to set the values with javascript or something else.
