### PR TITLE
[TwigBundle] made the filesystem loader compatible with Twig 2.0

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
+++ b/src/Symfony/Bundle/TwigBundle/Loader/FilesystemLoader.php
@@ -41,6 +41,25 @@ class FilesystemLoader extends \Twig_Loader_Filesystem
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function exists($template)
+    {
+        if (parent::exists($template)) {
+            return true;
+        }
+
+        // same logic as findTemplate below for the fallback
+        try {
+            $this->cache[(string) $template] = $this->locator->locate($this->parser->parse($template));
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
      * Returns the path to the template file.
      *
      * The file locator is used to locate the template when the naming convention

--- a/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/Loader/FilesystemLoaderTest.php
@@ -38,6 +38,21 @@ class FilesystemLoaderTest extends TestCase
         $this->assertEquals("This is a layout\n", $loader->getSource('TwigBundle::layout.html.twig'));
     }
 
+    public function testExists()
+    {
+        // should return true for templates that Twig does not find, but Symfony does
+        $parser = $this->getMock('Symfony\Component\Templating\TemplateNameParserInterface');
+        $locator = $this->getMock('Symfony\Component\Config\FileLocatorInterface');
+        $locator
+            ->expects($this->once())
+            ->method('locate')
+            ->will($this->returnValue($template = __DIR__.'/../DependencyInjection/Fixtures/Resources/views/layout.html.twig'))
+        ;
+        $loader = new FilesystemLoader($locator, $parser);
+
+        return $this->assertTrue($loader->exists($template));
+    }
+
     /**
      * @expectedException Twig_Error_Loader
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes (for Twig 2.x) |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | n/a |
| License | MIT |
| Doc PR | n/a |

Without adding the exists() method, the code happens to work by chance,
just because the current implementation of Twig exits() method calls
findTemplate().

But we know that it won't be the case anymore as of Twig 2.0.
