### PR TITLE
[Intl] Updated stubs to reflect ICU 51.2

### DIFF
--- a/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayOfWeekTransformer.php
+++ b/src/Symfony/Component/Intl/DateFormatter/DateFormat/DayOfWeekTransformer.php
@@ -29,6 +29,8 @@ class DayOfWeekTransformer extends Transformer
                 return $dayOfWeek;
             case 5:
                 return $dayOfWeek[0];
+            case 6:
+                return substr($dayOfWeek, 0, 2);
             default:
                 return substr($dayOfWeek, 0, 3);
         }
@@ -44,6 +46,8 @@ class DayOfWeekTransformer extends Transformer
                 return 'Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday';
             case 5:
                 return '[MTWFS]';
+            case 6:
+                return 'Mo|Tu|We|Th|Fr|Sa|Su';
             default:
                 return 'Mon|Tue|Wed|Thu|Fri|Sat|Sun';
         }

--- a/src/Symfony/Component/Intl/Intl.php
+++ b/src/Symfony/Component/Intl/Intl.php
@@ -184,7 +184,7 @@ class Intl
      */
     public static function getIcuStubVersion()
     {
-        return '50.1.2';
+        return '51.2';
     }
 
     /**

--- a/src/Symfony/Component/Intl/Resources/bin/icu.ini
+++ b/src/Symfony/Component/Intl/Resources/bin/icu.ini
@@ -7,3 +7,4 @@
 4.8 = http://source.icu-project.org/repos/icu/icu/tags/release-4-8-1-1/source
 49 = http://source.icu-project.org/repos/icu/icu/tags/release-49-1-2/source
 50 = http://source.icu-project.org/repos/icu/icu/tags/release-50-1-2/source
+51 = http://source.icu-project.org/repos/icu/icu/tags/release-51-2/source

--- a/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/DateFormatter/AbstractIntlDateFormatterTest.php
@@ -143,7 +143,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
             array('EEE', 0, 'Thu'),
             array('EEEE', 0, 'Thursday'),
             array('EEEEE', 0, 'T'),
-            array('EEEEEE', 0, 'Thu'),
+            array('EEEEEE', 0, 'Th'),
 
             array('E', 1296540000, 'Tue'), // 2011-02-01
             array('E', 1296950400, 'Sun'), // 2011-02-06
@@ -584,7 +584,7 @@ abstract class AbstractIntlDateFormatterTest extends \PHPUnit_Framework_TestCase
             array('EEE', 'Thu', 0),
             array('EEEE', 'Thursday', 0),
             array('EEEEE', 'T', 432000),
-            array('EEEEEE', 'Thu', 0),
+            array('EEEEEE', 'Th', 0),
         );
     }
 

--- a/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
+++ b/src/Symfony/Component/Intl/Tests/NumberFormatter/AbstractNumberFormatterTest.php
@@ -138,15 +138,15 @@ abstract class AbstractNumberFormatterTest extends \PHPUnit_Framework_TestCase
         return array(
             array(100, 'CHF', 'CHF', '%s100.00'),
             array(-100, 'CHF', 'CHF', '(%s100.00)'),
-            array(1000.12, 'CHF', 'CHF', '%s1,000.10'),
-            array('1000.12', 'CHF', 'CHF', '%s1,000.10'),
+            array(1000.12, 'CHF', 'CHF', '%s1,000.12'),
+            array('1000.12', 'CHF', 'CHF', '%s1,000.12'),
 
             // Rounding checks
-            array(1000.121, 'CHF', 'CHF', '%s1,000.10'),
-            array(1000.123, 'CHF', 'CHF', '%s1,000.10'),
-            array(1000.125, 'CHF', 'CHF', '%s1,000.10'),
-            array(1000.127, 'CHF', 'CHF', '%s1,000.15'),
-            array(1000.129, 'CHF', 'CHF', '%s1,000.15'),
+            array(1000.121, 'CHF', 'CHF', '%s1,000.12'),
+            array(1000.123, 'CHF', 'CHF', '%s1,000.12'),
+            array(1000.125, 'CHF', 'CHF', '%s1,000.12'),
+            array(1000.127, 'CHF', 'CHF', '%s1,000.13'),
+            array(1000.129, 'CHF', 'CHF', '%s1,000.13'),
 
             array(1200000.00, 'CHF', 'CHF', '%s1,200,000.00'),
             array(1200000.1, 'CHF', 'CHF', '%s1,200,000.10'),


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

In addition to the upgrade of the ICU component to ICU 51.2, this PR upgrades the stub classes to behave like their C counterparts do with ICU 51.2.
