### PR TITLE
[Finder] added scanner adapter

### DIFF
--- a/src/Symfony/Component/Finder/Finder.php
+++ b/src/Symfony/Component/Finder/Finder.php
@@ -69,8 +69,9 @@ class Finder implements \IteratorAggregate, \Countable
         $this
             ->addAdapter(new GnuFindAdapter())
             ->addAdapter(new BsdFindAdapter())
+            ->addAdapter(new Scanner\Adapter())
             ->addAdapter(new PhpAdapter(), -50)
-            ->setAdapter('php')
+            ->setAdapter('scanner')
         ;
     }
 

--- a/src/Symfony/Component/Finder/Scanner/Adapter.php
+++ b/src/Symfony/Component/Finder/Scanner/Adapter.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Scanner;
+
+use Symfony\Component\Finder\Adapter\AbstractAdapter;
+use Symfony\Component\Finder\Iterator;
+
+/**
+ * PHP finder engine implementation.
+ *
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class Adapter extends AbstractAdapter
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function searchInDirectory($dir)
+    {
+        $builder = Builder::create($this->mode, $this->minDepth, $this->maxDepth, $this->exclude);
+
+        foreach ($this->notPaths as $value) {
+            $builder->notPath($value);
+        }
+
+        foreach ($this->notNames as $value) {
+            $builder->notName($value);
+        }
+
+        foreach ($this->paths as $value) {
+            $builder->path($value);
+        }
+
+        foreach ($this->names as $value) {
+            $builder->name($value);
+        }
+
+        $scanner = new Scanner($dir, $builder->getConstraints(), $this->ignoreUnreadableDirs);
+        $iterator = $scanner->getIterator();
+
+        if ($this->sizes) {
+            $iterator = new Iterator\SizeRangeFilterIterator($iterator, $this->sizes);
+        }
+
+        if ($this->dates) {
+            $iterator = new Iterator\DateRangeFilterIterator($iterator, $this->dates);
+        }
+
+        if ($this->filters) {
+            $iterator = new Iterator\CustomFilterIterator($iterator, $this->filters);
+        }
+
+        if ($this->contains || $this->notContains) {
+            $iterator = new Iterator\FilecontentFilterIterator($iterator, $this->contains, $this->notContains);
+        }
+
+        if ($this->sort) {
+            $iteratorAggregate = new Iterator\SortableIterator($iterator, $this->sort);
+            $iterator = $iteratorAggregate->getIterator();
+        }
+
+        return $iterator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return 'scanner';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function canBeUsed()
+    {
+        return true;
+    }
+}

--- a/src/Symfony/Component/Finder/Scanner/Adapter.php
+++ b/src/Symfony/Component/Finder/Scanner/Adapter.php
@@ -44,7 +44,7 @@ class Adapter extends AbstractAdapter
             $builder->name(new Expression($value));
         }
 
-        $scanner = new Scanner($dir, $builder->build(), $this->ignoreUnreadableDirs);
+        $scanner = new Scanner($dir, $builder->build(), $this->ignoreUnreadableDirs, $this->followLinks);
         $iterator = $scanner->getIterator();
 
         if ($this->sizes) {

--- a/src/Symfony/Component/Finder/Scanner/Adapter.php
+++ b/src/Symfony/Component/Finder/Scanner/Adapter.php
@@ -26,25 +26,25 @@ class Adapter extends AbstractAdapter
      */
     public function searchInDirectory($dir)
     {
-        $builder = Builder::create($this->mode, $this->minDepth, $this->maxDepth, $this->exclude);
+        $builder = new Builder($this->mode, $this->minDepth, $this->maxDepth, $this->exclude);
 
         foreach ($this->notPaths as $value) {
-            $builder->notPath($value);
+            $builder->notPath(new Expression($value));
         }
 
         foreach ($this->notNames as $value) {
-            $builder->notName($value);
+            $builder->notName(new Expression($value));
         }
 
         foreach ($this->paths as $value) {
-            $builder->path($value);
+            $builder->path(new Expression($value));
         }
 
         foreach ($this->names as $value) {
-            $builder->name($value);
+            $builder->name(new Expression($value));
         }
 
-        $scanner = new Scanner($dir, $builder->getConstraints(), $this->ignoreUnreadableDirs);
+        $scanner = new Scanner($dir, $builder->build(), $this->ignoreUnreadableDirs);
         $iterator = $scanner->getIterator();
 
         if ($this->sizes) {

--- a/src/Symfony/Component/Finder/Scanner/Builder.php
+++ b/src/Symfony/Component/Finder/Scanner/Builder.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Scanner;
+
+/**
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class Builder
+{
+    private $type = Constraints::TYPE_ALL;
+    private $minDepth = 0;
+    private $maxDepth = PHP_INT_MAX;
+    private $excludedNames = array('.', '..');
+    private $pathnameConstraints = array();
+    private $filenameConstraints = array();
+
+    public static function create($type, $minDepth, $maxDepth, array $excludedNames)
+    {
+        $builder = new self();
+        $builder->type = $type;
+        $builder->minDepth = $minDepth;
+        $builder->maxDepth = $maxDepth;
+        $builder->excludedNames = array_merge($builder->excludedNames, $excludedNames);
+
+        return $builder;
+    }
+
+    public function notName($value)
+    {
+        $expression = new Expression($value);
+        $key = $expression->isRegex() ? 'excluded_patterns' : 'excluded_filenames';
+
+        if (!isset($this->filenameConstraints[$key])) {
+            $this->filenameConstraints[$key] = array();
+        }
+
+        $this->filenameConstraints[$key][] = $expression->getValue();
+
+        return $this;
+    }
+
+    public function notPath($value)
+    {
+        $expression = new Expression($value);
+        $regex = $expression->getRegex();
+        $key = $regex->isEnding() ? 'excluded_ending_patterns' : 'excluded_patterns';
+
+        if (!isset($this->pathnameConstraints[$key])) {
+            $this->pathnameConstraints[$key] = array();
+        }
+
+        $this->pathnameConstraints[$key][] = $regex;
+
+        return $this;
+    }
+
+    public function name($value)
+    {
+        $expression = new Expression($value);
+        $key = $expression->isRegex() ? 'included_patterns' : 'included_filenames';
+
+        if (!isset($this->filenameConstraints[$key])) {
+            $this->filenameConstraints[$key] = array();
+        }
+
+        $this->filenameConstraints[$key][] = $expression->getValue();
+
+        return $this;
+    }
+
+    public function path($value)
+    {
+        $expression = new Expression($value);
+        $regex = $expression->getRegex();
+        $key = $regex->isEnding() ? 'included_ending_patterns' : 'included_patterns';
+
+        if (!isset($this->pathnameConstraints[$key])) {
+            $this->pathnameConstraints[$key] = array();
+        }
+
+        $this->pathnameConstraints[$key][] = $regex;
+
+        return $this;
+    }
+
+    public function getConstraints()
+    {
+        foreach ($this->pathnameConstraints as $key => $regexs) {
+            $this->pathnameConstraints[$key] = array_map(function (Regex $regex) { return (string) $regex; }, Regex::mergeWithOr($regexs));
+        }
+
+        foreach ($this->filenameConstraints as $key => $regexs) {
+            if (false !== strpos($key, 'patterns')) {
+                $this->filenameConstraints[$key] = array_map(function (Regex $regex) { return (string) $regex; }, Regex::mergeWithOr($regexs));
+            }
+        }
+
+        return new Constraints(
+            $this->type, $this->minDepth, $this->maxDepth,
+            $this->excludedNames, $this->pathnameConstraints, $this->filenameConstraints
+        );
+    }
+}

--- a/src/Symfony/Component/Finder/Scanner/Constraints.php
+++ b/src/Symfony/Component/Finder/Scanner/Constraints.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Scanner;
+
+/**
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class Constraints
+{
+    const TYPE_ALL = 0;
+    const TYPE_FILES = 1;
+    const TYPE_DIRECTORIES = 2;
+
+    private $excludedNames;
+    private $minDepthRespected;
+    private $maxDepthExceeded;
+    private $pathnameExcluded;
+    private $pathnameIncluded;
+    private $directoryKept;
+    private $fileKept;
+
+    public function __construct($type, $minDepth, $maxDepth, array $excludedNames, array $pathnameConstraints, array $filenameConstraints)
+    {
+        $this->excludedNames = $excludedNames;
+
+        $this->minDepthRespected = 0 === $minDepth
+            ? function () { return true; }
+            : function ($depth) use ($minDepth) { return $depth >= $minDepth; };
+
+        $this->maxDepthExceeded = PHP_INT_MAX === $maxDepth
+            ? function () { return false; }
+            : function ($depth) use ($maxDepth) { return $depth > $maxDepth; };
+
+        $this->pathnameExcluded = isset($pathnameConstraints['excluded_patterns'])
+            ? self::buildPathnameTest($pathnameConstraints['excluded_patterns'])
+            : function () { return false; };
+
+        $this->pathnameIncluded = isset($pathnameConstraints['included_patterns'])
+            ? self::buildPathnameTest($pathnameConstraints['included_patterns'])
+            : function () { return true; };
+
+        $keptTest = empty($filenameConstraints) && !isset($pathnameConstraints['included_ending_patterns']) && !isset($pathnameConstraints['excluded_ending_patterns'])
+            ? function () { return true; }
+            : self::buildKeptTest($filenameConstraints, $pathnameConstraints);
+
+        $this->directoryKept = self::TYPE_FILES === $type
+            ? function () { return false; }
+            : $keptTest;
+
+        $this->fileKept = self::TYPE_DIRECTORIES === $type
+            ? function () { return false; }
+            : $keptTest;
+    }
+
+    public function filterFilenames(array $filenames)
+    {
+        return array_diff($filenames, $this->excludedNames);
+    }
+
+    public function isMinDepthRespected($depth)
+    {
+        $minDepthRespected = $this->minDepthRespected;
+
+        return $minDepthRespected($depth);
+    }
+
+    public function isMaxDepthExceeded($depth)
+    {
+        $maxDepthExceeded = $this->maxDepthExceeded;
+
+        return $maxDepthExceeded($depth);
+    }
+
+    public function isPathnameExcluded($pathname)
+    {
+        $pathnameExcluded = $this->pathnameExcluded;
+
+        return $pathnameExcluded($pathname);
+    }
+
+    public function isPathnameIncluded($pathname)
+    {
+        $pathnameIncluded = $this->pathnameIncluded;
+
+        return $pathnameIncluded($pathname);
+    }
+
+    public function isDirectoryKept($pathname, $filename)
+    {
+        $directoryKept = $this->directoryKept;
+
+        return $directoryKept($pathname, $filename);
+    }
+
+    public function isFileKept($pathname, $filename)
+    {
+        $fileKept = $this->fileKept;
+
+        return $fileKept($pathname, $filename);
+    }
+
+    private static function buildPathnameTest(array $patterns)
+    {
+        return function ($value) use ($patterns) {
+            foreach ($patterns as $pattern) {
+                if (preg_match($pattern, $value)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+    }
+
+    private static function buildKeptTest(array $filenameConstraints, array $pathnameConstraints)
+    {
+        $excludedTests = array();
+        $includedTests = array();
+
+        if (isset($filenameConstraints['excluded_filenames'])) {
+            $filenames = $filenameConstraints['excluded_filenames'];
+            $excludedTests[] = function ($pathname, $filename) use ($filenames) {
+                return in_array($filename, $filenames);
+            };
+        }
+
+        if (isset($filenameConstraints['excluded_patterns'])) {
+            $patterns = $filenameConstraints['excluded_patterns'];
+            $excludedTests[] = function ($pathname, $filename) use ($patterns) {
+                foreach ($patterns as $pattern) {
+                    if (preg_match($pattern, $filename)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+        }
+
+        if (isset($pathnameConstraints['excluded_ending_patterns'])) {
+            $patterns = $pathnameConstraints['excluded_ending_patterns'];
+            $excludedTests[] = function ($pathname, $filename) use ($patterns) {
+                foreach ($patterns as $pattern) {
+                    if (preg_match($pattern, $pathname)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+        }
+
+        if (isset($filenameConstraints['included_filenames'])) {
+            $filenames = $filenameConstraints['included_filenames'];
+            $includedTests[] = function ($pathname, $filename) use ($filenames) {
+                return in_array($filename, $filenames);
+            };
+        }
+
+        if (isset($filenameConstraints['included_patterns'])) {
+            $patterns = $filenameConstraints['included_patterns'];
+            $includedTests[] = function ($pathname, $filename) use ($patterns) {
+                foreach ($patterns as $pattern) {
+                    if (preg_match($pattern, $filename)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+        }
+
+        if (isset($pathnameConstraints['included_ending_patterns'])) {
+            $patterns = $pathnameConstraints['included_ending_patterns'];
+            $includedTests[] = function ($pathname, $filename) use ($patterns) {
+                foreach ($patterns as $pattern) {
+                    if (preg_match($pattern, $pathname)) {
+                        return true;
+                    }
+                }
+                return false;
+            };
+        }
+
+        return function ($pathname, $filename) use ($excludedTests, $includedTests) {
+            foreach ($excludedTests as $excludeTest) {
+                if ($excludeTest($pathname, $filename)) {
+                    return false;
+                }
+            }
+
+            foreach ($includedTests as $includedTest) {
+                if ($includedTest($pathname, $filename)) {
+                    return true;
+                }
+            }
+
+            return empty($includedTests);
+        };
+    }
+}

--- a/src/Symfony/Component/Finder/Scanner/Constraints.php
+++ b/src/Symfony/Component/Finder/Scanner/Constraints.php
@@ -132,6 +132,7 @@ class Constraints
                     return true;
                 }
             }
+
             return false;
         };
     }
@@ -156,6 +157,7 @@ class Constraints
                         return true;
                     }
                 }
+
                 return false;
             };
         }
@@ -168,6 +170,7 @@ class Constraints
                         return true;
                     }
                 }
+
                 return false;
             };
         }
@@ -187,6 +190,7 @@ class Constraints
                         return true;
                     }
                 }
+
                 return false;
             };
         }
@@ -199,6 +203,7 @@ class Constraints
                         return true;
                     }
                 }
+
                 return false;
             };
         }

--- a/src/Symfony/Component/Finder/Scanner/Constraints.php
+++ b/src/Symfony/Component/Finder/Scanner/Constraints.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Finder\Scanner;
 
 /**
+ * Scanner's files filtering constraints.
+ *
  * @author Jean-François Simon <contact@jfsimon.fr>
  */
 class Constraints
@@ -29,7 +31,17 @@ class Constraints
     private $keepDirectories;
     private $keepFiles;
 
-    public function __construct($type, $minDepth, $maxDepth, array $excludedNames, array $pathnameConstraints, array $filenameConstraints)
+    /**
+     * Constructor.
+     *
+     * @param int   $type
+     * @param int   $minDepth
+     * @param int   $maxDepth
+     * @param array $excludedNames
+     * @param array $pathnameConstraints
+     * @param array $filenameConstraints
+     */
+    public function __construct($type = self::TYPE_ALL, $minDepth = 0, $maxDepth = PHP_INT_MAX, array $excludedNames = array(), array $pathnameConstraints = array(), array $filenameConstraints = array())
     {
         $this->excludedNames = $excludedNames;
 
@@ -57,11 +69,25 @@ class Constraints
         $this->keepFiles = self::TYPE_DIRECTORIES !== $type;
     }
 
+    /**
+     * Filters file names.
+     *
+     * @param array $filenames
+     *
+     * @return array
+     */
     public function filterFilenames(array $filenames)
     {
         return array_diff($filenames, $this->excludedNames);
     }
 
+    /**
+     * Tests if min depth constraint is respected.
+     *
+     * @param int $depth
+     *
+     * @return bool
+     */
     public function isMinDepthRespected($depth)
     {
         if (!$this->minDepthRespected instanceof \Closure) {
@@ -71,6 +97,13 @@ class Constraints
         return call_user_func($this->minDepthRespected, $depth);
     }
 
+    /**
+     * Tests if max depth constraint is exceeded.
+     *
+     * @param int $depth
+     *
+     * @return bool
+     */
     public function isMaxDepthExceeded($depth)
     {
         if (!$this->maxDepthExceeded instanceof \Closure) {
@@ -80,6 +113,13 @@ class Constraints
         return call_user_func($this->maxDepthExceeded, $depth);
     }
 
+    /**
+     * Tests if pathname is excluded.
+     *
+     * @param string $pathname
+     *
+     * @return bool
+     */
     public function isPathnameExcluded($pathname)
     {
         if (!$this->pathnameExcluded instanceof \Closure) {
@@ -89,6 +129,13 @@ class Constraints
         return call_user_func($this->pathnameExcluded, $pathname);
     }
 
+    /**
+     * Tests if pathname is included.
+     *
+     * @param string $pathname
+     *
+     * @return bool
+     */
     public function isPathnameIncluded($pathname)
     {
         if (!$this->pathnameIncluded instanceof \Closure) {
@@ -98,6 +145,14 @@ class Constraints
         return call_user_func($this->pathnameIncluded, $pathname);
     }
 
+    /**
+     * Tests if directory must be kept.
+     *
+     * @param string $pathname
+     * @param string $filename
+     *
+     * @return bool
+     */
     public function isDirectoryKept($pathname, $filename)
     {
         if (!$this->keepDirectories) {
@@ -111,6 +166,14 @@ class Constraints
         return call_user_func($this->keep, $pathname, $filename);
     }
 
+    /**
+     * Tests if file must be kept.
+     *
+     * @param string $pathname
+     * @param string $filename
+     *
+     * @return bool
+     */
     public function isFileKept($pathname, $filename)
     {
         if (!$this->keepFiles) {
@@ -124,6 +187,13 @@ class Constraints
         return call_user_func($this->keep, $pathname, $filename);
     }
 
+    /**
+     * Builds a pathname test closure.
+     *
+     * @param string[] $patterns
+     *
+     * @return \Closure
+     */
     private static function buildPathnameTest(array $patterns)
     {
         return function ($value) use ($patterns) {
@@ -137,6 +207,14 @@ class Constraints
         };
     }
 
+    /**
+     * Builds a keep file test closure.
+     *
+     * @param array $filenameConstraints
+     * @param array $pathnameConstraints
+     *
+     * @return \Closure
+     */
     private static function buildKeptTest(array $filenameConstraints, array $pathnameConstraints)
     {
         $excludedTests = array();

--- a/src/Symfony/Component/Finder/Scanner/Expression.php
+++ b/src/Symfony/Component/Finder/Scanner/Expression.php
@@ -53,7 +53,7 @@ class Expression
 
     private static function stringToRegex($value)
     {
-        return '~(^|/)'.preg_quote($value, '#').'(/|$)~';
+        return '~(^|/)'.preg_quote($value, '~').'(/|$)~';
     }
 
     private static function globToRegex($pattern, $strictLeadingDot = true, $strictWildcardSlash = true)

--- a/src/Symfony/Component/Finder/Scanner/Expression.php
+++ b/src/Symfony/Component/Finder/Scanner/Expression.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Scanner;
+
+/**
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class Expression
+{
+    private $value;
+
+    public function __construct($pattern)
+    {
+        try {
+            $this->value = new Regex($pattern);
+        } catch (\InvalidArgumentException $e) {
+            if (self::isGlobPattern($pattern)) {
+                $this->value = new Regex(self::globToRegex($pattern));
+            } else {
+                $this->value = $pattern;
+            }
+        }
+    }
+
+    public function isRegex()
+    {
+        return $this->value instanceof Regex;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getRegex()
+    {
+        return $this->value instanceof Regex ? $this->value : new Regex(self::stringToRegex($this->value));
+    }
+
+    private static function isGlobPattern($pattern)
+    {
+        return !(false === strpos($pattern, '?') && false === strpos($pattern, '*') && false === strpos($pattern, '{'));
+    }
+
+    private static function stringToRegex($value)
+    {
+        return '~(^|/)'.preg_quote($value, '#').'(/|$)~';
+    }
+
+    private static function globToRegex($pattern, $strictLeadingDot = true, $strictWildcardSlash = true)
+    {
+        $firstByte = true;
+        $escaping = false;
+        $inCurlies = 0;
+        $regex = '';
+        $sizeGlob = strlen($pattern);
+        for ($i = 0; $i < $sizeGlob; $i++) {
+            $car = $pattern[$i];
+            if ($firstByte) {
+                if ($strictLeadingDot && '.' !== $car) {
+                    $regex .= '(?=[^\.])';
+                }
+
+                $firstByte = false;
+            }
+
+            if ('/' === $car) {
+                $firstByte = true;
+            }
+
+            if ('.' === $car || '(' === $car || ')' === $car || '|' === $car || '+' === $car || '^' === $car || '$' === $car) {
+                $regex .= "\\$car";
+            } elseif ('*' === $car) {
+                $regex .= $escaping ? '\\*' : ($strictWildcardSlash ? '[^/]*' : '.*');
+            } elseif ('?' === $car) {
+                $regex .= $escaping ? '\\?' : ($strictWildcardSlash ? '[^/]' : '.');
+            } elseif ('{' === $car) {
+                $regex .= $escaping ? '\\{' : '(';
+                if (!$escaping) {
+                    ++$inCurlies;
+                }
+            } elseif ('}' === $car && $inCurlies) {
+                $regex .= $escaping ? '}' : ')';
+                if (!$escaping) {
+                    --$inCurlies;
+                }
+            } elseif (',' === $car && $inCurlies) {
+                $regex .= $escaping ? ',' : '|';
+            } elseif ('\\' === $car) {
+                if ($escaping) {
+                    $regex .= '\\\\';
+                    $escaping = false;
+                } else {
+                    $escaping = true;
+                }
+
+                continue;
+            } else {
+                $regex .= $car;
+            }
+            $escaping = false;
+        }
+
+        return '~^'.$regex.'$~';
+    }
+}

--- a/src/Symfony/Component/Finder/Scanner/Regex.php
+++ b/src/Symfony/Component/Finder/Scanner/Regex.php
@@ -12,6 +12,8 @@
 namespace Symfony\Component\Finder\Scanner;
 
 /**
+ * Regex manipulator.
+ *
  * @author Jean-François Simon <contact@jfsimon.fr>
  */
 class Regex
@@ -22,6 +24,13 @@ class Regex
     private $starting;
     private $ending;
 
+    /**
+     * Constructor.
+     *
+     * @param string $pattern
+     *
+     * @throws \InvalidArgumentException
+     */
     public function __construct($pattern)
     {
         if (preg_match('/^(.{3,}?)([imsxuADU]*)$/', $pattern, $m)) {
@@ -48,21 +57,45 @@ class Regex
         throw new \InvalidArgumentException(sprintf('Pattern "%s" is not a valid regex.', $pattern));
     }
 
+    /**
+     * Returns regex as a string.
+     *
+     * @return string
+     */
     public function __toString()
     {
         return implode($this->pattern, $this->delimiters).$this->options;
     }
 
+    /**
+     * Tests if pattern starts with a `^`.
+     *
+     * @return bool
+     */
     public function isStarting()
     {
         return $this->starting;
     }
 
+    /**
+     * Tests if pattern ends with a `$`.
+     *
+     * @return bool
+     */
     public function isEnding()
     {
         return $this->ending;
     }
 
+    /**
+     * Merges given regexs with an OR condition (grouped by options).
+     *
+     * @param Regex[] $regexs
+     *
+     * @return Regex[]
+     *
+     * @throws \InvalidArgumentException
+     */
     public static function mergeWithOr(array $regexs)
     {
         $grouped = array();

--- a/src/Symfony/Component/Finder/Scanner/Regex.php
+++ b/src/Symfony/Component/Finder/Scanner/Regex.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Scanner;
+
+/**
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class Regex
+{
+    private $delimiters;
+    private $pattern;
+    private $options;
+    private $starting;
+    private $ending;
+
+    public function __construct($pattern)
+    {
+        if (preg_match('/^(.{3,}?)([imsxuADU]*)$/', $pattern, $m)) {
+            $start = substr($m[1], 0, 1);
+            $end   = substr($m[1], -1);
+
+            if (($start === $end && !preg_match('/[*?[:alnum:] \\\\]/', $start)) || ($start === '{' && $end === '}')) {
+                $this->delimiters = array($start, $end);
+                $this->pattern = substr($m[1], 1, -1);
+
+                // options are sorted for later comparison
+                $options = str_split($m[2]);
+                sort($options);
+                $this->options = implode('', $options);
+
+                // fixme: find something stronger
+                $this->starting = '^' === substr($this->pattern, 0, 1);
+                $this->ending = '$' === substr($this->pattern, -1);
+
+                return;
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf('Pattern "%s" is not a valid regex.', $pattern));
+    }
+
+    public function __toString()
+    {
+        return implode($this->pattern, $this->delimiters).$this->options;
+    }
+
+    public function isStarting()
+    {
+        return $this->starting;
+    }
+
+    public function isEnding()
+    {
+        return $this->ending;
+    }
+
+    public static function mergeWithOr(array $regexs)
+    {
+        $grouped = array();
+        foreach ($regexs as $regex) {
+            if (!$regex instanceof self) {
+                throw new \InvalidArgumentException('Only Regex instances must be provided.');
+            }
+            if (!isset($grouped[$regex->options])) {
+                $grouped[$regex->options] = array();
+            }
+            $grouped[$regex->options][] = $regex;
+        }
+
+        $merged = array();
+        foreach ($grouped as $group) {
+            if (count($group) === 1) {
+                $merged[] = $group[0];
+                continue;
+            }
+            $first = array_shift($group);
+            $first->pattern = sprintf('(%s)', $first->pattern);
+            foreach ($group as $regex) {
+                $first->pattern .= sprintf('|(%s)', $regex->pattern);
+            }
+            $merged[] = $first;
+        }
+
+        return $merged;
+    }
+}

--- a/src/Symfony/Component/Finder/Scanner/Scanner.php
+++ b/src/Symfony/Component/Finder/Scanner/Scanner.php
@@ -69,7 +69,7 @@ class Scanner implements \IteratorAggregate
                 if (!$this->constraints->isMaxDepthExceeded($relativeDepth)) {
                     $this->scanDirectory($relativePathname, $relativeDepth, $pathnameIncluded);
                 }
-            } elseif($keepFiles && $pathnameIncluded && $this->constraints->isFileKept($relativePathname, $filename)) {
+            } elseif ($keepFiles && $pathnameIncluded && $this->constraints->isFileKept($relativePathname, $filename)) {
                 $this->scannedFiles[$rootPathname] = new SplFileInfo($rootPathname, $relativePath, $relativePathname);
             }
         }

--- a/src/Symfony/Component/Finder/Scanner/Scanner.php
+++ b/src/Symfony/Component/Finder/Scanner/Scanner.php
@@ -80,7 +80,7 @@ class Scanner implements \IteratorAggregate
         $relativeDepth = $relativeDepth + 1;
 
         foreach ($this->constraints->filterFilenames($filenames) as $filename) {
-            $rootPathname = $rootPath.'/'.$filename;
+            $rootPathname = rtrim($rootPath, '/').'/'.$filename;
 
             if (is_link($rootPathname) && !$this->followLinks) {
                 continue;

--- a/src/Symfony/Component/Finder/Scanner/Scanner.php
+++ b/src/Symfony/Component/Finder/Scanner/Scanner.php
@@ -15,6 +15,8 @@ use Symfony\Component\Finder\Exception\AccessDeniedException;
 use Symfony\Component\Finder\SplFileInfo;
 
 /**
+ * Filesystem scanner.
+ *
  * @author Jean-François Simon <contact@jfsimon.fr>
  */
 class Scanner implements \IteratorAggregate
@@ -24,6 +26,13 @@ class Scanner implements \IteratorAggregate
     private $ignoreAccessDenied;
     private $scannedFiles;
 
+    /**
+     * Constructor.
+     *
+     * @param string      $rootPath
+     * @param Constraints $constraints
+     * @param bool        $ignoreAccessDenied
+     */
     public function __construct($rootPath, Constraints $constraints, $ignoreAccessDenied)
     {
         $this->rootPath = $rootPath;
@@ -32,6 +41,11 @@ class Scanner implements \IteratorAggregate
         $this->scannedFiles = new \ArrayIterator();
     }
 
+    /**
+     * Returns an iterator over filtered files.
+     *
+     * @return \ArrayIterator
+     */
     public function getIterator()
     {
         $this->scanDirectory('', 0);
@@ -39,6 +53,15 @@ class Scanner implements \IteratorAggregate
         return $this->scannedFiles;
     }
 
+    /**
+     * Scans a directory recursively.
+     *
+     * @param string $relativePath
+     * @param int    $relativeDepth
+     * @param bool   $relativePathIncluded
+     *
+     * @throws AccessDeniedException
+     */
     private function scanDirectory($relativePath, $relativeDepth, $relativePathIncluded = false)
     {
         $rootPath = $relativePath ? $this->rootPath.'/'.$relativePath : $this->rootPath;

--- a/src/Symfony/Component/Finder/Scanner/Scanner.php
+++ b/src/Symfony/Component/Finder/Scanner/Scanner.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Finder\Scanner;
+
+use Symfony\Component\Finder\Exception\AccessDeniedException;
+use Symfony\Component\Finder\SplFileInfo;
+
+/**
+ * @author Jean-François Simon <contact@jfsimon.fr>
+ */
+class Scanner implements \IteratorAggregate
+{
+    private $rootPath;
+    private $constraints;
+    private $ignoreAccessDenied;
+    private $scannedFiles;
+
+    public function __construct($rootPath, Constraints $constraints, $ignoreAccessDenied)
+    {
+        $this->rootPath = $rootPath;
+        $this->constraints = $constraints;
+        $this->ignoreAccessDenied = $ignoreAccessDenied;
+        $this->scannedFiles = new \ArrayIterator();
+    }
+
+    public function getIterator()
+    {
+        $this->scanDirectory('', 0);
+
+        return $this->scannedFiles;
+    }
+
+    private function scanDirectory($relativePath, $relativeDepth, $relativePathIncluded = false)
+    {
+        $rootPath = $relativePath ? $this->rootPath.'/'.$relativePath : $this->rootPath;
+
+        if (false === $filenames = @scandir($rootPath)) {
+            if ($this->ignoreAccessDenied) {
+                return;
+            }
+            throw new AccessDeniedException(sprintf('Directory "%s" is not readable.', $rootPath));
+        }
+
+        $keepFiles = $this->constraints->isMinDepthRespected($relativeDepth);
+        $relativeDepth = $relativeDepth + 1;
+
+        foreach ($this->constraints->filterFilenames($filenames) as $filename) {
+            $rootPathname = $rootPath.'/'.$filename;
+
+            $relativePathname = $relativePath ? $relativePath.'/'.$filename : $filename;
+            if ($this->constraints->isPathnameExcluded($relativePathname)) {
+                continue;
+            }
+
+            $pathnameIncluded = $relativePathIncluded || $this->constraints->isPathnameIncluded($relativePathname);
+            if (is_dir($rootPathname)) {
+                if ($keepFiles && $pathnameIncluded && $this->constraints->isDirectoryKept($relativePathname, $filename)) {
+                    $this->scannedFiles[$rootPathname] = new SplFileInfo($rootPathname, $relativePath, $relativePathname);
+                }
+                if (!$this->constraints->isMaxDepthExceeded($relativeDepth)) {
+                    $this->scanDirectory($relativePathname, $relativeDepth, $pathnameIncluded);
+                }
+            } elseif($keepFiles && $pathnameIncluded && $this->constraints->isFileKept($relativePathname, $filename)) {
+                $this->scannedFiles[$rootPathname] = new SplFileInfo($rootPathname, $relativePath, $relativePathname);
+            }
+        }
+    }
+}

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -799,7 +799,8 @@ class FinderTest extends Iterator\RealIteratorTestCase
             array(
                 new Adapter\BsdFindAdapter(),
                 new Adapter\GnuFindAdapter(),
-                new Adapter\PhpAdapter()
+                new Adapter\PhpAdapter(),
+                new \Symfony\Component\Finder\Scanner\Adapter(),
             ),
             function (Adapter\AdapterInterface $adapter) {
                 return $adapter->isSupported();

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -691,7 +691,7 @@ class FinderTest extends Iterator\RealIteratorTestCase
     {
         // test that by default, PhpAdapter is selected
         $adapters = Finder::create()->getAdapters();
-        $this->assertTrue($adapters[0] instanceof Adapter\PhpAdapter);
+        $this->assertTrue($adapters[0] instanceof \Symfony\Component\Finder\Scanner\Adapter);
 
         // test another adapter selection
         $adapters = Finder::create()->setAdapter('gnu_find')->getAdapters();

--- a/src/Symfony/Component/Finder/Tests/FinderTest.php
+++ b/src/Symfony/Component/Finder/Tests/FinderTest.php
@@ -547,6 +547,28 @@ class FinderTest extends Iterator\RealIteratorTestCase
     }
 
     /**
+     * @dataProvider getAdaptersTestData
+     */
+    public function testFollowSymlink(Adapter\AdapterInterface $adapter)
+    {
+        $done = symlink(self::toAbsolute('foo'), self::toAbsolute('foo_link'));
+
+        if (!$done) {
+            $this->markTestSkipped('Symbolic links are not available on this OS.');
+        }
+
+        $finder = $this->buildFinder($adapter);
+        $finder->files()->in(self::$tmpDir);
+        $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php', 'test.py', 'foo bar')), $finder->getIterator());
+
+        $finder = $this->buildFinder($adapter);
+        $finder->files()->followLinks()->in(self::$tmpDir);
+        $this->assertIterator($this->toAbsolute(array('foo/bar.tmp', 'test.php', 'test.py', 'foo bar', 'foo_link/bar.tmp')), $finder->getIterator());
+
+        unlink(self::toAbsolute('foo_link'));
+    }
+
+    /**
      * Searching in multiple locations involves AppendIterator which does an unnecessary rewind which leaves FilterIterator
      * with inner FilesystemIterator in an invalid state.
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| License | MIT |
| Tests pass? | yes |

This PR improves finder performance using a pure PHP adapter.

This adapter:
- only improve tests against the filename/path
- don't visit children of excluded directories
- tries to make the more calculations outside the loops

Benchmark:
- result can be found here: https://gist.github.com/jfsimon/f58d6dda383be9f1bfdd
- used framework is here: https://github.com/jfsimon/symfony-finder-benchmark
- I just benchmarked filenames/paths constraints, other parts of finder are not affected

---

_NB: I grouped all new classes in a single `Scanner` namespace._
- [x] Benchmark `if () { return }` vs `$closure()`
- [x] Add `followLink()` support and test it
