### PR TITLE
[WIP][DependencyInjection] Fixed a failing test for the YamlDumper.

### DIFF
--- a/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
+++ b/src/Symfony/Component/DependencyInjection/Dumper/YamlDumper.php
@@ -168,7 +168,7 @@ class YamlDumper extends Dumper
 
         $parameters = $this->prepareParameters($this->container->getParameterBag()->all(), $this->container->isFrozen());
 
-        return Yaml::dump(array('parameters' => $parameters), 2);
+        return Yaml::dump(array('parameters' => $parameters), 2, 2);
     }
 
     /**


### PR DESCRIPTION
Test is failing on environments where Yaml component is installed globally (i.e. with phpunit), since the default indentation level has changed.
