### PR TITLE
[TwigBundle] Fixed escaping of service identifiers in configuration

### DIFF
--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -81,7 +81,9 @@ class Configuration implements ConfigurationInterface
                     ->example(array('foo' => '"@bar"', 'pi' => 3.14))
                     ->prototype('array')
                         ->beforeNormalization()
-                            ->ifTrue(function($v){ return is_string($v) && 0 === strpos($v, '@'); })
+                            ->ifTrue(function($v){
+                                return is_string($v) && 0 === strpos($v, '@') && 0 !== strpos($v, '@@');
+                            })
                             ->then(function($v){ return array('id' => substr($v, 1), 'type' => 'service'); })
                         ->end()
                         ->beforeNormalization()

--- a/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/TwigBundle/DependencyInjection/Configuration.php
@@ -81,10 +81,14 @@ class Configuration implements ConfigurationInterface
                     ->example(array('foo' => '"@bar"', 'pi' => 3.14))
                     ->prototype('array')
                         ->beforeNormalization()
-                            ->ifTrue(function($v){
-                                return is_string($v) && 0 === strpos($v, '@') && 0 !== strpos($v, '@@');
+                            ->ifTrue(function($v){ return is_string($v) && 0 === strpos($v, '@'); })
+                            ->then(function($v){
+                                if (0 === strpos($v, '@@')) {
+                                    return substr($v, 1);
+                                }
+
+                                return array('id' => substr($v, 1), 'type' => 'service');
                             })
-                            ->then(function($v){ return array('id' => substr($v, 1), 'type' => 'service'); })
                         ->end()
                         ->beforeNormalization()
                             ->ifTrue(function($v){

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/php/full.php
@@ -8,6 +8,7 @@ $container->loadFromExtension('twig', array(
      ),
      'globals' => array(
          'foo' => '@bar',
+         'baz' => '@@qux',
          'pi'  => 3.14,
          'bad' => array('key' => 'foo'),
      ),

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/xml/full.xml
@@ -11,6 +11,7 @@
             <twig:resource>MyBundle::form.html.twig</twig:resource>
         </twig:form>
         <twig:global key="foo" id="bar" type="service" />
+        <twig:global key="baz">@@qux</twig:global>
         <twig:global key="pi">3.14</twig:global>
         <twig:path>path1</twig:path>
         <twig:path>path2</twig:path>

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/Fixtures/yml/full.yml
@@ -4,6 +4,7 @@ twig:
             - MyBundle::form.html.twig
     globals:
         foo: "@bar"
+        baz: "@@qux"
         pi:  3.14
         bad: {key: foo}
     auto_reload:         true

--- a/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
+++ b/src/Symfony/Bundle/TwigBundle/Tests/DependencyInjection/TwigExtensionTest.php
@@ -63,13 +63,15 @@ class TwigExtensionTest extends TestCase
         $this->assertEquals(new Reference('templating.globals'), $calls[0][1][1]);
         $this->assertEquals('foo', $calls[1][1][0], '->load() registers services as Twig globals');
         $this->assertEquals(new Reference('bar'), $calls[1][1][1], '->load() registers services as Twig globals');
-        $this->assertEquals('pi', $calls[2][1][0], '->load() registers variables as Twig globals');
-        $this->assertEquals(3.14, $calls[2][1][1], '->load() registers variables as Twig globals');
+        $this->assertEquals('baz', $calls[2][1][0], '->load() registers variables as Twig globals');
+        $this->assertEquals('@qux', $calls[2][1][1], '->load() allows escaping of service identifiers');
+        $this->assertEquals('pi', $calls[3][1][0], '->load() registers variables as Twig globals');
+        $this->assertEquals(3.14, $calls[3][1][1], '->load() registers variables as Twig globals');
 
         // Yaml and Php specific configs
         if (in_array($format, array('yml', 'php'))) {
-            $this->assertEquals('bad', $calls[3][1][0], '->load() registers variables as Twig globals');
-            $this->assertEquals(array('key' => 'foo'), $calls[3][1][1], '->load() registers variables as Twig globals');
+            $this->assertEquals('bad', $calls[4][1][0], '->load() registers variables as Twig globals');
+            $this->assertEquals(array('key' => 'foo'), $calls[4][1][1], '->load() registers variables as Twig globals');
         }
 
         // Twig options


### PR DESCRIPTION
To recreate, add the following to `config.yml`:

```
twig:
    globals:
        foo: "@@bar"
```

**Expected behaviour:** Twig has a global variable named `foo` containing the string `@bar`.

**Actual behaviour:** ServiceNotFoundException: The service "twig" has a dependency on a non-existent service "@bar".

Environment tested on:
- Symfony Standard Distribution 2.3.2
- OS X 10.8.4
- PHP 5.4.16
