### PR TITLE
[Process] Fix empty process argument escaping on Windows

### DIFF
--- a/src/Symfony/Component/Process/ProcessUtils.php
+++ b/src/Symfony/Component/Process/ProcessUtils.php
@@ -41,11 +41,15 @@ class ProcessUtils
         //@see https://bugs.php.net/bug.php?id=43784
         //@see https://bugs.php.net/bug.php?id=49446
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            if ('' === $argument) {
+                return escapeshellarg($argument);
+            }
+
             $escapedArgument = '';
             foreach (preg_split('/([%"])/i', $argument, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE) as $part) {
-                if ('"' == $part) {
+                if ('"' === $part) {
                     $escapedArgument .= '\\"';
-                } elseif ('%' == $part) {
+                } elseif ('%' === $part) {
                     $escapedArgument .= '^%';
                 } else {
                     $escapedArgument .= escapeshellarg($part);

--- a/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
+++ b/src/Symfony/Component/Process/Tests/ProcessUtilsTest.php
@@ -30,6 +30,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
                 array('"foo bar"', 'foo bar'),
                 array('^%"path"^%', '%path%'),
                 array('"<|>"\\"" "\\""\'f"', '<|>" "\'f'),
+                array('""', ''),
             );
         }
 
@@ -37,6 +38,7 @@ class ProcessUtilsTest extends \PHPUnit_Framework_TestCase
             array("'foo bar'", 'foo bar'),
             array("'%path%'", '%path%'),
             array("'<|>\" \"'\\''f'", '<|>" "\'f'),
+            array("''", ''),
         );
     }
 }


### PR DESCRIPTION
PR #6796 introduced a regression on Windows platform (symfony 2.3.0+), forgetting to escape explicitly requested empty arguments to `""` and return an empty string instead.

This behaviour is imo unintended and renders the component unusable for corner-cases, where you indeed want to specify an empty argument. One good example of this is assetic and compass, which (up to this day) relies on existence of empty parameters on windows.

Some panic and related links on the topic:
https://github.com/kriswallsmith/assetic/issues/455
https://github.com/kriswallsmith/assetic/pull/471
http://stackoverflow.com/questions/17001517/symfony2-3-with-compass ([diff](http://marker.to/KrctHM))
http://stackoverflow.com/questions/17135219/symfony-2-compass-with-assetic-on-windows-xp

Please consider a merge to master and a backport to 2.3.x
