### PR TITLE
[2.3] [HttpKernel] TraceableEventDispatcher loses listener priority

### DIFF
--- a/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Debug/TraceableEventDispatcherTest.php
@@ -148,6 +148,22 @@ class TraceableEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('foo1', 'foo2'), $called);
     }
 
+    public function testDispatchCallListenersWithPrioritySort()
+    {
+        $called = array();
+
+        $dispatcher = new EventDispatcher();
+        $tdispatcher = new TraceableEventDispatcher($dispatcher, new Stopwatch());
+        $tdispatcher->addListener('foo', $listener1 = function () use (&$called) { $called[] = 'foo1'; }, -10);
+        $tdispatcher->addListener('foo', $listener2 = function () use (&$called) { $called[] = 'foo2'; });
+        $tdispatcher->addListener('foo', $listener2 = function () use (&$called) { $called[] = 'foo3'; }, -5);
+        $tdispatcher->addListener('foo', $listener2 = function () use (&$called) { $called[] = 'foo4'; });
+
+        $tdispatcher->dispatch('foo');
+
+        $this->assertEquals(array('foo2', 'foo4', 'foo3', 'foo1'), $called);
+    }
+
     public function testDispatchNested()
     {
         $dispatcher = new TraceableEventDispatcher(new EventDispatcher(), new Stopwatch());


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Tests pass? | yes |
| Fixed tickets | #8426 |
| License | MIT |

This is alternative to the #8596.
