### PR TITLE
Fragment handler call set request instead of using listener

### DIFF
--- a/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/HttpKernelExtensionTest.php
@@ -49,16 +49,8 @@ class HttpKernelExtensionTest extends TestCase
         $strategy->expects($this->once())->method('getName')->will($this->returnValue('inline'));
         $strategy->expects($this->once())->method('render')->will($return);
 
-        // simulate a master request
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->will($this->returnValue(Request::create('/')))
-        ;
-
         $renderer = new FragmentHandler(array($strategy));
-        $renderer->onKernelRequest($event);
+        $renderer->setRequest(Request::create('/'));
 
         return $renderer;
     }

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -14,9 +14,9 @@
 
     <services>
         <service id="fragment.handler" class="%fragment.handler.class%">
-            <tag name="kernel.event_subscriber" />
             <argument type="collection" />
             <argument>%kernel.debug%</argument>
+            <call method="setRequest"><argument type="service" id="request" on-invalid="null" strict="false" /></call>
         </service>
 
         <service id="fragment.renderer.inline" class="%fragment.renderer.inline.class%">

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -93,6 +93,10 @@ class FragmentHandler
             throw new \InvalidArgumentException(sprintf('The "%s" renderer does not exist.', $renderer));
         }
 
+        if (null === $this->request) {
+            throw new \LogicException('Rendering a fragment can only be done when handling a master Request.');
+        }
+
         return $this->deliver($this->renderers[$renderer]->render($uri, $this->request, $options));
     }
 

--- a/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php
@@ -15,10 +15,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
-use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
  * Renders a URI that represents a resource fragment.
@@ -30,11 +26,11 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  *
  * @see FragmentRendererInterface
  */
-class FragmentHandler implements EventSubscriberInterface
+class FragmentHandler
 {
     private $debug;
     private $renderers;
-    private $requests;
+    private $request;
 
     /**
      * Constructor.
@@ -49,7 +45,6 @@ class FragmentHandler implements EventSubscriberInterface
             $this->addRenderer($renderer);
         }
         $this->debug = $debug;
-        $this->requests = array();
     }
 
     /**
@@ -63,23 +58,13 @@ class FragmentHandler implements EventSubscriberInterface
     }
 
     /**
-     * Stores the Request object.
+     * Sets the current Request.
      *
-     * @param GetResponseEvent $event A GetResponseEvent instance
+     * @param Request $request The current Request
      */
-    public function onKernelRequest(GetResponseEvent $event)
+    public function setRequest(Request $request = null)
     {
-        array_unshift($this->requests, $event->getRequest());
-    }
-
-    /**
-     * Removes the most recent Request object.
-     *
-     * @param FilterResponseEvent $event A FilterResponseEvent instance
-     */
-    public function onKernelResponse(FilterResponseEvent $event)
-    {
-        array_shift($this->requests);
+        $this->request = $request;
     }
 
     /**
@@ -108,7 +93,7 @@ class FragmentHandler implements EventSubscriberInterface
             throw new \InvalidArgumentException(sprintf('The "%s" renderer does not exist.', $renderer));
         }
 
-        return $this->deliver($this->renderers[$renderer]->render($uri, $this->requests[0], $options));
+        return $this->deliver($this->renderers[$renderer]->render($uri, $this->request, $options));
     }
 
     /**
@@ -126,7 +111,7 @@ class FragmentHandler implements EventSubscriberInterface
     protected function deliver(Response $response)
     {
         if (!$response->isSuccessful()) {
-            throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $this->requests[0]->getUri(), $response->getStatusCode()));
+            throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $this->request->getUri(), $response->getStatusCode()));
         }
 
         if (!$response instanceof StreamedResponse) {
@@ -134,14 +119,6 @@ class FragmentHandler implements EventSubscriberInterface
         }
 
         $response->sendContent();
-    }
-
-    public static function getSubscribedEvents()
-    {
-        return array(
-            KernelEvents::REQUEST  => 'onKernelRequest',
-            KernelEvents::RESPONSE => 'onKernelResponse',
-        );
     }
 
     // to be removed in 2.3

--- a/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
+++ b/src/Symfony/Component/HttpKernel/Tests/Fragment/FragmentHandlerTest.php
@@ -17,13 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
 {
-    protected function setUp()
-    {
-        if (!class_exists('Symfony\Component\EventDispatcher\EventDispatcher')) {
-            $this->markTestSkipped('The "EventDispatcher" component is not available');
-        }
-    }
-
     /**
      * @expectedException \InvalidArgumentException
      */
@@ -102,14 +95,7 @@ class FragmentHandlerTest extends \PHPUnit_Framework_TestCase
 
         $handler = new FragmentHandler();
         $handler->addRenderer($renderer);
-
-        $event = $this->getMockBuilder('Symfony\Component\HttpKernel\Event\GetResponseEvent')->disableOriginalConstructor()->getMock();
-        $event
-            ->expects($this->once())
-            ->method('getRequest')
-            ->will($this->returnValue(Request::create('/')))
-        ;
-        $handler->onKernelRequest($event);
+        $handler->setRequest(Request::create('/'));
 
         return $handler;
     }


### PR DESCRIPTION
These 2 commits were made in fabpot/contagious-services which was in #7007. I think these changes need to be applied to the 2.2 branch as well since if they are not applied then you can not create a request in an event listener class and have fragments render from a view without getting the following error:

`Undefined offset: 0 in .../src/Symfony/Component/HttpKernel/Fragment/FragmentHandler.php`

Not sure if this pull request can be applied without 2ffcfb98c870f1d88fcfc1e403e56613400394a9 and ec1e7ca6ac7364efecf5cc1ac891089a6d38da49 but from my testing.
