### PR TITLE
[TwigBridge] Prevent code extension to display warning

### DIFF
--- a/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/CodeExtension.php
@@ -137,7 +137,9 @@ class CodeExtension extends \Twig_Extension
     public function fileExcerpt($file, $line)
     {
         if (is_readable($file)) {
-            $code = highlight_file($file, true);
+            // highlight_file could throw warnings
+            // see https://bugs.php.net/bug.php?id=25725
+            $code = @highlight_file($file, true);
             // remove main code/span tags
             $code = preg_replace('#^<code.*?>\s*<span.*?>(.*)</span>\s*</code>#s', '\\1', $code);
             $content = preg_split('#<br />#', $code);

--- a/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Templating/Helper/CodeHelper.php
@@ -131,7 +131,9 @@ class CodeHelper extends Helper
                 }
             }
 
-            $code = highlight_file($file, true);
+            // highlight_file could throw warnings
+            // see https://bugs.php.net/bug.php?id=25725
+            $code = @highlight_file($file, true);
             // remove main code/span tags
             $code = preg_replace('#^<code.*?>\s*<span.*?>(.*)</span>\s*</code>#s', '\\1', $code);
             $content = preg_split('#<br />#', $code);

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -181,7 +181,7 @@ class ClassLoader
         $classPath .= str_replace('_', DIRECTORY_SEPARATOR, $className) . '.php';
 
         foreach ($this->prefixes as $prefix => $dirs) {
-            if (0 === strpos($class, $prefix)) {
+            if ($class === strstr($class, $prefix)) {
                 foreach ($dirs as $dir) {
                     if (file_exists($dir . DIRECTORY_SEPARATOR . $classPath)) {
                         return $dir . DIRECTORY_SEPARATOR . $classPath;


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |

During functional testing with phpunit and browserkit (and all their friends) when the application returns a `4XX` or a `5XX` response, symfony displays the trace with code context.

During a training, few people experienced a very weird issue with php 5.4, symfony 2.3.2, phpunit 3.7, Windows 7 or 8 and SensioLabsDesktop 0.5.

When they run functional  tests, and the application returns a `404`, in the "console" there was lot of warnings. I don't remember, sorry, but it was something about unexpected character and/or encoding. With the `@`, no more warnings.

I can't reproduce this issue on my computer (not windows). If needed, I can try to reproduce this bug on Monday at work.

And I am not sure the issue is from symfony... And I can't find the warning message in google. 
