### PR TITLE
[TwigBundle] Created stopwatch tag for profiling templates

### DIFF
--- a/src/Symfony/Bridge/Twig/CHANGELOG.md
+++ b/src/Symfony/Bridge/Twig/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+2.4.0
+-----
+
+ * added stopwatch tag to time templates with the WebProfilerBundle
+
 2.3.0
 -----
 

--- a/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
@@ -28,6 +28,11 @@ class StopwatchExtension extends \Twig_Extension
         $this->stopwatch = $stopwatch;
     }
 
+    public function getStopwatch()
+    {
+        return $this->stopwatch;
+    }
+
     public function getTokenParsers()
     {
         return array(
@@ -43,19 +48,5 @@ class StopwatchExtension extends \Twig_Extension
     public function getName()
     {
         return 'stopwatch';
-    }
-
-    public function startEvent($name)
-    {
-        if ($this->stopwatch instanceof Stopwatch) {
-            $this->stopwatch->start($name, 'template');
-        }
-    }
-
-    public function stopEvent($name)
-    {
-        if ($this->stopwatch instanceof Stopwatch) {
-            $this->stopwatch->stop($name);
-        }
     }
 }

--- a/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
@@ -22,12 +22,12 @@ use Symfony\Bridge\Twig\TokenParser\StopwatchTokenParser;
 class StopwatchExtension extends \Twig_Extension
 {
     private $stopwatch;
- 
+
     public function __construct(Stopwatch $stopwatch = null)
     {
         $this->stopwatch = $stopwatch;
     }
- 
+
     public function getTokenParsers()
     {
         return array(
@@ -39,19 +39,19 @@ class StopwatchExtension extends \Twig_Extension
             new StopwatchTokenParser($this->stopwatch !== null),
         );
     }
- 
+
     public function getName()
     {
         return 'stopwatch';
     }
- 
+
     public function startEvent($name)
     {
         if ($this->stopwatch instanceof Stopwatch) {
             $this->stopwatch->start($name, 'template');
         }
     }
- 
+
     public function stopEvent($name)
     {
         if ($this->stopwatch instanceof Stopwatch) {

--- a/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
+++ b/src/Symfony/Bridge/Twig/Extension/StopwatchExtension.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Extension;
+
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Bridge\Twig\TokenParser\StopwatchTokenParser;
+
+/**
+ * Twig extension for the stopwatch helper.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class StopwatchExtension extends \Twig_Extension
+{
+    private $stopwatch;
+ 
+    public function __construct(Stopwatch $stopwatch = null)
+    {
+        $this->stopwatch = $stopwatch;
+    }
+ 
+    public function getTokenParsers()
+    {
+        return array(
+            /*
+             * {% stopwatch foo %}
+             * Some stuff which will be recorded on the timeline
+             * {% endstopwatch %}
+             */
+            new StopwatchTokenParser($this->stopwatch !== null),
+        );
+    }
+ 
+    public function getName()
+    {
+        return 'stopwatch';
+    }
+ 
+    public function startEvent($name)
+    {
+        if ($this->stopwatch instanceof Stopwatch) {
+            $this->stopwatch->start($name, 'template');
+        }
+    }
+ 
+    public function stopEvent($name)
+    {
+        if ($this->stopwatch instanceof Stopwatch) {
+            $this->stopwatch->stop($name);
+        }
+    }
+}

--- a/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
+++ b/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Node;
+
+/**
+ * Represents a stopwatch node.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class StopwatchNode extends \Twig_Node
+{
+    public function __construct($name, $body, $lineno = 0, $tag = null)
+    {
+        parent::__construct(array('body' => $body), array('name' => $name), $lineno, $tag);
+    }
+ 
+    public function compile(\Twig_Compiler $compiler)
+    {
+        $name = $this->getAttribute('name');
+ 
+        $compiler
+            ->write('$this->env->getExtension(\'stopwatch\')->startEvent(\''.$name.'\');')
+            ->subcompile($this->getNode('body'))
+            ->write('$this->env->getExtension(\'stopwatch\')->stopEvent(\''.$name.'\');')
+            ->raw("\n");
+    }
+}

--- a/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
+++ b/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
@@ -22,11 +22,11 @@ class StopwatchNode extends \Twig_Node
     {
         parent::__construct(array('body' => $body), array('name' => $name), $lineno, $tag);
     }
- 
+
     public function compile(\Twig_Compiler $compiler)
     {
         $name = $this->getAttribute('name');
- 
+
         $compiler
             ->write('$this->env->getExtension(\'stopwatch\')->startEvent(\''.$name.'\');')
             ->subcompile($this->getNode('body'))

--- a/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
+++ b/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
@@ -25,12 +25,10 @@ class StopwatchNode extends \Twig_Node
 
     public function compile(\Twig_Compiler $compiler)
     {
-        $name = $this->getAttribute('name');
-
         $compiler
-            ->write('$this->env->getExtension(\'stopwatch\')->startEvent(\''.$name.'\');')
+            ->write(sprintf("\$this->env->getExtension('stopwatch')->getStopwatch()->start('%s', 'template');\n", $this->getAttribute('name')))
             ->subcompile($this->getNode('body'))
-            ->write('$this->env->getExtension(\'stopwatch\')->stopEvent(\''.$name.'\');')
-            ->raw("\n");
+            ->write(sprintf("\$this->env->getExtension('stopwatch')->getStopwatch()->stop('%s');\n", $this->getAttribute('name')))
+        ;
     }
 }

--- a/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
+++ b/src/Symfony/Bridge/Twig/Node/StopwatchNode.php
@@ -18,17 +18,27 @@ namespace Symfony\Bridge\Twig\Node;
  */
 class StopwatchNode extends \Twig_Node
 {
-    public function __construct($name, $body, $lineno = 0, $tag = null)
+    public function __construct(\Twig_NodeInterface $name, $body, \Twig_Node_Expression_AssignName $var, $lineno = 0, $tag = null)
     {
-        parent::__construct(array('body' => $body), array('name' => $name), $lineno, $tag);
+        parent::__construct(array('body' => $body, 'name' => $name, 'var' => $var), array(), $lineno, $tag);
     }
 
     public function compile(\Twig_Compiler $compiler)
     {
         $compiler
-            ->write(sprintf("\$this->env->getExtension('stopwatch')->getStopwatch()->start('%s', 'template');\n", $this->getAttribute('name')))
+            ->addDebugInfo($this)
+            ->write('')
+            ->subcompile($this->getNode('var'))
+            ->raw(' = ')
+            ->subcompile($this->getNode('name'))
+            ->write(";\n")
+            ->write("\$this->env->getExtension('stopwatch')->getStopwatch()->start(")
+            ->subcompile($this->getNode('var'))
+            ->raw(", 'template');\n")
             ->subcompile($this->getNode('body'))
-            ->write(sprintf("\$this->env->getExtension('stopwatch')->getStopwatch()->stop('%s');\n", $this->getAttribute('name')))
+            ->write("\$this->env->getExtension('stopwatch')->getStopwatch()->stop(")
+            ->subcompile($this->getNode('var'))
+            ->raw(");\n")
         ;
     }
 }

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\Tests\Extension;
+
+use Symfony\Bridge\Twig\Extension\StopwatchExtension;
+use Symfony\Component\Stopwatch\Stopwatch;
+use Symfony\Bridge\Twig\Tests\TestCase;
+
+class StopwatchExtensionTest extends TestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        if (!class_exists('Symfony\Component\Stopwatch\Stopwatch')) {
+            $this->markTestSkipped('The "Stopwatch" component is not available');
+        }
+    }
+
+    /**
+     * @expectedException \Twig_Error_Syntax
+     */
+    public function testFailIfNameAlreadyExists()
+    {
+        $this->testTiming('{% stopwatch foo %}{% endstopwatch %}{% stopwatch foo %}{% endstopwatch %}', array());
+    }
+
+    /**
+     * @expectedException \Twig_Error_Syntax
+     */
+    public function testFailIfStoppingWrongEvent()
+    {
+        $this->testTiming('{% stopwatch foo %}{% endstopwatch bar %}', array());
+    }
+
+    /**
+     * @dataProvider getTimingTemplates
+     */
+    public function testTiming($template, $events)
+    {
+        $twig = new \Twig_Environment(new \Twig_Loader_String(), array('debug' => true, 'cache' => false, 'autoescape' => true, 'optimizations' => 0));
+        $twig->addExtension(new StopwatchExtension($this->getStopwatch($events)));
+
+        try {
+            $nodes = $twig->render($template);
+        } catch (\Twig_Error_Runtime $e) {
+            throw $e->getPrevious();
+        }
+    }
+
+    public function getTimingTemplates()
+    {
+        return array(
+            array('{% stopwatch foo %}something{% endstopwatch %}', 'foo'),
+            array('{% stopwatch foo %}symfony2 is fun{% endstopwatch %}{% stopwatch bar %}something{% endstopwatch %}', array('foo', 'bar')),
+
+            array('{% stopwatch foo %}something{% endstopwatch foo %}', 'foo'),
+
+            array("{% stopwatch 'foo.bar' %}something{% endstopwatch %}", 'foo.bar'),
+        );
+    }
+
+    protected function getStopwatch($events = array())
+    {
+        $events = is_array($events) ? $events : array($events);
+        $stopwatch = $this->getMock('Symfony\Component\Stopwatch\Stopwatch');
+
+        $i = -1;
+        foreach ($events as $eventName) {
+            $stopwatch->expects($this->at(++$i))
+                ->method('start')
+                ->with($this->equalTo($eventName), 'template')
+            ;
+            $stopwatch->expects($this->at(++$i))
+                ->method('stop')
+                ->with($this->equalTo($eventName))
+            ;
+        }
+
+        return $stopwatch;
+    }
+}

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -31,7 +31,7 @@ class StopwatchExtensionTest extends TestCase
      */
     public function testFailIfStoppingWrongEvent()
     {
-        $this->testTiming('{% stopwatch foo %}{% endstopwatch bar %}', array());
+        $this->testTiming('{% stopwatch "foo" %}{% endstopwatch "bar" %}', array());
     }
 
     /**
@@ -52,11 +52,12 @@ class StopwatchExtensionTest extends TestCase
     public function getTimingTemplates()
     {
         return array(
-            array('{% stopwatch foo %}something{% endstopwatch %}', 'foo'),
-            array('{% stopwatch foo %}symfony2 is fun{% endstopwatch %}{% stopwatch bar %}something{% endstopwatch %}', array('foo', 'bar')),
-            array('{% stopwatch foo %}something{% endstopwatch foo %}', 'foo'),
+            array('{% stopwatch "foo" %}something{% endstopwatch %}', 'foo'),
+            array('{% stopwatch "foo" %}symfony2 is fun{% endstopwatch %}{% stopwatch "bar" %}something{% endstopwatch %}', array('foo', 'bar')),
+            array('{% set foo = "foo" %}{% stopwatch foo %}something{% endstopwatch %}', 'foo'),
+            array('{% set foo = "foo" %}{% stopwatch foo %}something {% set foo = "bar" %}{% endstopwatch %}', 'foo'),
             array('{% stopwatch "foo.bar" %}something{% endstopwatch %}', 'foo.bar'),
-            array('{% stopwatch foo %}something{% endstopwatch foo %}{% stopwatch foo %}something else{% endstopwatch foo %}', array('foo', 'foo')),
+            array('{% stopwatch "foo" %}something{% endstopwatch %}{% stopwatch "foo" %}something else{% endstopwatch %}', array('foo', 'foo')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -29,14 +29,6 @@ class StopwatchExtensionTest extends TestCase
     /**
      * @expectedException \Twig_Error_Syntax
      */
-    public function testFailIfNameAlreadyExists()
-    {
-        $this->testTiming('{% stopwatch foo %}{% endstopwatch %}{% stopwatch foo %}{% endstopwatch %}', array());
-    }
-
-    /**
-     * @expectedException \Twig_Error_Syntax
-     */
     public function testFailIfStoppingWrongEvent()
     {
         $this->testTiming('{% stopwatch foo %}{% endstopwatch bar %}', array());
@@ -64,6 +56,7 @@ class StopwatchExtensionTest extends TestCase
             array('{% stopwatch foo %}symfony2 is fun{% endstopwatch %}{% stopwatch bar %}something{% endstopwatch %}', array('foo', 'bar')),
             array('{% stopwatch foo %}something{% endstopwatch foo %}', 'foo'),
             array('{% stopwatch "foo.bar" %}something{% endstopwatch %}', 'foo.bar'),
+            array('{% stopwatch foo %}something{% endstopwatch foo %}{% stopwatch foo %}something else{% endstopwatch foo %}', array('foo', 'foo')),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
+++ b/src/Symfony/Bridge/Twig/Tests/Extension/StopwatchExtensionTest.php
@@ -62,10 +62,8 @@ class StopwatchExtensionTest extends TestCase
         return array(
             array('{% stopwatch foo %}something{% endstopwatch %}', 'foo'),
             array('{% stopwatch foo %}symfony2 is fun{% endstopwatch %}{% stopwatch bar %}something{% endstopwatch %}', array('foo', 'bar')),
-
             array('{% stopwatch foo %}something{% endstopwatch foo %}', 'foo'),
-
-            array("{% stopwatch 'foo.bar' %}something{% endstopwatch %}", 'foo.bar'),
+            array('{% stopwatch "foo.bar" %}something{% endstopwatch %}', 'foo.bar'),
         );
     }
 

--- a/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
@@ -21,7 +21,6 @@ use Symfony\Bridge\Twig\Node\StopwatchNode;
 class StopwatchTokenParser extends \Twig_TokenParser
 {
     protected $stopwatchIsAvailable;
-    protected $_events = array();
 
     public function __construct($stopwatchIsAvailable)
     {
@@ -39,11 +38,6 @@ class StopwatchTokenParser extends \Twig_TokenParser
         } else {
             $name = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
         }
-
-        if (in_array($name, $this->_events)) {
-            throw new \Twig_Error_Syntax(sprintf('The stopwatch event "%s" has already been defined.', $name));
-        }
-        $this->_events[] = $name;
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 

--- a/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Bridge\Twig\TokenParser;
+
+use Symfony\Bridge\Twig\Node\StopwatchNode;
+
+/**
+ * Token Parser for the stopwatch tag.
+ *
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class StopwatchTokenParser extends \Twig_TokenParser
+{
+    protected $stopwatchIsAvailable;
+    protected $_events = array();
+
+    public function __construct($stopwatchIsAvailable)
+    {
+        $this->stopwatchIsAvailable = $stopwatchIsAvailable;
+    }
+
+    public function parse(\Twig_Token $token)
+    {
+        $lineno = $token->getLine();
+        $stream = $this->parser->getStream();
+ 
+        // {% stopwatch bar %}
+        if ($stream->test(\Twig_Token::NAME_TYPE)) {
+            $name = $stream->expect(\Twig_Token::NAME_TYPE)->getValue();
+        } else {
+            $name = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
+        }
+
+        if (in_array($name, $this->_events)) {
+            throw new \Twig_Error_Syntax(sprintf("The stopwatch event '%s' has already been defined", $name));
+        }
+        $this->_events[] = $name;
+
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+ 
+        // {% endstopwatch %} or {% endstopwatch bar %}
+        $body = $this->parser->subparse(array($this, 'decideStopwatchEnd'), true);
+        if ($stream->test(\Twig_Token::NAME_TYPE) || $stream->test(\Twig_Token::STRING_TYPE)) {
+            $value = $stream->next()->getValue();
+
+            if ($name != $value) {
+                throw new \Twig_Error_Syntax(sprintf("Expected endstopwatch for event '%s' (but %s given)", $name, $value));
+            }
+        }
+        $stream->expect(\Twig_Token::BLOCK_END_TYPE);
+ 
+        if ($this->stopwatchIsAvailable) {
+            return new StopwatchNode($name, $body, $lineno, $this->getTag());
+        }
+
+        return $body;
+    }
+ 
+    public function decideStopwatchEnd(\Twig_Token $token)
+    {
+        return $token->test('endstopwatch');
+    }
+ 
+    public function getTag()
+    {
+        return 'stopwatch';
+    }
+}

--- a/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
@@ -32,7 +32,7 @@ class StopwatchTokenParser extends \Twig_TokenParser
     {
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
- 
+
         // {% stopwatch bar %}
         if ($stream->test(\Twig_Token::NAME_TYPE)) {
             $name = $stream->expect(\Twig_Token::NAME_TYPE)->getValue();
@@ -41,35 +41,35 @@ class StopwatchTokenParser extends \Twig_TokenParser
         }
 
         if (in_array($name, $this->_events)) {
-            throw new \Twig_Error_Syntax(sprintf("The stopwatch event '%s' has already been defined", $name));
+            throw new \Twig_Error_Syntax(sprintf('The stopwatch event "%s" has already been defined.', $name));
         }
         $this->_events[] = $name;
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
- 
+
         // {% endstopwatch %} or {% endstopwatch bar %}
         $body = $this->parser->subparse(array($this, 'decideStopwatchEnd'), true);
         if ($stream->test(\Twig_Token::NAME_TYPE) || $stream->test(\Twig_Token::STRING_TYPE)) {
             $value = $stream->next()->getValue();
 
             if ($name != $value) {
-                throw new \Twig_Error_Syntax(sprintf("Expected endstopwatch for event '%s' (but %s given)", $name, $value));
+                throw new \Twig_Error_Syntax(sprintf('Expected endstopwatch for event "%s" (but "%s" given).', $name, $value));
             }
         }
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
- 
+
         if ($this->stopwatchIsAvailable) {
             return new StopwatchNode($name, $body, $lineno, $this->getTag());
         }
 
         return $body;
     }
- 
+
     public function decideStopwatchEnd(\Twig_Token $token)
     {
         return $token->test('endstopwatch');
     }
- 
+
     public function getTag()
     {
         return 'stopwatch';

--- a/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
+++ b/src/Symfony/Bridge/Twig/TokenParser/StopwatchTokenParser.php
@@ -32,28 +32,17 @@ class StopwatchTokenParser extends \Twig_TokenParser
         $lineno = $token->getLine();
         $stream = $this->parser->getStream();
 
-        // {% stopwatch bar %}
-        if ($stream->test(\Twig_Token::NAME_TYPE)) {
-            $name = $stream->expect(\Twig_Token::NAME_TYPE)->getValue();
-        } else {
-            $name = $stream->expect(\Twig_Token::STRING_TYPE)->getValue();
-        }
+        // {% stopwatch 'bar' %}
+        $name = $this->parser->getExpressionParser()->parseExpression();
 
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-        // {% endstopwatch %} or {% endstopwatch bar %}
+        // {% endstopwatch %}
         $body = $this->parser->subparse(array($this, 'decideStopwatchEnd'), true);
-        if ($stream->test(\Twig_Token::NAME_TYPE) || $stream->test(\Twig_Token::STRING_TYPE)) {
-            $value = $stream->next()->getValue();
-
-            if ($name != $value) {
-                throw new \Twig_Error_Syntax(sprintf('Expected endstopwatch for event "%s" (but "%s" given).', $name, $value));
-            }
-        }
         $stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
         if ($this->stopwatchIsAvailable) {
-            return new StopwatchNode($name, $body, $lineno, $this->getTag());
+            return new StopwatchNode($name, $body, new \Twig_Node_Expression_AssignName($this->parser->getVarName(), $token->getLine()), $lineno, $this->getTag());
         }
 
         return $body;

--- a/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
+++ b/src/Symfony/Bundle/TwigBundle/Resources/config/twig.xml
@@ -18,6 +18,7 @@
         <parameter key="twig.extension.yaml.class">Symfony\Bridge\Twig\Extension\YamlExtension</parameter>
         <parameter key="twig.extension.form.class">Symfony\Bridge\Twig\Extension\FormExtension</parameter>
         <parameter key="twig.extension.httpkernel.class">Symfony\Bridge\Twig\Extension\HttpKernelExtension</parameter>
+        <parameter key="twig.extension.debug.stopwatch.class">Symfony\Bridge\Twig\Extension\StopwatchExtension</parameter>
         <parameter key="twig.form.engine.class">Symfony\Bridge\Twig\Form\TwigRendererEngine</parameter>
         <parameter key="twig.form.renderer.class">Symfony\Bridge\Twig\Form\TwigRenderer</parameter>
         <parameter key="twig.translation.extractor.class">Symfony\Bridge\Twig\Translation\TwigExtractor</parameter>
@@ -84,6 +85,11 @@
 
         <service id="twig.extension.yaml" class="%twig.extension.yaml.class%" public="false">
             <tag name="twig.extension" />
+        </service>
+
+        <service id="twig.extension.debug.stopwatch" class="%twig.extension.debug.stopwatch.class%" public="false">
+            <tag name="twig.extension" />
+            <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
         </service>
 
         <service id="twig.extension.httpkernel" class="%twig.extension.httpkernel.class%" public="false">


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #7953 |
| License | MIT |
| Doc PR | symfony/symfony-docs#2630 |

This PR is the continuation of #7953

This PR adds a new tag to Twig which you can use to time parts of a template and see it in the timing tab of the profiler.

Usage:

``` jinja
{% stopwatch foo %}
... some things that gets timed
{% endstopwatch %}
```
