### PR TITLE
[Config] Support binary notation.

### DIFF
--- a/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
+++ b/src/Symfony/Component/Config/Tests/Util/XmlUtilsTest.php
@@ -127,6 +127,7 @@ class XmlUtilsTest extends \PHPUnit_Framework_TestCase
             array('111,222,333,444', '111,222,333,444'),
             array('1111,2222,3333,4444,5555', '1111,2222,3333,4444,5555'),
             array('foo', 'foo'),
+            array(6, '0b0110'),
         );
     }
 }

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -191,7 +191,7 @@ class XmlUtils
                 return true;
             case 'false' === $lowercaseValue:
                 return false;
-            case '0b' == $value[0].$value[1]:
+            case strlen($value) > 2 && '0b' == $value[0].$value[1]:
                 return bindec($value);
             case is_numeric($value):
                 return '0x' == $value[0].$value[1] ? hexdec($value) : floatval($value);

--- a/src/Symfony/Component/Config/Util/XmlUtils.php
+++ b/src/Symfony/Component/Config/Util/XmlUtils.php
@@ -191,6 +191,8 @@ class XmlUtils
                 return true;
             case 'false' === $lowercaseValue:
                 return false;
+            case '0b' == $value[0].$value[1]:
+                return bindec($value);
             case is_numeric($value):
                 return '0x' == $value[0].$value[1] ? hexdec($value) : floatval($value);
             case preg_match('/^(-|\+)?[0-9]+(\.[0-9]+)?$/', $value):


### PR DESCRIPTION
This PR addresses issue #8066 . Binary notation is not caught by `is_numeric()` function so we need to implement it on our own.
