### PR TITLE
changed the ESI fragment renderer to be always registered

### DIFF
--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/esi.xml
@@ -7,7 +7,6 @@
     <parameters>
         <parameter key="esi.class">Symfony\Component\HttpKernel\HttpCache\Esi</parameter>
         <parameter key="esi_listener.class">Symfony\Component\HttpKernel\EventListener\EsiListener</parameter>
-        <parameter key="fragment.renderer.esi.class">Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer</parameter>
     </parameters>
 
     <services>
@@ -16,13 +15,6 @@
         <service id="esi_listener" class="%esi_listener.class%">
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="esi" on-invalid="ignore" />
-        </service>
-
-        <service id="fragment.renderer.esi" class="%fragment.renderer.esi.class%">
-            <tag name="kernel.fragment_renderer" />
-            <argument type="service" id="esi" />
-            <argument type="service" id="fragment.renderer.inline" />
-            <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
     </services>
 </container>

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/fragment_renderer.xml
@@ -9,6 +9,7 @@
         <parameter key="fragment.renderer.inline.class">Symfony\Component\HttpKernel\Fragment\InlineFragmentRenderer</parameter>
         <parameter key="fragment.renderer.hinclude.class">Symfony\Bundle\FrameworkBundle\Fragment\ContainerAwareHIncludeFragmentRenderer</parameter>
         <parameter key="fragment.renderer.hinclude.global_template"></parameter>
+        <parameter key="fragment.renderer.esi.class">Symfony\Component\HttpKernel\Fragment\EsiFragmentRenderer</parameter>
         <parameter key="fragment.path">/_fragment</parameter>
     </parameters>
 
@@ -31,6 +32,13 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="uri_signer" />
             <argument>%fragment.renderer.hinclude.global_template%</argument>
+            <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
+        </service>
+
+        <service id="fragment.renderer.esi" class="%fragment.renderer.esi.class%">
+            <tag name="kernel.fragment_renderer" />
+            <argument type="service" id="esi" on-invalid="null" />
+            <argument type="service" id="fragment.renderer.inline" />
             <call method="setFragmentPath"><argument>%fragment.path%</argument></call>
         </service>
     </services>

--- a/src/Symfony/Component/HttpKernel/Fragment/EsiFragmentRenderer.php
+++ b/src/Symfony/Component/HttpKernel/Fragment/EsiFragmentRenderer.php
@@ -35,7 +35,7 @@ class EsiFragmentRenderer extends RoutableFragmentRenderer
      * @param Esi                    $esi            An Esi instance
      * @param InlineFragmentRenderer $inlineStrategy The inline strategy to use when ESI is not supported
      */
-    public function __construct(Esi $esi, InlineFragmentRenderer $inlineStrategy)
+    public function __construct(Esi $esi = null, InlineFragmentRenderer $inlineStrategy)
     {
         $this->esi = $esi;
         $this->inlineStrategy = $inlineStrategy;
@@ -56,7 +56,7 @@ class EsiFragmentRenderer extends RoutableFragmentRenderer
      */
     public function render($uri, Request $request, array $options = array())
     {
-        if (!$this->esi->hasSurrogateEsiCapability($request)) {
+        if (!$this->esi || !$this->esi->hasSurrogateEsiCapability($request)) {
             return $this->inlineStrategy->render($uri, $request, $options);
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

This is an alternative implementation for #8427
