### PR TITLE
[Process] Fix #8739

### DIFF
--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -1221,8 +1221,8 @@ class Process
     /**
      * Handles the windows file handles fallbacks.
      *
-     * @param callable $callback A valid PHP callback
-     * @param Boolean $closeEmptyHandles if true, handles that are empty will be assumed closed
+     * @param callable $callback          A valid PHP callback
+     * @param Boolean  $closeEmptyHandles if true, handles that are empty will be assumed closed
      */
     private function processFileHandles($callback, $closeEmptyHandles = false)
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -39,6 +39,7 @@ class Process
     // Timeout Precision in seconds.
     const TIMEOUT_PRECISION = 0.2;
 
+    private $callback;
     private $commandline;
     private $cwd;
     private $env;
@@ -166,6 +167,7 @@ class Process
 
     public function __clone()
     {
+        $this->callback = null;
         $this->exitcode = null;
         $this->fallbackExitcode = null;
         $this->processInformation = null;
@@ -201,7 +203,7 @@ class Process
     {
         $this->start($callback);
 
-        return $this->wait($callback);
+        return $this->wait();
     }
 
     /**
@@ -236,7 +238,7 @@ class Process
         $this->stderr = '';
         $this->incrementalOutputOffset = 0;
         $this->incrementalErrorOutputOffset = 0;
-        $callback = $this->buildCallback($callback);
+        $this->callback = $this->buildCallback($callback);
         $descriptors = $this->getDescriptors();
 
         $commandline = $this->commandline;
@@ -265,67 +267,9 @@ class Process
             return;
         }
 
-        if (null === $this->stdin) {
-            fclose($this->pipes[0]);
-            unset($this->pipes[0]);
-
-            return;
-        }
-
-        $writePipes = array($this->pipes[0]);
-        unset($this->pipes[0]);
-        $stdinLen = strlen($this->stdin);
-        $stdinOffset = 0;
-
-        while ($writePipes) {
-            if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-                $this->processFileHandles($callback);
-            }
-
-            $r = $this->pipes;
-            $w = $writePipes;
-            $e = null;
-
-            if (false === $n = @stream_select($r, $w, $e, 0, ceil(static::TIMEOUT_PRECISION * 1E6))) {
-                // if a system call has been interrupted, forget about it, let's try again
-                if ($this->hasSystemCallBeenInterrupted()) {
-                    continue;
-                }
-                break;
-            }
-
-            // nothing has changed, let's wait until the process is ready
-            if (0 === $n) {
-                continue;
-            }
-
-            if ($w) {
-                $written = fwrite($writePipes[0], (binary) substr($this->stdin, $stdinOffset), 8192);
-                if (false !== $written) {
-                    $stdinOffset += $written;
-                }
-                if ($stdinOffset >= $stdinLen) {
-                    fclose($writePipes[0]);
-                    $writePipes = null;
-                }
-            }
-
-            foreach ($r as $pipe) {
-                $type = array_search($pipe, $this->pipes);
-                $data = fread($pipe, 8192);
-                if (strlen($data) > 0) {
-                    call_user_func($callback, $type == 1 ? self::OUT : self::ERR, $data);
-                }
-                if (false === $data || feof($pipe)) {
-                    fclose($pipe);
-                    unset($this->pipes[$type]);
-                }
-            }
-
-            $this->checkTimeout();
-        }
-
-        $this->updateStatus();
+        $this->writePipes(false);
+        $this->updateStatus(false);
+        $this->checkTimeout();
     }
 
     /**
@@ -371,55 +315,15 @@ class Process
      */
     public function wait($callback = null)
     {
-        $this->updateStatus();
-        $callback = $this->buildCallback($callback);
-        while ($this->pipes || (defined('PHP_WINDOWS_VERSION_BUILD') && $this->fileHandles)) {
-            if (defined('PHP_WINDOWS_VERSION_BUILD') && $this->fileHandles) {
-                $this->processFileHandles($callback, !$this->pipes);
-            }
-            $this->checkTimeout();
-
-            if ($this->pipes) {
-                $r = $this->pipes;
-                $w = null;
-                $e = null;
-
-                // let's have a look if something changed in streams
-                if (false === $n = @stream_select($r, $w, $e, 0, ceil(static::TIMEOUT_PRECISION * 1E6))) {
-                    // if a system call has been interrupted, forget about it, let's try again
-                    // otherwise, an error occured, let's reset pipes
-                    if (!$this->hasSystemCallBeenInterrupted()) {
-                        $this->pipes = array();
-                    }
-
-                    continue;
-                }
-
-                // nothing has changed
-                if (0 === $n) {
-                    continue;
-                }
-
-                foreach ($r as $pipe) {
-                    $type = array_search($pipe, $this->pipes);
-                    $data = fread($pipe, 8192);
-
-                    if (strlen($data) > 0) {
-                        // last exit code is output and caught to work around --enable-sigchild
-                        if (3 == $type) {
-                            $this->fallbackExitcode = (int) $data;
-                        } else {
-                            call_user_func($callback, $type == 1 ? self::OUT : self::ERR, $data);
-                        }
-                    }
-                    if (false === $data || feof($pipe)) {
-                        fclose($pipe);
-                        unset($this->pipes[$type]);
-                    }
-                }
-            }
+        $this->updateStatus(false);
+        if (null !== $callback) {
+            $callback = $this->buildCallback($callback);
         }
-        $this->updateStatus();
+        while ($this->processInformation['running']) {//  $this->pipes || (defined('PHP_WINDOWS_VERSION_BUILD') && $this->fileHandles)) {
+            $this->updateStatus(true);
+            $this->checkTimeout();
+        }
+        $this->updateStatus(false);
         if ($this->processInformation['signaled']) {
             if ($this->isSigchildEnabled()) {
                 throw new RuntimeException('The process has been signaled.');
@@ -466,7 +370,7 @@ class Process
             throw new RuntimeException('This PHP has been compiled with --enable-sigchild. The process identifier can not be retrieved.');
         }
 
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->isRunning() ? $this->processInformation['pid'] : null;
     }
@@ -507,7 +411,7 @@ class Process
      */
     public function getOutput()
     {
-        $this->updateOutput();
+        $this->readPipes(false);
 
         return $this->stdout;
     }
@@ -539,7 +443,7 @@ class Process
      */
     public function getErrorOutput()
     {
-        $this->updateErrorOutput();
+        $this->readPipes(false);
 
         return $this->stderr;
     }
@@ -578,7 +482,7 @@ class Process
             throw new RuntimeException('This PHP has been compiled with --enable-sigchild. You must use setEnhanceSigchildCompatibility() to use this method');
         }
 
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->exitcode;
     }
@@ -630,7 +534,7 @@ class Process
             throw new RuntimeException('This PHP has been compiled with --enable-sigchild. Term signal can not be retrieved');
         }
 
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->processInformation['signaled'];
     }
@@ -652,7 +556,7 @@ class Process
             throw new RuntimeException('This PHP has been compiled with --enable-sigchild. Term signal can not be retrieved');
         }
 
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->processInformation['termsig'];
     }
@@ -668,7 +572,7 @@ class Process
      */
     public function hasBeenStopped()
     {
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->processInformation['stopped'];
     }
@@ -684,7 +588,7 @@ class Process
      */
     public function getStopSignal()
     {
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->processInformation['stopsig'];
     }
@@ -700,7 +604,7 @@ class Process
             return false;
         }
 
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->processInformation['running'];
     }
@@ -722,7 +626,7 @@ class Process
      */
     public function isTerminated()
     {
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->status == self::STATUS_TERMINATED;
     }
@@ -736,7 +640,7 @@ class Process
      */
     public function getStatus()
     {
-        $this->updateStatus();
+        $this->updateStatus(false);
 
         return $this->status;
     }
@@ -1161,13 +1065,17 @@ class Process
     }
 
     /**
-     * Updates the status of the process.
+     * Updates the status of the process, reads pipes.
+     *
+     * @param Boolean $blocking Whether to use a clocking read call.
      */
-    protected function updateStatus()
+    protected function updateStatus($blocking)
     {
         if (self::STATUS_STARTED !== $this->status) {
             return;
         }
+
+        $this->readPipes($blocking);
 
         $this->processInformation = proc_get_status($this->process);
         if (!$this->processInformation['running']) {
@@ -1175,29 +1083,6 @@ class Process
             if (-1 !== $this->processInformation['exitcode']) {
                 $this->exitcode = $this->processInformation['exitcode'];
             }
-        }
-    }
-
-    /**
-     * Updates the current error output of the process (STDERR).
-     */
-    protected function updateErrorOutput()
-    {
-        if (isset($this->pipes[self::STDERR]) && is_resource($this->pipes[self::STDERR])) {
-            $this->addErrorOutput(stream_get_contents($this->pipes[self::STDERR]));
-        }
-    }
-
-    /**
-     * Updates the current output of the process (STDOUT).
-     */
-    protected function updateOutput()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD') && isset($this->fileHandles[self::STDOUT]) && is_resource($this->fileHandles[self::STDOUT])) {
-            fseek($this->fileHandles[self::STDOUT], $this->readBytes[self::STDOUT]);
-            $this->addOutput(stream_get_contents($this->fileHandles[self::STDOUT]));
-        } elseif (isset($this->pipes[self::STDOUT]) && is_resource($this->pipes[self::STDOUT])) {
-            $this->addOutput(stream_get_contents($this->pipes[self::STDOUT]));
         }
     }
 
@@ -1221,10 +1106,9 @@ class Process
     /**
      * Handles the windows file handles fallbacks.
      *
-     * @param callable $callback          A valid PHP callback
-     * @param Boolean  $closeEmptyHandles if true, handles that are empty will be assumed closed
+     * @param Boolean $closeEmptyHandles if true, handles that are empty will be assumed closed
      */
-    private function processFileHandles($callback, $closeEmptyHandles = false)
+    private function processFileHandles($closeEmptyHandles = false)
     {
         $fh = $this->fileHandles;
         foreach ($fh as $type => $fileHandle) {
@@ -1232,7 +1116,7 @@ class Process
             $data = fread($fileHandle, 8192);
             if (strlen($data) > 0) {
                 $this->readBytes[$type] += strlen($data);
-                call_user_func($callback, $type == 1 ? self::OUT : self::ERR, $data);
+                call_user_func($this->callback, $type == 1 ? self::OUT : self::ERR, $data);
             }
             if (false === $data || ($closeEmptyHandles && '' === $data && feof($fileHandle))) {
                 fclose($fileHandle);
@@ -1252,5 +1136,107 @@ class Process
 
         // stream_select returns false when the `select` system call is interrupted by an incoming signal
         return isset($lastError['message']) && false !== stripos($lastError['message'], 'interrupted system call');
+    }
+
+    /**
+     * Reads pipes, executes callback.
+     *
+     * @param Boolean $blocking Whether to use blocking calls or not.
+     */
+    private function readPipes($blocking)
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD') && $this->fileHandles) {
+            $this->processFileHandles(!$this->pipes);
+        }
+
+        if ($this->pipes) {
+            $r = $this->pipes;
+            $w = null;
+            $e = null;
+
+            // let's have a look if something changed in streams
+            if (false === $n = @stream_select($r, $w, $e, 0, $blocking ? ceil(self::TIMEOUT_PRECISION * 1E6) : 0)) {
+                // if a system call has been interrupted, forget about it, let's try again
+                // otherwise, an error occured, let's reset pipes
+                if (!$this->hasSystemCallBeenInterrupted()) {
+                    $this->pipes = array();
+                }
+
+                return;
+            }
+
+            // nothing has changed
+            if (0 === $n) {
+                return;
+            }
+
+            foreach ($r as $pipe) {
+                $type = array_search($pipe, $this->pipes);
+                $data = fread($pipe, 8192);
+
+                if (strlen($data) > 0) {
+                    // last exit code is output and caught to work around --enable-sigchild
+                    if (3 == $type) {
+                        $this->fallbackExitcode = (int) $data;
+                    } else {
+                        call_user_func($this->callback, $type == 1 ? self::OUT : self::ERR, $data);
+                    }
+                }
+                if (false === $data || feof($pipe)) {
+                    fclose($pipe);
+                    unset($this->pipes[$type]);
+                }
+            }
+        }
+    }
+
+    /**
+     * Writes data to pipes.
+     *
+     * @param Boolean $blocking Whether to use blocking calls or not.
+     */
+    private function writePipes($blocking)
+    {
+        if (null === $this->stdin) {
+            fclose($this->pipes[0]);
+            unset($this->pipes[0]);
+
+            return;
+        }
+
+        $writePipes = array($this->pipes[0]);
+        unset($this->pipes[0]);
+        $stdinLen = strlen($this->stdin);
+        $stdinOffset = 0;
+
+        while ($writePipes) {
+            $r = array();
+            $w = $writePipes;
+            $e = null;
+
+            if (false === $n = @stream_select($r, $w, $e, 0, $blocking ? ceil(static::TIMEOUT_PRECISION * 1E6) : 0)) {
+                // if a system call has been interrupted, forget about it, let's try again
+                if ($this->hasSystemCallBeenInterrupted()) {
+                    continue;
+                }
+                break;
+            }
+
+            // nothing has changed, let's wait until the process is ready
+            if (0 === $n) {
+                continue;
+            }
+
+            if ($w) {
+                $written = fwrite($writePipes[0], (binary) substr($this->stdin, $stdinOffset), 8192);
+                if (false !== $written) {
+                    $stdinOffset += $written;
+                }
+                if ($stdinOffset >= $stdinLen) {
+                    fclose($writePipes[0]);
+                    $writePipes = null;
+                }
+            }
+        }
     }
 }

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -271,7 +271,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testStop()
     {
-        $process = $this->getProcess('php -r "while (true) {}"');
+        $process = $this->getProcess('php -r "sleep(4);"');
         $process->start();
         $this->assertTrue($process->isRunning());
         $process->stop();
@@ -287,7 +287,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
     public function testIsNotSuccessful()
     {
-        $process = $this->getProcess('php -r "while (true) {}"');
+        $process = $this->getProcess('php -r "sleep(4);"');
         $process->start();
         $this->assertTrue($process->isRunning());
         $process->stop();
@@ -333,7 +333,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('Windows does not support POSIX signals');
         }
 
-        $process = $this->getProcess('php -r "while (true) {}"');
+        $process = $this->getProcess('php -r "sleep(4);"');
         $process->start();
         $process->stop();
         $this->assertTrue($process->hasBeenSignaled());
@@ -348,7 +348,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         // SIGTERM is only defined if pcntl extension is present
         $termSignal = defined('SIGTERM') ? SIGTERM : 15;
 
-        $process = $this->getProcess('php -r "while (true) {}"');
+        $process = $this->getProcess('php -r "sleep(4);"');
         $process->start();
         $process->stop();
 
@@ -367,7 +367,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         $termSignal = defined('SIGKILL') ? SIGKILL : 9;
 
-        $process = $this->getProcess('exec php -r "while (true) {}"');
+        $process = $this->getProcess('exec php -r "sleep(4);"');
         $process->start();
         posix_kill($process->getPid(), $termSignal);
 
@@ -399,7 +399,7 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
 
         // Sleep doesn't work as it will allow the process to handle signals and close
         // file handles from the other end.
-        $process = $this->getProcess('php -r "while (true) {}"');
+        $process = $this->getProcess('php -r "sleep 4"');
         $process->start();
 
         // PHP will deadlock when it tries to cleanup $process

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -65,6 +65,23 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertLessThan(1.8, $duration);
     }
 
+    public function testCallbacksAreExecutedWithStart()
+    {
+        $data = '';
+
+        $process = $this->getProcess('echo "foo";sleep 1;echo "foo"');
+        $process->start(function ($type, $buffer) use (&$data) {
+            $data .= $buffer;
+        });
+
+        $start = microtime(true);
+        while ($process->isRunning()) {
+            usleep(10000);
+        }
+
+        $this->assertEquals("foo\nfoo\n", $data);
+    }
+
     /**
      * tests results from sub processes
      *


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #8739 |
| License | MIT |

This adds a fix to #8739. Whenever a call is done to to any non-blocking methods (`Process::isRunning`, `Process::isStopped`, `Process::isTerminated`, `Process::getStatus`, `Process::getPid`...), buffers are read, and callback executed.

Such code will now work : 

```
$process->start(function ($type, $data) {
    echo $data;
});

while ($process->isRunning()) {
    // some stuff
    // callback is executed
}
```
