### PR TITLE
[Process] Fix #8742 : Signal-terminated processes are not successful

### DIFF
--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -483,6 +483,24 @@ abstract class AbstractProcessTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Caught SIGUSR1', $process->getOutput());
     }
 
+    public function testExitCodeIsAvailableAfterSignal()
+    {
+        $this->verifyPosixIsEnabled();
+
+        $process = $this->getProcess('sleep 4');
+        $process->start();
+        $process->signal(SIGKILL);
+
+        while ($process->isRunning()) {
+            usleep(10000);
+        }
+
+        $this->assertFalse($process->isRunning());
+        $this->assertTrue($process->hasBeenSignaled());
+        $this->assertFalse($process->isSuccessful());
+        $this->assertEquals(137, $process->getExitCode());
+    }
+
     /**
      * @expectedException Symfony\Component\Process\Exception\LogicException
      */

--- a/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildDisabledProcessTest.php
@@ -138,6 +138,11 @@ class SigchildDisabledProcessTest extends AbstractProcessTest
         $this->markTestSkipped('Retrieving Pid is not supported in sigchild environment');
     }
 
+    public function testExitCodeIsAvailableAfterSignal()
+    {
+        $this->markTestSkipped('Signal is not supported in sigchild environment');
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/SigchildEnabledProcessTest.php
@@ -98,6 +98,11 @@ class SigchildEnabledProcessTest extends AbstractProcessTest
         $this->markTestSkipped('Retrieving Pid is not supported in sigchild environment');
     }
 
+    public function testExitCodeIsAvailableAfterSignal()
+    {
+        $this->markTestSkipped('Signal is not supported in sigchild environment');
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | require #8741 to be merged to pass tests |
| Fixed tickets | #8742 |
| License | MIT |
