### PR TITLE
removed legacy artifact from Component/Routing/Router

### DIFF
--- a/src/Symfony/Component/Routing/Router.php
+++ b/src/Symfony/Component/Routing/Router.php
@@ -234,7 +234,7 @@ class Router implements RouterInterface
 
         $class = $this->options['matcher_cache_class'];
         $cache = new ConfigCache($this->options['cache_dir'].'/'.$class.'.php', $this->options['debug']);
-        if (!$cache->isFresh($class)) {
+        if (!$cache->isFresh()) {
             $dumper = $this->getMatcherDumperInstance();
 
             $options = array(


### PR DESCRIPTION
Hey,

while using the ConfigCache component I noticed that there is a wrong call of isFresh() in Symfony\Component\Routing\Router. ConfigCache->isFresh() doesn't accept any parameters anymore.

cheers,

Daniel
