### PR TITLE
[Process] Add a Process Manager

### DIFF
--- a/src/Symfony/Component/Process/Exception/ProcessManagerException.php
+++ b/src/Symfony/Component/Process/Exception/ProcessManagerException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Exception;
+
+/**
+ * Exception for the process manager.
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ */
+class ProcessManagerException extends RuntimeException
+{
+}

--- a/src/Symfony/Component/Process/Manager/ManagedProcess.php
+++ b/src/Symfony/Component/Process/Manager/ManagedProcess.php
@@ -1,0 +1,299 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Manager;
+
+use Symfony\Component\Process\ProcessableInterface;
+use Symfony\Component\Process\Exception\InvalidArgumentException;
+use Symfony\Component\Process\Exception\RuntimeException;
+
+/**
+ * Wrapper for ProcessableInterface used by the ProcessManager to manage
+ * subprocesses.
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ */
+class ManagedProcess implements ProcessableInterface
+{
+    /** @var ProcessableInterface */
+    private $process;
+    /** @var integer */
+    private $executions;
+    /** @var integer */
+    private $initialExecutions;
+    /** @var array */
+    private $failures = array();
+    /** @var Boolean */
+    private $hasRun = false;
+
+    public function __construct(ProcessableInterface $process, $executions = 1)
+    {
+        $this->process = $process;
+        $this->setExecutions($executions);
+    }
+
+    public function __clone()
+    {
+        $this->process = clone $this->process;
+    }
+
+    /**
+     * Gets the remaining number of executions.
+     *
+     * @return integer
+     */
+    public function getExecutions()
+    {
+        return $this->executions;
+    }
+
+    /**
+     * Sets the number of executions.
+     *
+     * @param integer $executions
+     *
+     * @return ManagedProcess
+     *
+     * @throws InvalidArgumentException
+     * @throws RuntimeException
+     */
+    public function setExecutions($executions)
+    {
+        if ($this->hasRun) {
+            throw new RuntimeException('Can not modify executions once the process started. Reset the process before modifying this.');
+        }
+
+        if ($executions < 1) {
+            throw new InvalidArgumentException('Executions must be a positive value.');
+        }
+
+        $this->executions = $this->initialExecutions = $executions;
+
+        return $this;
+    }
+
+    /**
+     * Retries the last execution.
+     *
+     * @return ManagedProcess
+     */
+    public function retry()
+    {
+        if (!$this->hasRun) {
+            throw new RuntimeException('Process must have run at least once to retry.');
+        }
+
+        $this->executions++;
+
+        return $this;
+    }
+
+    /**
+     * Resets the process.
+     *
+     * @return ManagedProcess
+     */
+    public function reset()
+    {
+        $this->hasRun = false;
+        $this->executions = $this->initialExecutions;
+        $this->failures = array();
+
+        return $this;
+    }
+
+    /**
+     * Checks if the process has run.
+     *
+     * @return Boolean
+     */
+    public function hasRun()
+    {
+        return $this->hasRun;
+    }
+
+    /**
+     * Checks if the process can still run.
+     *
+     * If the number of remaining executions is 0, it returns false.
+     *
+     * @return Boolean
+     */
+    public function canRun()
+    {
+        return $this->executions > 0;
+    }
+
+    /**
+     * Adds an execution failure.
+     *
+     * @param \Exception $e
+     *
+     * @return ManagedProcess
+     */
+    public function addFailure(\Exception $e)
+    {
+        $this->failures[] = $e;
+
+        return $this;
+    }
+
+    /**
+     * Returns execution failures.
+     * 
+     * @return \Exception[]
+     */
+    public function getFailures()
+    {
+        return $this->failures;
+    }
+
+    /**
+     * Returns the managed process.
+     *
+     * @return ProcessableInterface
+     */
+    public function getManagedProcess()
+    {
+        return $this->process;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run($callback = null)
+    {
+        if (!$this->canRun()) {
+            throw new RuntimeException('No remaining executions for the managed process.');
+        }
+
+        $this->hasRun = true;
+        $this->executions--;
+
+        return $this->process->run($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start($callback = null)
+    {
+        if (!$this->canRun()) {
+            throw new RuntimeException('No remaining executions for the managed process.');
+        }
+
+        $this->hasRun = true;
+        $this->process->start($callback);
+        $this->executions--;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function restart($callback = null)
+    {
+        $this->hasRun = true;
+        $process = clone $this;
+        $process->setManagedProcess($this->process->restart($callback));
+
+        return $process;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function wait($callback = null)
+    {
+        return $this->process->wait($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function signal($signal)
+    {
+        $this->process->signal($signal);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSuccessful()
+    {
+        return $this->process->isSuccessful();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRunning()
+    {
+        return $this->process->isRunning();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStarted()
+    {
+        return $this->process->isStarted();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTerminated()
+    {
+        return $this->process->isTerminated();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatus()
+    {
+        return $this->process->getStatus();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop($timeout = 10, $signal = null)
+    {
+        return $this->process->stop($timeout, $signal);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkTimeout()
+    {
+        $this->process->checkTimeout();
+    }
+
+    /**
+     * Sets the managed process
+     *
+     * @param ProcessableInterface $process
+     *
+     * @return ManagedProcess
+     */
+    private function setManagedProcess(ProcessableInterface $process)
+    {
+        $this->process = $process;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Process/Manager/ManagedProcess.php
+++ b/src/Symfony/Component/Process/Manager/ManagedProcess.php
@@ -246,6 +246,14 @@ class ManagedProcess implements ProcessableInterface
     /**
      * {@inheritdoc}
      */
+    public function isStopping()
+    {
+        return $this->process->isStopping();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isStarted()
     {
         return $this->process->isStarted();

--- a/src/Symfony/Component/Process/Manager/ProcessManager.php
+++ b/src/Symfony/Component/Process/Manager/ProcessManager.php
@@ -602,7 +602,7 @@ class ProcessManager implements ProcessableInterface, \Countable
      */
     private function handleException(ManagedProcess $process, \Exception $e, $errorMsg, $strategy)
     {
-        $this->log('error', $errorMsg);
+        $this->log('error', $errorMsg, array('error' => $e));
 
         if (static::STRATEGY_ABORT === $strategy) {
             $this->stop();
@@ -633,13 +633,14 @@ class ProcessManager implements ProcessableInterface, \Countable
      *
      * @param string $method  The logger method to use.
      * @param string $message The message to log.
+     * @param array  $context The context of the log message.
      *
      * @return ProcessManager
      */
-    private function log($method, $message)
+    private function log($method, $message, array $context = array())
     {
         if ($this->logger) {
-            call_user_func(array($this->logger, $method), $message);
+            call_user_func(array($this->logger, $method), $message, $context);
         }
 
         return $this;

--- a/src/Symfony/Component/Process/Manager/ProcessManager.php
+++ b/src/Symfony/Component/Process/Manager/ProcessManager.php
@@ -551,7 +551,7 @@ class ProcessManager implements ProcessableInterface, \Countable
                 }
             }
 
-            $canRun = $canRun || $process->canRun();
+            $canRun = $canRun || (false === $this->isStopping() && $process->canRun());
         }
 
         if (0 === $concurrent && false === $canRun) {

--- a/src/Symfony/Component/Process/Manager/ProcessManager.php
+++ b/src/Symfony/Component/Process/Manager/ProcessManager.php
@@ -1,0 +1,663 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Manager;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Process\ProcessableInterface;
+use Symfony\Component\Process\Exception\LogicException;
+use Symfony\Component\Process\Exception\InvalidArgumentException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
+use Symfony\Component\Process\Exception\ProcessManagerException;
+
+/**
+ * ProcessManager runs multiple processes parallely. 
+ *
+ * @author Romain Neutron <imprec@gmail.com>
+ * 
+ * @api
+ */
+class ProcessManager implements ProcessableInterface, \Countable
+{
+    const STRATEGY_ABORT = 0;
+    const STRATEGY_IGNORE = 1;
+    const STRATEGY_RETRY = 2;
+
+    /** @var Boolean */
+    private $isDaemon;
+    /** @var null|LoggerInterface */
+    private $logger;
+    /** @var string */
+    private $status;
+    /** @var integer */
+    private $maxParallel;
+    /** @var integer */
+    private $timeoutStrategy;
+    /** @var integer */
+    private $failureStrategy;
+    /** @var ManagedProcess[] */
+    private $processes = array();
+
+    public function __construct(LoggerInterface $logger = null, $maxParallel = null, $timeoutStrategy = self::STRATEGY_ABORT, $failureStrategy = self::STRATEGY_ABORT)
+    {
+        $this->isDaemon = false;
+        $this->logger = $logger;
+        $this->status = static::STATUS_READY;
+        $this->setMaxParallelProcesses($maxParallel);
+        $this->failureStrategy = $this->validateStrategy($failureStrategy);
+        $this->timeoutStrategy = $this->validateStrategy($timeoutStrategy);
+    }
+
+    public function __destruct()
+    {
+        $this->stop();
+    }
+
+    /**
+     * Sets the process manager behavior as daemon or not.
+     *
+     * @param Boolean $isDaemon
+     *
+     * @return ProcessManager
+     */
+    public function setDaemon($isDaemon)
+    {
+        $this->isDaemon = (Boolean) $isDaemon;
+
+        return $this;
+    }
+
+    /**
+     * Returns true if the process manager behaves as a daemon.
+     *
+     * In case it is, the manager will not stop until the stop method is
+     * explicitely called.
+     *
+     * @return Boolean
+     */
+    public function isDaemon()
+    {
+        return $this->isDaemon;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLogger(LoggerInterface $logger = null)
+    {
+        $this->logger = $logger;
+
+        return $this;
+    }
+
+    /**
+     * Returns the attached logger.
+     *
+     * @return LoggerInterface
+     */
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->processes);
+    }
+
+    /**
+     * Returns the managed processes.
+     *
+     * @return ManagedProcess[]
+     */
+    public function getManagedProcesses()
+    {
+        return $this->processes;
+    }
+
+    /**
+     * Sets the managed processes.
+     *
+     * @param array $processes An array of ManagedProcess instances.
+     *
+     * @return ProcessManager
+     *
+     * @throws ProcessManagerException
+     */
+    public function setManagedProcesses(array $processes)
+    {
+        if ($this->isRunning()) {
+            throw new ProcessManagerException('Can not set processes while running.');
+        }
+
+        foreach (array_keys($this->processes) as $name) {
+            $this->remove($name);
+        }
+
+        foreach ($processes as $name => $process) {
+            $this->attach($name, $process);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Gets the timeout strategy.
+     *
+     * @return integer One of the ProcessManager::STRATEGY_* constant
+     */
+    public function getTimeoutStrategy()
+    {
+        return $this->timeoutStrategy;
+    }
+
+    /**
+     * Sets the timeout strategy.
+     *
+     * This is used in case of the timeout of one of the managed process.
+     * If strategy is set to ProcessManager::STRATEGY_ABORT, all processes are
+     * stopped in case of a process timeout.
+     * If strategy is set to ProcessManager::STRATEGY_IGNORE, the timeout is
+     * ignored, remaining processes are run.
+     * If strategy is set to ProcessManager::STRATEGY_RETRY, the timed-out
+     * process is run again until success.
+     *
+     * @param integer $strategy One of the ProcessManager::STRATEGY_* constant
+     *
+     * @return ProcessManager
+     *
+     * @throws InvalidArgumentException In case the strategy is not valid
+     */
+    public function setTimeoutStrategy($strategy)
+    {
+        $this->timeoutStrategy = $this->validateStrategy($strategy);
+
+        return $this;
+    }
+
+    /**
+     * Gets the failure strategy.
+     *
+     * @return integer One of the ProcessManager::STRATEGY_* constant
+     */
+    public function getFailureStrategy()
+    {
+        return $this->failureStrategy;
+    }
+
+    /**
+     * Sets the failure strategy.
+     *
+     * This is used in case of the failure of one of the managed process.
+     * If strategy is set to ProcessManager::STRATEGY_ABORT, all processes are
+     * stopped in case of a process failure.
+     * If strategy is set to ProcessManager::STRATEGY_IGNORE, the failure is
+     * ignored, remaining processes are run.
+     * If strategy is set to ProcessManager::STRATEGY_RETRY, the failing
+     * process is run again until success.
+     *
+     * @param integer $strategy One of the ProcessManager::STRATEGY_* constant
+     *
+     * @return ProcessManager
+     *
+     * @throws InvalidArgumentException In case the strategy is not valid
+     */
+    public function setFailureStrategy($strategy)
+    {
+        $this->failureStrategy = $this->validateStrategy($strategy);
+
+        return $this;
+    }
+
+    /**
+     * Gets the maximum number of processes that can be run in parallel.
+     *
+     * @return integer
+     */
+    public function getMaxParallelProcesses()
+    {
+        return $this->maxParallel;
+    }
+
+    /**
+     * Sets the maximum number of processes that can be run in parallel.
+     *
+     * @param integer $maxParallel
+     *
+     * @return ProcessManager
+     *
+     * @throws InvalidArgumentException In case of invalid value
+     */
+    public function setMaxParallelProcesses($maximum)
+    {
+        if (null !== $maximum && 1 > $maximum) {
+            throw new InvalidArgumentException('Max parallel processes must be a positive value.');
+        }
+
+        $this->maxParallel = null === $maximum ? INF : (integer) $maximum;
+
+        return $this;
+    }
+
+    /**
+     * Checks if the given name refers to a managed process.
+     *
+     * @param string $name
+     *
+     * @return Boolean
+     */
+    public function has($name)
+    {
+        return isset($this->processes[$name]);
+    }
+
+    /**
+     * Adds a process to the managed ones.
+     *
+     * @param ProcessableInterface $process
+     * @param string               $name       A unique name to register the process. If not provided, a name will be generated.
+     * @param integer              $executions
+     *
+     * @return ProcessManager
+     *
+     * @throws InvalidArgumentException
+     */
+    public function add(ProcessableInterface $process, $name = null, $executions = 1)
+    {
+        if (null === $name) {
+            $name = $this->generateProcessName();
+        } elseif ($this->has($name)) {
+            throw new InvalidArgumentException(sprintf('A process named %s is already attached.', $name));
+        }
+
+        $this->attach($name, new ManagedProcess($process, $executions));
+
+        return $this;
+    }
+
+    /**
+     * Removes a Process from the manager given its name.
+     *
+     * @param string  $name    The name of the managed process.
+     * @param integer $timeout If the process is still running, the timeout to wait before sending a SIGKILL signal.
+     * @param integer $signal  If the process is still running, the signal to send after the timeout is reached.
+     *
+     * @return ManagedProcess The removed process
+     *
+     * @throws InvalidArgumentException In case no process with the given name exists.
+     */
+    public function remove($name, $timeout = 10, $signal = null)
+    {
+        if (!$this->has($name)) {
+            throw new InvalidArgumentException(sprintf('No process named %s is attached to the manager.', $name));
+        }
+
+        $process = $this->processes[$name];
+        $process->stop($timeout, $signal);
+        unset($this->processes[$name]);
+
+        return $process;
+    }
+
+    /**
+     * Returns a process given a name.
+     *
+     * @param string $name The name of the managed process
+     *
+     * @return ManagedProcess
+     *
+     * @throws InvalidArgumentException In case the process is unknown.
+     */
+    public function get($name)
+    {
+        if (!$this->has($name)) {
+            throw new InvalidArgumentException(sprintf('No process named %s is attached to the manager.', $name));
+        }
+
+        return $this->processes[$name];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run($callback = null)
+    {
+        $this->start($callback);
+
+        return $this->wait();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function start($callback = null)
+    {
+        if ($this->isRunning()) {
+            throw new ProcessManagerException('Manager is already running.');
+        }
+
+        if (0 === count($this) && !$this->isDaemon) {
+            throw new LogicException('No processes are currently managed.');
+        }
+
+        $this->status = static::STATUS_STARTED;
+        $this->updateProcesses($callback);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function restart($callback = null)
+    {
+        $process = clone($this);
+        $processes = array_map(function ($managed) {
+            $managed = clone($managed);
+            $managed->reset();
+
+            return $managed;
+        }, $process->getManagedProcesses());
+
+        $process->setManagedProcesses($processes);
+
+        return $process->start($callback);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function wait($callback = null)
+    {
+        while ($this->status !== static::STATUS_TERMINATED) {
+            $this->updateProcesses($callback);
+            usleep(10000);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function signal($signal)
+    {
+        if (!$this->isRunning()) {
+            throw new LogicException('Can not send signal on a non running process.');
+        }
+
+        foreach ($this->processes as $name => $process) {
+            if ($process->isRunning()) {
+                $this->log('debug', sprintf('Signaling process %s with signal "%d"', $name, $signal));
+                $process->signal($signal);
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isSuccessful()
+    {
+        if (count($this) === 0) {
+            throw new LogicException('No processes are currently managed.');
+        }
+
+        foreach ($this->processes as $process) {
+            if (!$process->isSuccessful()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isRunning()
+    {
+        $this->updateProcesses();
+
+        return in_array($this->status, array(static::STATUS_STARTED, static::STATUS_STOPPING), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isStarted()
+    {
+        return $this->status !== self::STATUS_READY;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isTerminated()
+    {
+        $this->updateProcesses();
+
+        return $this->status === self::STATUS_TERMINATED;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStatus()
+    {
+        $this->updateProcesses();
+
+        return $this->status;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop($timeout = 10, $signal = null)
+    {
+        $timeout = microtime(true) + $timeout;
+        $this->updateProcesses();
+
+        if (static::STATUS_STARTED !== $this->status) {
+            return;
+        }
+
+        $this->signal(null !== $signal ? $signal : (defined('SIGTERM') ? SIGTERM : 15));
+
+        do {
+            usleep(1000);
+            $running = $this->isRunning();
+        } while (true === $running && microtime(true) < $timeout);
+
+        if (true === $running) {
+            foreach ($this->processes as $name => $process) {
+                if ($process->isRunning()) {
+                    $this->log('info', sprintf('Stopping process %s', $name));
+                    $process->stop(0, $signal);
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkTimeout()
+    {
+        $this->updateProcesses();
+    }
+
+    /**
+     * Updates the managed process given the current status
+     *
+     * @param mixed $callback A callback to pass to starting processes.
+     *
+     * @return ProcessManager
+     */
+    private function updateProcesses($callback = null)
+    {
+        if (!in_array($this->status, array(static::STATUS_STARTED, static::STATUS_STOPPING), true)) {
+            return;
+        }
+
+        $concurrent = 0;
+        foreach ($this->processes as $name => $process) {
+            if ($concurrent >= $this->maxParallel) {
+                break;
+            }
+
+            if ($process->isRunning()) {
+                if ($this->doExecute($process, 'checkTimeout', array(), 'Managed process timed-out.')) {
+                    $concurrent++;
+                } else {
+                    $this->log('info', sprintf('Process %s timed-out.', $name));
+                }
+            } elseif (static::STATUS_STOPPING !== $this->status && $process->canRun()) {
+                if ($this->doExecute($process, 'start', array($callback), 'Unable to start the managed process.')) {
+                    $concurrent++;
+                    $this->log('debug', sprintf('Process %s started.', $name));
+                } else {
+                    $this->log('info', sprintf('Starting process %s failed.', $name));
+                }
+            }
+        }
+
+        if (0 === $concurrent) {
+            $this->status = static::STATUS_TERMINATED;
+        }
+
+        if (static::STATUS_STARTED === $this->status) {
+            $this->log('debug', sprintf('Currently running %d concurrent processes.', $concurrent));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Executes a method against a process.
+     *
+     * @param ManagedProcess $process  The managed process on which the method is called.
+     * @param string         $method   The name of the method to call.
+     * @param array          $args     The arguments to pass to the method call.
+     * @param string         $errorMsg The message of the exception and the logger in case of failure.
+     *
+     * @return Booleans True if the method call was successful, false otherwise.
+     */
+    private function doExecute(ManagedProcess $process, $method, $args = array(), $errorMsg = '')
+    {
+        try {
+            call_user_func_array(array($process, $method), $args);
+
+            return true;
+        } catch (ProcessTimedOutException $e) {
+            $this->handleException($process, $e, $errorMsg, $this->timeoutStrategy);
+        } catch (ProcessException $e) {
+            $this->handleException($process, $e, $errorMsg, $this->failureStrategy);
+        }
+
+        return false;
+    }
+
+    /**
+     * Handles a managed process exception, given the current configuration.
+     *
+     * @param ManagedProcess $process  The process that thrown the exception.
+     * @param \Exception     $e        The exception to handle.
+     * @param string         $errorMsg The error message
+     * @param integer        $strategy The strategy related to the exception.
+     *
+     * @return ProcessManager
+     *
+     * @throws ProcessManagerException In case the strategy aborts the run.
+     */
+    private function handleException(ManagedProcess $process, \Exception $e, $errorMsg, $strategy)
+    {
+        $this->log('error', $errorMsg);
+
+        if (static::STRATEGY_ABORT === $strategy) {
+            $this->stop();
+            throw new ProcessManagerException($errorMsg, $e->getCode(), $e);
+        }
+        if (static::STRATEGY_RETRY === $strategy) {
+            $process->retry();
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sends a log message to the logger, if available.
+     *
+     * @param string $method  The logger method to use.
+     * @param string $message The message to log.
+     *
+     * @return ProcessManager
+     */
+    private function log($method, $message)
+    {
+        if ($this->logger) {
+            call_user_func(array($this->logger, $method), $message);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Validates a strategy value.
+     *
+     * @param integer $strategy The strategy to validate
+     *
+     * @return integer The validated strategy.
+     *
+     * @throws InvalidArgumentException In case the strategy is invalid.
+     */
+    private function validateStrategy($strategy)
+    {
+        if (!in_array($strategy, array(static::STRATEGY_ABORT, static::STRATEGY_IGNORE, static::STRATEGY_RETRY), true)) {
+            throw new InvalidArgumentException('Invalid strategy.');
+        }
+
+        return $strategy;
+    }
+
+    /**
+     * Generates a process name.
+     *
+     * @return string
+     */
+    private function generateProcessName()
+    {
+        $n = count($this);
+        do {
+            $name = 'process #' . $n;
+            $n++;
+        } while ($this->has($name));
+
+        return $name;
+    }
+
+    /**
+     * Attaches a managed process.
+     *
+     * @param string         $name
+     * @param ManagedProcess $process
+     *
+     * @return ProcessManager
+     */
+    private function attach($name, ManagedProcess $process)
+    {
+        $this->processes[$name] = $process;
+
+        return $this;
+    }
+}

--- a/src/Symfony/Component/Process/Manager/ProcessManager.php
+++ b/src/Symfony/Component/Process/Manager/ProcessManager.php
@@ -511,6 +511,7 @@ class ProcessManager implements ProcessableInterface, \Countable
         }
 
         $concurrent = 0;
+        $canRun = false;
         foreach ($this->processes as $name => $process) {
             if ($concurrent >= $this->maxParallel) {
                 break;
@@ -530,9 +531,10 @@ class ProcessManager implements ProcessableInterface, \Countable
                     $this->log('info', sprintf('Starting process %s failed.', $name));
                 }
             }
+            $canRun = $canRun || $process->canRun();
         }
 
-        if (0 === $concurrent) {
+        if (0 === $concurrent && false === $canRun) {
             $this->status = static::STATUS_TERMINATED;
         }
 
@@ -589,6 +591,7 @@ class ProcessManager implements ProcessableInterface, \Countable
             throw new ProcessManagerException($errorMsg, $e->getCode(), $e);
         }
         if (static::STRATEGY_RETRY === $strategy) {
+            $process->addFailure($e);
             $process->retry();
         }
 

--- a/src/Symfony/Component/Process/Manager/ProcessManager.php
+++ b/src/Symfony/Component/Process/Manager/ProcessManager.php
@@ -543,7 +543,7 @@ class ProcessManager implements ProcessableInterface, \Countable
                 }
             }
 
-            $canRun = $canRun && $process->canRun();
+            $canRun = $canRun || $process->canRun();
         }
 
         if (0 === $concurrent && false === $canRun) {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -445,6 +445,14 @@ class Process implements ProcessInterface
     /**
      * {@inheritdoc}
      */
+    public function isStopping()
+    {
+        return $this->status === self::STATUS_STOPPING;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function isStarted()
     {
         return $this->status != self::STATUS_READY;

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -24,12 +24,8 @@ use Symfony\Component\Process\Exception\RuntimeException;
  *
  * @api
  */
-class Process implements ProcessableInterface
+class Process implements ProcessInterface
 {
-    const STDIN = 0;
-    const STDOUT = 1;
-    const STDERR = 2;
-
     // Timeout Precision in seconds.
     const TIMEOUT_PRECISION = 0.2;
 
@@ -254,11 +250,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns the Pid (process identifier), if applicable.
-     *
-     * @return integer|null The process id if running, null otherwise
-     *
-     * @throws RuntimeException In case --enable-sigchild is activated
+     * {@inheritdoc}
      */
     public function getPid()
     {
@@ -292,11 +284,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns the current output of the process (STDOUT).
-     *
-     * @return string The process output
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getOutput()
     {
@@ -324,11 +312,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns the current error output of the process (STDERR).
-     *
-     * @return string The process error output
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getErrorOutput()
     {
@@ -357,13 +341,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns the exit code returned by the process.
-     *
-     * @return integer The exit status code
-     *
-     * @throws RuntimeException In case --enable-sigchild is activated and the sigchild compatibility mode is disabled
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getExitCode()
     {
@@ -403,15 +381,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns true if the child process has been terminated by an uncaught signal.
-     *
-     * It always returns false on Windows.
-     *
-     * @return Boolean
-     *
-     * @throws RuntimeException In case --enable-sigchild is activated
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function hasBeenSignaled()
     {
@@ -425,15 +395,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns the number of the signal that caused the child process to terminate its execution.
-     *
-     * It is only meaningful if hasBeenSignaled() returns true.
-     *
-     * @return integer
-     *
-     * @throws RuntimeException In case --enable-sigchild is activated
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getTermSignal()
     {
@@ -447,13 +409,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns true if the child process has been stopped by a signal.
-     *
-     * It always returns false on Windows.
-     *
-     * @return Boolean
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function hasBeenStopped()
     {
@@ -463,13 +419,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Returns the number of the signal that caused the child process to stop its execution.
-     *
-     * It is only meaningful if hasBeenStopped() returns true.
-     *
-     * @return integer
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function getStopSignal()
     {
@@ -592,9 +542,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Gets the process timeout.
-     *
-     * @return float|null The timeout in seconds or null if it's disabled
+     * {@inheritdoc}
      */
     public function getTimeout()
     {
@@ -602,9 +550,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Gets the process idle timeout.
-     *
-     * @return float|null
+     * {@inheritdoc}
      */
     public function getIdleTimeout()
     {
@@ -612,15 +558,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Sets the process timeout.
-     *
-     * To disable the timeout, set this value to null.
-     *
-     * @param integer|float|null $timeout The timeout in seconds
-     *
-     * @return self The current Process instance
-     *
-     * @throws InvalidArgumentException if the timeout is negative
+     * {@inheritdoc}
      */
     public function setTimeout($timeout)
     {
@@ -630,13 +568,7 @@ class Process implements ProcessableInterface
     }
 
     /**
-     * Sets the process idle timeout.
-     *
-     * @param integer|float|null $timeout
-     *
-     * @return self The current Process instance.
-     *
-     * @throws InvalidArgumentException if the timeout is negative
+     * {@inheritdoc}
      */
     public function setIdleTimeout($timeout)
     {

--- a/src/Symfony/Component/Process/Process.php
+++ b/src/Symfony/Component/Process/Process.php
@@ -24,15 +24,8 @@ use Symfony\Component\Process\Exception\RuntimeException;
  *
  * @api
  */
-class Process
+class Process implements ProcessableInterface
 {
-    const ERR = 'err';
-    const OUT = 'out';
-
-    const STATUS_READY = 'ready';
-    const STATUS_STARTED = 'started';
-    const STATUS_TERMINATED = 'terminated';
-
     const STDIN = 0;
     const STDOUT = 1;
     const STDERR = 2;
@@ -174,23 +167,7 @@ class Process
     }
 
     /**
-     * Runs the process.
-     *
-     * The callback receives the type of output (out or err) and
-     * some bytes from the output in real-time. It allows to have feedback
-     * from the independent process during execution.
-     *
-     * The STDOUT and STDERR are also available after the process is finished
-     * via the getOutput() and getErrorOutput() methods.
-     *
-     * @param callback|null $callback A PHP callback to run whenever there is some
-     *                                output available on STDOUT or STDERR
-     *
-     * @return integer The exit status code
-     *
-     * @throws RuntimeException When process can't be launch or is stopped
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function run($callback = null)
     {
@@ -200,27 +177,7 @@ class Process
     }
 
     /**
-     * Starts the process and returns after sending the STDIN.
-     *
-     * This method blocks until all STDIN data is sent to the process then it
-     * returns while the process runs in the background.
-     *
-     * The termination of the process can be awaited with wait().
-     *
-     * The callback receives the type of output (out or err) and some bytes from
-     * the output in real-time while writing the standard input to the process.
-     * It allows to have feedback from the independent process during execution.
-     * If there is no callback passed, the wait() method can be called
-     * with true as a second parameter then the callback will get all data occurred
-     * in (and since) the start call.
-     *
-     * @param callback|null $callback A PHP callback to run whenever there is some
-     *                                output available on STDOUT or STDERR
-     *
-     * @return Process The process itself
-     *
-     * @throws RuntimeException When process can't be launch or is stopped
-     * @throws RuntimeException When process is already running
+     * {@inheritdoc}
      */
     public function start($callback = null)
     {
@@ -256,19 +213,7 @@ class Process
     }
 
     /**
-     * Restarts the process.
-     *
-     * Be warned that the process is cloned before being started.
-     *
-     * @param callable $callback A PHP callback to run whenever there is some
-     *                           output available on STDOUT or STDERR
-     *
-     * @return Process The new process
-     *
-     * @throws RuntimeException When process can't be launch or is stopped
-     * @throws RuntimeException When process is already running
-     *
-     * @see start()
+     * {@inheritdoc}
      */
     public function restart($callback = null)
     {
@@ -283,18 +228,7 @@ class Process
     }
 
     /**
-     * Waits for the process to terminate.
-     *
-     * The callback receives the type of output (out or err) and some bytes
-     * from the output in real-time while writing the standard input to the process.
-     * It allows to have feedback from the independent process during execution.
-     *
-     * @param callback|null $callback A valid PHP callback
-     *
-     * @return integer The exitcode of the process
-     *
-     * @throws RuntimeException When process timed out
-     * @throws RuntimeException When process stopped after receiving signal
+     * {@inheritdoc}
      */
     public function wait($callback = null)
     {
@@ -338,14 +272,7 @@ class Process
     }
 
     /**
-     * Sends a posix signal to the process.
-     *
-     * @param  integer $signal A valid posix signal (see http://www.php.net/manual/en/pcntl.constants.php)
-     * @return Process
-     *
-     * @throws LogicException   In case the process is not running
-     * @throws RuntimeException In case --enable-sigchild is activated
-     * @throws RuntimeException In case of failure
+     * {@inheritdoc}
      */
     public function signal($signal)
     {
@@ -468,11 +395,7 @@ class Process
     }
 
     /**
-     * Checks if the process ended successfully.
-     *
-     * @return Boolean true if the process ended successfully, false otherwise
-     *
-     * @api
+     * {@inheritdoc}
      */
     public function isSuccessful()
     {
@@ -556,9 +479,7 @@ class Process
     }
 
     /**
-     * Checks if the process is currently running.
-     *
-     * @return Boolean true if the process is currently running, false otherwise
+     * {@inheritdoc}
      */
     public function isRunning()
     {
@@ -572,9 +493,7 @@ class Process
     }
 
     /**
-     * Checks if the process has been started with no regard to the current state.
-     *
-     * @return Boolean true if status is ready, false otherwise
+     * {@inheritdoc}
      */
     public function isStarted()
     {
@@ -582,9 +501,7 @@ class Process
     }
 
     /**
-     * Checks if the process is terminated.
-     *
-     * @return Boolean true if process is terminated, false otherwise
+     * {@inheritdoc}
      */
     public function isTerminated()
     {
@@ -594,11 +511,7 @@ class Process
     }
 
     /**
-     * Gets the process status.
-     *
-     * The status is one of: ready, started, terminated.
-     *
-     * @return string The current process status
+     * {@inheritdoc}
      */
     public function getStatus()
     {
@@ -608,14 +521,7 @@ class Process
     }
 
     /**
-     * Stops the process.
-     *
-     * @param integer|float $timeout The timeout in seconds
-     * @param integer       $signal  A posix signal to send in case the process has not stop at timeout, default is SIGKILL
-     *
-     * @return integer The exit-code of the process
-     *
-     * @throws RuntimeException if the process got signaled
+     * {@inheritdoc}
      */
     public function stop($timeout = 10, $signal = null)
     {
@@ -933,12 +839,7 @@ class Process
     }
 
     /**
-     * Performs a check between the timeout definition and the time the process started.
-     *
-     * In case you run a background process (with the start method), you should
-     * trigger this method regularly to ensure the process timeout
-     *
-     * @throws ProcessTimedOutException In case the timeout was reached
+     * {@inheritdoc}
      */
     public function checkTimeout()
     {

--- a/src/Symfony/Component/Process/ProcessInterface.php
+++ b/src/Symfony/Component/Process/ProcessInterface.php
@@ -117,7 +117,7 @@ interface ProcessInterface extends ProcessableInterface
      * @throws InvalidArgumentException if the timeout is negative
      */
     public function setTimeout($timeout);
-    
+
     /**
      * Gets the process timeout.
      *
@@ -135,7 +135,7 @@ interface ProcessInterface extends ProcessableInterface
      * @throws InvalidArgumentException if the timeout is negative
      */
     public function setIdleTimeout($timeout);
-    
+
     /**
      * Gets the process idle timeout.
      *

--- a/src/Symfony/Component/Process/ProcessInterface.php
+++ b/src/Symfony/Component/Process/ProcessInterface.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process;
+
+use Symfony\Component\Process\Exception\RuntimeException;
+
+interface ProcessInterface extends ProcessableInterface
+{
+    const STDIN = 0;
+    const STDOUT = 1;
+    const STDERR = 2;
+
+    /**
+     * Returns the Pid (process identifier), if applicable.
+     *
+     * @return integer|null The process id if running, null otherwise
+     *
+     * @throws RuntimeException In case --enable-sigchild is activated
+     */
+    public function getPid();
+
+    /**
+     * Returns the current output of the process (STDOUT).
+     *
+     * @return string The process output
+     *
+     * @api
+     */
+    public function getOutput();
+
+    /**
+     * Returns the current error output of the process (STDERR).
+     *
+     * @return string The process error output
+     *
+     * @api
+     */
+    public function getErrorOutput();
+
+    /**
+     * Returns the exit code returned by the process.
+     *
+     * @return integer The exit status code
+     *
+     * @throws RuntimeException In case --enable-sigchild is activated and the sigchild compatibility mode is disabled
+     *
+     * @api
+     */
+    public function getExitCode();
+
+    /**
+     * Returns true if the child process has been terminated by an uncaught signal.
+     *
+     * It always returns false on Windows.
+     *
+     * @return Boolean
+     *
+     * @throws RuntimeException In case --enable-sigchild is activated
+     *
+     * @api
+     */
+    public function hasBeenSignaled();
+
+    /**
+     * Returns the number of the signal that caused the child process to terminate its execution.
+     *
+     * It is only meaningful if hasBeenSignaled() returns true.
+     *
+     * @return integer
+     *
+     * @throws RuntimeException In case --enable-sigchild is activated
+     *
+     * @api
+     */
+    public function getTermSignal();
+
+    /**
+     * Returns true if the child process has been stopped by a signal.
+     *
+     * It always returns false on Windows.
+     *
+     * @return Boolean
+     *
+     * @api
+     */
+    public function hasBeenStopped();
+
+    /**
+     * Returns the number of the signal that caused the child process to stop its execution.
+     *
+     * It is only meaningful if hasBeenStopped() returns true.
+     *
+     * @return integer
+     *
+     * @api
+     */
+    public function getStopSignal();
+
+    /**
+     * Sets the process timeout.
+     *
+     * To disable the timeout, set this value to null.
+     *
+     * @param integer|float|null $timeout The timeout in seconds
+     *
+     * @return self The current Process instance
+     *
+     * @throws InvalidArgumentException if the timeout is negative
+     */
+    public function setTimeout($timeout);
+    
+    /**
+     * Gets the process timeout.
+     *
+     * @return float|null The timeout in seconds or null if it's disabled
+     */
+    public function getTimeout();
+
+    /**
+     * Sets the process idle timeout.
+     *
+     * @param integer|float|null $timeout
+     *
+     * @return self The current Process instance.
+     *
+     * @throws InvalidArgumentException if the timeout is negative
+     */
+    public function setIdleTimeout($timeout);
+    
+    /**
+     * Gets the process idle timeout.
+     *
+     * @return float|null
+     */
+    public function getIdleTimeout();
+}

--- a/src/Symfony/Component/Process/ProcessableInterface.php
+++ b/src/Symfony/Component/Process/ProcessableInterface.php
@@ -133,6 +133,13 @@ interface ProcessableInterface
     public function isRunning();
 
     /**
+     * Checks if the process is currently stopping.
+     *
+     * @return Boolean true if the process is currently stopping, false otherwise
+     */
+    public function isStopping();
+
+    /**
      * Checks if the process has been started with no regard to the current state.
      *
      * @return Boolean true if status is ready, false otherwise

--- a/src/Symfony/Component/Process/ProcessableInterface.php
+++ b/src/Symfony/Component/Process/ProcessableInterface.php
@@ -22,6 +22,7 @@ interface ProcessableInterface
 
     const STATUS_READY = 'ready';
     const STATUS_STARTED = 'started';
+    const STATUS_STOPPING = 'stopping';
     const STATUS_TERMINATED = 'terminated';
 
     /**

--- a/src/Symfony/Component/Process/ProcessableInterface.php
+++ b/src/Symfony/Component/Process/ProcessableInterface.php
@@ -1,0 +1,178 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process;
+
+use Symfony\Component\Process\Exception\LogicException;
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Exception\RuntimeException;
+
+interface ProcessableInterface
+{
+    const ERR = 'err';
+    const OUT = 'out';
+
+    const STATUS_READY = 'ready';
+    const STATUS_STARTED = 'started';
+    const STATUS_TERMINATED = 'terminated';
+
+    /**
+     * Runs the process.
+     *
+     * The callback receives the type of output (out or err) and
+     * some bytes from the output in real-time. It allows to have feedback
+     * from the independent process during execution.
+     *
+     * The STDOUT and STDERR are also available after the process is finished
+     * via the getOutput() and getErrorOutput() methods.
+     *
+     * @param callback|null $callback A PHP callback to run whenever there is some
+     *                                output available on STDOUT or STDERR
+     *
+     * @return integer The exit status code
+     *
+     * @throws RuntimeException When process can't be launch or is stopped
+     *
+     * @api
+     */
+    public function run($callback = null);
+
+    /**
+     * Starts the process and returns after sending the STDIN.
+     *
+     * This method blocks until all STDIN data is sent to the process then it
+     * returns while the process runs in the background.
+     *
+     * The termination of the process can be awaited with wait().
+     *
+     * The callback receives the type of output (out or err) and some bytes from
+     * the output in real-time while writing the standard input to the process.
+     * It allows to have feedback from the independent process during execution.
+     * If there is no callback passed, the wait() method can be called
+     * with true as a second parameter then the callback will get all data occurred
+     * in (and since) the start call.
+     *
+     * @param callback|null $callback A PHP callback to run whenever there is some
+     *                                output available on STDOUT or STDERR
+     *
+     * @return Process The process itself
+     *
+     * @throws RuntimeException When process can't be launch or is stopped
+     * @throws RuntimeException When process is already running
+     */
+    public function start($callback = null);
+
+    /**
+     * Restarts the process.
+     *
+     * Be warned that the process is cloned before being started.
+     *
+     * @param callable $callback A PHP callback to run whenever there is some
+     *                           output available on STDOUT or STDERR
+     *
+     * @return Process The new process
+     *
+     * @throws RuntimeException When process can't be launch or is stopped
+     * @throws RuntimeException When process is already running
+     *
+     * @see start()
+     */
+    public function restart($callback = null);
+
+    /**
+     * Waits for the process to terminate.
+     *
+     * The callback receives the type of output (out or err) and some bytes
+     * from the output in real-time while writing the standard input to the process.
+     * It allows to have feedback from the independent process during execution.
+     *
+     * @param callback|null $callback A valid PHP callback
+     *
+     * @return integer The exitcode of the process
+     *
+     * @throws RuntimeException When process timed out
+     * @throws RuntimeException When process stopped after receiving signal
+     */
+    public function wait($callback = null);
+
+    /**
+     * Sends a posix signal to the process.
+     *
+     * @param  integer $signal A valid posix signal (see http://www.php.net/manual/en/pcntl.constants.php)
+     * @return Process
+     *
+     * @throws LogicException   In case the process is not running
+     * @throws RuntimeException In case --enable-sigchild is activated
+     * @throws RuntimeException In case of failure
+     */
+    public function signal($signal);
+
+    /**
+     * Checks if the process ended successfully.
+     *
+     * @return Boolean true if the process ended successfully, false otherwise
+     *
+     * @api
+     */
+    public function isSuccessful();
+
+    /**
+     * Checks if the process is currently running.
+     *
+     * @return Boolean true if the process is currently running, false otherwise
+     */
+    public function isRunning();
+
+    /**
+     * Checks if the process has been started with no regard to the current state.
+     *
+     * @return Boolean true if status is ready, false otherwise
+     */
+    public function isStarted();
+
+    /**
+     * Checks if the process is terminated.
+     *
+     * @return Boolean true if process is terminated, false otherwise
+     */
+    public function isTerminated();
+
+    /**
+     * Gets the process status.
+     *
+     * The status is one of: ready, started, terminated.
+     *
+     * @return string The current process status
+     */
+    public function getStatus();
+
+    /**
+     * Stops the process.
+     *
+     * @param integer|float $timeout The timeout in seconds
+     * @param integer       $signal  A posix signal to send in case the process has not stop at timeout, default is SIGKILL
+     *
+     * @return integer The exit-code of the process
+     *
+     * @throws RuntimeException if the process got signaled
+     */
+    public function stop($timeout = 10, $signal = null);
+
+    /**
+     * Performs a check between the timeout definition and the time the process started.
+     *
+     * In case you run a background process (with the start method), you should
+     * trigger this method regularly to ensure the process timeout
+     *
+     * @throws ProcessTimedOutException In case the timeout was reached
+     */
+    public function checkTimeout();
+}

--- a/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/AbstractProcessTest.php
@@ -19,114 +19,8 @@ use Symfony\Component\Process\Exception\RuntimeException;
 /**
  * @author Robert Schönthal <seroscho@googlemail.com>
  */
-abstract class AbstractProcessTest extends ProcessableTestCase
+abstract class AbstractProcessTest extends ProcessTestCase
 {
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     */
-    public function testNegativeTimeoutFromConstructor()
-    {
-        $this->getProcess('', null, null, null, -1);
-    }
-
-    /**
-     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
-     */
-    public function testNegativeTimeoutFromSetter()
-    {
-        $p = $this->getProcess('');
-        $p->setTimeout(-1);
-    }
-
-    public function testNullTimeout()
-    {
-        $p = $this->getProcess('');
-        $p->setTimeout(10);
-        $p->setTimeout(null);
-
-        $this->assertNull($p->getTimeout());
-    }
-
-    public function testCallbacksAreExecutedWithStart()
-    {
-        $data = '';
-
-        $process = $this->getProcess('echo foo && php -r "sleep(1);" && echo foo');
-        $process->start(function ($type, $buffer) use (&$data) {
-            $data .= $buffer;
-        });
-
-        while ($process->isRunning()) {
-            usleep(10000);
-        }
-
-        $this->assertEquals(2, preg_match_all('/foo/', $data, $matches));
-    }
-
-    /**
-     * tests results from sub processes
-     *
-     * @dataProvider responsesCodeProvider
-     */
-    public function testProcessResponses($expected, $getter, $code)
-    {
-        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
-        $p->run();
-
-        $this->assertSame($expected, $p->$getter());
-    }
-
-    /**
-     * tests results from sub processes
-     *
-     * @dataProvider pipesCodeProvider
-     */
-    public function testProcessPipes($code, $size)
-    {
-        $expected = str_repeat(str_repeat('*', 1024), $size) . '!';
-        $expectedLength = (1024 * $size) + 1;
-
-        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
-        $p->setStdin($expected);
-        $p->run();
-
-        $this->assertEquals($expectedLength, strlen($p->getOutput()));
-        $this->assertEquals($expectedLength, strlen($p->getErrorOutput()));
-    }
-
-    public function chainedCommandsOutputProvider()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            return array(
-                array("2 \r\n2\r\n", '&&', '2')
-            );
-        }
-
-        return array(
-            array("1\n1\n", ';', '1'),
-            array("2\n2\n", '&&', '2'),
-        );
-    }
-
-    /**
-     *
-     * @dataProvider chainedCommandsOutputProvider
-     */
-    public function testChainedCommandsOutput($expected, $operator, $input)
-    {
-        $process = $this->getProcess(sprintf('echo %s %s echo %s', $input, $operator, $input));
-        $process->run();
-        $this->assertEquals($expected, $process->getOutput());
-    }
-
-    public function testGetErrorOutput()
-    {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }')));
-
-        $p->run();
-        $this->assertEquals(3, preg_match_all('/ERROR/', $p->getErrorOutput(), $matches));
-    }
-
     public function testGetIncrementalErrorOutput()
     {
         $p = new Process(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { usleep(50000); file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }')));
@@ -136,14 +30,6 @@ abstract class AbstractProcessTest extends ProcessableTestCase
             $this->assertLessThanOrEqual(1, preg_match_all('/ERROR/', $p->getIncrementalErrorOutput(), $matches));
             usleep(20000);
         }
-    }
-
-    public function testGetOutput()
-    {
-        $p = new Process(sprintf('php -r %s', escapeshellarg('$n=0;while ($n<3) {echo \' foo \';$n++; usleep(500); }')));
-
-        $p->run();
-        $this->assertEquals(3, preg_match_all('/foo/', $p->getOutput(), $matches));
     }
 
     public function testGetIncrementalOutput()
@@ -157,19 +43,6 @@ abstract class AbstractProcessTest extends ProcessableTestCase
         }
     }
 
-    public function testExitCodeCommandFailed()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support POSIX exit code');
-        }
-
-        // such command run in bash return an exitcode 127
-        $process = $this->getProcess('nonexistingcommandIhopeneversomeonewouldnameacommandlikethis');
-        $process->run();
-
-        $this->assertGreaterThan(0, $process->getExitCode());
-    }
-
     public function testTTYCommand()
     {
         if (defined('PHP_WINDOWS_VERSION_BUILD')) {
@@ -180,7 +53,7 @@ abstract class AbstractProcessTest extends ProcessableTestCase
         $process->setTTY(true);
         $process->run();
 
-        $this->assertSame(Process::STATUS_TERMINATED, $process->getStatus());
+        $this->assertSame(ProcessableInterface::STATUS_TERMINATED, $process->getStatus());
     }
 
     public function testExitCodeText()
@@ -194,138 +67,10 @@ abstract class AbstractProcessTest extends ProcessableTestCase
         $this->assertEquals('Misuse of shell builtins', $process->getExitCodeText());
     }
 
-    public function testUpdateStatus()
-    {
-        $process = $this->getProcess('php -h');
-        $process->run();
-        $this->assertTrue(strlen($process->getOutput()) > 0);
-    }
-
-    public function testGetExitCodeIsNullOnStart()
-    {
-        $process = $this->getProcess('php -r "usleep(200000);"');
-        $this->assertNull($process->getExitCode());
-        $process->start();
-        $this->assertNull($process->getExitCode());
-        $process->wait();
-        $this->assertEquals(0, $process->getExitCode());
-    }
-
-    public function testGetExitCodeIsNullOnWhenStartingAgain()
-    {
-        $process = $this->getProcess('php -r "usleep(200000);"');
-        $process->run();
-        $this->assertEquals(0, $process->getExitCode());
-        $process->start();
-        $this->assertNull($process->getExitCode());
-        $process->wait();
-        $this->assertEquals(0, $process->getExitCode());
-    }
-
-    public function testGetExitCode()
-    {
-        $process = $this->getProcess('php -m');
-        $process->run();
-        $this->assertEquals(0, $process->getExitCode());
-    }
-
-    public function testProcessIsNotSignaled()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
-        }
-
-        $process = $this->getProcess('php -m');
-        $process->run();
-        $this->assertFalse($process->hasBeenSignaled());
-    }
-
-    public function testProcessWithoutTermSignalIsNotSignaled()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
-        }
-
-        $process = $this->getProcess('php -m');
-        $process->run();
-        $this->assertFalse($process->hasBeenSignaled());
-    }
-
-    public function testProcessWithoutTermSignal()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
-        }
-
-        $process = $this->getProcess('php -m');
-        $process->run();
-        $this->assertEquals(0, $process->getTermSignal());
-    }
-
-    public function testProcessIsSignaledIfStopped()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
-        }
-
-        $process = $this->getProcess('php -r "sleep(4);"');
-        $process->start();
-        $process->stop();
-        $this->assertTrue($process->hasBeenSignaled());
-    }
-
-    public function testProcessWithTermSignal()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
-        }
-
-        // SIGTERM is only defined if pcntl extension is present
-        $termSignal = defined('SIGTERM') ? SIGTERM : 15;
-
-        $process = $this->getProcess('php -r "sleep(4);"');
-        $process->start();
-        $process->stop();
-
-        $this->assertEquals($termSignal, $process->getTermSignal());
-    }
-
-    public function testProcessThrowsExceptionWhenExternallySignaled()
-    {
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            $this->markTestSkipped('Windows does not support POSIX signals');
-        }
-
-        if (!function_exists('posix_kill')) {
-            $this->markTestSkipped('posix_kill is required for this test');
-        }
-
-        $termSignal = defined('SIGKILL') ? SIGKILL : 9;
-
-        $process = $this->getProcess('exec php -r "while (true) {}"');
-        $process->start();
-        posix_kill($process->getPid(), $termSignal);
-
-        $this->setExpectedException('Symfony\Component\Process\Exception\RuntimeException', 'The process has been signaled with signal "9".');
-        $process->wait();
-    }
-
-    public function testPhpDeadlock()
-    {
-        $this->markTestSkipped('Can course php to hang');
-
-        // Sleep doesn't work as it will allow the process to handle signals and close
-        // file handles from the other end.
-        $process = $this->getProcess('php -r "while (true) {}"');
-        $process->start();
-
-        // PHP will deadlock when it tries to cleanup $process
-    }
-
     public function testRunProcessWithTimeout()
     {
         $timeout = 0.5;
-        $process = $this->getProcess('php -r "sleep(3);"');
+        $process = $this->getProcess('sleep 3');
         $process->setTimeout($timeout);
         $start = microtime(true);
         try {
@@ -337,6 +82,52 @@ abstract class AbstractProcessTest extends ProcessableTestCase
         $duration = microtime(true) - $start;
 
         $this->assertLessThan($timeout + Process::TIMEOUT_PRECISION, $duration);
+    }
+
+    /**
+     * tests results from sub processes
+     *
+     * @dataProvider pipesCodeProvider
+     */
+    public function testProcessPipes($code, $size)
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Test hangs on Windows & PHP due to https://bugs.php.net/bug.php?id=60120 and https://bugs.php.net/bug.php?id=51800');
+        }
+
+        $expected = str_repeat(str_repeat('*', 1024), $size) . '!';
+        $expectedLength = (1024 * $size) + 1;
+
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
+        $p->setStdin($expected);
+        $p->run();
+
+        $this->assertEquals($expectedLength, strlen($p->getOutput()));
+        $this->assertEquals($expectedLength, strlen($p->getErrorOutput()));
+    }
+
+    public function pipesCodeProvider()
+    {
+        $variations = array(
+            'fwrite(STDOUT, $in = file_get_contents(\'php://stdin\')); fwrite(STDERR, $in);',
+            'include \''.__DIR__.'/PipeStdinInStdoutStdErrStreamSelect.php\';',
+        );
+
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            // Avoid XL buffers on Windows because of https://bugs.php.net/bug.php?id=65650
+            $sizes = array(1, 2, 4, 8);
+        } else {
+            $sizes = array(1, 16, 64, 1024, 4096);
+        }
+
+        $codes = array();
+        foreach ($sizes as $size) {
+            foreach ($variations as $code) {
+                $codes[] = array($code, $size);
+            }
+        }
+
+        return $codes;
     }
 
     public function testCheckTimeoutOnStartedProcess()
@@ -403,141 +194,4 @@ abstract class AbstractProcessTest extends ProcessableTestCase
         }
     }
 
-    public function testGetPid()
-    {
-        $process = $this->getProcess('php -r "sleep(1);"');
-        $process->start();
-        $this->assertGreaterThan(0, $process->getPid());
-        $process->stop();
-    }
-
-    public function testGetPidIsNullBeforeStart()
-    {
-        $process = $this->getProcess('php -r "sleep(1);"');
-        $this->assertNull($process->getPid());
-    }
-
-    public function testGetPidIsNullAfterRun()
-    {
-        $process = $this->getProcess('php -m');
-        $process->run();
-        $this->assertNull($process->getPid());
-    }
-
-    public function testSignal()
-    {
-        $this->verifyPosixIsEnabled();
-
-        $process = $this->getProcess('exec php -f ' . __DIR__ . '/SignalListener.php');
-        $process->start();
-        usleep(500000);
-        $process->signal(SIGUSR1);
-
-        while ($process->isRunning() && false === strpos($process->getoutput(), 'Caught SIGUSR1')) {
-            usleep(10000);
-        }
-
-        $this->assertEquals('Caught SIGUSR1', $process->getOutput());
-    }
-
-    public function testExitCodeIsAvailableAfterSignal()
-    {
-        $this->verifyPosixIsEnabled();
-
-        $process = $this->getProcess('sleep 4');
-        $process->start();
-        $process->signal(SIGKILL);
-
-        while ($process->isRunning()) {
-            usleep(10000);
-        }
-
-        $this->assertFalse($process->isRunning());
-        $this->assertTrue($process->hasBeenSignaled());
-        $this->assertFalse($process->isSuccessful());
-        $this->assertEquals(137, $process->getExitCode());
-    }
-
-    /**
-     * @expectedException Symfony\Component\Process\Exception\LogicException
-     */
-    public function testSignalProcessNotRunning()
-    {
-        $this->verifyPosixIsEnabled();
-        $process = $this->getProcess('php -m');
-        $process->signal(SIGHUP);
-    }
-
-    public function responsesCodeProvider()
-    {
-        return array(
-            //expected output / getter / code to execute
-            //array(1,'getExitCode','exit(1);'),
-            //array(true,'isSuccessful','exit();'),
-            array('output', 'getOutput', 'echo \'output\';'),
-        );
-    }
-
-    public function pipesCodeProvider()
-    {
-        $variations = array(
-            'fwrite(STDOUT, $in = file_get_contents(\'php://stdin\')); fwrite(STDERR, $in);',
-            'include \''.__DIR__.'/PipeStdinInStdoutStdErrStreamSelect.php\';',
-        );
-
-        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
-            // Avoid XL buffers on Windows because of https://bugs.php.net/bug.php?id=65650
-            $sizes = array(1, 2, 4, 8);
-        } else {
-            $sizes = array(1, 16, 64, 1024, 4096);
-        }
-
-        $codes = array();
-        foreach ($sizes as $size) {
-            foreach ($variations as $code) {
-                $codes[] = array($code, $size);
-            }
-        }
-
-        return $codes;
-    }
-
-    /**
-     * provides default method names for simple getter/setter
-     */
-    public function methodProvider()
-    {
-        $defaults = array(
-            array('CommandLine'),
-            array('Timeout'),
-            array('WorkingDirectory'),
-            array('Env'),
-            array('Stdin'),
-            array('Options')
-        );
-
-        return $defaults;
-    }
-
-    protected function createProcess($commandline)
-    {
-        return $this->getProcess($commandline);
-    }
-
-    protected function getOutput(ProcessableInterface $process)
-    {
-        return $process->getOutput();
-    }
-
-    /**
-     * @param string  $commandline
-     * @param null    $cwd
-     * @param array   $env
-     * @param null    $stdin
-     * @param integer $timeout
-     * @param array   $options
-     *
-     * @return Process
-     */
-    abstract protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array());
 }

--- a/src/Symfony/Component/Process/Tests/Manager/ManagedProcessTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ManagedProcessTest.php
@@ -1,0 +1,338 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests\Manager;
+
+use Symfony\Component\Process\Tests\ProcessableTestCase;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessableInterface;
+use Symfony\Component\Process\Manager\ManagedProcess;
+
+class ManagedProcessTest extends ProcessableTestCase
+{
+    public function testExecutionsSetters()
+    {
+        $process = new ManagedProcess($this->createProcessMock(), 3);
+        $this->assertEquals(3, $process->getExecutions());
+
+        $process = new ManagedProcess($this->createProcessMock());
+        $this->assertEquals(1, $process->getExecutions());
+        $process->setExecutions(42);
+        $this->assertEquals(42, $process->getExecutions());
+    }
+
+    /**
+     * @dataProvider provideRunMethods
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     * @expectedExceptionMessage Can not modify executions once the process started. Reset the process before modifying this.
+     */
+    public function testExecutionsCanNotBeModifiedOnceTheProcessHasRun($runMethod)
+    {
+        $process = new ManagedProcess($this->createProcessMock(), 3);
+        call_user_func(array($process, $runMethod));
+        $process->setExecutions(3);
+    }
+
+    /**
+     * @dataProvider provideRunMethods
+     */
+    public function testExecutionsCanBeModifiedIfTheProcessIsReset($runMethod)
+    {
+        $process = new ManagedProcess($this->createProcessMock(), 3);
+        call_user_func(array($process, $runMethod));
+        $process->reset();
+        $process->setExecutions(3);
+    }
+
+    public function provideRunMethods()
+    {
+        return array(array('start'), array('run'));
+    }
+
+    /**
+     * @dataProvider provideInvalidExecutionsValues
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Executions must be a positive value.
+     */
+    public function testInvalidExecutionsValuesOnConstruct($executions)
+    {
+        new ManagedProcess($this->createProcessMock(), $executions);
+    }
+
+    /**
+     * @dataProvider provideInvalidExecutionsValues
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Executions must be a positive value.
+     */
+    public function testInvalidExecutionsValuesSetter($executions)
+    {
+        $process = new ManagedProcess($this->createProcessMock());
+        $process->setExecutions($executions);
+    }
+
+    protected function getOutput(ProcessableInterface $process)
+    {
+        return $process->getManagedProcess()->getOutput();
+    }
+
+    public function provideInvalidExecutionsValues()
+    {
+        return array(array(0), array(-4));
+    }
+
+    /**
+     * @dataProvider provideRunMethods
+     */
+    public function testRetryIncrementExecutionsAfterARun($runMethod)
+    {
+        $process = new ManagedProcess($this->createProcessMock(), 4);
+        call_user_func(array($process, $runMethod));
+        $process->retry();
+        $this->assertEquals(4, $process->getExecutions());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     * @expectedExceptionMessage Process must have run at least once to retry.
+     */
+    public function testRetryFailsIfProcessDidNotRunYet()
+    {
+        $process = new ManagedProcess($this->createProcessMock());
+        $process->retry();
+    }
+
+    public function testResetDoReset()
+    {
+        $process = new ManagedProcess($this->createProcessMock(), 4);
+        $process->run();
+        $process->addFailure(new \Exception('failure'));
+        $process->reset();
+
+        $this->assertEquals(4, $process->getExecutions());
+        $this->assertEquals(array(), $process->getFailures());
+        $this->assertFalse($process->hasRun());
+    }
+
+    /**
+     * @dataProvider provideRunMethods
+     */
+    public function testHasRun($runMethod)
+    {
+        $process = new ManagedProcess($this->createProcessMock());
+        $this->assertFalse($process->hasRun());
+        call_user_func(array($process, $runMethod));
+        $this->assertTrue($process->hasRun());
+    }
+
+    /**
+     * @dataProvider provideRunMethods
+     */
+    public function testCanRun($runMethod)
+    {
+        $process = new ManagedProcess($this->createProcessMock(), 2);
+        $this->assertTrue($process->canRun());
+        call_user_func(array($process, $runMethod));
+        $this->assertTrue($process->canRun());
+        call_user_func(array($process, $runMethod));
+        $this->assertFalse($process->canRun());
+        $process->retry();
+        $this->assertTrue($process->canRun());
+        call_user_func(array($process, $runMethod));
+        $this->assertFalse($process->canRun());
+    }
+
+    public function testFailuresGetterAndSetters()
+    {
+        $process = new ManagedProcess($this->createProcessMock());
+        $this->assertEquals(array(), $process->getFailures());
+        $exception1 = new \Exception('failure #1');
+        $process->addFailure($exception1);
+        $this->assertSame(array($exception1), $process->getFailures());
+        $exception2 = new \Exception('failure #2');
+        $process->addFailure($exception2);
+        $this->assertSame(array($exception1, $exception2), $process->getFailures());
+    }
+
+    public function testManagedProcessGetters()
+    {
+        $managed1 = $this->createProcessMock();
+        $process = new ManagedProcess($managed1);
+        $this->assertSame($managed1, $process->getManagedProcess());
+    }
+
+    /**
+     * @dataProvider provideRunMethods
+     */
+    public function testRunDecrementsExecutions($runMethod)
+    {
+        $process = new ManagedProcess($this->createProcessMock(), 3);
+        call_user_func(array($process, $runMethod));
+        $this->assertEquals(2, $process->getExecutions());
+        call_user_func(array($process, $runMethod));
+        $this->assertEquals(1, $process->getExecutions());
+    }
+
+    /**
+     * @dataProvider provideRunMethods
+     */
+    public function testRunMethodsFailsIfNotRemainingExecutions($runMethod)
+    {
+        $process = new ManagedProcess($this->createProcessMock());
+        call_user_func(array($process, $runMethod));
+        $this->setExpectedException('Symfony\Component\Process\Exception\RuntimeException', 'No remaining executions for the managed process.');
+        call_user_func(array($process, $runMethod));
+    }
+
+    public function testRunReturnsManagedProcessExitCode()
+    {
+        $callback = function () {};
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('run')
+            ->with($callback)
+            ->will($this->returnValue(42));
+        $process = new ManagedProcess($managed);
+        $this->assertEquals(42, $process->run($callback));
+    }
+
+    public function testStartReturnsTheObject()
+    {
+        $callback = function () {};
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('start')
+            ->with($callback)
+            ->will($this->returnValue(42));
+        $process = new ManagedProcess($managed);
+        $this->assertSame($process, $process->start($callback));
+    }
+
+    public function testRestartReturnsACloneContainingACloneOfTheManagedProcess()
+    {
+        $callback = function () {};
+        $managed = $this->createProcessMock();
+        $cloned = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('restart')
+            ->with($callback)
+            ->will($this->returnValue($cloned));
+        $process = new ManagedProcess($managed);
+        $retval = $process->restart($callback);
+        $this->assertNotSame($retval, $process);
+        $this->assertEquals($retval, $process);
+        $this->assertEquals($cloned, $retval->getManagedProcess());
+    }
+
+    public function testWaitReturnsManagedProcessExitCode()
+    {
+        $callback = function () {};
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('wait')
+            ->with($callback)
+            ->will($this->returnValue(42));
+        $process = new ManagedProcess($managed);
+        $this->assertEquals(42, $process->wait($callback));
+    }
+
+    public function testSignalReturnsManagedProcessItSelf()
+    {
+        $signal = 13;
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('signal')
+            ->with($signal);
+        $process = new ManagedProcess($managed);
+        $this->assertSame($process, $process->signal($signal));
+    }
+
+    public function testIsSuccessfulReturnsTheManagedProcessResult()
+    {
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('isSuccessful')
+            ->will($this->returnValue('return value'));
+        $process = new ManagedProcess($managed);
+        $this->assertSame('return value', $process->isSuccessful());
+    }
+
+    public function testIsStartedReturnsTheManagedProcessResult()
+    {
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('isStarted')
+            ->will($this->returnValue('return value'));
+        $process = new ManagedProcess($managed);
+        $this->assertSame('return value', $process->isStarted());
+    }
+
+    public function testIsRunningReturnsTheManagedProcessResult()
+    {
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('isRunning')
+            ->will($this->returnValue('return value'));
+        $process = new ManagedProcess($managed);
+        $this->assertSame('return value', $process->isRunning());
+    }
+
+    public function testIsTerminatedReturnsTheManagedProcessResult()
+    {
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('isTerminated')
+            ->will($this->returnValue('return value'));
+        $process = new ManagedProcess($managed);
+        $this->assertSame('return value', $process->isTerminated());
+    }
+
+    public function testGetStatusReturnsTheManagedProcessResult()
+    {
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('getStatus')
+            ->will($this->returnValue('return value'));
+        $process = new ManagedProcess($managed);
+        $this->assertSame('return value', $process->getStatus());
+    }
+
+    public function testStopReturnsTheExitCode()
+    {
+        $timeout = 42;
+        $signal = 18;
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('stop')
+            ->with($timeout, $signal)
+            ->will($this->returnValue(127));
+        $process = new ManagedProcess($managed);
+        $this->assertSame(127, $process->stop($timeout, $signal));
+    }
+
+    public function testCheckTimeoutChecksThetimeout()
+    {
+        $managed = $this->createProcessMock();
+        $managed->expects($this->once())
+            ->method('checkTimeout');
+        $process = new ManagedProcess($managed);
+        $process->checkTimeout();
+    }
+
+    public function createProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    {
+        return new ManagedProcess(new Process($commandline, $cwd, $env, $stdin, $timeout, $options));
+    }
+
+    private function createProcessMock()
+    {
+        return $this->getMock('Symfony\Component\Process\ProcessInterface');
+    }
+}

--- a/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
@@ -1,0 +1,419 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests\Manager;
+
+use Symfony\Component\Process\Tests\ProcessableTestCase;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessableInterface;
+use Symfony\Component\Process\Manager\ProcessManager;
+use Symfony\Component\Process\Manager\ManagedProcess;
+
+class ProcessManagerTest extends ProcessableTestCase
+{
+    /**
+     * @dataProvider provideInvalidConstructionArguments
+     */
+    public function testInvalidConstructorArguments($logger, $parallel, $timeoutStrategy, $failureStrategy, $errorMsg)
+    {
+        $this->setExpectedException('Symfony\Component\Process\Exception\InvalidArgumentException', $errorMsg);
+        new ProcessManager($logger, $parallel, $timeoutStrategy, $failureStrategy);
+    }
+
+    public function provideInvalidConstructionArguments()
+    {
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+
+        return array(
+            array($logger, 24, ProcessManager::STRATEGY_ABORT, 'invalid', 'Invalid strategy.'),
+            array($logger, 24, 'invalid', ProcessManager::STRATEGY_ABORT, 'Invalid strategy.'),
+            array($logger, -2, ProcessManager::STRATEGY_ABORT, ProcessManager::STRATEGY_ABORT, 'Max parallel processes must be a positive value.'),
+            array(null, 0, ProcessManager::STRATEGY_ABORT, ProcessManager::STRATEGY_ABORT, 'Max parallel processes must be a positive value.'),
+        );
+    }
+
+    public function testConstructorArguments()
+    {
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $manager = new ProcessManager($logger);
+
+        $this->assertSame($logger, $manager->getLogger());
+        $this->assertEquals(INF, $manager->getMaxParallelProcesses());
+        $this->assertEquals(ProcessManager::STRATEGY_ABORT, $manager->getFailureStrategy());
+        $this->assertEquals(ProcessManager::STRATEGY_ABORT, $manager->getTimeoutStrategy());
+
+        $manager = new ProcessManager(null, 24, ProcessManager::STRATEGY_IGNORE, ProcessManager::STRATEGY_RETRY);
+
+        $this->assertNull($manager->getLogger());
+        $this->assertEquals(24, $manager->getMaxParallelProcesses());
+        $this->assertEquals(ProcessManager::STRATEGY_RETRY, $manager->getFailureStrategy());
+        $this->assertEquals(ProcessManager::STRATEGY_IGNORE, $manager->getTimeoutStrategy());
+    }
+
+    public function testManagedProcessesMustBeSigneldIfRunningOnDestruction()
+    {
+        $process = new Process('php -r "sleep(4);"');
+
+        $manager = new ProcessManager();
+        $manager->add($process);
+        $manager->start();
+
+        $this->assertTrue($process->isRunning());
+        unset($manager);
+        $this->assertFalse($process->isRunning());
+        $this->assertTrue($process->hasBeenSignaled());
+    }
+
+    public function testLoggerGetterAndSetter()
+    {
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+
+        $manager = new ProcessManager();
+        $manager->setLogger($logger);
+        $this->assertSame($logger, $manager->getLogger());
+        $manager->setLogger(null);
+        $this->assertNull($manager->getLogger());
+    }
+
+    public function testCountableImplementation()
+    {
+        $manager = new ProcessManager();
+        $this->assertCount(0, $manager);
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 1');
+        $this->assertCount(1, $manager);
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 2');
+        $this->assertCount(2, $manager);
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 3');
+        $this->assertCount(3, $manager);
+        $manager->remove('proc 3');
+        $this->assertCount(2, $manager);
+        $manager->remove('proc 2');
+        $manager->remove('proc 1');
+        $this->assertCount(0, $manager);
+    }
+
+    public function testManagedProcessGettersAndSetters()
+    {
+        $manager = new ProcessManager();
+        $managed1 = $this->createManagedProcessMock();
+        $managed2 = $this->createManagedProcessMock();
+        $this->assertEquals(array(), $manager->getManagedProcesses());
+        $manager->setManagedProcesses(array($managed1, $managed2));
+        $this->assertSame(array($managed1, $managed2), $manager->getManagedProcesses());
+        $manager->setManagedProcesses(array());
+        $this->assertEquals(array(), $manager->getManagedProcesses());
+
+        $process = $this->getMock('Symfony\Component\Process\ProcessInterface');
+        $manager->add($process, 'proc 1');
+        $this->assertEquals(array('proc 1' => new ManagedProcess($process)), $manager->getManagedProcesses());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\ProcessManagerException
+     * @expectedExceptionMessage Can not set processes while running.
+     */
+    public function testSettingAManagedProcessIsNotPossibleWhileRunning()
+    {
+        $manager = new ProcessManager();
+        $manager->add(new Process('php -r "sleep(1);"'));
+        $manager->start();
+        $manager->setManagedProcesses(array($this->createManagedProcessMock()));
+    }
+
+    public function testVariousStrategies()
+    {
+        $manager = new ProcessManager();
+        $manager->setTimeoutStrategy(ProcessManager::STRATEGY_IGNORE);
+        $this->assertEquals(ProcessManager::STRATEGY_IGNORE, $manager->getTimeoutStrategy());
+        $this->assertEquals(ProcessManager::STRATEGY_ABORT, $manager->getFailureStrategy());
+        $manager->setFailureStrategy(ProcessManager::STRATEGY_RETRY);
+        $this->assertEquals(ProcessManager::STRATEGY_IGNORE, $manager->getTimeoutStrategy());
+        $this->assertEquals(ProcessManager::STRATEGY_RETRY, $manager->getFailureStrategy());
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid strategy.
+     */
+    public function testInvalidTimeoutStrategy()
+    {
+        $manager = new ProcessManager();
+        $manager->setTimeoutStrategy('invalid');
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid strategy.
+     */
+    public function testInvalidFailureStrategy()
+    {
+        $manager = new ProcessManager();
+        $manager->setFailureStrategy('invalid');
+    }
+
+    public function testMaxParallelProcessesGetterAndSetters()
+    {
+        $manager = new ProcessManager();
+        $this->assertEquals(INF, $manager->getMaxParallelProcesses());
+        $manager->setMaxParallelProcesses(42);
+        $this->assertEquals(42, $manager->getMaxParallelProcesses());
+        $manager->setMaxParallelProcesses(null);
+        $this->assertEquals(INF, $manager->getMaxParallelProcesses());
+    }
+
+    /**
+     * @dataProvider  provideInvalidMaximumParallelProcesses
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Max parallel processes must be a positive value.
+     */
+    public function testInvalidMaxParallelProcesses($maximum)
+    {
+        $manager = new ProcessManager();
+        $manager->setMaxParallelProcesses($maximum);
+    }
+
+    public function provideInvalidMaximumParallelProcesses()
+    {
+        return array(array(-3), array(0));
+    }
+
+    public function testHas()
+    {
+        $manager = new ProcessManager();
+        $this->assertFalse($manager->has('proc 1'));
+        $this->assertFalse($manager->has('proc 2'));
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 1');
+        $this->assertTrue($manager->has('proc 1'));
+        $this->assertFalse($manager->has('proc 2'));
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 2');
+        $this->assertTrue($manager->has('proc 1'));
+        $this->assertTrue($manager->has('proc 2'));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage A process named proc 1 is already attached.
+     */
+    public function testAddTwiceAProcessWithTheSameNameThrowsAnException()
+    {
+        $manager = new ProcessManager();
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 1');
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 1');
+    }
+
+    public function testRemovingAProcessStopsItAndRemovesIt()
+    {
+        $process = $this->getMock('Symfony\Component\Process\ProcessInterface');
+
+        $manager = new ProcessManager();
+        $manager->add($process, 'proc 1');
+
+        $timeout = 42;
+        $signal = 'signal';
+        $process->expects($this->once())
+            ->method('stop')
+            ->with($timeout, $signal);
+
+        $manager->remove('proc 1', $timeout, $signal);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage No process named proc 2 is attached to the manager.
+     */
+    public function testRemovingAnUnknownProcessThrowsAnException()
+    {
+        $manager = new ProcessManager();
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 1');
+        $manager->remove('proc 2');
+    }
+
+    public function testGetAProcess()
+    {
+        $process = $this->getMock('Symfony\Component\Process\ProcessInterface');
+
+        $manager = new ProcessManager();
+        $manager->add($process, 'proc 1');
+
+        $this->assertEquals(new ManagedProcess($process), $manager->get('proc 1'));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\InvalidArgumentException
+     * @expectedExceptionMessage No process named proc 2 is attached to the manager.
+     */
+    public function testGetAnUnknownProcessThrowsAnException()
+    {
+        $manager = new ProcessManager();
+        $manager->add($this->getMock('Symfony\Component\Process\ProcessInterface'), 'proc 1');
+        $manager->get('proc 2');
+    }
+
+    public function testDaemonGetterAndSetters()
+    {
+        $manager = new ProcessManager();
+        $this->assertFalse($manager->isDaemon());
+        $manager->setDaemon(true);
+        $this->assertTrue($manager->isDaemon());
+        $manager->setDaemon(false);
+        $this->assertFalse($manager->isDaemon());
+    }
+
+    public function testDaemonProcessManagerCanStartWIthoutAttachedProcesses()
+    {
+        $manager = new ProcessManager();
+        $manager->setDaemon(true);
+        $manager->start();
+        $manager->stop();
+    }
+
+    public function testFunctionalParallelTaskShouldRunParallelyWithRun()
+    {
+        $manager = new ProcessManager();
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $start = microtime(true);
+        $manager->run();
+        $duration = microtime(true) - $start;
+        // margin can be 0.1 second due to process start overhead
+        $this->assertLessThan(0.15, abs($duration - 0.5));
+    }
+
+    public function testFunctionalNonParallelTaskShouldNoRunParallelyWithRun()
+    {
+        $manager = new ProcessManager();
+        $manager->setMaxParallelProcesses(1);
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $start = microtime(true);
+        $manager->run();
+        $duration = microtime(true) - $start;
+        // wider error margin due to process start overhead
+        $this->assertLessThan(0.25, abs($duration - 1.5));
+    }
+
+    public function testFunctionalMixedParallelismWithRun()
+    {
+        $manager = new ProcessManager();
+        $manager->setMaxParallelProcesses(2);
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $start = microtime(true);
+        $manager->run();
+        $duration = microtime(true) - $start;
+        // wider error margin due to process start overhead
+        $this->assertLessThan(0.2, abs($duration - 1));
+    }
+
+    public function testFunctionalParallelTaskShouldRunParallelyWithStart()
+    {
+        $manager = new ProcessManager();
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $start = microtime(true);
+        $manager->start();
+        while ($manager->isRunning()) {
+            usleep(10000);
+        }
+        $duration = microtime(true) - $start;
+        // margin can be 0.1 second due to process start overhead
+        $this->assertLessThan(0.15, abs($duration - 0.5));
+    }
+
+    public function testFunctionalNonParallelTaskShouldNoRunParallelyWithStart()
+    {
+        $manager = new ProcessManager();
+        $manager->setMaxParallelProcesses(1);
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $start = microtime(true);
+        $manager->start();
+        while ($manager->isRunning()) {
+            usleep(10000);
+        }
+        $duration = microtime(true) - $start;
+        // wider error margin due to process start overhead
+        $this->assertLessThan(0.25, abs($duration - 1.5));
+    }
+
+    public function testFunctionalMixedParallelismWithStart()
+    {
+        $manager = new ProcessManager();
+        $manager->setMaxParallelProcesses(2);
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $start = microtime(true);
+        $manager->start();
+        while ($manager->isRunning()) {
+            usleep(10000);
+        }
+        $duration = microtime(true) - $start;
+        // wider error margin due to process start overhead
+        $this->assertLessThan(0.2, abs($duration - 1));
+    }
+
+    public function testFunctionalWaitWaitsForTheEndOfProcess()
+    {
+        $manager = new ProcessManager();
+        $manager->add(new Process('php -r "usleep(500000);"'));
+        $start = microtime(true);
+        $manager->start()
+            ->wait();
+        $duration = microtime(true) - $start;
+        $this->assertLessThan(0.15, abs($duration - 0.5));
+    }
+
+    public function testIsNotSuccessfulIfAtLeastOneProcessFailed()
+    {
+        $manager = new ProcessManager();
+        $manager->add(new Process('php -r "echo(\'hello\');"'));
+        $manager->add(new Process('php -r "echo(\'hello\');"'));
+        $manager->add(new Process('php -r "not php"'));
+        $manager->run();
+        $this->assertFalse($manager->isSuccessful());
+    }
+
+    public function testIsSuccessfulIfProcessesSucceeded()
+    {
+        $manager = new ProcessManager();
+        $manager->add(new Process('php -r "echo(\'hello\');"'));
+        $manager->add(new Process('php -r "echo(\'hello\');"'));
+        $manager->add(new Process('php -r "echo(\'hello\');"'));
+        $manager->run();
+        $this->assertTrue($manager->isSuccessful());
+    }
+
+    public function getOutput(ProcessableInterface $process)
+    {
+        return $process->get('test-one')->getManagedProcess()->getOutput();
+    }
+
+    private function createManagedProcessMock()
+    {
+        return $this->getMockBuilder('Symfony\Component\Process\Manager\ManagedProcess')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function createProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array())
+    {
+        $manager = new ProcessManager();
+        $manager->add(new Process($commandline, $cwd, $env, $stdin, $timeout, $options), 'test-one');
+
+        return $manager;
+    }
+}

--- a/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
@@ -446,6 +446,22 @@ class ProcessManagerTest extends ProcessableTestCase
         $this->assertTrue($manager->isSuccessful());
     }
 
+    public function testDaemonProcessManagerStopsOnStop()
+    {
+        declare(ticks=1);
+        $manager = new ProcessManager();
+        $manager->add(new Process('sleep 5'), 'test');
+        $manager->setDaemon(true);
+        pcntl_signal(SIGALRM, function () use ($manager) {
+            $manager->stop();
+        });
+        pcntl_alarm(1);
+        $start = microtime(true);
+        $manager->run();
+        $this->assertLessThan(0.1, abs((microtime(true) - $start) - 1));
+        $this->assertFalse($manager->isRunning());
+    }
+
     // add tests with various strategies and mustRun
 
     public function getOutput(ProcessableInterface $process)

--- a/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
@@ -299,7 +299,7 @@ class ProcessManagerTest extends ProcessableTestCase
         $manager->run();
         $duration = microtime(true) - $start;
         // wider error margin due to process start overhead
-        $this->assertLessThan(0.25, abs($duration - 1.5));
+        $this->assertLessThan(0.30, abs($duration - 1.5));
     }
 
     public function testFunctionalMixedParallelismWithRun()
@@ -413,6 +413,28 @@ class ProcessManagerTest extends ProcessableTestCase
         $this->assertFalse($manager->isSuccessful());
     }
 
+    public function testIsNotSuccessfulIfAProcessFailsWithIgnoreStrategy()
+    {
+        $process = new Process('php -r "not valid php"');
+
+        $manager = new ProcessManager();
+        $manager->setTimeoutStrategy(ProcessManager::STRATEGY_IGNORE);
+        $manager->add($process);
+        $manager->run();
+        $this->assertFalse($manager->isSuccessful());
+    }
+
+    public function testIsNotSuccessfulIfAProcessFailsWithAbortStrategy()
+    {
+        $process = new Process('php -r "not valid php"');
+
+        $manager = new ProcessManager();
+        $manager->setTimeoutStrategy(ProcessManager::STRATEGY_ABORT);
+        $manager->add($process);
+        $manager->run();
+        $this->assertFalse($manager->isSuccessful());
+    }
+
     public function testIsSuccessfulIfProcessesSucceeded()
     {
         $manager = new ProcessManager();
@@ -423,7 +445,7 @@ class ProcessManagerTest extends ProcessableTestCase
         $this->assertTrue($manager->isSuccessful());
     }
 
-    public function testIsNotSuccessfulIfAProcessTimeOutWithRetryStrategy()
+    public function testIsSuccessfulIfAProcessTimeOutWithRetryStrategyAndFinallySucceed()
     {
         $timeout = 0.1;
         $process = new Process('php -r "usleep(200000);"');

--- a/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
@@ -285,7 +285,7 @@ class ProcessManagerTest extends ProcessableTestCase
         $manager->run();
         $duration = microtime(true) - $start;
         // margin can be 0.1 second due to process start overhead
-        $this->assertLessThan(0.15, abs($duration - 0.5));
+        $this->assertLessThan(0.20, abs($duration - 0.5));
     }
 
     public function testFunctionalNonParallelTaskShouldNoRunParallelyWithRun()
@@ -346,7 +346,7 @@ class ProcessManagerTest extends ProcessableTestCase
         }
         $duration = microtime(true) - $start;
         // wider error margin due to process start overhead
-        $this->assertLessThan(0.25, abs($duration - 1.5));
+        $this->assertLessThan(0.30, abs($duration - 1.5));
     }
 
     public function testFunctionalMixedParallelismWithStart()

--- a/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
@@ -462,7 +462,18 @@ class ProcessManagerTest extends ProcessableTestCase
         $this->assertFalse($manager->isRunning());
     }
 
-    // add tests with various strategies and mustRun
+    public function testDaemonProcessManagerDoesNotStopOnceProcessesFinish()
+    {
+        declare(ticks=1);
+        $manager = new ProcessManager();
+        $manager->add(new Process('php -r "usleep(1000)"'), 'test');
+        $manager->setDaemon(true);
+        $manager->start();
+        sleep(1);
+        $this->assertTrue($manager->isRunning());
+        $manager->stop();
+        $this->assertFalse($manager->isRunning());
+    }
 
     public function getOutput(ProcessableInterface $process)
     {

--- a/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
@@ -472,7 +472,7 @@ class ProcessManagerTest extends ProcessableTestCase
     {
         declare(ticks=1);
         $manager = new ProcessManager();
-        $manager->add(new Process('sleep 5'), 'test');
+        $manager->add(new Process('sleep 5'), 'test', INF);
         $manager->setDaemon(true);
         pcntl_signal(SIGALRM, function () use ($manager) {
             $manager->stop();

--- a/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
+++ b/src/Symfony/Component/Process/Tests/Manager/ProcessManagerTest.php
@@ -58,9 +58,9 @@ class ProcessManagerTest extends ProcessableTestCase
         $this->assertEquals(ProcessManager::STRATEGY_IGNORE, $manager->getTimeoutStrategy());
     }
 
-    public function testManagedProcessesMustBeSigneldIfRunningOnDestruction()
+    public function testManagedProcessesMustBeStoppedIfRunningOnDestruction()
     {
-        $process = new Process('php -r "sleep(4);"');
+        $process = new Process('php -r "$n=0;while($n<=400){usleep(10000);$n++;}"');
 
         $manager = new ProcessManager();
         $manager->add($process);
@@ -393,7 +393,7 @@ class ProcessManagerTest extends ProcessableTestCase
 
     public function testIsNotSuccessfulIfAProcessTimeOutWithIgnoreStrategy()
     {
-        $process = new Process('php -r "while(true) {};"');
+        $process = new Process('php -r "$n = 0; while ($n<=200) {usleep(100000);$n++;}"');
         $process->setTimeout(0.1);
 
         $manager = new ProcessManager();

--- a/src/Symfony/Component/Process/Tests/ProcessTestCase.php
+++ b/src/Symfony/Component/Process/Tests/ProcessTestCase.php
@@ -1,0 +1,327 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\ProcessableInterface;
+use Symfony\Component\Process\Process;
+
+abstract class ProcessTestCase extends ProcessableTestCase
+{
+    /**
+     * tests results from sub processes
+     *
+     * @dataProvider pipesCodeProvider
+     */
+    public function testProcessPipes($code, $size)
+    {
+        $expected = str_repeat(str_repeat('*', 1024), $size) . '!';
+        $expectedLength = (1024 * $size) + 1;
+
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
+        $p->setStdin($expected);
+        $p->run();
+
+        $this->assertEquals($expectedLength, strlen($p->getOutput()));
+        $this->assertEquals($expectedLength, strlen($p->getErrorOutput()));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
+     */
+    public function testNegativeTimeoutFromConstructor()
+    {
+        $this->getProcess('', null, null, null, -1);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\InvalidArgumentException
+     */
+    public function testNegativeTimeoutFromSetter()
+    {
+        $p = $this->getProcess('');
+        $p->setTimeout(-1);
+    }
+
+    public function testNullTimeout()
+    {
+        $p = $this->getProcess('');
+        $p->setTimeout(10);
+        $p->setTimeout(null);
+
+        $this->assertNull($p->getTimeout());
+    }
+
+    /**
+     * tests results from sub processes
+     *
+     * @dataProvider responsesCodeProvider
+     */
+    public function testProcessResponses($expected, $getter, $code)
+    {
+        $p = $this->getProcess(sprintf('php -r %s', escapeshellarg($code)));
+        $p->run();
+
+        $this->assertSame($expected, $p->$getter());
+    }
+
+    public function chainedCommandsOutputProvider()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            return array(
+                array("2 \r\n2\r\n", '&&', '2')
+            );
+        }
+
+        return array(
+            array("1\n1\n", ';', '1'),
+            array("2\n2\n", '&&', '2'),
+        );
+    }
+
+    /**
+     *
+     * @dataProvider chainedCommandsOutputProvider
+     */
+    public function testChainedCommandsOutput($expected, $operator, $input)
+    {
+        $process = $this->getProcess(sprintf('echo %s %s echo %s', $input, $operator, $input));
+        $process->run();
+        $this->assertEquals($expected, $process->getOutput());
+    }
+
+    public function testGetErrorOutput()
+    {
+        $p = new Process(sprintf('php -r %s', escapeshellarg('$n = 0; while ($n < 3) { file_put_contents(\'php://stderr\', \'ERROR\'); $n++; }')));
+
+        $p->run();
+        $this->assertEquals(3, preg_match_all('/ERROR/', $p->getErrorOutput(), $matches));
+    }
+
+    public function testGetOutput()
+    {
+        $p = new Process(sprintf('php -r %s', escapeshellarg('$n=0;while ($n<3) {echo \' foo \';$n++; usleep(500); }')));
+
+        $p->run();
+        $this->assertEquals(3, preg_match_all('/foo/', $p->getOutput(), $matches));
+    }
+
+    public function testExitCodeCommandFailed()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX exit code');
+        }
+
+        // such command run in bash return an exitcode 127
+        $process = $this->getProcess('nonexistingcommandIhopeneversomeonewouldnameacommandlikethis');
+        $process->run();
+
+        $this->assertGreaterThan(0, $process->getExitCode());
+    }
+
+    public function testUpdateStatus()
+    {
+        $process = $this->getProcess('php -h');
+        $process->run();
+        $this->assertTrue(strlen($process->getOutput()) > 0);
+    }
+
+    public function testGetExitCodeIsNullOnStart()
+    {
+        $process = $this->getProcess('php -r "usleep(200000);"');
+        $this->assertNull($process->getExitCode());
+        $process->start();
+        $this->assertNull($process->getExitCode());
+        $process->wait();
+        $this->assertEquals(0, $process->getExitCode());
+    }
+
+    public function testGetExitCodeIsNullOnWhenStartingAgain()
+    {
+        $process = $this->getProcess('php -r "usleep(200000);"');
+        $process->run();
+        $this->assertEquals(0, $process->getExitCode());
+        $process->start();
+        $this->assertNull($process->getExitCode());
+        $process->wait();
+        $this->assertEquals(0, $process->getExitCode());
+    }
+
+    public function testGetExitCode()
+    {
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertEquals(0, $process->getExitCode());
+    }
+
+    public function testProcessIsNotSignaled()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertFalse($process->hasBeenSignaled());
+    }
+
+    public function testProcessWithoutTermSignalIsNotSignaled()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertFalse($process->hasBeenSignaled());
+    }
+
+    public function testProcessWithoutTermSignal()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertEquals(0, $process->getTermSignal());
+    }
+
+    public function testProcessIsSignaledIfStopped()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        $process = $this->getProcess('php -r "while (true) {}"');
+        $process->start();
+        $process->stop();
+        $this->assertTrue($process->hasBeenSignaled());
+    }
+
+    public function testProcessWithTermSignal()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        // SIGTERM is only defined if pcntl extension is present
+        $termSignal = defined('SIGTERM') ? SIGTERM : 15;
+
+        $process = $this->getProcess('php -r "while (true) {}"');
+        $process->start();
+        $process->stop();
+
+        $this->assertEquals($termSignal, $process->getTermSignal());
+    }
+
+    public function testProcessThrowsExceptionWhenExternallySignaled()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('Windows does not support POSIX signals');
+        }
+
+        if (!function_exists('posix_kill')) {
+            $this->markTestSkipped('posix_kill is required for this test');
+        }
+
+        $termSignal = defined('SIGKILL') ? SIGKILL : 9;
+
+        $process = $this->getProcess('exec php -r "while (true) {}"');
+        $process->start();
+        posix_kill($process->getPid(), $termSignal);
+
+        $this->setExpectedException('Symfony\Component\Process\Exception\RuntimeException', 'The process has been signaled with signal "9".');
+        $process->wait();
+    }
+
+    public function testPhpDeadlock()
+    {
+        $this->markTestSkipped('Can course php to hang');
+
+        // Sleep doesn't work as it will allow the process to handle signals and close
+        // file handles from the other end.
+        $process = $this->getProcess('php -r "while (true) {}"');
+        $process->start();
+
+        // PHP will deadlock when it tries to cleanup $process
+    }
+
+    public function testGetPid()
+    {
+        $process = $this->getProcess('php -r "sleep(1);"');
+        $process->start();
+        $this->assertGreaterThan(0, $process->getPid());
+        $process->stop();
+    }
+
+    public function testGetPidIsNullBeforeStart()
+    {
+        $process = $this->getProcess('php -r "sleep(1);"');
+        $this->assertNull($process->getPid());
+    }
+
+    public function testGetPidIsNullAfterRun()
+    {
+        $process = $this->getProcess('php -m');
+        $process->run();
+        $this->assertNull($process->getPid());
+    }
+    public function testExitCodeIsAvailableAfterSignal()
+    {
+        $this->verifyPosixIsEnabled();
+
+        $process = $this->getProcess('sleep 4');
+        $process->start();
+        $process->signal(SIGKILL);
+
+        while ($process->isRunning()) {
+            usleep(10000);
+        }
+
+        $this->assertFalse($process->isRunning());
+        $this->assertTrue($process->hasBeenSignaled());
+        $this->assertFalse($process->isSuccessful());
+        $this->assertEquals(137, $process->getExitCode());
+    }
+
+    public function responsesCodeProvider()
+    {
+        return array(
+            //expected output / getter / code to execute
+            //array(1,'getExitCode','exit(1);'),
+            //array(true,'isSuccessful','exit();'),
+            array('output', 'getOutput', 'echo \'output\';'),
+        );
+    }
+
+    protected function getOutput(ProcessableInterface $process)
+    {
+        return $process->getOutput();
+    }
+
+    protected function createProcess($commandline)
+    {
+        return $this->getProcess($commandline);
+    }
+
+    /**
+     * @param string  $commandline
+     * @param null    $cwd
+     * @param array   $env
+     * @param null    $stdin
+     * @param integer $timeout
+     * @param array   $options
+     *
+     * @return Process
+     */
+    abstract protected function getProcess($commandline, $cwd = null, array $env = null, $stdin = null, $timeout = 60, array $options = array());
+}

--- a/src/Symfony/Component/Process/Tests/ProcessableTestCase.php
+++ b/src/Symfony/Component/Process/Tests/ProcessableTestCase.php
@@ -1,0 +1,206 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Process\Tests;
+
+use Symfony\Component\Process\ProcessableInterface;
+
+abstract class ProcessableTestCase extends \PHPUnit_Framework_TestCase
+{
+    public function testStopWithTimeoutIsActuallyWorking()
+    {
+        $this->verifyPosixIsEnabled();
+
+        // exec is mandatory here since we send a signal to the process
+        // see https://github.com/symfony/symfony/issues/5030 about prepending
+        // command with exec
+        $p = $this->createProcess('exec php '.__DIR__.'/NonStopableProcess.php 3');
+        $p->start();
+        usleep(100000);
+        $start = microtime(true);
+        $p->stop(1.1, SIGKILL);
+        while ($p->isRunning()) {
+            usleep(1000);
+        }
+        $duration = microtime(true) - $start;
+
+        $this->assertLessThan(1.8, $duration);
+    }
+
+    public function testCallbackIsExecutedForOutput()
+    {
+        $p = $this->createProcess(sprintf('php -r %s', escapeshellarg('echo \'foo\';')));
+
+        $called = false;
+        $p->run(function ($type, $buffer) use (&$called) {
+            $called = $buffer === 'foo';
+        });
+
+        $this->assertTrue($called, 'The callback should be executed with the output');
+    }
+
+    public function testStartIsNonBlocking()
+    {
+        $process = $this->createProcess('php -r "sleep(4);"');
+        $start = microtime(true);
+        $process->start();
+        $end = microtime(true);
+        $this->assertLessThan(1 , $end-$start);
+    }
+
+    public function testStatus()
+    {
+        $process = $this->createProcess('php -r "usleep(500000);"');
+        $this->assertFalse($process->isRunning());
+        $this->assertFalse($process->isStarted());
+        $this->assertFalse($process->isTerminated());
+        $this->assertSame(ProcessableInterface::STATUS_READY, $process->getStatus());
+        $process->start();
+        $this->assertTrue($process->isRunning());
+        $this->assertTrue($process->isStarted());
+        $this->assertFalse($process->isTerminated());
+        $this->assertSame(ProcessableInterface::STATUS_STARTED, $process->getStatus());
+        $process->wait();
+        $this->assertFalse($process->isRunning());
+        $this->assertTrue($process->isStarted());
+        $this->assertTrue($process->isTerminated());
+        $this->assertSame(ProcessableInterface::STATUS_TERMINATED, $process->getStatus());
+    }
+
+    public function testStop()
+    {
+        $process = $this->createProcess('php -r "sleep(4);"');
+        $process->start();
+        $this->assertTrue($process->isRunning());
+        $process->stop();
+        $this->assertFalse($process->isRunning());
+    }
+
+    public function testIsSuccessful()
+    {
+        $process = $this->createProcess('php -m');
+        $process->run();
+        $this->assertTrue($process->isSuccessful());
+    }
+
+    public function testIsNotSuccessful()
+    {
+        $process = $this->createProcess('php -r "sleep(4);"');
+        $process->start();
+        $this->assertTrue($process->isRunning());
+        $process->stop();
+        $this->assertFalse($process->isSuccessful());
+    }
+
+    public function testIsSuccessfulOnlyAfterTerminated()
+    {
+        $process = $this->createProcess('php -r "sleep(1);"');
+        $process->start();
+        while ($process->isRunning()) {
+            $this->assertFalse($process->isSuccessful());
+            usleep(300000);
+        }
+
+        $this->assertTrue($process->isSuccessful());
+        $process = $this->createProcess('sleep 1');
+    }
+
+    public function testRestart()
+    {
+        $process1 = $this->createProcess('php -r "echo getmypid();"');
+        $process1->run();
+        $process2 = $process1->restart();
+        $process2->wait();
+
+        // Ensure that both processed finished and the output is numeric
+        $this->assertFalse($process1->isRunning());
+        $this->assertFalse($process2->isRunning());
+        $this->assertTrue(is_numeric($this->getOutput($process1)));
+        $this->assertTrue(is_numeric($this->getOutput($process2)));
+
+        // Ensure that restart returned a new process by check that the output is different
+        $this->assertNotEquals($this->getOutput($process1), $this->getOutput($process2));
+    }
+
+    public function testSignal()
+    {
+        $this->verifyPosixIsEnabled();
+
+        $process = $this->createProcess('exec php -f ' . __DIR__ . '/SignalListener.php');
+        $process->start();
+        usleep(500000);
+        $process->signal(SIGUSR1);
+
+        while ($process->isRunning() && false === strpos($this->getOutput($process), 'Caught SIGUSR1')) {
+            usleep(10000);
+        }
+
+        $this->assertEquals('Caught SIGUSR1', $this->getOutput($process));
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\LogicException
+     */
+    public function testSignalProcessNotRunning()
+    {
+        $this->verifyPosixIsEnabled();
+        $process = $this->createProcess('php -m');
+        $process->signal(SIGHUP);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testSignalWithWrongIntSignal()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('POSIX signals do not work on windows');
+        }
+
+        $process = $this->createProcess('php -r "sleep(3);"');
+        $process->start();
+        $process->signal(-4);
+    }
+
+    /**
+     * @expectedException Symfony\Component\Process\Exception\RuntimeException
+     */
+    public function testSignalWithWrongNonIntSignal()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('POSIX signals do not work on windows');
+        }
+
+        $process = $this->createProcess('php -r "sleep(3);"');
+        $process->start();
+        $process->signal('Céphalopodes');
+    }
+
+    protected function verifyPosixIsEnabled()
+    {
+        if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+            $this->markTestSkipped('POSIX signals do not work on windows');
+        }
+        if (!defined('SIGUSR1')) {
+            $this->markTestSkipped('The pcntl extension is not enabled');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    abstract protected function getOutput(ProcessableInterface $process);
+
+    /**
+     * @return ProcessableInterface
+     */
+    abstract protected function createProcess($commandline);
+}

--- a/src/Symfony/Component/Process/Tests/ProcessableTestCase.php
+++ b/src/Symfony/Component/Process/Tests/ProcessableTestCase.php
@@ -47,6 +47,22 @@ abstract class ProcessableTestCase extends \PHPUnit_Framework_TestCase
         $this->assertTrue($called, 'The callback should be executed with the output');
     }
 
+    public function testCallbacksAreExecutedWithStart()
+    {
+        $data = '';
+
+        $process = $this->createProcess('echo foo && php -r "sleep(1);" && echo foo');
+        $process->start(function ($type, $buffer) use (&$data) {
+            $data .= $buffer;
+        });
+
+        while ($process->isRunning()) {
+            usleep(10000);
+        }
+
+        $this->assertEquals(2, preg_match_all('/foo/', $data, $matches));
+    }
+
     public function testStartIsNonBlocking()
     {
         $process = $this->createProcess('php -r "sleep(4);"');

--- a/src/Symfony/Component/Process/composer.json
+++ b/src/Symfony/Component/Process/composer.json
@@ -16,7 +16,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "psr/log": "~1.0"
     },
     "autoload": {
         "psr-0": { "Symfony\\Component\\Process\\": "" }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes, require #8756 to be merged |
| Fixed tickets | #8454 |
| License | MIT |
| Doc PR | Not ready yet |

Hello, 

I'm looking for feedback for this process manager implementation.

This PR adds a [ProcessableInterface](https://github.com/romainneutron/symfony/blob/process-manager/src/Symfony/Component/Process/ProcessableInterface.php) that is implements by both `Process` and `ProcessManager`.

Once the API is ok, the remaining tasks are : 
- [ ] Write documentation.
- [x] Add more tests.
## Usage examples
### Run 4 jobs in parallel

``` php
$manager = new Symfony\Component\Process\Manager\ProcessManager();
$manager
    ->add(new Process('...'))
    ->add(new Process('...'))
    ->add(new Process('...'))
    ->add(new Process('...'))
    ->run();
```
### Run 4 jobs in queue

``` php
$manager = new Symfony\Component\Process\Manager\ProcessManager();
$manager
    ->setMaxParallelProcesses(1)
    ->add(new Process('...'))
    ->add(new Process('...'))
    ->add(new Process('...'))
    ->add(new Process('...'))
    ->run();
```
### Run 2 queues of 2 jobs in parallel

``` php
$queue1 = new Symfony\Component\Process\Manager\ProcessManager();
$queue1
    ->setMaxParallelProcesses(1)
    ->add(new Process('...'))
    ->add(new Process('...'));

$queue2 = new Symfony\Component\Process\Manager\ProcessManager();
$queue2
    ->setMaxParallelProcesses(1)
    ->add(new Process('...'))
    ->add(new Process('...'));

$manager = new Symfony\Component\Process\Manager\ProcessManager();
$manager
    ->add($queue1)
    ->add($queue2)
    ->run();
```
