### PR TITLE
in case of require an empty class for ClassLoader

### DIFF
--- a/src/Symfony/Component/ClassLoader/ApcClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ApcClassLoader.php
@@ -103,7 +103,7 @@ class ApcClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->findFile($class)) {
+        if ($class!='' and $file = $this->findFile($class)) {
             require $file;
 
             return true;

--- a/src/Symfony/Component/ClassLoader/ClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/ClassLoader.php
@@ -148,7 +148,7 @@ class ClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->findFile($class)) {
+        if ($class!="" and $file = $this->findFile($class)) {
             require $file;
 
             return true;

--- a/src/Symfony/Component/ClassLoader/DebugClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugClassLoader.php
@@ -92,7 +92,7 @@ class DebugClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->classFinder->findFile($class)) {
+        if ($class!="" and $file = $this->classFinder->findFile($class)) {
             require $file;
 
             if (!class_exists($class, false) && !interface_exists($class, false) && (!function_exists('trait_exists') || !trait_exists($class, false))) {

--- a/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/DebugUniversalClassLoader.php
@@ -52,7 +52,7 @@ class DebugUniversalClassLoader extends UniversalClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->findFile($class)) {
+        if ($class!="" and $file = $this->findFile($class)) {
             require $file;
 
             if (!class_exists($class, false) && !interface_exists($class, false) && (!function_exists('trait_exists') || !trait_exists($class, false))) {

--- a/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/UniversalClassLoader.php
@@ -247,7 +247,7 @@ class UniversalClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->findFile($class)) {
+        if ($class!='' and $file = $this->findFile($class)) {
             require $file;
 
             return true;

--- a/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/WinCacheClassLoader.php
@@ -100,7 +100,7 @@ class WinCacheClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->findFile($class)) {
+        if ($class!='' and $file = $this->findFile($class)) {
             require $file;
 
             return true;

--- a/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
+++ b/src/Symfony/Component/ClassLoader/XcacheClassLoader.php
@@ -97,7 +97,7 @@ class XcacheClassLoader
      */
     public function loadClass($class)
     {
-        if ($file = $this->findFile($class)) {
+        if ($class!='' and $file = $this->findFile($class)) {
             require $file;
 
             return true;


### PR DESCRIPTION
for some reason the function loadClass is requiring the $class which has no value.

It cause following error,I made some tweaks for them to avoid the error.

./error.log:2013/08/15 14:49:20 [error] 21114#0: *5396972 FastCGI sent in stderr: "PHP message: PHP Fatal error:  require(): Failed opening required '' (include_path='.:/usr/share/php:/usr/share/pear') in /var/www/www/releases/20130729091149/app/bootstrap.php.cache on line 1068" while reading response header from upstream, client: 1.1.1.1, server: www.test.com, request: "POST / HTTP/1.1", upstream: "fastcgi://unix:/var/run/www.php5-fpm.socket:", host: "www.test.com"

bootstrap.php.cache line1068:

```
    public function loadClass($class)
    {
        if ($file = $this->findFile($class)) {             <-------line 1068
            require $file;

            return true;
        }
    }
```
