### PR TITLE
Fix session incompatibility with Memcache and Redis type session storage...

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -209,14 +209,17 @@ class NativeSessionStorage implements SessionStorageInterface
 
         $ret = session_regenerate_id($destroy);
 
-        // workaround for https://bugs.php.net/bug.php?id=61470 as suggested by David Grudl
-        session_write_close();
-        if (isset($_SESSION)) {
-            $backup = $_SESSION;
-            session_start();
-            $_SESSION = $backup;
-        } else {
-            session_start();
+        if($this->getSaveHandler()->getSaveHandlerName() == 'files')
+        {
+            // workaround for https://bugs.php.net/bug.php?id=61470 as suggested by David Grudl
+            session_write_close();
+            if (isset($_SESSION)) {
+                $backup = $_SESSION;
+                session_start();
+                $_SESSION = $backup;
+            } else {
+                session_start();
+            }
         }
 
         return $ret;


### PR DESCRIPTION
... handlers

An attempt to fix issue 7380 and https://bugs.php.net/bug.php?id=61470, a file-based session issue, causes the following error when using a Memcache or Redis session store w/ Symfony security:  "Authentication exception occurred; redirecting to authentication entry point (A Token was not found in the SecurityContext.)"  Closes 7380.
