### PR TITLE
{HttpFoundation] [Session] fixed session compatibility with memcached/re...

### DIFF
--- a/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
+++ b/src/Symfony/Component/HttpFoundation/Session/Storage/NativeSessionStorage.php
@@ -210,13 +210,15 @@ class NativeSessionStorage implements SessionStorageInterface
         $ret = session_regenerate_id($destroy);
 
         // workaround for https://bugs.php.net/bug.php?id=61470 as suggested by David Grudl
-        session_write_close();
-        if (isset($_SESSION)) {
-            $backup = $_SESSION;
-            session_start();
-            $_SESSION = $backup;
-        } else {
-            session_start();
+        if($this->getSaveHandler()->getSaveHandlerName() === 'files') {
+            session_write_close();
+            if (isset($_SESSION)) {
+                $backup = $_SESSION;
+                session_start();
+                $_SESSION = $backup;
+            } else {
+                session_start();
+            }
         }
 
         return $ret;


### PR DESCRIPTION
...dis session storage

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | no (no new failng/errors introduced) |
| Fixed tickets | 7380 |
| License | MIT |

Per https://bugs.php.net/bug.php?id=61470, and in fixing #7380, the following error occurs when using a Memcache or Redis session store w/ Symfony security: "Authentication exception occurred; redirecting to authentication entry point (A Token was not found in the SecurityContext.)".  This patch applies the first fix only if the session store is "files"
